### PR TITLE
[nan-220] move internal-nango outside for readability and track runtime via a metric

### DIFF
--- a/packages/shared/lib/integrations/scripts/webhook/github-app-oauth-webhook-routing.ts
+++ b/packages/shared/lib/integrations/scripts/webhook/github-app-oauth-webhook-routing.ts
@@ -1,4 +1,4 @@
-import type { InternalNango as Nango } from './webhook.manager.js';
+import type { InternalNango as Nango } from './internal-nango.js';
 import get from 'lodash-es/get.js';
 import type { Config as ProviderConfig } from '../../../models/Provider.js';
 import type { Connection, ConnectionConfig } from '../../../models/Connection.js';

--- a/packages/shared/lib/integrations/scripts/webhook/github-app-webhook-routing.ts
+++ b/packages/shared/lib/integrations/scripts/webhook/github-app-webhook-routing.ts
@@ -1,4 +1,4 @@
-import type { InternalNango as Nango } from './webhook.manager.js';
+import type { InternalNango as Nango } from './internal-nango.js';
 import type { Config as ProviderConfig } from '../../../models/Provider.js';
 import crypto from 'crypto';
 

--- a/packages/shared/lib/integrations/scripts/webhook/hubspot-webhook-routing.ts
+++ b/packages/shared/lib/integrations/scripts/webhook/hubspot-webhook-routing.ts
@@ -1,4 +1,4 @@
-import type { InternalNango as Nango } from './webhook.manager.js';
+import type { InternalNango as Nango } from './internal-nango.js';
 import type { Config as ProviderConfig } from '../../../models/Provider.js';
 import crypto from 'crypto';
 

--- a/packages/shared/lib/integrations/scripts/webhook/hubspot-webhook-routing.unit.test.ts
+++ b/packages/shared/lib/integrations/scripts/webhook/hubspot-webhook-routing.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import crypto from 'crypto';
 import * as HubspotWebhookRouting from './hubspot-webhook-routing.js';
-import type { InternalNango as Nango } from './webhook.manager.js';
+import type { InternalNango as Nango } from './internal-nango.js';
 import type { Config as ProviderConfig } from '../../../models/Provider.js';
 
 vi.mock('crypto', async () => {

--- a/packages/shared/lib/integrations/scripts/webhook/internal-nango.ts
+++ b/packages/shared/lib/integrations/scripts/webhook/internal-nango.ts
@@ -1,0 +1,102 @@
+import get from 'lodash-es/get.js';
+import environmentService from '../../../services/environment.service.js';
+import type { Config as ProviderConfig } from './../../../models/Provider.js';
+import SyncClient from '../../../clients/sync.client.js';
+import type { SyncConfig } from './../../../models/Sync.js';
+import connectionService from '../../../services/connection.service.js';
+import { getSyncConfigsByConfigId } from '../../../services/sync/config/config.service.js';
+import { LogActionEnum } from '../../../models/Activity.js';
+import metricsManager, { MetricTypes } from '../../../utils/metrics.manager.js';
+
+export interface InternalNango {
+    getWebhooks: (environment_id: number, nango_config_id: number) => Promise<SyncConfig[] | null>;
+    executeScriptForWebhooks(integration: ProviderConfig, body: any, webhookType: string, connectionIdentifier: string, propName?: string): Promise<void>;
+}
+
+export const internalNango: InternalNango = {
+    getWebhooks: async (environment_id: number, nango_config_id: number) => {
+        const syncConfigs = await getSyncConfigsByConfigId(environment_id, nango_config_id);
+
+        if (!syncConfigs) {
+            return null;
+        }
+
+        const syncConfigsWithWebhooks = syncConfigs.filter((syncConfig: SyncConfig) => syncConfig.webhook_subscriptions);
+
+        return syncConfigsWithWebhooks;
+    },
+    executeScriptForWebhooks: async (integration: ProviderConfig, body: any, webhookType: string, connectionIdentifier: string, propName?: string) => {
+        const syncConfigsWithWebhooks = await internalNango.getWebhooks(integration.environment_id, integration.id as number);
+
+        if (!syncConfigsWithWebhooks) {
+            return;
+        }
+        const syncClient = await SyncClient.getInstance();
+
+        if (!get(body, connectionIdentifier)) {
+            await metricsManager.capture(
+                MetricTypes.INCOMING_WEBHOOK_ISSUE_WRONG_CONNECTION_IDENTIFIER,
+                'Incoming webhook had the wrong connection identifier',
+                LogActionEnum.WEBHOOK,
+                {
+                    environmentId: String(integration.environment_id),
+                    provider: integration.provider,
+                    providerConfigKey: integration.unique_key,
+                    connectionIdentifier,
+                    payload: JSON.stringify(body)
+                }
+            );
+
+            return;
+        }
+
+        const connections = await connectionService.findConnectionsByConnectionConfigValue(
+            propName || connectionIdentifier,
+            get(body, connectionIdentifier),
+            integration.environment_id
+        );
+
+        if (!connections || connections.length === 0) {
+            await metricsManager.capture(
+                MetricTypes.INCOMING_WEBHOOK_ISSUE_CONNECTION_NOT_FOUND,
+                'Incoming webhook received but no connection found for it',
+                LogActionEnum.WEBHOOK,
+                {
+                    environmentId: String(integration.environment_id),
+                    provider: integration.provider,
+                    providerConfigKey: integration.unique_key,
+                    propName: String(propName),
+                    connectionIdentifier,
+                    payload: JSON.stringify(body)
+                }
+            );
+            return;
+        }
+
+        const accountId = await environmentService.getAccountIdFromEnvironment(integration.environment_id);
+
+        await metricsManager.capture(MetricTypes.INCOMING_WEBHOOK_RECEIVED, 'Incoming webhook received and connection found for it', LogActionEnum.WEBHOOK, {
+            accountId: String(accountId),
+            environmentId: String(integration.environment_id),
+            provider: integration.provider,
+            providerConfigKey: integration.unique_key,
+            connectionIds: connections.map((connection) => connection.connection_id).join(',')
+        });
+
+        for (const syncConfig of syncConfigsWithWebhooks) {
+            const { webhook_subscriptions } = syncConfig;
+
+            if (!webhook_subscriptions) {
+                continue;
+            }
+
+            for (const webhook of webhook_subscriptions) {
+                if (get(body, webhookType) === webhook) {
+                    for (const connection of connections) {
+                        await syncClient?.triggerWebhook(connection, integration.provider, webhook, syncConfig.sync_name, body, integration.environment_id);
+                    }
+                }
+            }
+        }
+    }
+};

--- a/packages/shared/lib/integrations/scripts/webhook/jira-webhook-routing.ts
+++ b/packages/shared/lib/integrations/scripts/webhook/jira-webhook-routing.ts
@@ -1,4 +1,4 @@
-import type { InternalNango as Nango } from './webhook.manager.js';
+import type { InternalNango as Nango } from './internal-nango.js';
 import type { Config as ProviderConfig } from '../../../models/Provider.js';
 
 export default async function route(nango: Nango, integration: ProviderConfig, _headers: Record<string, any>, body: any) {

--- a/packages/shared/lib/integrations/scripts/webhook/slack-webhook-routing.ts
+++ b/packages/shared/lib/integrations/scripts/webhook/slack-webhook-routing.ts
@@ -1,4 +1,5 @@
-import type { InternalNango as Nango, WebhookResponse } from './webhook.manager.js';
+import type { WebhookResponse } from './webhook.manager.js';
+import type { InternalNango as Nango } from './internal-nango.js';
 import type { Config as ProviderConfig } from '../../../models/Provider.js';
 
 export default async function route(

--- a/packages/shared/lib/integrations/scripts/webhook/webhook.manager.ts
+++ b/packages/shared/lib/integrations/scripts/webhook/webhook.manager.ts
@@ -1,14 +1,10 @@
-import get from 'lodash-es/get.js';
 import configService from '../../../services/config.service.js';
-import SyncClient from '../../../clients/sync.client.js';
-import connectionService from '../../../services/connection.service.js';
-import { getSyncConfigsByConfigId } from '../../../services/sync/config/config.service.js';
-import type { SyncConfig } from './../../../models/Sync.js';
 import type { Config as ProviderConfig } from './../../../models/Provider.js';
-import webhookService from '../../../services/sync/notification/webhook.service.js';
 import environmentService from '../../../services/environment.service.js';
+import webhookService from '../../../services/sync/notification/webhook.service.js';
 import metricsManager, { MetricTypes } from '../../../utils/metrics.manager.js';
 import { LogActionEnum } from '../../../models/Activity.js';
+import { internalNango, InternalNango } from './internal-nango.js';
 
 import * as webhookHandlers from './index.js';
 
@@ -25,99 +21,6 @@ type WebhookHandlersMap = { [key: string]: WebhookHandler };
 
 const handlers: WebhookHandlersMap = webhookHandlers as unknown as WebhookHandlersMap;
 
-export interface InternalNango {
-    getWebhooks: (environment_id: number, nango_config_id: number) => Promise<SyncConfig[] | null>;
-    executeScriptForWebhooks(integration: ProviderConfig, body: any, webhookType: string, connectionIdentifier: string, propName?: string): Promise<void>;
-}
-
-const internalNango: InternalNango = {
-    getWebhooks: async (environment_id: number, nango_config_id: number) => {
-        const syncConfigs = await getSyncConfigsByConfigId(environment_id, nango_config_id);
-
-        if (!syncConfigs) {
-            return null;
-        }
-
-        const syncConfigsWithWebhooks = syncConfigs.filter((syncConfig: SyncConfig) => syncConfig.webhook_subscriptions);
-
-        return syncConfigsWithWebhooks;
-    },
-    executeScriptForWebhooks: async (integration: ProviderConfig, body: any, webhookType: string, connectionIdentifier: string, propName?: string) => {
-        const syncConfigsWithWebhooks = await internalNango.getWebhooks(integration.environment_id, integration.id as number);
-
-        if (!syncConfigsWithWebhooks) {
-            return;
-        }
-        const syncClient = await SyncClient.getInstance();
-
-        if (!get(body, connectionIdentifier)) {
-            await metricsManager.capture(
-                MetricTypes.INCOMING_WEBHOOK_ISSUE_WRONG_CONNECTION_IDENTIFIER,
-                'Incoming webhook had the wrong connection identifier',
-                LogActionEnum.WEBHOOK,
-                {
-                    environmentId: String(integration.environment_id),
-                    provider: integration.provider,
-                    providerConfigKey: integration.unique_key,
-                    connectionIdentifier,
-                    payload: JSON.stringify(body)
-                }
-            );
-
-            return;
-        }
-
-        const connections = await connectionService.findConnectionsByConnectionConfigValue(
-            propName || connectionIdentifier,
-            get(body, connectionIdentifier),
-            integration.environment_id
-        );
-
-        if (!connections || connections.length === 0) {
-            await metricsManager.capture(
-                MetricTypes.INCOMING_WEBHOOK_ISSUE_CONNECTION_NOT_FOUND,
-                'Incoming webhook received but no connection found for it',
-                LogActionEnum.WEBHOOK,
-                {
-                    environmentId: String(integration.environment_id),
-                    provider: integration.provider,
-                    providerConfigKey: integration.unique_key,
-                    propName: String(propName),
-                    connectionIdentifier,
-                    payload: JSON.stringify(body)
-                }
-            );
-            return;
-        }
-
-        const accountId = await environmentService.getAccountIdFromEnvironment(integration.environment_id);
-
-        await metricsManager.capture(MetricTypes.INCOMING_WEBHOOK_RECEIVED, 'Incoming webhook received and connection found for it', LogActionEnum.WEBHOOK, {
-            accountId: String(accountId),
-            environmentId: String(integration.environment_id),
-            provider: integration.provider,
-            providerConfigKey: integration.unique_key,
-            connectionIds: connections.map((connection) => connection.connection_id).join(',')
-        });
-
-        for (const syncConfig of syncConfigsWithWebhooks) {
-            const { webhook_subscriptions } = syncConfig;
-
-            if (!webhook_subscriptions) {
-                continue;
-            }
-
-            for (const webhook of webhook_subscriptions) {
-                if (get(body, webhookType) === webhook) {
-                    for (const connection of connections) {
-                        await syncClient?.triggerWebhook(connection, integration.provider, webhook, syncConfig.sync_name, body, integration.environment_id);
-                    }
-                }
-            }
-        }
-    }
-};
-
 async function execute(environmentUuid: string, providerConfigKey: string, headers: Record<string, any>, body: any): Promise<void | any> {
     if (!body) {
         return;
@@ -130,6 +33,8 @@ async function execute(environmentUuid: string, providerConfigKey: string, heade
         return;
     }
 
+    const accountId = await environmentService.getAccountIdFromEnvironment(integration.environment_id);
+
     const handler = handlers[`${provider.replace(/-/g, '')}Webhook`];
 
     let res: WebhookResponse | null | void = null;
@@ -140,6 +45,7 @@ async function execute(environmentUuid: string, providerConfigKey: string, heade
         }
     } catch (e) {
         await metricsManager.capture(MetricTypes.INCOMING_WEBHOOK_FAILED_PROCESSING, 'Incoming webhook failed processing', LogActionEnum.WEBHOOK, {
+            accountId: String(accountId),
             environmentId: String(integration.environment_id),
             provider: integration.provider,
             providerConfigKey: integration.unique_key,
@@ -153,6 +59,7 @@ async function execute(environmentUuid: string, providerConfigKey: string, heade
     await webhookService.forward(integration.environment_id, providerConfigKey, provider, webhookBodyToForward, headers);
 
     await metricsManager.capture(MetricTypes.INCOMING_WEBHOOK_PROCESSED_SUCCESSFULLY, 'Incoming webhook was processed successfully', LogActionEnum.WEBHOOK, {
+        accountId: String(accountId),
         environmentId: String(integration.environment_id),
         provider: integration.provider,
         providerConfigKey: integration.unique_key,

--- a/packages/shared/lib/utils/metrics.manager.ts
+++ b/packages/shared/lib/utils/metrics.manager.ts
@@ -26,6 +26,7 @@ export enum MetricTypes {
     SYNC_GET_RECORDS_QUERY_TIMEOUT = 'sync_get_records_query_timeout',
     FLOW_JOB_TIMEOUT_FAILURE = 'flow_job_failure',
     POST_CONNECTION_SCRIPT_FAILURE = 'post_connection_script_failure',
+    WEBHOOK_TRACK_RUNTIME = 'webhook_track_runtime',
     INCOMING_WEBHOOK_RECEIVED = 'incoming_webhook_received',
     INCOMING_WEBHOOK_ISSUE_WRONG_CONNECTION_IDENTIFIER = 'incoming_webhook_issue_wrong_connection_identifier',
     INCOMING_WEBHOOK_ISSUE_CONNECTION_NOT_FOUND = 'incoming_webhook_issue_connection_not_found',


### PR DESCRIPTION
## Describe your changes
Webhoook cleanup and tracking. Refactored to move the `internal-nango` object code to its own file as it was semi confusing in which the order the code ran IMO

## Issue ticket number and link
NAN-220

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [x] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
