### PR TITLE
fix: correctly display error message when creating a connection

### DIFF
--- a/packages/webapp/src/pages/ConnectionCreate.tsx
+++ b/packages/webapp/src/pages/ConnectionCreate.tsx
@@ -85,13 +85,13 @@ export default function IntegrationCreate() {
 
         nango
             .auth(target.integration_unique_key.value, target.connection_id.value, { params: connectionConfigParams || {} })
-            .catch((err: { message: string; type: string }) => {
-                setServerErrorMessage(`${err.type} error: ${err.message}`);
-            })
             .then(() => {
                 toast.success('Connection created!', { position: toast.POSITION.BOTTOM_CENTER });
                 analyticsTrack('web:connection_created', { provider: integration?.provider || 'unknown' });
                 navigate('/connections', { replace: true });
+            })
+            .catch((err: { message: string; type: string }) => {
+                setServerErrorMessage(`${err.type} error: ${err.message}`);
             });
     };
 
@@ -159,7 +159,7 @@ export default function IntegrationCreate() {
         }
 
         return `import Nango from '@nangohq/frontend';
-        
+
 let nango = new Nango(${argsStr});
 
 nango.auth('${integration?.uniqueKey}', '${connectionId}'${connectionConfigStr}).then((result: { providerConfigKey: string; connectionId: string }) => {


### PR DESCRIPTION
When a request to create a connection fails, the error message is not shown, and instead a "connection created!" success toast message is displayed.

This happens because the error is caught, handled, and then the success path is executed anyway.

This change reorders the catch block so that the success path is not executed in the case of any errors.