### PR TITLE
[Github #1276] fix create call

### DIFF
--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -217,8 +217,7 @@ export default class Nango {
         if ('username' in credentials || 'password' in credentials) {
             const basicCredentials = credentials as BasicApiCredentials;
             if (!basicCredentials.username) {
-                const authError = new AuthError('You must specify a username.', 'missingUsername');
-                throw authError;
+                throw new AuthError('You must specify a username.', 'missingUsername');
             }
 
             const url = this.hostBaseUrl + `/api-auth/basic/${providerConfigKey}${this.toQueryString(connectionId, connectionConfig as ConnectionConfig)}`;

--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -56,8 +56,7 @@ export default class Nango {
         this.publicKey = config.publicKey;
 
         if (!config.publicKey) {
-            const error = new AuthError('You must specify a public key (cf. documentation).', 'missingPublicKey');
-            throw error;
+            throw new AuthError('You must specify a public key (cf. documentation).', 'missingPublicKey');;
         }
 
         try {

--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -66,8 +66,7 @@ export default class Nango {
             const websocketUrl = new URL(config.websocketsPath, baseUrl);
             this.websocketsBaseUrl = websocketUrl.toString().replace('https://', 'wss://').replace('http://', 'ws://');
         } catch (err) {
-            const error = new AuthError('Invalid URL provided for the Nango host.', 'invalidHostUrl');
-            throw error;
+            throw new AuthError('Invalid URL provided for the Nango host.', 'invalidHostUrl');
         }
     }
 

--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -106,8 +106,7 @@ export default class Nango {
         try {
             new URL(url);
         } catch (err) {
-            const error = new AuthError('Invalid URL provided for the Nango host.', 'invalidHostUrl');
-            throw error;
+            throw new AuthError('Invalid URL provided for the Nango host.', 'invalidHostUrl');
         }
 
         return new Promise((resolve, reject) => {

--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -190,8 +190,7 @@ export default class Nango {
         const { params: credentials } = connectionConfigWithCredentials as ConnectionConfig;
 
         if (!credentials) {
-            const authError = new AuthError('You must specify credentials.', 'missingCredentials');
-            throw authError;
+            throw new AuthError('You must specify credentials.', 'missingCredentials');
         }
 
         if ('apiKey' in credentials) {

--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -166,7 +166,7 @@ export default class Nango {
         });
     }
 
-    public convertCredentialsToConfig(credentials: BasicApiCredentials | ApiKeyCredentials): ConnectionConfig {
+    private convertCredentialsToConfig(credentials: BasicApiCredentials | ApiKeyCredentials): ConnectionConfig {
         const params: Record<string, string> = {};
 
         if ('username' in credentials) {
@@ -186,7 +186,7 @@ export default class Nango {
         providerConfigKey: string,
         connectionId: string,
         connectionConfigWithCredentials: ConnectionConfig,
-        connectionConfig: ConnectionConfig
+        connectionConfig?: ConnectionConfig
     ): Promise<AuthResult> {
         const { params: credentials } = connectionConfigWithCredentials as ConnectionConfig;
 

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -76,7 +76,7 @@ export interface NangoSyncWebhookBody {
 
 export type LastAction = 'added' | 'updated' | 'deleted';
 
-interface RecordMetadata {
+export interface RecordMetadata {
     first_seen_at: Date;
     last_seen_at: Date;
     last_action: LastAction;

--- a/packages/webapp/src/pages/IntegrationCreate.tsx
+++ b/packages/webapp/src/pages/IntegrationCreate.tsx
@@ -279,7 +279,7 @@ export default function IntegrationCreate() {
                             )}
 
                             {(authMode === AuthModes.Basic || authMode === AuthModes.ApiKey) && !providerConfigKey && (
-                                <Info>
+                                <Info size={20}>
                                     The "{selectedProvider}" integration provider uses {authMode === AuthModes.Basic ? 'basic auth' : 'API Keys'} for authentication (<a href="https://docs.nango.dev/guides/oauth#connection-configuration" className="text-white underline hover:text-text-light-blue" rel="noreferrer" target="_blank">docs</a>).
                                 </Info>
                             )}


### PR DESCRIPTION
Resolves #1276 

- Export `RecordMetadata` in case users want to use that type for the `getRecords` response
- Small tweak to the info icon to be the correct size
![image](https://github.com/NangoHQ/nango/assets/1724137/4eeb3d76-20a0-49d4-b949-f43fd899a795)
