### PR TITLE
[nan-184] add in notion retry header logic

### DIFF
--- a/packages/shared/lib/models/Provider.ts
+++ b/packages/shared/lib/models/Provider.ts
@@ -1,4 +1,4 @@
-import type { CursorPagination, LinkPagination, OffsetPagination } from './Proxy.js';
+import type { RetryHeaderConfig, CursorPagination, LinkPagination, OffsetPagination } from './Proxy.js';
 import type { AuthModes } from './Auth.js';
 import type { TimestampsAndDeleted } from './Generic.js';
 import type { SyncConfig, Action } from './Sync.js';
@@ -24,10 +24,7 @@ export interface Template {
         query?: {
             api_key: string;
         };
-        retry?: {
-            at?: string;
-            after?: string;
-        };
+        retry?: RetryHeaderConfig;
         decompress?: boolean;
         paginate?: LinkPagination | CursorPagination | OffsetPagination;
     };

--- a/packages/shared/lib/models/Proxy.ts
+++ b/packages/shared/lib/models/Proxy.ts
@@ -4,18 +4,32 @@ import type { BasicApiCredentials, ApiKeyCredentials, AppCredentials } from './A
 import type { Connection } from './Connection.js';
 import type { Template as ProviderTemplate } from './Provider.js';
 
-export interface ApplicationConstructedProxyConfiguration {
+interface BaseProxyConfiguration {
     endpoint: string;
-    providerConfigKey: string;
-    connectionId: string;
     retries?: number;
     data?: unknown;
     headers?: Record<string, string>;
-    params?: string | Record<string, string>;
+    params?: string | Record<string, string | number>;
     paramsSerializer?: ParamsSerializerOptions;
     baseUrlOverride?: string;
+    responseType?: ResponseType;
+    retryHeader?: RetryHeaderConfig;
+}
+
+export interface UserProvidedProxyConfiguration extends BaseProxyConfiguration {
+    providerConfigKey?: string;
+    connectionId?: string;
+    retries?: number;
+    decompress?: boolean | string;
+
+    method?: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE' | 'get' | 'post' | 'patch' | 'put' | 'delete';
+    paginate?: Partial<CursorPagination> | Partial<LinkPagination> | Partial<OffsetPagination>;
+}
+
+export interface ApplicationConstructedProxyConfiguration extends BaseProxyConfiguration {
+    providerConfigKey: string;
+    connectionId: string;
     decompress?: boolean;
-    responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
 
     method: HTTP_VERB;
     provider: string;
@@ -26,23 +40,6 @@ export interface ApplicationConstructedProxyConfiguration {
 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
 
-export interface UserProvidedProxyConfiguration {
-    endpoint: string;
-    providerConfigKey?: string;
-    connectionId?: string;
-    retries?: number;
-    data?: unknown;
-    headers?: Record<string, string>;
-    params?: string | Record<string, string | number>;
-    paramsSerializer?: ParamsSerializerOptions;
-    baseUrlOverride?: string;
-    decompress?: boolean | string;
-
-    method?: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE' | 'get' | 'post' | 'patch' | 'put' | 'delete';
-    paginate?: Partial<CursorPagination> | Partial<LinkPagination> | Partial<OffsetPagination>;
-    responseType?: ResponseType;
-}
-
 export interface InternalProxyConfiguration {
     environmentId: number;
     accountId?: number;
@@ -51,6 +48,11 @@ export interface InternalProxyConfiguration {
     existingActivityLogId?: number;
     throwErrors?: boolean;
     connection?: Connection;
+}
+
+export interface RetryHeaderConfig {
+    at?: string;
+    after?: string;
 }
 
 export enum PaginationType {

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -89,6 +89,11 @@ interface OffsetPagination extends Pagination {
     offset_name_in_request: string;
 }
 
+interface RetryHeaderConfig {
+    at?: string;
+    after?: string;
+}
+
 export interface ProxyConfiguration {
     endpoint: string;
     providerConfigKey?: string;
@@ -102,6 +107,7 @@ export interface ProxyConfiguration {
     retries?: number;
     baseUrlOverride?: string;
     paginate?: Partial<CursorPagination> | Partial<LinkPagination> | Partial<OffsetPagination>;
+    retryHeader?: RetryHeaderConfig;
     responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
 }
 

--- a/packages/shared/lib/services/proxy.service.ts
+++ b/packages/shared/lib/services/proxy.service.ts
@@ -374,6 +374,13 @@ See https://docs.nango.dev/guides/proxy#proxy-requests for more information.`
             error?.response?.status === 429 ||
             ['ECONNRESET', 'ETIMEDOUT', 'ECONNABORTED'].includes(error?.code as string)
         ) {
+            if (config.retryHeader) {
+                const type = config.retryHeader.at ? 'at' : 'after';
+                const retryHeader = config.retryHeader.at ? config.retryHeader.at : config.retryHeader.after;
+
+                return this.retryHandler(activityLogId, environment_id, error, type, retryHeader as string);
+            }
+
             if (config.template.proxy && config.template.proxy.retry && (config.template.proxy?.retry?.at || config.template.proxy?.retry?.after)) {
                 const type = config.template.proxy.retry.at ? 'at' : 'after';
                 const retryHeader = config.template.proxy.retry.at ? config.template.proxy.retry.at : config.template.proxy.retry.after;

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -782,6 +782,8 @@ notion:
     authorization_method: header
     body_format: json
     proxy:
+        retry:
+            after: 'Retry-After'
         base_url: https://api.notion.com
         headers:
             'Notion-Version': '2022-06-28'


### PR DESCRIPTION
## Describe your changes
Adds in retry header logic for Notion. Also allows runtime configuration for a retry header to be passed from a sync script

## Issue ticket number and link
NAN-184

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
