### PR TITLE
Feat: Atlassan Provider

### DIFF
--- a/docs/docs/contribute-api.md
+++ b/docs/docs/contribute-api.md
@@ -36,6 +36,7 @@ provider-slug: # Shorthand for the provider, ideally the provider's name. Must b
         mycoolparam: value
     refresh_url: https://api.example.com/oauth/refresh # The URL to use for refreshing the access token (only if different from token_url)
     scope_separator: ',' # String to use to separate scopes. Defaults to ' ' (1 space) if not provided
+    extra_scopes: 'offline_access,read' #  Comma seperated string that will update the  connection scope 
 
     # Metadata capture
     redirect_uri_metadata:

--- a/docs/docs/providers/atlassian.md
+++ b/docs/docs/providers/atlassian.md
@@ -1,0 +1,33 @@
+---
+sidebar_label: Atlassian
+---
+
+# Atlassian API wiki
+
+:::note Working with the Atlassian API?
+Please add your learnings, favorite links and gotchas here by [editing this page](https://github.com/nangohq/nango/tree/master/docs/docs/providers/atlassian.md).
+
+:::
+
+## Using Atlassian with Nango
+
+Provider template name in Nango: `atlassian`  
+Follow our [quickstart](../quickstart.md) to add an OAuth integration with Atlassian in 5 minutes.
+
+## App registration & publishing
+
+**Rating: `Easy & fast`**
+Registering an app takes only a few minutes, and you can start building immediately: [App registration docs](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/)
+
+
+## Useful links
+
+-   [Web API docs (their REST API)](https://developer.atlassian.com/cloud/confluence/oauth-2-3lo-apps)
+-   [List of OAuth scopes](https://developer.atlassian.com/cloud/jira/platform/scopes-for-oauth-2-3LO-and-forge-apps/#classic-scopes)
+
+## API specific gotchas
+
+- When you create an OAuth 2.0 (3LO) app, it's private by default. This mean that third party users cannot be authorized. If you want to make your app public find the how-to [here](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/#distributing-your-oauth-2-0--3lo--apps)
+- Refresh tokens will expire after 365 days of non use and will expire by 90 days if the resource owner is inactive for 90 days, Make sure you call `nango.getToken()` at least every 365 days to trigger a refresh. See reference [here](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/#how-do-i-get-a-new-access-token--if-my-access-token-expires-or-is-revoked-).
+- To allow the possibility of refreshing the token the scope is updated with `offline_access`
+

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -156,6 +156,7 @@ const sidebars = {
             items: [
                 'providers/airtable',
                 'providers/asana',
+                'providers/atlassian',
                 'providers/bitbucket',
                 'providers/box',
                 'providers/braintree',

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -154,10 +154,16 @@ class OAuthController {
                 additionalAuthParams['code_challenge_method'] = 'S256';
             }
 
+            let scopes = providerConfig.oauth_scopes.split(',');
+            if (oauth2Template.extra_scopes) {
+                const extraScopes = oauth2Template.extra_scopes?.split(',')!;
+                scopes = [...scopes, ...extraScopes];
+            }
+
             const simpleOAuthClient = new simpleOauth2.AuthorizationCode(getSimpleOAuth2ClientConfig(providerConfig, template, connectionConfig));
             const authorizationUri = simpleOAuthClient.authorizeURL({
                 redirect_uri: callbackUrl,
-                scope: providerConfig.oauth_scopes.split(',').join(oauth2Template.scope_separator || ' '),
+                scope: scopes,
                 state: session.id,
                 ...additionalAuthParams
             });

--- a/packages/server/lib/models.ts
+++ b/packages/server/lib/models.ts
@@ -133,6 +133,8 @@ export interface ProviderTemplateOAuth2 extends ProviderTemplate {
     refresh_url?: string;
 
     token_request_auth_method?: 'basic';
+
+    extra_scopes?: string; //Some providers expect you to update their scopes
 }
 
 export type OAuth1RequestTokenResult = {

--- a/packages/server/providers.yaml
+++ b/packages/server/providers.yaml
@@ -360,3 +360,14 @@ zoom:
     token_url: https://zoom.us/oauth/token
     authorization_params:
         response_type: code
+atlassian:
+    auth_mode: OAUTH2
+    authorization_url: https://auth.atlassian.com/authorize
+    token_url: https://auth.atlassian.com/oauth/token
+    authorization_params:
+        audience: api.atlassian.com
+        prompt: consent
+    refresh_params:
+        grant_type: refresh_token
+    extra_scopes: offline_access
+


### PR DESCRIPTION
**Description**

This Pr adds `atlassian`  as a provider OAuth2 provider.

In addition, it also adds a new key to the provider yaml, this key is used to update the scopes of a connection, for example in `atlassian` to have a refresh token the scopes must have offline_access amongst the provided scope in the query param.

**Issue Reference**
https://github.com/NangoHQ/nango/issues/399