### PR TITLE
Fixes for documentation

### DIFF
--- a/docs/docs/nango-sync/contributing.md
+++ b/docs/docs/nango-sync/contributing.md
@@ -12,7 +12,7 @@ Here are some ideas on how to get started:
 * Join the [Slack community](https://nango.dev/slack) to get the latest news and discuss Nango with fellow contributors
 * Contribute [an example](real-world-examples.md) of using Nango with your favorite API
 * We have marked some [good first issues](https://github.com/NangoHQ/nango/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) for you
-* These docs are just [markdown pages in our repo](https://github.com/NangoHQ/nango/tree/main/docs/docs), feel free to edit them and submit PRs with improvements
+* These docs are just [markdown pages in our repo](https://github.com/nangohq/nango/tree/master/docs/docs), feel free to edit them and submit PRs with improvements
 
 If you need help with setting up your local development environment, want to chat with us first or just get to know the people behind the project don't be shy: We are online in the Slack Community all day and look forward to seeing you there.
 

--- a/docs/docs/providers/airtable.md
+++ b/docs/docs/providers/airtable.md
@@ -4,17 +4,17 @@ sidebar_label: Airtable
 # Airtable API wiki
 
 :::note Working with the Airtable API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/airtable.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/airtable.md).
 
 :::
 
 ## Using Airtable with Nango
-Provider template name in Nango: `airtable`  
+Provider template name in Nango: `airtable`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Airtable in 5 minutes.
 
 ## App registration & publishing
-**Rating: `Easy & fast`**  
-Registering an app takes only a few minutes and you can start building immediately: [App registration docs](https://airtable.com/developers/web/guides/oauth-integrations)  
+**Rating: `Easy & fast`**
+Registering an app takes only a few minutes and you can start building immediately: [App registration docs](https://airtable.com/developers/web/guides/oauth-integrations)
 To publish it (so any airtable user can install it) a few more details are needed (support email, terms) but no manual review: [Publishing docs](https://airtable.com/developers/web/guides/oauth-integrations#distributing-your-integration)
 
 

--- a/docs/docs/providers/asana.md
+++ b/docs/docs/providers/asana.md
@@ -4,12 +4,12 @@ sidebar_label: Asana
 # Asana API wiki
 
 :::note Working with the Asana API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/asana.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/asana.md).
 
 :::
 
 ## Using Asana with Nango
-Provider template name in Nango: `asana`  
+Provider template name in Nango: `asana`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Asana in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/bitbucket.md
+++ b/docs/docs/providers/bitbucket.md
@@ -4,12 +4,12 @@ sidebar_label: Bitbucket
 # Bitbucket API wiki
 
 :::note Working with the Bitbucket API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/bitbucket.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/bitbucket.md).
 
 :::
 
 ## Using Bitbucket with Nango
-Provider template name in Nango: `bitbucket`  
+Provider template name in Nango: `bitbucket`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Bitbucket in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/braintree.md
+++ b/docs/docs/providers/braintree.md
@@ -5,19 +5,19 @@ sidebar_label: Braintree
 # Braintree API wiki
 
 :::note Working with the Braintree API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/braintree.md).
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/braintree.md).
 
 :::
 
 ## Using Braintree with Nango
 
-Provider template name in Nango: `braintree`  
-If you want to connect to the Sandbox system use `braintree-sandbox`  
+Provider template name in Nango: `braintree`
+If you want to connect to the Sandbox system use `braintree-sandbox`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Braintree in 5 minutes.
 
 ## App registration & publishing
 
-**Rating: `Unknown`**  
+**Rating: `Unknown`**
 [According to their docs](https://developer.paypal.com/braintree/docs/guides/extend/oauth/overview) OAuth is in private beta testing for production, you need to contact them. You can sign up for an open beta with the Sandbox environment.
 
 ## Useful links

--- a/docs/docs/providers/brex.md
+++ b/docs/docs/providers/brex.md
@@ -4,12 +4,12 @@ sidebar_label: Brex
 # Brex API wiki
 
 :::note Working with the Brex API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/brex.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/brex.md).
 
 :::
 
 ## Using Brex with Nango
-Provider template name in Nango: `brex`  
+Provider template name in Nango: `brex`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Brex in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/clickup.md
+++ b/docs/docs/providers/clickup.md
@@ -4,12 +4,12 @@ sidebar_label: Clickup
 # Clickup API wiki
 
 :::note Working with the Clickup API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/clickup.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/clickup.md).
 
 :::
 
 ## Using Clickup with Nango
-Provider template name in Nango: `clickup`  
+Provider template name in Nango: `clickup`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Clickup in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/discord.md
+++ b/docs/docs/providers/discord.md
@@ -4,12 +4,12 @@ sidebar_label: Discord
 # Discord API wiki
 
 :::note Working with the Discord API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/discord.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/discord.md).
 
 :::
 
 ## Using Discord with Nango
-Provider template name in Nango: `discord`  
+Provider template name in Nango: `discord`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Discord in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/dropbox.md
+++ b/docs/docs/providers/dropbox.md
@@ -4,12 +4,12 @@ sidebar_label: Dropbox
 # Dropbox API wiki
 
 :::note Working with the Dropbox API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/dropbox.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/dropbox.md).
 
 :::
 
 ## Using Dropbox with Nango
-Provider template name in Nango: `dropbox`  
+Provider template name in Nango: `dropbox`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Dropbox in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/facebook.md
+++ b/docs/docs/providers/facebook.md
@@ -4,12 +4,12 @@ sidebar_label: Facebook
 # Facebook API wiki
 
 :::note Working with the Facebook API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/facebook.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/facebook.md).
 
 :::
 
 ## Using Facebook with Nango
-Provider template name in Nango: `facebook`  
+Provider template name in Nango: `facebook`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Facebook in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/freshbooks.md
+++ b/docs/docs/providers/freshbooks.md
@@ -4,12 +4,12 @@ sidebar_label: Freshbooks
 # Freshbooks API wiki
 
 :::note Working with the Freshbooks API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/freshbooks.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/freshbooks.md).
 
 :::
 
 ## Using Freshbooks with Nango
-Provider template name in Nango: `freshbooks`  
+Provider template name in Nango: `freshbooks`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Freshbooks in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/front.md
+++ b/docs/docs/providers/front.md
@@ -4,12 +4,12 @@ sidebar_label: Front
 # Front API wiki
 
 :::note Working with the Front API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/front.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/front.md).
 
 :::
 
 ## Using Front with Nango
-Provider template name in Nango: `front`  
+Provider template name in Nango: `front`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Front in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/github.md
+++ b/docs/docs/providers/github.md
@@ -4,12 +4,12 @@ sidebar_label: Github
 # Github API wiki
 
 :::note Working with the Github API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/github.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/github.md).
 
 :::
 
 ## Using Github with Nango
-Provider template name in Nango: `github`  
+Provider template name in Nango: `github`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Github in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/gitlab.md
+++ b/docs/docs/providers/gitlab.md
@@ -4,12 +4,12 @@ sidebar_label: Gitlab
 # Gitlab API wiki
 
 :::note Working with the Gitlab API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/gitlab.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/gitlab.md).
 
 :::
 
 ## Using Gitlab with Nango
-Provider template name in Nango: `gitlab`  
+Provider template name in Nango: `gitlab`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Gitlab in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/google-calendar.md
+++ b/docs/docs/providers/google-calendar.md
@@ -5,12 +5,12 @@ sidebar_label: Google Calendar
 # Google Calendar API wiki
 
 :::note Working with the Google Calendar API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/google-calendar.md).
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/google-calendar.md).
 :::
 
 ## Using Google Calendar with Nango
 
-Provider template name in Nango: `google-calendar`  
+Provider template name in Nango: `google-calendar`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Google Calendar in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/google-mail.md
+++ b/docs/docs/providers/google-mail.md
@@ -5,13 +5,13 @@ sidebar_label: Gmail
 # Gmail API wiki
 
 :::note Working with the Gmail API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/google-mail.md).
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/google-mail.md).
 
 :::
 
 ## Using Gmail with Nango
 
-Provider template name in Nango: `google-mail`  
+Provider template name in Nango: `google-mail`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Gmail in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/google-sheet.md
+++ b/docs/docs/providers/google-sheet.md
@@ -5,12 +5,12 @@ sidebar_label: GSheet
 # GSheet API wiki
 
 :::note Working with the Google Sheet API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/google-sheet.md).
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/google-sheet.md).
 :::
 
 ## Using GSheet with Nango
 
-Provider template name in Nango: `google-sheet`  
+Provider template name in Nango: `google-sheet`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with GSheet in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/google.md
+++ b/docs/docs/providers/google.md
@@ -5,12 +5,12 @@ sidebar_label: Google
 # Google API wiki
 
 :::note Working with the Google API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/google-mail.md).
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/google-mail.md).
 :::
 
 ## Using Google with Nango
 
-Provider template name in Nango: `google`  
+Provider template name in Nango: `google`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Google in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/greenhouse.md
+++ b/docs/docs/providers/greenhouse.md
@@ -4,12 +4,12 @@ sidebar_label: Greenhouse
 # Greenhouse API wiki
 
 :::note Working with the Greenhouse API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/greenhouse.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/greenhouse.md).
 
 :::
 
 ## Using Greenhouse with Nango
-Provider template name in Nango: `greenhouse`  
+Provider template name in Nango: `greenhouse`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Greenhouse in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/hubspot.md
+++ b/docs/docs/providers/hubspot.md
@@ -4,12 +4,12 @@ sidebar_label: HubSpot
 # HubSpot API wiki
 
 :::note Working with the HubSpot API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/hubspot.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/hubspot.md).
 
 :::
 
 ## Using HubSpot with Nango
-Provider template name in Nango: `hubspot`  
+Provider template name in Nango: `hubspot`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with HubSpot in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/intercom.md
+++ b/docs/docs/providers/intercom.md
@@ -4,12 +4,12 @@ sidebar_label: Intercom
 # Intercom API wiki
 
 :::note Working with the Intercom API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/intercom.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/intercom.md).
 
 :::
 
 ## Using Intercom with Nango
-Provider template name in Nango: `intercom`  
+Provider template name in Nango: `intercom`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Intercom in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/intuit.md
+++ b/docs/docs/providers/intuit.md
@@ -4,12 +4,12 @@ sidebar_label: Intuit
 # Intuit API wiki
 
 :::note Working with the Intuit API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/intuit.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/intuit.md).
 
 :::
 
 ## Using Intuit with Nango
-Provider template name in Nango: `intuit`  
+Provider template name in Nango: `intuit`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Intuit in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/jira.md
+++ b/docs/docs/providers/jira.md
@@ -4,12 +4,12 @@ sidebar_label: Jira
 # Jira API wiki
 
 :::note Working with the Jira API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/jira.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/jira.md).
 
 :::
 
 ## Using Jira with Nango
-Provider template name in Nango: `jira`  
+Provider template name in Nango: `jira`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Jira in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/lever.md
+++ b/docs/docs/providers/lever.md
@@ -4,12 +4,12 @@ sidebar_label: Lever
 # Lever API wiki
 
 :::note Working with the Lever API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/lever.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/lever.md).
 
 :::
 
 ## Using Lever with Nango
-Provider template name in Nango: `lever`  
+Provider template name in Nango: `lever`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Lever in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/linear.md
+++ b/docs/docs/providers/linear.md
@@ -4,12 +4,12 @@ sidebar_label: Linear
 # Linear API wiki
 
 :::note Working with the Linear API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/linear.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/linear.md).
 
 :::
 
 ## Using Linear with Nango
-Provider template name in Nango: `linear`  
+Provider template name in Nango: `linear`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Linear in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/linkedin.md
+++ b/docs/docs/providers/linkedin.md
@@ -4,12 +4,12 @@ sidebar_label: LinkedIn
 # LinkedIn API wiki
 
 :::note Working with the LinkedIn API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/linkedin.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/linkedin.md).
 
 :::
 
 ## Using LinkedIn with Nango
-Provider template name in Nango: `linkedin`  
+Provider template name in Nango: `linkedin`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with LinkedIn in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/microsoft-teams.md
+++ b/docs/docs/providers/microsoft-teams.md
@@ -4,12 +4,12 @@ sidebar_label: Microsoft Teams
 # Microsoft Teams API wiki
 
 :::note Working with the Microsoft Teams API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/microsoft-teams.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/microsoft-teams.md).
 
 :::
 
 ## Using Microsoft Teams with Nango
-Provider template name in Nango: `microsoft-teams`  
+Provider template name in Nango: `microsoft-teams`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Microsoft Teams in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/monday.md
+++ b/docs/docs/providers/monday.md
@@ -4,12 +4,12 @@ sidebar_label: Monday
 # Monday API wiki
 
 :::note Working with the Monday API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/monday.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/monday.md).
 
 :::
 
 ## Using Monday with Nango
-Provider template name in Nango: `monday`  
+Provider template name in Nango: `monday`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Monday in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/notion.md
+++ b/docs/docs/providers/notion.md
@@ -4,12 +4,12 @@ sidebar_label: Notion
 # Notion API wiki
 
 :::note Working with the Notion API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/notion.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/notion.md).
 
 :::
 
 ## Using Notion with Nango
-Provider template name in Nango: `notion`  
+Provider template name in Nango: `notion`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Notion in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/outreach.md
+++ b/docs/docs/providers/outreach.md
@@ -4,12 +4,12 @@ sidebar_label: Outreach
 # Outreach API wiki
 
 :::note Working with the Outreach API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/outreach.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/outreach.md).
 
 :::
 
 ## Using Outreach with Nango
-Provider template name in Nango: `outreach`  
+Provider template name in Nango: `outreach`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Outreach in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/pagerduty.md
+++ b/docs/docs/providers/pagerduty.md
@@ -4,12 +4,12 @@ sidebar_label: Pagerduty
 # Pagerduty API wiki
 
 :::note Working with the Pagerduty API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/pagerduty.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/pagerduty.md).
 
 :::
 
 ## Using Pagerduty with Nango
-Provider template name in Nango: `pagerduty`  
+Provider template name in Nango: `pagerduty`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Pagerduty in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/pipedrive.md
+++ b/docs/docs/providers/pipedrive.md
@@ -4,12 +4,12 @@ sidebar_label: Pipedrive
 # Pipedrive API wiki
 
 :::note Working with the Pipedrive API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/pipedrive.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/pipedrive.md).
 
 :::
 
 ## Using Pipedrive with Nango
-Provider template name in Nango: `pipedrive`  
+Provider template name in Nango: `pipedrive`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Pipedrive in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/quickbooks.md
+++ b/docs/docs/providers/quickbooks.md
@@ -4,12 +4,12 @@ sidebar_label: Quickbooks
 # Quickbooks API wiki
 
 :::note Working with the Quickbooks API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/quickbooks.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/quickbooks.md).
 
 :::
 
 ## Using Quickbooks with Nango
-Provider template name in Nango: `quickbooks`  
+Provider template name in Nango: `quickbooks`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Quickbooks in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/reddit.md
+++ b/docs/docs/providers/reddit.md
@@ -4,12 +4,12 @@ sidebar_label: Reddit
 # Reddit API wiki
 
 :::note Working with the Reddit API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/reddit.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/reddit.md).
 
 :::
 
 ## Using Reddit with Nango
-Provider template name in Nango: `reddit`  
+Provider template name in Nango: `reddit`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Reddit in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/sage.md
+++ b/docs/docs/providers/sage.md
@@ -4,12 +4,12 @@ sidebar_label: Sage
 # Sage API wiki
 
 :::note Working with the Sage API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/sage.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/sage.md).
 
 :::
 
 ## Using Sage with Nango
-Provider template name in Nango: `sage`  
+Provider template name in Nango: `sage`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Sage in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/salesloft.md
+++ b/docs/docs/providers/salesloft.md
@@ -4,12 +4,12 @@ sidebar_label: Salesloft
 # Salesloft API wiki
 
 :::note Working with the Salesloft API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/salesloft.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/salesloft.md).
 
 :::
 
 ## Using Salesloft with Nango
-Provider template name in Nango: `salesloft`  
+Provider template name in Nango: `salesloft`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Salesloft in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/shopify.md
+++ b/docs/docs/providers/shopify.md
@@ -4,12 +4,12 @@ sidebar_label: Shopify
 # Shopify API wiki
 
 :::note Working with the Shopify API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/shopify.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/shopify.md).
 
 :::
 
 ## Using Shopify with Nango
-Provider template name in Nango: `shopify`  
+Provider template name in Nango: `shopify`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Shopify in 5 minutes.
 
 Make sure you [read this](reference/configuration.md#connection-config) to set the correct shop subdomain before starting an OAuth flow for Shopify.

--- a/docs/docs/providers/slack.md
+++ b/docs/docs/providers/slack.md
@@ -4,12 +4,12 @@ sidebar_label: Slack
 # Slack API wiki
 
 :::note Working with the Slack API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/slack.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/slack.md).
 
 :::
 
 ## Using Slack with Nango
-Provider template name in Nango: `slack`  
+Provider template name in Nango: `slack`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Slack in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/splitwise.md
+++ b/docs/docs/providers/splitwise.md
@@ -4,12 +4,12 @@ sidebar_label: Splitwise
 # Splitwise API wiki
 
 :::note Working with the Splitwise API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/splitwise.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/splitwise.md).
 
 :::
 
 ## Using Splitwise with Nango
-Provider template name in Nango: `splitwise`  
+Provider template name in Nango: `splitwise`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Splitwise in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/trello.md
+++ b/docs/docs/providers/trello.md
@@ -4,12 +4,12 @@ sidebar_label: Trello
 # Trello API wiki
 
 :::note Working with the Trello API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/trello.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/trello.md).
 
 :::
 
 ## Using Trello with Nango
-Provider template name in Nango: `trello`  
+Provider template name in Nango: `trello`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Trello in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/twitter.md
+++ b/docs/docs/providers/twitter.md
@@ -4,12 +4,12 @@ sidebar_label: Twitter
 # Twitter API wiki
 
 :::note Working with the Twitter API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/twitter.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/twitter.md).
 
 :::
 
 ## Using Twitter with Nango
-Provider template name in Nango: `twitter`  
+Provider template name in Nango: `twitter`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Twitter in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/wave_accounting.md
+++ b/docs/docs/providers/wave_accounting.md
@@ -4,12 +4,12 @@ sidebar_label: Wave
 # Wave API wiki
 
 :::note Working with the Wave API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/wave-accounting.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/wave-accounting.md).
 
 :::
 
 ## Using Wave with Nango
-Provider template name in Nango: `wave-accounting`  
+Provider template name in Nango: `wave-accounting`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Wave in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/xero.md
+++ b/docs/docs/providers/xero.md
@@ -4,12 +4,12 @@ sidebar_label: Xero
 # Xero API wiki
 
 :::note Working with the Xero API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/xero.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/xero.md).
 
 :::
 
 ## Using Xero with Nango
-Provider template name in Nango: `xero`  
+Provider template name in Nango: `xero`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Xero in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/zendesk.md
+++ b/docs/docs/providers/zendesk.md
@@ -4,12 +4,12 @@ sidebar_label: Zendesk
 # Zendesk API wiki
 
 :::note Working with the Zendesk API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/zendesk.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/zendesk.md).
 
 :::
 
 ## Using Zendesk with Nango
-Provider template name in Nango: `zendesk`  
+Provider template name in Nango: `zendesk`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Zendesk in 5 minutes.
 
 Make sure you [read this](reference/configuration.md#connection-config) to set the correct subdomain before starting an OAuth flow for Zendesk.

--- a/docs/docs/providers/zoho-books.md
+++ b/docs/docs/providers/zoho-books.md
@@ -4,12 +4,12 @@ sidebar_label: Zoho books
 # Zoho books API wiki
 
 :::note Working with the Zoho books API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/zoho-books.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/zoho-books.md).
 
 :::
 
 ## Using Zoho books with Nango
-Provider template name in Nango: `zoho-books`  
+Provider template name in Nango: `zoho-books`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Zoho books in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/zoho-crm.md
+++ b/docs/docs/providers/zoho-crm.md
@@ -4,12 +4,12 @@ sidebar_label: Zoho CRM
 # Zoho CRM API wiki
 
 :::note Working with the Zoho CRM API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/zoho-crm.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/zoho-crm.md).
 
 :::
 
 ## Using Zoho CRM with Nango
-Provider template name in Nango: `zoho-crm`  
+Provider template name in Nango: `zoho-crm`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Zoho CRM in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/zoho-invoice.md
+++ b/docs/docs/providers/zoho-invoice.md
@@ -4,12 +4,12 @@ sidebar_label: Zoho Invoice
 # Zoho Invoice API wiki
 
 :::note Working with the Zoho Invoice API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/zoho-invoice.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/zoho-invoice.md).
 
 :::
 
 ## Using Zoho Invoice with Nango
-Provider template name in Nango: `zoho-invoice`  
+Provider template name in Nango: `zoho-invoice`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Zoho Invoice in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/providers/zoom.md
+++ b/docs/docs/providers/zoom.md
@@ -4,12 +4,12 @@ sidebar_label: Zoom
 # Zoom API wiki
 
 :::note Working with the Zoom API?
-Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/main/docs/docs/providers/zoom.md).  
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/zoom.md).
 
 :::
 
 ## Using Zoom with Nango
-Provider template name in Nango: `zoom`  
+Provider template name in Nango: `zoom`
 Follow our [getting started guide](../reference/guide.md) to add an OAuth integration with Zoom in 5 minutes.
 
 ## App registration & publishing

--- a/docs/docs/reference/guide.md
+++ b/docs/docs/reference/guide.md
@@ -75,7 +75,7 @@ var nango = new Nango('http://localhost:3003'); // Local
 var nango = new Nango('Server URL'); // Nango Cloud
 
 // Trigger an OAuth flow
-// Param 1: unique config key from Step 2 (bullet 4)
+// Param 1: unique config key from Step 1 (bullet 4)
 // Param 2: ID you will use to retrieve the connection (most often the user ID)
 nango
     .auth('github', '<connection-id>')
@@ -105,7 +105,7 @@ Nango offers a couple ways to retrieve fresh access tokens:
 
 In all cases, you need to tell Nango two things to get the access token:
 
--   The **Provider Config Key**, which identifies the OAuth provider configuration (from Step 2, bullet 4)
+-   The **Provider Config Key**, which identifies the OAuth provider configuration (from Step 1, bullet 4)
 -   The **Connection ID**, which identifies the connection containing the access token (from Step 3)
 
 ### Node SDK {#node-sdk}

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -48,7 +48,7 @@ const config = {
                     sidebarPath: require.resolve('./sidebars.js'),
                     // Please change this to your repo.
                     // Remove this to remove the "edit this page" links.
-                    editUrl: 'https://github.com/nangohq/nango/tree/main/docs/'
+                    editUrl: 'https://github.com/nangohq/nango/tree/master/docs/'
                 },
                 blog: false,
                 theme: {


### PR DESCRIPTION
The step-by-step guide in the docs was referring to "Step 2" in later steps but actually meant what is titled "Step 1" as the step titles are 0 indexed.
I changed the wording to the correct "Step 1".

The "edit page" links were also referencing to the "main" branch, however "master" is the primary branch here.