### PR TITLE
feat(activity):connection and integration filters in activities

### DIFF
--- a/packages/server/lib/controllers/activity.controller.ts
+++ b/packages/server/lib/controllers/activity.controller.ts
@@ -56,8 +56,8 @@ class ActivityController {
             const { environment } = response;
 
             const scripts = await getAllSyncAndActionNames(environment.id);
-            const integrations = await activityFilter(environment.id, 'integration');
-            const connections = await activityFilter(environment.id, 'connection');
+            const integrations = await activityFilter(environment.id, 'connection_id');
+            const connections = await activityFilter(environment.id, 'provider');
             res.send({ scripts, integrations, connections });
         } catch (error) {
             next(error);

--- a/packages/server/lib/controllers/activity.controller.ts
+++ b/packages/server/lib/controllers/activity.controller.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from 'express';
 import type { NextFunction } from 'express';
 
 import { getUserAccountAndEnvironmentFromSession } from '../utils/utils.js';
-import { connectionService, configService, getAllSyncAndActionNames, getTopLevelLogByEnvironment, getLogMessagesForLogs, errorManager } from '@nangohq/shared';
+import { activityFilter, getAllSyncAndActionNames, getTopLevelLogByEnvironment, getLogMessagesForLogs, errorManager } from '@nangohq/shared';
 
 class ActivityController {
     public async retrieve(req: Request, res: Response, next: NextFunction) {
@@ -56,8 +56,8 @@ class ActivityController {
             const { environment } = response;
 
             const scripts = await getAllSyncAndActionNames(environment.id);
-            const integrations = await configService.getAllNames(environment.id);
-            const connections = await connectionService.getAllNames(environment.id);
+            const integrations = await activityFilter(environment.id, 'integration');
+            const connections = await activityFilter(environment.id, 'connection');
             res.send({ scripts, integrations, connections });
         } catch (error) {
             next(error);

--- a/packages/shared/lib/services/activity/activity.service.ts
+++ b/packages/shared/lib/services/activity/activity.service.ts
@@ -256,7 +256,8 @@ export async function getTopLevelLogByEnvironment(
 }
 
 export async function activityFilter(environment_id: number, filterColumn: 'connection_id' | 'provider'): Promise<string[]> {
-    const logsQuery = db.knex.withSchema(db.schema())
+    const logsQuery = db.knex
+        .withSchema(db.schema())
         .from<ActivityLog>('_nango_activity_logs')
         .where({ environment_id })
         .whereNotNull(filterColumn)

--- a/packages/webapp/src/pages/Activity.tsx
+++ b/packages/webapp/src/pages/Activity.tsx
@@ -353,40 +353,45 @@ export default function Activity() {
         const value = e.target.value;
         setStatus(value);
         setLoaded(false);
+        setOffset(0);
 
-        navigate(location.pathname + '?' + queryString.stringify({ ...queryParams, status: value }));
+        navigate(location.pathname + '?' + queryString.stringify({ ...queryParams, status: value, offset: 0 }));
     }
 
     const handleScriptChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const value = e.target.value;
         setSelectedScript(value);
         setLoaded(false);
+        setOffset(0);
 
-        navigate(location.pathname + '?' + queryString.stringify({ ...queryParams, script: value }));
+        navigate(location.pathname + '?' + queryString.stringify({ ...queryParams, script: value, offset: 0 }));
     }
 
     const handleIntegrationChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const value = e.target.value;
         setSelectedIntegration(value);
         setLoaded(false);
+        setOffset(0);
 
-        navigate(location.pathname + '?' + queryString.stringify({ ...queryParams, integration: value }));
+        navigate(location.pathname + '?' + queryString.stringify({ ...queryParams, integration: value, offset: 0 }));
     }
 
     const handleConnectionChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const value = e.target.value;
         setSelectedConnection(value);
         setLoaded(false);
+        setOffset(0);
 
-        navigate(location.pathname + '?' + queryString.stringify({ ...queryParams, connection: value }));
+        navigate(location.pathname + '?' + queryString.stringify({ ...queryParams, connection: value, offset: 0 }));
     }
 
     const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const value = e.target.value;
         setDate(value);
         setLoaded(false);
+        setOffset(0);
 
-        navigate(location.pathname + '?' + queryString.stringify({ ...queryParams, date: value }));
+        navigate(location.pathname + '?' + queryString.stringify({ ...queryParams, date: value, offset: 0 }));
     }
 
     const onRemoveFilter = (action: (val: string) => void, prop: string) => {


### PR DESCRIPTION
## Describe your changes
Integrations and connections filters now fetch from activities. Also fixed the issue where filtered result differs in `offset` value from the one requested to the server.
![activity](https://github.com/NangoHQ/nango/assets/85742599/5634a78a-c4ad-4390-b5ec-0fbff4c0c4b8)

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
