### PR TITLE
Correct return type for listIntegrations

### DIFF
--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -139,7 +139,7 @@ export class Nango {
      * =======
      */
 
-    public async listIntegrations(): Promise<{ config: Pick<Integration, 'unique_key' | 'provider'>[] }> {
+    public async listIntegrations(): Promise<{ configs: Pick<Integration, 'unique_key' | 'provider'>[] }> {
         const url = `${this.serverUrl}/config`;
         const response = await axios.get(url, { headers: this.enrichHeaders({}) });
 


### PR DESCRIPTION
## Describe your changes
The [controller](https://github.com/NangoHQ/nango/blob/a910b15da8481c94e71c3c3ec1d6284e7b305b2c/packages/server/lib/controllers/config.controller.ts#L147C41-L147C41) returns `configs`, this change corrects to match the server.

## Issue ticket number and link
No issue

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: No existing tests for this library that I can find
- [ ] I added observability, otherwise the reason is: N/A
- [ ] I added analytics, otherwise the reason is: N/A
