### PR TITLE
[Github #1022] dryrun log messages

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -100,6 +100,7 @@ program
     .option('-e [environment]', 'The Nango environment, defaults to dev.', 'dev')
     .option('-l, --lastSyncDate [lastSyncDate]', 'Optional (for syncs only): last sync date to retrieve records greater than this date')
     .option('-i, --input [input]', 'Optional (for actions only): input to pass to the action script')
+    .option('-m, --metadata [metadata]', 'Optional (for syncs only): metadata to stub for the sync script')
     .action(async function (this: Command, sync: string, connectionId: string) {
         const { autoConfirm, debug, e: environment } = this.opts();
         await verifyNecessaryFiles(autoConfirm, debug);

--- a/packages/node-client/lib/types.ts
+++ b/packages/node-client/lib/types.ts
@@ -79,7 +79,7 @@ export interface ApiKeyCredentials {
 type AuthCredentials = OAuth2Credentials | OAuth1Credentials | BasicApiCredentials | ApiKeyCredentials;
 
 export interface Metadata {
-    [key: string]: string | Record<string, string>;
+    [key: string]: string | Record<string, any>;
 }
 
 export interface Connection {

--- a/packages/shared/lib/models/Connection.ts
+++ b/packages/shared/lib/models/Connection.ts
@@ -2,8 +2,7 @@ import type { AuthCredentials, ApiKeyCredentials, BasicApiCredentials, AppCreden
 import type { TimestampsAndDeleted } from './Generic.js';
 
 export interface Metadata {
-    fieldMapping: Record<string, string>;
-    [key: string]: string | Record<string, string>;
+    [key: string]: string | Record<string, any>;
 }
 
 export interface BaseConnection extends TimestampsAndDeleted {

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -182,6 +182,8 @@ interface NangoProps {
     dryRun?: boolean;
     track_deletes?: boolean;
     attributes?: object | undefined;
+
+    logMessages?: unknown[];
 }
 
 interface UserLogParameters {
@@ -395,6 +397,7 @@ export class NangoAction {
 export class NangoSync extends NangoAction {
     lastSyncDate?: Date;
     track_deletes = false;
+    logMessages?: unknown[] = [];
 
     constructor(config: NangoProps) {
         super(config);
@@ -405,6 +408,10 @@ export class NangoSync extends NangoAction {
 
         if (config.track_deletes) {
             this.track_deletes = config.track_deletes;
+        }
+
+        if (config.logMessages) {
+            this.logMessages = config.logMessages;
         }
     }
 
@@ -471,8 +478,8 @@ export class NangoSync extends NangoAction {
         }
 
         if (this.dryRun) {
-            console.log('A batch save call would save following data:');
-            console.log(JSON.stringify(results, null, 2));
+            this.logMessages?.push(`A batch save call would delete the following data`);
+            this.logMessages?.push(...results);
             return null;
         }
 
@@ -586,8 +593,8 @@ export class NangoSync extends NangoAction {
         }
 
         if (this.dryRun) {
-            console.log('A batch delete call would delete the following data:');
-            console.log(JSON.stringify(results, null, 2));
+            this.logMessages?.push(`A batch delete call would delete the following data`);
+            this.logMessages?.push(...results);
             return null;
         }
 

--- a/packages/shared/lib/services/sync/run.service.ts
+++ b/packages/shared/lib/services/sync/run.service.ts
@@ -38,6 +38,8 @@ interface SyncRunConfig {
     loadLocation?: string;
     debug?: boolean;
     input?: object;
+
+    logMessages?: string[];
 }
 
 export default class SyncRun {
@@ -55,6 +57,8 @@ export default class SyncRun {
     loadLocation?: string;
     debug?: boolean;
     input?: object;
+
+    logMessages: string[] = [];
 
     constructor(config: SyncRunConfig) {
         this.integrationService = config.integrationService;
@@ -90,6 +94,10 @@ export default class SyncRun {
 
         if (config.provider) {
             this.provider = config.provider;
+        }
+
+        if (config.logMessages) {
+            this.logMessages = config.logMessages;
         }
     }
 
@@ -239,7 +247,8 @@ export default class SyncRun {
                 lastSyncDate: lastSyncDate as Date,
                 dryRun: !this.writeToDb,
                 attributes: syncData.attributes,
-                track_deletes: trackDeletes as boolean
+                track_deletes: trackDeletes as boolean,
+                logMessages: this.logMessages
             });
 
             if (this.debug) {

--- a/packages/shared/lib/services/sync/run.service.ts
+++ b/packages/shared/lib/services/sync/run.service.ts
@@ -21,6 +21,7 @@ import type { NangoIntegrationData, NangoIntegration } from '../../integrations/
 import type { UpsertResponse, UpsertSummary } from '../../models/Data.js';
 import { LogActionEnum } from '../../models/Activity.js';
 import type { Environment } from '../../models/Environment';
+import type { Metadata } from '../../models/Connection';
 
 interface SyncRunConfig {
     integrationService: IntegrationServiceInterface;
@@ -39,7 +40,8 @@ interface SyncRunConfig {
     debug?: boolean;
     input?: object;
 
-    logMessages?: string[];
+    logMessages?: unknown[] | undefined;
+    stubbedMetadata?: Metadata | undefined;
 }
 
 export default class SyncRun {
@@ -58,7 +60,8 @@ export default class SyncRun {
     debug?: boolean;
     input?: object;
 
-    logMessages: string[] = [];
+    logMessages?: unknown[] | undefined = [];
+    stubbedMetadata?: Metadata | undefined = {};
 
     constructor(config: SyncRunConfig) {
         this.integrationService = config.integrationService;
@@ -98,6 +101,10 @@ export default class SyncRun {
 
         if (config.logMessages) {
             this.logMessages = config.logMessages;
+        }
+
+        if (config.stubbedMetadata) {
+            this.stubbedMetadata = config.stubbedMetadata;
         }
     }
 
@@ -248,7 +255,8 @@ export default class SyncRun {
                 dryRun: !this.writeToDb,
                 attributes: syncData.attributes,
                 track_deletes: trackDeletes as boolean,
-                logMessages: this.logMessages
+                logMessages: this.logMessages,
+                stubbedMetadata: this.stubbedMetadata
             });
 
             if (this.debug) {


### PR DESCRIPTION
Resolves #1022 
```
There are 28 logs messages remaining. Would you like to see the next 10 log messages? (y/n)
```
Resolves #1020 

```
(base) ➜  nango-integrations npx nango dryrun -h                                       
Usage: nango dryrun [options] <name> <connection_id>

Dry run the sync|action process to help with debugging against an existing connection in cloud.

Options:
  --auto-confirm                     Auto confirm yes to all prompts.
  --debug                            Run cli in debug mode, outputting verbose logs.
  -e [environment]                   The Nango environment, defaults to dev. (default: "dev")
  -l, --lastSyncDate [lastSyncDate]  Optional (for syncs only): last sync date to retrieve records greater than this date
  -i, --input [input]                Optional (for actions only): input to pass to the action script
  -m, --metadata [metadata]          Optional (for syncs only): metadata to stub for the sync script
  -h, --help                         display help for command
```