### PR TITLE
fix: issue when the setupId is unknown

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,15 @@ app.set('trust proxy', 1)
 app.use('/assets', express.static('./views/assets'))
 
 /**
+ * Logging request
+ */
+
+app.use((req, res, next) => {
+  console.log(new Date().toISOString(), req.method, req.originalUrl)
+  next()
+})
+
+/**
  * Project homepage
  */
 

--- a/src/legacy/functions/router.ts
+++ b/src/legacy/functions/router.ts
@@ -7,6 +7,7 @@ import { middleware as proxyHandler } from './lambda-request'
 import { PROXY_PREFIX, setProxyFunction } from '../middlewares/v4/intent-info'
 import Integration from './integration'
 import { getSetupDetails } from '../auth/clients/integrations'
+import { PizzlyError } from '../../lib/error-handling'
 
 const BUID = 'bearerUuid'
 
@@ -67,6 +68,11 @@ function buid(req, _res, next) {
 
 export async function setupId(req, _res, next) {
   const configuration = await getSetupDetails({ buid: req.buid, store: req.store, setupId: req.query.setupId })
+
+  if (!configuration) {
+    return next(new PizzlyError('unknown_configuration'))
+  }
+
   req.setupId = configuration.setupId
   req.configuration = configuration
 

--- a/src/lib/error-handling/index.ts
+++ b/src/lib/error-handling/index.ts
@@ -54,7 +54,8 @@ export class PizzlyError extends Error {
 
       case 'unknown_configuration':
         this.status = 404
-        this.message = 'That configuration ID could not be found on the database'
+        this.message = 'That configuration ID (setupId) could not be found on the database'
+        break
 
       // Invalid params (400)
       case 'invalid_integration':

--- a/views/dashboard/api-authentications-connect.ejs
+++ b/views/dashboard/api-authentications-connect.ejs
@@ -12,7 +12,12 @@
         <form>
           <fieldset>
             <label>Setup ID</label>
-            <input type="text" class="form-input" id="setupId" />
+            <input
+              type="text"
+              class="form-input"
+              id="setupId"
+              placeholder="Specify a setupId or left blank to use the last configuration saved"
+            />
           </fieldset>
           <fieldset>
             <label>Auth ID</label>


### PR DESCRIPTION
# Description

Passing an unknown `setupId` whilst triggering a `connect` raised an unhandled. This is now fixed.

Reproduce with this snippet on your machine:

```html
<!DOCTYPE html>
<html>
  <body>
    <script src="https://cdn.jsdelivr.net/npm/pizzly-js@latest/dist/index.umd.min.js"></script
    <script>
      const pizzly = new Pizzly('abc123...', { port: 8080 })
      pizzly.connect('github', { setupId: '4adf3721-a8b8-4d3f-9c7f-d6baee037263' })
    </script>
```

The setupId `4adf3721-a8b8-4d3f-9c7f-d6baee037263` is unknown and that error should now be catched.