### PR TITLE
fix(ci): incorrect commit sha in PR

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -10,9 +10,6 @@ concurrency:
     group: pulls/${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
-env:
-    # Do not use GITHUB_SHA it's incorrect in PRs
-    COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
     nango-persist:
@@ -21,28 +18,29 @@ jobs:
         with:
             package: persist
             run-cmd: ts-build
-            tags: -t nangohq/nango-persist:$COMMIT_SHA ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-persist:enterprise-$COMMIT_SHA -t nangohq/nango-persist:enterprise -t nangohq/nango-persist:hosted-$COMMIT_SHA -t nangohq/nango-persist:hosted' || '' }}
+            tags: -t nangohq/nango-persist:${{ env.COMMIT_SHA }} ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-persist:enterprise-${{ env.COMMIT_SHA }} -t nangohq/nango-persist:enterprise -t nangohq/nango-persist:hosted-${{ env.COMMIT_SHA }} -t nangohq/nango-persist:hosted' || '' }}
     nango-jobs:
         uses: ./.github/workflows/push-container.yaml
         secrets: inherit
         with:
             package: jobs
             run-cmd: ts-build
-            tags: -t nangohq/nango-jobs:$COMMIT_SHA ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-jobs:enterprise-$COMMIT_SHA -t nangohq/nango-jobs:enterprise -t nangohq/nango-jobs:hosted-$COMMIT_SHA -t nangohq/nango-jobs:hosted' || '' }}
+            tags: -t nangohq/nango-jobs:${{ env.COMMIT_SHA }} ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-jobs:enterprise-${{ env.COMMIT_SHA }} -t nangohq/nango-jobs:enterprise -t nangohq/nango-jobs:hosted-${{ env.COMMIT_SHA }} -t nangohq/nango-jobs:hosted' || '' }}
     nango-runner:
         uses: ./.github/workflows/push-container.yaml
         secrets: inherit
         with:
             package: runner
             run-cmd: ts-build
-            tags: -t nangohq/nango-runner:$COMMIT_SHA ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-runner:enterprise-$COMMIT_SHA -t nangohq/nango-runner:enterprise -t nangohq/nango-runner:hosted-$COMMIT_SHA -t nangohq/nango-runner:hosted' || '' }}
+            tags: -t nangohq/nango-runner:${{ env.COMMIT_SHA }} ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-runner:enterprise-${{ env.COMMIT_SHA }} -t nangohq/nango-runner:enterprise -t nangohq/nango-runner:hosted-${{ env.COMMIT_SHA }} -t nangohq/nango-runner:hosted' || '' }}
     nango-server-staging:
         uses: ./.github/workflows/push-container.yaml
         secrets: inherit
         with:
             package: server
             run-cmd: build:staging
-            tags: -t nangohq/nango-server:staging-$COMMIT_SHA
+            tags: -t nangohq/nango-server:staging-${{ env.COMMIT_SHA }}
+
     nango-server-prod:
         if: github.ref == 'refs/heads/master'
         uses: ./.github/workflows/push-container.yaml
@@ -50,7 +48,7 @@ jobs:
         with:
             package: server
             run-cmd: build:prod
-            tags: -t nangohq/nango-server:production-$COMMIT_SHA
+            tags: -t nangohq/nango-server:production-${{ env.COMMIT_SHA }}
     nango-server-self-hosted:
         if: github.ref == 'refs/heads/master'
         uses: ./.github/workflows/push-container.yaml
@@ -58,7 +56,7 @@ jobs:
         with:
             package: server
             run-cmd: build:hosted
-            tags: -t nangohq/nango-server:hosted -t nangohq/nango-server:hosted-$COMMIT_SHA
+            tags: -t nangohq/nango-server:hosted -t nangohq/nango-server:hosted-${{ env.COMMIT_SHA }}
     nango-server-enterprise:
         if: github.ref == 'refs/heads/master'
         uses: ./.github/workflows/push-container.yaml
@@ -66,4 +64,4 @@ jobs:
         with:
             package: server
             run-cmd: build:enterprise
-            tags: -t nangohq/nango-server:enterprise -t nangohq/nango-server:enterprise-$COMMIT_SHA
+            tags: -t nangohq/nango-server:enterprise -t nangohq/nango-server:enterprise-${{ env.COMMIT_SHA }}

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -9,6 +9,11 @@ on:
 concurrency:
     group: pulls/${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
+
+env:
+    # Do not use GITHUB_SHA it's incorrect in PRs
+    COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
 jobs:
     nango-persist:
         uses: ./.github/workflows/push-container.yaml
@@ -16,28 +21,28 @@ jobs:
         with:
             package: persist
             run-cmd: ts-build
-            tags: -t nangohq/nango-persist:$GITHUB_SHA ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-persist:enterprise-$GITHUB_SHA -t nangohq/nango-persist:enterprise -t nangohq/nango-persist:hosted-$GITHUB_SHA -t nangohq/nango-persist:hosted' || '' }}
+            tags: -t nangohq/nango-persist:$COMMIT_SHA ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-persist:enterprise-$COMMIT_SHA -t nangohq/nango-persist:enterprise -t nangohq/nango-persist:hosted-$COMMIT_SHA -t nangohq/nango-persist:hosted' || '' }}
     nango-jobs:
         uses: ./.github/workflows/push-container.yaml
         secrets: inherit
         with:
             package: jobs
             run-cmd: ts-build
-            tags: -t nangohq/nango-jobs:$GITHUB_SHA ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-jobs:enterprise-$GITHUB_SHA -t nangohq/nango-jobs:enterprise -t nangohq/nango-jobs:hosted-$GITHUB_SHA -t nangohq/nango-jobs:hosted' || '' }}
+            tags: -t nangohq/nango-jobs:$COMMIT_SHA ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-jobs:enterprise-$COMMIT_SHA -t nangohq/nango-jobs:enterprise -t nangohq/nango-jobs:hosted-$COMMIT_SHA -t nangohq/nango-jobs:hosted' || '' }}
     nango-runner:
         uses: ./.github/workflows/push-container.yaml
         secrets: inherit
         with:
             package: runner
             run-cmd: ts-build
-            tags: -t nangohq/nango-runner:$GITHUB_SHA ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-runner:enterprise-$GITHUB_SHA -t nangohq/nango-runner:enterprise -t nangohq/nango-runner:hosted-$GITHUB_SHA -t nangohq/nango-runner:hosted' || '' }}
+            tags: -t nangohq/nango-runner:$COMMIT_SHA ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-runner:enterprise-$COMMIT_SHA -t nangohq/nango-runner:enterprise -t nangohq/nango-runner:hosted-$COMMIT_SHA -t nangohq/nango-runner:hosted' || '' }}
     nango-server-staging:
         uses: ./.github/workflows/push-container.yaml
         secrets: inherit
         with:
             package: server
             run-cmd: build:staging
-            tags: -t nangohq/nango-server:staging-$GITHUB_SHA
+            tags: -t nangohq/nango-server:staging-$COMMIT_SHA
     nango-server-prod:
         if: github.ref == 'refs/heads/master'
         uses: ./.github/workflows/push-container.yaml
@@ -45,7 +50,7 @@ jobs:
         with:
             package: server
             run-cmd: build:prod
-            tags: -t nangohq/nango-server:production-$GITHUB_SHA
+            tags: -t nangohq/nango-server:production-$COMMIT_SHA
     nango-server-self-hosted:
         if: github.ref == 'refs/heads/master'
         uses: ./.github/workflows/push-container.yaml
@@ -53,7 +58,7 @@ jobs:
         with:
             package: server
             run-cmd: build:hosted
-            tags: -t nangohq/nango-server:hosted -t nangohq/nango-server:hosted-$GITHUB_SHA
+            tags: -t nangohq/nango-server:hosted -t nangohq/nango-server:hosted-$COMMIT_SHA
     nango-server-enterprise:
         if: github.ref == 'refs/heads/master'
         uses: ./.github/workflows/push-container.yaml
@@ -61,4 +66,4 @@ jobs:
         with:
             package: server
             run-cmd: build:enterprise
-            tags: -t nangohq/nango-server:enterprise -t nangohq/nango-server:enterprise-$GITHUB_SHA
+            tags: -t nangohq/nango-server:enterprise -t nangohq/nango-server:enterprise-$COMMIT_SHA

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
             package: runner
             run-cmd: ts-build
-            tags: -t nangohq/nango-runner:${{ github.event.pull_request.head.sha }} -t nangohq/nango-runner:enterprise-${{ github.event.pull_request.head.sha }} -t nangohq/nango-runner:enterprise -t nangohq/nango-runner:hosted-${{ github.event.pull_request.head.sha }} -t nangohq/nango-runner:hosted
+            tags: -t nangohq/nango-runner:${{ github.event.pull_request.head.sha }} ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-runner:enterprise-${{ github.event.pull_request.head.sha }} -t nangohq/nango-runner:enterprise -t nangohq/nango-runner:hosted-${{ github.event.pull_request.head.sha }} -t nangohq/nango-runner:hosted' || '' }}
     nango-server-staging:
         uses: ./.github/workflows/push-container.yaml
         secrets: inherit

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -17,28 +17,28 @@ jobs:
         with:
             package: persist
             run-cmd: ts-build
-            tags: -t nangohq/nango-persist:${{ github.sha }} ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-persist:enterprise-${{ github.sha }} -t nangohq/nango-persist:enterprise -t nangohq/nango-persist:hosted-${{ github.sha }} -t nangohq/nango-persist:hosted' || '' }}
+            tags: -t nangohq/nango-persist:${{ github.event.pull_request.head.sha }} ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-persist:enterprise-${{ github.event.pull_request.head.sha }} -t nangohq/nango-persist:enterprise -t nangohq/nango-persist:hosted-${{ github.event.pull_request.head.sha }} -t nangohq/nango-persist:hosted' || '' }}
     nango-jobs:
         uses: ./.github/workflows/push-container.yaml
         secrets: inherit
         with:
             package: jobs
             run-cmd: ts-build
-            tags: -t nangohq/nango-jobs:${{ github.sha }} ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-jobs:enterprise-${{ github.sha }} -t nangohq/nango-jobs:enterprise -t nangohq/nango-jobs:hosted-${{ github.sha }} -t nangohq/nango-jobs:hosted' || '' }}
+            tags: -t nangohq/nango-jobs:${{ github.event.pull_request.head.sha }} ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-jobs:enterprise-${{ github.event.pull_request.head.sha }} -t nangohq/nango-jobs:enterprise -t nangohq/nango-jobs:hosted-${{ github.event.pull_request.head.sha }} -t nangohq/nango-jobs:hosted' || '' }}
     nango-runner:
         uses: ./.github/workflows/push-container.yaml
         secrets: inherit
         with:
             package: runner
             run-cmd: ts-build
-            tags: -t nangohq/nango-runner:${{ github.sha }} ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-runner:enterprise-${{ github.sha }} -t nangohq/nango-runner:enterprise -t nangohq/nango-runner:hosted-${{ github.sha }} -t nangohq/nango-runner:hosted' || '' }}
+            tags: -t nangohq/nango-runner:${{ github.event.pull_request.head.sha }} -t nangohq/nango-runner:enterprise-${{ github.event.pull_request.head.sha }} -t nangohq/nango-runner:enterprise -t nangohq/nango-runner:hosted-${{ github.event.pull_request.head.sha }} -t nangohq/nango-runner:hosted
     nango-server-staging:
         uses: ./.github/workflows/push-container.yaml
         secrets: inherit
         with:
             package: server
             run-cmd: build:staging
-            tags: -t nangohq/nango-server:staging-${{ github.sha }}
+            tags: -t nangohq/nango-server:staging-${{ github.event.pull_request.head.sha }}
 
     nango-server-prod:
         if: github.ref == 'refs/heads/master'
@@ -47,7 +47,7 @@ jobs:
         with:
             package: server
             run-cmd: build:prod
-            tags: -t nangohq/nango-server:production-${{ github.sha }}
+            tags: -t nangohq/nango-server:production-${{ github.event.pull_request.head.sha }}
     nango-server-self-hosted:
         if: github.ref == 'refs/heads/master'
         uses: ./.github/workflows/push-container.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
             package: server
             run-cmd: build:hosted
-            tags: -t nangohq/nango-server:hosted -t nangohq/nango-server:hosted-${{ github.sha }}
+            tags: -t nangohq/nango-server:hosted -t nangohq/nango-server:hosted-${{ github.event.pull_request.head.sha }}
     nango-server-enterprise:
         if: github.ref == 'refs/heads/master'
         uses: ./.github/workflows/push-container.yaml
@@ -63,4 +63,4 @@ jobs:
         with:
             package: server
             run-cmd: build:enterprise
-            tags: -t nangohq/nango-server:enterprise -t nangohq/nango-server:enterprise-${{ github.sha }}
+            tags: -t nangohq/nango-server:enterprise -t nangohq/nango-server:enterprise-${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -10,7 +10,6 @@ concurrency:
     group: pulls/${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
-
 jobs:
     nango-persist:
         uses: ./.github/workflows/push-container.yaml
@@ -18,28 +17,28 @@ jobs:
         with:
             package: persist
             run-cmd: ts-build
-            tags: -t nangohq/nango-persist:${{ env.COMMIT_SHA }} ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-persist:enterprise-${{ env.COMMIT_SHA }} -t nangohq/nango-persist:enterprise -t nangohq/nango-persist:hosted-${{ env.COMMIT_SHA }} -t nangohq/nango-persist:hosted' || '' }}
+            tags: -t nangohq/nango-persist:${{ github.sha }} ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-persist:enterprise-${{ github.sha }} -t nangohq/nango-persist:enterprise -t nangohq/nango-persist:hosted-${{ github.sha }} -t nangohq/nango-persist:hosted' || '' }}
     nango-jobs:
         uses: ./.github/workflows/push-container.yaml
         secrets: inherit
         with:
             package: jobs
             run-cmd: ts-build
-            tags: -t nangohq/nango-jobs:${{ env.COMMIT_SHA }} ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-jobs:enterprise-${{ env.COMMIT_SHA }} -t nangohq/nango-jobs:enterprise -t nangohq/nango-jobs:hosted-${{ env.COMMIT_SHA }} -t nangohq/nango-jobs:hosted' || '' }}
+            tags: -t nangohq/nango-jobs:${{ github.sha }} ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-jobs:enterprise-${{ github.sha }} -t nangohq/nango-jobs:enterprise -t nangohq/nango-jobs:hosted-${{ github.sha }} -t nangohq/nango-jobs:hosted' || '' }}
     nango-runner:
         uses: ./.github/workflows/push-container.yaml
         secrets: inherit
         with:
             package: runner
             run-cmd: ts-build
-            tags: -t nangohq/nango-runner:${{ env.COMMIT_SHA }} ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-runner:enterprise-${{ env.COMMIT_SHA }} -t nangohq/nango-runner:enterprise -t nangohq/nango-runner:hosted-${{ env.COMMIT_SHA }} -t nangohq/nango-runner:hosted' || '' }}
+            tags: -t nangohq/nango-runner:${{ github.sha }} ${{ github.ref == 'refs/heads/master' && '-t nangohq/nango-runner:enterprise-${{ github.sha }} -t nangohq/nango-runner:enterprise -t nangohq/nango-runner:hosted-${{ github.sha }} -t nangohq/nango-runner:hosted' || '' }}
     nango-server-staging:
         uses: ./.github/workflows/push-container.yaml
         secrets: inherit
         with:
             package: server
             run-cmd: build:staging
-            tags: -t nangohq/nango-server:staging-${{ env.COMMIT_SHA }}
+            tags: -t nangohq/nango-server:staging-${{ github.sha }}
 
     nango-server-prod:
         if: github.ref == 'refs/heads/master'
@@ -48,7 +47,7 @@ jobs:
         with:
             package: server
             run-cmd: build:prod
-            tags: -t nangohq/nango-server:production-${{ env.COMMIT_SHA }}
+            tags: -t nangohq/nango-server:production-${{ github.sha }}
     nango-server-self-hosted:
         if: github.ref == 'refs/heads/master'
         uses: ./.github/workflows/push-container.yaml
@@ -56,7 +55,7 @@ jobs:
         with:
             package: server
             run-cmd: build:hosted
-            tags: -t nangohq/nango-server:hosted -t nangohq/nango-server:hosted-${{ env.COMMIT_SHA }}
+            tags: -t nangohq/nango-server:hosted -t nangohq/nango-server:hosted-${{ github.sha }}
     nango-server-enterprise:
         if: github.ref == 'refs/heads/master'
         uses: ./.github/workflows/push-container.yaml
@@ -64,4 +63,4 @@ jobs:
         with:
             package: server
             run-cmd: build:enterprise
-            tags: -t nangohq/nango-server:enterprise -t nangohq/nango-server:enterprise-${{ env.COMMIT_SHA }}
+            tags: -t nangohq/nango-server:enterprise -t nangohq/nango-server:enterprise-${{ github.sha }}

--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -13,10 +13,6 @@ on:
                 required: true
                 type: string
 
-env:
-  # Do not use GITHUB_SHA it's incorrect in PRs
-  COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-
 jobs:
     push-container:
         runs-on: ubuntu-latest
@@ -37,6 +33,7 @@ jobs:
               env:
                 PUSH: ${{ (env.CAN_PUSH == 'true') && '--push' || '' }}
               run: |
+                echo "Building ${{ inputs.package }}, ${{ inputs.tags }}"
                 npm run i
                 npm run ${{ inputs.run-cmd }}
                 node scripts/flows.js

--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -33,8 +33,8 @@ jobs:
               env:
                 PUSH: ${{ (env.CAN_PUSH == 'true') && '--push' || '' }}
               run: |
-                Building: '${{ inputs.package }}'
-                Tags: ${{ inputs.tags }}
+                echo "Building: '${{ inputs.package }}'"
+                echo "Tags: ${{ inputs.tags }}"
 
                 npm run i
                 npm run ${{ inputs.run-cmd }}

--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -17,7 +17,7 @@ jobs:
     push-container:
         runs-on: ubuntu-latest
         env:
-            CAN_PUSH: ${{ secrets.DOCKER_PASSWORD != '' && secrets.DOCKER_USERNAME != '' }}
+            CAN_PUSH: false
         steps:
             - uses: actions/checkout@v4
             - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -13,6 +13,10 @@ on:
                 required: true
                 type: string
 
+env:
+  # Do not use GITHUB_SHA it's incorrect in PRs
+  COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
 jobs:
     push-container:
         runs-on: ubuntu-latest

--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -17,7 +17,7 @@ jobs:
     push-container:
         runs-on: ubuntu-latest
         env:
-            CAN_PUSH: false
+            CAN_PUSH: ${{ secrets.DOCKER_PASSWORD != '' && secrets.DOCKER_USERNAME != '' }}
         steps:
             - uses: actions/checkout@v4
             - uses: docker/setup-buildx-action@v3
@@ -33,7 +33,9 @@ jobs:
               env:
                 PUSH: ${{ (env.CAN_PUSH == 'true') && '--push' || '' }}
               run: |
-                echo "Building ${{ inputs.package }}, ${{ inputs.tags }}"
+                Building: '${{ inputs.package }}'
+                Tags: ${{ inputs.tags }}
+
                 npm run i
                 npm run ${{ inputs.run-cmd }}
                 node scripts/flows.js


### PR DESCRIPTION
## Describe your changes

Seems like GitHub is creating a fake commit hash when running pull-request CI, we were pushing orphan image but we were saved by the jobs running twice (once with the correct hash). 

I wish I could use `env` but it's not working with `uses` https://github.com/orgs/community/discussions/25246



