### PR TITLE
Fix Zendesk documentation

### DIFF
--- a/docs-v2/integrations/all/zendesk.mdx
+++ b/docs-v2/integrations/all/zendesk.mdx
@@ -18,15 +18,17 @@ Integration template: [`zendesk`](https://nango.dev/providers.yaml)
 <Tip>We can implement missing features in &lt;48h, just ask for it in the [community](https://nango.dev/slack).</Tip>
 ## Getting started
 
--   [How to register an Application](https://developer.zendesk.com/api-reference/sales-crm/authentication/introduction/#application-registration)
--   [OAuth-related docs](https://developer.zendesk.com/api-reference/sales-crm/authentication/introduction/)
--   [List of OAuth scopes](https://developer.zendesk.com/api-reference/sales-crm/authentication/introduction/#scopes)
--   [API](https://developer.zendesk.com/api-reference/sales-crm/authentication/introduction/#scopes:~:text=Reference-,SYNC%20API,-Introduction)
+-   [How to register an Application](https://support.zendesk.com/hc/en-us/articles/4408845965210-Using-OAuth-authentication-with-your-application#topic_s21_lfs_qk)
+-   [List of OAuth scopes](https://support.zendesk.com/hc/en-us/articles/4408845965210#topic_gql_kbd_gt)
+-   [Setting up a global oAuth client](https://developer.zendesk.com/documentation/marketplace/building-a-marketplace-app/set-up-a-global-oauth-client/)
+-   [API](https://developer.zendesk.com/api-reference/)
 
 <Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
 
 ## API gotchas
 
 -   Make sure you specify the subdomain in the [Connection Configuration](/nango-auth/configuration) before starting an OAuth flow for Zendesk.
+-   Make sure to create a Zendesk oAuth app (`https://<USER-SUBDOMAIN>.zendesk.com/admin/apps-integrations/apis/zendesk-api/settings`), _not_ a Zendesk Sales CRM oAuth app. 
+-   Zendesk oAuth apps [must be made "global"](https://developer.zendesk.com/documentation/marketplace/building-a-marketplace-app/set-up-a-global-oauth-client/) to connect to multiple `<USER-SUBDOMAIN>`s.
 
 <Note>Add Getting Started links and Gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/zendesk.mdx)</Note>


### PR DESCRIPTION
The old docs references the Zendesk Sales CRM API, which is a different API/oAuth app setup (which [doesn't work with Nango](https://nango-community.slack.com/archives/C04ABR352H0/p1686683332907549) atm)

I'm _pretty sure_ I've got good links for everything, but the Zendesk docs are kinda all over the place, so probably some improvement potential.