### PR TITLE
Drop indexes for table sync_data_records that are not/little used

### DIFF
--- a/packages/shared/lib/db/migrations/20231213124728_drop_sync_data_records_indexes.cjs
+++ b/packages/shared/lib/db/migrations/20231213124728_drop_sync_data_records_indexes.cjs
@@ -1,0 +1,17 @@
+exports.config = { transaction: false };
+
+exports.up = function(knex) {
+    return knex.schema
+        .raw('DROP INDEX CONCURRENTLY created_at_index')
+        .raw('DROP INDEX CONCURRENTLY _nango_sync_data_records_data_hash_index')
+        .raw('DROP INDEX CONCURRENTLY _nango_sync_data_records_sync_job_id_index')
+        .raw('DROP INDEX CONCURRENTLY _nango_sync_data_records_external_is_deleted_index')
+        .raw('DROP INDEX CONCURRENTLY _nango_sync_data_records_external_deleted_at_index')
+        .raw('DROP INDEX CONCURRENTLY _nango_sync_data_records_deletes_data_hash_index')
+        .raw('DROP INDEX CONCURRENTLY _nango_sync_data_records_deletes_sync_job_id_index')
+        .raw('DROP INDEX CONCURRENTLY _nango_sync_data_records_deletes_external_is_deleted_index')
+        .raw('DROP INDEX CONCURRENTLY _nango_sync_data_records_deletes_external_deleted_at_index')
+        .raw('DROP INDEX CONCURRENTLY _nango_sync_jobs_deleted_index');
+};
+
+exports.down = function(knex) { };


### PR DESCRIPTION
Used the query described in the following blog post to determine which indexes are not (or rarely) used
http://www.databasesoup.com/2014/05/new-finding-unused-indexes-query.html

Those indexes have size > 10Mb and are on write-heavy tables. The goal with dropping those indexes is to lower the pressure on the database when writing into those tables.

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: n/a
- [ ] I added observability, otherwise the reason is: n/a
- [ ] I added analytics, otherwise the reason is: n/a
