### PR TITLE
Only push container images if PR or push from repo

### DIFF
--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -16,6 +16,8 @@ on:
 jobs:
     push-container:
         runs-on: ubuntu-latest
+        env:
+            CAN_PUSH: ${{ (github.event_name == 'push' && github.repository == 'nangohq/nango') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) }}
         steps:
             - uses: actions/checkout@v4
             - uses: docker/setup-buildx-action@v3
@@ -23,13 +25,13 @@ jobs:
               with:
                 node-version: '18.x'
             - uses: docker/login-action@v3
-              if: github.repository == 'nangohq/nango'
+              if: env.CAN_PUSH
               with:
                 username: ${{ secrets.DOCKER_USERNAME }}
                 password: ${{ secrets.DOCKER_PASSWORD }}
             - name: Build and push container
               env:
-                PUSH: ${{ (github.repository == 'nangohq/nango') && '--push' || '' }}
+                PUSH: ${{ (env.CAN_PUSH) && '--push' || '' }}
               run: |
                 npm run i
                 npm run ${{ inputs.run-cmd }}


### PR DESCRIPTION
## Describe your changes

Attempt number 2 at not logging into docker.hub and not pushing container image if PR comes from a fork (since the secret credentials are not available for fork)