### PR TITLE
[gh-1251] send html to close window after message is processed

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -7,6 +7,10 @@ rules:
   document-start: disable
   truthy:
     check-keys: false
+  comments:
+    require-starting-space: true
+    ignore-shebangs: true
+    min-spaces-from-content: 1
 
 ignore: |
     .github/workflows/*

--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -609,7 +609,6 @@ paths:
                                 properties:
                                     message:
                                         type: string
-                    
     /sync/trigger:
         post:
             description: Triggers an additional, one-off execution of specified sync(s) (for a given connection or all applicable connections if no connection is specified).
@@ -716,7 +715,7 @@ paths:
                                 properties:
                                     message:
                                         type: string
-        
+
     /sync/status:
         get:
             description: Get the status of specified sync(s) (for a given connection or all applicable connections if no connection is specified)

--- a/packages/server/lib/clients/web-socket.client.ts
+++ b/packages/server/lib/clients/web-socket.client.ts
@@ -32,18 +32,20 @@ class WSClient {
         if (clientId) {
             const client = this.getClient(clientId);
             if (client) {
-                client.send(
-                    JSON.stringify({
-                        message_type: WSMessageType.Error,
-                        provider_config_key: providerConfigKey,
-                        connection_id: connectionId,
-                        error_type: wsErr.type,
-                        error_desc: wsErr.message
-                    })
-                );
-
-                client.close();
-                this.removeClient(clientId);
+                const data = {
+                    message_type: WSMessageType.Error,
+                    provider_config_key: providerConfigKey,
+                    connection_id: connectionId,
+                    error_type: wsErr.type,
+                    error_desc: wsErr.message
+                };
+                // notify client synchronously to make sure auth is completed before sending the html that will close the window
+                this.syncSend(client, data)
+                    .catch((_error) => errorHtml(res, clientId, { type: 'timeout_error', message: 'Success message timed out' }))
+                    .finally(() => {
+                        client.close();
+                        this.removeClient(clientId);
+                    });
             }
         }
 
@@ -54,20 +56,50 @@ class WSClient {
         if (clientId) {
             const client = this.getClient(clientId);
             if (client) {
-                client.send(
-                    JSON.stringify({
-                        message_type: WSMessageType.Success,
-                        provider_config_key: providerConfigKey,
-                        connection_id: connectionId
-                    })
-                );
-
-                client.close();
-                this.removeClient(clientId);
+                const data = {
+                    message_type: WSMessageType.Success,
+                    provider_config_key: providerConfigKey,
+                    connection_id: connectionId
+                };
+                // notify client synchronously to make sure auth is completed before sending the html that will close the window
+                this.syncSend(client, data)
+                    .then((_res) => successHtml(res, clientId, providerConfigKey, connectionId))
+                    .catch((_error) => errorHtml(res, clientId, { type: 'timeout_error', message: 'Success message timed out' }))
+                    .finally(() => {
+                        client.close();
+                        this.removeClient(clientId);
+                    });
             }
+        } else {
+            successHtml(res, clientId, providerConfigKey, connectionId);
         }
+    }
 
-        successHtml(res, clientId, providerConfigKey, connectionId);
+    private syncSend(client: WebSocket, data: any) {
+        const messageId = uuid.v4();
+        const timeoutMs = 10000;
+        const message = { messageId: messageId, data };
+
+        const timeout = new Promise((_resolve, reject) => {
+            setTimeout(() => {
+                reject(new Error(`Synchronous websocket message '${messageId}' timed out after ${timeoutMs}ms`));
+            }, timeoutMs);
+        });
+        const send = new Promise(function (resolve, reject) {
+            client.onmessage = (message) => {
+                const { messageId: responseId, data } = JSON.parse(message.data.toString());
+                if (messageId === responseId) {
+                    return resolve(data);
+                }
+            };
+
+            client.onerror = (error) => {
+                return reject(error);
+            };
+
+            client.send(JSON.stringify(message));
+        });
+        return Promise.race([send, timeout]);
     }
 }
 


### PR DESCRIPTION
There is a race condition that could lead to the `The authorization window was closed before the authorization flow ` error if processing the success message coming from the server takes longer than closing the popup window and check if the window is closed

This fix ensure that the message sent by the server to the frontend via websocket is received and processed before returning the html