### PR TITLE
[gh-#791] await initiate and return null if sync exists

### DIFF
--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -707,7 +707,7 @@ class OAuthController {
 
             if (updatedConnection) {
                 const syncClient = await SyncClient.getInstance();
-                syncClient?.initiate(updatedConnection.id);
+                await syncClient?.initiate(updatedConnection.id);
             }
 
             await updateSuccessActivityLog(activityLogId, true);

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -43,7 +43,7 @@ export const createSync = async (nangoConnectionId: number, name: string): Promi
     const existingSync = await getSyncByIdAndName(nangoConnectionId, name);
 
     if (existingSync) {
-        throw new Error(`Sync with name ${name} already exists. Please reach out to support to report this issue.`);
+        return null;
     }
 
     const sync: Sync = {


### PR DESCRIPTION
@bastienbeurier figured out this dupe issue.

If a connection id is created again that has the same string already it would initiate another sync because the oauth flow was initiated again. This PR checks for an existing sync and returns null if it already exists so another sync isn't initiated.

Remaining item is to stop and delete some duplicate syncs that exist in the system now.