### PR TITLE
temporal worker: set maxConcurrentWorkflowTaskExecutions to 50

### DIFF
--- a/packages/jobs/lib/temporal.ts
+++ b/packages/jobs/lib/temporal.ts
@@ -46,7 +46,8 @@ export class Temporal {
             namespace: this.namespace,
             workflowsPath: createRequire(import.meta.url).resolve('./workflows'),
             activities,
-            taskQueue: TASK_QUEUE
+            taskQueue: TASK_QUEUE,
+            maxConcurrentWorkflowTaskExecutions: 50
         });
         // Worker connects to localhost by default and uses console.error for logging.
         // Customize the Worker by passing more options to create():

--- a/packages/worker/lib/worker.ts
+++ b/packages/worker/lib/worker.ts
@@ -37,7 +37,8 @@ async function run() {
         namespace,
         workflowsPath: createRequire(import.meta.url).resolve('./workflows'),
         activities,
-        taskQueue: TASK_QUEUE
+        taskQueue: TASK_QUEUE,
+        maxConcurrentWorkflowTaskExecutions: 50
     });
     // Worker connects to localhost by default and uses console.error for logging.
     // Customize the Worker by passing more options to create():


### PR DESCRIPTION
## Describe your changes
Capping temporal worker  option `maxConcurrentWorkflowTaskExecutions` to 50. 
The goal is to make sure the number of concurrent sync/actions doesn't spike out of control. It might slow down syncs/actions but will give us some protection against sudden volume spike

https://linear.app/nango/issue/NAN-156/cap-concurrent-temporal-workflows

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: n/a
- [ ] I added observability, otherwise the reason is: n/a
- [ ] I added analytics, otherwise the reason is: n/a
