### PR TITLE
fix(sdk): deprecate setLastSyncDate()

### DIFF
--- a/packages/cli/lib/services/parser.service.ts
+++ b/packages/cli/lib/services/parser.service.ts
@@ -35,12 +35,11 @@ class ParserService {
             'patch',
             'delete',
             'getConnection',
-            'setLastSyncDate',
             'getEnvironmentVariables',
             'triggerAction'
         ];
 
-        const disallowedActionCalls = ['batchSend', 'batchSave', 'batchDelete', 'setLastSyncDate'];
+        const disallowedActionCalls = ['batchSend', 'batchSave', 'batchDelete'];
 
         const deprecatedCalls: Record<string, string> = {
             batchSend: 'batchSave',

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -51,9 +51,7 @@ interface CreateConnectionOAuth2 extends OAuth2Credentials {
     type: AuthModes.OAuth2;
 }
 
-interface CustomHeaders {
-    [key: string]: string | number | boolean;
-}
+type CustomHeaders = Record<string, string | number | boolean>;
 
 export enum SyncType {
     INITIAL = 'INITIAL',

--- a/packages/persist/lib/controllers/persist.controller.ts
+++ b/packages/persist/lib/controllers/persist.controller.ts
@@ -1,6 +1,5 @@
 import type { NextFunction, Request, Response } from 'express';
 import {
-    setLastSyncDate,
     createActivityLogMessage,
     LogLevel,
     errorManager,
@@ -44,19 +43,6 @@ type RecordRequest = Request<
 >;
 
 class PersistController {
-    public async saveLastSyncDate(req: Request<{ syncId: string }, any, { lastSyncDate: Date }, any, Record<string, any>>, res: Response, next: NextFunction) {
-        const {
-            params: { syncId },
-            body: { lastSyncDate }
-        } = req;
-        const result = await setLastSyncDate(syncId, lastSyncDate);
-        if (result) {
-            res.status(201).send();
-        } else {
-            next(new Error(`Failed to save last sync date '${lastSyncDate}' for sync '${syncId}'`));
-        }
-    }
-
     public async saveActivityLog(
         req: Request<{ environmentId: number }, any, { activityLogId: number; level: LogLevel; msg: string }, any, Record<string, any>>,
         res: Response,

--- a/packages/persist/lib/server.ts
+++ b/packages/persist/lib/server.ts
@@ -27,22 +27,6 @@ server.use((req: Request, res: Response, next: NextFunction) => {
 server.get('/health', (_req: Request, res: Response) => {
     res.json({ status: 'ok' });
 });
-server.put(
-    '/sync/:syncId',
-    validateRequest({
-        params: z.object({
-            syncId: z.string()
-        }),
-        body: z.object({
-            lastSyncDate: z
-                .string()
-                .datetime()
-                .transform((value) => new Date(value))
-                .pipe(z.date()) as unknown as z.ZodDate
-        })
-    }),
-    persistController.saveLastSyncDate
-);
 
 server.post(
     '/environment/:environmentId/log',

--- a/packages/shared/lib/models/Activity.ts
+++ b/packages/shared/lib/models/Activity.ts
@@ -45,9 +45,7 @@ export enum LogActionEnum {
     WEBHOOK = 'webhook'
 }
 
-interface Message {
-    [index: string]: unknown | undefined | string | number | boolean | Record<string, string | boolean | number | unknown>;
-}
+type Message = Record<string, unknown | undefined | string | number | boolean | Record<string, string | boolean | number | unknown>>;
 
 export interface ActivityLog {
     id?: number;

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -596,6 +596,13 @@ export class NangoSync extends NangoAction {
     }
 
     /**
+     * Deprecated, reach out to support
+     */
+    public async setLastSyncDate(): Promise<void> {
+        logger.warn('setLastSyncDate is deprecated. Please contact us if you are using this method.');
+    }
+
+    /**
      * Deprecated, please use batchSave
      */
     public async batchSend<T = any>(results: T[], model: string): Promise<boolean | null> {

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -18,21 +18,21 @@ import logger from '../logger/console.js';
  */
 type LogLevel = 'info' | 'debug' | 'error' | 'warn' | 'http' | 'verbose' | 'silly';
 
-interface ParamEncoder {
-    (value: any, defaultEncoder: (value: any) => any): any;
-}
+type ParamEncoder = (value: any, defaultEncoder: (value: any) => any) => any;
 
 interface GenericFormData {
     append(name: string, value: any, options?: any): any;
 }
 
-interface SerializerVisitor {
-    (this: GenericFormData, value: any, key: string | number, path: null | Array<string | number>, helpers: FormDataVisitorHelpers): boolean;
-}
+type SerializerVisitor = (
+    this: GenericFormData,
+    value: any,
+    key: string | number,
+    path: null | (string | number)[],
+    helpers: FormDataVisitorHelpers
+) => boolean;
 
-interface CustomParamsSerializer {
-    (params: Record<string, any>, options?: ParamsSerializerOptions): string;
-}
+type CustomParamsSerializer = (params: Record<string, any>, options?: ParamsSerializerOptions) => string;
 
 interface FormDataVisitorHelpers {
     defaultVisitor: SerializerVisitor;
@@ -169,9 +169,7 @@ interface OAuth1Credentials extends CredentialsCommon {
 
 type AuthCredentials = OAuth2Credentials | OAuth1Credentials | BasicApiCredentials | ApiKeyCredentials | AppCredentials;
 
-interface Metadata {
-    [key: string]: string | Record<string, any>;
-}
+type Metadata = Record<string, string | Record<string, any>>;
 
 interface Connection {
     id?: number;
@@ -595,32 +593,6 @@ export class NangoSync extends NangoAction {
         if (config.stubbedMetadata) {
             this.stubbedMetadata = config.stubbedMetadata;
         }
-    }
-
-    /**
-     * Set Sync Last Sync Date
-     * @desc permanently set the last sync date for the sync
-     * to be used for the next sync run
-     */
-    public async setLastSyncDate(date: Date): Promise<boolean> {
-        if (date.toString() === 'Invalid Date') {
-            throw new Error('Invalid Date');
-        }
-        const response = await persistApi({
-            method: 'PUT',
-            url: `/sync/${this.syncId}`,
-            data: {
-                lastSyncDate: date
-            }
-        });
-        if (response.status > 299) {
-            logger.error(
-                `Request to persist API (setLastSyncDate) failed: errorCode=${response.status} response='${JSON.stringify(response.data)}'`,
-                this.stringify()
-            );
-            throw new Error(`cannot set lastSyncDate for sync '${this.syncId}'`);
-        }
-        return true;
     }
 
     /**

--- a/packages/shared/lib/services/sync/run.service.ts
+++ b/packages/shared/lib/services/sync/run.service.ts
@@ -191,7 +191,7 @@ export default class SyncRun {
             const secretKey = optionalSecretKey || (environment ? (environment?.secret_key as string) : '');
 
             const providerConfigKey = this.nangoConnection.provider_config_key;
-            const syncObject = integrations[providerConfigKey] as unknown as { [key: string]: NangoIntegration };
+            const syncObject = integrations[providerConfigKey] as unknown as Record<string, NangoIntegration>;
 
             let syncData: NangoIntegrationData;
 

--- a/packages/webapp/src/types.ts
+++ b/packages/webapp/src/types.ts
@@ -9,6 +9,7 @@ export interface ActivityResponse {
         | 'token'
         | 'sync'
         | 'sync deploy'
+        | 'sync init'
         | 'pause sync'
         | 'restart sync'
         | 'trigger sync'
@@ -20,9 +21,7 @@ export interface ActivityResponse {
     start: number;
     end: number;
     message: string;
-    messages: {
-        [index: string]: undefined | string | number;
-    }[];
+    messages: Record<string, undefined | string | number>[];
     connection_id: string;
     provider_config_key: string;
     provider: string;
@@ -31,9 +30,7 @@ export interface ActivityResponse {
     operation_name?: string;
 }
 
-export interface SyncResult {
-    [key: string]: Result;
-}
+export type SyncResult = Record<string, Result>;
 
 export interface Result {
     added: number;
@@ -57,9 +54,7 @@ export interface Sync {
     connections:
         | {
               connection_id: string;
-              metadata?: {
-                  [key: string]: string | Record<string, string>;
-              };
+              metadata?: Record<string, string | Record<string, string>>;
           }[]
         | null;
     metadata?: {

--- a/packages/webapp/src/types.ts
+++ b/packages/webapp/src/types.ts
@@ -9,7 +9,6 @@ export interface ActivityResponse {
         | 'token'
         | 'sync'
         | 'sync deploy'
-        | 'sync init'
         | 'pause sync'
         | 'restart sync'
         | 'trigger sync'


### PR DESCRIPTION
## Describe your changes

This function introduced around July 2023 not documented, and seemingly not used.
It was blocking us with the feature "Ability to trigger a full resync" because users could mess up with the `lastSyncDate`.


## Issue ticket number and link

Contributes to NAN-305


