### PR TITLE
docker-compose: use hosted tag for nango-server

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
             - nango
 
     nango-server:
-        image: nangohq/nango-server
+        image: nangohq/nango-server:hosted
         container_name: nango-server
         environment:
             - NANGO_DB_MIGRATION_FOLDER=/usr/nango-server/src/packages/shared/lib/db/migrations


### PR DESCRIPTION
## Describe your changes
docker-compose for self-hosting should use `@nangohq/nango-server:hosted` tag
