### PR TITLE
fix: Allow use of dynamic port for Nango DB in docker compose.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
             POSTGRES_USER: nango
             POSTGRES_DB: nango
         ports:
-            - '5432:5432'
+            - '${NANGO_DB_PORT:-5432}:5432'
         volumes:
             - ./nango-data:/var/lib/postgresql/data
         networks:

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -37,6 +37,13 @@ git clone https://github.com/NangoHQ/nango.git && cd nango
 docker compose up # Keep the tab open
 ```
 
+In the case you are already using port 5432 on your local machine, you can use
+
+```bash
+git clone https://github.com/NangoHQ/nango.git && cd nango
+NANGO_DB_PORT=2345 docker compose up # Keep the tab open
+```
+
 Once Nango is running locally, open the [dashboard](http://localhost:3003/) in your browser.
 
   </TabItem>


### PR DESCRIPTION
Fixes [issue](https://github.com/NangoHQ/nango/issues/495)