### PR TITLE
[gh-1251] fix race condition when closing oauth popup

### DIFF
--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -153,6 +153,11 @@ export default class Nango {
             );
             this.tm = setInterval(() => {
                 if (!this.win?.modal?.window || this.win?.modal?.window.closed) {
+                    if (this.win?.isProcessingMessage === true) {
+                        // Modal is still processing a web socket message from the server
+                        // We ignore the window being closed for now
+                        return;
+                    }
                     clearTimeout(this.tm as unknown as number);
                     this.win = null;
                     this.status = AuthorizationStatus.CANCELED;
@@ -312,6 +317,7 @@ class AuthorizationModal {
     public modal: Window;
     private swClient: WebSocket;
     private debug: boolean;
+    public isProcessingMessage = false;
 
     constructor(
         webSocketUrl: string,
@@ -348,7 +354,9 @@ class AuthorizationModal {
         this.swClient = new WebSocket(webSocketUrl);
 
         this.swClient.onmessage = (message: MessageEvent<any>) => {
+            this.isProcessingMessage = true;
             this.handleMessage(message, successHandler, errorHandler);
+            this.isProcessingMessage = false;
         };
     }
 


### PR DESCRIPTION
The logic checking if the oauth popup window is closed, running on intervals, could run while the websocket event handler is being executed, triggering an windowClosed error even though the popup was not closed by the user. 
Adding a delay around `this.handleMessage(...)` is a easy way to trigger the issue.

This fix ensures that when the `is the window close` logic is run, no error is resolved if the modal is still handling a message

Another solution could be to setup synchronous websocket message passing so the server return the html that contains the window close only after the websocket client (the modal) has confirmed the message has been processed. That's sound a bit complex for such a use case though