### PR TITLE
[Github #1094] track deletes updates

### DIFF
--- a/packages/shared/lib/services/sync/data/data.service.ts
+++ b/packages/shared/lib/services/sync/data/data.service.ts
@@ -1,7 +1,7 @@
 import { schema } from '../../../db/database.js';
 import { verifyUniqueKeysAreUnique } from './records.service.js';
 import { createActivityLogMessage } from '../../activity/activity.service.js';
-import { clearOldRecords } from './delete.service.js';
+import { clearOldRecords, updateCreatedAt } from './delete.service.js';
 import type { UpsertResponse } from '../../../models/Data.js';
 import type { DataRecord } from '../../../models/Sync.js';
 
@@ -57,6 +57,12 @@ export async function upsert(
                     affectedExternalIds
                 }
             };
+        }
+
+        if (track_deletes) {
+            // we need to main the created at date of the existing records so we know what
+            // was added and what was updated
+            await updateCreatedAt(nangoConnectionId, model, uniqueKey);
         }
 
         return {

--- a/packages/shared/lib/services/sync/data/delete.service.ts
+++ b/packages/shared/lib/services/sync/data/delete.service.ts
@@ -149,3 +149,39 @@ nango_connection_id = ? AND model = ?
         return false;
     }
 };
+
+/**
+ * Update Created At
+ * @desc using the DELETE_RECORDS_TABLE, update the created_at in the RECORDS_TABLE
+ * column using the value in the DELETE_RECORDS_TABLE
+ * where those same records exist in the RECORDS_TABLE using the uniqueKey
+ */
+export const updateCreatedAt = async (nangoConnectionId: number, model: string, uniqueKey: string) => {
+    const results = await schema()
+        .from<DataRecord>(DELETE_RECORDS_TABLE)
+        .innerJoin(RECORDS_TABLE, function () {
+            this.on(`${DELETE_RECORDS_TABLE}.${uniqueKey}`, '=', `${RECORDS_TABLE}.${uniqueKey}`)
+                .andOn(`${DELETE_RECORDS_TABLE}.nango_connection_id`, '=', db.knex.raw('?', [nangoConnectionId]))
+                .andOn(`${DELETE_RECORDS_TABLE}.model`, '=', db.knex.raw('?', [model]));
+        })
+        .select(`${DELETE_RECORDS_TABLE}.id`, `${DELETE_RECORDS_TABLE}.${uniqueKey}`, `${DELETE_RECORDS_TABLE}.created_at`);
+
+    if (!results || results.length === 0) {
+        return;
+    }
+
+    await Promise.all(
+        results.map(async (result: DataRecord) => {
+            await schema()
+                .from<DataRecord>(RECORDS_TABLE)
+                .where({
+                    nango_connection_id: nangoConnectionId,
+                    model,
+                    [uniqueKey]: result[uniqueKey]
+                })
+                .update({
+                    created_at: result.created_at as Date
+                });
+        })
+    );
+};

--- a/packages/shared/lib/services/sync/data/records.service.ts
+++ b/packages/shared/lib/services/sync/data/records.service.ts
@@ -223,4 +223,5 @@ export function verifyUniqueKeysAreUnique(data: DataResponse[], optionalUniqueKe
 
 export async function deleteRecordsBySyncId(sync_id: string): Promise<void> {
     await schema().from<SyncDataRecord>('_nango_sync_data_records').where({ sync_id }).del();
+    await schema().from<SyncDataRecord>('_nango_sync_data_records_deletes').where({ sync_id }).del();
 }


### PR DESCRIPTION
Resolves #1094 

- [ ] Add tests to support this
- [ ] Look into adding logic that when `track_deletes` is turned on from being previously off state is tracked correctly