### PR TITLE
Fix incorrect instruction in 'Quick Start' doc

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -188,7 +188,7 @@ Many OAuth providers provide short-lived access tokens (30-60 minutes). Nango re
 To obtain an access token use this command:
 
 ```bash
-npx nango token:get <CONNECTION-ID> <CONFIG-KEY>
+npx nango token:get <CONFIG-KEY> <CONNECTION-ID>
 ```
 
 ### Backend SDK


### PR DESCRIPTION
The docs provide the arguments in the incorrect order when using `cli` command to get an access token.