### PR TITLE
Fixed Shopify subdomain variable

### DIFF
--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -888,7 +888,7 @@ shopify:
     authorization_url: https://${connectionConfig.subdomain}.myshopify.com/admin/oauth/authorize
     token_url: https://${connectionConfig.subdomain}.myshopify.com/admin/oauth/access_token
     proxy:
-        base_url: https://{connectionConfig.subdomain}.myshopify.com
+        base_url: https://${connectionConfig.subdomain}.myshopify.com
 shortcut:
     auth_mode: API_KEY
     proxy:


### PR DESCRIPTION
The base_url subdomain variable was missing the $ prefix.