### PR TITLE
fix: if condition in push container github action

### DIFF
--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -25,13 +25,13 @@ jobs:
               with:
                 node-version: '18.x'
             - uses: docker/login-action@v3
-              if: env.CAN_PUSH
+              if: env.CAN_PUSH == 'true'
               with:
                 username: ${{ secrets.DOCKER_USERNAME }}
                 password: ${{ secrets.DOCKER_PASSWORD }}
             - name: Build and push container
               env:
-                PUSH: ${{ (env.CAN_PUSH) && '--push' || '' }}
+                PUSH: ${{ (env.CAN_PUSH == 'true') && '--push' || '' }}
               run: |
                 npm run i
                 npm run ${{ inputs.run-cmd }}


### PR DESCRIPTION
Attempt number 3456789 at preventing PR from external collaborators to fail because they cannot access repo secrets

fixing the if condition in the workflow
