### PR TITLE
fix 'importsNotUsedAsValues' deprecation error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "prettier": "^2.7.1",
                 "testcontainers": "^9.12.0",
                 "tsx": "^4.6.2",
-                "typescript": "^4.7.4",
+                "typescript": "^5.3.3",
                 "vitest": "^0.33.0"
             }
         },
@@ -13280,14 +13280,15 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.9.3",
-            "license": "Apache-2.0",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         },
         "node_modules/ufo": {
@@ -14184,7 +14185,7 @@
                 "babel-loader": "^9.1.2",
                 "esbuild": "^0.17.19",
                 "ts-node": "^10.9.1",
-                "typescript": "^5.0.4",
+                "typescript": "^5.3.3",
                 "webpack": "^5.85.1",
                 "webpack-cli": "^5.1.3",
                 "webpack-node-externals": "^3.0.0"
@@ -14230,18 +14231,6 @@
             "version": "1.0.0",
             "license": "MIT"
         },
-        "packages/cli/node_modules/typescript": {
-            "version": "5.0.4",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=12.20"
-            }
-        },
         "packages/frontend": {
             "name": "@nangohq/frontend",
             "version": "0.36.78",
@@ -14283,7 +14272,7 @@
                 "eslint-config-prettier": "^8.3.0",
                 "eslint-plugin-deprecation": "^1.2.1",
                 "nodemon": "^3.0.1",
-                "typescript": "^5.3.2"
+                "typescript": "^5.3.3"
             }
         },
         "packages/jobs/node_modules/@datadog/native-appsec": {
@@ -14584,18 +14573,6 @@
                 "node": ">= 4"
             }
         },
-        "packages/jobs/node_modules/typescript": {
-            "version": "5.3.3",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
-            }
-        },
         "packages/node-client": {
             "name": "@nangohq/node",
             "version": "0.36.78",
@@ -14627,19 +14604,7 @@
             "devDependencies": {
                 "@types/connect-timeout": "^0.0.39",
                 "@types/node": "^18.7.6",
-                "typescript": "^5.3.2"
-            }
-        },
-        "packages/runner/node_modules/typescript": {
-            "version": "5.3.3",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
+                "typescript": "^5.3.3"
             }
         },
         "packages/server": {
@@ -14698,7 +14663,7 @@
                 "@types/uuid": "^8.3.4",
                 "@types/ws": "^8.5.4",
                 "nodemon": "^3.0.1",
-                "typescript": "^4.7.4"
+                "typescript": "^5.3.3"
             },
             "engines": {
                 "node": ">=16.7",
@@ -14847,7 +14812,7 @@
                 "@types/node": "^18.7.6",
                 "@types/parse-link-header": "^2.0.0",
                 "@types/uuid": "^9.0.0",
-                "typescript": "^4.7.4"
+                "typescript": "^5.3.3"
             },
             "engines": {
                 "node": ">=16.7",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "prettier": "^2.7.1",
         "testcontainers": "^9.12.0",
         "tsx": "^4.6.2",
-        "typescript": "^4.7.4",
+        "typescript": "^5.3.3",
         "vitest": "^0.33.0"
     },
     "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
         "build": "tsc && npm run copyfiles",
         "copyfiles": "copyfiles -u 1 lib/templates/* dist",
         "dev": "npm run copyfiles && tsc -w",
-        "prepublishOnly": "npm install && npm run build"
+        "prepublishOnly": "npm install && npm run build && cp '../shared/dist/lib/sdk/sync.d.ts' './dist/nango-sync.d.ts' "
     },
     "dependencies": {
         "@babel/traverse": "^7.22.5",
@@ -61,7 +61,7 @@
         "babel-loader": "^9.1.2",
         "esbuild": "^0.17.19",
         "ts-node": "^10.9.1",
-        "typescript": "^5.0.4",
+        "typescript": "^5.3.3",
         "webpack": "^5.85.1",
         "webpack-cli": "^5.1.3",
         "webpack-node-externals": "^3.0.0"

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -47,6 +47,6 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-deprecation": "^1.2.1",
         "nodemon": "^3.0.1",
-        "typescript": "^5.3.2"
+        "typescript": "^5.3.3"
     }
 }

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -30,6 +30,6 @@
     "devDependencies": {
         "@types/connect-timeout": "^0.0.39",
         "@types/node": "^18.7.6",
-        "typescript": "^5.3.2"
+        "typescript": "^5.3.3"
     }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -72,6 +72,6 @@
         "@types/uuid": "^8.3.4",
         "@types/ws": "^8.5.4",
         "nodemon": "^3.0.1",
-        "typescript": "^4.7.4"
+        "typescript": "^5.3.3"
     }
 }

--- a/packages/shared/lib/services/sync/config/config.service.ts
+++ b/packages/shared/lib/services/sync/config/config.service.ts
@@ -635,8 +635,8 @@ export async function getNangoConfigIdAndLocationFromId(id: number): Promise<{ n
         .from<SyncConfig>(TABLE)
         .select(`${TABLE}.nango_config_id`, `${TABLE}.file_location`)
         .where({
-            [`${TABLE}.id`]: id,
-            [`${TABLE}.deleted`]: false
+            id,
+            deleted: false
         })
         .first();
 

--- a/packages/shared/lib/services/sync/data/records.service.ts
+++ b/packages/shared/lib/services/sync/data/records.service.ts
@@ -467,7 +467,7 @@ export async function getAllDataRecords(
 
         const customerResult = result.map((item) => item.record);
 
-        if (customerResult.length > (limit || 100)) {
+        if (customerResult.length > Number(limit || 100)) {
             customerResult.pop();
             rawResult.pop();
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -68,6 +68,6 @@
         "@types/node": "^18.7.6",
         "@types/parse-link-header": "^2.0.0",
         "@types/uuid": "^9.0.0",
-        "typescript": "^4.7.4"
+        "typescript": "^5.3.3"
     }
 }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -37,8 +37,6 @@ bump_and_npm_publish "@nangohq/shared" "$VERSION"
 npm update @nangohq/shared -w nango -w @nangohq/nango-server -w @nangohq/nango-jobs @nangohq/nango-runner
 
 # CLI
-# exporting the NangoSync type
-cp "$GIT_ROOT_DIR/packages/shared/dist/lib/sdk/sync.d.ts" "./packages/cli/dist/nango-sync.d.ts" && chmod +x "$GIT_ROOT_DIR/packages/cli/dist/index.js"
 bump_and_npm_publish "nango" "$VERSION"
 
 # Frontend

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@tsconfig/node18-strictest-esm/tsconfig.json",
   "compilerOptions": {
-    //"incremental": true,
+    "ignoreDeprecations": "5.0",
     "declaration": true,
     "sourceMap": true,
     "composite": true,


### PR DESCRIPTION
## Describe your changes
We are running into the following error when compiling individual package compare to using `npm run ts-build`:
> Option 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error

This seems to come from the fact that different packages uses diferrent version of typescript.
This PR aligns typescript version for all packages in the npm workspace, fixing errors caught by the compiler and ignore v5 warnings so all packages can be compiled individually or as a workspace

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
