### PR TITLE
Add stripe + ignore issue with refreshtoken/expat

### DIFF
--- a/packages/auth/lib/services/connection.service.ts
+++ b/packages/auth/lib/services/connection.service.ts
@@ -216,8 +216,6 @@ class ConnectionService {
                             2
                         )}`
                     );
-                } else if (rawAuthCredentials.refresh_token && !rawAuthCredentials.expires_at) {
-                    logger.info(`Got a refresh token but no information about expiration. Assuming the access token doesn't expire.`);
                 }
                 break;
             case ProviderAuthModes.OAuth1:

--- a/packages/auth/lib/services/connection.service.ts
+++ b/packages/auth/lib/services/connection.service.ts
@@ -217,13 +217,7 @@ class ConnectionService {
                         )}`
                     );
                 } else if (rawAuthCredentials.refresh_token && !rawAuthCredentials.expires_at) {
-                    throw new Error(
-                        `Cannot parse credentials, if OAuth2 access token credentials have a "refresh_token" property the "expires_at" property must also be set: ${JSON.stringify(
-                            rawAuthCredentials,
-                            undefined,
-                            2
-                        )}`
-                    );
+                    logger.info(`Got a refresh token but no information about expiration. Assuming the access token doesn't expire.`);
                 }
                 break;
             case ProviderAuthModes.OAuth1:

--- a/packages/auth/providers.yaml
+++ b/packages/auth/providers.yaml
@@ -242,6 +242,10 @@ splitwise:
     auth_mode: OAUTH2
     authorization_url: https://secure.splitwise.com/oauth/authorize
     token_url: https://secure.splitwise.com/oauth/token
+stripe:
+    auth_mode: OAUTH2
+    authorization_url: https://connect.stripe.com/oauth/authorize
+    token_url: https://connect.stripe.com/oauth/token
 trello:
     auth_mode: OAUTH1
     request_url: https://trello.com/1/OAuthGetRequestToken


### PR DESCRIPTION
Stripe returns a refresh token but no expiration info. The access token does not expire but a user can revoke it.

https://stripe.com/docs/connect/oauth-reference#post-token-response

Currently Nango checks for refresh token with expires_at in two places, one which logs it and the other which throws an error. I modified the spot that throws the error to just repeat the log. Silly to duplicate the logging but wanted to at least open the PR for discussion as this is one of the integrations I'd like the most.



### Alternative Solution

 if removing that exception doesn't work for some reason...

Some sort of flag that gets passed through from the provider template into the `checkCredentials` call.
```
stripe:
    auth_mode: OAUTH2
    authorization_url: https://connect.stripe.com/oauth/authorize
    token_url: https://connect.stripe.com/oauth/token
    ignore_missing_expire_at: true
```
I started added this and realized you have to pass the provider template through a lot of functions from `upsertConnection` to get to `checkCredentials` so maybe there is an easier way?

This does not cleanly handle the case of an end user revoking the token, but at that point there isn't much we can do anyways. Stripe posts a webhook to us when an end user revokes a token so we can handle it outside of Nango.

I saw a SalesForce issue that also had refresh token + expiration stuff so maybe we can make it work for both of these cases.