### PR TITLE
[nan-373] fix no return in an action and add test

### DIFF
--- a/packages/cli/lib/fixtures/no-async-return.ts
+++ b/packages/cli/lib/fixtures/no-async-return.ts
@@ -1,0 +1,5 @@
+import type { NangoSync } from './models';
+
+export default async function fetchData(nango: NangoSync) {
+    return nango.get({ endpoint: '/customer/addressBook' });
+}

--- a/packages/cli/lib/fixtures/no-async-return.ts
+++ b/packages/cli/lib/fixtures/no-async-return.ts
@@ -1,5 +1,5 @@
 import type { NangoSync } from './models';
 
-export default async function fetchData(nango: NangoSync) {
+export default async function fetchAddress(nango: NangoSync) {
     return nango.get({ endpoint: '/customer/addressBook' });
 }

--- a/packages/cli/lib/services/parser.service.ts
+++ b/packages/cli/lib/services/parser.service.ts
@@ -79,7 +79,9 @@ class ParserService {
                             (t.isIdentifier(parentPath.node.property, { name: 'then' }) || t.isIdentifier(parentPath.node.property, { name: 'catch' }))
                     );
 
-                    if (!isAwaited && !isThenOrCatch && nangoCalls.includes(callee.property.name)) {
+                    const isReturned = Boolean(path.findParent((parentPath) => t.isReturnStatement(parentPath.node)));
+
+                    if (!isAwaited && !isThenOrCatch && !isReturned && nangoCalls.includes(callee.property.name)) {
                         awaitMessage(callee.property.name, lineNumber);
                         areAwaited = false;
                     }

--- a/packages/cli/lib/sync.unit.test.ts
+++ b/packages/cli/lib/sync.unit.test.ts
@@ -358,6 +358,11 @@ describe('generate function tests', () => {
         expect(usedCorrectly).toBe(true);
     });
 
+    it('should not complain about awaiting when it is returned for an action', async () => {
+        const awaiting = parserService.callsAreUsedCorrectly(`${fixturesPath}/no-async-return.ts`, SyncConfigType.ACTION, ['SomeModel']);
+        expect(awaiting).toBe(true);
+    });
+
     it('should complain about an incorrect model', async () => {
         const awaiting = parserService.callsAreUsedCorrectly(`${fixturesPath}/bad-model.ts`, SyncConfigType.SYNC, ['GithubIssue']);
         expect(awaiting).toBe(false);


### PR DESCRIPTION
## Describe your changes
Fixes scenario where an action returns and complains about no awaiting
```
async function fetchAddress(nango: NangoSync, id: string) {
  return nango.get({
    endpoint: `/customer/${id}/addressBook`,
  });
}
```

Triggers
```
nango.get() calls must be awaited in "./netsuite-customers-sync.ts:49". Not awaiting can lead to unexpected results.
```

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
