### PR TITLE
feat: add hmac to webapp

### DIFF
--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -73,6 +73,7 @@ app.route('/config/:providerConfigKey').get(apiAuth, configController.getProvide
 app.route('/config').post(apiAuth, configController.createProviderConfig.bind(configController));
 app.route('/config').put(apiAuth, configController.editProviderConfig.bind(configController));
 app.route('/config/:providerConfigKey').delete(apiAuth, configController.deleteProviderConfig.bind(configController));
+app.route('/config/hmac').get(apiAuth, configController.getHmacConfig.bind(configController));
 app.route('/connection/:connectionId').get(apiAuth, connectionController.getConnectionCreds.bind(connectionController));
 app.route('/connection').get(apiAuth, connectionController.listConnections.bind(connectionController));
 app.route('/connection/:connectionId').delete(apiAuth, connectionController.deleteConnection.bind(connectionController));

--- a/packages/webapp/src/utils/api.tsx
+++ b/packages/webapp/src/utils/api.tsx
@@ -2,7 +2,6 @@ import { toast } from 'react-toastify';
 import { useSignout } from './user';
 import type { RunSyncCommand } from '../types';
 
-
 function requestErrorToast() {
     toast.error('Request error...', { position: toast.POSITION.BOTTOM_CENTER });
 }
@@ -424,7 +423,7 @@ export function useActivityAPI() {
         try {
             let res = await fetch(`/api/v1/activity?limit=${limit}&offset=${offset}`, {
                 method: 'GET',
-                headers: getHeaders(),
+                headers: getHeaders()
             });
 
             return res;
@@ -439,7 +438,7 @@ export function useGetSyncAPI() {
         try {
             const res = await fetch(`/api/v1/sync?connection_id=${connectionId}&provider_config_key=${providerConfigKey}`, {
                 method: 'GET',
-                headers: getHeaders(),
+                headers: getHeaders()
             });
 
             return res;
@@ -462,6 +461,20 @@ export function useRunSyncAPI() {
         } catch (e) {
             requestErrorToast();
         }
+    };
+}
 
+export function useHmacAPI() {
+    return async (connectionId: string, providerConfigKey: string) => {
+        try {
+            const res = await fetch(`/api/v1/config/hmac?connection_id=${connectionId}&provider_config_key=${providerConfigKey}`, {
+                method: 'GET',
+                headers: getHeaders()
+            });
+
+            return res;
+        } catch (e) {
+            requestErrorToast();
+        }
     };
 }


### PR DESCRIPTION
This change adds the hmac digest to the webapp if it is enabled. 

I noticed when I have it enabled, I can't click the `Start OAuth Flow` button as it throws `Missing HMAC digest.`

First PR here, so lmk if I need to modify anything. I tried going off existing patterns.