### PR TITLE
Added Owner and User sync for Hubspot

### DIFF
--- a/integration-templates/hubspot/hubspot-owner.ts
+++ b/integration-templates/hubspot/hubspot-owner.ts
@@ -1,0 +1,55 @@
+import type { NangoSync, HubspotOwner } from './models';
+
+interface Params {
+    limit: string;
+    [key: string]: any; // Allows additional properties
+}
+
+export default async function fetchData(nango: NangoSync): Promise<{HubspotOwner: HubspotOwner[]}> {
+    const MAX_PAGE = 100;
+
+    let page = 1;
+    let afterLink = null;
+
+    while (true) {
+        let payload = {
+            endpoint: '/crm/v3/owners',
+            params: {
+                limit: `${MAX_PAGE}`,
+            } as Params,
+        }
+
+        if ( ! afterLink) { // If there is no afterLink, then we are on the first page.
+            payload.params['after'] = afterLink;
+        }
+
+        const response = await nango.get(payload);
+
+        let pageData = response.data.results;
+
+        const mappedOwners: HubspotOwner[] = pageData.map((owner: HubspotOwner) => ({
+            id: owner.id,
+            email: owner.email,
+            firstName: owner.firstName,
+            lastName: owner.lastName,
+            userId: owner.userId,
+            createdAt: owner.createdAt,
+            updatedAt: owner.updatedAt,
+            archived: owner.archived,
+        }));
+
+        if (mappedOwners.length > 0) {
+            await nango.batchSave<HubspotOwner>(mappedOwners, 'HubspotOwner');
+            await nango.log(`Sent ${mappedOwners.length} owners`);
+        }
+
+        if (response.data.length == MAX_PAGE) {
+            page += 1;
+            afterLink = response.data.paging.next.after;
+        } else {
+            break;
+        }
+    }
+
+    return { HubspotOwner: [] }; // This returns an empty array
+}

--- a/integration-templates/hubspot/hubspot-user.ts
+++ b/integration-templates/hubspot/hubspot-user.ts
@@ -1,0 +1,52 @@
+import type { NangoSync, HubspotUser } from './models';
+
+interface Params {
+    limit: string;
+    [key: string]: any; // Allows additional properties such as the 'after' property
+}
+
+export default async function fetchData(nango: NangoSync): Promise<{HubspotUser: HubspotUser[]}> {
+    const MAX_PAGE = 100;
+
+    let page = 1;
+    let afterLink = null;
+
+    while (true) {
+        let payload = {
+            endpoint: '/settings/v3/users',
+            params: {
+                limit: `${MAX_PAGE}`,
+            } as Params,
+        }
+
+        if ( ! afterLink) { // If there is no afterLink, then we are on the first page.
+            payload.params['after'] = afterLink;
+        }
+
+        const response = await nango.get(payload);
+
+        let pageData = response.data.results;
+
+        const mappedUsers: HubspotUser[] = pageData.map((owner: HubspotUser) => ({
+            id: owner.id,
+            email: owner.email,
+            roleId: owner.roleId,
+            primaryTeamId: owner.primaryTeamId,
+            superAdmin: owner.superAdmin,
+        }));
+
+        if (mappedUsers.length > 0) {
+            await nango.batchSave<HubspotUser>(mappedUsers, 'HubspotUser');
+            await nango.log(`Sent ${mappedUsers.length} users`);
+        }
+
+        if (response.data.length == MAX_PAGE) {
+            page += 1;
+            afterLink = response.data.paging.next.after;
+        } else {
+            break;
+        }
+    }
+
+    return { HubspotUser: [] };
+}

--- a/integration-templates/hubspot/nango.yaml
+++ b/integration-templates/hubspot/nango.yaml
@@ -4,6 +4,14 @@ integrations:
       runs: every half hour
       returns:
         - HubspotServiceTicket
+    hubspot-owner:
+      runs: every day
+      returns:
+        - HubspotOwner
+    hubspot-user:
+      runs: every day
+      returns:
+        - HubspotUser
 
 models:
   HubspotServiceTicket:
@@ -19,3 +27,18 @@ models:
     pipelineStage: integer
     ticketCategory: string | null
     ticketPriority: string
+  HubspotOwner:
+    id: integer
+    email: string
+    firstName: string
+    lastName: string
+    userId: integer
+    createdAt: date
+    updatedAt: date
+    archived: boolean
+  HubspotUser:
+    id: integer
+    email: string
+    roleId: integer
+    primaryTeamId: integer
+    superAdmin: boolean


### PR DESCRIPTION
Tested in my Nango Dev environment;
```
nango deploy dev
Compiled "./hubspot-owner.ts" successfully
Compiled "./hubspot-service-ticket.ts" successfully
Compiled "./hubspot-user.ts" successfully
Compiled "./models.ts" successfully
{
  "newSyncs": [],
  "deletedSyncs": []
}
Do you want to continue y/n? y
Successfully deployed the syncs: hubspot-service-ticket@v4, hubspot-owner@v3, hubspot-user@v2!
```

Syncs have ran successfully after a manual trigger;
![Screenshot 2023-08-26 at 23 49 00](https://github.com/NangoHQ/nango/assets/528976/c7aceb52-907b-42f9-89b2-673da5514112)

