### PR TITLE
feat: save setup id with a successful authentication

### DIFF
--- a/src/legacy/auth/v3/context.ts
+++ b/src/legacy/auth/v3/context.ts
@@ -44,12 +44,12 @@ export const callbackContext = asyncMiddleware(
       throw new NoAuthInProgress()
     }
 
-    const { buid, connectParams, setupId } = req.session.context
+    const { buid, connectParams } = req.session.context
 
     req.isCallback = true
     req.connectParams = connectParams
     req.buid = buid
-    req.setupId = setupId
+    req.setupId = req.session.authConfig.setupDetails.setup_id
 
     next()
   }


### PR DESCRIPTION
# Description

Fix an issue where the `setup_id` was not saved alongside the authentication entry.

<img width="1062" alt="Screenshot 2020-05-14 at 11 26 41" src="https://user-images.githubusercontent.com/3255133/81917929-1cfb6980-95d6-11ea-85b4-7c58a0bfd424.png">
