### PR TITLE
in most cases don't run the create connection hook

### DIFF
--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -518,6 +518,8 @@ class ConnectionController {
             let oAuthCredentials: ImportedCredentials;
             let updatedConnection: { id: number } = {} as { id: number };
 
+            let runHook = false;
+
             if (template.auth_mode === ProviderAuthModes.OAuth2) {
                 const { access_token, refresh_token, expires_at, expires_in, metadata, connection_config } = req.body;
 
@@ -680,13 +682,14 @@ class ConnectionController {
 
                 if (imported) {
                     updatedConnection = imported;
+                    runHook = true;
                 }
             } else {
                 errorManager.errRes(res, 'unknown_oauth_type');
                 return;
             }
 
-            if (updatedConnection && updatedConnection.id) {
+            if (updatedConnection && updatedConnection.id && runHook) {
                 await connectionCreatedHook(
                     {
                         id: updatedConnection.id,


### PR DESCRIPTION
## Describe your changes
Syncs were created twice when importing an API connection, this fixes that.

## Issue ticket number and link
Fixes https://linear.app/nango/issue/NAN-254/[kula]-syncs-created-twice-when-importing-a-basic-auth-connection

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
