### PR TITLE
Add support for Auth0 APIs

### DIFF
--- a/docs-v2/integrations/all/auth0.mdx
+++ b/docs-v2/integrations/all/auth0.mdx
@@ -1,0 +1,32 @@
+---
+title: Auth0
+sidebarTitle: Auth0
+---
+
+API configuration: [`auth0`](https://nango.dev/providers.yaml)
+
+## Features
+
+| Feature                                                                          | Status                          |
+| -------------------------------------------------------------------------------- | ------------------------------- |
+| [Auth (OAuth)](/guides/oauth)                                                      | ✅                              |
+| [Syncs](/guides/sync) & [Actions](/guides/action)                                                              | ✅                              |
+| [Nango Proxy](/guides/proxy)                          | ✅   |
+| Auto-pagination                     | 🚫 (time to contribute: &lt;1h) |
+| API-specific rate limits | 🚫 (time to contribute: &lt;1h) |
+
+<Tip>We can implement missing features in &lt;48h, just ask for it in the [community](https://nango.dev/slack).</Tip>
+
+## Getting started
+
+-   [How to register an Application](https://auth0.com/docs/get-started/auth0-overview/create-applications)
+-   [OAuth-related docs](https://auth0.com/docs/get-started/authentication-and-authorization-flow/call-your-api-using-the-authorization-code-flow)
+-   [List of OAuth scopes](https://auth0.com/docs/get-started/apis/scopes/)
+
+<Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
+
+## API gotchas
+
+-   To get refresh_token, you will need to add **`offline_access`** to the list of your scopes.
+
+<Note>Add Getting Started links and Gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/okta.mdx)</Note>

--- a/docs-v2/integrations/other.mdx
+++ b/docs-v2/integrations/other.mdx
@@ -11,6 +11,7 @@ sidebarTitle: Other
 <CardGroup cols={4}>
     <Card title="Amazon" href="/integrations/all/amazon" color="#68a063" />
     <Card title="Atlassian" href="/integrations/all/atlassian" color="#68a063" />
+     <Card title="Auth0" href="/integrations/all/auth0" color="#68a063" />
     <Card title="Exact Online" href="integrations/all/exact-online" color="#68a063" />
     <Card title="Freshservice" href="integrations/all/freshservice" color="#68a063" />
     <Card title="Google" href="/integrations/all/google" color="#68a063" />

--- a/docs-v2/mint.json
+++ b/docs-v2/mint.json
@@ -173,6 +173,7 @@
                         "integrations/all/asana",
                         "integrations/all/ashby",
                         "integrations/all/atlassian",
+                        "integrations/all/auth0",
                         "integrations/all/bamboohr",
                         "integrations/all/battlenet",
                         "integrations/all/bitbucket",

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -101,6 +101,17 @@ atlassian:
         grant_type: refresh_token
     proxy:
         base_url: https://api.atlassian.com
+auth0:
+    auth_mode: OAUTH2
+    authorization_url: https://${connectionConfig.subdomain}.auth0.com/authorize
+    token_url: https://${connectionConfig.subdomain}.auth0.com/oauth/token
+    authorization_params:
+        response_type: code
+        response_mode: query
+    token_params:
+        grant_type: authorization_code
+    refresh_params:
+        grant_type: refresh_token
 bamboohr:
     auth_mode: OAUTH2
     authorization_url: https://${connectionConfig.subdomain}.bamboohr.com/authorize.php

--- a/packages/webapp/public/images/template-logos/auth0.svg
+++ b/packages/webapp/public/images/template-logos/auth0.svg
@@ -1,0 +1,10 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="256px" height="256px" viewBox="-1.6 -1.6 19.20 19.20" xmlns="http://www.w3.org/2000/svg" fill="none">
+<g id="SVGRepo_bgCarrier" stroke-width="0">
+<rect x="-1.6" y="-1.6" width="19.20" height="19.20" rx="1.92" fill="#ffffff" strokewidth="0"/>
+</g>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path fill="#000000" d="M12.549 1h-4.55l1.407 4.38h4.548l-3.68 2.61 1.406 4.405c2.37-1.725 3.143-4.336 2.274-7.016L12.55 1zM2.045 5.38h4.55L8 1H3.45L2.045 5.38c-.868 2.68-.094 5.29 2.275 7.015L5.725 7.99l-3.68-2.612zm2.275 7.015L8 15l3.68-2.605L8 9.745l-3.68 2.65z"/>
+</g>
+</svg>


### PR DESCRIPTION
##Describe your changes

- Added configuration for auth0 in providers.yaml
- Added auth0 to docs-v2.
- Added auth0 pages for Supported API groups in mint.json.
- Added auth0 SVG file in template-logos folder.
- Consolidate Auth0 docs pages

##Test

This provider has been used successfully in local development to connect to Auth0 and successfully call those endpoints after authorizing using Nango.

The documentation update was reviewed using ```npm run docs``` and verifying on localhost.
