### PR TITLE
[Github #1211] close open slack notifications on uninstall

### DIFF
--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -29,7 +29,8 @@ import {
     environmentService,
     accountService,
     SyncClient,
-    Connection
+    Connection,
+    slackNotificationService
 } from '@nangohq/shared';
 import { getUserAccountAndEnvironmentFromSession } from '../utils/utils.js';
 
@@ -442,9 +443,9 @@ class ConnectionController {
 
             const { success: sessionSuccess, response } = await getUserAccountAndEnvironmentFromSession(req);
 
-            if (sessionSuccess) {
+            if (sessionSuccess && response) {
                 const { environment } = response;
-                // TODO
+                await slackNotificationService.closeAllOpenNotifications(environment.id);
             }
 
             res.status(204).send();

--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -440,6 +440,13 @@ class ConnectionController {
 
             await connectionService.deleteConnection(connection, integration_key, info?.environmentId as number);
 
+            const { success: sessionSuccess, response } = await getUserAccountAndEnvironmentFromSession(req);
+
+            if (sessionSuccess) {
+                const { environment } = response;
+                // TODO
+            }
+
             res.status(204).send();
         } catch (err) {
             next(err);

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -16,6 +16,7 @@ import hmacService from './services/hmac.service.js';
 import syncRunService from './services/sync/run.service.js';
 import syncOrchestrator from './services/sync/orchestrator.service.js';
 import flowService from './services/flow.service.js';
+import slackNotificationService from './services/sync/notification/slack.service.js';
 import analytics, { AnalyticsTypes } from './utils/analytics.js';
 import logger from './logger/console.js';
 
@@ -64,6 +65,7 @@ export {
     syncOrchestrator,
     hmacService,
     flowService,
+    slackNotificationService,
     analytics,
     AnalyticsTypes,
     logger

--- a/packages/shared/lib/services/sync/notification/slack.service.ts
+++ b/packages/shared/lib/services/sync/notification/slack.service.ts
@@ -580,6 +580,19 @@ class SlackService {
             connection_list.length
         );
     }
+
+    async closeAllOpenNotifications(environment_id: number): Promise<void> {
+        await schema()
+            .from<SlackNotification>(TABLE)
+            .where({
+                environment_id,
+                open: true
+            })
+            .update({
+                open: false,
+                updated_at: new Date()
+            });
+    }
 }
 
 export default new SlackService();

--- a/packages/webapp/src/components/LeftNavBar.tsx
+++ b/packages/webapp/src/components/LeftNavBar.tsx
@@ -57,7 +57,7 @@ export default function LeftNavBar(props: LeftNavBarProps) {
 
     return (
         <div>
-            <div className="h-full pt-14 border-r-2 border-t-2 border-border-gray flex flex-col w-60 fixed bg-bg-black z-49 justify-between">
+            <div className="h-full pt-14 border-r-2 border-t-2 border-border-gray flex flex-col w-60 fixed bg-bg-black z-20 justify-between">
                 <div className="mt-8 px-6">
                     {envs.length > 0 && (
                         <div className="mb-8">


### PR DESCRIPTION
* Edge case handled if a user installs the slack app has an open notification, then uninstalls and then installs again on a new channel the open notification would try to attach to the old channel