### PR TITLE
[gh-#1040] Override auth params from nango.auth

### DIFF
--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -209,6 +209,8 @@ export default class Nango {
                 const val = connectionConfig.authorization_params[param];
                 if (typeof val === 'string') {
                     query.push(`authorization_params[${param}]=${val}`);
+                } else if (val === undefined) {
+                    query.push(`authorization_params[${param}]=undefined`);
                 }
             }
         }
@@ -221,7 +223,7 @@ interface ConnectionConfig {
     params: Record<string, string>;
     hmac?: string;
     user_scope?: string[];
-    authorization_params?: Record<string, string>;
+    authorization_params?: Record<string, string | undefined>;
     credentials?: BasicApiCredentials | ApiKeyCredentials;
 }
 

--- a/packages/server/lib/utils/utils.ts
+++ b/packages/server/lib/utils/utils.ts
@@ -62,8 +62,11 @@ export function missesInterpolationParam(str: string, replacers: Record<string, 
  * A helper function to extract the additional authorization parameters from the frontend Auth request.
  */
 export function getAdditionalAuthorizationParams(params: any): Record<string, string | undefined> {
-    let arr = Object.entries(params);
-    arr = arr.filter(([_, v]) => typeof v === 'string'); // Filter strings.
+    if (!params || typeof params !== 'object') {
+        return {};
+    }
+
+    let arr = Object.entries(params).filter(([_, v]) => typeof v === 'string'); // Filter strings
     let obj = Object.fromEntries(arr) as Record<string, string | undefined>;
     Object.keys(obj).forEach((key) => (obj[key] = obj[key] === 'undefined' ? undefined : obj[key])); // Detect undefined values to override template auth params.
     return obj;

--- a/packages/server/lib/utils/utils.ts
+++ b/packages/server/lib/utils/utils.ts
@@ -61,10 +61,12 @@ export function missesInterpolationParam(str: string, replacers: Record<string, 
 /**
  * A helper function to extract the additional authorization parameters from the frontend Auth request.
  */
-export function getAdditionalAuthorizationParams(params: any): Record<string, string> {
+export function getAdditionalAuthorizationParams(params: any): Record<string, string | undefined> {
     let arr = Object.entries(params);
-    arr = arr.filter(([_, v]) => typeof v === 'string'); // Filter strings
-    return Object.fromEntries(arr) as Record<string, string>;
+    arr = arr.filter(([_, v]) => typeof v === 'string'); // Filter strings.
+    let obj = Object.fromEntries(arr) as Record<string, string | undefined>;
+    Object.keys(obj).forEach((key) => (obj[key] = obj[key] === 'undefined' ? undefined : obj[key])); // Detect undefined values to override template auth params.
+    return obj;
 }
 
 /**

--- a/packages/server/lib/utils/utils.unit.test.ts
+++ b/packages/server/lib/utils/utils.unit.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from 'vitest';
-import { getConnectionMetadataFromTokenResponse, parseConnectionConfigParamsFromTemplate } from './utils.js';
+import { getConnectionMetadataFromTokenResponse, parseConnectionConfigParamsFromTemplate, getAdditionalAuthorizationParams } from './utils.js';
 import type { Template as ProviderTemplate } from '@nangohq/shared';
 
 describe('Utils unit tests', () => {
@@ -89,6 +89,54 @@ describe('Utils unit tests', () => {
         const params = {};
 
         const result = getConnectionMetadataFromTokenResponse(params, template);
+        expect(result).toEqual({});
+    });
+
+    it('Should return additional authorization params with string values only and preserve undefined values', () => {
+        const params = {
+            key1: 'value1',
+            key2: 123,
+            key3: true,
+            key4: 'undefined',
+            key5: 'value5'
+        };
+
+        const result = getAdditionalAuthorizationParams(params);
+        expect(result).toEqual({
+            key1: 'value1',
+            key4: undefined,
+            key5: 'value5'
+        });
+    });
+
+    it('Should return an empty object when no string values are present', () => {
+        const params = {
+            key1: 123,
+            key2: true
+        };
+
+        const result = getAdditionalAuthorizationParams(params);
+        expect(result).toEqual({});
+    });
+
+    it('Should handle an empty params object', () => {
+        const params = {};
+
+        const result = getAdditionalAuthorizationParams(params);
+        expect(result).toEqual({});
+    });
+
+    it('Should handle an non-object param', () => {
+        const params = "I'm not an object";
+
+        const result = getAdditionalAuthorizationParams(params);
+        expect(result).toEqual({});
+    });
+
+    it('Should handle a null & undefined param', () => {
+        let result = getAdditionalAuthorizationParams(null);
+        expect(result).toEqual({});
+        result = getAdditionalAuthorizationParams(undefined);
         expect(result).toEqual({});
     });
 });


### PR DESCRIPTION
Auth params defined in the `providers.yaml` templates can be overriden by the frontend `nango.auth` call. Template auth params can even be removed from the frontend, by setting the given param to `undefined`: 

```js
nango.auth('google', 'test-connection-id', { authorization_params: { prompt: undefined } });
```