### PR TITLE
frontend: adding logs to debug why Nango.auth() sometimes doesn't resolve

### DIFF
--- a/packages/server/lib/clients/web-socket.client.ts
+++ b/packages/server/lib/clients/web-socket.client.ts
@@ -32,19 +32,21 @@ class WSClient {
         if (clientId) {
             const client = this.getClient(clientId);
             if (client) {
-                client.send(
-                    JSON.stringify({
-                        message_type: WSMessageType.Error,
-                        provider_config_key: providerConfigKey,
-                        connection_id: connectionId,
-                        error_type: wsErr.type,
-                        error_desc: wsErr.message
-                    })
-                );
+                const data = JSON.stringify({
+                    message_type: WSMessageType.Error,
+                    provider_config_key: providerConfigKey,
+                    connection_id: connectionId,
+                    error_type: wsErr.type,
+                    error_desc: wsErr.message
+                });
+                client.send(data);
+                logger.info(`[notifyErr] message sent to "${clientId}: ${data}"`);
 
                 client.close();
                 this.removeClient(clientId);
             }
+        } else {
+            logger.warn(`[notifyErr] No client found for clientId "${clientId}"`);
         }
 
         errorHtml(res, clientId, wsErr);
@@ -54,17 +56,19 @@ class WSClient {
         if (clientId) {
             const client = this.getClient(clientId);
             if (client) {
-                client.send(
-                    JSON.stringify({
-                        message_type: WSMessageType.Success,
-                        provider_config_key: providerConfigKey,
-                        connection_id: connectionId
-                    })
-                );
+                const data = JSON.stringify({
+                    message_type: WSMessageType.Success,
+                    provider_config_key: providerConfigKey,
+                    connection_id: connectionId
+                });
+                client.send(data);
+                logger.info(`[notifySuccess] message sent to "${clientId}: ${data}"`);
 
                 client.close();
                 this.removeClient(clientId);
             }
+        } else {
+            logger.warn(`[notifySuccess] No client found for clientId "${clientId}"`);
         }
 
         successHtml(res, clientId, providerConfigKey, connectionId);


### PR DESCRIPTION
There is a possibility that the frontend doesn't connect to the websocket server fast enough (aka before the server sends the notifySuccess/Error). In this case the success/error message is never send.
This commit adds logging in notifySuccess/Err to test this theory and confirm if the server successfully sends those websocket messages

That would explain why this bug is not reproducible locally since the websocket connection would be really fast unlike in prod where the connection has to go through the internet :)