### PR TITLE
[gh-#1171]Validates Metadata and displays a friendly error message

### DIFF
--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -483,7 +483,12 @@ export const formatScriptError = (err: any, errorType: string, scriptName: strin
         errorMessage = String(err);
     }
 
-    const content = `The script failed to execute for ${scriptName} with the following error: ${errorMessage}`;
+    let content = `The script failed to execute for ${scriptName} with the following error: ${errorMessage}`;
+
+    if(err.type === 'missing_metadata' && (errorType === 'action_script_failure' || errorType === 'sync_script_failure')){
+        const integrationType = errorType.split('_')[0];
+        content = `This ${integrationType} requires inputs to run. Currently, it is missing ${(err.missingProperty as Array<string>).slice(0, -1).join(', ')} and ${(err.missingProperty as Array<string>).at(-1)}, so it cannot execute. Use the connection metadata to pass in inputs to this ${integrationType}. You can visit this page (https://docs.nango.dev/guides/advanced-auth#storing-custom-metadata-per-connection) to see what metadata is required for this ${integrationType}.`
+    }
 
     const status = err?.response?.status || 500;
     const error = new NangoError(errorType, content, status);

--- a/packages/worker/lib/integration.service.ts
+++ b/packages/worker/lib/integration.service.ts
@@ -91,7 +91,7 @@ class IntegrationService implements IntegrationServiceInterface {
                     return { success: false, error: new NangoError(content, 500), response: null };
                 }
             } catch (err: any) {
-                const errorType = isAction ? 'action_script_failure' : 'sync_script_failre';
+                const errorType = isAction ? 'action_script_failure' : 'sync_script_failure';
                 const { success, error, response } = formatScriptError(err, errorType, syncName);
 
                 if (activityLogId && writeToDb) {


### PR DESCRIPTION
- Resolves #1171 
<br>

screenshot of the activity log after locally triggered custom integration with no metadata
![ssc](https://github.com/NangoHQ/nango/assets/77796540/980f2a86-dc3b-44cf-be33-662f1659dd59)
