### PR TITLE
Add linkhut integration

### DIFF
--- a/packages/auth/providers.yaml
+++ b/packages/auth/providers.yaml
@@ -144,6 +144,10 @@ linkedin:
     authorization_url: https://www.linkedin.com/oauth/v2/authorization
     token_url: https://www.linkedin.com/oauth/v2/accessToken
     disable_pkce: true
+linkhut:
+    auth_mode: OAUTH2
+    authorization_url: https://ln.ht/_/oauth/authorize
+    token_url: https://api.ln.ht/v1/oauth/token
 microsoft-teams:
     auth_mode: OAUTH2
     authorization_url: https://login.microsoftonline.com/common/oauth2/v2.0/authorize


### PR DESCRIPTION
Adds provider for [linkhut](https://ln.ht/), an open source social bookmarking site (pointer to the OAuth documentation: https://docs.linkhut.org/overview.html#oauth-applications).

I have tested the OAuth flow and can confirm that it works (although I had to change a few things because linkhut doesn't allow for the `redirect_uri` to be `localhost` or not use `https`).

