### PR TITLE
[gh-#930] add retry after header

### DIFF
--- a/packages/server/lib/controllers/proxy.controller.ts
+++ b/packages/server/lib/controllers/proxy.controller.ts
@@ -317,6 +317,7 @@ See https://docs.nango.dev/guides/proxy#proxy-requests for more information.`
         }
         if (
             error?.response?.status.toString().startsWith('5') ||
+            error?.response?.status === 403 ||
             error?.response?.status === 429 ||
             ['ECONNRESET', 'ETIMEDOUT', 'ECONNABORTED'].includes(error?.code as string)
         ) {

--- a/packages/shared/lib/models/Provider.ts
+++ b/packages/shared/lib/models/Provider.ts
@@ -21,6 +21,7 @@ export interface Template {
         query?: {
             api_key: string;
         };
+        retry_header?: string;
     };
     authorization_url: string;
     authorization_params?: Record<string, string>;

--- a/packages/shared/lib/models/Provider.ts
+++ b/packages/shared/lib/models/Provider.ts
@@ -21,7 +21,10 @@ export interface Template {
         query?: {
             api_key: string;
         };
-        retry_header?: string;
+        retry?: {
+            at?: string;
+            after?: string;
+        };
     };
     authorization_url: string;
     authorization_params?: Record<string, string>;

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -199,7 +199,8 @@ discord:
     authorization_params:
         response_type: code
     proxy:
-        retry_header: 'Retry-After'
+        retry:
+            after: 'Retry-After'
 dropbox:
     auth_mode: OAUTH2
     authorization_url: https://www.dropbox.com/oauth2/authorize
@@ -301,6 +302,8 @@ github:
     token_url: https://github.com/login/oauth/access_token
     proxy:
         base_url: https://api.github.com
+        retry:
+            at: 'x-ratelimit-reset'
     docs: https://docs.github.com/en/rest
 gitlab:
     auth_mode: OAUTH2

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -198,6 +198,8 @@ discord:
     token_url: https://discord.com/api/oauth2/token
     authorization_params:
         response_type: code
+    proxy:
+        retry_header: 'Retry-After'
 dropbox:
     auth_mode: OAUTH2
     authorization_url: https://www.dropbox.com/oauth2/authorize


### PR DESCRIPTION
Resolves #930 

# Retry Header
* Adds a `proxy.retry.at || proxy.retry.after` property to the providers.yaml
* During the retry logic the exponential backoff will first look for an existing `proxy.retry` property in the template and if it exists will wait for that parsed value before the exponential backoff
* Also adds `requestHeaders` and `responseHeaders` to the failed response