### PR TITLE
Add support for Okta (service APIs)

### DIFF
--- a/docs-v2/integrations/all/okta.mdx
+++ b/docs-v2/integrations/all/okta.mdx
@@ -1,0 +1,32 @@
+---
+title: Okta
+sidebarTitle: Okta
+---
+
+API configuration: [`okta`](https://nango.dev/providers.yaml)
+
+## Features
+
+| Feature                                                                          | Status                          |
+| -------------------------------------------------------------------------------- | ------------------------------- |
+| [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
+| [Syncs](/guides/sync) & [Actions](/guides/action)                                                              | ✅                              |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
+| Auto-pagination                     | 🚫 (time to contribute: &lt;1h) |
+| API-specific rate limits | 🚫 (time to contribute: &lt;1h) |
+
+<Tip>We can implement missing features in &lt;48h, just ask for it in the [community](https://nango.dev/slack).</Tip>
+
+## Getting started
+
+-   [How to register an Application](https://developer.okta.com/docs/guides/implement-oauth-for-okta/main/#create-an-oauth-2-0-app-in-okta)
+-   [OAuth-related docs](https://developer.okta.com/docs/reference/api/oidc)
+-   [List of OAuth scopes](https://developer.okta.com/docs/api/oauth2/#oauth-20-scopes)
+
+<Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
+
+## API gotchas
+
+-   To get refresh_token, you will need to add **`offline_access`** to the list of your scopes.
+
+<Note>Add Getting Started links and Gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/okta.mdx)</Note>

--- a/docs-v2/integrations/other.mdx
+++ b/docs-v2/integrations/other.mdx
@@ -18,6 +18,7 @@ sidebarTitle: Other
     <Card title="HealthGorilla" href="/integrations/all/healthgorilla" color="#68a063" />
     <Card title="Intuit" href="/integrations/all/intuit" color="#68a063" />
     <Card title="Linkhut" href="/integrations/all/linkhut" color="#68a063" />
+    <Card title="Okta NLA" href="/integrations/all/okta" color="#68a063" />
     <Card title="Osu!" href="/integrations/all/osu" color="#68a063" />
     <Card title="Splitwise" href="/integrations/all/splitwise" color="#68a063" />
     <Card title="Twinfield" href="/integrations/all/twinfield" color="#68a063" />

--- a/docs-v2/mint.json
+++ b/docs-v2/mint.json
@@ -237,6 +237,7 @@
                         "integrations/all/nationbuilder",
                         "integrations/all/netsuite",
                         "integrations/all/notion",
+                        "integrations/all/okta",
                         "integrations/all/one-drive",
                         "integrations/all/osu",
                         "integrations/all/outreach",

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -766,6 +766,17 @@ notion:
             limit_name_in_request: page_size
             response_path: results
     docs: https://developers.notion.com/reference
+okta:
+    auth_mode: OAUTH2
+    authorization_url: https://${connectionConfig.subdomain}.okta.com/oauth2/v1/authorize
+    token_url: https://${connectionConfig.subdomain}.okta.com/oauth2/v1/token
+    authorization_params:
+        response_type: code
+        response_mode: query
+    token_params:
+        grant_type: authorization_code
+    refresh_params:
+        grant_type: refresh_token
 one-drive:
     alias: microsoft-teams
 osu:

--- a/packages/webapp/public/images/template-logos/okta.svg
+++ b/packages/webapp/public/images/template-logos/okta.svg
@@ -1,0 +1,11 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="256px" height="256px" viewBox="-1.6 -1.6 19.20 19.20" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#000000" stroke-width="0.00016">
+<g id="SVGRepo_bgCarrier" stroke-width="0">
+<rect x="-1.6" y="-1.6" width="19.20" height="19.20" rx="1.92" fill="#ffffff" strokewidth="0"/>
+</g>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path fill="#007DC1" d="M8 1C4.143 1 1 4.12 1 8s3.121 7 7 7 7-3.121 7-7-3.143-7-7-7zm0 10.5c-1.94 0-3.5-1.56-3.5-3.5S6.06 4.5 8 4.5s3.5 1.56 3.5 3.5-1.56 3.5-3.5 3.5z"/>
+</g>
+</svg>


### PR DESCRIPTION
##Describe your changes

Resolves #1367

- Added configuration for okta in providers.yaml
- Added okta to docs-v2.
- Added okta pages for Supported API groups in mint.json.
- Added okta SVG file in template-logos folder.
- Consolidate Okta docs pages

##Test

This provider has been used successfully in local development to connect to Okta and successfully call those endpoints after authorizing using Nango.

The documentation update was reviewed using ```npm run docs``` and verifying on localhost.