### PR TITLE
Make zod available within script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14161,7 +14161,8 @@
                 "semver": "^7.5.2",
                 "ts-node": "^10.9.1",
                 "typescript": "^5.3.3",
-                "vm": "^0.1.0"
+                "vm": "^0.1.0",
+                "zod": "^3.22.4"
             },
             "bin": {
                 "nango": "dist/index.js"
@@ -14595,7 +14596,8 @@
                 "connect-timeout": "^1.9.0",
                 "express": "^4.18.2",
                 "superjson": "^2.2.1",
-                "undici": "^6.2.1"
+                "undici": "^6.2.1",
+                "zod": "^3.22.4"
             },
             "devDependencies": {
                 "@types/connect-timeout": "^0.0.39",

--- a/packages/cli/lib/services/local-integration.service.ts
+++ b/packages/cli/lib/services/local-integration.service.ts
@@ -11,6 +11,7 @@ import {
 import * as vm from 'vm';
 import * as url from 'url';
 import * as crypto from 'crypto';
+import * as zod from 'zod';
 import { Buffer } from 'buffer';
 
 class IntegrationService implements IntegrationServiceInterface {
@@ -56,6 +57,8 @@ class IntegrationService implements IntegrationServiceInterface {
                                 return url;
                             case 'crypto':
                                 return crypto;
+                            case 'zod':
+                                return zod;
                             default:
                                 throw new Error(`Module '${moduleName}' is not allowed`);
                         }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,8 @@
         "semver": "^7.5.2",
         "ts-node": "^10.9.1",
         "typescript": "^5.3.3",
-        "vm": "^0.1.0"
+        "vm": "^0.1.0",
+        "zod": "^3.22.4"
     },
     "devDependencies": {
         "@babel/core": "^7.22.1",

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -4,6 +4,7 @@ import { Buffer } from 'buffer';
 import * as vm from 'vm';
 import * as url from 'url';
 import * as crypto from 'crypto';
+import * as zod from 'zod';
 
 export async function exec(nangoProps: NangoProps, isInvokedImmediately: boolean, isWebhook: boolean, code: string, codeParams?: object): Promise<object> {
     const isAction = isInvokedImmediately && !isWebhook;
@@ -27,6 +28,8 @@ export async function exec(nangoProps: NangoProps, isInvokedImmediately: boolean
                         return url;
                     case 'crypto':
                         return crypto;
+                    case 'zod':
+                        return zod;
                     default:
                         throw new Error(`Module '${moduleName}' is not allowed`);
                 }

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -25,7 +25,8 @@
         "connect-timeout": "^1.9.0",
         "express": "^4.18.2",
         "superjson": "^2.2.1",
-        "undici": "^6.2.1"
+        "undici": "^6.2.1",
+        "zod": "^3.22.4"
     },
     "devDependencies": {
         "@types/connect-timeout": "^0.0.39",


### PR DESCRIPTION
## Describe your changes

Making zod available within scripts so customers can use it to validate data.

Note: customers would need to run `npm install zod` manually before they can `nango compile/deploy` scripts using zod

## Issue ticket number and link

https://linear.app/nango/issue/NAN-230/[rumi]-support-zod-in-scripts

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
