### PR TITLE
jobs: fallback to default runner if account runner is not ready quickly

### DIFF
--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -1,31 +1,22 @@
 import { Temporal } from './temporal.js';
 import { server } from './server.js';
-import { featureFlags } from '@nangohq/shared';
 import './tracer.js';
 
 try {
     const port = parseInt(process.env['NANGO_JOBS_PORT'] || '3005', 10);
     server.listen(port);
     console.log(`🚀 Jobs service ready at http://localhost:${port}`);
-
     const temporalNs = process.env['TEMPORAL_NAMESPACE'] || 'default';
     const temporal = new Temporal(temporalNs);
+    temporal.start();
 
-    // TODO: remove flag check once jobs is fully enabled by default
-    let isTemporalStarted = false;
-    setInterval(async () => {
-        if (isTemporalStarted) {
-            return;
-        }
-        const isTemporalEnabled = await featureFlags.isEnabled('jobs-temporal', 'global', false);
-        if (isTemporalEnabled) {
-            isTemporalStarted = true;
-            temporal.start();
-        } else {
-            temporal.stop();
-            isTemporalStarted = false;
-        }
-    }, 5000);
+    // handle SIGTERM
+    process.on('SIGTERM', async () => {
+        temporal.stop();
+        server.server.close(async () => {
+            process.exit(0);
+        });
+    });
 } catch (err) {
     console.error(`[JOBS]: ${err}`);
     process.exit(1);

--- a/packages/jobs/lib/runner/local.runner.ts
+++ b/packages/jobs/lib/runner/local.runner.ts
@@ -3,7 +3,7 @@ import { execSync, spawn, ChildProcess } from 'child_process';
 import { getRunnerClient } from '@nangohq/nango-runner';
 
 export class LocalRunner implements Runner {
-    constructor(public readonly client: any, private readonly childProcess: ChildProcess) {}
+    constructor(public readonly id: string, public readonly client: any, private readonly childProcess: ChildProcess) {}
 
     async stop(): Promise<void> {
         this.childProcess.kill();
@@ -47,7 +47,7 @@ export class LocalRunner implements Runner {
             }
 
             const client = getRunnerClient(`http://localhost:${port}`);
-            return new LocalRunner(client, childProcess);
+            return new LocalRunner(runnerId, client, childProcess);
         } catch (err) {
             throw new Error(`Unable to get runner ${runnerId}: ${err}`);
         }

--- a/packages/jobs/lib/runner/render.runner.ts
+++ b/packages/jobs/lib/runner/render.runner.ts
@@ -7,7 +7,7 @@ const render = api('@render-api/v1.0#aiie8wizhlp1is9bu');
 render.auth(process.env['RENDER_API_KEY']);
 
 export class RenderRunner implements Runner {
-    constructor(public readonly client: any, private readonly serviceId: string) {}
+    constructor(public readonly id: string, public readonly client: any, private readonly serviceId: string) {}
 
     async stop(): Promise<void> {
         render.suspendService({ serviceId: this.serviceId });
@@ -40,7 +40,8 @@ export class RenderRunner implements Runner {
                         { key: 'NANGO_DB_PASSWORD', value: process.env['NANGO_DB_PASSWORD'] },
                         { key: 'NANGO_DB_PORT', value: process.env['NANGO_DB_PORT'] },
                         { key: 'NANGO_DB_SSL', value: process.env['NANGO_DB_SSL'] },
-                        { key: 'NANGO_ENCRYPTION_KEY', value: process.env['NANGO_ENCRYPTION_KEY'] }
+                        { key: 'NANGO_ENCRYPTION_KEY', value: process.env['NANGO_ENCRYPTION_KEY'] },
+                        { key: 'NODE_OPTIONS', value: '--max-old-space-size=384' }
                     ]
                 });
                 svc = res.data.service;
@@ -54,7 +55,7 @@ export class RenderRunner implements Runner {
                 console.log(res);
             }
             const client = getRunnerClient(`http://${runnerId}`);
-            return new RenderRunner(client, svc.id);
+            return new RenderRunner(runnerId, client, svc.id);
         } catch (err) {
             throw new Error(`Unable to get runner ${runnerId}: ${err}`);
         }

--- a/packages/jobs/lib/runner/runner.ts
+++ b/packages/jobs/lib/runner/runner.ts
@@ -1,12 +1,17 @@
 import { LocalRunner } from './local.runner.js';
 import { RenderRunner } from './render.runner.js';
+import { getEnv } from '@nangohq/shared';
+
+export function getRunnerId(suffix: string): string {
+    return `${getEnv()}-runner-account-${suffix}`;
+}
 
 export async function getRunner(runnerId: string): Promise<Runner> {
     const isRender = process.env['IS_RENDER'] === 'true';
     const runner = isRender ? await RenderRunner.get(runnerId) : await LocalRunner.get(runnerId);
 
     // Wait for runner to start and be healthy
-    const timeoutMs = isRender ? 90000 : 10000;
+    const timeoutMs = 5000;
     let healthCheck = false;
     let startTime = Date.now();
     while (!healthCheck && Date.now() - startTime < timeoutMs) {
@@ -24,6 +29,7 @@ export async function getRunner(runnerId: string): Promise<Runner> {
 }
 
 export interface Runner {
+    id: string;
     client: any;
     stop(): Promise<void>;
 }

--- a/packages/jobs/lib/temporal.ts
+++ b/packages/jobs/lib/temporal.ts
@@ -66,7 +66,6 @@ export class Temporal {
 
     stop() {
         if (this.workers) {
-            console.log('Stopping Temporal worker');
             this.workers.forEach((worker) => worker.shutdown());
         }
     }


### PR DESCRIPTION
## Describe your changes
Creating a new runner instance on Render can be slow (> 60s). This PR introduces a fallback mechanism where jobs would fallback to the default runner if runner is not ready quickly. That allows to still create runner for each account dynamically but not wait for it to be ready in order to run the first sync(s). The account specific runner will be used in subsequent sync(s) once it is ready

this commit is also removing the global temporal flag for jobs service as well as the runner-for-account flag. Having full account isolation is worth the extra cost. Later in January we will work on a solution to bring runner cost down (suspending/resuming on demand for instance)

I have tested locally
