### PR TITLE
salesforce integration: add prompt=consent ouath parameter

### DIFF
--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -915,6 +915,8 @@ salesforce:
     auth_mode: OAUTH2
     authorization_url: https://login.salesforce.com/services/oauth2/authorize
     token_url: https://login.salesforce.com/services/oauth2/token
+    authorization_params:
+        prompt: consent
     default_scopes:
         - offline_access
     token_response_metadata:


### PR DESCRIPTION
## Describe your changes
With the prompt parameter set to 'consent', an user would always be asked to allow access to given SF app, even if they are already logged in.

https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_web_server_flow.htm&type=5

Resolved #1371 


