### PR TITLE
Added support for apiSecret to api_key auth mode

### DIFF
--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -185,6 +185,9 @@ export default class Nango {
         }
         if ('apiKey' in credentials) {
             params['apiKey'] = credentials.apiKey || '';
+            if (credentials.apiSecret) {
+                params['apiSecret'] = credentials.apiSecret;
+            }
         }
 
         if ('privateKeyId' in credentials && 'issuerId' in credentials && 'privateKey' in credentials) {
@@ -336,6 +339,7 @@ interface BasicApiCredentials {
 
 interface ApiKeyCredentials {
     apiKey?: string;
+    apiSecret?: string;
 }
 
 interface AppStoreCredentials {

--- a/packages/server/lib/controllers/apiAuth.controller.ts
+++ b/packages/server/lib/controllers/apiAuth.controller.ts
@@ -130,9 +130,13 @@ class ApiAuthController {
                 errorManager.errRes(res, 'missing_api_key');
 
                 return;
+            } else if (config.provider === 'clari-copilot' && !req.body.apiSecret) {
+                errorManager.errRes(res, 'missing_api_secret');
+
+                return;
             }
 
-            const { apiKey } = req.body;
+            const { apiKey, apiSecret } = req.body;
 
             await createActivityLogMessage({
                 level: 'info',
@@ -150,7 +154,8 @@ class ApiAuthController {
                 config?.provider as string,
                 {
                     type: AuthModes.ApiKey,
-                    apiKey
+                    apiKey,
+                    apiSecret
                 },
                 connectionConfig,
                 environmentId,

--- a/packages/shared/lib/models/Auth.ts
+++ b/packages/shared/lib/models/Auth.ts
@@ -104,6 +104,7 @@ export interface BasicApiCredentials {
 export interface ApiKeyCredentials {
     type?: AuthModes.ApiKey;
     apiKey: string;
+    apiSecret?: string;
 }
 
 export type AuthCredentials = OAuth2Credentials | OAuth1Credentials;

--- a/packages/webapp/src/pages/ConnectionCreate.tsx
+++ b/packages/webapp/src/pages/ConnectionCreate.tsx
@@ -47,6 +47,7 @@ export default function IntegrationCreate() {
     const getIntegrationListAPI = useGetIntegrationListAPI();
     const getProjectInfoAPI = useGetProjectInfoAPI()
     const [apiKey, setApiKey] = useState('');
+    const [apiSecret, setApiSecret] = useState('');
     const [apiAuthUsername, setApiAuthUsername] = useState('');
     const [apiAuthPassword, setApiAuthPassword] = useState('');
     const [privateKeyId, setPrivateKeyId] = useState('');
@@ -141,6 +142,13 @@ export default function IntegrationCreate() {
         if (authMode === AuthModes.ApiKey) {
             credentials = {
                 apiKey
+            };
+        }
+
+        if (authMode === AuthModes.ApiKey && integration?.provider === 'clari-copilot') {
+            credentials = {
+                apiKey,
+                apiSecret
             };
         }
 
@@ -282,6 +290,13 @@ export default function IntegrationCreate() {
 }`;
         }
 
+if (integration?.authMode === AuthModes.ApiKey && integration?.provider === 'clari-copilot') {
+            apiAuthString = `
+    credentials: {
+      apiKey: '${apiKey}',
+      apiSecret: '${apiSecret}'
+}`;
+        }
         if (integration?.authMode === AuthModes.Basic) {
             apiAuthString = `
     credentials: {
@@ -511,6 +526,36 @@ nango.${integration?.authMode === AuthModes.None ? 'create' : 'auth'}('${integra
                                                     name="api_key"
                                                     optionalvalue={apiKey}
                                                     setoptionalvalue={setApiKey}
+                                                    required
+                                                />
+                                            </div>
+                                        </div>
+                                    )}
+                                    {integration?.provider === 'clari-copilot' && (
+                                        <div>
+                                            <div className="flex mt-6">
+                                                <label htmlFor="connection_id" className="text-text-light-gray block text-sm font-semibold">
+                                                    API Secret
+                                                </label>
+                                                <Tooltip
+                                                    text={
+                                                        <>
+                                                            <div className="flex text-black text-sm">
+                                                                <p>{`The API Secret to authenticate requests`}</p>
+                                                            </div>
+                                                        </>
+                                                    }
+                                                >
+                                                    <HelpCircle color="gray" className="h-5 ml-1"></HelpCircle>
+                                                </Tooltip>
+                                            </div>
+                                            <div className="mt-1">
+                                                <SecretInput
+                                                    copy={true}
+                                                    id="api_secret"
+                                                    name="api_secret"
+                                                    optionalvalue={apiSecret}
+                                                    setoptionalvalue={setApiSecret}
                                                     required
                                                 />
                                             </div>

--- a/packages/webapp/src/pages/ConnectionDetails.tsx
+++ b/packages/webapp/src/pages/ConnectionDetails.tsx
@@ -359,6 +359,14 @@ We could not retrieve and/or refresh your access token due to the following erro
                                                     </label>
                                                     <SecretInput disabled defaultValue={connection.credentials.apiKey} copy={true} />
                                                 </div>
+                                            {connection.credentials.apiSecret && (
+                                                <div className="mx-8 mt-8">
+                                                    <label htmlFor="apiSecret" className="text-text-light-gray block text-sm font-semibold">
+                                                        API Secret
+                                                    </label>
+                                                    <SecretInput disabled defaultValue={connection.credentials.apiSecret} copy={true} />
+                                                </div>
+                                            )}
                                             </div>
                                         )}
                                         {connection.credentials && connection.oauthType === AuthModes.Basic && (


### PR DESCRIPTION
## Describe your changes
For authentication in Clari Copilot, both apiKey and apiSecret have to be passed in the request header. To achieve this, I have added a provision to enable users to add an apiSecret while creating a connection with this provider. This will, in turn, be called when authenticating the request.

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
