### PR TITLE
[nan-256] add deleteSync endpoint

### DIFF
--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -119,6 +119,7 @@ app.route('/sync/pause').post(apiAuth, syncController.pause.bind(syncController)
 app.route('/sync/start').post(apiAuth, syncController.start.bind(syncController));
 app.route('/sync/provider').get(apiAuth, syncController.getSyncProvider.bind(syncController));
 app.route('/sync/status').get(apiAuth, syncController.getSyncStatus.bind(syncController));
+app.route('/sync/:syncId').delete(apiAuth, syncController.deleteSync.bind(syncController));
 app.route('/flow/attributes').get(apiAuth, syncController.getFlowAttributes.bind(syncController));
 app.route('/flow/configs').get(apiAuth, flowController.getFlowConfig.bind(flowController));
 app.route('/action/trigger').post(apiAuth, syncController.triggerAction.bind(syncController)); //TODO: to deprecate

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -423,6 +423,27 @@ export const verifyOwnership = async (nangoConnectionId: number, environment_id:
     return true;
 };
 
+export const isSyncValid = async (connection_id: string, provider_config_key: string, environment_id: number, sync_id: string): Promise<boolean> => {
+    const result = await schema()
+        .select('*')
+        .from<Sync>(TABLE)
+        .join('_nango_connections', '_nango_connections.id', `${TABLE}.nango_connection_id`)
+        .where({
+            environment_id,
+            [`${TABLE}.id`]: sync_id,
+            connection_id,
+            provider_config_key,
+            [`_nango_connections.deleted`]: false,
+            [`${TABLE}.deleted`]: false
+        });
+
+    if (result.length === 0) {
+        return false;
+    }
+
+    return true;
+};
+
 export const deleteSync = async (syncId: string): Promise<string> => {
     await schema().from<Sync>(TABLE).where({ id: syncId, deleted: false }).update({ deleted: true, deleted_at: new Date() });
 


### PR DESCRIPTION
## Describe your changes
To assist with deleting duplicate syncs adds in an endpoint to delete a sync. This isn't documented and shouldn't really be publiclzed since it leads to a weird state because it doesn't delete the sync config. It is useful in this case where duplicate syncs were created due to an import bug (#1542)

## Issue ticket number and link
NAN-256

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
