### PR TITLE
dropbox requires token_access_type=offline for refresh token

### DIFF
--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -192,6 +192,8 @@ dropbox:
     auth_mode: OAUTH2
     authorization_url: https://www.dropbox.com/oauth2/authorize
     token_url: https://api.dropboxapi.com/oauth2/token
+    authorization_params:
+        token_access_type: offline
 docusign:
     auth_mode: OAUTH2
     authorization_url: https://account.docusign.com/oauth/auth


### PR DESCRIPTION
Hi!

I noticed today that the dropbox integration is not using a refresh token. According to the [Dropbox API documentation](https://www.dropbox.com/developers/documentation/http/documentation#oauth2-token:~:text=token_access_type%20String%3F,to%20online.), authorization requests must be made with `token_access_type=offline` to work. 

Specifically, in their [oauth guide](https://developers.dropbox.com/oauth-guide):

> Note: you’ll need to include token_access_type=offline as a parameter on your Authorization URL in order to return a refresh_token inside your access token payload.

I confirmed that, with the current `providers.yaml` config for dropbox, requests of the form `http://localhost:3003/connection/test-connection-id3?provider_config_key=dropbox-development&refresh_token=true&force_refresh=true` return no refresh_token.

The google API has a very similar setup, where it requires an offline parameter in authorization, so I referred to it's configuration, and added these two lines to the dropbox `providers.yaml` config:

```yaml
authorization_params:
        token_access_type: offline
```

I tested Dropbox with this updated `providers.yaml` locally, I got back a refresh token:
```json
{
    "id": 57,
    "created_at": "2023-07-19T05:56:40.986Z",
    "updated_at": "2023-07-19T05:56:40.986Z",
    "provider_config_key": "dropbox-development",
    "connection_id": "test-connection-id3",
    "credentials": {
        "type": "OAUTH2",
        "access_token": "BLAH",
        "refresh_token": "this is now showing something",
        "expires_at": "2023-07-19T09:57:27.026Z",
        "raw": {
            "access_token": "BLAH",
            "token_type": "bearer",
            "expires_in": 14400,
            "expires_at": "2023-07-19T09:57:27.026Z"
        }
    },
    "connection_config": {},
    "account_id": 0,
    "metadata": {},
    "credentials_iv": null,
    "credentials_tag": null
}
```

Furthermore, the expiry is refreshing now.