### PR TITLE
[gh-#1362] parse expires at and provide it if not given

### DIFF
--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -538,6 +538,11 @@ class ConnectionController {
             if (template.auth_mode === ProviderAuthModes.OAuth2) {
                 const { access_token, refresh_token, expires_at, expires_in, metadata, connection_config } = req.body;
 
+                const { expires_at: parsedExpiresAt } = connectionService.parseRawCredentials(
+                    { access_token, refresh_token, expires_at, expires_in },
+                    template.auth_mode
+                ) as OAuth2Credentials;
+
                 if (!access_token) {
                     errorManager.errRes(res, 'missing_access_token');
                     return;
@@ -546,7 +551,7 @@ class ConnectionController {
                     type: template.auth_mode,
                     access_token,
                     refresh_token,
-                    expires_at,
+                    expires_at: expires_at || parsedExpiresAt,
                     expires_in,
                     metadata,
                     connection_config,


### PR DESCRIPTION
## Describe your changes
Extracts `expires_at` and provides it if not given when importing a connection

## Issue ticket number and link
Resolves #1362 

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: n/a
- [ ] I added observability, otherwise the reason is: n/a
- [ ] I added analytics, otherwise the reason is: n/a
