### PR TITLE
[Github #680] user scope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10024,11 +10024,11 @@
         },
         "packages/cli": {
             "name": "nango",
-            "version": "0.21.12",
+            "version": "0.21.13",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@babel/traverse": "^7.22.5",
-                "@nangohq/shared": "0.21.12",
+                "@nangohq/shared": "0.21.13",
                 "@vercel/ncc": "^0.36.1",
                 "axios": "^1.2.0",
                 "byots": "^5.0.0-dev.20221103.1.34",
@@ -10098,15 +10098,15 @@
         },
         "packages/frontend": {
             "name": "@nangohq/frontend",
-            "version": "0.21.12",
+            "version": "0.21.13",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY"
         },
         "packages/node-client": {
             "name": "@nangohq/node",
-            "version": "0.21.12",
+            "version": "0.21.13",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@nangohq/shared": "0.21.12",
+                "@nangohq/shared": "0.21.13",
                 "axios": "^1.2.0"
             },
             "engines": {
@@ -10115,11 +10115,11 @@
         },
         "packages/server": {
             "name": "@nangohq/nango-server",
-            "version": "0.21.12",
+            "version": "0.21.13",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@hapi/boom": "^10.0.1",
-                "@nangohq/shared": "0.21.12",
+                "@nangohq/shared": "0.21.13",
                 "@sentry/node": "^7.37.2",
                 "@temporalio/client": "^1.7.4",
                 "axios": "^1.3.4",
@@ -10178,7 +10178,7 @@
         },
         "packages/shared": {
             "name": "@nangohq/shared",
-            "version": "0.21.12",
+            "version": "0.21.13",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.348.0",
@@ -10237,10 +10237,10 @@
         },
         "packages/worker": {
             "name": "@nangohq/nango-worker",
-            "version": "0.21.12",
+            "version": "0.21.13",
             "dependencies": {
-                "@nangohq/node": "0.21.12",
-                "@nangohq/shared": "0.21.12",
+                "@nangohq/node": "0.21.13",
+                "@nangohq/shared": "0.21.13",
                 "@temporalio/activity": "^1.5.2",
                 "@temporalio/client": "^1.5.2",
                 "@temporalio/worker": "^1.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10024,11 +10024,11 @@
         },
         "packages/cli": {
             "name": "nango",
-            "version": "0.21.9",
+            "version": "0.21.12",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@babel/traverse": "^7.22.5",
-                "@nangohq/shared": "0.21.9",
+                "@nangohq/shared": "0.21.12",
                 "@vercel/ncc": "^0.36.1",
                 "axios": "^1.2.0",
                 "byots": "^5.0.0-dev.20221103.1.34",
@@ -10098,15 +10098,15 @@
         },
         "packages/frontend": {
             "name": "@nangohq/frontend",
-            "version": "0.21.9",
+            "version": "0.21.12",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY"
         },
         "packages/node-client": {
             "name": "@nangohq/node",
-            "version": "0.21.9",
+            "version": "0.21.12",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@nangohq/shared": "0.21.9",
+                "@nangohq/shared": "0.21.12",
                 "axios": "^1.2.0"
             },
             "engines": {
@@ -10115,11 +10115,11 @@
         },
         "packages/server": {
             "name": "@nangohq/nango-server",
-            "version": "0.21.9",
+            "version": "0.21.12",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@hapi/boom": "^10.0.1",
-                "@nangohq/shared": "0.21.9",
+                "@nangohq/shared": "0.21.12",
                 "@sentry/node": "^7.37.2",
                 "@temporalio/client": "^1.7.4",
                 "axios": "^1.3.4",
@@ -10178,7 +10178,7 @@
         },
         "packages/shared": {
             "name": "@nangohq/shared",
-            "version": "0.21.9",
+            "version": "0.21.12",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.348.0",
@@ -10237,10 +10237,10 @@
         },
         "packages/worker": {
             "name": "@nangohq/nango-worker",
-            "version": "0.21.9",
+            "version": "0.21.12",
             "dependencies": {
-                "@nangohq/node": "0.21.9",
-                "@nangohq/shared": "0.21.9",
+                "@nangohq/node": "0.21.12",
+                "@nangohq/shared": "0.21.12",
                 "@temporalio/activity": "^1.5.2",
                 "@temporalio/client": "^1.5.2",
                 "@temporalio/worker": "^1.5.2",

--- a/packages/cli/docker/docker-compose.yaml
+++ b/packages/cli/docker/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
             - nango
 
     nango-server:
-        image: nangohq/nango-server:0.21.12
+        image: nangohq/nango-server:0.21.13
         container_name: nango-server
         environment:
             - TEMPORAL_ADDRESS=temporal:7233
@@ -33,7 +33,7 @@ services:
             - nango
 
     nango-worker:
-        image: nangohq/nango-worker:0.21.12
+        image: nangohq/nango-worker:0.21.13
         container_name: nango-worker
         restart: always
         ports:

--- a/packages/cli/docker/docker-compose.yaml
+++ b/packages/cli/docker/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
             - nango
 
     nango-server:
-        image: nangohq/nango-server:0.21.9
+        image: nangohq/nango-server:0.21.12
         container_name: nango-server
         environment:
             - TEMPORAL_ADDRESS=temporal:7233
@@ -33,7 +33,7 @@ services:
             - nango
 
     nango-worker:
-        image: nangohq/nango-worker:0.21.9
+        image: nangohq/nango-worker:0.21.12
         container_name: nango-worker
         restart: always
         ports:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nango",
-    "version": "0.21.12",
+    "version": "0.21.13",
     "description": "Nango's CLI tool.",
     "type": "module",
     "main": "dist/index.js",
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@babel/traverse": "^7.22.5",
-        "@nangohq/shared": "0.21.12",
+        "@nangohq/shared": "0.21.13",
         "@vercel/ncc": "^0.36.1",
         "axios": "^1.2.0",
         "byots": "^5.0.0-dev.20221103.1.34",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nango",
-    "version": "0.21.9",
+    "version": "0.21.12",
     "description": "Nango's CLI tool.",
     "type": "module",
     "main": "dist/index.js",
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@babel/traverse": "^7.22.5",
-        "@nangohq/shared": "0.21.9",
+        "@nangohq/shared": "0.21.12",
         "@vercel/ncc": "^0.36.1",
         "axios": "^1.2.0",
         "byots": "^5.0.0-dev.20221103.1.34",

--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -108,6 +108,10 @@ export default class Nango {
             if (connectionConfig.hmac) {
                 query.push(`hmac=${connectionConfig.hmac}`);
             }
+
+            if (connectionConfig.user_scope) {
+                query.push(`user_scope=${connectionConfig.user_scope.join(',')}`);
+            }
         }
 
         return query.length === 0 ? '' : '?' + query.join('&');
@@ -121,6 +125,7 @@ export default class Nango {
 interface ConnectionConfig {
     params: Record<string, string>;
     hmac?: string;
+    user_scope?: string[];
 }
 
 enum AuthorizationStatus {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nangohq/frontend",
-    "version": "0.21.9",
+    "version": "0.21.12",
     "description": "Nango's frontend library for OAuth handling.",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nangohq/frontend",
-    "version": "0.21.12",
+    "version": "0.21.13",
     "description": "Nango's frontend library for OAuth handling.",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/node-client/package.json
+++ b/packages/node-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nangohq/node",
-    "version": "0.21.9",
+    "version": "0.21.12",
     "description": "Nango's Node client.",
     "type": "module",
     "main": "dist/index.js",
@@ -13,7 +13,7 @@
     },
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
-        "@nangohq/shared": "0.21.9",
+        "@nangohq/shared": "0.21.12",
         "axios": "^1.2.0"
     },
     "engines": {

--- a/packages/node-client/package.json
+++ b/packages/node-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nangohq/node",
-    "version": "0.21.12",
+    "version": "0.21.13",
     "description": "Nango's Node client.",
     "type": "module",
     "main": "dist/index.js",
@@ -13,7 +13,7 @@
     },
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
-        "@nangohq/shared": "0.21.12",
+        "@nangohq/shared": "0.21.13",
         "axios": "^1.2.0"
     },
     "engines": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nangohq/nango-server",
-    "version": "0.21.12",
+    "version": "0.21.13",
     "description": "Nango OAuth's server.",
     "type": "module",
     "main": "dist/server.js",
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@hapi/boom": "^10.0.1",
-        "@nangohq/shared": "0.21.12",
+        "@nangohq/shared": "0.21.13",
         "@sentry/node": "^7.37.2",
         "@temporalio/client": "^1.7.4",
         "axios": "^1.3.4",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nangohq/nango-server",
-    "version": "0.21.9",
+    "version": "0.21.12",
     "description": "Nango OAuth's server.",
     "type": "module",
     "main": "dist/server.js",
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@hapi/boom": "^10.0.1",
-        "@nangohq/shared": "0.21.9",
+        "@nangohq/shared": "0.21.12",
         "@sentry/node": "^7.37.2",
         "@temporalio/client": "^1.7.4",
         "axios": "^1.3.4",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nangohq/shared",
-    "version": "0.21.9",
+    "version": "0.21.12",
     "description": "Nango's shared components.",
     "type": "module",
     "main": "dist/lib/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nangohq/shared",
-    "version": "0.21.12",
+    "version": "0.21.13",
     "description": "Nango's shared components.",
     "type": "module",
     "main": "dist/lib/index.js",

--- a/packages/webapp/package-lock.json
+++ b/packages/webapp/package-lock.json
@@ -1,19 +1,19 @@
 {
     "name": "webapp",
-    "version": "0.21.12",
+    "version": "0.21.13",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "webapp",
-            "version": "0.21.12",
+            "version": "0.21.13",
             "dependencies": {
                 "@geist-ui/core": "^2.3.8",
                 "@geist-ui/icons": "^1.0.2",
                 "@headlessui/react": "^1.7.12",
                 "@heroicons/react": "^2.0.16",
                 "@mantine/prism": "^5.10.5",
-                "@nangohq/frontend": "0.21.12",
+                "@nangohq/frontend": "0.21.13",
                 "@testing-library/jest-dom": "^5.16.5",
                 "@testing-library/react": "^13.4.0",
                 "@testing-library/user-event": "^13.5.0",
@@ -3049,9 +3049,9 @@
             }
         },
         "node_modules/@nangohq/frontend": {
-            "version": "0.21.12",
-            "resolved": "https://registry.npmjs.org/@nangohq/frontend/-/frontend-0.21.12.tgz",
-            "integrity": "sha512-ldiM0tAzakWTiCs/8WRbVsM0OKPcAx1VAAsc3yTCBw3E2spwCjk97tO2ZG4YhT3AMajqLdSFhCNHZvTsQTboAw=="
+            "version": "0.21.13",
+            "resolved": "https://registry.npmjs.org/@nangohq/frontend/-/frontend-0.21.13.tgz",
+            "integrity": "sha512-LxtGXAAAd9akcHd6NVQTNpI5lNih17kgjmYY86J0krRBTUMo0sc8x9r5nJRxv1URMcfkCJX7CLv7HFBDsxkVgg=="
         },
         "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
             "version": "5.1.1-v1",
@@ -18597,9 +18597,9 @@
             "requires": {}
         },
         "@nangohq/frontend": {
-            "version": "0.21.12",
-            "resolved": "https://registry.npmjs.org/@nangohq/frontend/-/frontend-0.21.12.tgz",
-            "integrity": "sha512-ldiM0tAzakWTiCs/8WRbVsM0OKPcAx1VAAsc3yTCBw3E2spwCjk97tO2ZG4YhT3AMajqLdSFhCNHZvTsQTboAw=="
+            "version": "0.21.13",
+            "resolved": "https://registry.npmjs.org/@nangohq/frontend/-/frontend-0.21.13.tgz",
+            "integrity": "sha512-LxtGXAAAd9akcHd6NVQTNpI5lNih17kgjmYY86J0krRBTUMo0sc8x9r5nJRxv1URMcfkCJX7CLv7HFBDsxkVgg=="
         },
         "@nicolo-ribaudo/eslint-scope-5-internals": {
             "version": "5.1.1-v1",

--- a/packages/webapp/package-lock.json
+++ b/packages/webapp/package-lock.json
@@ -1,19 +1,19 @@
 {
     "name": "webapp",
-    "version": "0.21.9",
+    "version": "0.21.12",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "webapp",
-            "version": "0.21.9",
+            "version": "0.21.12",
             "dependencies": {
                 "@geist-ui/core": "^2.3.8",
                 "@geist-ui/icons": "^1.0.2",
                 "@headlessui/react": "^1.7.12",
                 "@heroicons/react": "^2.0.16",
                 "@mantine/prism": "^5.10.5",
-                "@nangohq/frontend": "0.21.9",
+                "@nangohq/frontend": "0.21.12",
                 "@testing-library/jest-dom": "^5.16.5",
                 "@testing-library/react": "^13.4.0",
                 "@testing-library/user-event": "^13.5.0",
@@ -3049,9 +3049,9 @@
             }
         },
         "node_modules/@nangohq/frontend": {
-            "version": "0.21.9",
-            "resolved": "https://registry.npmjs.org/@nangohq/frontend/-/frontend-0.21.9.tgz",
-            "integrity": "sha512-bSztij6aK1xNSe3vCBP1oRvBm54HMMe84tL1esWp9cQUURDE1abC6/C3AUYXESs9GCi1Nl5pi1ga6am4nmNTtg=="
+            "version": "0.21.12",
+            "resolved": "https://registry.npmjs.org/@nangohq/frontend/-/frontend-0.21.12.tgz",
+            "integrity": "sha512-ldiM0tAzakWTiCs/8WRbVsM0OKPcAx1VAAsc3yTCBw3E2spwCjk97tO2ZG4YhT3AMajqLdSFhCNHZvTsQTboAw=="
         },
         "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
             "version": "5.1.1-v1",
@@ -18597,9 +18597,9 @@
             "requires": {}
         },
         "@nangohq/frontend": {
-            "version": "0.21.9",
-            "resolved": "https://registry.npmjs.org/@nangohq/frontend/-/frontend-0.21.9.tgz",
-            "integrity": "sha512-bSztij6aK1xNSe3vCBP1oRvBm54HMMe84tL1esWp9cQUURDE1abC6/C3AUYXESs9GCi1Nl5pi1ga6am4nmNTtg=="
+            "version": "0.21.12",
+            "resolved": "https://registry.npmjs.org/@nangohq/frontend/-/frontend-0.21.12.tgz",
+            "integrity": "sha512-ldiM0tAzakWTiCs/8WRbVsM0OKPcAx1VAAsc3yTCBw3E2spwCjk97tO2ZG4YhT3AMajqLdSFhCNHZvTsQTboAw=="
         },
         "@nicolo-ribaudo/eslint-scope-5-internals": {
             "version": "5.1.1-v1",

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "webapp",
-    "version": "0.21.12",
+    "version": "0.21.13",
     "private": true,
     "dependencies": {
         "@geist-ui/core": "^2.3.8",
@@ -8,7 +8,7 @@
         "@headlessui/react": "^1.7.12",
         "@heroicons/react": "^2.0.16",
         "@mantine/prism": "^5.10.5",
-        "@nangohq/frontend": "0.21.12",
+        "@nangohq/frontend": "0.21.13",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "webapp",
-    "version": "0.21.9",
+    "version": "0.21.12",
     "private": true,
     "dependencies": {
         "@geist-ui/core": "^2.3.8",
@@ -8,7 +8,7 @@
         "@headlessui/react": "^1.7.12",
         "@heroicons/react": "^2.0.16",
         "@mantine/prism": "^5.10.5",
-        "@nangohq/frontend": "0.21.9",
+        "@nangohq/frontend": "0.21.12",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",

--- a/packages/webapp/src/components/ui/input/TagsInput.tsx
+++ b/packages/webapp/src/components/ui/input/TagsInput.tsx
@@ -5,7 +5,7 @@ import useSet from '../../../hooks/useSet';
 
 type TagsInputProps = Omit<JSX.IntrinsicElements['input'], 'defaultValue'> & { defaultValue?: string; selectedScopes?: string[]; addToScopesSet?: (scope: string) => void; removeFromSelectedSet?: (scope: string) => void };
 
-const TagsInput = forwardRef<HTMLInputElement, TagsInputProps>(function TagsInput({ className, defaultValue, ...props }, ref) {
+const TagsInput = forwardRef<HTMLInputElement, TagsInputProps>(function TagsInput({ className, defaultValue, selectedScopes: optionalSelectedScopes, addToScopesSet: optionalAddToScopesSet, removeFromSelectedSet: optionalRemoveFromSelectedSet, ...props }, ref) {
     const defaultScopes = useMemo(() => {
         return !!defaultValue ? defaultValue.split(',') : [];
     }, [defaultValue]);
@@ -17,10 +17,10 @@ const TagsInput = forwardRef<HTMLInputElement, TagsInputProps>(function TagsInpu
     useEffect(() => {
         if (defaultScopes.length) {
             defaultScopes.forEach((scope) => {
-                typeof props.addToScopesSet === 'function' ? props.addToScopesSet(scope.trim()) : addToScopesSet(scope.trim());;
+                typeof optionalAddToScopesSet === 'function' ? optionalAddToScopesSet(scope.trim()) : addToScopesSet(scope.trim());;
             });
         }
-    }, [defaultScopes, addToScopesSet, props]);
+    }, [defaultScopes, addToScopesSet, optionalAddToScopesSet]);
 
     function handleEnter(e: KeyboardEvent<HTMLInputElement>) {
         //quick check for empty inputs
@@ -35,20 +35,20 @@ const TagsInput = forwardRef<HTMLInputElement, TagsInputProps>(function TagsInpu
             if (enteredValue.includes(',')) {
                 const enteredScopes = enteredValue.split(',');
                 enteredScopes.forEach((scope) => {
-                    typeof props.addToScopesSet === 'function' ? props.addToScopesSet(scope.trim()) : addToScopesSet(scope.trim());;
+                    typeof optionalAddToScopesSet === 'function' ? optionalAddToScopesSet(scope.trim()) : addToScopesSet(scope.trim());;
                 });
                 setEnteredValue('');
                 setError('');
                 return;
             }
-            typeof props.addToScopesSet === 'function' ? props.addToScopesSet(enteredValue.trim()) : addToScopesSet(enteredValue.trim());
+            typeof optionalAddToScopesSet === 'function' ? optionalAddToScopesSet(enteredValue.trim()) : addToScopesSet(enteredValue.trim());
             setEnteredValue('');
             setError('');
         }
     }
 
     function removeScope(scopeToBeRemoved: string) {
-        typeof props.removeFromSelectedSet === 'function' ? props.removeFromSelectedSet(scopeToBeRemoved) : removeFromSelectedSet(scopeToBeRemoved);
+        typeof optionalRemoveFromSelectedSet === 'function' ? optionalRemoveFromSelectedSet(scopeToBeRemoved) : removeFromSelectedSet(scopeToBeRemoved);
     }
 
     function showInvalid() {
@@ -58,7 +58,7 @@ const TagsInput = forwardRef<HTMLInputElement, TagsInputProps>(function TagsInpu
         }
     }
 
-    const scopes = props.selectedScopes ?? selectedScopes;
+    const scopes = optionalSelectedScopes ?? selectedScopes;
 
     return (
         <>

--- a/packages/webapp/src/components/ui/input/TagsInput.tsx
+++ b/packages/webapp/src/components/ui/input/TagsInput.tsx
@@ -3,7 +3,7 @@ import { X } from '@geist-ui/icons';
 
 import useSet from '../../../hooks/useSet';
 
-type TagsInputProps = Omit<JSX.IntrinsicElements['input'], 'defaultValue'> & { defaultValue: string };
+type TagsInputProps = Omit<JSX.IntrinsicElements['input'], 'defaultValue'> & { defaultValue?: string; selectedScopes?: string[]; addToScopesSet?: (scope: string) => void; removeFromSelectedSet?: (scope: string) => void };
 
 const TagsInput = forwardRef<HTMLInputElement, TagsInputProps>(function TagsInput({ className, defaultValue, ...props }, ref) {
     const defaultScopes = useMemo(() => {
@@ -17,10 +17,10 @@ const TagsInput = forwardRef<HTMLInputElement, TagsInputProps>(function TagsInpu
     useEffect(() => {
         if (defaultScopes.length) {
             defaultScopes.forEach((scope) => {
-                addToScopesSet(scope.trim());
+                typeof props.addToScopesSet === 'function' ? props.addToScopesSet(scope.trim()) : addToScopesSet(scope.trim());;
             });
         }
-    }, [defaultScopes, addToScopesSet]);
+    }, [defaultScopes, addToScopesSet, props]);
 
     function handleEnter(e: KeyboardEvent<HTMLInputElement>) {
         //quick check for empty inputs
@@ -35,20 +35,20 @@ const TagsInput = forwardRef<HTMLInputElement, TagsInputProps>(function TagsInpu
             if (enteredValue.includes(',')) {
                 const enteredScopes = enteredValue.split(',');
                 enteredScopes.forEach((scope) => {
-                    addToScopesSet(scope.trim());
+                    typeof props.addToScopesSet === 'function' ? props.addToScopesSet(scope.trim()) : addToScopesSet(scope.trim());;
                 });
                 setEnteredValue('');
                 setError('');
                 return;
             }
-            addToScopesSet(enteredValue.trim());
+            typeof props.addToScopesSet === 'function' ? props.addToScopesSet(enteredValue.trim()) : addToScopesSet(enteredValue.trim());
             setEnteredValue('');
             setError('');
         }
     }
 
     function removeScope(scopeToBeRemoved: string) {
-        removeFromSelectedSet(scopeToBeRemoved);
+        typeof props.removeFromSelectedSet === 'function' ? props.removeFromSelectedSet(scopeToBeRemoved) : removeFromSelectedSet(scopeToBeRemoved);
     }
 
     function showInvalid() {
@@ -58,10 +58,12 @@ const TagsInput = forwardRef<HTMLInputElement, TagsInputProps>(function TagsInpu
         }
     }
 
+    const scopes = props.selectedScopes ?? selectedScopes;
+
     return (
         <>
             <div className="flex gap-3">
-                <input onInvalid={showInvalid} value={selectedScopes.join(',')} {...props} hidden />
+                <input onInvalid={showInvalid} value={scopes.join(',')} {...props} hidden />
                 <input
                     ref={ref}
                     value={enteredValue}
@@ -78,9 +80,9 @@ const TagsInput = forwardRef<HTMLInputElement, TagsInputProps>(function TagsInpu
                 </button>
             </div>
             {error && <p className="text-red-600 text-sm mt-3">{error}</p>}
-            {!!selectedScopes.length && (
+            {Boolean(scopes.length) && (
                 <div className="px-2 pt-2 mt-3 pb-11 mb-3 flex flex-wrap rounded-lg border border-border-gray">
-                    {selectedScopes.map((selectedScope, i) => {
+                    {scopes.map((selectedScope, i) => {
                         return (
                             <span
                                 key={selectedScope + i}

--- a/packages/webapp/src/pages/ConnectionCreate.tsx
+++ b/packages/webapp/src/pages/ConnectionCreate.tsx
@@ -6,10 +6,12 @@ import { Prism } from '@mantine/prism';
 import { HelpCircle } from '@geist-ui/icons';
 import { Tooltip } from '@geist-ui/core';
 
+import useSet from '../hooks/useSet';
 import { isHosted, isStaging, baseUrl, isCloud } from '../utils/utils';
 import { useGetIntegrationListAPI, useGetProjectInfoAPI } from '../utils/api';
 import { useAnalyticsTrack } from '../utils/analytics';
 import DashboardLayout from '../layout/DashboardLayout';
+import TagsInput from '../components/ui/input/TagsInput';
 import { LeftNavBarItems } from '../components/LeftNavBar';
 
 interface Integration {
@@ -28,6 +30,7 @@ export default function IntegrationCreate() {
     const [integration, setIntegration] = useState<Integration | null>(null);
     const [connectionId, setConnectionId] = useState<string>('test-connection-id');
     const [connectionConfigParams, setConnectionConfigParams] = useState<Record<string, string> | null>(null);
+    const [selectedScopes, addToScopesSet, removeFromSelectedSet] = useSet<string>();
     const [publicKey, setPublicKey] = useState('');
     const [hostUrl, setHostUrl] = useState('');
     const getIntegrationListAPI = useGetIntegrationListAPI();
@@ -79,12 +82,13 @@ export default function IntegrationCreate() {
             integration_unique_key: { value: string };
             connection_id: { value: string };
             connection_config_params: { value: string };
+            user_scopes: { value: string };
         };
 
-        let nango = new Nango({ host: hostUrl, publicKey: isCloud() ? publicKey : undefined });
+        const nango = new Nango({ host: hostUrl, publicKey: isCloud() ? publicKey : undefined, debug: true });
 
         nango
-            .auth(target.integration_unique_key.value, target.connection_id.value, { params: connectionConfigParams || {} })
+            .auth(target.integration_unique_key.value, target.connection_id.value, { user_scope: selectedScopes || [], params: connectionConfigParams || {} })
             .then(() => {
                 toast.success('Connection created!', { position: toast.POSITION.BOTTOM_CENTER });
                 analyticsTrack('web:connection_created', { provider: integration?.provider || 'unknown' });
@@ -106,7 +110,6 @@ export default function IntegrationCreate() {
         }
 
         let params: Record<string, string> = {};
-        console.log(integration.connectionConfigParams);
         for (let i in integration.connectionConfigParams) {
             params[integration.connectionConfigParams[i]] = '';
         }
@@ -145,12 +148,11 @@ export default function IntegrationCreate() {
 
         let argsStr = args.length > 0 ? `{ ${args.join(', ')}}` : '';
 
-        var connectionConfigStr = '';
+        let connectionConfigStr = '';
 
         // Iterate of connectionConfigParams and create a string.
         if (connectionConfigParams != null && Object.keys(connectionConfigParams).length >= 0) {
             connectionConfigStr = ', { params: { ';
-            console.log(connectionConfigParams);
             for (const [key, value] of Object.entries(connectionConfigParams)) {
                 connectionConfigStr += `${key}: '${value}', `;
             }
@@ -158,11 +160,22 @@ export default function IntegrationCreate() {
             connectionConfigStr += ' }}';
         }
 
+        let userScopesStr = '';
+
+        if (selectedScopes != null && selectedScopes.length > 0) {
+            userScopesStr = ', { user_scope: [ ';
+            for (const scope of selectedScopes) {
+                userScopesStr += `'${scope}', `;
+            }
+            userScopesStr = userScopesStr.slice(0, -2);
+            userScopesStr += ' ] }';
+        }
+
         return `import Nango from '@nangohq/frontend';
 
-let nango = new Nango(${argsStr});
+const nango = new Nango(${argsStr});
 
-nango.auth('${integration?.uniqueKey}', '${connectionId}'${connectionConfigStr}).then((result: { providerConfigKey: string; connectionId: string }) => {
+nango.auth('${integration?.uniqueKey}', '${connectionId}'${connectionConfigStr}${userScopesStr}).then((result: { providerConfigKey: string; connectionId: string }) => {
     // do something
 }).catch((err: { message: string; type: string }) => {
     // handle error
@@ -227,6 +240,28 @@ nango.auth('${integration?.uniqueKey}', '${connectionId}'${connectionConfigStr})
                                     </div>
                                 </div>
                             </div>
+                            {integration?.provider === 'slack' && (
+                                <div>
+                                    <div className="flex mt-6">
+                                        <label htmlFor="user_scopes" className="text-text-light-gray block text-sm font-semibold">
+                                            User Scopes (Slack Only)
+                                        </label>
+                                    </div>
+                                    <div className="mt-1">
+                                        <TagsInput
+                                            id="scopes"
+                                            name="user_scopes"
+                                            type="text"
+                                            defaultValue={''}
+                                            selectedScopes={selectedScopes}
+                                            addToScopesSet={addToScopesSet}
+                                            removeFromSelectedSet={removeFromSelectedSet}
+                                            minLength={1}
+                                        />
+                                    </div>
+                                </div>
+                            )}
+
                             {integration?.connectionConfigParams?.map((paramName: string) => (
                                 <div key={paramName}>
                                     <div className="flex mt-6">

--- a/packages/webapp/src/pages/ConnectionCreate.tsx
+++ b/packages/webapp/src/pages/ConnectionCreate.tsx
@@ -85,7 +85,7 @@ export default function IntegrationCreate() {
             user_scopes: { value: string };
         };
 
-        const nango = new Nango({ host: hostUrl, publicKey: isCloud() ? publicKey : undefined, debug: true });
+        const nango = new Nango({ host: hostUrl, publicKey: isCloud() ? publicKey : undefined });
 
         nango
             .auth(target.integration_unique_key.value, target.connection_id.value, { user_scope: selectedScopes || [], params: connectionConfigParams || {} })

--- a/packages/webapp/src/pages/ConnectionCreate.tsx
+++ b/packages/webapp/src/pages/ConnectionCreate.tsx
@@ -253,6 +253,7 @@ nango.auth('${integration?.uniqueKey}', '${connectionId}'${connectionConfigStr}$
                                             name="user_scopes"
                                             type="text"
                                             defaultValue={''}
+                                            onChange={() => null}
                                             selectedScopes={selectedScopes}
                                             addToScopesSet={addToScopesSet}
                                             removeFromSelectedSet={removeFromSelectedSet}

--- a/packages/webapp/tsconfig.json
+++ b/packages/webapp/tsconfig.json
@@ -19,5 +19,6 @@
         "noEmit": true,
         "jsx": "react-jsx"
     },
+    "references": [{ "path": "../frontend" }],
     "include": ["src"]
 }

--- a/packages/webapp/tsconfig.json
+++ b/packages/webapp/tsconfig.json
@@ -19,6 +19,5 @@
         "noEmit": true,
         "jsx": "react-jsx"
     },
-    "references": [{ "path": "../frontend" }],
     "include": ["src"]
 }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nangohq/nango-worker",
-    "version": "0.21.12",
+    "version": "0.21.13",
     "type": "module",
     "main": "dist/worker.js",
     "scripts": {
@@ -15,8 +15,8 @@
         "directory": "packages/worker"
     },
     "dependencies": {
-        "@nangohq/node": "0.21.12",
-        "@nangohq/shared": "0.21.12",
+        "@nangohq/node": "0.21.13",
+        "@nangohq/shared": "0.21.13",
         "@temporalio/activity": "^1.5.2",
         "@temporalio/client": "^1.5.2",
         "@temporalio/worker": "^1.5.2",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nangohq/nango-worker",
-    "version": "0.21.9",
+    "version": "0.21.12",
     "type": "module",
     "main": "dist/worker.js",
     "scripts": {
@@ -15,8 +15,8 @@
         "directory": "packages/worker"
     },
     "dependencies": {
-        "@nangohq/node": "0.21.9",
-        "@nangohq/shared": "0.21.9",
+        "@nangohq/node": "0.21.12",
+        "@nangohq/shared": "0.21.12",
         "@temporalio/activity": "^1.5.2",
         "@temporalio/client": "^1.5.2",
         "@temporalio/worker": "^1.5.2",


### PR DESCRIPTION
Resolves #680 

* Adds the slack specific "User Scopes" option in the connection
* Updates the TagInput component to allow overrides for the `useSet` implementation so the scopes state can be tracked in the parent component
* Adjusts the frontend to push the user scope if provided and update the `ConnectionConfig` to have the optional `user_scope` type
* Updates the oauth controller to parse the user_scope query and set it to the `session.connectionConfig` so that it saves to the database. Puts the user_scope in the `additionalAuthParams` object

![image](https://github.com/NangoHQ/nango/assets/1724137/1b85cdfb-991a-42bb-9131-2c8533571c53)
![image](https://github.com/NangoHQ/nango/assets/1724137/92aa77be-f760-434d-b5f2-ac888e19f9f8)

