### PR TITLE
[nan-258] allow exponential backoffs to kick in for a proxy call

### DIFF
--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -308,7 +308,13 @@ export class NangoAction {
                 throw new Error(`Connection not found using the provider config key ${this.providerConfigKey} and connection id ${this.connectionId}`);
             }
 
-            return proxyService.routeOrConfigure(config, { ...internalConfig, connection: connection as Connection }) as Promise<AxiosResponse<T>>;
+            const responseOrError = await proxyService.routeOrConfigure(config, { ...internalConfig, connection: connection as Connection });
+
+            if (responseOrError instanceof Error) {
+                throw responseOrError;
+            }
+
+            return responseOrError as unknown as Promise<AxiosResponse<T>>;
         }
     }
 

--- a/packages/shared/lib/services/proxy.service.ts
+++ b/packages/shared/lib/services/proxy.service.ts
@@ -483,9 +483,7 @@ See https://docs.nango.dev/guides/proxy#proxy-requests for more information.`
 
             const response: AxiosResponse = await backOff(
                 () => {
-                    //return axios.get(url, { ...options, headers });
-                    //return axios.get(url, { ...options, headers });
-                    return axios.get(url, { ...options, headers, timeout: 10 });
+                    return axios.get(url, { ...options, headers });
                 },
                 { numOfAttempts: Number(config.retries), retry: this.retry.bind(this, activityLogId, environment_id, config) }
             );

--- a/packages/shared/lib/services/proxy.service.ts
+++ b/packages/shared/lib/services/proxy.service.ts
@@ -491,8 +491,7 @@ See https://docs.nango.dev/guides/proxy#proxy-requests for more information.`
 
             const response: AxiosResponse = await backOff(
                 () => {
-                    //return axios.get(url, { ...options, headers });
-                    return axios.get(url, { ...options, headers, timeout: 10 });
+                    return axios.get(url, { ...options, headers });
                 },
                 { numOfAttempts: Number(config.retries), retry: this.retry.bind(this, activityLogId, environment_id, config) }
             );

--- a/packages/shared/lib/services/proxy.service.ts
+++ b/packages/shared/lib/services/proxy.service.ts
@@ -23,7 +23,7 @@ class ProxyService {
     public async routeOrConfigure(
         externalConfig: ApplicationConstructedProxyConfiguration | UserProvidedProxyConfiguration,
         internalConfig: InternalProxyConfiguration
-    ): Promise<ServiceResponse<ApplicationConstructedProxyConfiguration> | AxiosResponse | AxiosError | void> {
+    ): Promise<ServiceResponse<ApplicationConstructedProxyConfiguration> | AxiosResponse | AxiosError> {
         const { success: validationSuccess, error: validationError } = await this.validateAndLog(externalConfig, internalConfig);
 
         const { throwErrors } = internalConfig;


### PR DESCRIPTION
## Describe your changes
Turns out the update (https://github.com/NangoHQ/nango/pull/1527) throwing an error cancels the exponential backoff logic. This addition checks if we're attempting to retry and if so doesn't throw the error but rather returns it so the exponential back off / retry logic can kick in. Some of our larger customers rely heavily on the retry logic / parsing of headers so this is pretty important for them giving this fix some urgency.

## Issue ticket number and link
NAN-258

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
