### PR TITLE
Add GitHub API gotcha

### DIFF
--- a/docs/docs/providers/github.md
+++ b/docs/docs/providers/github.md
@@ -24,4 +24,4 @@ _No links yet, feel free to contribute it (or check out [airtable](airtable.md) 
 
 ## API specific gotchas
 
-_No gotchas yet, feel free to contribute it (or check out [airtable](airtable.md) for an example)_
+* The API seems to always require `user-agent` header


### PR DESCRIPTION
I spent too long trying to figure it out that Github API requires `user-agent` header to exist to work. Hope this saves some time from others.