### PR TITLE
Simplify provider contributions

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,8 @@ services:
     nango-server:
         image: nango.docker.scarf.sh/nangohq/nango-server
         container_name: nango-server
+        volumes:
+            - ${PWD}/packages/auth/providers.yaml:/usr/nango-server/src/packages/auth/providers.yaml
         restart: always
         env_file:
             - .env
@@ -24,5 +26,14 @@ services:
             - nango-db
         networks:
             - nango
+
+    test-website:
+        build: ./packages/frontend/bin/
+        restart: always
+        ports:
+            - '8001:7000'
+        depends_on:
+            - nango-db
+
 networks:
     nango:

--- a/docs/docs/contribute-api.md
+++ b/docs/docs/contribute-api.md
@@ -60,13 +60,13 @@ To test your new provider:
 
 The docker compose configuration in the root of the repo `docker-compose.yaml` will run 3 containers.
 
-1. Postres
+1. Postgres DB
 2. Nango Server
-3. A Simple Test Website to Trigger the OAuth Flow
+3. Test Website to Trigger the OAuth Flow
 
 The providers.yaml file from step 1 is synced between the host machine (your laptop) and the running Nango Server container. When you add new provider templates to that yaml the running Nango Server will pick them up.
 
-If your changes don't seem to be getting picked up you:
+If your changes don't seem to be getting picked up, then try:
 
 ```
 # Force a restart, which will load in the yaml again
@@ -78,7 +78,7 @@ docker compose run nango-server cat packages/auth/providers.yaml
 
 When you are ready to test your new provider template:
 
-### 1. Add your client credentials to the local server by running the npx nango command
+### 1. Add your client credentials to the local Nango Server by running the npx nango command
 
 ```
 npx nango config:create <unique-config-key> <template-name> <cliend-id> <client-secret> <scopes>
@@ -98,9 +98,10 @@ You can modify the ports in the docker compose if there are any conflicts with o
 In the cli run the npx nango command to fetch a new token or make a curl request to the locally running Nango Server.
 
 ```
-npx nango token:get <unique-config-key> <connection-id>
+> npx nango token:get <unique-config-key> <connection-id>
 
-curl 'http://localhost:3003/connection/<connection-id>?provider_config_key=<unique-config-key>'
+
+> curl 'http://localhost:3003/connection/<connection-id>?provider_config_key=<unique-config-key>'
 ```
 
 Once you've confirmed the access token was returned, then you are ready to submit a PR.

--- a/docs/docs/contribute-api.md
+++ b/docs/docs/contribute-api.md
@@ -62,30 +62,38 @@ The docker compose configuration in the root of the repo `docker-compose.yaml` w
 
 1. Postres
 2. Nango Server
-3. A simple test frontend
+3. A Simple Test Website to Trigger the OAuth Flow
 
 The providers.yaml file from step 1 is synced between the host machine (your laptop) and the running Nango Server container. When you add new provider templates to that yaml the running Nango Server will pick them up.
 
-If your changes don't seem to be getting picked up you can call `docker compose restart nango-server` to force it to restart which will load in the yaml again. You can also run `docker compose run nango-server cat packages/auth/providers.yaml` which will print the contents of the providers file as the container sees it.
+If your changes don't seem to be getting picked up you:
+
+```
+# Force a restart, which will load in the yaml again
+docker compose restart nango-server
+
+# print the contents of the providers file from inside the container
+docker compose run nango-server cat packages/auth/providers.yaml
+```
 
 When you are ready to test your new provider template:
 
-1. Add your client credentials to the local server by running the npx nango command
+### 1. Add your client credentials to the local server by running the npx nango command
 
 ```
-npx nango config:create <unique-config-key-from-4> <template-name-from-1> <cliend-id-from-2> <client-secret-from-2> <scopes-from-2>
+npx nango config:create <unique-config-key> <template-name> <cliend-id> <client-secret> <scopes>
 
 ```
 
 Note: if you've already configured environment variables for Nango Cloud or your own remote instance of Nango then you may need to unset those variables as they will interfere with your local testing.
 
-2. Navigate to the Test Website and Trigger the OAuth Flow
+### 2. Navigate to the Test Website and Trigger the OAuth Flow
 
 The test site should be running at [http://localhost:8001/bin/quickstart.html](http://localhost:8001/bin/quickstart.html)
 
 You can modify the ports in the docker compose if there are any conflicts with other local services on your host machine.
 
-3. Request an Access Token from Your New Provider
+### 3. Request an Access Token from Your New Provider
 
 In the cli run the npx nango command to fetch a new token or make a curl request to the locally running Nango Server.
 

--- a/docs/docs/contribute-api.md
+++ b/docs/docs/contribute-api.md
@@ -58,38 +58,44 @@ Fork the repo and edit the `packages/auth/providers.yaml` file as explained abov
 
 To test your new provider:
 
-1. Add a provider config for the new provider with the CLI (see [Quickstart](quickstart.md) if needed)
-2. Start Nango locally (see below)
-3. Use the built-in test page to trigger an OAuth flow of your new provider. For this CD to `packages/frontend` and run a local Python web server with `python3 -m http.server 8000`. You can now access the test page at [http://localhost:8000/bin/sample.html](http://localhost:8000/bin/sample.html).
-4. Run a full OAuth dance and make sure it works as expected
+The docker compose configuration in the root of the repo `docker-compose.yaml` will run 3 containers.
 
-**To run Nango locally follow these steps:**
+1. Postres
+2. Nango Server
+3. A simple test frontend
 
-You need the latest stable node version as well as a recent version of npm (or npm compatible package manager) installed on your machine.
+The providers.yaml file from step 1 is synced between the host machine (your laptop) and the running Nango Server container. When you add new provider templates to that yaml the running Nango Server will pick them up.
 
-In the root of the repo run:
+If your changes don't seem to be getting picked up you can call `docker compose restart nango-server` to force it to restart which will load in the yaml again. You can also run `docker compose run nango-server cat packages/auth/providers.yaml` which will print the contents of the providers file as the container sees it.
 
-```bash
-npm i
-npm run ts-build
+When you are ready to test your new provider template:
+
+1. Add your client credentials to the local server by running the npx nango command
+
+```
+npx nango config:create <unique-config-key-from-4> <template-name-from-1> <cliend-id-from-2> <client-secret-from-2> <scopes-from-2>
+
 ```
 
-Then start the Postgresql docker container. The easiest way to do this is to run docker compose and then stop the Nango server (but keep the DB running):
+Note: if you've already configured environment variables for Nango Cloud or your own remote instance of Nango then you may need to unset those variables as they will interfere with your local testing.
 
-```bash
-docker compose up
+2. Navigate to the Test Website and Trigger the OAuth Flow
+
+The test site should be running at [http://localhost:8001/bin/quickstart.html](http://localhost:8001/bin/quickstart.html)
+
+You can modify the ports in the docker compose if there are any conflicts with other local services on your host machine.
+
+3. Request an Access Token from Your New Provider
+
+In the cli run the npx nango command to fetch a new token or make a curl request to the locally running Nango Server.
+
+```
+npx nango token:get <unique-config-key> <connection-id>
+
+curl 'http://localhost:3003/connection/<connection-id>?provider_config_key=<unique-config-key>'
 ```
 
-Then stop the Nango server and keep the postgres container running.
-
-Now you can start the Nango server locally:
-
-```bash
-cd packages/server
-npm run start
-```
-
-After a short while you should see a message that the server is running an listening on port 3003.
+Once you've confirmed the access token was returned, then you are ready to submit a PR.
 
 ## Step 3: Submit your PR
 

--- a/packages/frontend/bin/Dockerfile
+++ b/packages/frontend/bin/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:latest
+ADD . /
+EXPOSE 7000
+CMD python -m http.server 7000


### PR DESCRIPTION
Hey Yall!

I've enjoyed adding the Stripe provider. PR for that coming soon. I did make some tweaks to how the Nango Server is running locally which I think makes it easier for folks to contribute new provider templates.

I updated the docs to reflect the changes, but to summarize...

1. Updated the docker-compsose.yaml so the providers.yaml is synced between host and running docker container
2. Added another running container for the frontend test website

So now instead of running docker compse up, stopping the server, navigating to the server folder and running it locally, then in another shell window running the frontend test site with a python simple server also on the local machine.... it is all just done with the one `docker compose up` command.

This worked well for me. Let me know if you have an questions or feedback on the PR.