### PR TITLE
[Github #1192] slack alerts

### DIFF
--- a/packages/cli/lib/sync.ts
+++ b/packages/cli/lib/sync.ts
@@ -105,7 +105,9 @@ export const generate = async (debug = false, inParentDirectory = false) => {
 
     const interfaceDefinitions = buildInterfaces(models, integrations, debug);
 
-    fs.writeFileSync(`${dirPrefix}/${TYPES_FILE_NAME}`, interfaceDefinitions.join('\n'));
+    if (interfaceDefinitions) {
+        fs.writeFileSync(`${dirPrefix}/${TYPES_FILE_NAME}`, interfaceDefinitions.join('\n'));
+    }
 
     if (debug) {
         printDebug(`Interfaces from the ${nangoConfigFile} file written to ${TYPES_FILE_NAME}`);
@@ -333,7 +335,9 @@ const createModelFile = async (notify = false) => {
     const configData: NangoConfig = yaml.load(configContents) as unknown as NangoConfig;
     const { models, integrations } = configData;
     const interfaceDefinitions = buildInterfaces(models, integrations);
-    fs.writeFileSync(`./${TYPES_FILE_NAME}`, interfaceDefinitions.join('\n'));
+    if (interfaceDefinitions) {
+        fs.writeFileSync(`./${TYPES_FILE_NAME}`, interfaceDefinitions.join('\n'));
+    }
 
     // insert NangoSync types to the bottom of the file
     const typesContent = fs.readFileSync(`${getNangoRootPath()}/${NangoSyncTypesFileLocation}`, 'utf8');
@@ -857,7 +861,8 @@ const nangoCallsAreUsedCorrectly = (filePath: string, type = SyncConfigType.SYNC
         'delete',
         'getConnection',
         'setLastSyncDate',
-        'getEnvironmentVariables'
+        'getEnvironmentVariables',
+        'triggerAction'
     ];
 
     const disallowedActionCalls = ['batchSend', 'batchSave', 'batchDelete', 'setLastSyncDate'];

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -383,7 +383,7 @@ export function getFieldType(rawField: string | NangoModel, debug = false): stri
     }
 }
 
-export function buildInterfaces(models: NangoModel, integrations: NangoIntegration, debug = false): (string | undefined)[] {
+export function buildInterfaces(models: NangoModel, integrations: NangoIntegration, debug = false): (string | undefined)[] | null {
     const returnedModels = Object.keys(integrations).reduce((acc, providerConfigKey) => {
         const syncObject = integrations[providerConfigKey] as unknown as { [key: string]: NangoIntegration };
         const syncNames = Object.keys(syncObject);
@@ -401,6 +401,10 @@ export function buildInterfaces(models: NangoModel, integrations: NangoIntegrati
         }
         return acc;
     }, [] as string[]);
+
+    if (!models) {
+        return null;
+    }
 
     const interfaceDefinitions = Object.keys(models).map((modelName: string) => {
         const fields = models[modelName] as NangoModel;

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -615,7 +615,9 @@ export class Nango {
 
         const headers = {
             'Content-Type': 'application/json',
-            'Accept-Encoding': 'application/json'
+            'Accept-Encoding': 'application/json',
+            'Nango-Is-Sync': this.isSync,
+            'Nango-Is-Dry-Run': this.dryRun
         };
 
         if (additionalHeader) {

--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -25,7 +25,8 @@ import {
     AnalyticsTypes,
     NangoError,
     createActivityLogAndLogMessage,
-    environmentService
+    environmentService,
+    accountService
 } from '@nangohq/shared';
 import { getUserAccountAndEnvironmentFromSession } from '../utils/utils.js';
 
@@ -393,6 +394,48 @@ class ConnectionController {
             }
 
             await connectionService.deleteConnection(connection, providerConfigKey, environmentId);
+
+            res.status(204).send();
+        } catch (err) {
+            next(err);
+        }
+    }
+
+    async deleteAdminConnection(req: Request, res: Response, next: NextFunction) {
+        try {
+            const connectionId = req.params['connectionId'] as string;
+
+            if (!connectionId) {
+                errorManager.errRes(res, 'missing_connection_id');
+                return;
+            }
+
+            const integration_key = process.env['NANGO_SLACK_INTEGRATION_KEY'] || 'slack';
+            const nangoAdminUUID = process.env['NANGO_ADMIN_UUID'];
+            const env = 'prod';
+
+            const info = await accountService.getAccountAndEnvironmentIdByUUID(nangoAdminUUID as string, env);
+            const {
+                success,
+                error,
+                response: connection
+            } = await connectionService.getConnection(connectionId as string, integration_key, info?.environmentId as number);
+
+            if (!success) {
+                errorManager.errResFromNangoErr(res, error);
+
+                return;
+            }
+
+            if (connection == null) {
+                const environmentName = await environmentService.getEnvironmentName(info?.environmentId as number);
+                const error = new NangoError('unknown_connection', { connectionId, providerConfigKey: integration_key, environmentName });
+                errorManager.errResFromNangoErr(res, error);
+
+                return;
+            }
+
+            await connectionService.deleteConnection(connection, integration_key, info?.environmentId as number);
 
             res.status(204).send();
         } catch (err) {

--- a/packages/server/lib/controllers/environment.controller.ts
+++ b/packages/server/lib/controllers/environment.controller.ts
@@ -37,7 +37,7 @@ class EnvironmentController {
                 errorManager.errResFromNangoErr(res, sessionError);
                 return;
             }
-            const { environment } = response;
+            const { environment, account } = response;
 
             if (!isCloud()) {
                 environment.websockets_path = getWebsocketsPath();
@@ -56,7 +56,7 @@ class EnvironmentController {
 
             const environmentVariables = await environmentService.getEnvironmentVariables(environment.id);
 
-            res.status(200).send({ account: { ...environment, env_variables: environmentVariables, host: getBaseUrl() } });
+            res.status(200).send({ account: { ...environment, env_variables: environmentVariables, host: getBaseUrl(), uuid: account.uuid } });
         } catch (err) {
             next(err);
         }

--- a/packages/server/lib/controllers/proxy.controller.ts
+++ b/packages/server/lib/controllers/proxy.controller.ts
@@ -159,7 +159,7 @@ class ProxyController {
             const queryString = querystring.stringify(query);
             let endpoint = `${path}${queryString ? `?${queryString}` : ''}`;
 
-            if (!endpoint) {
+            if (!endpoint && !baseUrlOverride) {
                 await createActivityLogMessageAndEnd({
                     level: 'error',
                     environment_id,
@@ -804,7 +804,7 @@ See https://docs.nango.dev/guides/proxy#proxy-requests for more information.`
         }
 
         const fullEndpoint = interpolateIfNeeded(
-            `${mapProxyBaseUrlInterpolationFormat(base)}/${endpoint}`,
+            `${mapProxyBaseUrlInterpolationFormat(base)}${endpoint ? '/' : ''}${endpoint}`,
             connectionCopyWithParsedConnectionConfig(connection) as unknown as Record<string, string>
         );
 

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -142,6 +142,7 @@ app.route('/api/v1/provider').get(connectionController.listProviders.bind(connec
 app.route('/api/v1/connection').get(webAuth, connectionController.listConnections.bind(connectionController));
 app.route('/api/v1/connection/:connectionId').get(webAuth, connectionController.getConnectionWeb.bind(connectionController));
 app.route('/api/v1/connection/:connectionId').delete(webAuth, connectionController.deleteConnection.bind(connectionController));
+app.route('/api/v1/connection/admin/:connectionId').delete(webAuth, connectionController.deleteAdminConnection.bind(connectionController));
 app.route('/api/v1/user').get(webAuth, userController.getUser.bind(userController));
 app.route('/api/v1/user/name').put(webAuth, userController.editName.bind(userController));
 app.route('/api/v1/user/password').put(webAuth, userController.editPassword.bind(userController));

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -126,11 +126,13 @@ app.route('/api/v1/environment/webhook').post(webAuth, environmentController.upd
 app.route('/api/v1/environment/hmac').get(webAuth, environmentController.getHmacDigest.bind(environmentController));
 app.route('/api/v1/environment/hmac-enabled').post(webAuth, environmentController.updateHmacEnabled.bind(environmentController));
 app.route('/api/v1/environment/webhook-send').post(webAuth, environmentController.updateAlwaysSendWebhook.bind(environmentController));
+app.route('/api/v1/environment/slack-notifications-enabled').post(webAuth, environmentController.updateSlackNotificationsEnabled.bind(environmentController));
 app.route('/api/v1/environment/hmac-key').post(webAuth, environmentController.updateHmacKey.bind(environmentController));
 app.route('/api/v1/environment/environment-variables').post(webAuth, environmentController.updateEnvironmentVariables.bind(environmentController));
 app.route('/api/v1/environment/rotate-key').post(webAuth, environmentController.rotateKey.bind(accountController));
 app.route('/api/v1/environment/revert-key').post(webAuth, environmentController.revertKey.bind(accountController));
 app.route('/api/v1/environment/activate-key').post(webAuth, environmentController.activateKey.bind(accountController));
+app.route('/api/v1/environment/admin-auth').get(webAuth, environmentController.getAdminAuthInfo.bind(environmentController));
 app.route('/api/v1/integration').get(webAuth, configController.listProviderConfigsWeb.bind(configController));
 app.route('/api/v1/integration/:providerConfigKey').get(webAuth, configController.getProviderConfig.bind(configController));
 app.route('/api/v1/integration').put(webAuth, configController.editProviderConfigWeb.bind(connectionController));

--- a/packages/shared/lib/clients/sync.client.ts
+++ b/packages/shared/lib/clients/sync.client.ts
@@ -436,21 +436,24 @@ class SyncClient {
         actionName: string,
         input: object,
         activityLogId: number,
-        environment_id: number
+        environment_id: number,
+        writeLogs = true
     ): Promise<ServiceResponse> {
         const workflowId = generateActionWorkflowId(actionName, connection.connection_id as string);
 
         try {
-            await createActivityLogMessage({
-                level: 'info',
-                environment_id,
-                activity_log_id: activityLogId as number,
-                content: `Starting action workflow ${workflowId} in the task queue: ${TASK_QUEUE}`,
-                params: {
-                    input: JSON.stringify(input, null, 2)
-                },
-                timestamp: Date.now()
-            });
+            if (writeLogs) {
+                await createActivityLogMessage({
+                    level: 'info',
+                    environment_id,
+                    activity_log_id: activityLogId as number,
+                    content: `Starting action workflow ${workflowId} in the task queue: ${TASK_QUEUE}`,
+                    params: {
+                        input: JSON.stringify(input, null, 2)
+                    },
+                    timestamp: Date.now()
+                });
+            }
 
             const actionHandler = await this.client?.workflow.execute('action', {
                 taskQueue: TASK_QUEUE,
@@ -466,9 +469,8 @@ class SyncClient {
             });
 
             const { success, error, response } = actionHandler;
-            console.log(success, error, response);
 
-            if (success === false || error) {
+            if (writeLogs && (success === false || error)) {
                 await createActivityLogMessageAndEnd({
                     level: 'error',
                     environment_id,
@@ -480,28 +482,35 @@ class SyncClient {
                 return { success, error, response };
             }
 
-            await createActivityLogMessageAndEnd({
-                level: 'info',
-                environment_id,
-                activity_log_id: activityLogId as number,
-                timestamp: Date.now(),
-                content: `The action workflow ${workflowId} was successfully run. A truncated response is: ${JSON.stringify(response, null, 2)?.slice(0, 100)}`
-            });
+            if (writeLogs) {
+                await createActivityLogMessageAndEnd({
+                    level: 'info',
+                    environment_id,
+                    activity_log_id: activityLogId as number,
+                    timestamp: Date.now(),
+                    content: `The action workflow ${workflowId} was successfully run. A truncated response is: ${JSON.stringify(response, null, 2)?.slice(
+                        0,
+                        100
+                    )}`
+                });
 
-            await updateSuccessActivityLog(activityLogId as number, true);
+                await updateSuccessActivityLog(activityLogId as number, true);
+            }
 
             return { success, error, response };
         } catch (e) {
             const errorMessage = JSON.stringify(e, ['message', 'name'], 2);
             const error = new NangoError('action_failure', { errorMessage });
 
-            await createActivityLogMessageAndEnd({
-                level: 'error',
-                environment_id,
-                activity_log_id: activityLogId as number,
-                timestamp: Date.now(),
-                content: `The action workflow ${workflowId} failed with error: ${e}`
-            });
+            if (writeLogs) {
+                await createActivityLogMessageAndEnd({
+                    level: 'error',
+                    environment_id,
+                    activity_log_id: activityLogId as number,
+                    timestamp: Date.now(),
+                    content: `The action workflow ${workflowId} failed with error: ${e}`
+                });
+            }
 
             await errorManager.report(e, {
                 source: ErrorSourceEnum.PLATFORM,

--- a/packages/shared/lib/clients/sync.client.ts
+++ b/packages/shared/lib/clients/sync.client.ts
@@ -431,14 +431,14 @@ class SyncClient {
         }
     }
 
-    async triggerAction(
+    async triggerAction<T = any>(
         connection: NangoConnection,
         actionName: string,
         input: object,
         activityLogId: number,
         environment_id: number,
         writeLogs = true
-    ): Promise<ServiceResponse> {
+    ): Promise<ServiceResponse<T>> {
         const workflowId = generateActionWorkflowId(actionName, connection.connection_id as string);
 
         try {

--- a/packages/shared/lib/db/migrations/20231027135906_slack_notifications_option.cjs
+++ b/packages/shared/lib/db/migrations/20231027135906_slack_notifications_option.cjs
@@ -1,0 +1,13 @@
+const tableName = '_nango_environments';
+
+exports.up = function (knex, _) {
+    return knex.schema.withSchema('nango').alterTable(tableName, function (table) {
+        table.boolean('slack_notifications').defaultTo(false);
+    });
+};
+
+exports.down = function (knex, _) {
+    return knex.schema.withSchema('nango').table(tableName, function (table) {
+        table.dropColumn('slack_notifications');
+    });
+};

--- a/packages/shared/lib/db/migrations/20231030112937_slack_notifications_table.cjs
+++ b/packages/shared/lib/db/migrations/20231030112937_slack_notifications_table.cjs
@@ -1,0 +1,17 @@
+const DB_TABLE = '_nango_slack_notifications';
+
+exports.up = async function (knex, _) {
+    return knex.schema.withSchema('nango').createTable(DB_TABLE, function (table) {
+        table.increments('id').primary();
+        table.boolean('open').defaultTo(true).index();
+        table.integer('environment_id').unsigned().references('id').inTable(`nango._nango_environments`).index();
+        table.string('name').index();
+        table.string('type');
+        table.specificType('connection_list', 'integer ARRAY');
+        table.timestamps(true, true);
+    });
+};
+
+exports.down = async function (knex, _) {
+    return knex.schema.withSchema('nango').dropTable(DB_TABLE);
+};

--- a/packages/shared/lib/db/migrations/20231030112937_slack_notifications_table.cjs
+++ b/packages/shared/lib/db/migrations/20231030112937_slack_notifications_table.cjs
@@ -8,6 +8,8 @@ exports.up = async function (knex, _) {
         table.string('name').index();
         table.string('type');
         table.specificType('connection_list', 'integer ARRAY');
+        table.string('slack_timestamp');
+        table.string('admin_slack_timestamp');
         table.timestamps(true, true);
     });
 };

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -9,7 +9,6 @@ import errorManager, { ErrorSourceEnum } from './utils/error.manager.js';
 import metricsManager, { MetricTypes } from './utils/metrics.manager.js';
 import accountService from './services/account.service.js';
 import environmentService from './services/environment.service.js';
-import webhookService from './services/webhook.service.js';
 import userService from './services/user.service.js';
 import remoteFileService from './services/file/remote.service.js';
 import localFileService from './services/file/local.service.js';
@@ -59,7 +58,6 @@ export {
     accountService,
     environmentService,
     userService,
-    webhookService,
     remoteFileService,
     localFileService,
     syncRunService,

--- a/packages/shared/lib/models/Environment.ts
+++ b/packages/shared/lib/models/Environment.ts
@@ -23,4 +23,5 @@ export interface Environment extends Timestamps {
     pending_secret_key_iv?: string | null;
     pending_secret_key_tag?: string | null;
     pending_public_key?: string | null;
+    slack_notifications?: boolean;
 }

--- a/packages/shared/lib/models/SlackNotification.ts
+++ b/packages/shared/lib/models/SlackNotification.ts
@@ -1,0 +1,11 @@
+import type { Timestamps } from './Generic';
+import type { SyncType } from './Sync';
+
+export interface SlackNotification extends Timestamps {
+    id?: number;
+    open: boolean;
+    environment_id: number;
+    name: string;
+    type: SyncType;
+    connection_list: number[];
+}

--- a/packages/shared/lib/models/SlackNotification.ts
+++ b/packages/shared/lib/models/SlackNotification.ts
@@ -1,12 +1,12 @@
 import type { Timestamps } from './Generic';
-import type { SyncType } from './Sync';
+import type { SyncConfigType } from './Sync';
 
 export interface SlackNotification extends Timestamps {
     id?: number;
     open: boolean;
     environment_id: number;
     name: string;
-    type: SyncType;
+    type: SyncConfigType;
     connection_list: number[];
     slack_timestamp?: string;
     admin_slack_timestamp?: string;

--- a/packages/shared/lib/models/SlackNotification.ts
+++ b/packages/shared/lib/models/SlackNotification.ts
@@ -8,4 +8,6 @@ export interface SlackNotification extends Timestamps {
     name: string;
     type: SyncType;
     connection_list: number[];
+    slack_timestamp?: string;
+    admin_slack_timestamp?: string;
 }

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -57,6 +57,16 @@ class AccountService {
 
         return { accountId, environmentId: environment[0].id };
     }
+
+    async getUUIDFromAccountId(accountId: number): Promise<string | null> {
+        const account = await db.knex.withSchema(db.schema()).select('uuid').from<Account>(`_nango_accounts`).where({ id: accountId });
+
+        if (account == null || account.length == 0 || account[0] == null) {
+            return null;
+        }
+
+        return account[0].uuid;
+    }
 }
 
 export default new AccountService();

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -5,6 +5,7 @@ import type { Environment } from '../models/Environment.js';
 import type { EnvironmentVariable } from '../models/EnvironmentVariable.js';
 import type { Account } from '../models/Admin.js';
 import { LogActionEnum } from '../models/Activity.js';
+import accountService from './account.service.js';
 import errorManager, { ErrorSourceEnum } from '../utils/error.manager.js';
 import { isCloud } from '../utils/utils.js';
 
@@ -111,6 +112,20 @@ class EnvironmentService {
         }
 
         return result[0].account_id;
+    }
+
+    async getAccountUUIDFromEnvironment(environment_id: number): Promise<string | null> {
+        const result = await db.knex.withSchema(db.schema()).select('account_id').from<Environment>(TABLE).where({ id: environment_id });
+
+        if (result == null || result.length == 0 || result[0] == null) {
+            return null;
+        }
+
+        const accountId = result[0].account_id;
+
+        const uuid = await accountService.getUUIDFromAccountId(accountId);
+
+        return uuid;
     }
 
     async getAccountIdAndEnvironmentIdByPublicKey(publicKey: string): Promise<{ accountId: number; environmentId: number } | null> {

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -325,6 +325,20 @@ class EnvironmentService {
         return db.knex.withSchema(db.schema()).from<Environment>(TABLE).where({ id }).update({ always_send_webhook }, ['id']);
     }
 
+    async editSlackNotifications(slack_notifications: boolean, id: number): Promise<Environment | null> {
+        return db.knex.withSchema(db.schema()).from<Environment>(TABLE).where({ id }).update({ slack_notifications }, ['id']);
+    }
+
+    async getSlackNotificationsEnabled(environmentId: number): Promise<boolean | null> {
+        const result = await db.knex.withSchema(db.schema()).select('slack_notifications').from<Environment>(TABLE).where({ id: environmentId });
+
+        if (result == null || result.length == 0 || result[0] == null) {
+            return null;
+        }
+
+        return result[0].slack_notifications;
+    }
+
     async editHmacKey(hmacKey: string, id: number): Promise<Environment | null> {
         return db.knex.withSchema(db.schema()).from<Environment>(TABLE).where({ id }).update({ hmac_key: hmacKey }, ['id']);
     }

--- a/packages/shared/lib/services/nango-config.service.ts
+++ b/packages/shared/lib/services/nango-config.service.ts
@@ -9,6 +9,7 @@ import { isCloud } from '../utils/utils.js';
 import type { ServiceResponse } from '../models/Generic.js';
 import { SyncConfigType } from '../models/Sync.js';
 import { NangoError } from '../utils/error.js';
+import { JAVASCRIPT_PRIMITIVES } from '../utils/utils.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -70,8 +71,12 @@ export function getRootDir(optionalLoadLocation?: string) {
     }
 }
 
-function getFieldsForModel(modelName: string, config: NangoConfig): { name: string; type: string }[] {
+function getFieldsForModel(modelName: string, config: NangoConfig): { name: string; type: string }[] | null {
     const modelFields = [];
+
+    if (JAVASCRIPT_PRIMITIVES.includes(modelName)) {
+        return null;
+    }
     const modelData = config.models[modelName] || config.models[`${modelName.slice(0, -1)}`];
 
     for (const fieldName in modelData) {
@@ -80,7 +85,9 @@ function getFieldsForModel(modelName: string, config: NangoConfig): { name: stri
             const extendedModels = (fieldType as string).split(',');
             for (const extendedModel of extendedModels) {
                 const extendedFields = getFieldsForModel(extendedModel.trim(), config);
-                modelFields.push(...extendedFields);
+                if (extendedFields) {
+                    modelFields.push(...extendedFields);
+                }
             }
         } else if (typeof fieldType === 'object') {
             for (const subFieldName in fieldType) {
@@ -115,7 +122,7 @@ export function convertConfigObject(config: NangoConfig): SimplifiedNangoIntegra
             if (sync.returns) {
                 const syncReturns = Array.isArray(sync.returns) ? sync.returns : [sync.returns];
                 syncReturns.forEach((model) => {
-                    const modelFields = getFieldsForModel(model, config);
+                    const modelFields = getFieldsForModel(model, config) as { name: string; type: string }[];
                     models.push({ name: model, fields: modelFields });
                 });
             }

--- a/packages/shared/lib/services/notification.service.ts
+++ b/packages/shared/lib/services/notification.service.ts
@@ -2,13 +2,19 @@ import axios, { AxiosError } from 'axios';
 import { backOff } from 'exponential-backoff';
 import { SyncType } from '../models/Sync.js';
 import type { NangoConnection } from '../models/Connection';
+import type { ServiceResponse } from '../models/Generic';
 import type { SyncResult, NangoSyncWebhookBody } from '../models/Sync';
 import environmentService from './environment.service.js';
-import { createActivityLogMessage } from './activity/activity.service.js';
+import { LogActionEnum, LogLevel } from '../models/Activity.js';
+import { updateSuccess as updateSuccessActivityLog, createActivityLogMessage, createActivityLogAndLogMessage } from './activity/activity.service.js';
+import { getBaseUrl } from '../utils/utils.js';
+import connectionService from './connection.service.js';
+import accountService from './account.service.js';
+import SyncClient from '../clients/sync.client.js';
 
 const RETRY_ATTEMPTS = 10;
 
-class WebhookService {
+class NotificationService {
     private retry = async (activityLogId: number, environment_id: number, error: AxiosError, attemptNumber: number): Promise<boolean> => {
         if (error?.response && (error?.response?.status < 200 || error?.response?.status >= 300)) {
             const content = `Webhook response received an ${
@@ -29,7 +35,7 @@ class WebhookService {
         return false;
     };
 
-    async sendUpdate(
+    async sendWebhook(
         nangoConnection: NangoConnection,
         syncName: string,
         model: string,
@@ -122,6 +128,86 @@ class WebhookService {
             });
         }
     }
+
+    async reportFailure(
+        nangoConnection: NangoConnection,
+        syncName: string,
+        syncType: SyncType,
+        originalActivityLogId: number,
+        environment_id: number,
+        provider: string
+    ) {
+        const slackNotificationsEnabled = await environmentService.getSlackNotificationsEnabled(nangoConnection.environment_id);
+
+        if (!slackNotificationsEnabled) {
+            return;
+        }
+
+        const actionName = 'flow-result-notifier-action';
+
+        if (syncName === actionName) {
+            return;
+        }
+
+        const envName = await environmentService.getEnvironmentName(nangoConnection.environment_id);
+        const payload = {
+            title: `${syncType} Failure`,
+            content: `The ${syncType} sync for ${syncName} failed. Please check the logs (${getBaseUrl()}/activity?env=${envName}&activity_log_id=${originalActivityLogId}) for more information.`,
+            connectionCount: 1, // TODO
+            status: 'open',
+            name: syncName,
+            providerConfigKey: nangoConnection.provider_config_key,
+            provider
+        };
+
+        const syncClient = await SyncClient.getInstance();
+
+        const integrationKey = process.env['NANGO_SLACK_INTEGRATION_KEY'] || 'slack';
+        const nangoAdminUUID = process.env['NANGO_ADMIN_UUID'];
+        const env = 'prod';
+        const info = await accountService.getAccountAndEnvironmentIdByUUID(nangoAdminUUID as string, env);
+        const [nangoAdminConnection] = await connectionService.getConnectionsByEnvironmentAndConfig(info?.environmentId as number, integrationKey);
+
+        if (!nangoAdminConnection) {
+            return;
+        }
+
+        const { success: actionSuccess, error: actionError } = (await syncClient?.triggerAction(
+            nangoAdminConnection,
+            actionName,
+            payload,
+            originalActivityLogId,
+            environment_id,
+            false
+        )) as ServiceResponse;
+
+        const log = {
+            level: 'info' as LogLevel,
+            success: true,
+            action: LogActionEnum.ACTION,
+            start: Date.now(),
+            end: Date.now(),
+            timestamp: Date.now(),
+            connection_id: nangoAdminConnection?.connection_id as string,
+            provider_config_key: nangoAdminConnection?.provider_config_key as string,
+            provider: integrationKey,
+            environment_id: info?.environmentId as number,
+            operation_name: actionName
+        };
+
+        const content = actionSuccess
+            ? `The action ${actionName} was successfully triggered for the ${syncType} ${syncName} for environment ${info?.environmentId} for account ${info?.accountId}.`
+            : `The action ${actionName} failed to trigger for the ${syncType} ${syncName} with the error: ${actionError} for environment ${info?.environmentId} for account ${info?.accountId}.`;
+
+        const activityLogId = await createActivityLogAndLogMessage(log, {
+            level: actionSuccess ? 'info' : 'error',
+            environment_id: info?.environmentId as number as number,
+            timestamp: Date.now(),
+            content
+        });
+
+        await updateSuccessActivityLog(activityLogId as number, actionSuccess);
+    }
 }
 
-export default new WebhookService();
+export default new NotificationService();

--- a/packages/shared/lib/services/notification.service.ts
+++ b/packages/shared/lib/services/notification.service.ts
@@ -172,15 +172,6 @@ class NotificationService {
             return;
         }
 
-        const { success: actionSuccess, error: actionError } = (await syncClient?.triggerAction(
-            nangoAdminConnection,
-            actionName,
-            payload,
-            originalActivityLogId,
-            environment_id,
-            false
-        )) as ServiceResponse;
-
         const log = {
             level: 'info' as LogLevel,
             success: true,
@@ -194,6 +185,15 @@ class NotificationService {
             environment_id: info?.environmentId as number,
             operation_name: actionName
         };
+
+        const { success: actionSuccess, error: actionError } = (await syncClient?.triggerAction(
+            nangoAdminConnection,
+            actionName,
+            payload,
+            originalActivityLogId,
+            environment_id,
+            false
+        )) as ServiceResponse;
 
         const content = actionSuccess
             ? `The action ${actionName} was successfully triggered for the ${syncType} ${syncName} for environment ${info?.environmentId} for account ${info?.accountId}.`

--- a/packages/shared/lib/services/sync/config/config.service.ts
+++ b/packages/shared/lib/services/sync/config/config.service.ts
@@ -218,6 +218,7 @@ export async function getActionConfigByNameAndProviderConfigKey(environment_id: 
             nango_config_id,
             sync_name: name,
             deleted: false,
+            active: true,
             type: SyncConfigType.ACTION
         })
         .first();

--- a/packages/shared/lib/services/sync/notification/slack.service.ts
+++ b/packages/shared/lib/services/sync/notification/slack.service.ts
@@ -1,0 +1,334 @@
+import { schema, dbNamespace } from '../../../db/database.js';
+import type { SlackNotification } from '../../../models/SlackNotification';
+import type { NangoConnection } from '../../../models/Connection';
+import type { ServiceResponse } from '../../../models/Generic';
+import type { SyncType } from '../../../models/Sync';
+import environmentService from '../../environment.service.js';
+import { LogActionEnum, LogLevel } from '../../../models/Activity.js';
+import { updateSuccess as updateSuccessActivityLog, createActivityLogMessage, createActivityLog } from '../../activity/activity.service.js';
+import { getBaseUrl } from '../../../utils/utils.js';
+import connectionService from '../../connection.service.js';
+import accountService from '../../account.service.js';
+import SyncClient from '../../../clients/sync.client.js';
+
+const TABLE = dbNamespace + 'slack_notifications';
+
+interface NotificationResponse {
+    isOpen: boolean;
+    connectionCount: number;
+}
+
+class SlackService {
+    private actionName = 'flow-result-notifier-action';
+    private integrationKey = process.env['NANGO_SLACK_INTEGRATION_KEY'] || 'slack';
+    private nangoAdminUUID = process.env['NANGO_ADMIN_UUID'];
+    private env = 'prod';
+
+    private async getNangoAdminConnection() {
+        const info = await accountService.getAccountAndEnvironmentIdByUUID(this.nangoAdminUUID as string, this.env);
+        const [nangoAdminConnection] = await connectionService.getConnectionsByEnvironmentAndConfig(info?.environmentId as number, this.integrationKey);
+
+        return { info, nangoAdminConnection };
+    }
+
+    async reportFailure(
+        nangoConnection: NangoConnection,
+        syncName: string,
+        syncType: SyncType,
+        originalActivityLogId: number,
+        environment_id: number,
+        provider: string
+    ) {
+        const slackNotificationsEnabled = await environmentService.getSlackNotificationsEnabled(nangoConnection.environment_id);
+
+        if (!slackNotificationsEnabled) {
+            return;
+        }
+
+        if (syncName === this.actionName) {
+            return;
+        }
+
+        const { success, error, response: slackNotificationStatus } = await this.addFailingConnection(nangoConnection, syncName, syncType);
+
+        const adminConnection = await this.getNangoAdminConnection();
+
+        if (!adminConnection) {
+            return;
+        }
+
+        const { info, nangoAdminConnection } = adminConnection;
+
+        const log = {
+            level: 'info' as LogLevel,
+            success: false,
+            action: LogActionEnum.ACTION,
+            start: Date.now(),
+            end: Date.now(),
+            timestamp: Date.now(),
+            connection_id: nangoAdminConnection?.connection_id as string,
+            provider_config_key: nangoAdminConnection?.provider_config_key as string,
+            provider: this.integrationKey,
+            environment_id: info?.environmentId as number,
+            operation_name: this.actionName
+        };
+
+        const activityLogId = await createActivityLog(log);
+
+        if (!success || !slackNotificationStatus) {
+            await createActivityLogMessage({
+                level: 'error',
+                environment_id,
+                activity_log_id: activityLogId as number,
+                content: `Failed looking up the slack notification using the slack notification service. The error was: ${error}`,
+                timestamp: Date.now()
+            });
+
+            return;
+        }
+
+        // There is an open slack notification so no need to send another notification
+        if (slackNotificationStatus.isOpen) {
+            return;
+        }
+
+        const envName = await environmentService.getEnvironmentName(nangoConnection.environment_id);
+
+        const payload = {
+            title: `${syncType} Failure`,
+            content: `The ${syncType} "${syncName}" failed. Please check the logs (${getBaseUrl()}/activity?env=${envName}&activity_log_id=${originalActivityLogId}) for more information.`,
+            connectionCount: slackNotificationStatus.connectionCount,
+            status: 'open',
+            name: syncName,
+            providerConfigKey: nangoConnection.provider_config_key,
+            provider
+        };
+
+        const syncClient = await SyncClient.getInstance();
+
+        const { success: actionSuccess, error: actionError } = (await syncClient?.triggerAction(
+            nangoAdminConnection as NangoConnection,
+            this.actionName,
+            payload,
+            originalActivityLogId,
+            environment_id,
+            false
+        )) as ServiceResponse;
+
+        const content = actionSuccess
+            ? `The action ${this.actionName} was successfully triggered for the ${syncType} ${syncName} for environment ${info?.environmentId} for account ${info?.accountId}.`
+            : `The action ${this.actionName} failed to trigger for the ${syncType} ${syncName} with the error: ${actionError} for environment ${info?.environmentId} for account ${info?.accountId}.`;
+
+        await createActivityLogMessage({
+            level: actionSuccess ? 'info' : 'error',
+            activity_log_id: activityLogId as number,
+            environment_id: info?.environmentId as number as number,
+            timestamp: Date.now(),
+            content,
+            params: payload
+        });
+
+        await updateSuccessActivityLog(activityLogId as number, actionSuccess);
+    }
+
+    async reportResolution(
+        nangoConnection: NangoConnection,
+        syncName: string,
+        syncType: SyncType,
+        originalActivityLogId: number,
+        environment_id: number,
+        provider: string
+    ) {
+        const slackNotificationsEnabled = await environmentService.getSlackNotificationsEnabled(nangoConnection.environment_id);
+
+        if (!slackNotificationsEnabled) {
+            return;
+        }
+
+        if (syncName === this.actionName) {
+            return;
+        }
+
+        const envName = await environmentService.getEnvironmentName(nangoConnection.environment_id);
+
+        const payload = {
+            title: `${syncType} Success`,
+            content: `The ${syncType} "${syncName}" had failing connection(s) and now all connections are successful. See (${getBaseUrl()}/activity?env=${envName}&activity_log_id=${originalActivityLogId}) for the log message.`,
+            connectionCount: 0,
+            status: 'closed',
+            name: syncName,
+            providerConfigKey: nangoConnection.provider_config_key,
+            provider
+        };
+
+        const syncClient = await SyncClient.getInstance();
+        const adminConnection = await this.getNangoAdminConnection();
+
+        if (!adminConnection) {
+            return;
+        }
+
+        const { info, nangoAdminConnection } = adminConnection;
+
+        const log = {
+            level: 'info' as LogLevel,
+            success: false,
+            action: LogActionEnum.ACTION,
+            start: Date.now(),
+            end: Date.now(),
+            timestamp: Date.now(),
+            connection_id: nangoAdminConnection?.connection_id as string,
+            provider_config_key: nangoAdminConnection?.provider_config_key as string,
+            provider: this.integrationKey,
+            environment_id: info?.environmentId as number,
+            operation_name: this.actionName
+        };
+
+        const activityLogId = await createActivityLog(log);
+
+        const { success: actionSuccess, error: actionError } = (await syncClient?.triggerAction(
+            nangoAdminConnection as NangoConnection,
+            this.actionName,
+            payload,
+            originalActivityLogId,
+            environment_id,
+            false
+        )) as ServiceResponse;
+
+        const content = actionSuccess
+            ? `The action ${this.actionName} was successfully triggered for the ${syncType} ${syncName} for environment ${info?.environmentId} for account ${info?.accountId}.`
+            : `The action ${this.actionName} failed to trigger for the ${syncType} ${syncName} with the error: ${actionError} for environment ${info?.environmentId} for account ${info?.accountId}.`;
+
+        await createActivityLogMessage({
+            level: actionSuccess ? 'info' : 'error',
+            activity_log_id: activityLogId as number,
+            environment_id: info?.environmentId as number as number,
+            timestamp: Date.now(),
+            content,
+            params: payload
+        });
+
+        await updateSuccessActivityLog(activityLogId as number, actionSuccess);
+    }
+
+    async hasOpenNotification(nangoConnection: NangoConnection, name: string): Promise<Pick<SlackNotification, 'id' | 'connection_list'> | null> {
+        const hasOpenNotification = await schema().select('id', 'connection_list').from<SlackNotification>(TABLE).where({
+            open: true,
+            environment_id: nangoConnection.environment_id,
+            name
+        });
+
+        if (!hasOpenNotification || !hasOpenNotification.length) {
+            return null;
+        }
+
+        return { id: hasOpenNotification[0].id, connection_list: hasOpenNotification[0].connection_list };
+    }
+
+    async createNotification(nangoConnection: NangoConnection, name: string, type: SyncType): Promise<void> {
+        await schema()
+            .from<SlackNotification>(TABLE)
+            .insert({
+                open: true,
+                environment_id: nangoConnection.environment_id,
+                name,
+                type,
+                connection_list: [nangoConnection.id as number]
+            });
+    }
+
+    async addFailingConnection(nangoConnection: NangoConnection, name: string, type: SyncType): Promise<ServiceResponse<NotificationResponse>> {
+        const isOpen = await this.hasOpenNotification(nangoConnection, name);
+
+        if (!isOpen) {
+            await this.createNotification(nangoConnection, name, type);
+
+            return {
+                success: true,
+                error: null,
+                response: {
+                    isOpen: false,
+                    connectionCount: 1
+                }
+            };
+        }
+
+        const { id, connection_list } = isOpen;
+
+        if (connection_list.includes(nangoConnection.id as number)) {
+            return {
+                success: true,
+                error: null,
+                response: {
+                    isOpen: true,
+                    connectionCount: connection_list.length
+                }
+            };
+        }
+
+        connection_list.push(nangoConnection.id as number);
+
+        await schema()
+            .from<SlackNotification>(TABLE)
+            .where({ id: id as number })
+            .update({
+                connection_list,
+                updated_at: new Date()
+            });
+
+        return {
+            success: true,
+            error: null,
+            response: {
+                isOpen: true,
+                connectionCount: connection_list.length
+            }
+        };
+    }
+
+    async removeFailingConnection(
+        nangoConnection: NangoConnection,
+        name: string,
+        type: SyncType,
+        originalActivityLogId: number,
+        environment_id: number,
+        provider: string
+    ): Promise<void> {
+        const slackNotificationsEnabled = await environmentService.getSlackNotificationsEnabled(nangoConnection.environment_id);
+
+        if (!slackNotificationsEnabled) {
+            return;
+        }
+
+        const isOpen = await this.hasOpenNotification(nangoConnection, name);
+
+        if (!isOpen) {
+            return;
+        }
+
+        const { id, connection_list } = isOpen;
+
+        const index = connection_list.indexOf(nangoConnection.id as number);
+
+        if (index === -1) {
+            return;
+        }
+
+        connection_list.splice(index, 1);
+
+        await schema()
+            .from<SlackNotification>(TABLE)
+            .where({ id: id as number })
+            .update({
+                open: connection_list.length > 0,
+                connection_list,
+                updated_at: new Date()
+            });
+
+        if (connection_list.length === 0) {
+            await this.reportResolution(nangoConnection, name, type, originalActivityLogId, environment_id, provider);
+        }
+    }
+}
+
+export default new SlackService();

--- a/packages/shared/lib/services/sync/notification/slack.service.ts
+++ b/packages/shared/lib/services/sync/notification/slack.service.ts
@@ -240,12 +240,6 @@ class SlackService {
         admin_slack_timestamp: string,
         connectionCount: number
     ) {
-        const slackNotificationsEnabled = await environmentService.getSlackNotificationsEnabled(nangoConnection.environment_id);
-
-        if (!slackNotificationsEnabled) {
-            return;
-        }
-
         if (syncName === this.actionName) {
             return;
         }

--- a/packages/shared/lib/services/sync/notification/slack.service.ts
+++ b/packages/shared/lib/services/sync/notification/slack.service.ts
@@ -73,8 +73,8 @@ class SlackService {
 
         const syncClient = await SyncClient.getInstance();
 
-        const accountId = await environmentService.getAccountIdFromEnvironment(environment_id);
-        payload.content = `${payload.content} [Account ${accountId} Environment ${environment_id}]`;
+        const accountUUID = await environmentService.getAccountUUIDFromEnvironment(environment_id);
+        payload.content = `${payload.content} [Account ${accountUUID} Environment ${environment_id}]`;
 
         if (ts) {
             payload.ts = ts;
@@ -132,8 +132,8 @@ class SlackService {
 
         const { success, error, response: slackNotificationStatus } = await this.addFailingConnection(nangoConnection, syncName, syncType);
 
-        const accountId = await environmentService.getAccountIdFromEnvironment(environment_id);
-        const slackConnectionId = `account-${accountId}`;
+        const accountUUID = await environmentService.getAccountUUIDFromEnvironment(environment_id);
+        const slackConnectionId = `account-${accountUUID}`;
         const nangoEnvironmentId = await this.getAdminEnvironmentId();
         const { success: connectionSuccess, response: slackConnection } = await connectionService.getConnection(
             slackConnectionId,
@@ -214,8 +214,8 @@ class SlackService {
         );
 
         const content = actionSuccess
-            ? `The action ${this.actionName} was successfully triggered for the ${syncType} ${syncName} for environment ${slackConnection?.environment_id} for account ${accountId}.`
-            : `The action ${this.actionName} failed to trigger for the ${syncType} ${syncName} with the error: ${actionError} for environment ${slackConnection?.environment_id} for account ${accountId}.`;
+            ? `The action ${this.actionName} was successfully triggered for the ${syncType} ${syncName} for environment ${slackConnection?.environment_id} for account ${accountUUID}.`
+            : `The action ${this.actionName} failed to trigger for the ${syncType} ${syncName} with the error: ${actionError} for environment ${slackConnection?.environment_id} for account ${accountUUID}.`;
 
         await createActivityLogMessage({
             level: actionSuccess ? 'info' : 'error',
@@ -266,9 +266,9 @@ class SlackService {
 
         const syncClient = await SyncClient.getInstance();
 
-        const accountId = await environmentService.getAccountIdFromEnvironment(environment_id);
+        const accountUUID = await environmentService.getAccountUUIDFromEnvironment(environment_id);
         const nangoEnvironmentId = await this.getAdminEnvironmentId();
-        const slackConnectionId = `account-${accountId}`;
+        const slackConnectionId = `account-${accountUUID}`;
         const { success: connectionSuccess, response: slackConnection } = await connectionService.getConnection(
             slackConnectionId,
             this.integrationKey,
@@ -307,8 +307,8 @@ class SlackService {
         await this.sendDuplicateNotificationToNangoAdmins(payload, originalActivityLogId, environment_id, undefined, admin_slack_timestamp);
 
         const content = actionSuccess
-            ? `The action ${this.actionName} was successfully triggered for the ${syncType} ${syncName} for environment ${slackConnection?.environment_id} for account ${accountId}.`
-            : `The action ${this.actionName} failed to trigger for the ${syncType} ${syncName} with the error: ${actionError} for environment ${slackConnection?.environment_id} for account ${accountId}.`;
+            ? `The action ${this.actionName} was successfully triggered for the ${syncType} ${syncName} for environment ${slackConnection?.environment_id} for account ${accountUUID}.`
+            : `The action ${this.actionName} failed to trigger for the ${syncType} ${syncName} with the error: ${actionError} for environment ${slackConnection?.environment_id} for account ${accountUUID}.`;
 
         await createActivityLogMessage({
             level: actionSuccess ? 'info' : 'error',

--- a/packages/shared/lib/services/sync/run.service.ts
+++ b/packages/shared/lib/services/sync/run.service.ts
@@ -340,7 +340,7 @@ export default class SyncRun {
                 // means a void response from the sync script which is expected
                 // and means that they're using batchSave or batchDelete
                 if (userDefinedResults === undefined) {
-                    await this.finishSync(models, syncStartDate, syncData.version as string, trackDeletes);
+                    await this.finishSync(models, syncStartDate, syncData.version as string, totalRunTime, trackDeletes);
 
                     return { success: true, error: null, response: true };
                 }
@@ -381,6 +381,7 @@ export default class SyncRun {
                                     models.length,
                                     syncStartDate,
                                     syncData.version as string,
+                                    totalRunTime,
                                     trackDeletes
                                 );
                             }
@@ -414,7 +415,15 @@ export default class SyncRun {
                                 if (upsertResult.success) {
                                     const { summary } = upsertResult;
 
-                                    await this.reportResults(model, summary as UpsertSummary, i, models.length, syncStartDate, syncData.version as string);
+                                    await this.reportResults(
+                                        model,
+                                        summary as UpsertSummary,
+                                        i,
+                                        models.length,
+                                        syncStartDate,
+                                        syncData.version as string,
+                                        totalRunTime
+                                    );
                                 }
 
                                 if (!upsertResult.success) {
@@ -450,7 +459,7 @@ export default class SyncRun {
         return { success: true, error: null, response: result };
     }
 
-    async finishSync(models: string[], syncStartDate: Date, version: string, trackDeletes?: boolean): Promise<void> {
+    async finishSync(models: string[], syncStartDate: Date, version: string, totalRunTime: number, trackDeletes?: boolean): Promise<void> {
         let i = 0;
         for (const model of models) {
             if (trackDeletes) {
@@ -469,6 +478,7 @@ export default class SyncRun {
                 models.length,
                 syncStartDate,
                 version,
+                totalRunTime,
                 trackDeletes
             );
             i++;
@@ -482,6 +492,7 @@ export default class SyncRun {
         numberOfModels: number,
         syncStartDate: Date,
         version: string,
+        totalRunTime: number,
         trackDeletes?: boolean
     ): Promise<void> {
         if (!this.writeToDb || !this.activityLogId || !this.syncJobId) {
@@ -602,6 +613,7 @@ export default class SyncRun {
                 syncId: this.syncId as string,
                 syncJobId: String(this.syncJobId),
                 syncType: this.syncType,
+                totalRunTime: `${totalRunTime} seconds`,
                 debug: String(this.debug)
             },
             `syncId:${this.syncId}`

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -913,6 +913,9 @@ slack:
     token_url: https://slack.com/api/oauth.v2.access
     token_response_metadata:
         - incoming_webhook.url
+        - incoming_webhook.channel
+        - incoming_webhook.channel_id
+        - bot_user_id
     proxy:
         base_url: https://slack.com/api
         paginate:

--- a/packages/webapp/src/components/ui/button/Button.tsx
+++ b/packages/webapp/src/components/ui/button/Button.tsx
@@ -10,7 +10,8 @@ const buttonStyles = cva('disabled:pointer-events-none disabled:opacity-50 round
             secondary: 'bg-[#282828] text-white hover:bg-gray-800',
             success: 'bg-green-700 text-white hover:bg-green-500',
             danger: 'bg-red-700 text-white hover:bg-red-500',
-            zombie: 'bg-transparent text-white hover:bg-gray-700'
+            zombie: 'bg-transparent text-white hover:bg-gray-700',
+            yellow: 'bg-yellow-500 text-white hover:bg-yellow-400'
         },
         size: {
             xs: 'h-8 py-1 px-2',

--- a/packages/webapp/src/components/ui/input/SecretInput.tsx
+++ b/packages/webapp/src/components/ui/input/SecretInput.tsx
@@ -9,7 +9,7 @@ const SecretInput = forwardRef<HTMLInputElement, SecretInputProps>(function Pass
 
     const [changedValue, setChangedValue] = useState(props.defaultValue);
 
-    const value = props.optionalvalue || changedValue;
+    const value = props.optionalvalue === null ? '' : props.optionalvalue || changedValue;
     const updateValue = props.setoptionalvalue || setChangedValue;
 
     const toggleSecretVisibility = useCallback(() => setIsSecretVisible(!isSecretVisible), [isSecretVisible, setIsSecretVisible]);

--- a/packages/webapp/src/pages/Activity.tsx
+++ b/packages/webapp/src/pages/Activity.tsx
@@ -340,6 +340,7 @@ export default function Activity() {
                                                             </div>
                                                             <Link
                                                                 to={`/connections/${activity.provider_config_key}/${activity.connection_id}${activity?.action === 'sync' ? '#sync' : ''}`}
+                                                                className="flex items-center"
                                                             >
                                                                 {activity.operation_name && (
                                                                     <Tooltip text={activity.operation_name} type="dark">

--- a/packages/webapp/src/pages/ConnectionCreate.tsx
+++ b/packages/webapp/src/pages/ConnectionCreate.tsx
@@ -71,7 +71,6 @@ export default function IntegrationCreate() {
         }
     }, [isHmacEnabled, integration?.uniqueKey, connectionId, getHmacAPI]);
 
-
     useEffect(() => {
         const getIntegrations = async () => {
             let res = await getIntegrationListAPI();

--- a/packages/webapp/src/pages/ProjectSettings.tsx
+++ b/packages/webapp/src/pages/ProjectSettings.tsx
@@ -43,7 +43,7 @@ export default function ProjectSettings() {
 
     const [hmacKey, setHmacKey] = useState('');
     const [hmacEnabled, setHmacEnabled] = useState(false);
-    const [accountId, setAccountId] = useState<number>();
+    const [accountUUID, setAccountUUID] = useState<number>();
     const [alwaysSendWebhook, setAlwaysSendWebhook] = useState(false);
     const [hmacEditMode, setHmacEditMode] = useState(false);
     const [envVariables, setEnvVariables] = useState<{ name: string; value: string }[]>([]);
@@ -82,7 +82,7 @@ export default function ProjectSettings() {
 
                 setWebhookUrl(account.webhook_url || '');
                 setHostUrl(account.host);
-                setAccountId(account.account_id);
+                setAccountUUID(account.uuid);
 
                 setHmacEnabled(account.hmac_enabled);
                 setAlwaysSendWebhook(account.always_send_webhook);
@@ -314,7 +314,7 @@ export default function ProjectSettings() {
     const disconnectSlack = async () => {
         await updateSlackNotifications(false);
 
-        const res = await fetch(`/api/v1/connection/admin/account-${accountId}`, {
+        const res = await fetch(`/api/v1/connection/admin/account-${accountUUID}`, {
             method: 'DELETE'
         });
 
@@ -327,7 +327,7 @@ export default function ProjectSettings() {
     }
 
     const connectSlack = async () => {
-        const connectionId =  `account-${accountId}`;
+        const connectionId =  `account-${accountUUID}`;
 
         const res = await fetch(`/api/v1/environment/admin-auth?connection_id=${connectionId}`, {
             method: 'GET',
@@ -838,7 +838,7 @@ export default function ProjectSettings() {
                                             </button>
                                         </div>
                                     </form>
-                                    {env === 'prod' && (
+                                    {env !== 'prod' && (
                                         <>
                                             <Button className="mt-6" variant="yellow" onClick={slackIsConnected ? disconnectSlack : connectSlack}>
                                                 {slackIsConnected ? 'Disconnect Slack' : 'Connect Slack'}

--- a/packages/webapp/src/pages/ProjectSettings.tsx
+++ b/packages/webapp/src/pages/ProjectSettings.tsx
@@ -519,6 +519,33 @@ export default function ProjectSettings() {
                                     </div>
                                 </div>
                             </div>
+                            {env === 'prod' && (
+                                <div className="flex items-center justify-between mx-8 mt-8">
+                                    <div>
+                                        <label htmlFor="slack_alerts" className="flex text-text-light-gray items-center block text-sm font-semibold mb-2">
+                                            Slack Alerts
+                                        <Tooltip
+                                            text={
+                                                <div className="flex text-black text-sm">
+                                                    {slackIsConnected ?
+                                                        'Stop receiving Slack alerts to a public channel of your choice when a syncs or actions fail.' :
+                                                        'Receive Slack alerts to a public channel of your choice when a syncs or actions fail.'
+                                                    }
+                                                </div>
+                                            }
+                                        >
+                                            <HelpCircle color="gray" className="h-5 ml-1"></HelpCircle>
+                                        </Tooltip>
+                                        </label>
+                                    </div>
+                                    <div className="">
+                                        <Button className="items-center" variant="primary" onClick={slackIsConnected ? disconnectSlack : connectSlack}>
+                                            <img src={`images/template-logos/slack.svg`} alt="" className="flex h-7 pb-0.5" />
+                                            {slackIsConnected ? 'Disconnect' : 'Connect'}
+                                        </Button>
+                                    </div>
+                                </div>
+                            )}
                             <div>
                                 <div className="mx-8 mt-8">
                                     <div className="flex text-white  mb-2">
@@ -670,7 +697,7 @@ export default function ProjectSettings() {
                                             text={
                                                 <>
                                                     <div className="flex text-black text-sm">
-                                                        {`When running a sync a webhook can always be sent after completion or only sent when data is added, created, or deleted.`}
+                                                        {`If checked, a webhook wil be sent on every sync run completion, even if no data has changed.`}
                                                     </div>
                                                 </>
                                             }
@@ -838,25 +865,6 @@ export default function ProjectSettings() {
                                             </button>
                                         </div>
                                     </form>
-                                    {env === 'prod' && (
-                                        <>
-                                            <Button className="mt-6" variant="yellow" onClick={slackIsConnected ? disconnectSlack : connectSlack}>
-                                                {slackIsConnected ? 'Disconnect Slack' : 'Connect Slack'}
-                                            </Button>
-                                            <Tooltip
-                                                text={
-                                                    <div className="flex text-black text-sm">
-                                                        {slackIsConnected ?
-                                                            'Stop receiving Slack alerts when a sync or action fails' :
-                                                            'Receive Slack alerts when a sync or action fails.'
-                                                        }
-                                                    </div>
-                                                }
-                                            >
-                                                <HelpCircle color="gray" className="h-5 ml-1"></HelpCircle>
-                                            </Tooltip>
-                                        </>
-                                    )}
                                 </div>
                             </div>
                         </div>

--- a/packages/webapp/src/pages/ProjectSettings.tsx
+++ b/packages/webapp/src/pages/ProjectSettings.tsx
@@ -838,7 +838,7 @@ export default function ProjectSettings() {
                                             </button>
                                         </div>
                                     </form>
-                                    {env !== 'prod' && (
+                                    {env === 'prod' && (
                                         <>
                                             <Button className="mt-6" variant="yellow" onClick={slackIsConnected ? disconnectSlack : connectSlack}>
                                                 {slackIsConnected ? 'Disconnect Slack' : 'Connect Slack'}


### PR DESCRIPTION
Resolves #1192 
Resolves #1151 

* Allows users to set up Slack notifications for failing syncs

# Deployment To Dos
- [x] Deploy the `flow-result-notifier-action` to the Nango admin account on both staging and prod
- [ ] Create the `admin-slack` connection

![image](https://github.com/NangoHQ/nango/assets/1724137/f77af65a-6231-4346-adbf-2b4b66b4a9b7)
