### PR TITLE
fix: nangoProps lastSyncDate is not decoded as a Date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7631,6 +7631,20 @@
             "version": "1.0.6",
             "license": "MIT"
         },
+        "node_modules/copy-anything": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+            "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+            "dependencies": {
+                "is-what": "^4.1.8"
+            },
+            "engines": {
+                "node": ">=12.13"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mesqueeb"
+            }
+        },
         "node_modules/copyfiles": {
             "version": "2.4.1",
             "license": "MIT",
@@ -9965,6 +9979,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-what": {
+            "version": "4.1.16",
+            "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+            "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+            "engines": {
+                "node": ">=12.13"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mesqueeb"
             }
         },
         "node_modules/isarray": {
@@ -13206,6 +13231,17 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/superjson": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.1.tgz",
+            "integrity": "sha512-8iGv75BYOa0xRJHK5vRLEjE2H/i4lulTjzpUXic3Eg8akftYjkmQDa8JARQ42rlczXyFR3IeRoeFCc7RxHsYZA==",
+            "dependencies": {
+                "copy-anything": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "license": "MIT",
@@ -15333,6 +15369,7 @@
                 "knex": "^2.4.2",
                 "md5": "^2.3.0",
                 "nanoid": "3.x",
+                "superjson": "^2.2.1",
                 "uuid": "^9.0.0"
             },
             "devDependencies": {
@@ -15702,7 +15739,8 @@
                 "@nangohq/shared": "0.36.63",
                 "@trpc/client": "^10.44.0",
                 "@trpc/server": "^10.44.0",
-                "api": "^6.1.1"
+                "api": "^6.1.1",
+                "superjson": "^2.2.1"
             },
             "devDependencies": {
                 "@types/node": "^18.7.6",

--- a/packages/jobs/lib/client.ts
+++ b/packages/jobs/lib/client.ts
@@ -1,8 +1,10 @@
 import { CreateTRPCProxyClient, createTRPCProxyClient, httpBatchLink } from '@trpc/client';
 import type { AppRouter } from './server.js';
+import superjson from 'superjson';
 
 export function getJobsClient(url: string): CreateTRPCProxyClient<AppRouter> {
     return createTRPCProxyClient<AppRouter>({
+        transformer: superjson,
         links: [httpBatchLink({ url })]
     });
 }

--- a/packages/jobs/lib/server.ts
+++ b/packages/jobs/lib/server.ts
@@ -1,7 +1,10 @@
 import { initTRPC } from '@trpc/server';
 import { createHTTPServer } from '@trpc/server/adapters/standalone';
+import superjson from 'superjson';
 
-const t = initTRPC.create();
+export const t = initTRPC.create({
+    transformer: superjson
+});
 
 const router = t.router;
 const publicProcedure = t.procedure;

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -34,6 +34,7 @@
         "knex": "^2.4.2",
         "md5": "^2.3.0",
         "nanoid": "3.x",
+        "superjson": "^2.2.1",
         "uuid": "^9.0.0"
     },
     "devDependencies": {

--- a/packages/runner/lib/client.ts
+++ b/packages/runner/lib/client.ts
@@ -1,8 +1,10 @@
 import { CreateTRPCProxyClient, createTRPCProxyClient, httpBatchLink } from '@trpc/client';
 import type { AppRouter } from './server.js';
+import superjson from 'superjson';
 
 export function getRunnerClient(url: string): CreateTRPCProxyClient<AppRouter> {
     return createTRPCProxyClient<AppRouter>({
+        transformer: superjson,
         links: [httpBatchLink({ url })]
     });
 }

--- a/packages/runner/lib/client.unit.test.ts
+++ b/packages/runner/lib/client.unit.test.ts
@@ -35,8 +35,15 @@ describe('Runner client', () => {
             logMessages: [],
             stubbedMetadata: {}
         };
-        const jsCode = 'f = () => { return [1, 2, 3] }; exports.default = f';
-        const isInvokedImmediately = true;
+        const jsCode = `
+        f = (nango) => {
+            const s = nango.lastSyncDate.toISOString();
+            const b = Buffer.from("hello world");
+            return [1, 2, 3]
+        };
+        exports.default = f
+        `;
+        const isInvokedImmediately = false;
         const isWebhook = false;
         const run = client.run.mutate({ nangoProps, isInvokedImmediately, isWebhook, code: jsCode });
         await expect(run).resolves.toEqual([1, 2, 3]);

--- a/packages/runner/lib/server.ts
+++ b/packages/runner/lib/server.ts
@@ -2,8 +2,11 @@ import { initTRPC } from '@trpc/server';
 import { createHTTPServer } from '@trpc/server/adapters/standalone';
 import type { NangoProps } from '@nangohq/shared';
 import { exec } from './exec.js';
+import superjson from 'superjson';
 
-const t = initTRPC.create();
+export const t = initTRPC.create({
+    transformer: superjson
+});
 
 // const logging = t.middleware(async (opts) => {
 //     // TODO

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -21,7 +21,8 @@
         "@nangohq/shared": "0.36.63",
         "@trpc/client": "^10.44.0",
         "@trpc/server": "^10.44.0",
-        "api": "^6.1.1"
+        "api": "^6.1.1",
+        "superjson": "^2.2.1"
     },
     "devDependencies": {
         "@types/node": "^18.7.6",


### PR DESCRIPTION
using superjson as recommended on trpc documentation to ensure Dates are properly decoded.
Otherwise, trying to apply a date function to `nango.lastSyncDate` will throw an error since it would be considered a string

## Issue ticket number and link
https://linear.app/nango/issue/NAN-186/nangolastsyncdate-gets-passed-as-string-instead-of-date

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
