### PR TITLE
[nan-311] don't attempt to start a sync if using hosted version

### DIFF
--- a/packages/shared/lib/hooks/hooks.ts
+++ b/packages/shared/lib/hooks/hooks.ts
@@ -14,9 +14,7 @@ export const connectionCreated = async (
 
     if (options.initiateSync === true && !hosted) {
         const syncClient = await SyncClient.getInstance();
-        if (syncClient) {
-            syncClient?.initiate(connection.id as number);
-        }
+        syncClient?.initiate(connection.id as number);
     }
 
     if (options.runPostConnectionScript === true) {

--- a/packages/shared/lib/hooks/hooks.ts
+++ b/packages/shared/lib/hooks/hooks.ts
@@ -2,6 +2,7 @@ import SyncClient from '../clients/sync.client.js';
 import type { RecentlyCreatedConnection } from '../models/Connection.js';
 import integrationPostConnectionScript from '../integrations/scripts/connection/connection.manager.js';
 import webhookService from '../services/notification/webhook.service.js';
+import { isCloud, isLocal, isEnterprise } from '../utils/utils.js';
 
 export const connectionCreated = async (
     connection: RecentlyCreatedConnection,
@@ -9,9 +10,13 @@ export const connectionCreated = async (
     activityLogId: number | null,
     options: { initiateSync?: boolean; runPostConnectionScript?: boolean } = { initiateSync: true, runPostConnectionScript: true }
 ): Promise<void> => {
-    if (options.initiateSync === true) {
+    const hosted = !isCloud() && !isLocal() && !isEnterprise();
+
+    if (options.initiateSync === true && !hosted) {
         const syncClient = await SyncClient.getInstance();
-        syncClient?.initiate(connection.id as number);
+        if (syncClient) {
+            syncClient?.initiate(connection.id as number);
+        }
     }
 
     if (options.runPostConnectionScript === true) {


### PR DESCRIPTION
## Describe your changes
Reported in the community that the call to the connection endpoint response is very slow on a hosted version

## Issue ticket number and link
NAN-311

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
