### PR TITLE
fix: Bad request request when requesting for refresh token

### DIFF
--- a/docs/docs/contribute-api.md
+++ b/docs/docs/contribute-api.md
@@ -34,6 +34,8 @@ provider-slug: # Shorthand for the provider, ideally the provider's name. Must b
         response_type: code
     token_params: # Additional parameters to pass along in the token request
         mycoolparam: value
+    refresh_params: # Additional parameters to pass along in the refresh token request, if this is not provided it will use the token_params if it exist
+        grant_type: refresh_token
     refresh_url: https://api.example.com/oauth/refresh # The URL to use for refreshing the access token (only if different from token_url)
     scope_separator: ',' # String to use to separate scopes. Defaults to ' ' (1 space) if not provided
 

--- a/packages/server/lib/clients/oauth2.client.ts
+++ b/packages/server/lib/clients/oauth2.client.ts
@@ -47,7 +47,7 @@ export function getSimpleOAuth2ClientConfig(providerConfig: ProviderConfig, temp
     };
 }
 
-export async function getFreshOAuth2Credentials(connection: Connection, config: ProviderConfig, template: ProviderTemplate): Promise<OAuth2Credentials> {
+export async function getFreshOAuth2Credentials(connection: Connection, config: ProviderConfig, template: ProviderTemplateOAuth2): Promise<OAuth2Credentials> {
     let credentials = connection.credentials as OAuth2Credentials;
     const client = new AuthorizationCode(getSimpleOAuth2ClientConfig(config, template, connection.connection_config));
     const oldAccessToken = client.createToken({
@@ -57,7 +57,9 @@ export async function getFreshOAuth2Credentials(connection: Connection, config: 
     });
 
     let additionalParams = {};
-    if (template.token_params) {
+    if(template.refresh_params?.grant_type){
+        additionalParams = template.refresh_params;
+    }else if (template.token_params){
         additionalParams = template.token_params;
     }
 

--- a/packages/server/lib/clients/oauth2.client.ts
+++ b/packages/server/lib/clients/oauth2.client.ts
@@ -57,9 +57,9 @@ export async function getFreshOAuth2Credentials(connection: Connection, config: 
     });
 
     let additionalParams = {};
-    if(template.refresh_params?.grant_type){
+    if (template.refresh_params?.grant_type) {
         additionalParams = template.refresh_params;
-    }else if (template.token_params){
+    } else if (template.token_params) {
         additionalParams = template.token_params;
     }
 

--- a/packages/server/lib/clients/oauth2.client.ts
+++ b/packages/server/lib/clients/oauth2.client.ts
@@ -57,7 +57,7 @@ export async function getFreshOAuth2Credentials(connection: Connection, config: 
     });
 
     let additionalParams = {};
-    if (template.refresh_params?.grant_type) {
+    if (template.refresh_params) {
         additionalParams = template.refresh_params;
     } else if (template.token_params) {
         additionalParams = template.token_params;

--- a/packages/server/lib/models.ts
+++ b/packages/server/lib/models.ts
@@ -127,6 +127,10 @@ export interface ProviderTemplateOAuth2 extends ProviderTemplate {
     token_params?: {
         grant_type?: 'authorization_code' | 'client_credentials';
     };
+
+    refresh_params?: {
+        grant_type: 'refresh_token';
+    }
     authorization_method?: OAuthAuthorizationMethod;
     body_format?: OAuthBodyFormat;
 

--- a/packages/server/lib/models.ts
+++ b/packages/server/lib/models.ts
@@ -130,7 +130,7 @@ export interface ProviderTemplateOAuth2 extends ProviderTemplate {
 
     refresh_params?: {
         grant_type: 'refresh_token';
-    }
+    };
     authorization_method?: OAuthAuthorizationMethod;
     body_format?: OAuthBodyFormat;
 

--- a/packages/server/lib/services/connection.service.ts
+++ b/packages/server/lib/services/connection.service.ts
@@ -1,5 +1,5 @@
 import type { AuthCredentials, OAuth2Credentials, OAuth1Credentials, ProviderTemplate, CredentialsRefresh, StoredConnection } from '../models.js';
-import { ProviderAuthModes } from '../models.js';
+import { ProviderAuthModes, ProviderTemplateOAuth2 } from '../models.js';
 import { getFreshOAuth2Credentials } from '../clients/oauth2.client.js';
 import db from '../db/database.js';
 import type { ProviderConfig, Connection } from '../models.js';
@@ -170,7 +170,7 @@ class ConnectionService {
                         let rawCreds = await providerClientManager.refreshToken(providerConfig, connection);
                         newCredentials = this.parseRawCredentials(rawCreds, ProviderAuthModes.OAuth2) as OAuth2Credentials;
                     } else {
-                        newCredentials = await getFreshOAuth2Credentials(connection, providerConfig, template);
+                        newCredentials = await getFreshOAuth2Credentials(connection, providerConfig, template as ProviderTemplateOAuth2);
                     }
 
                     connection.credentials = newCredentials;


### PR DESCRIPTION
**Description**
We use the same grant type to request access tokens when we refresh them as we do when we initially request them. For example, we use "authorization_code" as the value for the "grant_type" key in the query parameters when requesting access tokens. We do the same thing for refreshing tokens. However, this does not follow the OAuth 2.0 standard.

**What this PR does**
This PR updates the provider template to add refresh parameters. If the request parameters are not provided, it defaults to the token parameters.

**Issue**
Solves the issue [here](https://github.com/NangoHQ/nango/issues/429)