### PR TITLE
enviornment srv: fetch env from db if not in cache

### DIFF
--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -96,7 +96,12 @@ class EnvironmentService {
         }
 
         if (!this.environmentAccountSecrets[secretKey]) {
-            return null;
+            // If the secret key is not in the cache, try to get it from the database
+            const fromDb = await db.knex.withSchema(db.schema()).select('*').from<Environment>(TABLE).where({ secret_key: secretKey }).first();
+            if (fromDb == null) {
+                return null;
+            }
+            this.addToEnvironmentSecretCache(fromDb);
         }
 
         const { accountId, environmentId } = this.environmentAccountSecrets[secretKey] as EnvironmentAccount;

--- a/packages/shared/lib/services/environment.service.unit.test.ts
+++ b/packages/shared/lib/services/environment.service.unit.test.ts
@@ -8,38 +8,46 @@ const environmentAccounts = [
     { id: 2, account_id: '456', name: 'env2', secret_key: 'key2' },
     { id: 3, account_id: '789', name: 'env3', secret_key: 'key3' }
 ];
+const extraAccount = { id: 4, account_id: '1011', name: 'env4', secret_key: 'key4' };
 
-describe('Environment secret cache', () => {
-    it('Caches all secrets as expected', async () => {
+describe('Environment service', () => {
+    it('can retrieve secrets', async () => {
         vi.mock('../db/database.js', async () => {
+            const actual = (await vi.importActual('../db/database.js')) as any;
             return {
                 default: {
-                    schema: () => {
-                        return {
-                            select: () => {
-                                return {
-                                    from: () => {
-                                        return Promise.resolve(environmentAccounts);
-                                    }
-                                };
-                            }
-                        };
-                    },
+                    schema: actual.schema,
                     knex: {
                         withSchema: () => {
                             return {
                                 select: () => {
                                     return {
-                                        from: () => {
-                                            return Promise.resolve(environmentAccounts);
-                                        }
-                                    };
-                                },
-                                from: () => {
-                                    return {
-                                        insert: (args: any) => {
-                                            return Promise.resolve([{ id: 1, ...args }]);
-                                        }
+                                        from: () =>
+                                            new Proxy(
+                                                {
+                                                    where: ({ secret_key }: { secret_key: string }) => {
+                                                        return {
+                                                            first: () => {
+                                                                if (secret_key === extraAccount.secret_key) {
+                                                                    return Promise.resolve(extraAccount);
+                                                                } else {
+                                                                    return Promise.resolve(null);
+                                                                }
+                                                            }
+                                                        };
+                                                    }
+                                                },
+                                                {
+                                                    get(target, prop, receiver) {
+                                                        if (prop === Symbol.iterator) {
+                                                            return function* () {
+                                                                yield* environmentAccounts;
+                                                            };
+                                                        }
+                                                        return Reflect.get(target, prop, receiver);
+                                                    }
+                                                }
+                                            )
                                     };
                                 }
                             };
@@ -51,11 +59,17 @@ describe('Environment secret cache', () => {
         vi.spyOn(encryptionManager, 'decryptEnvironment').mockImplementation((environmentAccount: Environment | null) => {
             return environmentAccount;
         });
+        vi.spyOn(environmentService as any, 'addToEnvironmentSecretCache');
 
         await environmentService.cacheSecrets();
         expect(await environmentService.getAccountIdAndEnvironmentIdBySecretKey('key1')).toEqual({ accountId: '123', environmentId: 1 });
         expect(await environmentService.getAccountIdAndEnvironmentIdBySecretKey('key2')).toEqual({ accountId: '456', environmentId: 2 });
         expect(await environmentService.getAccountIdAndEnvironmentIdBySecretKey('key3')).toEqual({ accountId: '789', environmentId: 3 });
-        expect(await environmentService.getAccountIdAndEnvironmentIdBySecretKey('key4')).toEqual(null);
+        expect(await environmentService.getAccountIdAndEnvironmentIdBySecretKey('key4')).toEqual({ accountId: '1011', environmentId: 4 });
+        expect(await environmentService.getAccountIdAndEnvironmentIdBySecretKey('key5')).toEqual(null);
+
+        // retrieving the same key again should not call addToEnvironmentSecretCache again
+        expect(await environmentService.getAccountIdAndEnvironmentIdBySecretKey('key4')).toEqual({ accountId: '1011', environmentId: 4 });
+        expect((environmentService as any).addToEnvironmentSecretCache).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
## Describe your changes
environment service is now fetching from the db if env is not cached yet. 
This allows server to load environment that would have been created after it started

## Issue ticket number and link
#1295

## Checklist before requesting a review
- [x] I added tests
- [ ] I observability, otherwise the reason is: N/A
- [ ] I added analytics, otherwise the reason is: N/A
