### PR TITLE
fix: connectionConfigParams parsing

### DIFF
--- a/packages/server/lib/controllers/config.controller.ts
+++ b/packages/server/lib/controllers/config.controller.ts
@@ -58,10 +58,7 @@ class ConfigController {
                     creationDate: config.created_at
                 };
                 if (template && template.auth_mode !== AuthModes.App && template.auth_mode !== AuthModes.Custom) {
-                    integration['connectionConfigParams'] = parseConnectionConfigParamsFromTemplate(template!).filter(
-                        // we ignore connection config params that are in the token response metadata or redirect url metadata
-                        (element) => [...(template.token_response_metadata || []), ...(template.redirect_uri_metadata || [])].indexOf(element) == -1
-                    );
+                    integration['connectionConfigParams'] = parseConnectionConfigParamsFromTemplate(template!);
                 }
                 return integration;
             });


### PR DESCRIPTION
## Describe your changes

parseConnectionConfigParamsFromTemplate: connection config parameters found in proxy attributes can be ignored if found in redirect_uri_metadata or token_response_metadata unless they are also in authorization_url or token_url 

Examples:
```
salesforce:
    auth_mode: OAUTH2
    authorization_url: https://login.salesforce.com/services/oauth2/authorize
    token_url: https://login.salesforce.com/services/oauth2/token
    token_response_metadata:
        - instance_url
    proxy:
        base_url: ${connectionConfig.instance_url}
```
=> `${connectionConfig.instance_url}` can be ignored because it is returned within the token response metadata

```
wildix-pbx:
    auth_mode: OAUTH2
    authorization_url: https://${connectionConfig.subdomain}.wildixin.com/authorization/oauth2
    token_url: https://${connectionConfig.subdomain}.wildixin.com/authorization/oauth2Token
    redirect_uri_metadata:
        - subdomain
    proxy:
        base_url: https://${connectionConfig.subdomain}.wildixin.com

```
=> `{connectionConfig.subdomain}` is also in `redirect_uri_metadata` but cannot be ignored because it is needed in the `autorization_url` and/or `token_url`

The fix consists in only filtering out parameters in proxy attribute if also in `redirect_uri_metadata` or `token_uri_metadata` and never filter out config parameter from `authorization_url` or `token_url`

Reported on Slack https://nango-community.slack.com/archives/C04ABR352H0/p1707764280095979

https://linear.app/nango/issue/NAN-365/subdomain-connectionconfig-parameter-not-showing-for-wildix-pbx

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
