### PR TITLE
feat: option to limit frontend call to the proxy service

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -15,3 +15,9 @@ export AUTHENTICATION_PASSWORD=""
 #
 export SECRET_KEY=""
 export PUBLISHABLE_KEY=""
+#
+# 3. Allow or disable requests to the proxy service using a publishable key.
+#    FALSE by default to allow request with a publishable key or a secret key.
+#    Set to TRUE to only allow access having a valid secret key.
+#
+export PROXY_USES_SECRET_KEY_ONLY=false

--- a/src/routes/proxy.ts
+++ b/src/routes/proxy.ts
@@ -11,8 +11,24 @@ import { incomingRequestHandler } from '../lib/proxy'
 
 const proxy = express.Router()
 
+/**
+ * Proxy authentication middleware
+ *
+ * Authenticated requests to the proxy service can use both a publishable key
+ * (using ?pizzly_pkey=... as a query string) or a secret key (using
+ * the Authentication header).
+ *
+ * By default requests using a publishable key are allowed, even if, as its name
+ * implies, the publishable key is public (available in your website source code).
+ * It's still considered safe, as you need both a valid publishable key and authId
+ * to make requests to a third party API.
+ */
+
 proxy.use((req, res, next) => {
-  if (req.query['pizzly_pkey']) {
+  // Limit access to the requests having a valid secret key only
+  const proxyUsesSecretKeyOnly = Boolean(process.env.PROXY_USES_SECRET_KEY_ONLY)
+
+  if (!proxyUsesSecretKeyOnly && req.query['pizzly_pkey']) {
     return access.publishableKey(req, res, next)
   } else {
     return access.secretKey(req, res, next)


### PR DESCRIPTION
# Description

As discussed with @cfabianski, an extra-option seems preferable to let a developer disallow access to the proxy service when the request uses a publishable key. 

By default, this option is disabled. Meaning the proxy service allows requests having whether a valid secret key or a valid publishable key. To enable this option, change your `.envrc` file as follow:

```
#
# Secure your instance
#
# ...
#
# 3. Allow or disable requests to the proxy service using a publishable key.
#    FALSE by default to allow request with a publishable key or a secret key.
#    Set to TRUE to only allow access having a valid secret key.
#
export PROXY_USES_SECRET_KEY_ONLY=TRUE
```