### PR TITLE
refactor: Add support for querying an immediate refresh of the provider's refresh token

### DIFF
--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -26,16 +26,17 @@ export class Nango {
     }
 
     /**
-     * Get fresh access credentials to authenticate your requests.
-     *
-     * @remarks
      * For OAuth 2: returns the access token directly as a string.
      * For OAuth 2: If you want to obtain a new refresh token from the provider before the current token has expired,
-     * you can set the instantRefresh argument to true."
+     * you can set the forceRefresh argument to true."
      * For OAuth 1: returns an object with 'oAuthToken' and 'oAuthTokenSecret' fields.
-     */
-    public async getToken(providerConfigKey: string, connectionId: string, instantRefresh = false) {
-        let response = await this.getConnectionDetails(providerConfigKey, connectionId, instantRefresh);
+     * @param providerConfigKey - This is the unique Config Key for the integration
+     * @param connectionId - This is the unique connection identifier used to identify this connection
+     * @param [forceRefresh] - When set, this is used to  obtain a new refresh token from the provider before the current token has expired,
+     * you can set the forceRefresh argument to true.
+     * */
+    public async getToken(providerConfigKey: string, connectionId: string, forceRefresh?: boolean) {
+        let response = await this.getConnectionDetails(providerConfigKey, connectionId, forceRefresh);
 
         switch (response.data.credentials.type) {
             case 'OAUTH2':
@@ -48,22 +49,32 @@ export class Nango {
     }
 
     /**
-     * Get the full (fresh) credentials payload returned by the external API, which also contains access credentials.
-     */
-    public async getRawTokenResponse(providerConfigKey: string, connectionId: string) {
-        let response = await this.getConnectionDetails(providerConfigKey, connectionId);
+     * Get the full (fresh) credentials payload returned by the external API,
+     * which also contains access credentials.
+     * @param providerConfigKey - This is the unique Config Key for the integration
+     * @param connectionId - This is the unique connection identifier used to identify this connection
+     * @param [forceRefresh] - When set, this is used to  obtain a new refresh token from the provider before the current token has expired,
+     * you can set the forceRefresh argument to true.
+     * */
+    public async getRawTokenResponse(providerConfigKey: string, connectionId: string, forceRefresh?: boolean) {
+        let response = await this.getConnectionDetails(providerConfigKey, connectionId, forceRefresh);
         return response.data.credentials.raw;
     }
 
     /**
-     * Get the Connection object, which also contains access credentials and full credentials payload returned by the external API.
+     * Get the Connection object, which also contains access credentials and full credentials payload
+     * returned by the external API.
+     * @param providerConfigKey - This is the unique Config Key for the integration
+     * @param connectionId - This is the unique connection identifier used to identify this connection
+     * @param [forceRefresh] - When set, this is used to  obtain a new refresh token from the provider before the current token has expired,
+     * you can set the forceRefresh argument to true.
      */
-    public async getConnection(providerConfigKey: string, connectionId: string) {
-        let response = await this.getConnectionDetails(providerConfigKey, connectionId);
+    public async getConnection(providerConfigKey: string, connectionId: string, forceRefresh?: boolean) {
+        let response = await this.getConnectionDetails(providerConfigKey, connectionId, forceRefresh);
         return response.data;
     }
 
-    private async getConnectionDetails(providerConfigKey: string, connectionId: string, instantRefresh = false) {
+    private async getConnectionDetails(providerConfigKey: string, connectionId: string, forceRefresh = false) {
         let url = `${this.serverUrl}/connection/${connectionId}`;
 
         let headers = {
@@ -73,7 +84,7 @@ export class Nango {
 
         let params = {
             provider_config_key: providerConfigKey,
-            instant_refresh: instantRefresh
+            force_refresh: forceRefresh
         };
 
         return axios.get(url, { params: params, headers: this.enrichHeaders(headers) });

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -30,10 +30,12 @@ export class Nango {
      *
      * @remarks
      * For OAuth 2: returns the access token directly as a string.
+     * For OAuth 2: If you want to obtain a new refresh token from the provider before the current token has expired,
+     * you can set the instantRefresh argument to true."
      * For OAuth 1: returns an object with 'oAuthToken' and 'oAuthTokenSecret' fields.
      */
-    public async getToken(providerConfigKey: string, connectionId: string) {
-        let response = await this.getConnectionDetails(providerConfigKey, connectionId);
+    public async getToken(providerConfigKey: string, connectionId: string, instantRefresh = false) {
+        let response = await this.getConnectionDetails(providerConfigKey, connectionId, instantRefresh);
 
         switch (response.data.credentials.type) {
             case 'OAUTH2':
@@ -61,7 +63,7 @@ export class Nango {
         return response.data;
     }
 
-    private async getConnectionDetails(providerConfigKey: string, connectionId: string) {
+    private async getConnectionDetails(providerConfigKey: string, connectionId: string, instantRefresh = false) {
         let url = `${this.serverUrl}/connection/${connectionId}`;
 
         let headers = {
@@ -70,7 +72,8 @@ export class Nango {
         };
 
         let params = {
-            provider_config_key: providerConfigKey
+            provider_config_key: providerConfigKey,
+            instant_refresh: instantRefresh
         };
 
         return axios.get(url, { params: params, headers: this.enrichHeaders(headers) });

--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -149,7 +149,7 @@ class ConnectionController {
             let accountId = getAccount(res);
             let connectionId = req.params['connectionId'] as string;
             let providerConfigKey = req.query['provider_config_key'] as string;
-            const instantRefresh = req.query['instant_refresh'] === 'true'; // This allows us to instantly refresh the token instead of waiting for the token to expire
+            const instantRefresh = req.query['force_refresh'] === 'true'; // This allows us to instantly refresh the token instead of waiting for the token to expire
             if (connectionId == null) {
                 errorManager.errRes(res, 'missing_connection');
                 return;

--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -149,7 +149,7 @@ class ConnectionController {
             let accountId = getAccount(res);
             let connectionId = req.params['connectionId'] as string;
             let providerConfigKey = req.query['provider_config_key'] as string;
-
+            const instantRefresh = req.query['instant_refresh'] === 'true'; // This allows us to instantly refresh the token instead of waiting for the token to expire
             if (connectionId == null) {
                 errorManager.errRes(res, 'missing_connection');
                 return;
@@ -177,7 +177,12 @@ class ConnectionController {
             let template: ProviderTemplate | undefined = configService.getTemplate(config.provider);
 
             if (connection.credentials.type === ProviderAuthModes.OAuth2) {
-                connection.credentials = await connectionService.refreshOauth2CredentialsIfNeeded(connection, config, template as ProviderTemplateOAuth2);
+                connection.credentials = await connectionService.refreshOauth2CredentialsIfNeeded(
+                    connection,
+                    config,
+                    template as ProviderTemplateOAuth2,
+                    instantRefresh
+                );
             }
 
             analytics.track('server:connection_fetched', accountId, { provider: config.provider });

--- a/packages/server/lib/services/connection.service.ts
+++ b/packages/server/lib/services/connection.service.ts
@@ -138,7 +138,8 @@ class ConnectionService {
     public async refreshOauth2CredentialsIfNeeded(
         connection: Connection,
         providerConfig: ProviderConfig,
-        template: ProviderTemplateOAuth2
+        template: ProviderTemplateOAuth2,
+        instantRefresh = false
     ): Promise<OAuth2Credentials> {
         let connectionId = connection.connection_id;
         let credentials = connection.credentials as OAuth2Credentials;
@@ -158,8 +159,8 @@ class ConnectionService {
         }
 
         let refresh =
-            providerClient.shouldIntrospectToken(providerConfig.provider) && (await providerClient.introspectedTokenExpired(providerConfig, connection));
-
+            instantRefresh ||
+            (providerClient.shouldIntrospectToken(providerConfig.provider) && (await providerClient.introspectedTokenExpired(providerConfig, connection)));
         // If not expiration date is set, e.g. Github, we assume the token doesn't expire (unless introspection enable like Salesforce).
         if (credentials.refresh_token && (refresh || (credentials.expires_at && isTokenExpired(credentials.expires_at)))) {
             const promise = new Promise<OAuth2Credentials>(async (resolve, reject) => {
@@ -184,6 +185,7 @@ class ConnectionService {
 
                     resolve(newCredentials);
                 } catch (e) {
+                    console.log(e);
                     // Remove ourselves from the array of running refreshes
                     this.runningCredentialsRefreshes = this.runningCredentialsRefreshes.filter((value) => {
                         return !(value.providerConfigKey === providerConfigKey && value.connectionId === connectionId);

--- a/packages/server/lib/services/connection.service.ts
+++ b/packages/server/lib/services/connection.service.ts
@@ -185,7 +185,6 @@ class ConnectionService {
 
                     resolve(newCredentials);
                 } catch (e) {
-                    console.log(e);
                     // Remove ourselves from the array of running refreshes
                     this.runningCredentialsRefreshes = this.runningCredentialsRefreshes.filter((value) => {
                         return !(value.providerConfigKey === providerConfigKey && value.connectionId === connectionId);

--- a/packages/server/providers.yaml
+++ b/packages/server/providers.yaml
@@ -9,6 +9,7 @@ asana:
     auth_mode: OAUTH2
     authorization_url: https://app.asana.com/-/oauth_authorize
     token_url: https://app.asana.com/-/oauth_token
+    refresh_url: https://app.asana.com/-/oauth_token
     token_params:
         grant_type: authorization_code
     auth:


### PR DESCRIPTION
**Discription**

This PR adds a new query parameter, `instant_refresh`, when obtaining a connection. When set to true, this parameter allows for the immediate creation of a fresh refresh token from the provider, bypassing the need to wait for the access token to expire.