### PR TITLE
pin dd-trace to 4.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2820,18 +2820,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/@datadog/native-appsec": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-5.0.0.tgz",
-            "integrity": "sha512-Ks8a4L49N40w+TJjj2e9ncGssUIEjo4wnmUFjPBRvlLGuVj1VJLxCx7ztpd8eTycM5QQlzggCDOP6CMEVmeZbA==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "node-gyp-build": "^3.9.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/@datadog/native-iast-rewriter": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.2.1.tgz",
@@ -2882,22 +2870,6 @@
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/@datadog/pprof": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-4.1.0.tgz",
-            "integrity": "sha512-g7EWI185nwSuFwlmnAGDPxbPsqe+ipOoDB2oP841WMNRaJBPRdg5J90c+6ucmyltuC9VpTrmzzqcachkOTzZEQ==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "delay": "^5.0.0",
-                "node-gyp-build": "<4.0",
-                "p-limit": "^3.1.0",
-                "pprof-format": "^2.0.7",
-                "source-map": "^0.7.4"
-            },
-            "engines": {
-                "node": ">=14"
             }
         },
         "node_modules/@datadog/sketches-js": {
@@ -7855,75 +7827,6 @@
             "integrity": "sha512-Wyk5n/5KUj3GfVKV2jtDbtChC/Ff9fjKsBcg4ZtYW1yQe3DXNHcGURvmoxhqQdfOQ9TwyMjnfyv1lyYcOkFkFA==",
             "engines": {
                 "node": ">=12.17"
-            }
-        },
-        "node_modules/dd-trace": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-4.21.0.tgz",
-            "integrity": "sha512-nuFHfDJNy039Qns1sbJdIbXeP1ZmUioctwzXfw60k4Dif8dC3RmrHebvW48EbYCKrJj3Awri/vmwcBNf6xNpHw==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "@datadog/native-appsec": "5.0.0",
-                "@datadog/native-iast-rewriter": "2.2.1",
-                "@datadog/native-iast-taint-tracking": "1.6.4",
-                "@datadog/native-metrics": "^2.0.0",
-                "@datadog/pprof": "4.1.0",
-                "@datadog/sketches-js": "^2.1.0",
-                "@opentelemetry/api": "^1.0.0",
-                "@opentelemetry/core": "^1.14.0",
-                "crypto-randomuuid": "^1.0.0",
-                "dc-polyfill": "^0.1.2",
-                "ignore": "^5.2.4",
-                "import-in-the-middle": "^1.4.2",
-                "int64-buffer": "^0.1.9",
-                "ipaddr.js": "^2.1.0",
-                "istanbul-lib-coverage": "3.2.0",
-                "jest-docblock": "^29.7.0",
-                "koalas": "^1.0.2",
-                "limiter": "^1.1.4",
-                "lodash.kebabcase": "^4.1.1",
-                "lodash.pick": "^4.4.0",
-                "lodash.sortby": "^4.7.0",
-                "lodash.uniq": "^4.5.0",
-                "lru-cache": "^7.14.0",
-                "methods": "^1.1.2",
-                "module-details-from-path": "^1.0.3",
-                "msgpack-lite": "^0.1.26",
-                "node-abort-controller": "^3.1.1",
-                "opentracing": ">=0.12.1",
-                "path-to-regexp": "^0.1.2",
-                "pprof-format": "^2.0.7",
-                "protobufjs": "^7.2.5",
-                "retry": "^0.13.1",
-                "semver": "^7.5.4",
-                "tlhunter-sorted-set": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/dd-trace/node_modules/ipaddr.js": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
-            "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/dd-trace/node_modules/lru-cache": {
-            "version": "7.18.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/dd-trace/node_modules/retry": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-            "engines": {
-                "node": ">= 4"
             }
         },
         "node_modules/debug": {
@@ -13687,11 +13590,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/tlhunter-sorted-set": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/tlhunter-sorted-set/-/tlhunter-sorted-set-0.1.0.tgz",
-            "integrity": "sha512-eGYW4bjf1DtrHzUYxYfAcSytpOkA44zsr7G2n3PV7yOUR23vmkGe3LL4R+1jL9OsXtbsFOwe8XtbCrabeaEFnw=="
-        },
         "node_modules/tmp": {
             "version": "0.0.33",
             "license": "MIT",
@@ -15428,7 +15326,7 @@
                 "@trpc/client": "^10.44.1",
                 "@trpc/server": "^10.44.1",
                 "@types/fs-extra": "^11.0.1",
-                "dd-trace": "^4.21.0",
+                "dd-trace": "4.20.0",
                 "dotenv": "^16.0.3",
                 "fs-extra": "^11.1.1",
                 "js-yaml": "^4.1.0",
@@ -15448,6 +15346,34 @@
                 "eslint-plugin-deprecation": "^1.2.1",
                 "nodemon": "^3.0.1",
                 "typescript": "^5.3.2"
+            }
+        },
+        "packages/jobs/node_modules/@datadog/native-appsec": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-4.0.0.tgz",
+            "integrity": "sha512-myTguXJ3VQHS2E1ylNsSF1avNpDmq5t+K4Q47wdzeakGc3sDIDDyEbvuFTujl9c9wBIkup94O1mZj5DR37ajzA==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/jobs/node_modules/@datadog/pprof": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-4.0.1.tgz",
+            "integrity": "sha512-TavqyiyQZOaUM9eQB07r8+K/T1CqKyOdsUGxpN79+BF+eOQBpTj/Cte6KdlhcUSKL3h5hSjC+vlgA7uW2qtVhA==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "delay": "^5.0.0",
+                "node-gyp-build": "<4.0",
+                "p-limit": "^3.1.0",
+                "pprof-format": "^2.0.7",
+                "source-map": "^0.7.4"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "packages/jobs/node_modules/@eslint/eslintrc": {
@@ -15516,6 +15442,58 @@
             "dev": true,
             "dependencies": {
                 "sprintf-js": "~1.0.2"
+            }
+        },
+        "packages/jobs/node_modules/dd-trace": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-4.20.0.tgz",
+            "integrity": "sha512-y7IDLSSt6nww6zMdw/I8oLdfgOQADIOkERCNdfSzlBrXHz5CHimEOFfsHN87ag0mn6vusr06aoi+CQRZSNJz2g==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@datadog/native-appsec": "4.0.0",
+                "@datadog/native-iast-rewriter": "2.2.1",
+                "@datadog/native-iast-taint-tracking": "1.6.4",
+                "@datadog/native-metrics": "^2.0.0",
+                "@datadog/pprof": "4.0.1",
+                "@datadog/sketches-js": "^2.1.0",
+                "@opentelemetry/api": "^1.0.0",
+                "@opentelemetry/core": "^1.14.0",
+                "crypto-randomuuid": "^1.0.0",
+                "dc-polyfill": "^0.1.2",
+                "ignore": "^5.2.4",
+                "import-in-the-middle": "^1.4.2",
+                "int64-buffer": "^0.1.9",
+                "ipaddr.js": "^2.1.0",
+                "istanbul-lib-coverage": "3.2.0",
+                "jest-docblock": "^29.7.0",
+                "koalas": "^1.0.2",
+                "limiter": "^1.1.4",
+                "lodash.kebabcase": "^4.1.1",
+                "lodash.pick": "^4.4.0",
+                "lodash.sortby": "^4.7.0",
+                "lodash.uniq": "^4.5.0",
+                "lru-cache": "^7.14.0",
+                "methods": "^1.1.2",
+                "module-details-from-path": "^1.0.3",
+                "msgpack-lite": "^0.1.26",
+                "node-abort-controller": "^3.1.1",
+                "opentracing": ">=0.12.1",
+                "path-to-regexp": "^0.1.2",
+                "pprof-format": "^2.0.7",
+                "protobufjs": "^7.2.4",
+                "retry": "^0.13.1",
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/jobs/node_modules/dd-trace/node_modules/ignore": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+            "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "packages/jobs/node_modules/eslint": {
@@ -15665,6 +15643,30 @@
                 "node": ">= 4"
             }
         },
+        "packages/jobs/node_modules/ipaddr.js": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+            "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "packages/jobs/node_modules/lru-cache": {
+            "version": "7.18.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/jobs/node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
         "packages/jobs/node_modules/typescript": {
             "version": "5.3.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
@@ -15733,7 +15735,7 @@
                 "connect-session-knex": "^3.0.1",
                 "cookie-parser": "^1.4.6",
                 "cors": "^2.8.5",
-                "dd-trace": "^4.19.0",
+                "dd-trace": "4.20.0",
                 "dotenv": "^16.0.3",
                 "exponential-backoff": "^3.1.1",
                 "express": "^4.18.2",
@@ -15781,6 +15783,102 @@
             "engines": {
                 "node": ">=16.7",
                 "npm": ">=6.14.11"
+            }
+        },
+        "packages/server/node_modules/@datadog/native-appsec": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-4.0.0.tgz",
+            "integrity": "sha512-myTguXJ3VQHS2E1ylNsSF1avNpDmq5t+K4Q47wdzeakGc3sDIDDyEbvuFTujl9c9wBIkup94O1mZj5DR37ajzA==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/server/node_modules/@datadog/pprof": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-4.0.1.tgz",
+            "integrity": "sha512-TavqyiyQZOaUM9eQB07r8+K/T1CqKyOdsUGxpN79+BF+eOQBpTj/Cte6KdlhcUSKL3h5hSjC+vlgA7uW2qtVhA==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "delay": "^5.0.0",
+                "node-gyp-build": "<4.0",
+                "p-limit": "^3.1.0",
+                "pprof-format": "^2.0.7",
+                "source-map": "^0.7.4"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "packages/server/node_modules/dd-trace": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-4.20.0.tgz",
+            "integrity": "sha512-y7IDLSSt6nww6zMdw/I8oLdfgOQADIOkERCNdfSzlBrXHz5CHimEOFfsHN87ag0mn6vusr06aoi+CQRZSNJz2g==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@datadog/native-appsec": "4.0.0",
+                "@datadog/native-iast-rewriter": "2.2.1",
+                "@datadog/native-iast-taint-tracking": "1.6.4",
+                "@datadog/native-metrics": "^2.0.0",
+                "@datadog/pprof": "4.0.1",
+                "@datadog/sketches-js": "^2.1.0",
+                "@opentelemetry/api": "^1.0.0",
+                "@opentelemetry/core": "^1.14.0",
+                "crypto-randomuuid": "^1.0.0",
+                "dc-polyfill": "^0.1.2",
+                "ignore": "^5.2.4",
+                "import-in-the-middle": "^1.4.2",
+                "int64-buffer": "^0.1.9",
+                "ipaddr.js": "^2.1.0",
+                "istanbul-lib-coverage": "3.2.0",
+                "jest-docblock": "^29.7.0",
+                "koalas": "^1.0.2",
+                "limiter": "^1.1.4",
+                "lodash.kebabcase": "^4.1.1",
+                "lodash.pick": "^4.4.0",
+                "lodash.sortby": "^4.7.0",
+                "lodash.uniq": "^4.5.0",
+                "lru-cache": "^7.14.0",
+                "methods": "^1.1.2",
+                "module-details-from-path": "^1.0.3",
+                "msgpack-lite": "^0.1.26",
+                "node-abort-controller": "^3.1.1",
+                "opentracing": ">=0.12.1",
+                "path-to-regexp": "^0.1.2",
+                "pprof-format": "^2.0.7",
+                "protobufjs": "^7.2.4",
+                "retry": "^0.13.1",
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/server/node_modules/ipaddr.js": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+            "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "packages/server/node_modules/lru-cache": {
+            "version": "7.18.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/server/node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "packages/shared": {

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -27,7 +27,7 @@
         "@trpc/client": "^10.44.1",
         "@trpc/server": "^10.44.1",
         "@types/fs-extra": "^11.0.1",
-        "dd-trace": "^4.21.0",
+        "dd-trace": "4.20.0",
         "dotenv": "^16.0.3",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -29,7 +29,7 @@
         "connect-session-knex": "^3.0.1",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
-        "dd-trace": "^4.19.0",
+        "dd-trace": "4.20.0",
         "dotenv": "^16.0.3",
         "exponential-backoff": "^3.1.1",
         "express": "^4.18.2",


### PR DESCRIPTION
it looks like v4.21.0 have introduced a memory leak. See https://github.com/DataDog/dd-trace-js/issues/3887 We are seeing some crash in nango-server due to
`RangeError: Maximum call stack size exceeded` error. Pinning dd-trace to 4.20.0 which doesn't seem to be affected by the memory leak until the problem is fixed
