### PR TITLE
Add banner about unified API to cloud

### DIFF
--- a/packages/webapp/src/components/Banner.tsx
+++ b/packages/webapp/src/components/Banner.tsx
@@ -1,13 +1,14 @@
 import { ArrowUpRight, X } from '@geist-ui/icons';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { isCloud } from '../utils/utils';
 
 export default function Banner() {
     const [flashBanner, setFlashBanner] = useState(true);
 
     return (
         <>
-            {flashBanner && (
+            {flashBanner && isCloud() && (
                 <div className="h-10 bg-white flex items-center justify-center text-sm gap-1 relative">
                     <span>Interested in the Nango Unified API? </span>
                     {/* TODO: add redirect uri */}

--- a/packages/webapp/src/components/Banner.tsx
+++ b/packages/webapp/src/components/Banner.tsx
@@ -8,7 +8,7 @@ export default function Banner() {
     return (
         <>
             {flashBanner && (
-                <div className="w-scree h-10 bg-white flex items-center justify-center text-sm gap-1 relative">
+                <div className="h-10 bg-white flex items-center justify-center text-sm gap-1 relative">
                     <span>Interested in the Nango Unified API? </span>
                     {/* TODO: add redirect uri */}
                     <Link to={'/'} className="cursor-pointer font-bold underline underline-offset-2 flex items-center">

--- a/packages/webapp/src/components/Banner.tsx
+++ b/packages/webapp/src/components/Banner.tsx
@@ -1,0 +1,22 @@
+import { ArrowUpRight, X } from '@geist-ui/icons';
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+export default function Banner() {
+    const [flashBanner, setFlashBanner] = useState(true);
+
+    return (
+        <>
+            {flashBanner && (
+                <div className="w-scree h-10 bg-white flex items-center justify-center text-sm gap-1 relative">
+                    <span>Interested in the Nango Unified API? </span>
+                    {/* TODO: add redirect uri */}
+                    <Link to={'/'} className="cursor-pointer font-bold underline underline-offset-2 flex items-center">
+                        Join the Beta <ArrowUpRight />
+                    </Link>
+                    <X onClick={() => setFlashBanner(false)} className="absolute right-3 cursor-pointer hover:bg-gray-200 rounded-md" />
+                </div>
+            )}
+        </>
+    );
+}

--- a/packages/webapp/src/layout/DashboardLayout.tsx
+++ b/packages/webapp/src/layout/DashboardLayout.tsx
@@ -1,3 +1,4 @@
+import Banner from '../components/Banner';
 import LeftNavBar, { LeftNavBarItems } from '../components/LeftNavBar';
 import TopNavBar from '../components/TopNavBar';
 
@@ -9,6 +10,7 @@ interface DashboardLayoutI {
 export default function DashboardLayout({ children, selectedItem }: DashboardLayoutI) {
     return (
         <div className="h-full">
+            <Banner />
             <TopNavBar />
             <div className="flex h-full max-w-6xl">
                 <LeftNavBar selectedItem={selectedItem} />

--- a/packages/webapp/src/layout/DashboardLayout.tsx
+++ b/packages/webapp/src/layout/DashboardLayout.tsx
@@ -9,13 +9,13 @@ interface DashboardLayoutI {
 
 export default function DashboardLayout({ children, selectedItem }: DashboardLayoutI) {
     return (
-        <div className="h-full">
+        <>
             <Banner />
             <TopNavBar />
             <div className="flex h-full max-w-6xl">
                 <LeftNavBar selectedItem={selectedItem} />
                 <div className="ml-60 pt-14 max-w-4xl mx-auto">{children}</div>
             </div>
-        </div>
+        </>
     );
 }


### PR DESCRIPTION
closes #636

This PR adds a top banner UI would look like this.
![banner](https://github.com/NangoHQ/nango/assets/87567452/b95e1950-945b-404f-b8bd-38636e64a796)

1. Added the banner at top of the screen unlike the design as most of the banner in other webapps are generally on top.
2. TODO: from the conversation in #636 I couldn't able to figureout what should be the redirecting url for this banner so I left a placeholder for now :)
3. Also the localStorage part, I guess if we store state in localStorage we might not able show it again on the UI until user manually resets it. So maybe we can use sessionStorage or simply react state would do the work (before a single refresh) since the banner would temporary I assume. 

suggestion?




