### PR TITLE
github action workflows cannot be in subfolder

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,0 +1,51 @@
+name: "[Release] Build service images"
+on: [push, pull_request]
+concurrency:
+    group: pulls/${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+jobs:
+    nango-jobs:
+        uses: ./.github/workflows/push-container.yaml
+        secrets: inherit
+        with:
+            package: jobs
+            run-cmd: ts-build
+            tags: -t nangohq/nango-jobs:${{ github.sha }}
+    nango-runner:
+        uses: ./.github/workflows/push-container.yaml
+        secrets: inherit
+        with:
+            package: runner
+            run-cmd: ts-build
+            tags: -t nangohq/nango-runner:${{ github.sha }}
+    nango-server-staging:
+        uses: ./.github/workflows/push-container.yaml
+        secrets: inherit
+        with:
+            package: server
+            run-cmd: build:staging
+            tags: -t nangohq/nango-server:staging-${{ github.sha }}
+    nango-server-prod:
+        if: github.ref == 'refs/heads/master'
+        uses: ./.github/workflows/push-container.yaml
+        secrets: inherit
+        with:
+            package: server
+            run-cmd: build:prod
+            tags: -t nangohq/nango-server:production-${{ github.sha }}
+    nango-server-self-hosted:
+        if: github.ref == 'refs/heads/master'
+        uses: ./.github/workflows/push-container.yaml
+        secrets: inherit
+        with:
+            package: server
+            run-cmd: build:hosted
+            tags: -t nangohq/nango-server:hosted -t nangohq/nango-server:hosted-${{ github.sha }}
+    nango-server-enterprise:
+        if: github.ref == 'refs/heads/master'
+        uses: ./.github/workflows/push-container.yaml
+        secrets: inherit
+        with:
+            package: server
+            run-cmd: build:enterprise
+            tags: -t nangohq/nango-server:enterprise -t nangohq/nango-server:enterprise-${{ github.sha }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,79 @@
+name: "[Release] Deploy service"
+
+on:
+    workflow_dispatch:
+        inputs:
+            stage:
+                type: choice
+                description: "stage to deploy to, defaults to staging"
+                required: true
+                default: "staging"
+                options:
+                    - staging
+                    - production
+            service:
+                type: choice
+                description: "Service to deploy, defaults to server"
+                required: true
+                default: "server"
+                options:
+                    - server
+                    - jobs
+                    - runner
+
+jobs:
+    deploy_server:
+        if: inputs.service == 'server'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - uses: docker/login-action@v3
+              with:
+                username: ${{ secrets.DOCKER_USERNAME }}
+                password: ${{ secrets.DOCKER_PASSWORD }}
+            - name: Push tag
+              run: |
+                docker buildx imagetools create nangohq/nango-server:${{ inputs.stage }}-${{ github.sha }} --tag nangohq/nango-server:${{ inputs.stage }}
+            - name: Deploy server
+              run: |
+                SERVICE_ID=${{ fromJson('{ production: "srv-cfifsvha6gdq1k7u46a0", staging: "srv-ci1oqkm4dad20aa0cd9g" }')[inputs.stage] }}
+                curl --request POST "https://api.render.com/v1/services/$SERVICE_ID/deploys" --header "authorization: Bearer ${{ secrets.RENDER_API_KEY }}"
+    deploy_jobs:
+        if: inputs.service == 'jobs'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - uses: docker/login-action@v3
+              with:
+                username: ${{ secrets.DOCKER_USERNAME }}
+                password: ${{ secrets.DOCKER_PASSWORD }}
+            - name: Push tag
+              run: |
+                docker buildx imagetools create nangohq/nango-jobs:${{ github.sha }} --tag nangohq/nango-jobs:${{ inputs.stage }}
+            - name: Deploy jobs
+              run: |
+                SERVICE_ID=${{ fromJson('{ production: "srv-clvvtdug1b2c73cklps0", staging: "srv-clthttda73kc73ejflg0" }')[inputs.stage] }}
+                curl --request POST "https://api.render.com/v1/services/$SERVICE_ID/deploys" --header "authorization: Bearer ${{ secrets.RENDER_API_KEY }}"
+    deploy_runners:
+        if: inputs.service == 'runner'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - uses: docker/login-action@v3
+              with:
+                username: ${{ secrets.DOCKER_USERNAME }}
+                password: ${{ secrets.DOCKER_PASSWORD }}
+            - name: Push tag
+              run: |
+                docker buildx imagetools create nangohq/nango-runner:${{ github.sha }} --tag nangohq/nango-runner:${{ inputs.stage }}
+            - name: Deploy all runners
+              env:
+                API_KEY: ${{ secrets.RENDER_API_KEY }}
+                ENVIRONMENT: ${{ inputs.stage }}
+                RUNNER_OWNER_ID: ${{ secrets.RENDER_RUNNER_OWNER_ID }}
+              run: |
+                bash ./scripts/deploy/runners.bash
+

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,33 @@
+name: "[Release] NPM publish"
+
+on:
+    workflow_dispatch:
+        inputs:
+            version:
+                type: string
+                description: "Version to publish"
+                required: true
+                default: "0.0.0"
+
+jobs:
+    npm-publish:
+        if: github.ref == 'refs/heads/master'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                token: ${{ secrets.GH_PAT }}
+            - uses: actions/setup-node@v3
+              with:
+                node-version: '18.x'
+                registry-url: 'https://registry.npmjs.org'
+            - name: Publish npm packages
+              env:
+                NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+              shell: bash
+              run: |
+                bash ./scripts/publish.sh ${{ inputs.version }}
+            - uses: stefanzweifel/git-auto-commit-action@v5
+              with:
+                commit_message: Update npm packages version
+                file_pattern: '*.json'

--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -1,0 +1,34 @@
+name: Push container
+
+on:
+    workflow_call:
+        inputs:
+            package:
+                required: true
+                type: string
+            run-cmd:
+                required: true
+                type: string
+            tags:
+                required: true
+                type: string
+
+jobs:
+    push-container:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: docker/setup-buildx-action@v3
+            - uses: actions/setup-node@v3
+              with:
+                node-version: '18.x'
+            - uses: docker/login-action@v3
+              with:
+                username: ${{ secrets.DOCKER_USERNAME }}
+                password: ${{ secrets.DOCKER_PASSWORD }}
+            - name: Build and push container
+              run: |
+                npm run i
+                npm run ${{ inputs.run-cmd }}
+                docker buildx build -f packages/${{ inputs.package }}/Dockerfile --platform linux/amd64 ${{ inputs.tags }} . --no-cache --output type=registry
+


### PR DESCRIPTION
I moved the deploy workflows in a subfolder at the last minute but that was a mistake. They must be at the root

> You must store workflow files in the .github/workflows directory of your repository.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#about-yaml-syntax-for-workflows

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
