### PR TITLE
[nan-103] add composite index

### DIFF
--- a/packages/shared/lib/db/migrations/20231205184840_records_composite_index.cjs
+++ b/packages/shared/lib/db/migrations/20231205184840_records_composite_index.cjs
@@ -2,12 +2,12 @@ const tableName = '_nango_sync_data_records';
 
 exports.up = function (knex, _) {
     return knex.schema.withSchema('nango').alterTable(tableName, function (table) {
-        table.index(['created_at', 'id']);
+        table.index(['nango_connection_id', 'model', 'created_at', 'id'], 'idx_nango_records_composite');
     });
 };
 
 exports.down = function (knex, _) {
     return knex.schema.withSchema('nango').table(tableName, function (table) {
-        table.dropIndex(['created_at', 'id']);
+        table.dropIndex(['nango_connection_id', 'model', 'created_at', 'id'], 'idx_nango_records_composite');
     });
 };

--- a/packages/shared/lib/db/migrations/20231205184840_records_composite_index.cjs
+++ b/packages/shared/lib/db/migrations/20231205184840_records_composite_index.cjs
@@ -1,13 +1,11 @@
 const tableName = '_nango_sync_data_records';
 
-exports.up = function (knex, _) {
-    return knex.schema.withSchema('nango').alterTable(tableName, function (table) {
-        table.index(['nango_connection_id', 'model', 'created_at', 'id'], 'idx_nango_records_composite');
-    });
+exports.config = { transaction: false };
+
+exports.up = function(knex) {
+  return knex.schema.raw('CREATE INDEX CONCURRENTLY idx_nango_records_composite ON nango._nango_sync_data_records (nango_connection_id, model, created_at, id)');
 };
 
-exports.down = function (knex, _) {
-    return knex.schema.withSchema('nango').table(tableName, function (table) {
-        table.dropIndex(['nango_connection_id', 'model', 'created_at', 'id'], 'idx_nango_records_composite');
-    });
+exports.down = function(knex) {
+  return knex.schema.raw('DROP INDEX CONCURRENTLY idx_nango_records_composite');
 };

--- a/packages/shared/lib/db/migrations/20231205184840_records_composite_index.cjs
+++ b/packages/shared/lib/db/migrations/20231205184840_records_composite_index.cjs
@@ -1,0 +1,13 @@
+const tableName = '_nango_sync_data_records';
+
+exports.up = function (knex, _) {
+    return knex.schema.withSchema('nango').alterTable(tableName, function (table) {
+        table.index(['created_at', 'id']);
+    });
+};
+
+exports.down = function (knex, _) {
+    return knex.schema.withSchema('nango').table(tableName, function (table) {
+        table.dropIndex(['created_at', 'id']);
+    });
+};


### PR DESCRIPTION
## Describe your changes
Adds a composite index on the `['nango_connection_id', 'model', 'created_at', 'id']` field to improve the `order by`. Note that this migration runs using concurrently as to not lock the table when performing the migration. This table has a lot of active writes since syncs write to it frequently.

## Issue ticket number and link
NAN-103

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
