### PR TITLE
fix(ui): show frequency in connection's sync page

### DIFF
--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -270,6 +270,7 @@ export const getSyncs = async (nangoConnection: Connection): Promise<Sync[]> => 
         .from<Sync>(TABLE)
         .select(
             `${TABLE}.*`,
+            `${TABLE}.frequency as frequency_override`,
             `${SYNC_SCHEDULE_TABLE}.schedule_id`,
             `${SYNC_SCHEDULE_TABLE}.frequency`,
             `${SYNC_SCHEDULE_TABLE}.offset`,

--- a/packages/webapp/src/pages/ConnectionDetails.tsx
+++ b/packages/webapp/src/pages/ConnectionDetails.tsx
@@ -571,7 +571,10 @@ We could not retrieve and/or refresh your access token due to the following erro
                                                         {interpretNextRun(sync.futureActionTimes) === '-' ? (
                                                             <li className="ml-3 w-32 text-sm text-gray-500">-</li>
                                                         ) : (
-                                                            <Tooltip text={interpretNextRun(sync.futureActionTimes, sync.latest_sync?.updated_at)[1]} type="dark">
+                                                            <Tooltip text={<div>
+                                                                {interpretNextRun(sync.futureActionTimes, sync.latest_sync?.updated_at)[1]}
+                                                                <br/>
+                                                                Frequency: {sync.frequency_override || sync.frequency}{sync.frequency_override && <> (override)</>}</div>} type="dark">
                                                                 <li className="ml-3 w-32 text-sm text-gray-500">{interpretNextRun(sync.futureActionTimes, sync.latest_sync?.updated_at)[0]}</li>
                                                             </Tooltip>
                                                         )}

--- a/packages/webapp/src/types.ts
+++ b/packages/webapp/src/types.ts
@@ -61,6 +61,7 @@ export interface SyncResponse {
     nango_connection_id: number;
     name: string;
     frequency: string;
+    frequency_override: string | null;
     futureActionTimes: number[];
     offset: number;
     schedule_status: 'RUNNING' | 'PAUSED' | 'STOPPED';


### PR DESCRIPTION
## Describe your changes

Displays the frequency in the connection's sync page, when you hover the next run.
Also displays if the frequency is not the default one (override).

<img width="1132" alt="Screenshot 2024-01-24 at 17 00 40" src="https://github.com/NangoHQ/nango/assets/1637651/e8e83787-63dc-485e-822f-91ebd48269a7">
<img width="1154" alt="Screenshot 2024-01-24 at 17 01 22" src="https://github.com/NangoHQ/nango/assets/1637651/aa87bf9b-0089-4153-951b-ae89dadb0d5e">
