### PR TITLE
Fix Salesforce articles SOQL query

### DIFF
--- a/integration-templates/salesforce/salesforce-articles.ts
+++ b/integration-templates/salesforce/salesforce-articles.ts
@@ -20,7 +20,7 @@ function buildQuery(customFields: string[], lastSyncDate?: Date): string {
     `;
 
     if (lastSyncDate) {
-        baseQuery += ` WHERE LastModifiedDate > ${lastSyncDate.toISOString()}`;
+        baseQuery += ` AND LastModifiedDate > ${lastSyncDate.toISOString()}`;
     }
 
     return baseQuery;


### PR DESCRIPTION
There were two `WHERE` clauses in the sample query.