### PR TITLE
fix: make frontend sdk ssr friendly

### DIFF
--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -40,11 +40,6 @@ export default class Nango {
         } catch (err) {
             throw new Error(`Invalid URL provided for the Nango host: ${this.hostBaseUrl}`);
         }
-
-        if (!window) {
-            const errorMessage = "Couldn't initialize Nango frontend. The window object is undefined. Are you using Nango frontend from a browser?";
-            throw new Error(errorMessage);
-        }
     }
 
     public auth(providerConfigKey: string, connectionId: string, connectionConfig?: ConnectionConfig): Promise<any> {


### PR DESCRIPTION
closes #335

This PR make's the `@nango/frontend` sdk compatible with SSR, I've gone through the sdk's code and I don't think we should be doing a `window` object check as we are doing nothing with window object while initlizing. More over all the actions that might need access to `window` are only executed only when your interact with UI on the client side.

PS: Tested in a NextJS project.
Thanks :)