### PR TITLE
add feature flag feature

### DIFF
--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -20,6 +20,7 @@ import flowService from './services/flow.service.js';
 import slackNotificationService from './services/sync/notification/slack.service.js';
 import analytics, { AnalyticsTypes } from './utils/analytics.js';
 import logger from './logger/console.js';
+import featureFlags from './utils/featureflags.js';
 
 export * from './services/activity/activity.service.js';
 export * from './services/sync/sync.service.js';
@@ -71,5 +72,6 @@ export {
     slackNotificationService,
     analytics,
     AnalyticsTypes,
-    logger
+    logger,
+    featureFlags
 };

--- a/packages/shared/lib/utils/featureflags.ts
+++ b/packages/shared/lib/utils/featureflags.ts
@@ -1,0 +1,39 @@
+import { RedisKVStore } from './kvstore/RedisStore.js';
+import { getRedisUrl } from './utils.js';
+
+class FeatureFlags {
+    redis: RedisKVStore | undefined;
+
+    constructor(redis: RedisKVStore | undefined) {
+        try {
+            this.redis = redis;
+        } catch (e) {
+            console.log('Feature flags not enabled');
+        }
+    }
+
+    async isEnabled(key: string, distinctId: string, fallback: boolean, isExcludingFlag: boolean = false): Promise<boolean> {
+        if (!this.redis) {
+            return fallback;
+        }
+        return this.redis.exists(`flag:${key}:${distinctId}`).then(
+            (r) => {
+                return isExcludingFlag ? !r : r;
+            },
+            (_) => {
+                return fallback;
+            }
+        );
+    }
+}
+
+const redis = await (async () => {
+    let redis: RedisKVStore | undefined;
+    const url = getRedisUrl();
+    if (url) {
+        redis = new RedisKVStore(url);
+        await redis.connect();
+    }
+    return redis;
+})();
+export default new FeatureFlags(redis);

--- a/packages/shared/lib/utils/kvstore/InMemoryStore.ts
+++ b/packages/shared/lib/utils/kvstore/InMemoryStore.ts
@@ -40,6 +40,10 @@ export class InMemoryKVStore implements KVStore {
         return Promise.resolve();
     }
 
+    public async exists(key: string): Promise<boolean> {
+        return Promise.resolve(this.store.has(key));
+    }
+
     private isExpired(value: Value): boolean {
         if (value.ttlInMs > 0 && value.timestamp + value.ttlInMs < Date.now()) {
             return true;

--- a/packages/shared/lib/utils/kvstore/InMemoryStore.unit.test.ts
+++ b/packages/shared/lib/utils/kvstore/InMemoryStore.unit.test.ts
@@ -63,4 +63,9 @@ describe('InMemoryKVStore', () => {
         const value = await store.get('key');
         expect(value).toBeNull();
     });
+    it('should allow checking if a key exists', async () => {
+        await expect(store.exists('key')).resolves.toEqual(false);
+        store.set('key', 'value');
+        await expect(store.exists('key')).resolves.toEqual(true);
+    });
 });

--- a/packages/shared/lib/utils/kvstore/KVStore.ts
+++ b/packages/shared/lib/utils/kvstore/KVStore.ts
@@ -2,4 +2,5 @@ export interface KVStore {
     set(key: string, value: string, canOverride?: boolean, ttlInMs?: number): Promise<void>;
     get(key: string): Promise<string | null>;
     delete(key: string): Promise<void>;
+    exists(key: string): Promise<boolean>;
 }

--- a/packages/shared/lib/utils/kvstore/RedisStore.ts
+++ b/packages/shared/lib/utils/kvstore/RedisStore.ts
@@ -9,7 +9,7 @@ export class RedisKVStore implements KVStore {
         this.client = createClient({ url: url });
 
         this.client.on('error', (err) => {
-            console.error(`Redis (publisher) error: ${err}`);
+            console.error(`Redis (kvstore) error: ${err}`);
         });
     }
 
@@ -33,6 +33,10 @@ export class RedisKVStore implements KVStore {
         if (res !== 'OK') {
             throw new Error(`Failed to set key: ${key}, value: ${value}, canOverride: ${canOverride}, ttlInMs: ${ttlInMs}`);
         }
+    }
+
+    public async exists(key: string): Promise<boolean> {
+        return (await this.client.exists(key)) > 0;
     }
 
     public async delete(key: string): Promise<void> {


### PR DESCRIPTION
It checks if a key exists in Redis. If key exists, then flag is enabled 
3rd param is the fallback value if key existence cannot be determined. 
4th optional param allows to make a reversed flag (aka: will be enable if the key DOESN'T exist)

how to use it:
```
const flag = await featureFlags.isEnabled('FLAG_NAME', DISTINCT_ID, false);
```

To create the key in redis use `redis-cli`
```
// set the key
SET flag:FLAG_NAME:DISTINCT_ID 1
// delete the key
DEL flag:FLAG_NAME:DISTINCT_ID
```

https://www.notion.so/nangohq/Feature-flags-a20349a27ad644aa912b161b7558c459

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is: n/a
- [ ] I added analytics, otherwise the reason is: n/a
