### PR TITLE
fix: Mural authorization URL.

### DIFF
--- a/packages/server/providers.yaml
+++ b/packages/server/providers.yaml
@@ -283,8 +283,8 @@ monday:
     token_url: https://auth.monday.com/oauth2/token
 mural:
     auth_mode: OAUTH2
-    authorization_url: https://app.mural.md/api/public/v1/authorization/oauth2
-    token_url: https://app.mural.md/api/public/v1/authorization/oauth2/token
+    authorization_url: https://app.mural.co/api/public/v1/authorization/oauth2
+    token_url: https://app.mural.co/api/public/v1/authorization/oauth2/token
     authorization_params:
         response_type: code
     token_params:


### PR DESCRIPTION
During a random QA, I found this issue here.