### PR TITLE
Add support for paypal and paypal-sandbox endpoints

### DIFF
--- a/docs-v2/integrations/all/paypal.mdx
+++ b/docs-v2/integrations/all/paypal.mdx
@@ -3,7 +3,7 @@ title: Paypal
 sidebarTitle: Paypal
 ---
 
-API configuration: [`paypal`](https://nango.dev/providers.yaml)
+API configuration: [`paypal`](https://nango.dev/providers.yaml), [`paypal-sandbox`](https://nango.dev/providers.yaml)
 
 ## Features
 

--- a/docs-v2/integrations/all/paypal.mdx
+++ b/docs-v2/integrations/all/paypal.mdx
@@ -1,0 +1,32 @@
+---
+title: Paypal
+sidebarTitle: Paypal
+---
+
+API configuration: [`paypal`](https://nango.dev/providers.yaml)
+
+## Features
+
+| Feature                                                                          | Status                          |
+| -------------------------------------------------------------------------------- | ------------------------------- |
+| [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
+| [Syncs](/guides/sync) & [Actions](/guides/action)                                                              | ✅                              |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
+| Auto-pagination                     | 🚫 (time to contribute: &lt;1h) |
+| API-specific rate limits | 🚫 (time to contribute: &lt;1h) |
+
+<Tip>We can implement missing features in &lt;48h, just ask for it in the [community](https://nango.dev/slack).</Tip>
+
+## Getting started
+
+-   [How to register an Application](https://developer.paypal.com/dashboard/applications/live)
+-   [OAuth-related docs](https://developer.paypal.com/api/rest/authentication/)
+-   [List of OAuth scopes](https://developer.paypal.com/api/rest/requests#:~:text=if%20not%20provided.-,scope,-Optional)
+
+<Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
+
+## API gotchas
+
+- Specific parameters for the OAuth flow can be used for testing according to the [documentation](https://developer.paypal.com/tools/sandbox).
+
+<Note>Add Getting Started links and Gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/paypal.mdx)</Note>

--- a/docs-v2/integrations/payment.mdx
+++ b/docs-v2/integrations/payment.mdx
@@ -6,6 +6,7 @@
 <CardGroup cols={4}>
     <Card title="Braintree" href="/integrations/all/braintree" color="#68a063" />
     <Card title="Gumroad" href="/integrations/all/gumroad" color="#68a063" />
+    <Card title="Paypal" href="/integrations/all/paypal" color="#68a063" />
     <Card title="Pennylane" href="/integrations/all/pennylane" color="#68a063" />
     <Card title="Splitwise" href="/integrations/all/splitwise" color="#68a063" />
     <Card title="Squareup" href="/integrations/all/squareup" color="#68a063" />

--- a/docs-v2/mint.json
+++ b/docs-v2/mint.json
@@ -241,6 +241,7 @@
                         "integrations/all/pagerduty",
                         "integrations/all/pandadoc",
                         "integrations/all/payfit",
+                        "integrations/all/paypal",
                         "integrations/all/pennylane",
                         "integrations/all/pipedrive",
                         "integrations/all/qualtrics",

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -803,6 +803,28 @@ payfit:
         response_type: code
     token_params:
         grant_type: authorization_code
+paypal:
+    auth_mode: OAUTH2
+    authorization_url: https://www.paypal.com/signin/authorize
+    token_url: https://api.paypal.com/v1/oauth2/token
+    token_request_auth_method: basic
+    authorization_params:
+        response_type: code
+    token_params:
+        grant_type: authorization_code
+    refresh_params:
+        grant_type: refresh_token
+paypal-sandbox:
+    auth_mode: OAUTH2
+    authorization_url: https://www.sandbox.paypal.com/signin/authorize
+    token_url: https://api-m.sandbox.paypal.com/v1/oauth2/token
+    token_request_auth_method: basic
+    authorization_params:
+        response_type: code
+    token_params:
+        grant_type: authorization_code
+    refresh_params:
+        grant_type: refresh_token
 pennylane:
     auth_mode: OAUTH2
     authorization_url: https://app.pennylane.com/oauth/authorize

--- a/packages/webapp/public/images/template-logos/paypal-sandbox.svg
+++ b/packages/webapp/public/images/template-logos/paypal-sandbox.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg xmlns="http://www.w3.org/2000/svg"
+aria-label="PayPal" role="img"
+viewBox="0 0 512 512"><rect
+width="512" height="512"
+rx="15%"
+fill="#ffffff"/><path fill="#002c8a" d="M377 184.8L180.7 399h-72c-5 0-9-5-8-10l48-304c1-7 7-12 14-12h122c84 3 107 46 92 112z"/><path fill="#009be1" d="M380.2 165c30 16 37 46 27 86-13 59-52 84-109 85l-16 1c-6 0-10 4-11 10l-13 79c-1 7-7 12-14 12h-60c-5 0-9-5-8-10l22-143c1-5 182-120 182-120z"/><path fill="#001f6b" d="M197 292l20-127a14 14 0 0 1 13-11h96c23 0 40 4 54 11-5 44-26 115-128 117h-44c-5 0-10 4-11 10z"/></svg>

--- a/packages/webapp/public/images/template-logos/paypal.svg
+++ b/packages/webapp/public/images/template-logos/paypal.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg xmlns="http://www.w3.org/2000/svg"
+aria-label="PayPal" role="img"
+viewBox="0 0 512 512"><rect
+width="512" height="512"
+rx="15%"
+fill="#ffffff"/><path fill="#002c8a" d="M377 184.8L180.7 399h-72c-5 0-9-5-8-10l48-304c1-7 7-12 14-12h122c84 3 107 46 92 112z"/><path fill="#009be1" d="M380.2 165c30 16 37 46 27 86-13 59-52 84-109 85l-16 1c-6 0-10 4-11 10l-13 79c-1 7-7 12-14 12h-60c-5 0-9-5-8-10l22-143c1-5 182-120 182-120z"/><path fill="#001f6b" d="M197 292l20-127a14 14 0 0 1 13-11h96c23 0 40 4 54 11-5 44-26 115-128 117h-44c-5 0-10 4-11 10z"/></svg>


### PR DESCRIPTION
##Describe your changes
- Added configuration for paypal and paypal-sandbox in providers.yaml
- Added paypal and paypal-sandbox to docs-v2.
- Added paypal pages for Supported API groups in mint.json.
- Added paypal SVG files in template-logos folder.
- Consolidate Paypal docs pages
## Test
This provider has been used successfully in local development to connect to Paypal/Paypal-sandbox and successfully call those endpoints after authorizing using Nango.

The documentation update was reviewed using ```npm run docs``` and verifying on localhost.
