### PR TITLE
Fix pipedrive base URL

### DIFF
--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -702,7 +702,7 @@ pipedrive:
     authorization_url: https://oauth.pipedrive.com/oauth/authorize
     token_url: https://oauth.pipedrive.com/oauth/token
     proxy:
-        base_url: https://${connectionConfig.subdomain}.pipedrive.com
+        base_url: https://api.pipedrive.com
 qualtrics:
     auth_mode: OAUTH2
     authorization_url: https://${connectionConfig.subdomain}.qualtrics.com/oauth2/auth


### PR DESCRIPTION
While Pipedrive does create subdomains for its web app, the API URL seems to be static.

Got this error in the Nango dashboard:
```
2023-10-06T13:42:16.702Z
GET request to https://${connection_config.subdomain}.pipedrive.com/v1/activities?start_time=2023-10-03&end_time=2023-10-14&limit=30 failed
url: https://${connection_config.subdomain}.pipedrive.com/v1/activities?start_time=2023-10-03&end_time=2023-10-14&limit=30
code: ENOTFOUND
stack: Error: getaddrinfo ENOTFOUND ${connection_config.subdomain}.pipedrive.com at AxiosError.from (file:///usr/nango-server/src/node_modules/axios/lib/core/AxiosError.js:89:14) at RedirectableRequest.handleRequestError (file:///usr/nango-server/src/node_modules/axios/lib/adapters/http.js:577:25) at RedirectableRequest.emit (node:events:517:28) at RedirectableRequest.emit (node:domain:489:12) at eventHandlers.<computed> (/usr/nango-server/src/node_modules/follow-redirects/index.js:14:24) at ClientRequest.emit (node:events:529:35) at ClientRequest.emit (node:domain:489:12) at TLSSocket.socketErrorListener (node:_http_client:501:9) at TLSSocket.emit (node:events:517:28) at TLSSocket.emit (node:domain:489:12) at emitErrorNT (node:internal/streams/destroy:151:8) at emitErrorCloseNT (node:internal/streams/destroy:116:3) at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
method: get
status:
message: getaddrinfo ENOTFOUND ${connection_config.subdomain}.pipedrive.com
```

Same request with `Base-Url-Override: https://api.pipedrive.com` header:
```
2023-10-06T13:53:37.323Z
GET request to https://api.pipedrive.com/v1/activities?start_time=2023-10-03&end_time=2023-10-14&limit=30 was successful
headers: {"accept":"application/json","content-type":"application/json"}
```

Not sure if this needs updating in other places as well?