### PR TITLE
Fix faulty Nango import for node in language-snippets util

### DIFF
--- a/packages/webapp/src/utils/language-snippets.tsx
+++ b/packages/webapp/src/utils/language-snippets.tsx
@@ -1,5 +1,5 @@
 export const nodeSnippet = (model: string, secretKey: string, connectionId: string, providerConfigKey: string) => {
-        return `import Nango from '@nangohq/node';
+        return `import { Nango } from '@nangohq/node';
 const nango = new Nango({ secretKey: '${secretKey}' });
 
 const issues = await nango.listRecords({


### PR DESCRIPTION
Using a default instead of a named import leads to an error.

