### PR TITLE
Mark Proxy as supported for all integrations in docs

### DIFF
--- a/docs-v2/integrations/all/accelo.mdx
+++ b/docs-v2/integrations/all/accelo.mdx
@@ -11,7 +11,7 @@ API Configuration: [`accelo`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/adobe.mdx
+++ b/docs-v2/integrations/all/adobe.mdx
@@ -11,7 +11,7 @@ API Configuration: [`adobe`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/amazon.mdx
+++ b/docs-v2/integrations/all/amazon.mdx
@@ -11,7 +11,7 @@ API Configuration: [`amazon`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/atlassian.mdx
+++ b/docs-v2/integrations/all/atlassian.mdx
@@ -11,7 +11,7 @@ API Configuration: [`atlassian`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/bamboohr.mdx
+++ b/docs-v2/integrations/all/bamboohr.mdx
@@ -11,7 +11,7 @@ API Configuration: [`bambookhr`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/battlenet.mdx
+++ b/docs-v2/integrations/all/battlenet.mdx
@@ -11,7 +11,7 @@ API Configuration: [`battlenet`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/bitbucket.mdx
+++ b/docs-v2/integrations/all/bitbucket.mdx
@@ -11,7 +11,7 @@ API Configuration: [`bitbucket`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/boldsign.mdx
+++ b/docs-v2/integrations/all/boldsign.mdx
@@ -11,7 +11,7 @@ API Configuration: [`boldsign`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/box.mdx
+++ b/docs-v2/integrations/all/box.mdx
@@ -11,7 +11,7 @@ API Configuration: [`box`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/braintree.mdx
+++ b/docs-v2/integrations/all/braintree.mdx
@@ -11,7 +11,7 @@ API Configurations: [`braintree`](https://nango.dev/providers.yaml), [`braintree
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/brex.mdx
+++ b/docs-v2/integrations/all/brex.mdx
@@ -11,7 +11,7 @@ API Configurations: [`brex`](https://nango.dev/providers.yaml), [`brex-staging`]
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/calendly.mdx
+++ b/docs-v2/integrations/all/calendly.mdx
@@ -11,7 +11,7 @@ API Configuration: [`calendly`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/clickup.mdx
+++ b/docs-v2/integrations/all/clickup.mdx
@@ -11,7 +11,7 @@ API Configuration: [`clickup`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/confluence.mdx
+++ b/docs-v2/integrations/all/confluence.mdx
@@ -11,7 +11,7 @@ API Configuration: [`confluence`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/contentstack.mdx
+++ b/docs-v2/integrations/all/contentstack.mdx
@@ -11,7 +11,7 @@ API Configuration: [`contentstack`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/deel.mdx
+++ b/docs-v2/integrations/all/deel.mdx
@@ -11,7 +11,7 @@ API Configurations: [`deel`](https://nango.dev/providers.yaml), [`deel-sandbox`]
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/digitalocean.mdx
+++ b/docs-v2/integrations/all/digitalocean.mdx
@@ -11,7 +11,7 @@ API Configuration: [`digitalocean`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/discord.mdx
+++ b/docs-v2/integrations/all/discord.mdx
@@ -11,7 +11,7 @@ API Configuration: [`discord`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/docusign.mdx
+++ b/docs-v2/integrations/all/docusign.mdx
@@ -11,7 +11,7 @@ API Configuration: [`docusign`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/dropbox.mdx
+++ b/docs-v2/integrations/all/dropbox.mdx
@@ -11,7 +11,7 @@ API Configuration: [`dropbox`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/epic-games.mdx
+++ b/docs-v2/integrations/all/epic-games.mdx
@@ -11,7 +11,7 @@ API Configuration: [`epic-games`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/facebook.mdx
+++ b/docs-v2/integrations/all/facebook.mdx
@@ -11,7 +11,7 @@ API Configuration: [`facebook`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/factorial.mdx
+++ b/docs-v2/integrations/all/factorial.mdx
@@ -11,7 +11,7 @@ API Configuration: [`factorial`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/figjam.mdx
+++ b/docs-v2/integrations/all/figjam.mdx
@@ -11,7 +11,7 @@ API Configuration: [`figjam`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/figma.mdx
+++ b/docs-v2/integrations/all/figma.mdx
@@ -11,7 +11,7 @@ API Configuration: [`figma`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/fitbit.mdx
+++ b/docs-v2/integrations/all/fitbit.mdx
@@ -11,7 +11,7 @@ API Configuration: [`fitbit`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/freshbooks.mdx
+++ b/docs-v2/integrations/all/freshbooks.mdx
@@ -11,7 +11,7 @@ API Configuration: [`freshbooks`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/front.mdx
+++ b/docs-v2/integrations/all/front.mdx
@@ -11,7 +11,7 @@ API Configuration: [`front`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/gitlab.mdx
+++ b/docs-v2/integrations/all/gitlab.mdx
@@ -11,7 +11,7 @@ API Configuration: [`gitlab`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/google.mdx
+++ b/docs-v2/integrations/all/google.mdx
@@ -11,7 +11,7 @@ API Configuration: [`google`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/gorgias.mdx
+++ b/docs-v2/integrations/all/gorgias.mdx
@@ -11,7 +11,7 @@ API Configuration: [`gorgias`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/greenhouse.mdx
+++ b/docs-v2/integrations/all/greenhouse.mdx
@@ -11,7 +11,7 @@ API Configuration: [`greenhouse`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/gusto.mdx
+++ b/docs-v2/integrations/all/gusto.mdx
@@ -11,7 +11,7 @@ API Configuration: [`gusto`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/healthgorilla.mdx
+++ b/docs-v2/integrations/all/healthgorilla.mdx
@@ -11,7 +11,7 @@ API Configuration: [`healthgorilla`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/instagram.mdx
+++ b/docs-v2/integrations/all/instagram.mdx
@@ -11,7 +11,7 @@ API Configuration: [`instagram`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/intercom.mdx
+++ b/docs-v2/integrations/all/intercom.mdx
@@ -11,7 +11,7 @@ API Configuration: [`intercom`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/intuit.mdx
+++ b/docs-v2/integrations/all/intuit.mdx
@@ -11,7 +11,7 @@ API Configuration: [`intuit`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/jira.mdx
+++ b/docs-v2/integrations/all/jira.mdx
@@ -11,7 +11,7 @@ API Configuration: [`jira`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/keap.mdx
+++ b/docs-v2/integrations/all/keap.mdx
@@ -11,7 +11,7 @@ API Configuration: [`keap`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/lever.mdx
+++ b/docs-v2/integrations/all/lever.mdx
@@ -11,7 +11,7 @@ API Configuration: [`lever`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/linear.mdx
+++ b/docs-v2/integrations/all/linear.mdx
@@ -11,7 +11,7 @@ API Configuration: [`linear`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/linkedin.mdx
+++ b/docs-v2/integrations/all/linkedin.mdx
@@ -11,7 +11,7 @@ API Configuration: [`linkedin`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/mailchimp.mdx
+++ b/docs-v2/integrations/all/mailchimp.mdx
@@ -11,7 +11,7 @@ API Configuration: [`mailchimp`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/microsoft-teams.mdx
+++ b/docs-v2/integrations/all/microsoft-teams.mdx
@@ -11,7 +11,7 @@ API Configuration: [`microsoft-teams`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/miro.mdx
+++ b/docs-v2/integrations/all/miro.mdx
@@ -11,7 +11,7 @@ API Configuration: [`miro`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/monday.mdx
+++ b/docs-v2/integrations/all/monday.mdx
@@ -11,7 +11,7 @@ API Configuration: [`monday`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/mural.mdx
+++ b/docs-v2/integrations/all/mural.mdx
@@ -11,7 +11,7 @@ API Configuration: [`mural`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/one-drive.mdx
+++ b/docs-v2/integrations/all/one-drive.mdx
@@ -11,7 +11,7 @@ API Configuration: [`one-drive`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/osu.mdx
+++ b/docs-v2/integrations/all/osu.mdx
@@ -11,7 +11,7 @@ API Configuration: [`osu`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/outreach.mdx
+++ b/docs-v2/integrations/all/outreach.mdx
@@ -11,7 +11,7 @@ API Configuration: [`outreach`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/pagerduty.mdx
+++ b/docs-v2/integrations/all/pagerduty.mdx
@@ -11,7 +11,7 @@ API Configuration: [`pagerduty`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/pandadoc.mdx
+++ b/docs-v2/integrations/all/pandadoc.mdx
@@ -11,7 +11,7 @@ API Configuration: [`pandadoc`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/payfit.mdx
+++ b/docs-v2/integrations/all/payfit.mdx
@@ -11,7 +11,7 @@ API Configuration: [`payfit`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/pipedrive.mdx
+++ b/docs-v2/integrations/all/pipedrive.mdx
@@ -11,7 +11,7 @@ API Configuration: [`pipedrive`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/qualtrics.mdx
+++ b/docs-v2/integrations/all/qualtrics.mdx
@@ -11,7 +11,7 @@ API Configuration: [`qualtrics`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/quickbooks.mdx
+++ b/docs-v2/integrations/all/quickbooks.mdx
@@ -11,7 +11,7 @@ API Configuration: [`quickbooks`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/ramp.mdx
+++ b/docs-v2/integrations/all/ramp.mdx
@@ -11,7 +11,7 @@ API Configurations: [`ramp`](https://nango.dev/providers.yaml), [`ramp-sandbox`]
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/reddit.mdx
+++ b/docs-v2/integrations/all/reddit.mdx
@@ -11,7 +11,7 @@ API Configuration: [`reddit`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/sage.mdx
+++ b/docs-v2/integrations/all/sage.mdx
@@ -11,7 +11,7 @@ API Configuration: [`sage`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/salesforce.mdx
+++ b/docs-v2/integrations/all/salesforce.mdx
@@ -11,7 +11,7 @@ API Configuration: [`salesforce`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/salesloft.mdx
+++ b/docs-v2/integrations/all/salesloft.mdx
@@ -11,7 +11,7 @@ API Configuration: [`salesloft`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/segment.mdx
+++ b/docs-v2/integrations/all/segment.mdx
@@ -11,7 +11,7 @@ API Configuration: [`segment`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/shopify.mdx
+++ b/docs-v2/integrations/all/shopify.mdx
@@ -13,7 +13,7 @@ API Configuration: [`shopify`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/smugmug.mdx
+++ b/docs-v2/integrations/all/smugmug.mdx
@@ -11,7 +11,7 @@ API Configuration: [`smugsmug`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/splitwise.mdx
+++ b/docs-v2/integrations/all/splitwise.mdx
@@ -11,7 +11,7 @@ API Configuration: [`splitwise`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/spotify.mdx
+++ b/docs-v2/integrations/all/spotify.mdx
@@ -11,7 +11,7 @@ API Configuration: [`spotify`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/squareup.mdx
+++ b/docs-v2/integrations/all/squareup.mdx
@@ -11,7 +11,7 @@ API Configuration: [`squareup`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/stackexchange.mdx
+++ b/docs-v2/integrations/all/stackexchange.mdx
@@ -11,7 +11,7 @@ API Configuration: [`stackexchange`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/strava.mdx
+++ b/docs-v2/integrations/all/strava.mdx
@@ -11,7 +11,7 @@ API Configuration: [`strava`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/stripe.mdx
+++ b/docs-v2/integrations/all/stripe.mdx
@@ -11,7 +11,7 @@ API Configuration: [`stripe`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/survey-monkey.mdx
+++ b/docs-v2/integrations/all/survey-monkey.mdx
@@ -11,7 +11,7 @@ API Configuration: [`survey-monkey`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | 🚫                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/teamwork.mdx
+++ b/docs-v2/integrations/all/teamwork.mdx
@@ -11,7 +11,7 @@ API Configuration: [`teamwork`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/tiktok.mdx
+++ b/docs-v2/integrations/all/tiktok.mdx
@@ -11,7 +11,7 @@ API Configuration: [`tiktok`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/todoist.mdx
+++ b/docs-v2/integrations/all/todoist.mdx
@@ -11,7 +11,7 @@ API Configuration: [`todoist`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/trello.mdx
+++ b/docs-v2/integrations/all/trello.mdx
@@ -11,7 +11,7 @@ API Configuration: [`trello`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/twinfield.mdx
+++ b/docs-v2/integrations/all/twinfield.mdx
@@ -11,7 +11,7 @@ API Configuration: [`twinfield`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/twitch.mdx
+++ b/docs-v2/integrations/all/twitch.mdx
@@ -11,7 +11,7 @@ API Configuration: [`twitch`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/twitter.mdx
+++ b/docs-v2/integrations/all/twitter.mdx
@@ -11,7 +11,7 @@ API Configurations: [`twitter`](https://nango.dev/providers.yaml) for OAuth1, [`
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/typeform.mdx
+++ b/docs-v2/integrations/all/typeform.mdx
@@ -11,7 +11,7 @@ API Configuration: [`typeform`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/uber.mdx
+++ b/docs-v2/integrations/all/uber.mdx
@@ -11,7 +11,7 @@ API Configuration: [`uber`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/wakatime.mdx
+++ b/docs-v2/integrations/all/wakatime.mdx
@@ -11,7 +11,7 @@ API Configuration: [`wakatime`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/wave-accounting.mdx
+++ b/docs-v2/integrations/all/wave-accounting.mdx
@@ -11,7 +11,7 @@ API Configuration: [`wave-accounting`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/xero.mdx
+++ b/docs-v2/integrations/all/xero.mdx
@@ -11,7 +11,7 @@ API Configuration: [`xero`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/yahoo.mdx
+++ b/docs-v2/integrations/all/yahoo.mdx
@@ -11,7 +11,7 @@ API Configuration: [`yahoo`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/yandex.mdx
+++ b/docs-v2/integrations/all/yandex.mdx
@@ -11,7 +11,7 @@ API Configuration: [`yandex`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/youtube.mdx
+++ b/docs-v2/integrations/all/youtube.mdx
@@ -11,7 +11,7 @@ API Configuration: [`youtube`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/zapier-nla.mdx
+++ b/docs-v2/integrations/all/zapier-nla.mdx
@@ -11,7 +11,7 @@ API Configuration: [`zapier-nla`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/zendesk.mdx
+++ b/docs-v2/integrations/all/zendesk.mdx
@@ -19,7 +19,7 @@ Nango currently only supports OAuth for the Helpdesk apps. If you need the CRM o
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/zenefits.mdx
+++ b/docs-v2/integrations/all/zenefits.mdx
@@ -11,7 +11,7 @@ API Configuration: [`zenefits`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/zoho-books.mdx
+++ b/docs-v2/integrations/all/zoho-books.mdx
@@ -11,7 +11,7 @@ API Configuration: [`zoho-books`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/zoho-crm.mdx
+++ b/docs-v2/integrations/all/zoho-crm.mdx
@@ -11,7 +11,7 @@ API Configuration: [`zoho-crm`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/zoho-desk.mdx
+++ b/docs-v2/integrations/all/zoho-desk.mdx
@@ -11,7 +11,7 @@ API Configuration: [`zoho-desk`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/zoho-invoice.mdx
+++ b/docs-v2/integrations/all/zoho-invoice.mdx
@@ -11,7 +11,7 @@ API Configuration: [`zoho-invoice`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 

--- a/docs-v2/integrations/all/zoom.mdx
+++ b/docs-v2/integrations/all/zoom.mdx
@@ -11,7 +11,7 @@ API Configuration: [`zoom`](https://nango.dev/providers.yaml)
 | -------------------------------------------------------------------------------- | ------------------------------- |
 | [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
 | [Sync](/guides/sync)                                                              | ✅                              |
-| [Nango Proxy](/guides/proxy)                          | 🚫 (time to contribute: &lt;1h) |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
 | [Auto-pagination](/nango-sync/configuration#auto-pagination)                     | 🚫 (time to contribute: &lt;1h) |
 | [API-specific rate limits](/nango-sync/configuration#rate-limits-retry-policies) | 🚫 (time to contribute: &lt;1h) |
 


### PR DESCRIPTION
The Proxy is supported for all integrations, it just needs the `baseUrlOverride` parameter in the Node SDK when `base_api_url` is not set in the `providers.yaml`. 