### PR TITLE
[nan-208] trust temporal on sync schedule discrepencies

### DIFF
--- a/packages/shared/lib/services/sync/orchestrator.service.ts
+++ b/packages/shared/lib/services/sync/orchestrator.service.ts
@@ -288,7 +288,7 @@ export class Orchestrator {
                 }
 
                 const { schedule, latestJob, status, nextScheduledSyncAt } = await this.fetchSyncData(sync?.id as string, environmentId);
-                const reportedStatus = await this.buildReportedStatus(sync, latestJob, schedule, status, nextScheduledSyncAt, includeJobStatus);
+                const reportedStatus = await this.reportedStatus(sync, latestJob, schedule, status, nextScheduledSyncAt, includeJobStatus);
 
                 syncsWithStatus.push(reportedStatus);
             }
@@ -304,7 +304,7 @@ export class Orchestrator {
 
             for (const sync of syncs) {
                 const { schedule, latestJob, status, nextScheduledSyncAt } = await this.fetchSyncData(sync?.id as string, environmentId);
-                const reportedStatus = await this.buildReportedStatus(sync, latestJob, schedule, status, nextScheduledSyncAt, includeJobStatus);
+                const reportedStatus = await this.reportedStatus(sync, latestJob, schedule, status, nextScheduledSyncAt, includeJobStatus);
 
                 syncsWithStatus.push(reportedStatus);
             }
@@ -386,7 +386,7 @@ export class Orchestrator {
         return { schedule, latestJob, status, nextScheduledSyncAt };
     }
 
-    private async buildReportedStatus(
+    private async reportedStatus(
         sync: Sync,
         latestJob: SyncJob | null,
         schedule: SyncSchedule | null,

--- a/packages/shared/lib/services/sync/schedule.service.ts
+++ b/packages/shared/lib/services/sync/schedule.service.ts
@@ -57,16 +57,18 @@ export const markAllAsStopped = async (): Promise<void> => {
     await schema().update({ status: ScheduleStatus.STOPPED }).from<SyncSchedule>(TABLE);
 };
 
-export const updateScheduleStatus = async (schedule_id: string, status: SyncCommand, activityLogId: number, environment_id: number): Promise<void> => {
+export const updateScheduleStatus = async (schedule_id: string, status: SyncCommand, activityLogId: number | null, environment_id: number): Promise<void> => {
     try {
         await schema().update({ status: SyncCommandToScheduleStatus[status] }).from<SyncSchedule>(TABLE).where({ schedule_id, deleted: false });
     } catch (error: any) {
-        await createActivityLogDatabaseErrorMessageAndEnd(
-            `Failed to update schedule status to ${status} for schedule_id: ${schedule_id}.`,
-            error,
-            activityLogId,
-            environment_id
-        );
+        if (activityLogId) {
+            await createActivityLogDatabaseErrorMessageAndEnd(
+                `Failed to update schedule status to ${status} for schedule_id: ${schedule_id}.`,
+                error,
+                activityLogId,
+                environment_id
+            );
+        }
     }
 };
 

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -9,12 +9,13 @@ import {
     SyncStatus,
     SyncWithSchedule,
     SlimSync,
-    SlimAction
+    SlimAction,
+    SyncCommand
 } from '../../models/Sync.js';
 import type { Connection, NangoConnection } from '../../models/Connection.js';
 import SyncClient from '../../clients/sync.client.js';
 import { updateSuccess as updateSuccessActivityLog, createActivityLogMessage, createActivityLogMessageAndEnd } from '../activity/activity.service.js';
-import { markAllAsStopped } from './schedule.service.js';
+import { updateScheduleStatus, markAllAsStopped } from './schedule.service.js';
 import {
     getActiveCustomSyncConfigsByEnvironmentId,
     getSyncConfigsByProviderConfigKey,
@@ -319,9 +320,23 @@ export const getSyncs = async (nangoConnection: Connection): Promise<Sync[]> => 
             `${SYNC_SCHEDULE_TABLE}.schedule_id`
         );
 
-    const syncsWithSchedule = result.map((sync) => {
+    const syncsWithSchedule = result.map(async (sync) => {
         const { schedule_id } = sync;
         const schedule = scheduleResponse?.schedules.find((schedule) => schedule.scheduleId === schedule_id);
+        // if a disagreement trust temporal
+        if (schedule?.info?.paused && sync.schedule_status !== SyncStatus.PAUSED) {
+            sync = {
+                ...sync,
+                schedule_status: SyncStatus.PAUSED
+            };
+            await updateScheduleStatus(schedule_id, SyncCommand.PAUSE, null, nangoConnection.environment_id);
+        } else if (!schedule?.info?.paused && sync.schedule_status === SyncStatus.PAUSED) {
+            sync = {
+                ...sync,
+                schedule_status: SyncStatus.RUNNING
+            };
+            await updateScheduleStatus(schedule_id, SyncCommand.UNPAUSE, null, nangoConnection.environment_id);
+        }
         const futureActionTimes = schedule?.info?.futureActionTimes?.map((long) => long?.seconds?.toNumber()) || [];
 
         return {
@@ -331,7 +346,7 @@ export const getSyncs = async (nangoConnection: Connection): Promise<Sync[]> => 
     });
 
     if (Array.isArray(syncsWithSchedule) && syncsWithSchedule.length > 0) {
-        return syncsWithSchedule;
+        return Promise.all(syncsWithSchedule);
     }
 
     return [];


### PR DESCRIPTION
## Describe your changes
There have been instances where the sync schedule gets out of step as provided by temporal. This can be due to double clicking in the UI or server issues. This updates the logic to resolve to what temporal says vs. our database in regards to the sync schedule. Also refactors to make the code more DRY

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
