### PR TITLE
feat(connections):connection list pagination

### DIFF
--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -277,6 +277,9 @@ class ConnectionController {
 
     async listConnections(req: Request, res: Response, next: NextFunction) {
         try {
+            const limit = req.query['limit'] ? parseInt(req.query['limit'] as string) : 20;
+            const offset = req.query['offset'] ? parseInt(req.query['offset'] as string) : 0;
+            const integration = req.query['integration']?.toString();
             const { success, error, response } = await getEnvironmentAndAccountId(res, req);
             if (!success || response === null) {
                 errorManager.errResFromNangoErr(res, error);
@@ -285,7 +288,7 @@ class ConnectionController {
             const { accountId, environmentId, isWeb } = response;
 
             const { connectionId } = req.query;
-            const connections = await connectionService.listConnections(environmentId, connectionId as string);
+            const connections = await connectionService.listConnections(environmentId, connectionId as string, limit, offset, integration as string);
 
             if (!isWeb) {
                 analytics.track(AnalyticsTypes.CONNECTION_LIST_FETCHED, accountId);
@@ -709,6 +712,21 @@ class ConnectionController {
             res.status(201).send(req.body);
         } catch (err) {
             next(err);
+        }
+    }
+    public async getPossibleFilters(req: Request, res: Response, next: NextFunction) {
+        try {
+            const { success: sessionSuccess, error: sessionError, response } = await getUserAccountAndEnvironmentFromSession(req);
+            if (!sessionSuccess || response === null) {
+                errorManager.errResFromNangoErr(res, sessionError);
+                return;
+            }
+            const { environment } = response;
+
+            const integrations = await connectionService.getAllIntegrations(environment.id);
+            res.send({ integrations });
+        } catch (error) {
+            next(error);
         }
     }
 }

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -184,6 +184,7 @@ app.route('/api/v1/integration/:providerConfigKey').delete(webAuth, configContro
 app.route('/api/v1/provider').get(connectionController.listProviders.bind(connectionController));
 
 app.route('/api/v1/connection').get(webAuth, connectionController.listConnections.bind(connectionController));
+app.route('/api/v1/connection-filters').get(webAuth, connectionController.getPossibleFilters.bind(connectionController));
 app.route('/api/v1/connection/:connectionId').get(webAuth, connectionController.getConnectionWeb.bind(connectionController));
 app.route('/api/v1/connection/:connectionId').delete(webAuth, connectionController.deleteConnection.bind(connectionController));
 app.route('/api/v1/connection/admin/:connectionId').delete(webAuth, connectionController.deleteAdminConnection.bind(connectionController));

--- a/packages/webapp/src/pages/ConnectionList.tsx
+++ b/packages/webapp/src/pages/ConnectionList.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 
 import { useGetConnectionListAPI } from '../utils/api';
 import DashboardLayout from '../layout/DashboardLayout';
 import { LeftNavBarItems } from '../components/LeftNavBar';
-
+import { XCircleIcon } from '@heroicons/react/24/outline';
+import { ChevronsLeft } from '@geist-ui/icons';
 import { useStore } from '../store';
+import queryString from 'query-string';
 
 interface Connection {
     id: number;
@@ -16,11 +18,21 @@ interface Connection {
 }
 
 export default function ConnectionList() {
+    const navigate = useNavigate();
     const [loaded, setLoaded] = useState(false);
-    const [connections, setConnections] = useState<Connection[] | null>(null);
+    const [limit] = useState(20);
+    const [offset, setOffset] = useState(0);
+    const [selectedIntegration, setSelectedIntegration] = useState<string>('');
+    const location = useLocation();
+    const queryParams = queryString.parse(location.search);
+    const [filtersFetched, setFiltersFetched] = useState(false);
+    const [integrations, setIntegrations] = useState<string[]>([]);
+    const [connections, setConnections] = useState<Connection[]>([]);
+    const initialOffset: string | (string | null)[] | null = queryParams.offset;
+    const initialIntegration: string | (string | null)[] | null = queryParams.integration;
     const getConnectionListAPI = useGetConnectionListAPI();
 
-    const env = useStore(state => state.cookieValue);
+    const env = useStore((state) => state.cookieValue);
 
     useEffect(() => {
         setLoaded(false);
@@ -28,7 +40,17 @@ export default function ConnectionList() {
 
     useEffect(() => {
         const getConnections = async () => {
-            let res = await getConnectionListAPI();
+            let queryOffset = offset;
+            if (initialOffset && typeof initialOffset === 'string') {
+                setOffset(parseInt(initialOffset));
+                queryOffset = parseInt(initialOffset);
+            }
+            let queryIntegration = selectedIntegration;
+            if (initialIntegration && typeof initialIntegration === 'string') {
+                setSelectedIntegration(initialIntegration);
+                queryIntegration = initialIntegration;
+            }
+            let res = await getConnectionListAPI(limit, queryOffset, queryIntegration);
 
             if (res?.status === 200) {
                 let data = await res.json();
@@ -40,7 +62,89 @@ export default function ConnectionList() {
             setLoaded(true);
             getConnections();
         }
-    }, [getConnectionListAPI, loaded, setLoaded]);
+    }, [getConnectionListAPI, loaded, setLoaded, limit, offset, selectedIntegration, initialIntegration, initialOffset]);
+
+    useEffect(() => {
+        const getFilters = async () => {
+            if (connections.length > 0) {
+                const res = await fetch(`/api/v1/connection-filters/`, {
+                    method: 'GET',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Accept: 'application/json'
+                    }
+                });
+
+                if (res?.status === 200) {
+                    try {
+                        const filters = await res.json();
+
+                        if (filters) {
+                            if (filters?.integrations.length > 0) {
+                                filters.integrations.sort((a: string, b: string) => a.localeCompare(b));
+                                setIntegrations(filters.integrations);
+                            }
+                        }
+                        setFiltersFetched(true);
+                    } catch (e) {
+                        console.error(e);
+                    }
+                }
+            }
+        };
+
+        if (!filtersFetched) {
+            getFilters();
+        }
+    }, [connections, filtersFetched, setFiltersFetched]);
+
+    const decrementPage = () => {
+        if (offset - limit >= 0) {
+            const newOffset = offset - limit;
+            setOffset(newOffset);
+            setLoaded(false);
+
+            navigate(location.pathname + '?' + queryString.stringify({ ...queryParams, offset: newOffset }));
+        }
+    };
+
+    const incrementPage = () => {
+        if (connections.length < limit) {
+            return;
+        }
+
+        const newOffset = offset + limit;
+        setOffset(newOffset);
+        setLoaded(false);
+
+        navigate(location.pathname + '?' + queryString.stringify({ ...queryParams, offset: newOffset }));
+    };
+
+    const resetOffset = () => {
+        setOffset(0);
+        setLoaded(false);
+
+        navigate(location.pathname + '?' + queryString.stringify({ ...queryParams, offset: 0 }));
+    };
+
+    const onRemoveFilter = (action: (val: string) => void, prop: string) => {
+        action('');
+        setLoaded(false);
+        const url = window.location.pathname;
+        const searchParams = new URLSearchParams(window.location.search);
+        searchParams.delete(prop);
+
+        const updatedUrl = url + '?' + searchParams.toString();
+        navigate(updatedUrl);
+    };
+
+    const handleIntegrationChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const value = e.target.value;
+        setSelectedIntegration(value);
+        setLoaded(false);
+        setOffset(0);
+        navigate(location.pathname + '?' + queryString.stringify({ integration: value }));
+    };
 
     return (
         <DashboardLayout selectedItem={LeftNavBarItems.Connections}>
@@ -52,33 +156,99 @@ export default function ConnectionList() {
                             Add New
                         </Link>
                     </div>
+                    {loaded && connections.length === 0 && !selectedIntegration ? null : (
+                        <div className="flex justify-between p-3 mb-6 items-center border border-border-gray rounded-md min-w-[1150px]">
+                            <div className="flex space-x-10 justify-between px-2 w-full">
+                                {integrations.length > 0 && (
+                                    <div className="flex w-full items-center">
+                                        <select
+                                            id="integration"
+                                            name="integration"
+                                            className="bg-bg-black border-none text-text-light-gray block w-full appearance-none py-2 text-base shadow-sm"
+                                            onChange={handleIntegrationChange}
+                                            value={selectedIntegration}
+                                        >
+                                            <option value="" disabled>
+                                                Integration
+                                            </option>
+                                            {integrations.map((integration: string) => (
+                                                <option key={integration} value={integration}>
+                                                    {integration}
+                                                </option>
+                                            ))}
+                                        </select>
+                                        {selectedIntegration && (
+                                            <XCircleIcon
+                                                onClick={() => onRemoveFilter(setSelectedIntegration, 'integration')}
+                                                className="flex h-7 h-7 cursor-pointer text-blue-400"
+                                            />
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                            <div className="flex">
+                                {offset >= limit * 3 && <ChevronsLeft onClick={resetOffset} className="flex stroke-white cursor-pointer mr-3" size="16" />}
+                                <span
+                                    onClick={decrementPage}
+                                    className={`flex ${
+                                        offset - limit >= 0 ? 'cursor-pointer hover:bg-gray-700' : ''
+                                    } h-8 mr-2 rounded-md px-3 pt-1.5 text-sm text-white bg-gray-800`}
+                                >
+                                    <svg aria-hidden="true" className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                                        <path
+                                            fillRule="evenodd"
+                                            d="M7.707 14.707a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l2.293 2.293a1 1 0 010 1.414z"
+                                            clipRule="evenodd"
+                                        ></path>
+                                    </svg>
+                                </span>
+                                <span
+                                    onClick={incrementPage}
+                                    className={`flex ${
+                                        connections.length < limit ? '' : 'cursor-pointer hover:bg-gray-700'
+                                    } h-8 rounded-md px-3 pt-1.5 text-sm text-white bg-gray-800`}
+                                >
+                                    <svg aria-hidden="true" className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                                        <path
+                                            fillRule="evenodd"
+                                            d="M12.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-2.293-2.293a1 1 0 010-1.414z"
+                                            clipRule="evenodd"
+                                        ></path>
+                                    </svg>
+                                </span>
+                            </div>
+                        </div>
+                    )}
+
                     <div className="h-fit border border-border-gray rounded-md text-white text-sm">
                         <table className="table-auto">
                             <tbody className="px-4">
-                                {connections.map(({ id, connection_id: connectionId, provider, provider_config_key: providerConfigKey, created: creationDate }) => (
-                                    <tr key={`tr-${id}`}>
-                                        <td
-                                            className={`mx-8 flex place-content-center ${
-                                                id !== connections.at(-1)?.id ? 'border-b border-border-gray' : ''
-                                            } h-16`}
-                                        >
-                                            <div className="mt-5 w-largecell text-t font-mono">`{connectionId}`</div>
-                                            <div className="mt-4 w-80 flex pl-8">
-                                                <img src={`images/template-logos/${provider}.svg`} alt="" className="h-7 mt-0.5 mr-0.5" />
-                                                <p className="mt-1.5 mr-4 ml-0.5">{providerConfigKey}</p>
-                                            </div>
-                                            <div className="pl-8 flex pt-4">
-                                                <p className="mt-1.5 mr-4 text-text-dark-gray">{new Date(creationDate).toLocaleDateString()}</p>
-                                                <Link
-                                                    to={`/connections/${encodeURIComponent(providerConfigKey)}/${encodeURIComponent(connectionId)}`}
-                                                    className="flex h-8 rounded-md pl-2 pr-3 pt-1.5 text-sm text-white bg-gray-800 hover:bg-gray-700"
-                                                >
-                                                    <p>View</p>
-                                                </Link>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                ))}
+                                {connections.map(
+                                    ({ id, connection_id: connectionId, provider, provider_config_key: providerConfigKey, created: creationDate }) => (
+                                        <tr key={`tr-${id}`}>
+                                            <td
+                                                className={`mx-8 flex place-content-center ${
+                                                    id !== connections.at(-1)?.id ? 'border-b border-border-gray' : ''
+                                                } h-16`}
+                                            >
+                                                <div className="mt-5 w-largecell text-t font-mono">`{connectionId}`</div>
+                                                <div className="mt-4 w-80 flex pl-8">
+                                                    <img src={`images/template-logos/${provider}.svg`} alt="" className="h-7 mt-0.5 mr-0.5" />
+                                                    <p className="mt-1.5 mr-4 ml-0.5">{providerConfigKey}</p>
+                                                </div>
+                                                <div className="pl-8 flex pt-4">
+                                                    <p className="mt-1.5 mr-4 text-text-dark-gray">{new Date(creationDate).toLocaleDateString()}</p>
+                                                    <Link
+                                                        to={`/connections/${encodeURIComponent(providerConfigKey)}/${encodeURIComponent(connectionId)}`}
+                                                        className="flex h-8 rounded-md pl-2 pr-3 pt-1.5 text-sm text-white bg-gray-800 hover:bg-gray-700"
+                                                    >
+                                                        <p>View</p>
+                                                    </Link>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    )
+                                )}
                             </tbody>
                         </table>
                     </div>

--- a/packages/webapp/src/utils/api.tsx
+++ b/packages/webapp/src/utils/api.tsx
@@ -464,9 +464,16 @@ export function useGetProvidersAPI() {
 export function useGetConnectionListAPI() {
     const signout = useSignout();
 
-    return async () => {
+    return async (limit: number, offset: number, integration?: string) => {
         try {
-            let res = await fetch('/api/v1/connection', { headers: getHeaders() });
+            const res = await fetch(
+                `/api/v1/connection?limit=${limit}&offset=${offset}` +
+                    `${integration ? `&integration=${integration}` : ''}`,
+                {
+                    method: 'GET',
+                    headers: getHeaders()
+                }
+            );
 
             if (res.status === 401) {
                 return signout();


### PR DESCRIPTION
## Describe your changes
I have added pagination to the connection list endpoint. With this, users can now either increment or decrement the connection list page using a specific offset and limit number. I also added the option to allow users to filter the connection list page by integrations.
![connections_pagination](https://github.com/NangoHQ/nango/assets/85742599/88cd984f-021d-4803-8a2f-623290872855)


## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
