### PR TITLE
feat: add publishable key to pizzly js

### DIFF
--- a/src/clients/javascript/src/connect.ts
+++ b/src/clients/javascript/src/connect.ts
@@ -14,12 +14,13 @@
 import Types from './types'
 
 export default class PizzlyConnect {
+  private key: string
   private integration: string
   private options?: Types.ConnectOptions
   private status: AuthorizationStatus = AuthorizationStatus.IDLE
   private origin: string
 
-  constructor(integration: string, options: Types.ConnectOptions, origin: string) {
+  constructor(integration: string, options: Types.ConnectOptions, key: string, origin: string) {
     if (!integration) {
       throw new Error("Couldn't connect. Missing argument: integration (string)")
     }
@@ -30,6 +31,7 @@ export default class PizzlyConnect {
 
     this.integration = integration
     this.options = options
+    this.key = key
     this.origin = origin
   }
 
@@ -39,8 +41,8 @@ export default class PizzlyConnect {
    */
 
   trigger(): Promise<Types.ConnectSuccess> {
-    const query = this.connectOptionsToQueryString(this.options)
-    const url = `${this.origin}/auth/${this.integration}?${query}`
+    const query = this.toQueryString(this.key, this.options)
+    const url = `${this.origin}/auth/${this.integration}` + (query ? `?${query}` : '')
 
     return new Promise((resolve, reject) => {
       const handler = (e?: MessageEvent) => {
@@ -93,18 +95,18 @@ export default class PizzlyConnect {
    * e.g. authId=...&setupId=...
    */
 
-  connectOptionsToQueryString(options?: Types.ConnectOptions): string {
+  toQueryString(key?: string, options?: Types.ConnectOptions): string {
     let query: string[] = []
 
-    if (!options) {
-      return ''
+    if (key && typeof key === 'string') {
+      query.push(`pizzly_pkey=${key}`)
     }
 
-    if (typeof options.authId === 'string') {
+    if (options && typeof options.authId === 'string') {
       query.push(`authId=${options.authId}`)
     }
 
-    if (typeof options.setupId === 'string') {
+    if (options && typeof options.setupId === 'string') {
       query.push(`setupId=${options.setupId}`)
     }
 

--- a/src/clients/javascript/src/index.ts
+++ b/src/clients/javascript/src/index.ts
@@ -16,15 +16,12 @@ export default class Pizzly {
   /**
    * Initialize Pizzly
    *
+   * const pizzly = new Pizzly()
    * const pizzly = new Pizzly(PUBLISHABLE_KEY)
    * const pizzly = new Pizzly(PUBLISHABLE_KEY, options)
    */
 
   constructor(key: string, options?: { protocol?: string; hostname?: string; port?: number | string }) {
-    if (!key) {
-      throw new Error("Pizzly JS can't be initialized: missing publishable key.")
-    }
-
     if (!window) {
       throw new Error("Couldn't connect. The window object is undefined. Are you using connect from a browser?")
     }
@@ -44,7 +41,7 @@ export default class Pizzly {
    */
 
   public connect(integration: string, options?: Types.ConnectOptions) {
-    const connect = new PizzlyConnect(integration, options || {}, this.origin)
+    const connect = new PizzlyConnect(integration, options || {}, this.key, this.origin)
     return connect.trigger()
   }
 
@@ -53,14 +50,14 @@ export default class Pizzly {
    */
 
   public integration(integration: string, options?: Types.IntegrationOptions) {
-    return new PizzlyIntegration(integration, options || {}, this.origin)
+    return new PizzlyIntegration(integration, options || {}, this.key, this.origin)
   }
 
   /**
    * Save config
    */
 
-  public saveConfig() {}
+  // public saveConfig() {}
 
   /**
    * Some helpers

--- a/views/dashboard/api-authentications-connect.ejs
+++ b/views/dashboard/api-authentications-connect.ejs
@@ -36,7 +36,7 @@
         e.preventDefault()
 
         const setupId = document.getElementById('setupId').value || null
-        const pizzly = new Pizzly('PUBLISHABLE-KEY')
+        const pizzly = new Pizzly('<%= process.env.PUBLISHABLE_KEY %>')
 
         pizzly
           .connect('<%= req.params.integration %>', { setupId })


### PR DESCRIPTION
# Description

Authenticate requests to Pizzly with a publishable key (if provided). The publishable key must be provided as a query string, as follows:

```
?pizzly_pkey=${publishableKey}
?pizzly_pkey=${publishableKey}&foo=bar
```