### PR TITLE
proxy_url connection parameter config optional

### DIFF
--- a/packages/server/lib/controllers/config.controller.ts
+++ b/packages/server/lib/controllers/config.controller.ts
@@ -55,7 +55,10 @@ class ConfigController {
                     creationDate: config.created_at
                 };
                 if (template && template.auth_mode !== AuthModes.App && template.auth_mode !== AuthModes.Custom) {
-                    integration['connectionConfigParams'] = parseConnectionConfigParamsFromTemplate(template!);
+                    integration['connectionConfigParams'] = parseConnectionConfigParamsFromTemplate(template!).filter(
+                        // we ignore connection config params that are in the token response metadata or redirect url metadata
+                        (element) => [...(template.token_response_metadata || []), ...(template.redirect_uri_metadata || [])].indexOf(element) == -1
+                    );
                 }
                 return integration;
             });


### PR DESCRIPTION
## Describe your changes

We currently requires the instance_url config param to be fill in by the user in the connection creation script, even though the instance url is retrieve from the token response metadata.
This commit filter out any connection config param if it is also part of token response metadata

## Issue ticket number and link
https://linear.app/nango/issue/NAN-259/[ninetailed]-salesforce-instance-url-should-not-be-a-mandatory

I have tested that providers like Salesforce, pipedrive or wildix-pbx don't show config param when creating a connection. Also verified providers like Freshdesk show the extra field 
