### PR TITLE
fix: error detail for postgresql 22001 error

### DIFF
--- a/packages/shared/lib/services/sync/data/data.service.ts
+++ b/packages/shared/lib/services/sync/data/data.service.ts
@@ -92,7 +92,7 @@ export async function upsert(
         let errorDetail = '';
         switch (error.code) {
             case '22001': {
-                errorDetail = 'Payload too big. Limit = 256MB';
+                errorDetail = 'String length exceeds the column’s maximum length (string_data_right_truncation)';
                 break;
             }
         }


### PR DESCRIPTION
Error 22001 is not related to row size but happens when trying to insert a string longer than the column's max size
https://www.postgresql.org/docs/current/errcodes-appendix.html

This is the error procurementScience is hitting. Probably because the model id is too long.

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
