### PR TITLE
[NAN-76] sync heartbeat to know when a sync or action has stalled

### DIFF
--- a/packages/cli/lib/services/local-integration.service.ts
+++ b/packages/cli/lib/services/local-integration.service.ts
@@ -7,6 +7,7 @@ import { Buffer } from 'buffer';
 class IntegrationService implements IntegrationServiceInterface {
     async runScript(
         syncName: string,
+        _syncId: string,
         _activityLogId: number | undefined,
         nango: NangoSync,
         _integrationData: NangoIntegrationData,

--- a/packages/shared/lib/models/Sync.ts
+++ b/packages/shared/lib/models/Sync.ts
@@ -290,6 +290,7 @@ export interface SyncConfigWithProvider {
 export interface IntegrationServiceInterface {
     runScript(
         syncName: string,
+        syncId: string,
         activityLogId: number | undefined,
         nango: NangoSync,
         integrationData: NangoIntegrationData,

--- a/packages/shared/lib/models/Sync.ts
+++ b/packages/shared/lib/models/Sync.ts
@@ -298,6 +298,7 @@ export interface IntegrationServiceInterface {
         writeToDb: boolean,
         isAction: boolean,
         optionalLoadLocation?: string,
-        input?: object
+        input?: object,
+        temporalContext?: unknown
     ): Promise<any>;
 }

--- a/packages/shared/lib/models/Sync.ts
+++ b/packages/shared/lib/models/Sync.ts
@@ -1,3 +1,4 @@
+import type { Context } from '@temporalio/activity';
 import { LogActionEnum } from './Activity.js';
 import type { HTTP_VERB, Timestamps, TimestampsAndDeleted } from './Generic.js';
 import type { NangoSync } from '../sdk/sync.js';
@@ -299,6 +300,6 @@ export interface IntegrationServiceInterface {
         isAction: boolean,
         optionalLoadLocation?: string,
         input?: object,
-        temporalContext?: unknown
+        temporalContext?: Context
     ): Promise<any>;
 }

--- a/packages/shared/lib/services/sync/run.service.ts
+++ b/packages/shared/lib/services/sync/run.service.ts
@@ -1,3 +1,4 @@
+import type { Context } from '@temporalio/activity';
 import { loadLocalNangoConfig, nangoConfigFile } from '../nango-config.service.js';
 import type { NangoConnection } from '../../models/Connection.js';
 import { SyncResult, SyncType, SyncStatus, Job as SyncJob, IntegrationServiceInterface } from '../../models/Sync.js';
@@ -43,6 +44,8 @@ interface SyncRunConfig {
 
     logMessages?: unknown[] | undefined;
     stubbedMetadata?: Metadata | undefined;
+
+    temporalContext?: Context;
 }
 
 export default class SyncRun {
@@ -63,6 +66,8 @@ export default class SyncRun {
 
     logMessages?: unknown[] | undefined = [];
     stubbedMetadata?: Metadata | undefined = undefined;
+
+    temporalContext?: Context;
 
     constructor(config: SyncRunConfig) {
         this.integrationService = config.integrationService;
@@ -106,6 +111,10 @@ export default class SyncRun {
 
         if (config.stubbedMetadata) {
             this.stubbedMetadata = config.stubbedMetadata;
+        }
+
+        if (config.temporalContext) {
+            this.temporalContext = config.temporalContext;
         }
     }
 
@@ -294,6 +303,7 @@ export default class SyncRun {
                     response: userDefinedResults
                 } = await this.integrationService.runScript(
                     this.syncName,
+                    this.syncId as string,
                     this.activityLogId as number,
                     nango,
                     syncData,

--- a/packages/shared/lib/services/sync/run.service.ts
+++ b/packages/shared/lib/services/sync/run.service.ts
@@ -303,7 +303,8 @@ export default class SyncRun {
                     response: userDefinedResults
                 } = await this.integrationService.runScript(
                     this.syncName,
-                    this.syncId as string,
+                    (this.syncId as string) ||
+                        `${this.syncName}-${this.nangoConnection.environment_id}-${this.nangoConnection.provider_config_key}-${this.nangoConnection.connection_id}`,
                     this.activityLogId as number,
                     nango,
                     syncData,

--- a/packages/shared/lib/services/sync/run.service.ts
+++ b/packages/shared/lib/services/sync/run.service.ts
@@ -311,7 +311,8 @@ export default class SyncRun {
                     this.writeToDb,
                     this.isAction,
                     this.loadLocation,
-                    this.input
+                    this.input,
+                    this.temporalContext
                 );
 
                 if (!success || (error && userDefinedResults === null)) {

--- a/packages/worker/lib/activities.ts
+++ b/packages/worker/lib/activities.ts
@@ -56,6 +56,8 @@ export async function runAction(args: ActionArgs): Promise<ServiceResponse> {
         nangoConnection?.environment_id as number
     )) as ProviderConfig;
 
+    const context: Context = Context.current();
+
     const syncRun = new syncRunService({
         integrationService,
         writeToDb: true,
@@ -66,7 +68,8 @@ export async function runAction(args: ActionArgs): Promise<ServiceResponse> {
         activityLogId,
         input,
         provider: syncConfig.provider,
-        debug: false
+        debug: false,
+        temporalContext: context
     });
 
     const actionResults = await syncRun.run();
@@ -243,6 +246,7 @@ export async function syncProvider(
             syncType,
             activityLogId,
             provider: syncConfig.provider,
+            temporalContext,
             debug
         });
 

--- a/packages/worker/lib/integration.service.ts
+++ b/packages/worker/lib/integration.service.ts
@@ -1,3 +1,4 @@
+import type { Context } from '@temporalio/activity';
 import { NodeVM } from 'vm2';
 import {
     IntegrationServiceInterface,
@@ -14,8 +15,15 @@ import {
 } from '@nangohq/shared';
 
 class IntegrationService implements IntegrationServiceInterface {
+    public runningScripts: { [key: string]: Context } = {};
+
+    constructor() {
+        this.sendHeartbeat();
+    }
+
     async runScript(
         syncName: string,
+        syncId: string,
         activityLogId: number | undefined,
         nango: NangoSync,
         integrationData: NangoIntegrationData,
@@ -23,7 +31,8 @@ class IntegrationService implements IntegrationServiceInterface {
         writeToDb: boolean,
         isAction: boolean,
         optionalLoadLocation?: string,
-        input?: object
+        input?: object,
+        temporalContext?: Context
     ): Promise<ServiceResponse<any>> {
         try {
             const script: string | null =
@@ -60,6 +69,10 @@ class IntegrationService implements IntegrationServiceInterface {
             }
 
             try {
+                if (temporalContext) {
+                    this.runningScripts[syncId] = temporalContext;
+                }
+
                 const vm = new NodeVM({
                     console: 'inherit',
                     sandbox: { nango },
@@ -75,6 +88,8 @@ class IntegrationService implements IntegrationServiceInterface {
                 if (typeof scriptExports.default === 'function') {
                     const results = isAction ? await scriptExports.default(nango, input) : await scriptExports.default(nango);
 
+                    delete this.runningScripts[syncId];
+
                     return { success: true, error: null, response: results };
                 } else {
                     const content = `There is no default export that is a function for ${syncName}`;
@@ -87,6 +102,8 @@ class IntegrationService implements IntegrationServiceInterface {
                             timestamp: Date.now()
                         });
                     }
+
+                    delete this.runningScripts[syncId];
 
                     return { success: false, error: new NangoError(content, 500), response: null };
                 }
@@ -104,6 +121,8 @@ class IntegrationService implements IntegrationServiceInterface {
                     });
                 }
 
+                delete this.runningScripts[syncId];
+
                 return { success, error, response };
             }
         } catch (err) {
@@ -120,8 +139,20 @@ class IntegrationService implements IntegrationServiceInterface {
                 });
             }
 
+            delete this.runningScripts[syncId];
+
             return { success: false, error: new NangoError(content, 500), response: null };
         }
+    }
+
+    private sendHeartbeat() {
+        setInterval(() => {
+            Object.keys(this.runningScripts).forEach((syncId) => {
+                const context = this.runningScripts[syncId];
+
+                context?.heartbeat();
+            });
+        });
     }
 }
 

--- a/packages/worker/lib/integration.service.ts
+++ b/packages/worker/lib/integration.service.ts
@@ -88,8 +88,6 @@ class IntegrationService implements IntegrationServiceInterface {
                 if (typeof scriptExports.default === 'function') {
                     const results = isAction ? await scriptExports.default(nango, input) : await scriptExports.default(nango);
 
-                    delete this.runningScripts[syncId];
-
                     return { success: true, error: null, response: results };
                 } else {
                     const content = `There is no default export that is a function for ${syncName}`;
@@ -102,8 +100,6 @@ class IntegrationService implements IntegrationServiceInterface {
                             timestamp: Date.now()
                         });
                     }
-
-                    delete this.runningScripts[syncId];
 
                     return { success: false, error: new NangoError(content, 500), response: null };
                 }
@@ -121,8 +117,6 @@ class IntegrationService implements IntegrationServiceInterface {
                     });
                 }
 
-                delete this.runningScripts[syncId];
-
                 return { success, error, response };
             }
         } catch (err) {
@@ -139,9 +133,9 @@ class IntegrationService implements IntegrationServiceInterface {
                 });
             }
 
-            delete this.runningScripts[syncId];
-
             return { success: false, error: new NangoError(content, 500), response: null };
+        } finally {
+            delete this.runningScripts[syncId];
         }
     }
 

--- a/packages/worker/lib/integration.service.ts
+++ b/packages/worker/lib/integration.service.ts
@@ -152,7 +152,7 @@ class IntegrationService implements IntegrationServiceInterface {
 
                 context?.heartbeat();
             });
-        });
+        }, 600000);
     }
 }
 

--- a/packages/worker/lib/integration.service.ts
+++ b/packages/worker/lib/integration.service.ts
@@ -152,7 +152,7 @@ class IntegrationService implements IntegrationServiceInterface {
 
                 context?.heartbeat();
             });
-        }, 600000);
+        }, 300000);
     }
 }
 

--- a/packages/worker/lib/workflows.ts
+++ b/packages/worker/lib/workflows.ts
@@ -11,7 +11,7 @@ const { routeSync, scheduleAndRouteSync, runAction } = proxyActivities<typeof ac
         initialInterval: '5m',
         maximumAttempts: 3
     },
-    heartbeatTimeout: '10m'
+    heartbeatTimeout: '30m'
 });
 
 export async function initialSync(args: InitialSyncArgs): Promise<boolean | object | null> {

--- a/packages/worker/lib/workflows.ts
+++ b/packages/worker/lib/workflows.ts
@@ -10,7 +10,8 @@ const { routeSync, scheduleAndRouteSync, runAction } = proxyActivities<typeof ac
     retry: {
         initialInterval: '5m',
         maximumAttempts: 3
-    }
+    },
+    heartbeatTimeout: '10m'
 });
 
 export async function initialSync(args: InitialSyncArgs): Promise<boolean | object | null> {


### PR DESCRIPTION
## Describe your changes
For each sync store the syncId and temporal context in memory and send a heartbeat every 5 minutes. Set temporal to timeout if a heartbeat is not received within 30 minutes

## Issue ticket number and link
NAN-76

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: n/a
- [ ] I added observability, otherwise the reason is: n/a
- [ ] I added analytics, otherwise the reason is: n/a
