### PR TITLE
fix(reporting): add error in datadog APM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2838,33 +2838,6 @@
                 "node": ">=14"
             }
         },
-        "node_modules/@datadog/native-iast-rewriter": {
-            "version": "2.2.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "lru-cache": "^7.14.0",
-                "node-gyp-build": "^4.5.0"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@datadog/native-iast-rewriter/node_modules/lru-cache": {
-            "version": "7.18.3",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
-            "version": "4.7.0",
-            "license": "MIT",
-            "bin": {
-                "node-gyp-build": "bin.js",
-                "node-gyp-build-optional": "optional.js",
-                "node-gyp-build-test": "build-test.js"
-            }
-        },
         "node_modules/@datadog/native-iast-taint-tracking": {
             "version": "1.6.4",
             "hasInstallScript": true,
@@ -10066,20 +10039,12 @@
             "version": "4.0.1",
             "license": "MIT"
         },
-        "node_modules/lodash.kebabcase": {
-            "version": "4.1.1",
-            "license": "MIT"
-        },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "license": "MIT"
         },
         "node_modules/lodash.once": {
             "version": "4.1.1",
-            "license": "MIT"
-        },
-        "node_modules/lodash.pick": {
-            "version": "4.4.0",
             "license": "MIT"
         },
         "node_modules/lodash.setwith": {
@@ -10102,10 +10067,6 @@
         "node_modules/lodash.union": {
             "version": "4.6.0",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/lodash.uniq": {
-            "version": "4.5.0",
             "license": "MIT"
         },
         "node_modules/log-symbols": {
@@ -14540,7 +14501,7 @@
                 "@trpc/client": "^10.44.1",
                 "@trpc/server": "^10.44.1",
                 "@types/fs-extra": "^11.0.1",
-                "dd-trace": "4.20.0",
+                "dd-trace": "5.2.0",
                 "dotenv": "^16.0.3",
                 "fs-extra": "^11.1.1",
                 "js-yaml": "^4.1.0",
@@ -14562,32 +14523,6 @@
                 "eslint-plugin-deprecation": "^1.2.1",
                 "nodemon": "^3.0.1",
                 "typescript": "^5.3.3"
-            }
-        },
-        "packages/jobs/node_modules/@datadog/native-appsec": {
-            "version": "4.0.0",
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "node-gyp-build": "^3.9.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "packages/jobs/node_modules/@datadog/pprof": {
-            "version": "4.0.1",
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "delay": "^5.0.0",
-                "node-gyp-build": "<4.0",
-                "p-limit": "^3.1.0",
-                "pprof-format": "^2.0.7",
-                "source-map": "^0.7.4"
-            },
-            "engines": {
-                "node": ">=14"
             }
         },
         "packages/jobs/node_modules/@eslint/eslintrc": {
@@ -14651,56 +14586,6 @@
             "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
-            }
-        },
-        "packages/jobs/node_modules/dd-trace": {
-            "version": "4.20.0",
-            "hasInstallScript": true,
-            "license": "(Apache-2.0 OR BSD-3-Clause)",
-            "dependencies": {
-                "@datadog/native-appsec": "4.0.0",
-                "@datadog/native-iast-rewriter": "2.2.1",
-                "@datadog/native-iast-taint-tracking": "1.6.4",
-                "@datadog/native-metrics": "^2.0.0",
-                "@datadog/pprof": "4.0.1",
-                "@datadog/sketches-js": "^2.1.0",
-                "@opentelemetry/api": "^1.0.0",
-                "@opentelemetry/core": "^1.14.0",
-                "crypto-randomuuid": "^1.0.0",
-                "dc-polyfill": "^0.1.2",
-                "ignore": "^5.2.4",
-                "import-in-the-middle": "^1.4.2",
-                "int64-buffer": "^0.1.9",
-                "ipaddr.js": "^2.1.0",
-                "istanbul-lib-coverage": "3.2.0",
-                "jest-docblock": "^29.7.0",
-                "koalas": "^1.0.2",
-                "limiter": "^1.1.4",
-                "lodash.kebabcase": "^4.1.1",
-                "lodash.pick": "^4.4.0",
-                "lodash.sortby": "^4.7.0",
-                "lodash.uniq": "^4.5.0",
-                "lru-cache": "^7.14.0",
-                "methods": "^1.1.2",
-                "module-details-from-path": "^1.0.3",
-                "msgpack-lite": "^0.1.26",
-                "node-abort-controller": "^3.1.1",
-                "opentracing": ">=0.12.1",
-                "path-to-regexp": "^0.1.2",
-                "pprof-format": "^2.0.7",
-                "protobufjs": "^7.2.4",
-                "retry": "^0.13.1",
-                "semver": "^7.5.4"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "packages/jobs/node_modules/dd-trace/node_modules/ignore": {
-            "version": "5.3.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
             }
         },
         "packages/jobs/node_modules/eslint": {
@@ -14841,27 +14726,6 @@
                 "node": ">= 4"
             }
         },
-        "packages/jobs/node_modules/ipaddr.js": {
-            "version": "2.1.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "packages/jobs/node_modules/lru-cache": {
-            "version": "7.18.3",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "packages/jobs/node_modules/retry": {
-            "version": "0.13.1",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
         "packages/node-client": {
             "name": "@nangohq/node",
             "version": "0.37.18",
@@ -14882,7 +14746,7 @@
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@nangohq/shared": "^0.37.8",
-                "dd-trace": "^5.2.0",
+                "dd-trace": "5.2.0",
                 "express": "^4.18.2",
                 "zod": "^3.22.4",
                 "zod-express": "^0.0.8"
@@ -14947,7 +14811,7 @@
                 "connect-session-knex": "^3.0.1",
                 "cookie-parser": "^1.4.6",
                 "cors": "^2.8.5",
-                "dd-trace": "4.20.0",
+                "dd-trace": "5.2.0",
                 "dotenv": "^16.0.3",
                 "exponential-backoff": "^3.1.1",
                 "express": "^4.18.2",
@@ -14999,96 +14863,6 @@
                 "npm": ">=6.14.11"
             }
         },
-        "packages/server/node_modules/@datadog/native-appsec": {
-            "version": "4.0.0",
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "node-gyp-build": "^3.9.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "packages/server/node_modules/@datadog/pprof": {
-            "version": "4.0.1",
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "delay": "^5.0.0",
-                "node-gyp-build": "<4.0",
-                "p-limit": "^3.1.0",
-                "pprof-format": "^2.0.7",
-                "source-map": "^0.7.4"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "packages/server/node_modules/dd-trace": {
-            "version": "4.20.0",
-            "hasInstallScript": true,
-            "license": "(Apache-2.0 OR BSD-3-Clause)",
-            "dependencies": {
-                "@datadog/native-appsec": "4.0.0",
-                "@datadog/native-iast-rewriter": "2.2.1",
-                "@datadog/native-iast-taint-tracking": "1.6.4",
-                "@datadog/native-metrics": "^2.0.0",
-                "@datadog/pprof": "4.0.1",
-                "@datadog/sketches-js": "^2.1.0",
-                "@opentelemetry/api": "^1.0.0",
-                "@opentelemetry/core": "^1.14.0",
-                "crypto-randomuuid": "^1.0.0",
-                "dc-polyfill": "^0.1.2",
-                "ignore": "^5.2.4",
-                "import-in-the-middle": "^1.4.2",
-                "int64-buffer": "^0.1.9",
-                "ipaddr.js": "^2.1.0",
-                "istanbul-lib-coverage": "3.2.0",
-                "jest-docblock": "^29.7.0",
-                "koalas": "^1.0.2",
-                "limiter": "^1.1.4",
-                "lodash.kebabcase": "^4.1.1",
-                "lodash.pick": "^4.4.0",
-                "lodash.sortby": "^4.7.0",
-                "lodash.uniq": "^4.5.0",
-                "lru-cache": "^7.14.0",
-                "methods": "^1.1.2",
-                "module-details-from-path": "^1.0.3",
-                "msgpack-lite": "^0.1.26",
-                "node-abort-controller": "^3.1.1",
-                "opentracing": ">=0.12.1",
-                "path-to-regexp": "^0.1.2",
-                "pprof-format": "^2.0.7",
-                "protobufjs": "^7.2.4",
-                "retry": "^0.13.1",
-                "semver": "^7.5.4"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "packages/server/node_modules/ipaddr.js": {
-            "version": "2.1.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "packages/server/node_modules/lru-cache": {
-            "version": "7.18.3",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "packages/server/node_modules/retry": {
-            "version": "0.13.1",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
         "packages/shared": {
             "name": "@nangohq/shared",
             "version": "0.37.18",
@@ -15107,6 +14881,7 @@
                 "braintree": "^3.15.0",
                 "cors": "^2.8.5",
                 "dayjs": "^1.11.7",
+                "dd-trace": "5.2.0",
                 "ejs": "^3.1.5",
                 "exponential-backoff": "^3.1.1",
                 "fs-extra": "^11.1.1",

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -27,7 +27,7 @@
         "@trpc/client": "^10.44.1",
         "@trpc/server": "^10.44.1",
         "@types/fs-extra": "^11.0.1",
-        "dd-trace": "4.20.0",
+        "dd-trace": "5.2.0",
         "dotenv": "^16.0.3",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1.0",

--- a/packages/persist/package.json
+++ b/packages/persist/package.json
@@ -19,7 +19,7 @@
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
         "@nangohq/shared": "^0.37.8",
-        "dd-trace": "^5.2.0",
+        "dd-trace": "5.2.0",
         "express": "^4.18.2",
         "zod": "^3.22.4",
         "zod-express": "^0.0.8"

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -51,6 +51,7 @@ import {
 import oAuthSessionService from './services/oauth-session.service.js';
 import { deleteOldActivityLogs } from './jobs/index.js';
 import migrate from './utils/migrate.js';
+import tracer from './apm.js';
 
 const { NANGO_MIGRATE_AT_START = 'true' } = process.env;
 
@@ -213,7 +214,7 @@ if (!isCloud() && !isEnterprise()) {
 
 // Error handling.
 app.use(async (e: any, req: Request, res: Response, __: any) => {
-    await errorManager.handleGenericError(e, req, res);
+    await errorManager.handleGenericError(e, req, res, tracer);
 });
 
 // Webapp assets, static files and build.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -29,7 +29,7 @@
         "connect-session-knex": "^3.0.1",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
-        "dd-trace": "4.20.0",
+        "dd-trace": "5.2.0",
         "dotenv": "^16.0.3",
         "exponential-backoff": "^3.1.1",
         "express": "^4.18.2",

--- a/packages/shared/lib/utils/error.manager.ts
+++ b/packages/shared/lib/utils/error.manager.ts
@@ -114,11 +114,7 @@ class ErrorManager {
             // https://github.com/DataDog/dd-trace-js/issues/1944
             const span = tracer.scope().active();
             if (span) {
-                span.addTags({
-                    'error.msg': e.message,
-                    'error.stack': e.stack,
-                    'error.type': e.name
-                });
+                span.setTag('error', e);
             }
         }
     }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -29,6 +29,7 @@
         "axios": "^1.3.4",
         "braintree": "^3.15.0",
         "cors": "^2.8.5",
+        "dd-trace": "5.2.0",
         "dayjs": "^1.11.7",
         "ejs": "^3.1.5",
         "exponential-backoff": "^3.1.1",


### PR DESCRIPTION
## Describe your changes

Adding error in datadog APM automatically. 
Because of a "bug" in dd-trace, the errors are not reported automatically when used in express (cf: https://github.com/DataDog/dd-trace-js/issues/1944)
To resolve that we can tag the error manually. 


## Issue ticket number and link

Fixes NAN-320

## Checklist before requesting a review
- [x] I added observability


## Examples
| before | after |
|--------|-------|
|    <img width="1344" alt="Screenshot 2024-02-05 at 15 21 07" src="https://github.com/NangoHQ/nango/assets/1637651/0ab9d8f8-a1af-4268-b362-ef0ba5772c90">    |  <img width="1354" alt="Screenshot 2024-02-05 at 15 20 54" src="https://github.com/NangoHQ/nango/assets/1637651/c3962bd0-5e14-4b0e-b055-822acffde1ea">     |


