### PR TITLE
Prevent multiple oauth token refresh to occur at the same time

### DIFF
--- a/packages/shared/lib/utils/kvstore/InMemoryStore.ts
+++ b/packages/shared/lib/utils/kvstore/InMemoryStore.ts
@@ -1,0 +1,49 @@
+import type { KVStore } from './KVStore';
+
+interface Value {
+    value: string;
+    timestamp: number;
+    ttlInMs: number;
+}
+
+export class InMemoryKVStore implements KVStore {
+    private store: Map<string, Value>;
+
+    constructor() {
+        this.store = new Map();
+    }
+
+    public async get(key: string): Promise<string | null> {
+        const res = this.store.get(key);
+        if (res === undefined) {
+            return null;
+        }
+        if (this.isExpired(res)) {
+            this.store.delete(key);
+            return null;
+        }
+        return Promise.resolve(res.value);
+    }
+
+    public async set(key: string, value: string, canOverride: boolean = true, ttlInMs: number = 0): Promise<void> {
+        const res = this.store.get(key);
+        const isExpired = res && this.isExpired(res);
+        if (isExpired || canOverride || res === undefined) {
+            this.store.set(key, { value: value, timestamp: Date.now(), ttlInMs: ttlInMs });
+            return Promise.resolve();
+        }
+        return Promise.reject('Key already exists');
+    }
+
+    public async delete(key: string): Promise<void> {
+        this.store.delete(key);
+        return Promise.resolve();
+    }
+
+    private isExpired(value: Value): boolean {
+        if (value.ttlInMs > 0 && value.timestamp + value.ttlInMs < Date.now()) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/packages/shared/lib/utils/kvstore/InMemoryStore.unit.test.ts
+++ b/packages/shared/lib/utils/kvstore/InMemoryStore.unit.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { InMemoryKVStore } from './InMemoryStore';
+
+describe('InMemoryKVStore', () => {
+    let store: InMemoryKVStore;
+    beforeEach(() => {
+        store = new InMemoryKVStore();
+    });
+
+    it('should set and get a value', async () => {
+        store.set('key', 'value');
+        const value = await store.get('key');
+        expect(value).toEqual('value');
+    });
+
+    it('should return null for a non-existent key', async () => {
+        const value = await store.get('do-not-exist');
+        expect(value).toBeNull();
+    });
+
+    it('should allow overriding a key', async () => {
+        store.set('key', 'value');
+        await store.set('key', 'value2', true);
+        const value = await store.get('key');
+        expect(value).toEqual('value2');
+    });
+
+    it('should not allow overriding a key', async () => {
+        store.set('key', 'value');
+        await expect(store.set('key', 'value2', false)).rejects.toEqual('Key already exists');
+    });
+
+    it('should return null for a key that has expired', async () => {
+        const ttlInMs = 1000;
+        store.set('key', 'value', true, ttlInMs);
+        await new Promise((resolve) => setTimeout(resolve, ttlInMs * 2));
+        const value = await store.get('key');
+        expect(value).toBeNull();
+    });
+
+    it('should not return null for a key that has not expired', async () => {
+        const ttlInMs = 2000;
+        store.set('key', 'value', true, ttlInMs);
+        await new Promise((resolve) => setTimeout(resolve, ttlInMs / 2));
+        const value = await store.get('key');
+        expect(value).toEqual('value');
+    });
+
+    it('should allow setting an expired key', async () => {
+        store.set('key', 'value', false, 10);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        await expect(store.set('key', 'value', false)).resolves.not.toThrow();
+    });
+
+    it('should allow setting a key with a TTL of 0', async () => {
+        store.set('key', 'value', true, 0);
+        const value = await store.get('key');
+        expect(value).toEqual('value');
+    });
+
+    it('should allow deleting a key', async () => {
+        store.delete('key');
+        const value = await store.get('key');
+        expect(value).toBeNull();
+    });
+});

--- a/packages/shared/lib/utils/kvstore/KVStore.ts
+++ b/packages/shared/lib/utils/kvstore/KVStore.ts
@@ -1,0 +1,5 @@
+export interface KVStore {
+    set(key: string, value: string, canOverride?: boolean, ttlInMs?: number): Promise<void>;
+    get(key: string): Promise<string | null>;
+    delete(key: string): Promise<void>;
+}

--- a/packages/shared/lib/utils/kvstore/RedisStore.ts
+++ b/packages/shared/lib/utils/kvstore/RedisStore.ts
@@ -1,0 +1,41 @@
+import type { KVStore } from './KVStore';
+import { createClient } from 'redis';
+import type { RedisClientType } from 'redis';
+
+export class RedisKVStore implements KVStore {
+    private client: RedisClientType;
+
+    constructor(url: string) {
+        this.client = createClient({ url: url });
+
+        this.client.on('error', (err) => {
+            console.error(`Redis (publisher) error: ${err}`);
+        });
+    }
+
+    public async connect(): Promise<void> {
+        return this.client.connect().then(() => {});
+    }
+
+    public async get(key: string): Promise<string | null> {
+        return this.client.get(key);
+    }
+
+    public async set(key: string, value: string, canOverride: boolean = true, ttlInMs: number = 0): Promise<void> {
+        let options: any = {};
+        if (ttlInMs > 0) {
+            options['PX'] = ttlInMs;
+        }
+        if (!canOverride) {
+            options['NX'] = true;
+        }
+        const res = await this.client.set(key, value, options);
+        if (res !== 'OK') {
+            throw new Error(`Failed to set key: ${key}, value: ${value}, canOverride: ${canOverride}, ttlInMs: ${ttlInMs}`);
+        }
+    }
+
+    public async delete(key: string): Promise<void> {
+        await this.client.del(key);
+    }
+}

--- a/packages/shared/lib/utils/lock/locking.ts
+++ b/packages/shared/lib/utils/lock/locking.ts
@@ -1,0 +1,43 @@
+import type { KVStore } from '../kvstore/KVStore.js';
+
+export class Locking {
+    private store: KVStore;
+
+    constructor(store: KVStore) {
+        this.store = store;
+    }
+
+    public async tryAcquire(key: string, ttlInMs: number, acquitistionTimeoutMs: number): Promise<void> {
+        if (ttlInMs <= 0) {
+            throw new Error(`lock's TTL must be greater than 0`);
+        }
+        if (acquitistionTimeoutMs <= 0) {
+            throw new Error(`acquitistionTimeoutMs must be greater than 0`);
+        }
+        const start = Date.now();
+        while (Date.now() - start < acquitistionTimeoutMs) {
+            try {
+                await this.acquire(key, ttlInMs);
+                return;
+            } catch (e) {
+                await new Promise((resolve) => setTimeout(resolve, 50));
+            }
+        }
+        throw new Error(`Acquiring lock for key: ${key} timed out after ${acquitistionTimeoutMs}ms`);
+    }
+
+    public async acquire(key: string, ttlInMs: number): Promise<void> {
+        if (ttlInMs <= 0) {
+            throw new Error(`lock's TTL must be greater than 0`);
+        }
+        try {
+            await this.store.set(key, '1', false, ttlInMs);
+        } catch (e) {
+            throw new Error(`Failed to acquire lock for key: ${key}`);
+        }
+    }
+
+    public async release(key: string): Promise<void> {
+        await this.store.delete(key);
+    }
+}

--- a/packages/shared/lib/utils/lock/locking.unit.test.ts
+++ b/packages/shared/lib/utils/lock/locking.unit.test.ts
@@ -1,0 +1,52 @@
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { Locking } from './locking';
+import { InMemoryKVStore } from '../kvstore/InMemoryStore';
+
+describe('Locking', () => {
+    let store: InMemoryKVStore;
+    let locking: Locking;
+    let KEY = 'key';
+
+    beforeAll(async () => {
+        store = new InMemoryKVStore();
+        locking = new Locking(store);
+    });
+
+    beforeEach(async () => {
+        store.delete(KEY);
+    });
+
+    it('should acquire and release a lock', async () => {
+        await locking.acquire(KEY, 1000);
+        await locking.release(KEY);
+    });
+
+    it('should throws an error if ttlInMs is not positive', async () => {
+        await expect(locking.acquire(KEY, 0)).rejects.toEqual(new Error(`lock's TTL must be greater than 0`));
+        await expect(locking.tryAcquire(KEY, 0, 10000)).rejects.toThrowError(`lock's TTL must be greater than 0`);
+    });
+
+    it('should prevents acquisition of existing lock', async () => {
+        await locking.acquire(KEY, 1000);
+        await expect(locking.acquire(KEY, 1000)).rejects.toThrowError('Failed to acquire lock for key: key');
+    });
+
+    it('should aquire an expired lock', async () => {
+        await locking.acquire(KEY, 200);
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        await locking.acquire(KEY, 200);
+    });
+
+    it('should wait and acquire a expired lock', async () => {
+        await locking.acquire(KEY, 1000);
+        await expect(locking.tryAcquire(KEY, 200, 2000)).resolves.not.toThrow();
+    });
+
+    it('should wait and acquire a released lock', async () => {
+        await locking.acquire(KEY, 1000);
+        setTimeout(() => {
+            locking.release(KEY);
+        }, 500);
+        await expect(locking.tryAcquire(KEY, 200, 1000)).resolves.not.toThrow();
+    });
+});


### PR DESCRIPTION
## Describe your changes

The goal is to make sure that multiple request to refresh the oauth token are not conflicting and overriding each other. The implementation is using Redis to add a lock around the oauth token refresh logic

## Issue ticket number and link
Third part of https://www.notion.so/nangohq/Nov-2023-Server-Horizontal-Scaling-209359b01bac4457aaba95a4eb8d3b5a

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests
- [ ] I observability, otherwise the reason is: we can [monitor](https://us3.datadoghq.com/apm/traces?query=%40_top_level%3A1%20env%3Aproduction%20-service%3Anango-postgres%20%40http.path_group%3A%2Fconnection%2F%2A%20%40http.method%3AGET&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&graphType=flamegraph&historicalData=false&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&spanType=service-entry&traceQuery=&view=spans&start=1701250099281&end=1701250999281&paused=false) requests to GET `/connections/ID`
- [ ] I added analytics, otherwise the reason is: n/a
