### PR TITLE
fix: jobs should depends on shared v0.36.88

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14189,52 +14189,6 @@
                 "node": ">=16.7"
             }
         },
-        "packages/cli/node_modules/@nangohq/shared": {
-            "version": "0.36.87",
-            "resolved": "https://registry.npmjs.org/@nangohq/shared/-/shared-0.36.87.tgz",
-            "integrity": "sha512-T8rT4Bvme7/M3JMvHPt3bVTVYk+YCn7lsxQHVskkLWfxy5d5RxsOUs9Ku6v9W/t6IwsfXLasuLA44BBdBHs7gw==",
-            "dependencies": {
-                "@aws-sdk/client-s3": "^3.348.0",
-                "@datadog/datadog-api-client": "^1.16.0",
-                "@hapi/boom": "^10.0.1",
-                "@nangohq/node": "^0.36.87",
-                "@sentry/node": "^7.37.2",
-                "@temporalio/client": "^1.5.2",
-                "@types/fs-extra": "^11.0.1",
-                "amqplib": "^0.10.3",
-                "archiver": "^6.0.1",
-                "axios": "^1.3.4",
-                "braintree": "^3.15.0",
-                "cors": "^2.8.5",
-                "dayjs": "^1.11.7",
-                "ejs": "^3.1.5",
-                "exponential-backoff": "^3.1.1",
-                "fs-extra": "^11.1.1",
-                "human-to-cron": "^0.3.1",
-                "ip": "^1.1.8",
-                "js-yaml": "^4.1.0",
-                "jsonwebtoken": "^9.0.2",
-                "knex": "^2.3.0",
-                "lodash-es": "^4.17.21",
-                "md5": "^2.3.0",
-                "ms": "^2.1.3",
-                "openapi3-ts": "^4.1.2",
-                "parse-link-header": "^2.0.0",
-                "pg": "^8.8.0",
-                "posthog-node": "^3.1.3",
-                "redis": "^4.6.11",
-                "rimraf": "^5.0.1",
-                "semver": "^7.5.4",
-                "simple-oauth2": "^5.0.0",
-                "uuid": "^9.0.0",
-                "winston": "^3.8.2",
-                "winston-daily-rotate-file": "^4.7.1"
-            },
-            "engines": {
-                "node": ">=16.7",
-                "npm": ">=6.14.11"
-            }
-        },
         "packages/cli/node_modules/@types/node": {
             "version": "20.1.7",
             "dev": true,
@@ -14261,47 +14215,6 @@
                 "ajv": "^8.0.1"
             }
         },
-        "packages/cli/node_modules/archiver": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/archiver/-/archiver-6.0.1.tgz",
-            "integrity": "sha512-CXGy4poOLBKptiZH//VlWdFuUC1RESbdZjGjILwBuZ73P7WkAUN0htfSfBq/7k6FRFlpu7bg4JOkj1vU9G6jcQ==",
-            "dependencies": {
-                "archiver-utils": "^4.0.1",
-                "async": "^3.2.4",
-                "buffer-crc32": "^0.2.1",
-                "readable-stream": "^3.6.0",
-                "readdir-glob": "^1.1.2",
-                "tar-stream": "^3.0.0",
-                "zip-stream": "^5.0.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "packages/cli/node_modules/archiver-utils": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-4.0.1.tgz",
-            "integrity": "sha512-Q4Q99idbvzmgCTEAAhi32BkOyq8iVI5EwdO0PmBDSGIzzjYNdcFn7Q7k3OzbLy4kLUPXfJtG6fO2RjftXbobBg==",
-            "dependencies": {
-                "glob": "^8.0.0",
-                "graceful-fs": "^4.2.0",
-                "lazystream": "^1.0.0",
-                "lodash": "^4.17.15",
-                "normalize-path": "^3.0.0",
-                "readable-stream": "^3.6.0"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "packages/cli/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
         "packages/cli/node_modules/commander": {
             "version": "10.0.1",
             "license": "MIT",
@@ -14309,144 +14222,9 @@
                 "node": ">=14"
             }
         },
-        "packages/cli/node_modules/compress-commons": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-5.0.1.tgz",
-            "integrity": "sha512-MPh//1cERdLtqwO3pOFLeXtpuai0Y2WCd5AhtKxznqM7WtaMYaOEMSgn45d9D10sIHSfIKE603HlOp8OPGrvag==",
-            "dependencies": {
-                "crc-32": "^1.2.0",
-                "crc32-stream": "^5.0.0",
-                "normalize-path": "^3.0.0",
-                "readable-stream": "^3.6.0"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "packages/cli/node_modules/crc32-stream": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-5.0.0.tgz",
-            "integrity": "sha512-B0EPa1UK+qnpBZpG+7FgPCu0J2ETLpXq09o9BkLkEAhdB6Z61Qo4pJ3JYu0c+Qi+/SAL7QThqnzS06pmSSyZaw==",
-            "dependencies": {
-                "crc-32": "^1.2.0",
-                "readable-stream": "^3.4.0"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "packages/cli/node_modules/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "packages/cli/node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "license": "MIT"
-        },
-        "packages/cli/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/cli/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "packages/cli/node_modules/rimraf": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
-            "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
-            "dependencies": {
-                "glob": "^10.3.7"
-            },
-            "bin": {
-                "rimraf": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "packages/cli/node_modules/rimraf/node_modules/glob": {
-            "version": "10.3.10",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-            "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^2.3.5",
-                "minimatch": "^9.0.1",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-                "path-scurry": "^1.10.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "packages/cli/node_modules/rimraf/node_modules/minimatch": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "packages/cli/node_modules/tar-stream": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
-            "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
-            "dependencies": {
-                "b4a": "^1.6.4",
-                "fast-fifo": "^1.2.0",
-                "streamx": "^2.15.0"
-            }
-        },
-        "packages/cli/node_modules/zip-stream": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-5.0.1.tgz",
-            "integrity": "sha512-UfZ0oa0C8LI58wJ+moL46BDIMgCQbnsb+2PoiJYtonhBsMh2bq1eRBVkvjfVsqbEHd9/EgKPUuL9saSSsec8OA==",
-            "dependencies": {
-                "archiver-utils": "^4.0.1",
-                "compress-commons": "^5.0.1",
-                "readable-stream": "^3.6.0"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
         },
         "packages/frontend": {
             "name": "@nangohq/frontend",
@@ -14458,7 +14236,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@nangohq/nango-runner": "^1.0.0",
-                "@nangohq/shared": "^0.36.87",
+                "@nangohq/shared": "^0.36.88",
                 "@octokit/plugin-retry": "^6.0.0",
                 "@octokit/plugin-throttling": "^7.0.0",
                 "@octokit/rest": "^20.0.1",
@@ -14563,52 +14341,6 @@
                 "node": ">=10.10.0"
             }
         },
-        "packages/jobs/node_modules/@nangohq/shared": {
-            "version": "0.36.87",
-            "resolved": "https://registry.npmjs.org/@nangohq/shared/-/shared-0.36.87.tgz",
-            "integrity": "sha512-T8rT4Bvme7/M3JMvHPt3bVTVYk+YCn7lsxQHVskkLWfxy5d5RxsOUs9Ku6v9W/t6IwsfXLasuLA44BBdBHs7gw==",
-            "dependencies": {
-                "@aws-sdk/client-s3": "^3.348.0",
-                "@datadog/datadog-api-client": "^1.16.0",
-                "@hapi/boom": "^10.0.1",
-                "@nangohq/node": "^0.36.87",
-                "@sentry/node": "^7.37.2",
-                "@temporalio/client": "^1.5.2",
-                "@types/fs-extra": "^11.0.1",
-                "amqplib": "^0.10.3",
-                "archiver": "^6.0.1",
-                "axios": "^1.3.4",
-                "braintree": "^3.15.0",
-                "cors": "^2.8.5",
-                "dayjs": "^1.11.7",
-                "ejs": "^3.1.5",
-                "exponential-backoff": "^3.1.1",
-                "fs-extra": "^11.1.1",
-                "human-to-cron": "^0.3.1",
-                "ip": "^1.1.8",
-                "js-yaml": "^4.1.0",
-                "jsonwebtoken": "^9.0.2",
-                "knex": "^2.3.0",
-                "lodash-es": "^4.17.21",
-                "md5": "^2.3.0",
-                "ms": "^2.1.3",
-                "openapi3-ts": "^4.1.2",
-                "parse-link-header": "^2.0.0",
-                "pg": "^8.8.0",
-                "posthog-node": "^3.1.3",
-                "redis": "^4.6.11",
-                "rimraf": "^5.0.1",
-                "semver": "^7.5.4",
-                "simple-oauth2": "^5.0.0",
-                "uuid": "^9.0.0",
-                "winston": "^3.8.2",
-                "winston-daily-rotate-file": "^4.7.1"
-            },
-            "engines": {
-                "node": ">=16.7",
-                "npm": ">=6.14.11"
-            }
-        },
         "packages/jobs/node_modules/acorn": {
             "version": "7.4.1",
             "dev": true,
@@ -14620,79 +14352,12 @@
                 "node": ">=0.4.0"
             }
         },
-        "packages/jobs/node_modules/archiver": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/archiver/-/archiver-6.0.1.tgz",
-            "integrity": "sha512-CXGy4poOLBKptiZH//VlWdFuUC1RESbdZjGjILwBuZ73P7WkAUN0htfSfBq/7k6FRFlpu7bg4JOkj1vU9G6jcQ==",
-            "dependencies": {
-                "archiver-utils": "^4.0.1",
-                "async": "^3.2.4",
-                "buffer-crc32": "^0.2.1",
-                "readable-stream": "^3.6.0",
-                "readdir-glob": "^1.1.2",
-                "tar-stream": "^3.0.0",
-                "zip-stream": "^5.0.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "packages/jobs/node_modules/archiver-utils": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-4.0.1.tgz",
-            "integrity": "sha512-Q4Q99idbvzmgCTEAAhi32BkOyq8iVI5EwdO0PmBDSGIzzjYNdcFn7Q7k3OzbLy4kLUPXfJtG6fO2RjftXbobBg==",
-            "dependencies": {
-                "glob": "^8.0.0",
-                "graceful-fs": "^4.2.0",
-                "lazystream": "^1.0.0",
-                "lodash": "^4.17.15",
-                "normalize-path": "^3.0.0",
-                "readable-stream": "^3.6.0"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
         "packages/jobs/node_modules/argparse": {
             "version": "1.0.10",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
-            }
-        },
-        "packages/jobs/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "packages/jobs/node_modules/compress-commons": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-5.0.1.tgz",
-            "integrity": "sha512-MPh//1cERdLtqwO3pOFLeXtpuai0Y2WCd5AhtKxznqM7WtaMYaOEMSgn45d9D10sIHSfIKE603HlOp8OPGrvag==",
-            "dependencies": {
-                "crc-32": "^1.2.0",
-                "crc32-stream": "^5.0.0",
-                "normalize-path": "^3.0.0",
-                "readable-stream": "^3.6.0"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "packages/jobs/node_modules/crc32-stream": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-5.0.0.tgz",
-            "integrity": "sha512-B0EPa1UK+qnpBZpG+7FgPCu0J2ETLpXq09o9BkLkEAhdB6Z61Qo4pJ3JYu0c+Qi+/SAL7QThqnzS06pmSSyZaw==",
-            "dependencies": {
-                "crc-32": "^1.2.0",
-                "readable-stream": "^3.4.0"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
             }
         },
         "packages/jobs/node_modules/dd-trace": {
@@ -14864,24 +14529,6 @@
                 "node": ">=4"
             }
         },
-        "packages/jobs/node_modules/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "packages/jobs/node_modules/glob-parent": {
             "version": "5.1.2",
             "dev": true,
@@ -14891,17 +14538,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "packages/jobs/node_modules/glob/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "packages/jobs/node_modules/ignore": {
@@ -14926,91 +14562,11 @@
                 "node": ">=12"
             }
         },
-        "packages/jobs/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
         "packages/jobs/node_modules/retry": {
             "version": "0.13.1",
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
-            }
-        },
-        "packages/jobs/node_modules/rimraf": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
-            "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
-            "dependencies": {
-                "glob": "^10.3.7"
-            },
-            "bin": {
-                "rimraf": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "packages/jobs/node_modules/rimraf/node_modules/glob": {
-            "version": "10.3.10",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-            "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^2.3.5",
-                "minimatch": "^9.0.1",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-                "path-scurry": "^1.10.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "packages/jobs/node_modules/rimraf/node_modules/minimatch": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "packages/jobs/node_modules/tar-stream": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
-            "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
-            "dependencies": {
-                "b4a": "^1.6.4",
-                "fast-fifo": "^1.2.0",
-                "streamx": "^2.15.0"
-            }
-        },
-        "packages/jobs/node_modules/zip-stream": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-5.0.1.tgz",
-            "integrity": "sha512-UfZ0oa0C8LI58wJ+moL46BDIMgCQbnsb+2PoiJYtonhBsMh2bq1eRBVkvjfVsqbEHd9/EgKPUuL9saSSsec8OA==",
-            "dependencies": {
-                "archiver-utils": "^4.0.1",
-                "compress-commons": "^5.0.1",
-                "readable-stream": "^3.6.0"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
             }
         },
         "packages/node-client": {

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -16,7 +16,7 @@
     },
     "dependencies": {
         "@nangohq/nango-runner": "^1.0.0",
-        "@nangohq/shared": "^0.36.87",
+        "@nangohq/shared": "^0.36.88",
         "@octokit/plugin-retry": "^6.0.0",
         "@octokit/plugin-throttling": "^7.0.0",
         "@octokit/rest": "^20.0.1",


### PR DESCRIPTION
## Describe your changes
In the last npm publish autocommit, shared dependency was not updated to the latest version. Updating it manually

