### PR TITLE
fix(ci): missing alternatives sha on master

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -17,28 +17,28 @@ jobs:
         with:
             package: persist
             run-cmd: ts-build
-            tags: -t nangohq/nango-persist:${{ github.event.pull_request.head.sha }} ${{ github.ref == 'refs/heads/master' && format('-t nangohq/nango-persist:enterprise-{0} -t nangohq/nango-persist:enterprise -t nangohq/nango-persist:hosted-{1} -t nangohq/nango-persist:hosted', github.event.pull_request.head.sha, github.event.pull_request.head.sha)  || '' }}
+            tags: -t nangohq/nango-persist:${{ github.event.pull_request.head.sha || github.sha }} ${{ github.ref == 'refs/heads/master' && format('-t nangohq/nango-persist:enterprise-{0} -t nangohq/nango-persist:enterprise -t nangohq/nango-persist:hosted-{1} -t nangohq/nango-persist:hosted', github.event.pull_request.head.sha || github.sha, github.event.pull_request.head.sha || github.sha)  || '' }}
     nango-jobs:
         uses: ./.github/workflows/push-container.yaml
         secrets: inherit
         with:
             package: jobs
             run-cmd: ts-build
-            tags: -t nangohq/nango-jobs:${{ github.event.pull_request.head.sha }} ${{ github.ref == 'refs/heads/master' && format('-t nangohq/nango-jobs:enterprise-{0} -t nangohq/nango-jobs:enterprise -t nangohq/nango-jobs:hosted-{1} -t nangohq/nango-jobs:hosted', github.event.pull_request.head.sha, github.event.pull_request.head.sha) || '' }}
+            tags: -t nangohq/nango-jobs:${{ github.event.pull_request.head.sha || github.sha }} ${{ github.ref == 'refs/heads/master' && format('-t nangohq/nango-jobs:enterprise-{0} -t nangohq/nango-jobs:enterprise -t nangohq/nango-jobs:hosted-{1} -t nangohq/nango-jobs:hosted', github.event.pull_request.head.sha || github.sha, github.event.pull_request.head.sha || github.sha) || '' }}
     nango-runner:
         uses: ./.github/workflows/push-container.yaml
         secrets: inherit
         with:
             package: runner
             run-cmd: ts-build
-            tags: -t nangohq/nango-runner:${{ github.event.pull_request.head.sha }} ${{ github.ref == 'refs/heads/master' && format('-t nangohq/nango-runner:enterprise-{0} -t nangohq/nango-runner:enterprise -t nangohq/nango-runner:hosted-{1} -t nangohq/nango-runner:hosted', github.event.pull_request.head.sha, github.event.pull_request.head.sha) || '' }}
+            tags: -t nangohq/nango-runner:${{ github.event.pull_request.head.sha || github.sha }} ${{ github.ref == 'refs/heads/master' && format('-t nangohq/nango-runner:enterprise-{0} -t nangohq/nango-runner:enterprise -t nangohq/nango-runner:hosted-{1} -t nangohq/nango-runner:hosted', github.event.pull_request.head.sha || github.sha, github.event.pull_request.head.sha || github.sha) || '' }}
     nango-server-staging:
         uses: ./.github/workflows/push-container.yaml
         secrets: inherit
         with:
             package: server
             run-cmd: build:staging
-            tags: -t nangohq/nango-server:staging-${{ github.event.pull_request.head.sha }}
+            tags: -t nangohq/nango-server:staging-${{ github.event.pull_request.head.sha || github.sha }}
 
     nango-server-prod:
         if: github.ref == 'refs/heads/master'
@@ -47,7 +47,7 @@ jobs:
         with:
             package: server
             run-cmd: build:prod
-            tags: -t nangohq/nango-server:production-${{ github.event.pull_request.head.sha }}
+            tags: -t nangohq/nango-server:production-${{ github.event.pull_request.head.sha || github.sha }}
     nango-server-self-hosted:
         if: github.ref == 'refs/heads/master'
         uses: ./.github/workflows/push-container.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
             package: server
             run-cmd: build:hosted
-            tags: -t nangohq/nango-server:hosted -t nangohq/nango-server:hosted-${{ github.event.pull_request.head.sha }}
+            tags: -t nangohq/nango-server:hosted -t nangohq/nango-server:hosted-${{ github.event.pull_request.head.sha || github.sha }}
     nango-server-enterprise:
         if: github.ref == 'refs/heads/master'
         uses: ./.github/workflows/push-container.yaml
@@ -63,4 +63,4 @@ jobs:
         with:
             package: server
             run-cmd: build:enterprise
-            tags: -t nangohq/nango-server:enterprise -t nangohq/nango-server:enterprise-${{ github.event.pull_request.head.sha }}
+            tags: -t nangohq/nango-server:enterprise -t nangohq/nango-server:enterprise-${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
## Describe your changes

Third time's a charm.
Obviously it would be too easy if `github.event.pull_request.head.sha` were always there.
https://github.com/search?q=%22github.event.pull_request.head.sha+%7C%7C+github.sha%22&type=code 😭 