### PR TITLE
fix: webapp fix version flick

### DIFF
--- a/packages/webapp/src/components/LeftNavBar.tsx
+++ b/packages/webapp/src/components/LeftNavBar.tsx
@@ -180,14 +180,12 @@ export default function LeftNavBar(props: LeftNavBarProps) {
                             </ul>
                         </div>
                     )}
-                    {version && (
-                        <div>
-                            <hr className="border-border-gray border my-1" />
-                            <span className="flex py-1 items-center text-center text-gray-500 justify-center text-sm">
-                                v{version}
-                            </span>
-                        </div>
-                    )}
+                    <div>
+                        <hr className="border-border-gray border my-1" />
+                        <span className="flex py-1 items-center text-center text-gray-500 justify-center text-sm">
+                            {version ? `v${version}` : '-'}
+                        </span>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Describe your changes

The version number is async loaded, since it is conditionally rendered it causes a flick at the bottom side of the left navbar:
![300723847-2bada5a0-8cd1-4c39-b1b8-6acab507df75](https://github.com/NangoHQ/nango/assets/39590344/870c0f42-6c15-4ae1-af6e-e082e865d9ec)


I defaulted it to an `-` when the version is loading, getting rid of the flick above ☝️ 



## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: