### PR TITLE
push container workflow: don't push if docker secrets are not available

### DIFF
--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -17,7 +17,7 @@ jobs:
     push-container:
         runs-on: ubuntu-latest
         env:
-            CAN_PUSH: ${{ (github.event_name == 'push' && github.repository == 'nangohq/nango') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) }}
+            CAN_PUSH: ${{ secrets.DOCKER_PASSWORD != '' && secrets.DOCKER_USERNAME != '' }}
         steps:
             - uses: actions/checkout@v4
             - uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Describe your changes
My attempt number 2 at not pushing container when PR is coming from a non-collaborator has failed. :(

Instead of having a complicated condition to try to detect if container can be pushed, we now simply check if the secrets are available. 
