### PR TITLE
persist: always track records size/count, not just when writing was successful

### DIFF
--- a/packages/persist/lib/controllers/persist.controller.ts
+++ b/packages/persist/lib/controllers/persist.controller.ts
@@ -244,9 +244,12 @@ class PersistController {
                 syncId,
                 syncJobId,
                 model,
-                activityLogId
+                activityLogId,
+                'records.count': records.length,
+                'records.sizeInBytes': Buffer.byteLength(JSON.stringify(records), 'utf8')
             }
         });
+
         const {
             success,
             error,
@@ -293,11 +296,6 @@ class PersistController {
                     deleted: summary?.deletedKeys?.length as number
                 }
             };
-
-            span.addTags({
-                'records.count': records.length,
-                'records.sizeInBytes': Buffer.byteLength(JSON.stringify(records), 'utf8')
-            });
 
             await createActivityLogMessage({
                 level: 'info',


### PR DESCRIPTION
## Describe your changes

We currently only track the batchSave records size and count after writing to db was successful
It is most useful to always store this info regardless of the operation result

I noticed while investigating procurementScience issue with writing a ExternalBlobMetadata

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
