### PR TITLE
refactor proxy service so proxying doesn't require access to db

### DIFF
--- a/packages/server/lib/controllers/proxy.controller.ts
+++ b/packages/server/lib/controllers/proxy.controller.ts
@@ -318,7 +318,7 @@ class ProxyController {
             const activityLogs: ActivityLogMessage[] = [];
             const headers = proxyService.constructHeaders(config);
             const requestConfig: AxiosRequestConfig = {
-                method: method,
+                method,
                 url,
                 responseType: 'stream',
                 headers,

--- a/packages/server/lib/controllers/proxy.controller.ts
+++ b/packages/server/lib/controllers/proxy.controller.ts
@@ -49,8 +49,8 @@ class ProxyController {
             const retries = req.get('Retries') as string;
             const baseUrlOverride = req.get('Base-Url-Override') as string;
             const decompress = req.get('Decompress') as string;
-            const isSync = (req.get('Nango-Is-Sync') as string) == 'true';
-            const isDryRun = (req.get('Nango-Is-Dry-Run') as string) == 'true';
+            const isSync = (req.get('Nango-Is-Sync') as string) === 'true';
+            const isDryRun = (req.get('Nango-Is-Dry-Run') as string) === 'true';
             const existingActivityLogId = req.get('Nango-Activity-Log-Id') as number | string;
             const environment_id = getEnvironmentId(res);
             const accountId = getAccount(res);

--- a/packages/shared/lib/integrations/scripts/connection/github-app-oauth-post-connection.ts
+++ b/packages/shared/lib/integrations/scripts/connection/github-app-oauth-post-connection.ts
@@ -1,18 +1,20 @@
 import type { InternalNango as Nango } from './connection.manager.js';
 import { AuthModes, OAuth2Credentials } from '../../../models/Auth.js';
+import axios from 'axios';
 
 export default async function execute(nango: Nango) {
+    const connection = await nango.getConnection();
     const response = await nango.proxy({
-        endpoint: `/user`
+        endpoint: `/user`,
+        connectionId: connection.connection_id,
+        providerConfigKey: connection.provider_config_key
     });
 
-    if (!response || !response.data) {
+    if (axios.isAxiosError(response) || !response || !response.data) {
         return;
     }
 
     const handle = response.data.login;
-
-    const connection = await nango.getConnection();
 
     let updatedConfig: Record<string, string | OAuth2Credentials> = {
         handle

--- a/packages/shared/lib/integrations/scripts/connection/hubspot-post-connection.ts
+++ b/packages/shared/lib/integrations/scripts/connection/hubspot-post-connection.ts
@@ -1,9 +1,15 @@
 import type { InternalNango as Nango } from './connection.manager.js';
+import axios from 'axios';
 
 export default async function execute(nango: Nango) {
-    const response = await nango.proxy({ endpoint: '/account-info/v3/details' });
+    const connection = await nango.getConnection();
+    const response = await nango.proxy({
+        endpoint: '/account-info/v3/details',
+        connectionId: connection.connection_id,
+        providerConfigKey: connection.provider_config_key
+    });
 
-    if (!response || !response.data || !response.data.portalId) {
+    if (axios.isAxiosError(response) || !response || !response.data || !response.data.portalId) {
         return;
     }
     const portalId = response.data.portalId;

--- a/packages/shared/lib/integrations/scripts/connection/jira-post-connection.ts
+++ b/packages/shared/lib/integrations/scripts/connection/jira-post-connection.ts
@@ -1,21 +1,27 @@
 import type { InternalNango as Nango } from './connection.manager.js';
+import axios from 'axios';
 
 export default async function execute(nango: Nango) {
+    const connection = await nango.getConnection();
     const response = await nango.proxy({
-        endpoint: `oauth/token/accessible-resources`
+        endpoint: `oauth/token/accessible-resources`,
+        connectionId: connection.connection_id,
+        providerConfigKey: connection.provider_config_key
     });
 
-    if (!response || !response.data || response.data.length === 0 || !response.data[0].id) {
+    if (axios.isAxiosError(response) || !response || !response.data || response.data.length === 0 || !response.data[0].id) {
         return;
     }
 
     const cloudId = response.data[0].id;
 
     const accountResponse = await nango.proxy({
-        endpoint: `ex/jira/${cloudId}/rest/api/3/myself`
+        endpoint: `ex/jira/${cloudId}/rest/api/3/myself`,
+        connectionId: connection.connection_id,
+        providerConfigKey: connection.provider_config_key
     });
 
-    if (!accountResponse || !accountResponse.data || accountResponse.data.length === 0) {
+    if (axios.isAxiosError(accountResponse) || !accountResponse || !accountResponse.data || accountResponse.data.length === 0) {
         await nango.updateConnectionConfig({ cloudId });
         return;
     }

--- a/packages/shared/lib/integrations/scripts/connection/linear-post-connection.ts
+++ b/packages/shared/lib/integrations/scripts/connection/linear-post-connection.ts
@@ -1,4 +1,5 @@
 import type { InternalNango as Nango } from './connection.manager.js';
+import axios from 'axios';
 
 export default async function execute(nango: Nango) {
     const query = `
@@ -8,13 +9,16 @@ export default async function execute(nango: Nango) {
             }
         }`;
 
+    const connection = await nango.getConnection();
     const response = await nango.proxy({
         endpoint: '/graphql',
         data: { query },
-        method: 'POST'
+        method: 'POST',
+        connectionId: connection.connection_id,
+        providerConfigKey: connection.provider_config_key
     });
 
-    if (!response || !response.data || !response.data.data?.organization?.id) {
+    if (axios.isAxiosError(response) || !response || !response.data || !response.data.data?.organization?.id) {
         return;
     }
 

--- a/packages/shared/lib/integrations/scripts/webhook/github-app-oauth-webhook-routing.ts
+++ b/packages/shared/lib/integrations/scripts/webhook/github-app-oauth-webhook-routing.ts
@@ -62,7 +62,7 @@ async function handleCreateWebhook(integration: ProviderConfig, body: any) {
             return;
         }
 
-        const template = await configService.getTemplate(integration?.provider as string);
+        const template = configService.getTemplate(integration?.provider as string);
 
         const activityLogId = connection.connection_config['pendingLog'];
         delete connection.connection_config['pendingLog'];

--- a/packages/shared/lib/models/Proxy.ts
+++ b/packages/shared/lib/models/Proxy.ts
@@ -5,6 +5,8 @@ import type { Connection } from './Connection.js';
 import type { Template as ProviderTemplate } from './Provider.js';
 
 interface BaseProxyConfiguration {
+    providerConfigKey: string;
+    connectionId: string;
     endpoint: string;
     retries?: number;
     data?: unknown;
@@ -17,20 +19,13 @@ interface BaseProxyConfiguration {
 }
 
 export interface UserProvidedProxyConfiguration extends BaseProxyConfiguration {
-    providerConfigKey?: string;
-    connectionId?: string;
-    retries?: number;
     decompress?: boolean | string;
-
     method?: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE' | 'get' | 'post' | 'patch' | 'put' | 'delete';
     paginate?: Partial<CursorPagination> | Partial<LinkPagination> | Partial<OffsetPagination>;
 }
 
 export interface ApplicationConstructedProxyConfiguration extends BaseProxyConfiguration {
-    providerConfigKey: string;
-    connectionId: string;
     decompress?: boolean;
-
     method: HTTP_VERB;
     provider: string;
     token: string | BasicApiCredentials | ApiKeyCredentials | AppCredentials;
@@ -41,13 +36,9 @@ export interface ApplicationConstructedProxyConfiguration extends BaseProxyConfi
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
 
 export interface InternalProxyConfiguration {
-    environmentId: number;
-    accountId?: number;
-    isFlow?: boolean;
-    isDryRun?: boolean;
+    provider: string;
+    connection: Connection;
     existingActivityLogId?: number;
-    throwErrors?: boolean;
-    connection?: Connection;
 }
 
 export interface RetryHeaderConfig {

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -331,7 +331,7 @@ export class NangoAction {
 
             if (activityLogs) {
                 for (const log of activityLogs) {
-                    if (log.level == 'debug') continue;
+                    if (log.level === 'debug') continue;
                     this.log(log.content, { level: log.level });
                 }
             }

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -332,7 +332,7 @@ export class NangoAction {
             if (activityLogs) {
                 for (const log of activityLogs) {
                     if (log.level === 'debug') continue;
-                    this.log(log.content, { level: log.level });
+                    await this.log(log.content, { level: log.level });
                 }
             }
 

--- a/packages/shared/lib/sdk/sync.unit.test.ts
+++ b/packages/shared/lib/sdk/sync.unit.test.ts
@@ -14,6 +14,7 @@ vi.mock('@nangohq/node', () => {
 
 describe('Pagination', () => {
     const providerConfigKey = 'github';
+    const connectionId = 'connection-1';
 
     const cursorPagination: CursorPagination = {
         type: 'cursor',
@@ -45,6 +46,7 @@ describe('Pagination', () => {
             secretKey: 'encrypted',
             serverUrl: 'https://example.com',
             providerConfigKey,
+            connectionId,
             dryRun: true
         };
         nangoAction = new NangoAction(config);
@@ -124,7 +126,8 @@ describe('Pagination', () => {
             endpoint,
             params: { offset: '3', per_page: 3 },
             paginate: paginationConfigOverride,
-            providerConfigKey: 'github'
+            providerConfigKey,
+            connectionId
         });
     });
 

--- a/packages/shared/lib/services/config.service.ts
+++ b/packages/shared/lib/services/config.service.ts
@@ -21,10 +21,25 @@ class ConfigService {
     public DEMO_GITHUB_CONFIG_KEY = 'demo-github-integration';
 
     private getTemplatesFromFile() {
-        const templatesPath = path.join(dirname(), '../../../providers.yaml');
+        const templatesPath = () => {
+            // find the providers.yaml file
+            // recursively searching in parent directories
+            const findProvidersYaml = (dir: string): string => {
+                const providersYamlPath = path.join(dir, 'providers.yaml');
+                if (fs.existsSync(providersYamlPath)) {
+                    return providersYamlPath;
+                }
+                const parentDir = path.dirname(dir);
+                if (parentDir === dir) {
+                    throw new NangoError('providers_yaml_not_found');
+                }
+                return findProvidersYaml(parentDir);
+            };
+            return findProvidersYaml(dirname());
+        };
 
         try {
-            const fileEntries = yaml.load(fs.readFileSync(templatesPath).toString()) as { [key: string]: ProviderTemplate | ProviderTemplateAlias };
+            const fileEntries = yaml.load(fs.readFileSync(templatesPath()).toString()) as { [key: string]: ProviderTemplate | ProviderTemplateAlias };
 
             if (fileEntries == null) {
                 throw new NangoError('provider_template_loading_failed');

--- a/packages/shared/lib/services/proxy.service.ts
+++ b/packages/shared/lib/services/proxy.service.ts
@@ -120,15 +120,13 @@ class ProxyService {
                 break;
         }
 
-        if (activityLogId) {
-            activityLogs.push({
-                level: 'debug',
-                environment_id: connection.environment_id,
-                activity_log_id: activityLogId as number,
-                timestamp: Date.now(),
-                content: 'Proxy: token retrieved successfully'
-            });
-        }
+        activityLogs.push({
+            level: 'debug',
+            environment_id: connection.environment_id,
+            activity_log_id: activityLogId as number,
+            timestamp: Date.now(),
+            content: 'Proxy: token retrieved successfully'
+        });
 
         let template: ProviderTemplate | undefined;
         try {
@@ -136,44 +134,38 @@ class ProxyService {
         } catch (error) {}
 
         if (!template || ((!template.proxy || !template.proxy.base_url) && !baseUrlOverride)) {
-            if (activityLogId) {
-                activityLogs.push({
-                    level: 'error',
-                    environment_id: connection.environment_id,
-                    activity_log_id: activityLogId as number,
-                    timestamp: Date.now(),
-                    content: `${Date.now()} The proxy is not supported for this provider ${provider}. You can easily add support by following the instructions at https://docs.nango.dev/contribute/nango-auth.
+            activityLogs.push({
+                level: 'error',
+                environment_id: connection.environment_id,
+                activity_log_id: activityLogId as number,
+                timestamp: Date.now(),
+                content: `${Date.now()} The proxy is not supported for this provider ${provider}. You can easily add support by following the instructions at https://docs.nango.dev/contribute/nango-auth.
             You can also use the baseUrlOverride to get started right away.
             See https://docs.nango.dev/guides/proxy#proxy-requests for more information.`
-                });
-            }
+            });
 
             return { success: false, error: new NangoError('missing_base_api_url'), response: null, activityLogs };
         }
 
-        if (activityLogId) {
-            activityLogs.push({
-                level: 'debug',
-                environment_id: connection.environment_id,
-                activity_log_id: activityLogId,
-                timestamp: Date.now(),
-                content: `Proxy: API call configuration constructed successfully with the base api url set to ${baseUrlOverride || template.proxy.base_url}`
-            });
-        }
+        activityLogs.push({
+            level: 'debug',
+            environment_id: connection.environment_id,
+            activity_log_id: activityLogId as number,
+            timestamp: Date.now(),
+            content: `Proxy: API call configuration constructed successfully with the base api url set to ${baseUrlOverride || template.proxy.base_url}`
+        });
 
         if (!baseUrlOverride && template.proxy.base_url && endpoint.includes(template.proxy.base_url)) {
             endpoint = endpoint.replace(template.proxy.base_url, '');
         }
 
-        if (activityLogId) {
-            activityLogs.push({
-                level: 'debug',
-                environment_id: connection.environment_id,
-                activity_log_id: activityLogId,
-                timestamp: Date.now(),
-                content: `Endpoint set to ${endpoint} with retries set to ${retries}`
-            });
-        }
+        activityLogs.push({
+            level: 'debug',
+            environment_id: connection.environment_id,
+            activity_log_id: activityLogId as number,
+            timestamp: Date.now(),
+            content: `Endpoint set to ${endpoint} with retries set to ${retries}`
+        });
 
         if (headers && headers['Content-Type'] === 'multipart/form-data') {
             const formData = new FormData();

--- a/packages/shared/lib/services/proxy.service.unit.test.ts
+++ b/packages/shared/lib/services/proxy.service.unit.test.ts
@@ -4,7 +4,7 @@ import { HTTP_VERB, AuthModes, UserProvidedProxyConfiguration, InternalProxyConf
 import type { ApplicationConstructedProxyConfiguration } from '../models/Proxy.js';
 import type { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
-describe('Proxy Controller Construct Header Tests', () => {
+describe('Proxy service Construct Header Tests', () => {
     it('Should correctly construct a header using an api key with multiple headers', () => {
         const config = {
             endpoint: 'https://api.nangostarter.com',
@@ -210,7 +210,7 @@ describe('Proxy Controller Construct Header Tests', () => {
     });
 });
 
-describe('Proxy Controller Construct URL Tests', () => {
+describe('Proxy service Construct URL Tests', () => {
     it('should correctly construct url with no trailing slash and no leading slash', () => {
         const config = {
             template: {
@@ -481,7 +481,7 @@ describe('Proxy Controller Construct URL Tests', () => {
         await proxyService.retryHandler(1, 1, mockAxiosError, 'after', 'x-rateLimit-reset-after');
         const after = Date.now();
         const diff = after - before;
-        expect(diff).toBeGreaterThan(1000);
+        expect(diff).toBeGreaterThanOrEqual(1000);
         expect(diff).toBeLessThan(2000);
     });
 

--- a/packages/shared/lib/services/proxy.service.unit.test.ts
+++ b/packages/shared/lib/services/proxy.service.unit.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, it } from 'vitest';
 import proxyService from './proxy.service.js';
-import { HTTP_VERB, AuthModes } from '../models/index.js';
+import { HTTP_VERB, AuthModes, UserProvidedProxyConfiguration, InternalProxyConfiguration, OAuth2Credentials } from '../models/index.js';
 import type { ApplicationConstructedProxyConfiguration } from '../models/Proxy.js';
 import type { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
@@ -504,5 +504,190 @@ describe('Proxy Controller Construct URL Tests', () => {
         const diff = after - before;
         expect(diff).toBeGreaterThan(1000);
         expect(diff).toBeLessThan(2000);
+    });
+});
+
+describe('Proxy service configure', () => {
+    it('Should fail if no endpoint', () => {
+        const externalConfig: UserProvidedProxyConfiguration = {
+            method: 'GET',
+            providerConfigKey: 'provider-config-key-1',
+            connectionId: 'connection-1',
+            endpoint: ''
+        };
+        const internalConfig: InternalProxyConfiguration = {
+            provider: 'provider-1',
+            connection: {
+                environment_id: 1,
+                connection_id: 'connection-1',
+                provider_config_key: 'provider-config-key-1',
+                credentials: {} as OAuth2Credentials,
+                connection_config: {}
+            },
+            existingActivityLogId: 1
+        };
+        const { success, error, response, activityLogs } = proxyService.configure(externalConfig, internalConfig);
+        expect(success).toBe(false);
+        expect(response).toBeNull();
+        expect(error).toBeDefined();
+        expect(error?.message).toContain('missing_endpoint');
+        expect(activityLogs.length).toBe(1);
+        expect(activityLogs[0]).toMatchObject({
+            environment_id: 1,
+            activity_log_id: 1,
+            level: 'error'
+        });
+    });
+    it('Should fail if no connectionId', () => {
+        const externalConfig: UserProvidedProxyConfiguration = {
+            method: 'GET',
+            providerConfigKey: 'provider-config-key-1',
+            connectionId: '',
+            endpoint: 'https://example.com'
+        };
+        const internalConfig: InternalProxyConfiguration = {
+            provider: 'provider-1',
+            connection: {
+                environment_id: 1,
+                connection_id: 'connection-1',
+                provider_config_key: 'provider-config-key-1',
+                credentials: {} as OAuth2Credentials,
+                connection_config: {}
+            },
+            existingActivityLogId: 1
+        };
+        const { success, error, response, activityLogs } = proxyService.configure(externalConfig, internalConfig);
+        expect(success).toBe(false);
+        expect(response).toBeNull();
+        expect(error).toBeDefined();
+        expect(error?.message).toContain('missing_connection_id');
+        expect(activityLogs.length).toBe(1);
+        expect(activityLogs[0]).toMatchObject({
+            environment_id: 1,
+            activity_log_id: 1,
+            level: 'error'
+        });
+    });
+    it('Should fail if no providerConfigKey', () => {
+        const externalConfig: UserProvidedProxyConfiguration = {
+            method: 'GET',
+            providerConfigKey: '',
+            connectionId: 'connection-1',
+            endpoint: 'https://example.com'
+        };
+        const internalConfig: InternalProxyConfiguration = {
+            provider: 'provider-1',
+            connection: {
+                environment_id: 1,
+                connection_id: 'connection-1',
+                provider_config_key: 'provider-config-key-1',
+                credentials: {} as OAuth2Credentials,
+                connection_config: {}
+            },
+            existingActivityLogId: 1
+        };
+        const { success, error, response, activityLogs } = proxyService.configure(externalConfig, internalConfig);
+        expect(success).toBe(false);
+        expect(response).toBeNull();
+        expect(error).toBeDefined();
+        expect(error?.message).toContain('missing_provider_config_key');
+        expect(activityLogs.length).toBe(1);
+        expect(activityLogs[0]).toMatchObject({
+            environment_id: 1,
+            activity_log_id: 1,
+            level: 'error'
+        });
+    });
+    it('Should fail if unknown provider', () => {
+        const externalConfig: UserProvidedProxyConfiguration = {
+            method: 'GET',
+            providerConfigKey: 'provider-config-key-1',
+            connectionId: 'connection-1',
+            endpoint: 'https://example.com'
+        };
+        const internalConfig: InternalProxyConfiguration = {
+            provider: 'unknown',
+            connection: {
+                environment_id: 1,
+                connection_id: 'connection-1',
+                provider_config_key: 'provider-config-key-1',
+                credentials: {} as OAuth2Credentials,
+                connection_config: {}
+            },
+            existingActivityLogId: 1
+        };
+        const { success, error, response, activityLogs } = proxyService.configure(externalConfig, internalConfig);
+        expect(success).toBe(false);
+        expect(response).toBeNull();
+        expect(error).toBeDefined();
+        expect(error?.message).toContain('proxy is not supported');
+        expect(activityLogs.length).toBe(3);
+        expect(activityLogs[2]).toMatchObject({
+            environment_id: 1,
+            activity_log_id: 1,
+            level: 'error'
+        });
+    });
+    it('Should succeed', () => {
+        const externalConfig: UserProvidedProxyConfiguration = {
+            method: 'GET',
+            providerConfigKey: 'provider-config-key-1',
+            connectionId: 'connection-1',
+            endpoint: '/api/test',
+            retries: 3,
+            baseUrlOverride: 'https://api.github.com.override',
+            headers: {
+                'x-custom': 'custom-value'
+            },
+            params: { foo: 'bar' },
+            responseType: 'blob'
+        };
+        const internalConfig: InternalProxyConfiguration = {
+            provider: 'github',
+            connection: {
+                environment_id: 1,
+                connection_id: 'connection-1',
+                provider_config_key: 'provider-config-key-1',
+                credentials: {} as OAuth2Credentials,
+                connection_config: {}
+            },
+            existingActivityLogId: 1
+        };
+        const { success, error, response, activityLogs } = proxyService.configure(externalConfig, internalConfig);
+        expect(success).toBe(true);
+        expect(response).toMatchObject({
+            endpoint: '/api/test',
+            method: 'GET',
+            template: {
+                auth_mode: 'OAUTH2',
+                authorization_url: 'https://github.com/login/oauth/authorize',
+                token_url: 'https://github.com/login/oauth/access_token',
+                proxy: {
+                    base_url: 'https://api.github.com'
+                },
+                docs: 'https://docs.github.com/en/rest'
+            },
+            token: '',
+            provider: 'github',
+            providerConfigKey: 'provider-config-key-1',
+            connectionId: 'connection-1',
+            headers: {
+                'x-custom': 'custom-value'
+            },
+            retries: 3,
+            baseUrlOverride: 'https://api.github.com.override',
+            decompress: false,
+            connection: {
+                environment_id: 1,
+                connection_id: 'connection-1',
+                provider_config_key: 'provider-config-key-1',
+                credentials: {},
+                connection_config: {}
+            },
+            params: { foo: 'bar' },
+            responseType: 'blob'
+        });
+        expect(error).toBeNull();
+        expect(activityLogs.length).toBe(4);
     });
 });

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -491,7 +491,7 @@ export class NangoError extends Error {
             default:
                 this.status = 500;
                 this.type = 'unhandled_' + type;
-                this.message = `An unhandled error ${this.payload} has occurred: ${type}`;
+                this.message = `An unhandled error of type '${type}' with payload '${JSON.stringify(this.payload)}' has occured`;
         }
     }
 


### PR DESCRIPTION
We don't want runners to have direct access to the database. The goal of this commit is to remove database dependency when calling the proxy service, while still executing the http request directly without going through our own API

This commit is refactoring the `proxyService.routeOrConfigure` function, splitting the function into 2 (`configure` and `route`, removing any db access within `configure` by passing all required data as inputs and returning the activity logs instead of writing them from within the function. Basically making the `configure` function side-effects free.

## Issue ticket number and link
https://linear.app/nango/issue/NAN-291/call-to-nangoproxy-in-script-should-not-require-database-access-from
https://linear.app/nango/issue/NAN-282/[internal-tech-debt]-refactor-proxy-routeorconfigure-method

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
