### PR TITLE
frontend: add option to auth() to enable closed window detection

### DIFF
--- a/docs-v2/integrations/all/microsoft-tenant-specific.mdx
+++ b/docs-v2/integrations/all/microsoft-tenant-specific.mdx
@@ -23,7 +23,7 @@ If you want to sync data from Microsoft Graph, use the [Microsoft Teams provider
 ## Getting started
 
 -   [Create an Azure app registration for the specific application](https://go.microsoft.com/fwlink/?linkid=2083908).
-    -   Add permissions for the appropriate app on the `API Permissions` tab 
+    -   Add permissions for the appropriate app on the `API Permissions` tab
 -   [OAuth-related docs](https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow).
     -   See particularly the `tenant` parameter under [Request an authorization code](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#request-an-authorization-code).
         This `tenant` parameter must be provided as [extra configuration to the frontend SDK](https://docs.nango.dev/sdks/frontend#oauth-flows-requiring-extra-configuration).
@@ -36,8 +36,7 @@ This endpoint supports services authorized using an Azure App Registration in an
 
 > - Microsoft Dynamics 365 Finance and Operations
 
-<Tip>You _can_ use this provider for general Microsoft Graph access (and the major Microsoft SaaS services like Teams, OneDrive, other Office 365 services, etc.) by setting the `tenant` to `common` but we recommend using the [Microsoft Teams provider](/integrations/all/microsoft-teams) instead which includes sync capability.
-</Tip>
+<Tip>You _can_ use this provider for general Microsoft Graph access (and the major Microsoft SaaS services like Teams, OneDrive, other Office 365 services, etc.) by setting the `tenant` to `common` but we recommend using the [Microsoft Teams provider](/integrations/all/microsoft-teams) instead which includes sync capability.</Tip>
 
 
 ## API gotchas

--- a/docs-v2/sdks/frontend.mdx
+++ b/docs-v2/sdks/frontend.mdx
@@ -54,7 +54,7 @@ let nango = new Nango({ host: '<INSTANCE-URL>', publicKey: '<PUBLIC-KEY>', webso
 
 ## Collecting & storing end-user credentials
 
-You store end-user credentials with the `nango.auth` method. 
+You store end-user credentials with the `nango.auth` method.
 
 <Tabs>
 
@@ -169,3 +169,16 @@ nango.auth('zendesk', '<CONNECTION-ID>', {
     params: { subdomain: '<ZENDESK-SUBDOMAIN>' }
 });
 ```
+
+## Detect closed authorization page
+
+To fail when the authorization window is closed before the authorization flow is completed
+pass in the extra parameter `detectClosedAuthWindow` to `nango.auth()`
+
+```js
+nango.auth('zendesk', '<CONNECTION-ID>', {
+     detectClosedAuthWindow: true,
+     ...
+});
+```
+

--- a/packages/frontend/lib/providers.ts
+++ b/packages/frontend/lib/providers.ts
@@ -1,9 +1,0 @@
-interface ProviderOptions {
-    detectClosedLoginWindow?: boolean;
-}
-
-export const providerOptions: Record<string, ProviderOptions> = {
-    shopify: {
-        detectClosedLoginWindow: false
-    }
-};

--- a/packages/webapp/src/pages/AuthLink.tsx
+++ b/packages/webapp/src/pages/AuthLink.tsx
@@ -44,9 +44,9 @@ export default function AuthLink() {
         if (username && password) {
             credentials = {
                 username,
-                password,
+                password
             };
-        };
+        }
 
         if (apiKey) {
             credentials = {


### PR DESCRIPTION
## Describe your changes

The solution to disable closed auth window detection for shopify introduced in this PR is flawed. https://github.com/NangoHQ/nango/pull/1528
It relies on `providerConfigKey` which can be randomly set by the customer.

We discussed with @bastienbeurier and @rguldener about potential solutions to deal with this problem but they are all brittle and more complex. Given this is a very tiny feature of the Nango platform (and we have been spending a lot of time working on it), it has been decided to disable the automatic detection of closed auth page by default with an option for the customer to enable it if their workflow depends on it and the provider allows it

This is a breaking change and would require careful release and communication 
