### PR TITLE
remove db env vars for new runner

### DIFF
--- a/packages/jobs/lib/runner/render.runner.ts
+++ b/packages/jobs/lib/runner/render.runner.ts
@@ -70,12 +70,6 @@ export class RenderRunner implements Runner {
                     envVars: [
                         { key: 'NODE_ENV', value: process.env['NODE_ENV'] },
                         { key: 'NANGO_CLOUD', value: process.env['NANGO_CLOUD'] },
-                        { key: 'NANGO_DB_HOST', value: process.env['NANGO_DB_HOST'] },
-                        { key: 'NANGO_DB_NAME', value: process.env['NANGO_DB_NAME'] },
-                        { key: 'NANGO_DB_PASSWORD', value: process.env['NANGO_DB_PASSWORD'] },
-                        { key: 'NANGO_DB_PORT', value: process.env['NANGO_DB_PORT'] },
-                        { key: 'NANGO_DB_SSL', value: process.env['NANGO_DB_SSL'] },
-                        { key: 'NANGO_ENCRYPTION_KEY', value: process.env['NANGO_ENCRYPTION_KEY'] },
                         { key: 'NODE_OPTIONS', value: '--max-old-space-size=384' },
                         { key: 'RUNNER_ID', value: runnerId },
                         { key: 'NOTIFY_IDLE_ENDPOINT', value: `${jobsServiceUrl}/idle` },


### PR DESCRIPTION
runners don't access the db directly anymore. Saving data is now done via the persist API

Left to do: remove the env vars for all existing runners

## Issue ticket number and link
https://linear.app/nango/issue/NAN-292/remove-database-env-vars-from-the-runner

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
