### PR TITLE
Improve pre-built Slack syncs

### DIFF
--- a/integration-templates/slack/nango.yaml
+++ b/integration-templates/slack/nango.yaml
@@ -12,6 +12,7 @@ integrations:
 
         slack-messages:
             runs: every hour
+            description: 'Syncs Slack messages, thread replies and reactions from messages & thread replies for all channels, group dms and dms the bot is a part of. For every channel it will do an initial full sync on first detection of the channel. For subsequent runs it will sync messages, threads & reactions from the last 10 days. Scopes required: channels:read, and at least one of channels:history,groups:history,mpim:history,im:history'
             returns:
                 - SlackMessage
                 - SlackMessageReply

--- a/integration-templates/slack/nango.yaml
+++ b/integration-templates/slack/nango.yaml
@@ -2,11 +2,13 @@ integrations:
     slack: # scopes: channels:read,channels:history,channels:join,users:read
         slack-users:
             runs: every hour
+            description: 'Syncs information about all Users on the Slack workspace. Scopes: users:read'
             returns:
                 - SlackUser
 
         slack-channels:
             runs: every hour
+            description: 'Syncs information about all Slack channels. Which channels get synced (public, private, IMs, group DMs) dependson the scopes. If joinPublicChannels is set to true, the bot will automatically join all public channels as well. Scopes: At least one of channels:read, groups:read, mpim:read, im:read. To also join public channels: channels:join'
             returns:
                 - SlackChannel
 

--- a/integration-templates/slack/slack-channels.ts
+++ b/integration-templates/slack/slack-channels.ts
@@ -3,6 +3,8 @@ import type { SlackChannel, NangoSync } from './models';
 export default async function fetchData(nango: NangoSync) {
     const responses = await getAllPages(nango, 'conversations.list');
 
+    let metadata = (await nango.getMetadata()) || {};
+
     const mappedChannels: SlackChannel[] = responses.map((record: any) => {
         return {
             id: record.id,
@@ -25,7 +27,9 @@ export default async function fetchData(nango: NangoSync) {
     });
 
     // Now let's also join all public channels where we are not yet a member
-    await joinPublicChannels(nango, mappedChannels);
+    if (metadata['joinPublicChannels']) {
+        await joinPublicChannels(nango, mappedChannels);
+    }
 
     // Save channels
     await nango.batchSave(mappedChannels, 'SlackChannel');


### PR DESCRIPTION
Added description for all Slack syncs to `nango.yaml`

Improved/fixed Slack channels sync:
`slack-channels` sync now only auto-joins all public channels if `joinPublicChannels` is set to true in the metadata.
Technically, this is a breaking change, but after a quick check by @khaliqgant, this doesn't seem to be used by anybody in production.
=> resolves #1167 

Improved the slack messages sync:
- Stores last sync date per channel: Upon detection of a new channel, a full refresh is done. Afterward, incremental sync of the last 10 days.
- If a channel no longer shows up, it removes it from the metadata of synced channels (but does not delete any existing records). This way, if it shows up again, a full refresh sync is done again.
- Uses new `nango.paginate`
- Centralizes saving of message and reply reactions


