### PR TITLE
disable yamllint line-length rule

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,9 +1,7 @@
 extends: default
 
 rules:
-  line-length:
-    max: 200
-    level: warning
+  line-length: disable
   document-start: disable
   truthy:
     check-keys: false


### PR DESCRIPTION
A lot of yaml files (integrations templates or spec.yaml) have long lines (ex: description). Disabling the yamlllint line-length rule since it is not very meaningful