### PR TITLE
docs: rename dashboard user/password

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -8,8 +8,8 @@ export COOKIE_SECRET="CHANGE_ME"
 #
 # 1. Secure access to the dashboard
 #
-export AUTHENTICATION_USER=""
-export AUTHENTICATION_PASSWORD=""
+export DASHBOARD_USER=""
+export DASHBOARD_PASSWORD=""
 #
 # 2. Secure requests to the API
 #

--- a/src/lib/access/index.ts
+++ b/src/lib/access/index.ts
@@ -8,8 +8,8 @@ import { PizzlyError } from '../error-handling'
 
 const basic = (req: Request, res: Response, next: NextFunction) => {
   const credentials = {
-    user: process.env.AUTHENTICATION_USER,
-    password: process.env.AUTHENTICATION_PASSWORD
+    user: process.env.DASHBOARD_USER,
+    password: process.env.DASHBOARD_PASSWORD
   }
 
   if (!credentials.user && !credentials.password) {


### PR DESCRIPTION
# Description

While writing the guide on "Secure your instance", it felt like the variables to authenticate with the password could have a better name.