### PR TITLE
fix(api): /sync/status returns execution frequency

### DIFF
--- a/docs-v2/sdks/node.mdx
+++ b/docs-v2/sdks/node.mdx
@@ -313,6 +313,7 @@ console.log(syncStatuses);
             "type": "INCREMENTAL",
             "finishedAt": "2023-11-09T12:58:06.205Z",
             "nextScheduledSyncAt": "2023-11-10T00:58:04.000Z"
+            "frequency": "2d"
         },
         {
             "id": "3463bfdd-3fa2-418c-9e53-09f59416fe5f",
@@ -321,6 +322,7 @@ console.log(syncStatuses);
             "status": "SUCCESS",
             "finishedAt": "2023-11-04T12:58:06.205Z",
             "nextScheduledSyncAt": "2023-11-10T01:58:04.000Z",
+            "frequency": "1d"
             "latestResult": {
                 "SalesforceTicket": {
                     "added": 27,

--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -915,6 +915,9 @@ paths:
                                                 nextScheduledSyncAt:
                                                     type: string
                                                     description: ISO string of the next scheduled sync time
+                                                frequency:
+                                                    type: string
+                                                    description: The execution frequency of the sync
                                                 latestResult:
                                                     type: object
                                                     description: Additional information regarding the latest result of the sync. Contains a model name with added, updated and deleted records

--- a/packages/node-client/lib/types.ts
+++ b/packages/node-client/lib/types.ts
@@ -162,6 +162,7 @@ export interface SyncStatus {
     nextScheduledSyncAt: string;
     name: string;
     status: 'RUNNING' | 'SUCCESS' | 'ERROR' | 'PAUSED' | 'STOPPED';
+    frequency: string;
     latestResult: Record<string, StatusAction>;
 }
 

--- a/packages/shared/lib/models/Sync.ts
+++ b/packages/shared/lib/models/Sync.ts
@@ -62,6 +62,7 @@ export interface ReportedSyncJobStatus {
     status: SyncStatus;
     latestResult?: SyncResultByModel;
     jobStatus?: SyncStatus;
+    frequency: string;
 }
 
 export interface SyncModelSchema {

--- a/packages/shared/lib/services/sync/orchestrator.service.ts
+++ b/packages/shared/lib/services/sync/orchestrator.service.ts
@@ -306,6 +306,7 @@ export class Orchestrator {
                     nextScheduledSyncAt,
                     name: sync?.name as string,
                     status,
+                    frequency: schedule?.frequency,
                     latestResult: latestJob?.result
                 } as ReportedSyncJobStatus;
                 if (includeJobStatus) {
@@ -345,6 +346,7 @@ export class Orchestrator {
                     nextScheduledSyncAt,
                     name: sync?.name,
                     status,
+                    frequency: schedule?.frequency,
                     latestResult: latestJob?.result
                 } as ReportedSyncJobStatus;
                 if (includeJobStatus) {


### PR DESCRIPTION
## Describe your changes

`GET /sync/status` now returns the effective frequency of the sync 

