### PR TITLE
fix(docker): dist is not compiled in the docker image but copied

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 node_modules
 **/node_modules
 npm-debug.log
-**/dist
 
 # Private keys can be in there
 **/.env


### PR DESCRIPTION
## Describe your changes

Seems like I broke the docker image in #1651 
I thought we were compiling the code inside the docker image but looks like we are copying the dist after