### PR TITLE
fix(app): Encode URLs when redirecting

### DIFF
--- a/packages/webapp/src/pages/ConnectionList.tsx
+++ b/packages/webapp/src/pages/ConnectionList.tsx
@@ -63,7 +63,7 @@ export default function ConnectionList() {
                                                     <div className="pl-8 flex pt-4">
                                                         <p className="mt-1.5 mr-4 text-text-dark-gray">{new Date(creationDate).toLocaleDateString()}</p>
                                                         <Link
-                                                            to={`/connection/${providerConfigKey}/${connectionId}`}
+                                                            to={`/connection/${encodeURIComponent(providerConfigKey)}/${encodeURIComponent(connectionId)}`}
                                                             className="flex h-8 rounded-md pl-2 pr-3 pt-1.5 text-sm text-white bg-gray-800 hover:bg-gray-700"
                                                         >
                                                             <p>View</p>


### PR DESCRIPTION
This PR encodes the user-provided IDs in the URL. The error happens if you have a slash in your connection ID, e.g., `tea_2MSb8jd6VDptcAcVJuPcJhte3Yc/calendly`, then the redirect doesn't work.

The fix is to redirect a user to https://app.nango.dev/connection/calendly/tea_2MSb8jd6VDptcAcVJuPcJhte3Yc%2Fcalendly instead of https://app.nango.dev/connection/calendly/tea_2MSb8jd6VDptcAcVJuPcJhte3Yc/calendly.

Link to Slack: https://nango-community.slack.com/archives/C04ABR352H0/p1680077423232399