### PR TITLE
fix: remove access management on /auth

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -10,19 +10,11 @@ import * as express from 'express'
 import bodyParser from 'body-parser'
 import cookieParser from 'cookie-parser'
 import passport from 'passport'
-import * as access from '../lib/access'
 import authV3 from '../legacy/auth/v3/router'
 import { initializeDB } from '../lib/database'
 
 const { COOKIE_SECRET } = process.env
 const auth = express.Router()
-
-/**
- * Secure requests with
- * a publishable key
- */
-
-auth.use(access.publishableKey)
 
 /**
  * Parse the body


### PR DESCRIPTION
# Description

Temporarily remove the access management on the `/auth` endpoint. 

Main reason, the way it's built today requires that a `pizzly_pkey` parameters is provided in the callback URL. Which is not going to happen. Second reason is that 99.99% of the auth service is inside the `/legacy` directory.

All the others endpoints (`/dashboard/`, `/proxy/`, `/api/`) are still protected.
