### PR TITLE
github action: no need for on.pull_request

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,5 +1,5 @@
 name: "[Release] Build service images"
-on: [push, pull_request]
+on: [push]
 concurrency:
     group: pulls/${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,6 +1,6 @@
 name: Docker Check
 
-on: [push, pull_request]
+on: [push]
 
 concurrency:
     group: docker-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/integration-flows.yaml
+++ b/.github/workflows/integration-flows.yaml
@@ -1,6 +1,6 @@
 name: Nango Integration Flows Compile
 
-on: [push, pull_request]
+on: [push]
 
 concurrency:
     group: flows-compile--${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,6 @@
 name: Run Unit & Integration Tests
 
-on: [push, pull_request]
+on: [push]
 
 concurrency:
     group: tests-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -1,6 +1,6 @@
 name: Yaml Validation
 
-on: [push, pull_request]
+on: [push]
 
 concurrency:
     group: validation-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Unless we want to filter on some branches or paths it is not necessary to run workflows on pull_request if running them on push

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
