### PR TITLE
frontend: disable login window detection when needed

### DIFF
--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -2,6 +2,8 @@
  * Copyright (c) 2023 Nango, all rights reserved.
  */
 
+import { providerOptions } from './providers.js';
+
 const prodHost = 'https://api.nango.dev';
 const debugLogPrefix = 'NANGO DEBUG LOG: ';
 
@@ -152,20 +154,25 @@ export default class Nango {
                 { width: this.width, height: this.height },
                 this.debug
             );
-            this.tm = setInterval(() => {
-                if (!this.win?.modal?.window || this.win?.modal?.window.closed) {
-                    if (this.win?.isProcessingMessage === true) {
-                        // Modal is still processing a web socket message from the server
-                        // We ignore the window being closed for now
-                        return;
+            // some provider might have cross-origin setup that prevents us to detect if the window is closed
+            // if so we disable the login window closing detection
+            const detectClosedModal = providerOptions[providerConfigKey]?.detectClosedLoginWindow;
+            if (detectClosedModal !== false) {
+                this.tm = setInterval(() => {
+                    if (!this.win?.modal?.window || this.win?.modal?.window.closed) {
+                        if (this.win?.isProcessingMessage === true) {
+                            // Modal is still processing a web socket message from the server
+                            // We ignore the window being closed for now
+                            return;
+                        }
+                        clearTimeout(this.tm as unknown as number);
+                        this.win = null;
+                        this.status = AuthorizationStatus.CANCELED;
+                        const error = new AuthError('The authorization window was closed before the authorization flow was completed', 'windowClosed');
+                        reject(error);
                     }
-                    clearTimeout(this.tm as unknown as number);
-                    this.win = null;
-                    this.status = AuthorizationStatus.CANCELED;
-                    const error = new AuthError('The authorization window was closed before the authorization flow was completed', 'windowClosed');
-                    reject(error);
-                }
-            }, 500);
+                }, 500);
+            }
         });
     }
 

--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -154,7 +154,7 @@ export default class Nango {
                 { width: this.width, height: this.height },
                 this.debug
             );
-            // some provider might have cross-origin setup that prevents us to detect if the window is closed
+            // some providers might have cross-origin setup that prevents us from detecting if the window is closed
             // if so we disable the login window closing detection
             const detectClosedModal = providerOptions[providerConfigKey]?.detectClosedLoginWindow;
             if (detectClosedModal !== false) {

--- a/packages/frontend/lib/providers.ts
+++ b/packages/frontend/lib/providers.ts
@@ -1,0 +1,9 @@
+interface ProviderOptions {
+    detectClosedLoginWindow?: boolean;
+}
+
+export const providerOptions: Record<string, ProviderOptions> = {
+    shopify: {
+        detectClosedLoginWindow: false
+    }
+};


### PR DESCRIPTION
## Describe your changes
shopify login page set the `Cross-Origin-Opener-Policy: same-origin` header which prevents us to access attributes of the login window, in particular if the window was closed manually (window.closed is always true).
This commit introduces provider-based options where we can disable the login window closing detection per provider, otherwise nango.auth() would throw a `authorization window was closed before the authorization flow was completed` error



## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
