### PR TITLE
Add support for Microsoft tenant-specific endpoints

### DIFF
--- a/docs-v2/integrations/all/microsoft-tenant-specific.mdx
+++ b/docs-v2/integrations/all/microsoft-tenant-specific.mdx
@@ -1,0 +1,47 @@
+---
+title: Microsoft Tenant Specific Endpoints
+sidebarTitle: Microsoft Tenant Specific
+---
+
+API configuration: [`microsoft-tenant-specific`](https://nango.dev/providers.yaml)
+
+## Features
+
+| Feature                                                                          | Status                          |
+| -------------------------------------------------------------------------------- | ------------------------------- |
+| [Auth (OAuth)](/guides/oauth)                                                    | ✅                              |
+| [Syncs](/guides/sync) & [Actions](/guides/action)                                | 🚫                              |
+| [Nango Proxy](/guides/proxy)                                                     | 🚫                              |
+| Auto-pagination                                                                  | 🚫                              |
+| API-specific rate limits                                                          | 🚫                              |
+
+Sync is not provided for this provider as it is a generic mechanism to access unspecified APIs so there is no consistent way to sync data.
+If you want to sync data from Microsoft Graph, use the [Microsoft Teams provider](/integrations/all/microsoft-teams) instead.
+
+<Tip>We can implement missing features in &lt;48h, just ask for it in the [community](https://nango.dev/slack).</Tip>
+## Getting started
+
+-   [Create an Azure app registration for the specific application](https://go.microsoft.com/fwlink/?linkid=2083908).
+    -   Add permissions for the appropriate app on the `API Permissions` tab 
+-   [OAuth-related docs](https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow)
+    -   See particularly the `tenant` parameter under [Request an authorization code](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#request-an-authorization-code).
+        This `tenant` parameter must be provided as [extra configuration to the frontend SDK](https://docs.nango.dev/sdks/frontend#oauth-flows-requiring-extra-configuration).
+-   [List of OAuth scopes](https://learn.microsoft.com/en-us/azure/active-directory/develop/permissions-consent-overview)
+    -   The specific scopes required will depend on the application being accessed.  This might use the [.default scope with the resource's identifier URI](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#the-default-scope)
+
+<Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
+
+This endpoint supports services authorised using an Azure App Registration in any accessible tenant, including:
+
+> - Microsoft Dynamics 365 Finance and Operations
+
+<Tip>You _can_ use this provider for general Microsoft Graph access (and the major Microsoft SaaS services like Teams, 
+     OneDrive, other Office 365 services, etc.) by setting the `tenant` to `common` but we recommend using the 
+     [Microsoft Teams provider](/integrations/all/microsoft-teams) instead which includes sync capability.</Tip>
+
+
+## API gotchas
+
+<Note>
+    Add Getting Started links and Gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft-tenant-specific.mdx)
+</Note>

--- a/docs-v2/integrations/erp.mdx
+++ b/docs-v2/integrations/erp.mdx
@@ -9,6 +9,7 @@ sidebarTitle: ERP
 </Tip>
 
 <CardGroup cols={4}>
+    <Card title="Microsoft Dynamics 365 Finance & Operations" href="/integrations/all/microsoft-tenant-specific" color="#68a063" />
     <Card title="Netsuite" href="/integrations/all/netsuite" color="#68a063" />
     <Card title="Sage" href="/integrations/all/sage" color="#68a063" />
 </CardGroup>

--- a/docs-v2/mint.json
+++ b/docs-v2/mint.json
@@ -223,6 +223,7 @@
                         "integrations/all/linkedin",
                         "integrations/all/mailchimp",
                         "integrations/all/microsoft-teams",
+                        "integrations/all/microsoft-tenant-specific",
                         "integrations/all/miro",
                         "integrations/all/mixpanel",
                         "integrations/all/monday",

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -621,6 +621,21 @@ microsoft-teams:
         grant_type: authorization_code
     refresh_params:
         grant_type: refresh_token
+microsoft-tenant-specific:
+    auth_mode: OAUTH2
+    authorization_url: https://login.microsoftonline.com/${connectionConfig.tenant}/oauth2/v2.0/authorize
+    token_url: https://login.microsoftonline.com/${connectionConfig.tenant}/oauth2/v2.0/token
+    disable_pkce: true
+    default_scopes:
+        - offline_access
+    authorization_params:
+        response_type: code
+        response_mode: query
+        prompt: consent
+    token_params:
+        grant_type: authorization_code
+    refresh_params:
+        grant_type: refresh_token
 mixpanel:
     auth_mode: BASIC
     proxy:


### PR DESCRIPTION
#  Summary

The `microsoft-teams` provider works for shared/saas Microsoft services that are in the `common` tenant.  This provider is essentially the same but allows the `tenant` to be provided as a Frontend SDK additional config parameter so that any tenant can be accessed.

This is required for services that are tenant specific and are not available in the general `common` tenant as the tenant id can be a random value.

This has been added as a new provider rather than changing the existing `microsoft-teams` one so as not to break backwards compatibility for users of that one.  This new provider also does not provide any sync configuration as it is unknown which service will be behind the Azure app registration so there isn't anything consistent to sync.

See the docs update included with the PR for more details.

# Tests

This provider has been used successfully in local development to connect to Microsoft Dynamics 365 Finance & Operations and successfully call those endpoints after authorising using Nango and a custom Azure App registration (after adding the `Dynamics ERP` API permissions to the App registration).

The documentation update was reviewed using `npm run docs` and verifying on localhost.