### PR TITLE
fix docs

### DIFF
--- a/docs-v2/api-reference/sync/update-connection-frequency.mdx
+++ b/docs-v2/api-reference/sync/update-connection-frequency.mdx
@@ -3,3 +3,4 @@ title: 'Update sync connection frequency'
 openapi: 'PUT /sync/update-connection-frequency'
 ---
 
+Update the frequency of a specific sync and connection

--- a/docs-v2/mint.json
+++ b/docs-v2/mint.json
@@ -235,6 +235,7 @@
                         "integrations/all/gitlab",
                         "integrations/all/gong",
                         "integrations/all/google",
+                        "integrations/all/google-ads",
                         "integrations/all/google-calendar",
                         "integrations/all/google-mail",
                         "integrations/all/google-sheet",

--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -932,7 +932,7 @@ paths:
                                         type: string
 
     /sync/update-connection-frequency:
-        get:
+        put:
             description: Update a sync's connection frequency or revert to the default frequency
             requestBody:
                 required: true
@@ -952,13 +952,13 @@ paths:
                                 connection_id:
                                     type: string
                                     description: The ID of the connection
-                                sync:
+                                sync_name:
                                     type: string
                                     description: The name of the sync you want to update
                                 frequency:
                                     type: string
                                     nullable: true
-                                    description: The frequency you want to set. Set null to revert to the default frequency
+                                    description: "The frequency you want to set (ex: 'every hour'). Set null to revert to the default frequency"
             responses:
                 '200':
                     description: Successfully updated the frequency


### PR DESCRIPTION
## Describe your changes
Docs page https://docs.nango.dev/api-reference/sync/update-connection-frequency is empty. Fixing the openapi spec.
Also adding google-ads to mint.json
