### PR TITLE
Document `init` `dev` `generate` commands better in docs

### DIFF
--- a/docs-v2/core-concepts.mdx
+++ b/docs-v2/core-concepts.mdx
@@ -126,3 +126,14 @@ Nango's infrastructure consists of the following components, that we see compani
 -   SDKs, REST API & webhooks to access the data sync from external APIs
 -   Admin console to manage & observe integrations
 -   REST API to manage integrations programmatically
+
+## CLI Commands
+
+### `init`
+The `init` command is the first optional command you run when setting up Nango. It sets up the Nango environment for your project. For more details, refer to the [CLI documentation](/sdks/cli).
+
+### `dev`
+The `dev` command is the fundamental command for developing on Nango. It watches over your project files and builds the necessary output for Nango to run. For more details, refer to the [CLI documentation](/sdks/cli).
+
+### `generate`
+The `generate` command is an optional helper command that generates initial scaffolds for sync scripts. For more details, refer to the [CLI documentation](/sdks/cli).

--- a/docs-v2/sdks/cli.mdx
+++ b/docs-v2/sdks/cli.mdx
@@ -78,5 +78,3 @@ NANGO_CLI_UPGRADE_MODE=prompt # Default value
 
 # Whether to prompt before deployments.
 NANGO_DEPLOY_AUTO_CONFIRM=false # Default value
-```
-NANGO_DEPLOY_AUTO_CONFIRM=false # Default value

--- a/docs-v2/sdks/cli.mdx
+++ b/docs-v2/sdks/cli.mdx
@@ -78,3 +78,5 @@ NANGO_CLI_UPGRADE_MODE=prompt # Default value
 
 # Whether to prompt before deployments.
 NANGO_DEPLOY_AUTO_CONFIRM=false # Default value
+```
+NANGO_DEPLOY_AUTO_CONFIRM=false # Default value

--- a/docs-v2/sdks/cli.mdx
+++ b/docs-v2/sdks/cli.mdx
@@ -42,6 +42,17 @@ Get details about a specific command by running:
 nango [command] --help
 ```
 
+## Command Details
+
+### `init`
+The `init` command is the first optional command you run when setting up Nango. It creates a `nango-integrations` directory and adds files for the example Github integration. However, it does not create a `dist/*` folder. It should be used to initialize Nango.
+
+### `dev`
+The `dev` command is the fundamental and mandatory command for developing on Nango. It watches over `nango.yaml` to generate the `models.ts` file (both model interfaces + sync helper classes) and watches over sync scripts to build the `dist/*` folder. It should not generate nor edit sync script .ts files. It should be used during the development process.
+
+### `generate`
+The `generate` command is an optional helper command that generates initial scaffolds for sync scripts (once). To do so, it also needs to (redundantly with `dev`) generate the `models.ts` file. It should be used to generate initial scaffolds for sync scripts and the `models.ts` file.
+
 ## Flags & environment variables
 
 Global command flags:
@@ -67,5 +78,3 @@ NANGO_CLI_UPGRADE_MODE=prompt # Default value
 
 # Whether to prompt before deployments.
 NANGO_DEPLOY_AUTO_CONFIRM=false # Default value
-```
-

--- a/docs-v2/sdks/cli.mdx
+++ b/docs-v2/sdks/cli.mdx
@@ -79,3 +79,4 @@ NANGO_CLI_UPGRADE_MODE=prompt # Default value
 # Whether to prompt before deployments.
 NANGO_DEPLOY_AUTO_CONFIRM=false # Default value
 ```
+

--- a/docs-v2/sdks/cli.mdx
+++ b/docs-v2/sdks/cli.mdx
@@ -78,3 +78,4 @@ NANGO_CLI_UPGRADE_MODE=prompt # Default value
 
 # Whether to prompt before deployments.
 NANGO_DEPLOY_AUTO_CONFIRM=false # Default value
+```


### PR DESCRIPTION
This PR was copied from sweepai-dev#5 and generated by [Sweep](https://github.com/sweepai/sweep).
Resolves #828.

---
## Description
This PR updates the documentation to provide clearer and more detailed explanations of the `init`, `dev`, and `generate` commands in the Nango CLI.

## Changes Made
- Updated `cli.mdx` file in the `docs-v2/sdks` directory to include detailed explanations of the `init`, `dev`, and `generate` commands. Each command is described in terms of its functionality, the files it creates or modifies, and when it should be used.
- Added a new section in the `core-concepts.mdx` file in the `docs-v2` directory to provide an overview of the `init`, `dev`, and `generate` commands and their role in the Nango framework.