### PR TITLE
Persist: increase request size limit

### DIFF
--- a/packages/persist/lib/server.ts
+++ b/packages/persist/lib/server.ts
@@ -7,7 +7,7 @@ import './tracer.js';
 import { logLevelValues } from '@nangohq/shared';
 
 export const server = express();
-server.use(express.json());
+server.use(express.json({ limit: '100mb' }));
 
 server.use((req: Request, res: Response, next: NextFunction) => {
     const originalSend = res.send;


### PR DESCRIPTION
## Describe your changes

express.json middleware default limit is 100kb
https://expressjs.com/en/api.html#express.json
Data sent to the persist API can be much bigger.

We are tracing the number of records and their size. So we can later analyze and tweak the limit. We can also modify the batch size if needed

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
