### PR TITLE
CLI should depends on shared 0.36.88

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14141,7 +14141,7 @@
             "dependencies": {
                 "@babel/traverse": "^7.22.5",
                 "@inquirer/prompts": "^2.3.0",
-                "@nangohq/shared": "^0.36.87",
+                "@nangohq/shared": "^0.36.88",
                 "@vercel/ncc": "^0.36.1",
                 "ajv": "^8.12.0",
                 "ajv-errors": "^3.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "@babel/traverse": "^7.22.5",
         "@inquirer/prompts": "^2.3.0",
-        "@nangohq/shared": "^0.36.87",
+        "@nangohq/shared": "^0.36.88",
         "@vercel/ncc": "^0.36.1",
         "ajv": "^8.12.0",
         "ajv-errors": "^3.0.0",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -29,12 +29,12 @@ npm install
 
 # Node client
 bump_and_npm_publish "@nangohq/node" "$VERSION"
-npm install @nangohq/node@latest -w @nangohq/shared
+npm install "@nangohq/node@$VERSION" -w @nangohq/shared
 
 # Shared
 node scripts/flows.js
 bump_and_npm_publish "@nangohq/shared" "$VERSION"
-npm install @nangohq/shared@latest -w nango -w @nangohq/nango-server -w @nangohq/nango-jobs -w @nangohq/nango-runner
+npm install "@nangohq/shared@$VERSION" -w nango -w @nangohq/nango-server -w @nangohq/nango-jobs -w @nangohq/nango-runner
 
 # CLI
 bump_and_npm_publish "nango" "$VERSION"


### PR DESCRIPTION
CLI should depends on shared 0.36.88

publish script: use explicit version instead of latest when updating dependencies
