### PR TITLE
sdk/sync: proxy should log to console

### DIFF
--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -6,6 +6,7 @@ import axios from 'axios';
 import { getPersistAPIUrl, safeStringify } from '../utils/utils.js';
 import type { IntegrationWithCreds } from '@nangohq/node/lib/types.js';
 import type { UserProvidedProxyConfiguration } from '../models/Proxy.js';
+import logger from '../logger/console.js';
 
 /*
  *
@@ -333,6 +334,19 @@ export class NangoAction {
                 for (const log of activityLogs) {
                     if (log.level === 'debug') continue;
                     await this.log(log.content, { level: log.level });
+                    switch (log.level) {
+                        case 'error':
+                            logger.error(log.content);
+                            break;
+                        case 'warn':
+                            logger.warn(log.content);
+                            break;
+                        case 'info':
+                            logger.info(log.content);
+                            break;
+                        default:
+                            logger.debug(log.content);
+                    }
                 }
             }
 
@@ -396,7 +410,7 @@ export class NangoAction {
     }
 
     public async setFieldMapping(fieldMapping: Record<string, string>): Promise<AxiosResponse<void>> {
-        console.warn('setFieldMapping is deprecated. Please use setMetadata instead.');
+        logger.warn('setFieldMapping is deprecated. Please use setMetadata instead.');
         return this.nango.setMetadata(this.providerConfigKey as string, this.connectionId as string, fieldMapping);
     }
 
@@ -413,7 +427,7 @@ export class NangoAction {
     }
 
     public async getFieldMapping(): Promise<Metadata> {
-        console.warn('getFieldMapping is deprecated. Please use getMetadata instead.');
+        logger.warn('getFieldMapping is deprecated. Please use getMetadata instead.');
         const metadata = await this.nango.getMetadata(this.providerConfigKey as string, this.connectionId as string);
         return (metadata['fieldMapping'] as Metadata) || {};
     }
@@ -450,7 +464,7 @@ export class NangoAction {
         const content = safeStringify(args);
 
         if (this.dryRun) {
-            console.log(...args);
+            logger.info([...args]);
             return;
         }
 
@@ -469,7 +483,7 @@ export class NangoAction {
         });
 
         if (response.status > 299) {
-            console.error(`Request to persist API (log) failed: errorCode=${response.status} response='${JSON.stringify(response.data)}'`, this.stringify());
+            logger.error(`Request to persist API (log) failed: errorCode=${response.status} response='${JSON.stringify(response.data)}'`, this.stringify());
             throw new Error(`Cannot save log for activityLogId '${this.activityLogId}'`);
         }
         return;
@@ -600,7 +614,7 @@ export class NangoSync extends NangoAction {
             }
         });
         if (response.status > 299) {
-            console.error(
+            logger.error(
                 `Request to persist API (setLastSyncDate) failed: errorCode=${response.status} response='${JSON.stringify(response.data)}'`,
                 this.stringify()
             );
@@ -613,14 +627,14 @@ export class NangoSync extends NangoAction {
      * Deprecated, please use batchSave
      */
     public async batchSend<T = any>(results: T[], model: string): Promise<boolean | null> {
-        console.warn('batchSend will be deprecated in future versions. Please use batchSave instead.');
+        logger.warn('batchSend will be deprecated in future versions. Please use batchSave instead.');
         return this.batchSave(results, model);
     }
 
     public async batchSave<T = any>(results: T[], model: string): Promise<boolean | null> {
         if (!results || results.length === 0) {
             if (this.dryRun) {
-                console.log('batchSave received an empty array. No records to save.');
+                logger.info('batchSave received an empty array. No records to save.');
             }
             return true;
         }
@@ -651,7 +665,7 @@ export class NangoSync extends NangoAction {
                 }
             });
             if (response.status > 299) {
-                console.error(
+                logger.error(
                     `Request to persist API (batchSave) failed: errorCode=${response.status} response='${JSON.stringify(response.data)}'`,
                     this.stringify()
                 );
@@ -664,7 +678,7 @@ export class NangoSync extends NangoAction {
     public async batchDelete<T = any>(results: T[], model: string): Promise<boolean | null> {
         if (!results || results.length === 0) {
             if (this.dryRun) {
-                console.log('batchDelete received an empty array. No records to delete.');
+                logger.info('batchDelete received an empty array. No records to delete.');
             }
             return true;
         }
@@ -695,7 +709,7 @@ export class NangoSync extends NangoAction {
                 }
             });
             if (response.status > 299) {
-                console.error(
+                logger.error(
                     `Request to persist API (batchDelete) failed: errorCode=${response.status} response='${JSON.stringify(response.data)}'`,
                     this.stringify()
                 );
@@ -708,7 +722,7 @@ export class NangoSync extends NangoAction {
     public async batchUpdate<T = any>(results: T[], model: string): Promise<boolean | null> {
         if (!results || results.length === 0) {
             if (this.dryRun) {
-                console.log('batchUpdate received an empty array. No records to update.');
+                logger.info('batchUpdate received an empty array. No records to update.');
             }
             return true;
         }
@@ -739,7 +753,7 @@ export class NangoSync extends NangoAction {
                 }
             });
             if (response.status > 299) {
-                console.error(
+                logger.error(
                     `Request to persist API (batchUpdate) failed: errorCode=${response.status} response='${JSON.stringify(response.data)}'`,
                     this.stringify()
                 );


### PR DESCRIPTION
## Describe your changes

Now that the sdk doesn't call createActivityLogMessage directly but send the log to persist API, the log message are not logged to the console anymore in the runner. This commit ensures activityLogs are also printed to the console

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
