### PR TITLE
NANGO-677: Allow the websockets path to be configured

### DIFF
--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -14,12 +14,14 @@ const enum WSMessageType {
 
 export default class Nango {
     private hostBaseUrl: string;
+    private websocketsBaseUrl: string;
     private status: AuthorizationStatus;
     private publicKey: string | undefined;
     private debug = false;
 
-    constructor(config: { host?: string; publicKey?: string; debug?: boolean } = {}) {
+    constructor(config: { host?: string; websocketsPath?: string; publicKey?: string; debug?: boolean } = {}) {
         config.host = config.host || prodHost; // Default to Nango Cloud.
+        config.websocketsPath = config.websocketsPath || '/'; // Default to root path.
         this.debug = config.debug || false;
 
         if (this.debug) {
@@ -36,7 +38,11 @@ export default class Nango {
         }
 
         try {
-            new URL(this.hostBaseUrl);
+            const baseUrl = new URL(this.hostBaseUrl);
+            // Build the websockets url based on the host url.
+            // The websockets path is considered relative to the baseUrl, and with the protocol updated
+            const websocketUrl = new URL(config.websocketsPath, baseUrl);
+            this.websocketsBaseUrl = websocketUrl.toString().replace('https://', 'wss://').replace('http://', 'ws://');
         } catch (err) {
             throw new Error(`Invalid URL provided for the Nango host: ${this.hostBaseUrl}`);
         }
@@ -82,7 +88,7 @@ export default class Nango {
             this.status = AuthorizationStatus.BUSY;
 
             // Open authorization modal
-            new AuthorizationModal(this.hostBaseUrl, url, successHandler, errorHandler, this.debug);
+            new AuthorizationModal(this.websocketsBaseUrl, url, successHandler, errorHandler, this.debug);
         });
     }
 
@@ -142,7 +148,7 @@ class AuthorizationModal {
     private debug: boolean;
 
     constructor(
-        host: string,
+        webSocketUrl: string,
         url: string,
         successHandler: (providerConfigKey: string, connectionId: string) => any,
         errorHandler: (errorType: string, errorDesc: string) => any,
@@ -172,7 +178,7 @@ class AuthorizationModal {
 
         this.modal = window.open('', '_blank', this.featuresToString())!;
 
-        this.swClient = new WebSocket(host.replace('https://', 'wss://').replace('http://', 'ws://'));
+        this.swClient = new WebSocket(webSocketUrl);
 
         this.swClient.onmessage = (message: MessageEvent<any>) => {
             this.handleMessage(message, successHandler, errorHandler);

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -30,7 +30,7 @@ import oAuthSessionService from './services/oauth-session.service.js';
 import { deleteOldActivityLogs } from './jobs/index.js';
 import migrate from './utils/migrate.js';
 
-const { NANGO_MIGRATE_AT_START = 'true' } = process.env;
+const { NANGO_MIGRATE_AT_START = 'true', NANGO_WEBSOCKETS_PATH = '/' } = process.env;
 
 const app = express();
 
@@ -133,7 +133,7 @@ app.get('*', (_, res) => {
 });
 
 const server = http.createServer(app);
-const wsServer = new WebSocketServer({ server });
+const wsServer = new WebSocketServer({ server, path: NANGO_WEBSOCKETS_PATH });
 
 wsServer.on('connection', (ws: WebSocket) => {
     webSocketClient.addClient(ws);


### PR DESCRIPTION
# Summary

The websockets path is currently hardcoded to `/` which makes it hard to
firewall or otherwise filter requests to the dashboard (which should be
very secure) from requests to the websockets (which must be open
publicly).

This adds:

- `NANGO_WEBSOCKETS_PATH` to the server's (optional) environment
  variables.  This defaults to `/` for backwards compatibility
- `websocketsPath` as an optional config parameter to the frontend
  `Nango` control. This defaults to `/` for backwards compatibility.

*WARNING*: This PR is not complete and requires work to update the
WebApp to also allow it to use an updated websockets path for the
inline OAuth flow on the `Add New Connection` page.

# Testing

TBC based on completing the above.