### PR TITLE
feat: add separate command to migrate database

### DIFF
--- a/packages/server/lib/migrate.ts
+++ b/packages/server/lib/migrate.ts
@@ -1,0 +1,4 @@
+import migrate from './utils/migrate.js';
+
+await migrate();
+process.exit(0);

--- a/packages/server/lib/utils/migrate.ts
+++ b/packages/server/lib/utils/migrate.ts
@@ -1,0 +1,13 @@
+import db from '../db/database.js';
+import path from 'path';
+import { dirname } from '../utils/utils.js';
+import Logger from '../utils/logger.js';
+import { encryptionManager } from '@nangohq/shared';
+
+export default async function migrate() {
+    Logger.info('Migrating database ...');
+    await db.knex.raw(`CREATE SCHEMA IF NOT EXISTS ${db.schema()}`);
+    await db.migrate(path.join(dirname(), '../../lib/db/migrations'));
+    await encryptionManager.encryptDatabaseIfNeeded();
+    Logger.info('✅ Migrated database');
+}


### PR DESCRIPTION
Currently the Nango server performs the database migration at process startup before it starts accepting API calls. If you want to run multiple instances of Nango server for high availability purposes, then this is not ideal as those instances may attempt to perform the database migration at the same time, which can lead to random failures and corruption.

This change keeps the existing behaviour, but introduces a new flag `NANGO_MIGRATE_AT_START`, which when set to `false` will stop the database migration from happening at process startup.

Instead, the database migration can be explicitly run by running `node packages/server/dist/migrate.js`. This should be done once and once only before the Nango server instances are started. My intention is to run this from a Helm pre-install hook.