### PR TITLE
Add Zapier NLA Provider

### DIFF
--- a/docs/docs/providers/zapier-nla.md
+++ b/docs/docs/providers/zapier-nla.md
@@ -1,0 +1,31 @@
+---
+sidebar_label: Zapier NLA
+---
+
+# Zapier NLA (Natural Language Actions) API wiki
+
+:::note Working with the Zapier NLA API?
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/zapier-nla.md).
+
+:::
+
+## Using Zapier NLA with Nango
+
+Provider template name in Nango: `zapier-nla`  
+Follow our [quickstart](../quickstart.md) to add an OAuth integration with Zapier NLA in 5 minutes.
+
+## App registration & publishing
+
+**Rating: `Easy & fast`**
+
+Apply for API access here: [App registration](https://zapier.com/l/natural-language-actions)
+
+They will email you the OAuth credentials for your app.
+
+## Useful links
+
+-   [Zapier NLA docs (their REST API)](https://nla.zapier.com/api/v1/docs)
+
+## API specific gotchas
+
+-   Your API users will configure their own Natural Language Actions which your Application can call on their behalf

--- a/packages/server/providers.yaml
+++ b/packages/server/providers.yaml
@@ -319,6 +319,10 @@ yahoo:
     auth_mode: OAUTH2
     authorization_url: https://api.login.yahoo.com/oauth2/request_auth
     token_url: https://api.login.yahoo.com/oauth2/get_token
+zapier-nla:
+    auth_mode: OAUTH2
+    authorization_url: https://nla.zapier.com/oauth/authorize/
+    token_url: https://nla.zapier.com/oauth/token/
 zendesk:
     auth_mode: OAUTH2
     authorization_url: https://${connectionConfig.params.subdomain}.zendesk.com/oauth/authorizations/new


### PR DESCRIPTION
Oauth2 provider for Zapier NLA

Zapier recently released an API for natural language actions
- https://zapier.com/l/natural-language-actions
- https://nla.zapier.com/api/v1/docs