### PR TITLE
Fix docs on api-reference

### DIFF
--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -769,7 +769,7 @@ paths:
                                     description: The ID of the connection. If omitted, the syncs will be triggered for all relevant connections.
                                 syncs:
                                     type: array
-                                    descriptions: A list of sync names that you wish to trigger.
+                                    description: A list of sync names that you wish to trigger.
                                     items:
                                         type: string
             responses:
@@ -805,7 +805,7 @@ paths:
                                     description: The ID of the connection. If omitted, the syncs will be started for all relevant connections.
                                 syncs:
                                     type: array
-                                    descriptions: A list of sync names that you wish to start.
+                                    description: A list of sync names that you wish to start.
                                     items:
                                         type: string
             responses:
@@ -840,7 +840,7 @@ paths:
                                     description: The ID of the connection. If omitted, the syncs will be paused for all relevant connections.
                                 syncs:
                                     type: array
-                                    descriptions: A list of sync names that you wish to pause.
+                                    description: A list of sync names that you wish to pause.
                                     items:
                                         type: string
             responses:


### PR DESCRIPTION
## Describe your changes
Updated property `description` on api-reference for the various endpoints; `/sync/trigger` , `/sync/start` and `/sync/pause`

The documentation update was reviewed using `npm run docs` and verifying on localhost.

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
