### PR TITLE
[Github Issue #572] remove env req as it shouldn't be required

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,8 +20,6 @@ services:
         volumes:
             - ${PWD}/packages/server/providers.yaml:/usr/nango-server/src/packages/server/providers.yaml
         restart: always
-        env_file:
-            - .env
         ports:
             - '3003:3003'
         depends_on:


### PR DESCRIPTION
* Any .env files will get picked up by docker compose automatically so there shouldn't be a need to explicitly specify an `env_file`. If there were multiple files or there was some override logic then that env_file specification could/should be used
* Added https://github.com/NangoHQ/nango/pull/575 as well to verify this doesn't happen moving forward. BTW the Github actions added I believe need to be added as pre merge checks within this repo for them to show below

![image](https://user-images.githubusercontent.com/1724137/234083214-9b4892c7-7e25-49cd-88fb-4c45ff423656.png)


Let me know if I'm missing something here!