### PR TITLE
Hide postgress error internal details

### DIFF
--- a/packages/shared/lib/services/sync/data/data.service.ts
+++ b/packages/shared/lib/services/sync/data/data.service.ts
@@ -85,8 +85,8 @@ export async function upsert(
         errorMessage += `Model: ${model}, Unique Key: ${uniqueKey}, Nango Connection ID: ${nangoConnectionId}.\n`;
         errorMessage += `Attempted to insert/update/delete: ${responseWithoutDuplicates.length} records\n`;
 
-        if ('code' in error) errorMessage += `Error code: ${error.code}.\n`;
-        if ('detail' in error) errorMessage += `Detail: ${error.detail}.\n`;
+        if (error.code) errorMessage += `Error code: ${error.code}.\n`;
+        if (error.detail) errorMessage += `Detail: ${error.detail}.\n`;
 
         errorMessage += `Error Message: ${error.message}`;
 

--- a/packages/shared/lib/services/sync/data/data.service.ts
+++ b/packages/shared/lib/services/sync/data/data.service.ts
@@ -86,9 +86,17 @@ export async function upsert(
         errorMessage += `Attempted to insert/update/delete: ${responseWithoutDuplicates.length} records\n`;
 
         if (error.code) errorMessage += `Error code: ${error.code}.\n`;
-        if (error.detail) errorMessage += `Detail: ${error.detail}.\n`;
 
-        errorMessage += `Error Message: ${error.message}`;
+        console.log(`${errorMessage}${error}`);
+
+        let errorDetail = '';
+        switch (error.code) {
+            case '22001': {
+                errorDetail = 'Payload too big. Limit = 256MB';
+                break;
+            }
+        }
+        if (errorDetail) errorMessage += `Info: ${errorDetail}.\n`;
 
         return {
             success: false,


### PR DESCRIPTION
Postgress errors don't always have `detail` defined. ex:

<img width="603" alt="Screenshot 2023-12-08 at 21 37 06" src="https://github.com/NangoHQ/nango/assets/233326/50251ccc-8c31-4b7d-8c4a-b3281f69224f">

This fix ensures the error displayed to end users doesn't contain `Detail: undefined` if no detail

<img width="543" alt="Screenshot 2023-12-08 at 21 38 57" src="https://github.com/NangoHQ/nango/assets/233326/1736a166-910d-4fd3-8e6d-dc94b3ef4e14">

https://linear.app/nango/issue/NAN-114/%5Bmarkprompt%5D-fix-error-message-for-batchsave-payload-size

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: n/a
- [ ] I added observability, otherwise the reason is: n/a
- [ ] I added analytics, otherwise the reason is: n/a
