### PR TITLE
sdk: fix setMetadata argument type

### DIFF
--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -326,7 +326,7 @@ export class NangoAction {
         return this.nango.getConnection(this.providerConfigKey as string, this.connectionId as string);
     }
 
-    public async setMetadata(metadata: Record<string, string>): Promise<AxiosResponse<void>> {
+    public async setMetadata(metadata: Record<string, any>): Promise<AxiosResponse<void>> {
         return this.nango.setMetadata(this.providerConfigKey as string, this.connectionId as string, metadata);
     }
 


### PR DESCRIPTION
## Describe your changes
`setMetadata` sdk function had the wrong type. It can accept any object not just string