### PR TITLE
Fixes Extra Configuration textbox missing

### DIFF
--- a/packages/server/lib/utils/utils.ts
+++ b/packages/server/lib/utils/utils.ts
@@ -149,10 +149,11 @@ export function parseJsonDateAware(input: string) {
 }
 
 export function parseConnectionConfigParamsFromTemplate(template: ProviderTemplate): string[] {
-    if (template.token_url || template.authorization_url) {
+    if (template.token_url || template.authorization_url || template.proxy?.base_url) {
         const tokenUrlMatches = template.token_url?.match(/\${connectionConfig\.([^{}]*)}/g);
         const authorizationUrlMatches = template.authorization_url?.match(/\${connectionConfig\.([^{}]*)}/g);
-        const params = [...(tokenUrlMatches || []), ...(authorizationUrlMatches || [])].filter((value, index, array) => array.indexOf(value) === index);
+        const proxyBaseUrlMatches = template.proxy?.base_url?.match(/\${connectionConfig\.([^{}]*)}/g);
+        const params = [...(tokenUrlMatches || []), ...(authorizationUrlMatches || []), ...(proxyBaseUrlMatches || [])].filter((value, index, array) => array.indexOf(value) === index);
         return params.map((param) => param.replace('${connectionConfig.', '').replace('}', '')); // Remove the ${connectionConfig.'} and return only the param name.
     }
 

--- a/packages/server/lib/utils/utils.unit.test.ts
+++ b/packages/server/lib/utils/utils.unit.test.ts
@@ -4,6 +4,7 @@ import type { Template as ProviderTemplate } from '@nangohq/shared';
 
 describe('Utils unit tests', () => {
     it('Should parse template connection config params', () => {
+        // parsing connectionConfigParams from authorization_url
         const authTemplate = {
             name: 'braintree',
             provider: 'braintree',
@@ -13,6 +14,7 @@ describe('Utils unit tests', () => {
         const connectionConfigAuth = parseConnectionConfigParamsFromTemplate(authTemplate as unknown as ProviderTemplate);
         expect(connectionConfigAuth).toEqual(['auth']);
 
+        // parsing connectionConfigParams from token_url
         const tokenTemplate = {
             name: 'braintree',
             provider: 'braintree',
@@ -21,6 +23,18 @@ describe('Utils unit tests', () => {
 
         const connectionConfigToken = parseConnectionConfigParamsFromTemplate(tokenTemplate as unknown as ProviderTemplate);
         expect(connectionConfigToken).toEqual(['token']);
+
+        // parsing connectionConfigParams from proxy.base_url
+        const proxyBaseUrlTemplate = {
+            name: 'freshdesk',
+            provider: 'freshdesk',
+            proxy: {
+                base_url: 'https://${connectionConfig.subdomain}.freshdesk.com'
+            }
+        };
+
+        const connectionConfigProxyBaseUrl = parseConnectionConfigParamsFromTemplate(proxyBaseUrlTemplate as unknown as ProviderTemplate);
+        expect(connectionConfigProxyBaseUrl).toEqual(['subdomain']);
     });
 
     it('Should extract metadata from token response based on template', () => {


### PR DESCRIPTION
## Describe your changes
1. Updated `parseConnectionConfigParamsFromTemplate` to parse `proxy.base_url` in `/server/utils/utils.ts`.
2. Added test case for this in `/server/utils/utils.unit.test.ts`.
3. Tested locally if the `connectionConfigParams` has parsed `proxy.base_url` value in the response to the `ListIntegrations` request. 
4. Tested the presence of **Extra Configuration: {param}** textbox in the UI and executed proxy API call successfully.

## With Extra Configuration Textbox
![With Extra Configuration Textbox](https://github.com/NangoHQ/nango/assets/94439978/bbcf7345-c7f7-45b5-b887-14dd688e50a4)

## PROXY API Call Success
![PROXY API Call Success](https://github.com/NangoHQ/nango/assets/94439978/a7d5cb43-0ceb-489d-890c-eb97686bcb12)

## Issue ticket number and link
fixes #1422

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests: Added test case for proxy.base_url.
