### PR TITLE
fixes: Webapp session expired: redirect to login + longer session

### DIFF
--- a/packages/server/lib/clients/auth.client.ts
+++ b/packages/server/lib/clients/auth.client.ts
@@ -41,7 +41,7 @@ export class AuthClient {
                 store: sessionStore,
                 name: 'nango_session',
                 unset: 'destroy',
-                cookie: { maxAge: 60 * 60 * 1000, secure: false },
+                cookie: { maxAge: 30 * 24 * 60 * 60 * 1000, secure: false },
                 rolling: true
             })
         );

--- a/packages/webapp/src/components/LeftNavBar.tsx
+++ b/packages/webapp/src/components/LeftNavBar.tsx
@@ -5,6 +5,7 @@ import { Activity, Briefcase, User } from '@geist-ui/icons';
 
 import { useStore } from '../store';
 import { isCloud } from '../utils/utils';
+import { useSignout } from '../utils/user';
 
 export enum LeftNavBarItems {
     Integrations = 0,
@@ -24,10 +25,18 @@ export default function LeftNavBar(props: LeftNavBarProps) {
     const [envs, setEnvs] = useState<{ name: string; }[]>([]);
     const [version, setVersion] = useState<string>('');
 
+    const signout = useSignout();
+
     useEffect(() => {
         fetch('/api/v1/meta')
-            .then(res => res.json())
+            .then(res => {
+                if(res.status === 401) {
+                    return signout();
+                }
+                return res.json();
+            })
             .then(data => {
+                if(!data) return;
                 setEnvs(data.environments);
                 setVersion(data.version);
             })

--- a/packages/webapp/src/pages/ProjectSettings.tsx
+++ b/packages/webapp/src/pages/ProjectSettings.tsx
@@ -379,6 +379,12 @@ export default function ProjectSettings() {
                                             </>
                                         )}
                                     </div>
+                                    {hasPendingPublicKey && (
+                                        <div className=" text-red-500 text-sm">
+                                            Click 'Activate' to use this new key. Until then, Nango expects the old key. After activation the old key don't
+                                            work.
+                                        </div>
+                                    )}
                                 </div>
                             </div>
                             <div>
@@ -446,6 +452,12 @@ export default function ProjectSettings() {
                                             </>
                                         )}
                                     </div>
+                                    {hasPendingSecretKey && (
+                                        <div className=" text-red-500 text-sm">
+                                            Click 'Activate' to use this new key. Until then, Nango expects the old key. After activation the old key don't
+                                            work.
+                                        </div>
+                                    )}
                                 </div>
                             </div>
                             <div>

--- a/packages/webapp/src/pages/ProjectSettings.tsx
+++ b/packages/webapp/src/pages/ProjectSettings.tsx
@@ -381,8 +381,7 @@ export default function ProjectSettings() {
                                     </div>
                                     {hasPendingPublicKey && (
                                         <div className=" text-red-500 text-sm">
-                                            Click 'Activate' to use this new key. Until then, Nango expects the old key. After activation the old key don't
-                                            work.
+                                            Click 'Activate' to use this new key. Until then, Nango expects the old key. After activation the old key won't work.
                                         </div>
                                     )}
                                 </div>
@@ -454,8 +453,7 @@ export default function ProjectSettings() {
                                     </div>
                                     {hasPendingSecretKey && (
                                         <div className=" text-red-500 text-sm">
-                                            Click 'Activate' to use this new key. Until then, Nango expects the old key. After activation the old key don't
-                                            work.
+                                            Click 'Activate' to use this new key. Until then, Nango expects the old key. After activation the old key won't work.
                                         </div>
                                     )}
                                 </div>


### PR DESCRIPTION
Resolves #1108

After the session expires, user is redirected to signin page, without encountering an error, and also session's duration is elongated to 30 days.

https://github.com/NangoHQ/nango/assets/77796540/82a38958-7c5b-4557-98d9-cd82611aa6fe

