### PR TITLE
fix(api): deploying sync now keeps frequency override

### DIFF
--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -298,15 +298,20 @@ export async function deployPreBuilt(
         if (previousSyncAndActionConfig) {
             bumpedVersion = increment(previousSyncAndActionConfig.version as string | number).toString();
 
-            const syncs = await getSyncsByProviderConfigAndSyncName(environment_id, provider_config_key, sync_name);
-            for (const sync of syncs) {
-                if (!runs) {
-                    continue;
-                }
-                const { success, error } = await updateSyncScheduleFrequency(sync.id as string, runs, sync_name, environment_id, activityLogId as number);
+            if (runs) {
+                const syncsConfig = await getSyncsByProviderConfigAndSyncName(environment_id, provider_config_key, sync_name);
+                for (const syncConfig of syncsConfig) {
+                    const { success, error } = await updateSyncScheduleFrequency(
+                        syncConfig.id as string,
+                        syncConfig?.frequency || runs,
+                        sync_name,
+                        environment_id,
+                        activityLogId as number
+                    );
 
-                if (!success) {
-                    return { success, error, response: null };
+                    if (!success) {
+                        return { success, error, response: null };
+                    }
                 }
             }
         }
@@ -563,15 +568,21 @@ async function compileDeployInfo(
             });
         }
 
-        const syncs = await getSyncsByProviderConfigAndSyncName(environment_id, providerConfigKey, syncName);
-        for (const sync of syncs) {
-            if (!runs) {
-                continue;
-            }
-            const { success, error } = await updateSyncScheduleFrequency(sync.id as string, runs, syncName, environment_id, activityLogId as number);
+        if (runs) {
+            const syncsConfig = await getSyncsByProviderConfigAndSyncName(environment_id, providerConfigKey, syncName);
 
-            if (!success) {
-                return { success, error, response: null };
+            for (const syncConfig of syncsConfig) {
+                const { success, error } = await updateSyncScheduleFrequency(
+                    syncConfig.id as string,
+                    syncConfig?.frequency || runs,
+                    syncName,
+                    environment_id,
+                    activityLogId as number
+                );
+
+                if (!success) {
+                    return { success, error, response: null };
+                }
             }
         }
     }


### PR DESCRIPTION
Follow up #1548 

## Describe your changes

When redeploying a sync the frequency used was the one from the yaml even if we had previously overrode the frequency via the API.
Now we fetch the value and use it if defined.

This is the only 2 places I could think of since I don't have all the knowledge, please tell me if there is any other place I should consider.



