### PR TITLE
Fix: connection config params

### DIFF
--- a/packages/server/lib/controllers/config.controller.ts
+++ b/packages/server/lib/controllers/config.controller.ts
@@ -1,4 +1,4 @@
-import type { Request, Response, NextFunction } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import configService from '../services/config.service.js';
 import type { ProviderConfig } from '../models.js';
 import analytics from '../utils/analytics.js';
@@ -22,15 +22,16 @@ class ConfigController {
 
             let integrations = configs.map((config) => {
                 let template = configService.getTemplates()[config.provider];
-                let connectionConfigParams = parseConnectionConfigParamsFromTemplate(template!);
-
-                return {
+                let integration: any = {
                     uniqueKey: config.unique_key,
                     provider: config.provider,
                     connectionCount: connections.filter((connection) => connection.provider === config.unique_key).length,
-                    creationDate: config.created_at,
-                    connectionConfigParams: connectionConfigParams
+                    creationDate: config.created_at
                 };
+                if (template) {
+                    integration['connectionConfigParams'] = parseConnectionConfigParamsFromTemplate(template!);
+                }
+                return integration;
             });
 
             res.status(200).send({
@@ -39,6 +40,7 @@ class ConfigController {
                 })
             });
         } catch (err) {
+            console.log(err);
             next(err);
         }
     }

--- a/packages/server/providers.yaml
+++ b/packages/server/providers.yaml
@@ -9,7 +9,6 @@ asana:
     auth_mode: OAUTH2
     authorization_url: https://app.asana.com/-/oauth_authorize
     token_url: https://app.asana.com/-/oauth_token
-    refresh_url: https://app.asana.com/-/oauth_token
     token_params:
         grant_type: authorization_code
     auth:

--- a/packages/server/providers.yaml
+++ b/packages/server/providers.yaml
@@ -9,6 +9,7 @@ asana:
     auth_mode: OAUTH2
     authorization_url: https://app.asana.com/-/oauth_authorize
     token_url: https://app.asana.com/-/oauth_token
+    refresh_url: https://app.asana.com/-/oauth_token
     token_params:
         grant_type: authorization_code
     auth:


### PR DESCRIPTION
During development, it's possible that integration has already been created for a provider. However, if the pull request (PR) is not merged and the developer changes their branch, this integration will exist on their database but not on the provider yaml template. This will cause a 500 error when attempting to render the integrations page.

To address this issue, this PR adds a conditional check to parseConnectionConfigParamsFromTemplate to verify if the template exists.