### PR TITLE
Add google doc integration

### DIFF
--- a/docs-v2/integrations/all/google-doc.mdx
+++ b/docs-v2/integrations/all/google-doc.mdx
@@ -1,0 +1,32 @@
+---
+title: GDoc
+sidebarTitle: GDoc
+---
+
+Integration template: [`google-doc`](https://nango.dev/providers.yaml)
+
+## Features
+
+| Feature                                                                          | Status                          |
+| -------------------------------------------------------------------------------- | ------------------------------- |
+| [Auth (OAuth)](/nango-auth)                                                      | ✅                              |
+| [Sync](/nango-sync)                                                              | ✅                              |
+| [Assisted requests](/nango-sync/guides/direct-requests)                          | 🚫 (time to contribute: &lt;1h) |
+| [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
+| [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
+
+<Tip>We can implement missing features in &lt;48h, just ask for it in the [community](https://nango.dev/slack).</Tip>
+## Getting started
+
+-   [GDoc access token specs](https://cloud.google.com/iam/docs/reference/sts/rest/v1/TopLevel/token#response-body)
+-   [Google Docs OAuth scopes](https://developers.google.com/identity/protocols/oauth2/scopes#docs)
+
+<Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
+
+## API gotchas
+
+-   While setting up the OAuth app, use the `https://www.googleapis.com/auth/documents` scope for extended capabilities
+
+<Note>
+    Add Getting Started links and Gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/google-doc.mdx)
+</Note>

--- a/docs-v2/mint.json
+++ b/docs-v2/mint.json
@@ -171,6 +171,7 @@
                 "integrations/all/gitlab",
                 "integrations/all/google",
                 "integrations/all/google-calendar",
+                "integrations/all/google-doc",
                 "integrations/all/google-mail",
                 "integrations/all/google-sheet",
                 "integrations/all/gorgias",

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -271,6 +271,10 @@ google-calendar:
     alias: google
     base_api_url: https://www.googleapis.com
     docs: https://developers.google.com/calendar/api/v3/reference
+google-docs:
+    alias: google
+    base_api_url: https://docs.googleapis.com
+    docs: https://developers.google.com/docs/api/reference/rest
 google-mail:
     alias: google
     base_api_url: https://gmail.googleapis.com


### PR DESCRIPTION
Added integration for Google Docs
- added `google-doc` to `provider.yaml` (modeled after `google-sheet`)
- added integration to documentation: created `google-doc.mdx` and added to `docs/mint.json`