### PR TITLE
Update import connection check to not throw unncessarily

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -73,7 +73,10 @@ class ConnectionService {
             throw new NangoError('unknown_provider_config');
         }
 
-        const connection = await this.getConnection(connection_id, provider_config_key, accountId);
+        let connection = undefined;
+        try {
+            connection = await this.getConnection(connection_id, provider_config_key, accountId);
+        } catch {}
 
         if (connection) {
             throw new NangoError('connection_already_exists');


### PR DESCRIPTION
Currently, the `ConnectionService.importConnection` method performs a check using a call to `ConnectionService.getConnection` to ensure that a connection does **not** currently exist. However,  `ConnectionService.getConnection` throws an error if the connection is not found, rather than a null value. `ConnectionService.importConnection` does not expect this, and thus the same error is thrown in that method as well.

This fix will allow for connections to be imported as intended. 