### PR TITLE
Fix contribute tutorial

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,90 @@
+version: '3.9'
+services:
+    nango-db:
+        image: postgres
+        container_name: nango-db
+        environment:
+            POSTGRES_PASSWORD: nango
+            POSTGRES_USER: nango
+            POSTGRES_DB: nango
+        ports:
+            - '${NANGO_DB_PORT:-5432}:5432'
+        volumes:
+            - ./nango-data:/var/lib/postgresql/data
+        networks:
+            - nango
+
+    nango-server:
+        image: nangohq/nango-server
+        container_name: nango-server
+        environment:
+            - TEMPORAL_ADDRESS=temporal:7233
+            - NANGO_DB_MIGRATION_FOLDER=/usr/nango-server/src/packages/shared/lib/db/migrations
+            - NANGO_SECRET_KEY=${NANGO_SECRET_KEY}
+            - NANGO_ENCRYPTION_KEY=${NANGO_ENCRYPTION_KEY}
+            - NANGO_DB_USER=${NANGO_DB_USER}
+            - NANGO_DB_PASSWORD=${NANGO_DB_PASSWORD}
+            - NANGO_DB_HOST=${NANGO_DB_HOST}
+            - NANGO_DB_NAME=${NANGO_DB_NAME}
+            - NANGO_DB_SSL=${NANGO_DB_SSL}
+            - NANGO_DB_POOL_MIN=${NANGO_DB_POOL_MIN}
+            - NANGO_DB_POOL_MAX=${NANGO_DB_POOL_MAX}
+            - SERVER_PORT=${SERVER_PORT}
+            - NANGO_SERVER_URL=${NANGO_SERVER_URL:-http://localhost:3003}
+            - NANGO_CALLBACK_URL=${NANGO_CALLBACK_URL}
+            - NANGO_DASHBOARD_USERNAME=${NANGO_DASHBOARD_USERNAME}
+            - NANGO_DASHBOARD_PASSWORD=${NANGO_DASHBOARD_PASSWORD}
+            - LOG_LEVEL=${LOG_LEVEL:-info}
+            - TELEMETRY=${TELEMETRY}
+            - NANGO_HMAC_ENABLED=${NANGO_HMAC_ENABLED}
+            - NANGO_HMAC_ALGORITHM=${NANGO_HMAC_ALGORITHM}
+            - NANGO_HMAC_KEY=${NANGO_HMAC_KEY}
+        volumes:
+            - './packages/shared/providers.yaml:/usr/nango-server/src/packages/shared/providers.yaml'
+        restart: always
+        ports:
+            - '${SERVER_PORT:-3003}:${SERVER_PORT:-3003}'
+        depends_on:
+            - nango-db
+        networks:
+            - nango
+
+    nango-worker:
+        image: nangohq/nango-worker
+        container_name: nango-worker
+        restart: always
+        ports:
+            - '${WORKER_PORT:-3004}:${WORKER_PORT:-3004}'
+        environment:
+            - TEMPORAL_ADDRESS=temporal:7233
+            - NANGO_SECRET_KEY=${NANGO_SECRET_KEY}
+            - NANGO_ENCRYPTION_KEY=${NANGO_ENCRYPTION_KEY}
+            - NANGO_DB_USER=${NANGO_DB_USER}
+            - NANGO_DB_PASSWORD=${NANGO_DB_PASSWORD}
+            - NANGO_DB_HOST=${NANGO_DB_HOST}
+            - NANGO_DB_NAME=${NANGO_DB_NAME}
+            - NANGO_DB_SSL=${NANGO_DB_SSL}
+        depends_on:
+            - nango-db
+            - temporal
+        networks:
+            - nango
+
+    temporal:
+        image: temporalio/auto-setup
+        container_name: temporal
+        depends_on:
+            - nango-db
+        environment:
+            - DB=postgresql
+            - DB_PORT=5432
+            - POSTGRES_USER=nango
+            - POSTGRES_PWD=nango
+            - POSTGRES_SEEDS=nango-db
+        ports:
+            - 7233:7233
+        networks:
+            - nango
+
+networks:
+    nango:

--- a/docs-v2/contribute.mdx
+++ b/docs-v2/contribute.mdx
@@ -1,18 +1,18 @@
 ---
 title: 'Add an API'
 sidebarTitle: 'Add an API'
-description: 'Contribute a new API Configuration. It is fast and easy!'
+description: 'Make Nango compatible with any new API in minutes!'
 ---
 
 ## How API Configurations work in Nango
 
-You can make Nango compatible with any new API in minutes! All it takes is to contribute a new API Configuration, and all Nango users will be able to start building integrations for this API.
+Contributing a new API Configuration means Nango users will be able to build integrations for this API.
 
-The only required part of the configuration is related to authentication. The rest of the configuration is optional and simplifies the process of building integrations for this API (e.g. helpers for proxying requests, paginating, handling rate limits).
+The only required part of the configuration is related to authentication. The rest is optional and optimizes the developer experience of building integrations for this API (e.g. Proxy default base URL, pagination helper, rate-limit helper).
 
 API Configurations take the form of short YAML entries, living in a single file called [providers.yaml](https://nango.dev/providers.yaml). Most API Configurations only need to make use of 2-3 configuration keys, but in some cases you might need more.
 
-The most commonly used configuration options are:
+## API Configuration options
 
 ```yaml
 provider-slug: # Shorthand for the provider, ideally the provider's name. Must be unique. Kebab case.
@@ -52,57 +52,32 @@ provider-slug: # Shorthand for the provider, ideally the provider's name. Must b
 ### Step 1: Add your new provider to `providers.yaml`
 
 Fork the repo and edit the [providers.yaml](https://nango.dev/providers.yaml) file as explained
-above to add support for the new provider. The API documentation should contain
-all the details you need on the OAuth flow to complete this step.
+above to add support for the new API.
 
 ### Step 2: Test your new provider
 
 <Tip>
-Some OAuth providers are very restrictive with callback URIs and require https
-or don't allow `localhost` as a domain/URL. This can make it very hard to test
-things locally.
-
-The easiest workaround we found is to use this simple service:
-[https://redirectmeto.com](https://redirectmeto.com/).
-
-With this the Nango localhost callback URL becomes
-`https://redirectmeto.com/http://localhost:3003/oauth/callback` and you will
-need to update the `NANGO_CALLBACK_URL` in the `.env` file:
-
+Some APIs require `https` or forbid `localhost` in the callback URL, which makes local development harder. A workaround is to use [https://redirectmeto.com](https://redirectmeto.com/). In this case, edit the `.env` file with your new (local) callback URL:
 ```bash
 NANGO_CALLBACK_URL=https://redirectmeto.com/http://localhost:3003/oauth/callback
 ```
-
 </Tip>
 
-To test your new provider:
-
-Start the docker containers:
-
-<Tip>
-    We recommend you install nango globally via the command
-    ```bash
-    npm install nango -g
-    ```
-</Tip>
+To test your new provider, go to the `nango` folder root and run:
 
 ```bash
-nango start # Keep the tab open.
+docker compose up
 ```
-
-<Tip>
-To propagate your changes after editing the `providers.yaml` file, kill the tab (or press `Ctrl` + `c`), then rerun `nango start`.
-</Tip>
 
 When you are ready to test your new API Configuration:
 
-**1\. Add your client credentials to the local Nango Server**
+**Add your client credentials to the local Nango Server**
 
 Open the [local Dashboard](http://localhost:3003) in your browser and add a new
 [Integration](/core-concepts#integrations) with your freshly added provider (it should show up in the provider
 dropdown).
 
-**2\. Trigger the OAuth Flow**
+**Trigger the OAuth Flow**
 
 Run an OAuth flow on the
 [local Dashboard](http://localhost:3003/connection/create).
@@ -110,7 +85,7 @@ Run an OAuth flow on the
 You can modify the ports in the docker compose if there are any conflicts with
 other local services on your host machine.
 
-**3\. Check the access token in the dashboard**
+**Check the access token in the dashboard**
 
 If all goes well you should see your new Connection in the
 [Connections tab](http://localhost:3003/connections) in the dashboard.


### PR DESCRIPTION
Detected following a thread with a contributor struggling to run the `/contribute` tutorial [on the community](https://nango-community.slack.com/archives/C04ABR352H0/p1688561037848479).

The `/contrbiute` docs tutorial was broken because it uses the CLI's `docker-compose.yaml` file which does no link to the local `providers.yaml` file. So editing the `providers.yaml` would not be reflected when running `nango start`. 

In general, I think we should remove Docker-related capabilities from the nango CLI. This separates concerns nicely: 
- The CLI is used by non-contributors and doesn't need to know about Docker
- Contributors download the `nango` folder and run Docker commands directly, without the help of the CLI

I re-introduced the `nango` folder root-level `docker-compose.yaml`, linked to the local `providers.yaml` file, and edited the `/contibute` tutorial accordingly. 