### PR TITLE
fix: runner can run script for up to 24h

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3275,6 +3275,14 @@
             "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
             "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw=="
         },
+        "node_modules/@fastify/busboy": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+            "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@grpc/grpc-js": {
             "version": "1.7.3",
             "license": "Apache-2.0",
@@ -5525,6 +5533,15 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/connect-timeout": {
+            "version": "0.0.39",
+            "resolved": "https://registry.npmjs.org/@types/connect-timeout/-/connect-timeout-0.0.39.tgz",
+            "integrity": "sha512-PHUX9yixjm4qjQ27Uz+F5cyG9Fio9iY7e6eWHvNT0wbA8eu9JaDqxRRiXn5uYnd09zx1fM+wEHnuBHMm9gwOuQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/express": "*"
+            }
+        },
         "node_modules/@types/cookie-parser": {
             "version": "1.4.3",
             "dev": true,
@@ -7575,6 +7592,76 @@
                 "node": ">=8"
             }
         },
+        "node_modules/connect-timeout": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.9.0.tgz",
+            "integrity": "sha512-q4bsBIPd+eSGtnh/u6EBOKfuG+4YvwsN0idlOsg6KAw71Qpi0DCf2eCc/Va63QU9qdOeYC8katxoC+rHMNygZg==",
+            "dependencies": {
+                "http-errors": "~1.6.1",
+                "ms": "2.0.0",
+                "on-finished": "~2.3.0",
+                "on-headers": "~1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/connect-timeout/node_modules/depd": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/connect-timeout/node_modules/http-errors": {
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+            "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+            "dependencies": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.0",
+                "statuses": ">= 1.4.0 < 2"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/connect-timeout/node_modules/inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+        },
+        "node_modules/connect-timeout/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        },
+        "node_modules/connect-timeout/node_modules/on-finished": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/connect-timeout/node_modules/setprototypeof": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+        },
+        "node_modules/connect-timeout/node_modules/statuses": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/content-disposition": {
             "version": "0.5.4",
             "license": "MIT",
@@ -8941,7 +9028,8 @@
         },
         "node_modules/express": {
             "version": "4.18.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+            "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
@@ -14051,6 +14139,17 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/undici": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.2.1.tgz",
+            "integrity": "sha512-7Wa9thEM6/LMnnKtxJHlc8SrTlDmxqJecgz1iy8KlsN0/iskQXOQCuPkrZLXbElPaSw5slFFyKIKXyJ3UtbApw==",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18.0"
+            }
+        },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
             "dev": true,
@@ -15721,9 +15820,13 @@
                 "@trpc/client": "^10.44.0",
                 "@trpc/server": "^10.44.0",
                 "api": "^6.1.1",
-                "superjson": "^2.2.1"
+                "connect-timeout": "^1.9.0",
+                "express": "^4.18.2",
+                "superjson": "^2.2.1",
+                "undici": "^6.2.1"
             },
             "devDependencies": {
+                "@types/connect-timeout": "^0.0.39",
                 "@types/node": "^18.7.6",
                 "typescript": "^5.3.2"
             }

--- a/packages/jobs/lib/integration.service.ts
+++ b/packages/jobs/lib/integration.service.ts
@@ -102,6 +102,7 @@ class IntegrationService implements IntegrationServiceInterface {
                 });
                 return { success: true, error: null, response: res };
             } catch (err: any) {
+                runSpan.setTag('error', err);
                 let errorType = 'sync_script_failure';
                 if (isWebhook) {
                     errorType = 'webhook_script_failure';
@@ -124,6 +125,7 @@ class IntegrationService implements IntegrationServiceInterface {
                 runSpan.finish();
             }
         } catch (err) {
+            span.setTag('error', err);
             const errorMessage = JSON.stringify(err, ['message', 'name', 'stack'], 2);
             const content = `There was an error running integration '${syncName}': ${errorMessage}`;
 

--- a/packages/runner/lib/app.ts
+++ b/packages/runner/lib/app.ts
@@ -3,8 +3,9 @@ import { server } from './server.js';
 try {
     const port = parseInt(process.argv[2] || '3006', 10);
     const id = process.argv[3] || 'unknown-id';
-    server.listen(port);
-    console.log(`🚀 Runner '${id}' ready at http://localhost:${port}`);
+    server.listen(port, () => {
+        console.log(`🚀 Runner '${id}' ready at http://localhost:${port}`);
+    });
 } catch (err) {
     console.error(`Unable to start runner: ${err}`);
     process.exit(1);

--- a/packages/runner/lib/client.ts
+++ b/packages/runner/lib/client.ts
@@ -1,10 +1,25 @@
 import { CreateTRPCProxyClient, createTRPCProxyClient, httpBatchLink } from '@trpc/client';
 import type { AppRouter } from './server.js';
 import superjson from 'superjson';
+import { fetch, Agent } from 'undici';
 
 export function getRunnerClient(url: string): CreateTRPCProxyClient<AppRouter> {
     return createTRPCProxyClient<AppRouter>({
         transformer: superjson,
-        links: [httpBatchLink({ url })]
+        links: [
+            httpBatchLink({
+                url,
+                fetch(url, options) {
+                    return fetch(url, {
+                        ...options,
+                        dispatcher: new Agent({
+                            headersTimeout: 0,
+                            connectTimeout: 0,
+                            bodyTimeout: 0
+                        })
+                    });
+                }
+            })
+        ]
     });
 }

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -22,9 +22,13 @@
         "@trpc/client": "^10.44.0",
         "@trpc/server": "^10.44.0",
         "api": "^6.1.1",
-        "superjson": "^2.2.1"
+        "connect-timeout": "^1.9.0",
+        "express": "^4.18.2",
+        "superjson": "^2.2.1",
+        "undici": "^6.2.1"
     },
     "devDependencies": {
+        "@types/connect-timeout": "^0.0.39",
         "@types/node": "^18.7.6",
         "typescript": "^5.3.2"
     }


### PR DESCRIPTION
trpc is using undici fetch under the hood which has default timeout value of 300s. Therefore all mutation calls from jobs would fail after 5mins.
Overriding the fetch timeout options to disable any fetch timeouts 
Also adding a 24h timeout on the server side.

## Issue ticket number and link
https://linear.app/nango/issue/NAN-199/fix-long-running-script
