### PR TITLE
jobs: caching runner

### DIFF
--- a/packages/jobs/lib/runner/runner.ts
+++ b/packages/jobs/lib/runner/runner.ts
@@ -1,17 +1,28 @@
+import type { KVStore } from '@nangohq/shared/lib/utils/kvstore/KVStore.js';
 import { LocalRunner } from './local.runner.js';
 import { RenderRunner } from './render.runner.js';
-import { getEnv, LogActionEnum, metricsManager, MetricTypes } from '@nangohq/shared';
+import { getEnv, getRedisUrl, InMemoryKVStore, RedisKVStore } from '@nangohq/shared';
+
+export enum RunnerType {
+    Local = 'local',
+    Render = 'render'
+}
+
+export interface Runner {
+    runnerType: RunnerType;
+    id: string;
+    client: any;
+    url: string;
+    suspend(): Promise<void>;
+    toJSON(): any;
+}
 
 export function getRunnerId(suffix: string): string {
     return `${getEnv()}-runner-account-${suffix}`;
 }
 
 export async function getOrStartRunner(runnerId: string): Promise<Runner> {
-    const isRender = process.env['IS_RENDER'] === 'true';
-    try {
-        const runner = isRender ? await RenderRunner.getOrStart(runnerId) : await LocalRunner.getOrStart(runnerId);
-
-        // Wait for runner to start and be healthy
+    const waitForRunner = async function (runner: Runner): Promise<void> {
         const timeoutMs = 5000;
         let healthCheck = false;
         const startTime = Date.now();
@@ -26,26 +37,20 @@ export async function getOrStartRunner(runnerId: string): Promise<Runner> {
         if (!healthCheck) {
             throw new Error(`Runner '${runnerId}' hasn't started after ${timeoutMs}ms,`);
         }
-        return runner;
-    } catch (e) {
-        await metricsManager.capture(
-            MetricTypes.RENDER_RUNNER_FAILURE_RESOLVED_BACK_TO_LOCAL,
-            'Render runner cannnot be accessed',
-            LogActionEnum.INFRASTRUCTURE,
-            {
-                runnerId: String(runnerId),
-                error: String(e)
-            }
-        );
+    };
 
-        return await LocalRunner.getOrStart(runnerId);
+    const cachedRunner = await runnersCache.get(runnerId);
+    if (cachedRunner) {
+        try {
+            await waitForRunner(cachedRunner);
+            return cachedRunner;
+        } catch (err) {}
     }
-}
-
-export interface Runner {
-    id: string;
-    client: any;
-    suspend(): Promise<void>;
+    const isRender = process.env['IS_RENDER'] === 'true';
+    const runner = isRender ? await RenderRunner.getOrStart(runnerId) : await LocalRunner.getOrStart(runnerId);
+    await waitForRunner(runner);
+    await runnersCache.set(runner);
+    return runner;
 }
 
 export async function suspendRunner(runnerId: string): Promise<void> {
@@ -57,4 +62,55 @@ export async function suspendRunner(runnerId: string): Promise<void> {
             await runner.suspend();
         }
     }
+    await runnersCache.delete(runnerId);
 }
+
+// Caching the runners to minimize calls made to Render api
+// and to better handle Render rate limits and potential downtime
+
+class RunnerCache {
+    constructor(private readonly store: KVStore) {}
+
+    private cacheKey(s: string): string {
+        return `jobs:runner:${s}`;
+    }
+
+    async get(runnerId: string): Promise<Runner | undefined> {
+        try {
+            const cached = await this.store.get(this.cacheKey(runnerId));
+            if (cached) {
+                const obj = JSON.parse(cached);
+                switch (obj.runnerType) {
+                    case RunnerType.Local:
+                        return LocalRunner.fromJSON(obj);
+                    case RunnerType.Render:
+                        return RenderRunner.fromJSON(obj);
+                }
+            }
+            return undefined;
+        } catch (err) {
+            return undefined;
+        }
+    }
+
+    async set(runner: Runner): Promise<void> {
+        const ttl = 7 * 24 * 60 * 60 * 1000; // 7 days
+        await this.store.set(this.cacheKey(runner.id), JSON.stringify(runner), true, ttl);
+    }
+
+    async delete(runnerId: string): Promise<void> {
+        await this.store.delete(runnerId);
+    }
+}
+
+const runnersCache = await (async () => {
+    let store: KVStore;
+    const url = getRedisUrl();
+    if (url) {
+        store = new RedisKVStore(url);
+        await (store as RedisKVStore).connect();
+    } else {
+        store = new InMemoryKVStore();
+    }
+    return new RunnerCache(store);
+})();

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -47,6 +47,9 @@ export * from './utils/utils.js';
 export * from './utils/error.js';
 export * from './db/database.js';
 export * from './constants.js';
+export * from './utils/kvstore/KVStore.js';
+export * from './utils/kvstore/InMemoryStore.js';
+export * from './utils/kvstore/RedisStore.js';
 
 export * from './sdk/sync.js';
 

--- a/packages/shared/lib/utils/metrics.manager.ts
+++ b/packages/shared/lib/utils/metrics.manager.ts
@@ -31,8 +31,7 @@ export enum MetricTypes {
     INCOMING_WEBHOOK_ISSUE_CONNECTION_NOT_FOUND = 'incoming_webhook_issue_connection_not_found',
     INCOMING_WEBHOOK_ISSUE_WEBHOOK_SUBSCRIPTION_NOT_FOUND_REGISTERED = 'incoming_webhook_issue_webhook_subscription_not_found_registered',
     INCOMING_WEBHOOK_PROCESSED_SUCCESSFULLY = 'incoming_webhook_processed_successfully',
-    INCOMING_WEBHOOK_FAILED_PROCESSING = 'incoming_webhook_failed_processing',
-    RENDER_RUNNER_FAILURE_RESOLVED_BACK_TO_LOCAL = 'render_runner_failure_resolved_back_to_local'
+    INCOMING_WEBHOOK_FAILED_PROCESSING = 'incoming_webhook_failed_processing'
 }
 
 class MetricsManager {


### PR DESCRIPTION
First small step to make nango-jobs more resilient to Render downtime without compromising code execution isolation.
Before this change jobs would be hitting Render API to fetch Runner info and check it is running.
Job is now caching the runner and don't call Render on subsequent scripts if it already knows the runner.
It is also going to help with Render rate-limts as we grow.

Caveat: if Render is down, no new Runner would be created.

This change is also fixing a bug where when running locally each script will start a new runner process. Now same cached runner is being re-used