### PR TITLE
[gh-#1036] unpause sync starts right away and adjusts the offset

### DIFF
--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -426,7 +426,7 @@ class SyncController {
             const activityLogId = await createActivityLog(log);
 
             const syncClient = await SyncClient.getInstance();
-            await syncClient?.runSyncCommand(schedule_id, sync_id, command, activityLogId as number);
+            await syncClient?.runSyncCommand(schedule_id, sync_id, command, activityLogId as number, environment.id);
             await updateScheduleStatus(schedule_id, command, activityLogId as number);
 
             await createActivityLogMessageAndEnd({

--- a/packages/shared/lib/clients/sync.client.ts
+++ b/packages/shared/lib/clients/sync.client.ts
@@ -16,7 +16,7 @@ import {
 import { createSyncJob, updateRunId } from '../services/sync/job.service.js';
 import { getInterval } from '../services/nango-config.service.js';
 import { getSyncConfig } from '../services/sync/config.service.js';
-import { createSchedule as createSyncSchedule } from '../services/sync/schedule.service.js';
+import { updateOffset, createSchedule as createSyncSchedule, getScheduleById } from '../services/sync/schedule.service.js';
 import connectionService from '../services/connection.service.js';
 import configService from '../services/config.service.js';
 import { createSync } from '../services/sync/sync.service.js';
@@ -345,7 +345,7 @@ class SyncClient {
         return schedules;
     }
 
-    async runSyncCommand(scheduleId: string, _syncId: string, command: SyncCommand, activityLogId: number) {
+    async runSyncCommand(scheduleId: string, _syncId: string, command: SyncCommand, activityLogId: number, environmentId: number) {
         const scheduleHandle = this.client?.schedule.getHandle(scheduleId);
 
         try {
@@ -368,7 +368,20 @@ class SyncClient {
                     }
                     break;
                 case SyncCommand.UNPAUSE:
-                    await scheduleHandle?.unpause();
+                    {
+                        await scheduleHandle?.unpause();
+                        await scheduleHandle?.trigger(OVERLAP_POLICY);
+                        const schedule = await getScheduleById(scheduleId);
+                        if (schedule) {
+                            const { frequency } = schedule;
+                            const { success, response } = getInterval(frequency, new Date());
+                            if (success && response) {
+                                const { offset } = response;
+                                await this.updateSyncSchedule(scheduleId, frequency, offset, environmentId);
+                                await updateOffset(scheduleId, offset);
+                            }
+                        }
+                    }
                     break;
                 case SyncCommand.RUN:
                     await scheduleHandle?.trigger(OVERLAP_POLICY);
@@ -455,7 +468,7 @@ class SyncClient {
         }
     }
 
-    async updateSyncSchedule(schedule_id: string, interval: string, offset: number, syncName: string, activityLogId: number, environmentId: number) {
+    async updateSyncSchedule(schedule_id: string, interval: string, offset: number, environmentId: number, syncName?: string, activityLogId?: number) {
         function updateFunction(scheduleDescription: ScheduleDescription) {
             scheduleDescription.spec = {
                 intervals: [
@@ -473,12 +486,14 @@ class SyncClient {
 
             await scheduleHandle?.update(updateFunction);
 
-            await createActivityLogMessage({
-                level: 'info',
-                activity_log_id: activityLogId as number,
-                content: `Updated sync "${syncName}" schedule "${schedule_id}" with interval ${interval} and offset ${offset}.`,
-                timestamp: Date.now()
-            });
+            if (activityLogId && syncName) {
+                await createActivityLogMessage({
+                    level: 'info',
+                    activity_log_id: activityLogId as number,
+                    content: `Updated sync "${syncName}" schedule "${schedule_id}" with interval ${interval} and offset ${offset}.`,
+                    timestamp: Date.now()
+                });
+            }
         } catch (e) {
             await errorManager.report(e, {
                 source: ErrorSourceEnum.PLATFORM,

--- a/packages/shared/lib/db/migrations/20230928133211_activity_log_session_id_index.cjs
+++ b/packages/shared/lib/db/migrations/20230928133211_activity_log_session_id_index.cjs
@@ -1,0 +1,14 @@
+const tableName = '_nango_activity_logs';
+
+exports.up = function (knex, _) {
+    return knex.schema.withSchema('nango').table(tableName, function (table) {
+        table.index('session_id');
+    });
+};
+
+exports.down = function (knex, _) {
+    return knex.schema.withSchema('nango').table(tableName, function (table) {
+        table.dropIndex('session_id');
+    });
+};
+

--- a/packages/shared/lib/services/activity/activity.service.ts
+++ b/packages/shared/lib/services/activity/activity.service.ts
@@ -7,6 +7,22 @@ import logger from '../../logger/console.js';
 const activityLogTableName = '_nango_activity_logs';
 const activityLogMessageTableName = '_nango_activity_log_messages';
 
+/**
+ * _nango_activity_logs
+ * _nango_activity_log_messages
+ * @desc Store activity logs for all user facing operations
+ *
+ * _nango_activity_logs:
+ *      index:
+ *          - environment_id
+ *          - session_id
+ *
+ * _nango_activity_log_messages:
+ *     index:
+ *          - activity_log_id: activity_log_id_index
+ *          - created_at: created_at_index
+ */
+
 export async function createActivityLog(log: ActivityLog): Promise<number | null> {
     if (!log.environment_id) {
         return null;

--- a/packages/shared/lib/services/nango-config.service.ts
+++ b/packages/shared/lib/services/nango-config.service.ts
@@ -199,6 +199,10 @@ export function getOffset(interval: string, date: Date): number {
 
     const offset = nowMilliseconds % intervalMilliseconds;
 
+    if (isNaN(offset)) {
+        return 0;
+    }
+
     return offset;
 }
 
@@ -236,10 +240,25 @@ export function getInterval(runs: string, date: Date): ServiceResponse<{ interva
         return { success: true, error: null, response };
     }
 
+    if (runs === 'every month') {
+        const response = { interval: '30d', offset: getOffset('30d', date) };
+        return { success: true, error: null, response };
+    }
+
+    if (runs === 'every week') {
+        const response = { interval: '1w', offset: getOffset('1w', date) };
+        return { success: true, error: null, response };
+    }
+
     const interval = runs.replace('every ', '');
 
     if (ms(interval) < ms('5m')) {
         const error = new NangoError('sync_interval_too_short');
+        return { success: false, error, response: null };
+    }
+
+    if (!ms(interval)) {
+        const error = new NangoError('sync_interval_invalid');
         return { success: false, error, response: null };
     }
 

--- a/packages/shared/lib/services/nango-config.service.unit.test.ts
+++ b/packages/shared/lib/services/nango-config.service.unit.test.ts
@@ -7,6 +7,7 @@ describe('Nango Config Interval tests', () => {
         expect(success).toBe(false);
         expect(error?.message).toBe('Sync interval is too short. The minimum interval is 5 minutes.');
     });
+
     it('Can parse every half day', async () => {
         const date = new Date('2023-07-18T00:00:00');
         let { success, error, response } = NangoConfigService.getInterval('every half day', date);
@@ -20,6 +21,7 @@ describe('Nango Config Interval tests', () => {
         expect(error).toBe(null);
         expect(response).toEqual({ interval: '12h', offset: 600000 });
     });
+
     it('Can parse every 1.5 hours', async () => {
         const date = new Date('2023-07-18T00:00:00');
         const { success, error, response } = NangoConfigService.getInterval('every 1.5 hours', date);
@@ -27,11 +29,75 @@ describe('Nango Config Interval tests', () => {
         expect(error).toBe(null);
         expect(response).toEqual({ interval: '1.5 hours', offset: 0 });
     });
+
     it('Can parse every day', async () => {
         const date = new Date('2023-07-18T00:00:00');
         const { success, error, response } = NangoConfigService.getInterval('every day', date);
         expect(success).toBe(true);
         expect(error).toBe(null);
         expect(response).toEqual({ interval: '1d', offset: 0 });
+    });
+
+    it('Can parse every 5 minutes', async () => {
+        const date = new Date('2023-07-18T00:00:00');
+        const { success, error, response } = NangoConfigService.getInterval('every 5m', date);
+        expect(success).toBe(true);
+        expect(error).toBe(null);
+        expect(response).toEqual({ interval: '5m', offset: 0 });
+    });
+
+    it('Can parse every 10 minutes', async () => {
+        const date = new Date('2023-07-18T00:00:00');
+        const { success, error, response } = NangoConfigService.getInterval('every 10m', date);
+        expect(success).toBe(true);
+        expect(error).toBe(null);
+        expect(response).toEqual({ interval: '10m', offset: 0 });
+    });
+
+    it('Can parse every week', async () => {
+        const date = new Date('2023-07-18T00:00:00');
+        const { success, error, response } = NangoConfigService.getInterval('every week', date);
+        expect(success).toBe(true);
+        expect(error).toBe(null);
+        expect(response).toEqual({ interval: '1w', offset: 0 });
+    });
+
+    it('Can parse every month', async () => {
+        const date = new Date('2023-07-18T00:00:00');
+        const { success, error, response } = NangoConfigService.getInterval('every month', date);
+        expect(success).toBe(true);
+        expect(error).toBe(null);
+        expect(response).toEqual({ interval: '30d', offset: 0 });
+    });
+
+    it('Returns error for unsupported interval format', async () => {
+        const date = new Date('2023-07-18T00:00:00');
+        const { success, error } = NangoConfigService.getInterval('every yearasdad', date);
+        expect(success).toBe(false);
+        expect(error?.message).toBe('Sync interval is invalid. The interval should be a time unit.');
+    });
+
+    it('Can parse intervals with different starting offset', async () => {
+        const date = new Date('2023-07-18T12:30:00');
+        const { success, error, response } = NangoConfigService.getInterval('every 1h', date);
+        expect(success).toBe(true);
+        expect(error).toBe(null);
+        expect(response).toEqual({ interval: '1h', offset: 1800000 });
+    });
+
+    it('Gives back a correct offset', async () => {
+        const date = new Date('2023-07-18T12:30:00');
+        const { success, error, response } = NangoConfigService.getInterval('every 1h', date);
+        expect(success).toBe(true);
+        expect(error).toBe(null);
+        expect(response).toEqual({ interval: '1h', offset: 1800000 });
+    });
+
+    it('Gives back a correct offset with 5 after with an interval of 30 minutes', async () => {
+        const date = new Date('2023-07-18T12:35:00');
+        const { success, error, response } = NangoConfigService.getInterval('every 30m', date);
+        expect(success).toBe(true);
+        expect(error).toBe(null);
+        expect(response).toEqual({ interval: '30m', offset: 300000 }); // 300000 is 5 minutes
     });
 });

--- a/packages/shared/lib/services/sync/orchestrator.service.ts
+++ b/packages/shared/lib/services/sync/orchestrator.service.ts
@@ -174,7 +174,7 @@ export class Orchestrator {
                 const schedule = await getSchedule(sync?.id as string);
 
                 const syncClient = await SyncClient.getInstance();
-                await syncClient?.runSyncCommand(schedule?.schedule_id as string, sync?.id as string, command, activityLogId as number);
+                await syncClient?.runSyncCommand(schedule?.schedule_id as string, sync?.id as string, command, activityLogId as number, environmentId);
                 await updateScheduleStatus(schedule?.schedule_id as string, command, activityLogId as number);
             }
         } else {
@@ -190,7 +190,7 @@ export class Orchestrator {
             for (const sync of syncs) {
                 const schedule = await getSchedule(sync?.id as string);
                 const syncClient = await SyncClient.getInstance();
-                await syncClient?.runSyncCommand(schedule?.schedule_id as string, sync?.id as string, command, activityLogId as number);
+                await syncClient?.runSyncCommand(schedule?.schedule_id as string, sync?.id as string, command, activityLogId as number, environmentId);
                 await updateScheduleStatus(schedule?.schedule_id as string, command, activityLogId as number);
             }
         }

--- a/packages/shared/lib/services/sync/schedule.service.ts
+++ b/packages/shared/lib/services/sync/schedule.service.ts
@@ -17,6 +17,12 @@ export const createSchedule = async (sync_id: string, frequency: string, offset:
     });
 };
 
+export const getScheduleById = async (schedule_id: string): Promise<SyncSchedule | null> => {
+    const result = await schema().select('*').from<SyncSchedule>(TABLE).where({ schedule_id, deleted: false }).first();
+
+    return result || null;
+};
+
 export const getSchedule = async (sync_id: string): Promise<SyncSchedule | null> => {
     const result = await schema().select('*').from<SyncSchedule>(TABLE).where({ sync_id, deleted: false }).first();
 
@@ -87,12 +93,16 @@ export const updateSyncScheduleFrequency = async (
     if (existingSchedule.frequency !== frequency) {
         await schema().update({ frequency }).from<SyncSchedule>(TABLE).where({ sync_id, deleted: false });
         const syncClient = await SyncClient.getInstance();
-        await syncClient?.updateSyncSchedule(existingSchedule.schedule_id, frequency, offset, syncName, activityLogId, environmentId);
+        await syncClient?.updateSyncSchedule(existingSchedule.schedule_id, frequency, offset, environmentId, syncName, activityLogId);
 
         return { success: true, error: null, response: true };
     }
 
     return { success: true, error: null, response: false };
+};
+
+export const updateOffset = async (schedule_id: string, offset: number): Promise<void> => {
+    await schema().update({ offset }).from<SyncSchedule>(TABLE).where({ schedule_id, deleted: false });
 };
 
 export const deleteSchedulesBySyncId = async (sync_id: string): Promise<void> => {

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -23,6 +23,7 @@ const TABLE = dbNamespace + 'syncs';
 const SYNC_JOB_TABLE = dbNamespace + 'sync_jobs';
 const SYNC_SCHEDULE_TABLE = dbNamespace + 'sync_schedules';
 const SYNC_CONFIG_TABLE = dbNamespace + 'sync_configs';
+const ACTIVITY_LOG_TABLE = dbNamespace + 'activity_logs';
 
 /**
  * Sync Service
@@ -257,10 +258,12 @@ export const getSyncs = async (nangoConnection: Connection): Promise<Sync[]> => 
                         'status', nango.${SYNC_JOB_TABLE}.status,
                         'sync_config_id', nango.${SYNC_JOB_TABLE}.sync_config_id,
                         'version', nango.${SYNC_CONFIG_TABLE}.version,
-                        'models', nango.${SYNC_CONFIG_TABLE}.models
+                        'models', nango.${SYNC_CONFIG_TABLE}.models,
+                        'activity_log_id', nango.${ACTIVITY_LOG_TABLE}.id
                     )
                     FROM nango.${SYNC_JOB_TABLE}
                     JOIN nango.${SYNC_CONFIG_TABLE} ON nango.${SYNC_CONFIG_TABLE}.id = nango.${SYNC_JOB_TABLE}.sync_config_id
+                    LEFT JOIN nango.${ACTIVITY_LOG_TABLE} ON nango.${ACTIVITY_LOG_TABLE}.session_id = nango.${SYNC_JOB_TABLE}.id::text
                     WHERE nango.${SYNC_JOB_TABLE}.sync_id = nango.${TABLE}.id
                     AND nango.${SYNC_JOB_TABLE}.deleted = false
                     AND nango.${SYNC_CONFIG_TABLE}.deleted = false

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -331,6 +331,11 @@ export class NangoError extends Error {
                 this.message = 'Sync interval is too short. The minimum interval is 5 minutes.';
                 break;
 
+            case 'sync_interval_invalid':
+                this.status = 400;
+                this.message = 'Sync interval is invalid. The interval should be a time unit.';
+                break;
+
             default:
                 this.status = 500;
                 this.type = 'unhandled_' + type;

--- a/packages/webapp/src/pages/ConnectionDetails.tsx
+++ b/packages/webapp/src/pages/ConnectionDetails.tsx
@@ -479,34 +479,39 @@ We could not retrieve and/or refresh your access token due to the following erro
                                                             <p className="inline-block text-red-500 text-sm">stopped</p>
                                                         </div>
                                                     )}
+                                                    {sync?.schedule_status === 'RUNNING' && sync?.latest_sync === null && (
+                                                        <div className={errorBubbleStyles}>
+                                                            <ErrorBubble />
+                                                        </div>
+                                                    )}
                                                     {sync?.latest_sync?.status === 'STOPPED' &&
                                                         sync.schedule_status !== 'PAUSED' &&
-                                                        (sync.latest_sync.activity_log_id !== null ? (
+                                                        (sync.latest_sync.activity_log_id && sync.latest_sync.activity_log_id !== null ? (
                                                             <Link
                                                                 to={`/activity?activity_log_id=${sync.latest_sync?.activity_log_id}`}
                                                                 className={errorBubbleStyles}
                                                             >
                                                                 <ErrorBubble />
                                                             </Link>
-                                                        ) : (
-                                                            <div className={errorBubbleStyles}>
-                                                                <ErrorBubble />
-                                                            </div>
-                                                        ))}
+                                                    ) : (
+                                                        <div className={errorBubbleStyles}>
+                                                            <ErrorBubble />
+                                                        </div>
+                                                    ))}
                                                     {sync.latest_sync?.status === 'RUNNING' &&
                                                         sync.schedule_status !== 'PAUSED' &&
-                                                        (sync.latest_sync?.activity_log_id !== null ? (
+                                                        (sync.latest_sync.activity_log_id && sync.latest_sync?.activity_log_id !== null ? (
                                                             <Link
                                                                 to={`/activity?activity_log_id=${sync.latest_sync?.activity_log_id}`}
                                                                 className={runningBubbleStyles}
                                                             >
                                                                 <RunningBubble />
                                                             </Link>
-                                                        ) : (
-                                                            <div className={runningBubbleStyles}>
-                                                                <RunningBubble />
-                                                            </div>
-                                                        ))}
+                                                    ) : (
+                                                        <div className={runningBubbleStyles}>
+                                                            <RunningBubble />
+                                                        </div>
+                                                    ))}
                                                     {sync.latest_sync?.status === 'SUCCESS' &&
                                                         sync.schedule_status !== 'PAUSED' &&
                                                         (sync.latest_sync?.activity_log_id !== null ? (
@@ -516,11 +521,11 @@ We could not retrieve and/or refresh your access token due to the following erro
                                                             >
                                                                 <SuccessBubble />
                                                             </Link>
-                                                        ) : (
-                                                            <div className={successBubbleStyles}>
-                                                                <SuccessBubble />
-                                                            </div>
-                                                        ))}
+                                                    ) : (
+                                                        <div className={successBubbleStyles}>
+                                                            <SuccessBubble />
+                                                        </div>
+                                                    ))}
                                                 </li>
                                                 {sync.latest_sync?.result && Object.keys(sync.latest_sync?.result).length > 0 ? (
                                                     <Tooltip text={<pre>{parseLatestSyncResult(sync.latest_sync.result, sync.latest_sync.models)}</pre>} type="dark">


### PR DESCRIPTION
Resolves #1036 

* link activity log id again by session_id and add index 
* Clean up error state display on connection details 
* add sync_config_id earlier in the run service for proper linking
* Adds additional unit tests to the config interval and offset methods