### PR TITLE
[Github #1026] slack webhook capture

### DIFF
--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -724,6 +724,8 @@ slack:
     auth_mode: OAUTH2
     authorization_url: https://slack.com/oauth/v2/authorize
     token_url: https://slack.com/api/oauth.v2.access
+    token_response_metadata:
+        - incoming_webhook.url
     proxy:
         base_url: https://slack.com/api
     docs: https://api.slack.com/apis


### PR DESCRIPTION
Resolves #1026

Adds:
- [x] Support for dot notation
- [x] Support for booleans
- [x] Additional tests

This was put in the `connectionConfig` with this in mind https://www.notion.so/nangohq/August-2023-Metadata-consolidation-edbfc7b8dab64cfea21ab60fce809299?pvs=4.

If the user wants to grab the content they can run a getConnection call and then grab the connection_config:

```
const connection = await nango.getConnection()
const url = connection.connection_config['webhhook.url']
```

<img width="1052" alt="image" src="https://github.com/NangoHQ/nango/assets/1724137/ed75554c-32a1-40a9-9af9-25f6c1a20172">
