### PR TITLE
Adds missing grant type for stripe-app provider

### DIFF
--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -1200,6 +1200,8 @@ stripe-app:
     disable_pkce: true
     proxy:
         base_url: https://api.stripe.com
+    refresh_params:
+        grant_type: refresh_token
 survey-monkey:
     auth_mode: OAUTH2
     authorization_url: https://api.surveymonkey.com/oauth/authorize


### PR DESCRIPTION
## Describe your changes

Adds missing `refresh_params` to the `stripe-app` integration