### PR TITLE
perf: ⚡️ added docker volume to the postgres in docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/*
 .DS_Store
 logs/*
+nango-data/*
+.idea/*

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,8 @@ services:
             POSTGRES_DB: nango
         ports:
             - '5432:5432'
+        volumes:
+            - ./nango-data:/var/lib/postgresql/data
         networks:
             - nango
 


### PR DESCRIPTION
**What this PR does**

This PR adds a docker volume in the docker-compose for the Postgres service, this will allow the persistence of the configuration even if the service is restarted.

**Which issue does this solve**
[Here](https://github.com/NangoHQ/nango/issues/372)
