### PR TITLE
feat(telemetry): use dd-trace for metrics

### DIFF
--- a/packages/jobs/lib/activities.ts
+++ b/packages/jobs/lib/activities.ts
@@ -17,10 +17,10 @@ import {
     createActivityLogAndLogMessage,
     ErrorSourceEnum,
     errorManager,
-    metricsManager,
+    telemetry,
     updateSyncJobStatus,
     updateLatestJobSyncStatus,
-    MetricTypes,
+    LogTypes,
     isInitialSyncStillRunning,
     initialSyncExists,
     getSyncByIdAndName,
@@ -94,7 +94,7 @@ export async function scheduleAndRouteSync(args: ContinuousSyncArgs): Promise<bo
 
         logger.log('info', content);
 
-        await metricsManager.capture(MetricTypes.SYNC_OVERLAP, content, LogActionEnum.SYNC, {
+        await telemetry.log(LogTypes.SYNC_OVERLAP, content, LogActionEnum.SYNC, {
             environmentId: String(nangoConnection?.environment_id),
             connectionId: nangoConnection?.connection_id as string,
             providerConfigKey: nangoConnection?.provider_config_key as string,
@@ -170,7 +170,7 @@ export async function scheduleAndRouteSync(args: ContinuousSyncArgs): Promise<bo
             content
         });
 
-        await metricsManager.capture(MetricTypes.SYNC_FAILURE, content, LogActionEnum.SYNC, {
+        await telemetry.log(LogTypes.SYNC_FAILURE, content, LogActionEnum.SYNC, {
             environmentId: String(environmentId),
             connectionId: nangoConnection?.connection_id as string,
             providerConfigKey: nangoConnection?.provider_config_key as string,
@@ -284,7 +284,7 @@ export async function syncProvider(
             content
         });
 
-        await metricsManager.capture(MetricTypes.SYNC_OVERLAP, content, LogActionEnum.SYNC, {
+        await telemetry.log(LogTypes.SYNC_OVERLAP, content, LogActionEnum.SYNC, {
             environmentId: String(nangoConnection?.environment_id),
             syncId,
             connectionId: nangoConnection?.connection_id as string,
@@ -388,7 +388,7 @@ export async function reportFailure(
         content += `due to a unknown failure.`;
     }
 
-    await metricsManager.capture(MetricTypes.FLOW_JOB_TIMEOUT_FAILURE, content, LogActionEnum.SYNC, {
+    await telemetry.log(LogTypes.FLOW_JOB_TIMEOUT_FAILURE, content, LogActionEnum.SYNC, {
         environmentId: String(nangoConnection?.environment_id),
         name,
         connectionId: nangoConnection?.connection_id as string,

--- a/packages/server/lib/controllers/appAuth.controller.ts
+++ b/packages/server/lib/controllers/appAuth.controller.ts
@@ -15,9 +15,9 @@ import {
     connectionService,
     LogActionEnum,
     createActivityLogMessageAndEnd,
-    metricsManager,
+    telemetry,
     AuthOperation,
-    MetricTypes,
+    LogTypes,
     AuthModes
 } from '@nangohq/shared';
 import { missesInterpolationParam } from '../utils/utils.js';
@@ -170,8 +170,8 @@ class AppAuthController {
                     timestamp: Date.now()
                 });
 
-                await metricsManager.capture(
-                    MetricTypes.AUTH_TOKEN_REQUEST_FAILURE,
+                await telemetry.log(
+                    LogTypes.AUTH_TOKEN_REQUEST_FAILURE,
                     `App auth token retrieval request process failed ${error?.message}`,
                     LogActionEnum.AUTH,
                     {
@@ -234,7 +234,7 @@ class AppAuthController {
                 timestamp: Date.now()
             });
 
-            await metricsManager.capture(MetricTypes.AUTH_TOKEN_REQUEST_SUCCESS, 'App auth token request succeeded', LogActionEnum.AUTH, {
+            await telemetry.log(LogTypes.AUTH_TOKEN_REQUEST_SUCCESS, 'App auth token request succeeded', LogActionEnum.AUTH, {
                 environmentId: String(environmentId),
                 providerConfigKey: String(providerConfigKey),
                 provider: String(config.provider),
@@ -258,7 +258,7 @@ class AppAuthController {
                 url: req.originalUrl
             });
 
-            await metricsManager.capture(MetricTypes.AUTH_TOKEN_REQUEST_FAILURE, `App auth request process failed ${content}`, LogActionEnum.AUTH, {
+            await telemetry.log(LogTypes.AUTH_TOKEN_REQUEST_FAILURE, `App auth request process failed ${content}`, LogActionEnum.AUTH, {
                 environmentId: String(environmentId),
                 providerConfigKey: String(providerConfigKey),
                 connectionId: String(connectionId)

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -44,8 +44,8 @@ import {
     providerClientManager,
     errorManager,
     analytics,
-    metricsManager,
-    MetricTypes,
+    telemetry,
+    LogTypes,
     AnalyticsTypes,
     hmacService,
     ErrorSourceEnum,
@@ -83,7 +83,7 @@ class OAuthController {
                 analytics.track(AnalyticsTypes.PRE_WS_OAUTH, accountId);
             }
 
-            await metricsManager.capture(MetricTypes.AUTH_TOKEN_REQUEST_START, 'OAuth request process start', LogActionEnum.AUTH, {
+            await telemetry.log(LogTypes.AUTH_TOKEN_REQUEST_START, 'OAuth request process start', LogActionEnum.AUTH, {
                 environmentId: String(environmentId),
                 accountId: String(accountId),
                 providerConfigKey: String(providerConfigKey),
@@ -397,7 +397,7 @@ class OAuthController {
                     });
                 }
 
-                await metricsManager.capture(MetricTypes.AUTH_TOKEN_REQUEST_CALLBACK_RECEIVED, 'OAuth2 callback url received', LogActionEnum.AUTH, {
+                await telemetry.log(LogTypes.AUTH_TOKEN_REQUEST_CALLBACK_RECEIVED, 'OAuth2 callback url received', LogActionEnum.AUTH, {
                     environmentId: String(environment_id),
                     callbackUrl,
                     providerConfigKey: String(providerConfigKey),
@@ -452,7 +452,7 @@ class OAuthController {
 
             const content = WSErrBuilder.UnkownError().message + '\n' + prettyError;
 
-            await metricsManager.capture(MetricTypes.AUTH_TOKEN_REQUEST_FAILURE, `OAuth2 request process failed ${content}`, LogActionEnum.AUTH, {
+            await telemetry.log(LogTypes.AUTH_TOKEN_REQUEST_FAILURE, `OAuth2 request process failed ${content}`, LogActionEnum.AUTH, {
                 callbackUrl,
                 environmentId: String(environment_id),
                 providerConfigKey: String(providerConfigKey),
@@ -651,7 +651,7 @@ class OAuthController {
         // if they end the flow early, be sure to have an end time
         await addEndTimeActivityLog(activityLogId as number);
 
-        await metricsManager.capture(MetricTypes.AUTH_TOKEN_REQUEST_CALLBACK_RECEIVED, 'OAuth1 callback url received', LogActionEnum.AUTH, {
+        await telemetry.log(LogTypes.AUTH_TOKEN_REQUEST_CALLBACK_RECEIVED, 'OAuth1 callback url received', LogActionEnum.AUTH, {
             environmentId: String(environment_id),
             callbackUrl,
             providerConfigKey: String(providerConfigKey),
@@ -802,7 +802,7 @@ class OAuthController {
                 }
             });
 
-            await metricsManager.capture(MetricTypes.AUTH_TOKEN_REQUEST_FAILURE, 'OAuth2 token request failed with a missing code', LogActionEnum.AUTH, {
+            await telemetry.log(LogTypes.AUTH_TOKEN_REQUEST_FAILURE, 'OAuth2 token request failed with a missing code', LogActionEnum.AUTH, {
                 environmentId: String(environment_id),
                 providerConfigKey: String(providerConfigKey),
                 provider: String(config.provider),
@@ -931,8 +931,8 @@ class OAuthController {
                     timestamp: Date.now()
                 });
 
-                await metricsManager.capture(
-                    MetricTypes.AUTH_TOKEN_REQUEST_FAILURE,
+                await telemetry.log(
+                    LogTypes.AUTH_TOKEN_REQUEST_FAILURE,
                     'OAuth2 token request failed, response from the server could not be parsed',
                     LogActionEnum.AUTH,
                     {
@@ -1048,7 +1048,7 @@ class OAuthController {
                 await updateSuccessActivityLog(activityLogId, template.auth_mode === ProviderAuthModes.Custom ? null : true);
             }
 
-            await metricsManager.capture(MetricTypes.AUTH_TOKEN_REQUEST_SUCCESS, 'OAuth2 token request succeeded', LogActionEnum.AUTH, {
+            await telemetry.log(LogTypes.AUTH_TOKEN_REQUEST_SUCCESS, 'OAuth2 token request succeeded', LogActionEnum.AUTH, {
                 environmentId: String(environment_id),
                 providerConfigKey: String(providerConfigKey),
                 provider: String(config.provider),
@@ -1069,7 +1069,7 @@ class OAuthController {
                 }
             });
 
-            await metricsManager.capture(MetricTypes.AUTH_TOKEN_REQUEST_FAILURE, 'OAuth2 token request failed', LogActionEnum.AUTH, {
+            await telemetry.log(LogTypes.AUTH_TOKEN_REQUEST_FAILURE, 'OAuth2 token request failed', LogActionEnum.AUTH, {
                 environmentId: String(environment_id),
                 providerConfigKey: String(providerConfigKey),
                 provider: String(config.provider),
@@ -1176,7 +1176,7 @@ class OAuthController {
                     url: session.callbackUrl
                 });
 
-                await metricsManager.capture(MetricTypes.AUTH_TOKEN_REQUEST_SUCCESS, 'OAuth1 token request succeeded', LogActionEnum.AUTH, {
+                await telemetry.log(LogTypes.AUTH_TOKEN_REQUEST_SUCCESS, 'OAuth1 token request succeeded', LogActionEnum.AUTH, {
                     environmentId: String(environment_id),
                     providerConfigKey: String(providerConfigKey),
                     provider: String(config.provider),
@@ -1218,7 +1218,7 @@ class OAuthController {
                 });
                 const prettyError = JSON.stringify(e, ['message', 'name'], 2);
 
-                await metricsManager.capture(MetricTypes.AUTH_TOKEN_REQUEST_FAILURE, 'OAuth1 token request failed', LogActionEnum.AUTH, {
+                await telemetry.log(LogTypes.AUTH_TOKEN_REQUEST_FAILURE, 'OAuth1 token request failed', LogActionEnum.AUTH, {
                     environmentId: String(environment_id),
                     providerConfigKey: String(providerConfigKey),
                     provider: String(config.provider),

--- a/packages/server/lib/controllers/webhook.controller.ts
+++ b/packages/server/lib/controllers/webhook.controller.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import type { Span } from 'dd-trace';
 import tracer from '../tracer.js';
-import { routeWebhook, featureFlags, environmentService, metricsManager, MetricTypes } from '@nangohq/shared';
+import { routeWebhook, featureFlags, environmentService, telemetry, MetricTypes } from '@nangohq/shared';
 
 class WebhookController {
     async receive(req: Request, res: Response, next: NextFunction) {
@@ -44,12 +44,7 @@ class WebhookController {
                 const endTime = Date.now();
                 const totalRunTime = (endTime - startTime) / 1000;
 
-                await metricsManager.captureMetric(
-                    MetricTypes.WEBHOOK_TRACK_RUNTIME,
-                    `${new Date().toISOString()}-${providerConfigKey}`,
-                    `webhook-${providerConfigKey}`,
-                    totalRunTime
-                );
+                await telemetry.duration(MetricTypes.WEBHOOK_TRACK_RUNTIME, totalRunTime);
             } else {
                 res.status(404).send();
 

--- a/packages/shared/lib/clients/sync.client.ts
+++ b/packages/shared/lib/clients/sync.client.ts
@@ -21,7 +21,7 @@ import { updateOffset, createSchedule as createSyncSchedule, getScheduleById } f
 import connectionService from '../services/connection.service.js';
 import configService from '../services/config.service.js';
 import { createSync } from '../services/sync/sync.service.js';
-import metricsManager, { MetricTypes } from '../utils/metrics.manager.js';
+import telemetry, { LogTypes, MetricTypes } from '../utils/telemetry.js';
 import errorManager, { ErrorSourceEnum } from '../utils/error.manager.js';
 import { NangoError } from '../utils/error.js';
 import type { RunnerOutput } from '../models/Runner.js';
@@ -530,8 +530,8 @@ class SyncClient {
                 await updateSuccessActivityLog(activityLogId, true);
             }
 
-            await metricsManager.capture(
-                MetricTypes.ACTION_SUCCESS,
+            await telemetry.log(
+                LogTypes.ACTION_SUCCESS,
                 content,
                 LogActionEnum.ACTION,
                 {
@@ -571,8 +571,8 @@ class SyncClient {
                 }
             });
 
-            await metricsManager.capture(
-                MetricTypes.ACTION_FAILURE,
+            await telemetry.log(
+                LogTypes.ACTION_FAILURE,
                 content,
                 LogActionEnum.ACTION,
                 {
@@ -588,7 +588,7 @@ class SyncClient {
         } finally {
             const endTime = Date.now();
             const totalRunTime = (endTime - startTime) / 1000;
-            await metricsManager.captureMetric(MetricTypes.ACTION_TRACK_RUNTIME, actionName, 'action', totalRunTime);
+            await telemetry.duration(MetricTypes.ACTION_TRACK_RUNTIME, totalRunTime);
         }
     }
 

--- a/packages/shared/lib/hooks/hooks.ts
+++ b/packages/shared/lib/hooks/hooks.ts
@@ -9,7 +9,7 @@ import type { HTTP_VERB } from '../models/Generic.js';
 import type { Template as ProviderTemplate } from '../models/Provider.js';
 import integrationPostConnectionScript from '../integrations/scripts/connection/connection.manager.js';
 import webhookService from '../services/notification/webhook.service.js';
-import { SpanTypes } from '../utils/metrics.manager.js';
+import { SpanTypes } from '../utils/telemetry.js';
 import { isCloud, isLocal, isEnterprise } from '../utils/utils.js';
 import { Result, resultOk, resultErr } from '../utils/result.js';
 import { NangoError } from '../utils/error.js';

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -6,7 +6,7 @@ import connectionService from './services/connection.service.js';
 import providerClientManager from './clients/provider.client.js';
 import SyncClient from './clients/sync.client.js';
 import errorManager, { ErrorSourceEnum } from './utils/error.manager.js';
-import metricsManager, { MetricTypes, SpanTypes } from './utils/metrics.manager.js';
+import telemetry, { LogTypes, SpanTypes, MetricTypes } from './utils/telemetry.js';
 import accountService from './services/account.service.js';
 import environmentService from './services/environment.service.js';
 import userService from './services/user.service.js';
@@ -63,7 +63,8 @@ export {
     providerClientManager,
     SyncClient,
     errorManager,
-    metricsManager,
+    telemetry,
+    LogTypes,
     MetricTypes,
     SpanTypes,
     ErrorSourceEnum,

--- a/packages/shared/lib/integrations/scripts/connection/connection.manager.ts
+++ b/packages/shared/lib/integrations/scripts/connection/connection.manager.ts
@@ -7,15 +7,13 @@ import type { UserProvidedProxyConfiguration } from '../../../models/Proxy.js';
 import proxyService from '../../../services/proxy.service.js';
 import connectionService from '../../../services/connection.service.js';
 import environmentService from '../../../services/environment.service.js';
-import metricsManager, { MetricTypes } from '../../../utils/metrics.manager.js';
+import telemetry, { LogTypes } from '../../../utils/telemetry.js';
 
 import * as postConnectionHandlers from './index.js';
 
-interface PostConnectionHandler {
-    (internalNango: InternalNango): Promise<void>;
-}
+type PostConnectionHandler = (internalNango: InternalNango) => Promise<void>;
 
-type PostConnectionHandlersMap = { [key: string]: PostConnectionHandler };
+type PostConnectionHandlersMap = Record<string, PostConnectionHandler>;
 
 const handlers: PostConnectionHandlersMap = postConnectionHandlers as unknown as PostConnectionHandlersMap;
 
@@ -106,7 +104,7 @@ async function execute(createdConnection: RecentlyCreatedConnection, provider: s
                     content: `Post connection script failed with the error: ${errorString}`
                 });
 
-                await metricsManager.capture(MetricTypes.POST_CONNECTION_SCRIPT_FAILURE, `Post connection script failed, ${errorString}`, LogActionEnum.AUTH, {
+                await telemetry.log(LogTypes.POST_CONNECTION_SCRIPT_FAILURE, `Post connection script failed, ${errorString}`, LogActionEnum.AUTH, {
                     environmentId: String(environment_id),
                     connectionId: connection_id,
                     providerConfigKey: provider_config_key,
@@ -124,7 +122,7 @@ async function execute(createdConnection: RecentlyCreatedConnection, provider: s
 
         const errorString = JSON.stringify(errorDetails);
 
-        await metricsManager.capture(MetricTypes.POST_CONNECTION_SCRIPT_FAILURE, `Post connection manager failed, ${errorString}`, LogActionEnum.AUTH, {
+        await telemetry.log(LogTypes.POST_CONNECTION_SCRIPT_FAILURE, `Post connection manager failed, ${errorString}`, LogActionEnum.AUTH, {
             environmentId: String(environment_id),
             connectionId: connection_id,
             providerConfigKey: provider_config_key,

--- a/packages/shared/lib/integrations/scripts/webhook/internal-nango.ts
+++ b/packages/shared/lib/integrations/scripts/webhook/internal-nango.ts
@@ -7,7 +7,7 @@ import type { SyncConfig } from './../../../models/Sync.js';
 import connectionService from '../../../services/connection.service.js';
 import { getSyncConfigsByConfigIdForWebhook } from '../../../services/sync/config/config.service.js';
 import { LogActionEnum } from '../../../models/Activity.js';
-import metricsManager, { MetricTypes } from '../../../utils/metrics.manager.js';
+import telemetry, { LogTypes } from '../../../utils/telemetry.js';
 
 export interface InternalNango {
     getWebhooks: (environment_id: number, nango_config_id: number) => Promise<SyncConfig[]>;
@@ -28,8 +28,8 @@ export const internalNango: InternalNango = {
         const syncClient = await SyncClient.getInstance();
 
         if (!get(body, connectionIdentifier)) {
-            await metricsManager.capture(
-                MetricTypes.INCOMING_WEBHOOK_ISSUE_WRONG_CONNECTION_IDENTIFIER,
+            await telemetry.log(
+                LogTypes.INCOMING_WEBHOOK_ISSUE_WRONG_CONNECTION_IDENTIFIER,
                 'Incoming webhook had the wrong connection identifier',
                 LogActionEnum.WEBHOOK,
                 {
@@ -64,8 +64,8 @@ export const internalNango: InternalNango = {
         }
 
         if (!connections || connections.length === 0) {
-            await metricsManager.capture(
-                MetricTypes.INCOMING_WEBHOOK_ISSUE_CONNECTION_NOT_FOUND,
+            await telemetry.log(
+                LogTypes.INCOMING_WEBHOOK_ISSUE_CONNECTION_NOT_FOUND,
                 'Incoming webhook received but no connection found for it',
                 LogActionEnum.WEBHOOK,
                 {
@@ -82,7 +82,7 @@ export const internalNango: InternalNango = {
 
         const accountId = await environmentService.getAccountIdFromEnvironment(integration.environment_id);
 
-        await metricsManager.capture(MetricTypes.INCOMING_WEBHOOK_RECEIVED, 'Incoming webhook received and connection found for it', LogActionEnum.WEBHOOK, {
+        await telemetry.log(LogTypes.INCOMING_WEBHOOK_RECEIVED, 'Incoming webhook received and connection found for it', LogActionEnum.WEBHOOK, {
             accountId: String(accountId),
             environmentId: String(integration.environment_id),
             provider: integration.provider,

--- a/packages/shared/lib/integrations/scripts/webhook/webhook.manager.ts
+++ b/packages/shared/lib/integrations/scripts/webhook/webhook.manager.ts
@@ -1,7 +1,7 @@
 import configService from '../../../services/config.service.js';
 import environmentService from '../../../services/environment.service.js';
 import webhookService from '../../../services/notification/webhook.service.js';
-import metricsManager, { MetricTypes } from '../../../utils/metrics.manager.js';
+import telemetry, { LogTypes } from '../../../utils/telemetry.js';
 import { LogActionEnum } from '../../../models/Activity.js';
 import { internalNango } from './internal-nango.js';
 
@@ -33,7 +33,7 @@ async function execute(environmentUuid: string, providerConfigKey: string, heade
             res = await handler(internalNango, integration, headers, body, rawBody);
         }
     } catch (e) {
-        await metricsManager.capture(MetricTypes.INCOMING_WEBHOOK_FAILED_PROCESSING, 'Incoming webhook failed processing', LogActionEnum.WEBHOOK, {
+        await telemetry.log(LogTypes.INCOMING_WEBHOOK_FAILED_PROCESSING, 'Incoming webhook failed processing', LogActionEnum.WEBHOOK, {
             accountId: String(accountId),
             environmentId: String(integration.environment_id),
             provider: integration.provider,
@@ -47,7 +47,7 @@ async function execute(environmentUuid: string, providerConfigKey: string, heade
 
     await webhookService.forward(integration.environment_id, providerConfigKey, provider, webhookBodyToForward, headers);
 
-    await metricsManager.capture(MetricTypes.INCOMING_WEBHOOK_PROCESSED_SUCCESSFULLY, 'Incoming webhook was processed successfully', LogActionEnum.WEBHOOK, {
+    await telemetry.log(LogTypes.INCOMING_WEBHOOK_PROCESSED_SUCCESSFULLY, 'Incoming webhook was processed successfully', LogActionEnum.WEBHOOK, {
         accountId: String(accountId),
         environmentId: String(integration.environment_id),
         provider: integration.provider,

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -29,7 +29,7 @@ import { NangoError } from '../utils/error.js';
 import type { Metadata, ConnectionConfig, Connection, StoredConnection, BaseConnection, NangoConnection } from '../models/Connection.js';
 import type { ServiceResponse } from '../models/Generic.js';
 import encryptionManager from '../utils/encryption.manager.js';
-import metricsManager, { MetricTypes } from '../utils/metrics.manager.js';
+import telemetry, { LogTypes } from '../utils/telemetry.js';
 import {
     AppCredentials,
     AuthModes as ProviderAuthModes,
@@ -315,7 +315,7 @@ class ConnectionService {
         if (!connectionId) {
             const error = new NangoError('missing_connection');
 
-            await metricsManager.capture(MetricTypes.GET_CONNECTION_FAILURE, error.message, LogActionEnum.AUTH, {
+            await telemetry.log(LogTypes.GET_CONNECTION_FAILURE, error.message, LogActionEnum.AUTH, {
                 environmentId: String(environment_id),
                 connectionId,
                 providerConfigKey
@@ -327,7 +327,7 @@ class ConnectionService {
         if (!providerConfigKey) {
             const error = new NangoError('missing_provider_config');
 
-            await metricsManager.capture(MetricTypes.GET_CONNECTION_FAILURE, error.message, LogActionEnum.AUTH, {
+            await telemetry.log(LogTypes.GET_CONNECTION_FAILURE, error.message, LogActionEnum.AUTH, {
                 environmentId: String(environment_id),
                 connectionId,
                 providerConfigKey
@@ -348,7 +348,7 @@ class ConnectionService {
 
             const error = new NangoError('unknown_connection', { connectionId, providerConfigKey, environmentName });
 
-            await metricsManager.capture(MetricTypes.GET_CONNECTION_FAILURE, error.message, LogActionEnum.AUTH, {
+            await telemetry.log(LogTypes.GET_CONNECTION_FAILURE, error.message, LogActionEnum.AUTH, {
                 environmentId: String(environment_id),
                 connectionId,
                 providerConfigKey
@@ -695,7 +695,7 @@ class ConnectionService {
         const shouldRefresh = await this.shouldRefreshCredentials(connection, credentials, providerConfig, template, instantRefresh);
 
         if (shouldRefresh) {
-            await metricsManager.capture(MetricTypes.AUTH_TOKEN_REFRESH_START, 'Token refresh is being started', LogActionEnum.AUTH, {
+            await telemetry.log(LogTypes.AUTH_TOKEN_REFRESH_START, 'Token refresh is being started', LogActionEnum.AUTH, {
                 environmentId: String(environment_id),
                 connectionId,
                 providerConfigKey,
@@ -715,7 +715,7 @@ class ConnectionService {
 
                 const { success, error, response: newCredentials } = await this.getNewCredentials(connection, providerConfig, template);
                 if (!success || !newCredentials) {
-                    await metricsManager.capture(MetricTypes.AUTH_TOKEN_REFRESH_FAILURE, `Token refresh failed, ${error?.message}`, LogActionEnum.AUTH, {
+                    await telemetry.log(LogTypes.AUTH_TOKEN_REFRESH_FAILURE, `Token refresh failed, ${error?.message}`, LogActionEnum.AUTH, {
                         environmentId: String(environment_id),
                         connectionId,
                         providerConfigKey,
@@ -727,7 +727,7 @@ class ConnectionService {
                 connection.credentials = newCredentials;
                 await this.updateConnection(connection);
 
-                await metricsManager.capture(MetricTypes.AUTH_TOKEN_REFRESH_SUCCESS, 'Token refresh was successful', LogActionEnum.AUTH, {
+                await telemetry.log(LogTypes.AUTH_TOKEN_REFRESH_SUCCESS, 'Token refresh was successful', LogActionEnum.AUTH, {
                     environmentId: String(environment_id),
                     connectionId,
                     providerConfigKey,
@@ -749,7 +749,7 @@ class ConnectionService {
 
                 const errorString = JSON.stringify(errorDetails);
 
-                await metricsManager.capture(MetricTypes.AUTH_TOKEN_REFRESH_FAILURE, `Token refresh failed, ${errorString}`, LogActionEnum.AUTH, {
+                await telemetry.log(LogTypes.AUTH_TOKEN_REFRESH_FAILURE, `Token refresh failed, ${errorString}`, LogActionEnum.AUTH, {
                     environmentId: String(environment_id),
                     connectionId,
                     providerConfigKey,

--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -25,7 +25,7 @@ import {
     SyncEndpoint
 } from '../../../models/Sync.js';
 import { NangoError } from '../../../utils/error.js';
-import metricsManager, { MetricTypes } from '../../../utils/metrics.manager.js';
+import telemetry, { LogTypes } from '../../../utils/telemetry.js';
 import { getEnv } from '../../../utils/utils.js';
 import { nangoConfigFile } from '../../nango-config.service.js';
 import { getSyncAndActionConfigByParams, increment, getSyncAndActionConfigsBySyncNameAndConfigId } from './config.service.js';
@@ -121,7 +121,7 @@ export async function deploy(
     try {
         const flowIds = await schema().from<SyncConfig>(TABLE).insert(insertData).returning('id');
 
-        const endpoints: Array<SyncEndpoint> = [];
+        const endpoints: SyncEndpoint[] = [];
         flowIds.forEach((row, index) => {
             const flow = flows[index] as IncomingFlowConfig;
             if (flow.endpoints && row.id) {
@@ -164,8 +164,8 @@ export async function deploy(
             .map((flow) => flow['syncName'])
             .join(', ')}).`;
 
-        await metricsManager.capture(
-            MetricTypes.SYNC_DEPLOY_SUCCESS,
+        await telemetry.log(
+            LogTypes.SYNC_DEPLOY_SUCCESS,
             shortContent,
             LogActionEnum.SYNC_DEPLOY,
             {
@@ -190,8 +190,8 @@ export async function deploy(
 
         const shortContent = `Failure to deploy the syncs (${flowsWithVersions.map((flow) => flow.syncName).join(', ')}).`;
 
-        await metricsManager.capture(
-            MetricTypes.SYNC_DEPLOY_FAILURE,
+        await telemetry.log(
+            LogTypes.SYNC_DEPLOY_FAILURE,
             shortContent,
             LogActionEnum.SYNC_DEPLOY,
             {
@@ -414,7 +414,7 @@ export async function deployPreBuilt(
     try {
         const syncIds = await schema().from<SyncConfig>(TABLE).insert(insertData).returning('id');
 
-        const endpoints: Array<SyncEndpoint> = [];
+        const endpoints: SyncEndpoint[] = [];
         syncIds.forEach((row, index) => {
             const sync = configs[index] as IncomingPreBuiltFlowConfig;
             if (sync.endpoints && row.id) {
@@ -465,8 +465,8 @@ export async function deployPreBuilt(
             content
         });
 
-        await metricsManager.capture(
-            MetricTypes.SYNC_DEPLOY_SUCCESS,
+        await telemetry.log(
+            LogTypes.SYNC_DEPLOY_SUCCESS,
             content,
             LogActionEnum.SYNC_DEPLOY,
             {
@@ -487,8 +487,8 @@ export async function deployPreBuilt(
         const content = `Failed to deploy the ${nameOfType}${configs.length === 1 ? '' : 's'} (${configs.map((config) => config.name).join(', ')}).`;
         await createActivityLogDatabaseErrorMessageAndEnd(content, e, activityLogId as number, environment_id);
 
-        await metricsManager.capture(
-            MetricTypes.SYNC_DEPLOY_FAILURE,
+        await telemetry.log(
+            LogTypes.SYNC_DEPLOY_FAILURE,
             content,
             LogActionEnum.SYNC_DEPLOY,
             {

--- a/packages/shared/lib/services/sync/data/records.service.ts
+++ b/packages/shared/lib/services/sync/data/records.service.ts
@@ -16,7 +16,7 @@ import db, { schema } from '../../../db/database.js';
 import connectionService from '../../connection.service.js';
 import { NangoError } from '../../../utils/error.js';
 import encryptionManager from '../../../utils/encryption.manager.js';
-import metricsManager, { MetricTypes } from '../../../utils/metrics.manager.js';
+import telemetry, { LogTypes } from '../../../utils/telemetry.js';
 import { LogActionEnum } from '../../../models/Activity.js';
 
 export const formatDataRecords = (
@@ -115,7 +115,7 @@ export async function getDataRecords(
         throw new Error(`No connection found for connectionId ${connectionId} and providerConfigKey ${providerConfigKey}`);
     }
 
-    await metricsManager.capture(MetricTypes.SYNC_GET_RECORDS_DEPRECATED_METHOD_USED, `Deprecated get records method`, LogActionEnum.SYNC, {
+    await telemetry.log(LogTypes.SYNC_GET_RECORDS_DEPRECATED_METHOD_USED, `Deprecated get records method`, LogActionEnum.SYNC, {
         environmentId: String(environmentId),
         connectionId,
         providerConfigKey,
@@ -124,7 +124,7 @@ export async function getDataRecords(
     });
 
     if (order) {
-        await metricsManager.capture(MetricTypes.SYNC_GET_RECORDS_ORDER_USED, `Order used in get records with a order value of ${order}`, LogActionEnum.SYNC, {
+        await telemetry.log(LogTypes.SYNC_GET_RECORDS_ORDER_USED, `Order used in get records with a order value of ${order}`, LogActionEnum.SYNC, {
             environmentId: String(environmentId),
             connectionId,
             providerConfigKey,
@@ -139,53 +139,38 @@ export async function getDataRecords(
     switch (sortBy) {
         case 'updated_at': {
             sort = 'updated_at';
-            await metricsManager.capture(
-                MetricTypes.SYNC_GET_RECORDS_SORT_BY_USED,
-                `Sort by used in get records with a sort value of ${sort}`,
-                LogActionEnum.SYNC,
-                {
-                    environmentId: String(environmentId),
-                    connectionId,
-                    providerConfigKey,
-                    delta: String(delta),
-                    sort,
-                    model
-                }
-            );
+            await telemetry.log(LogTypes.SYNC_GET_RECORDS_SORT_BY_USED, `Sort by used in get records with a sort value of ${sort}`, LogActionEnum.SYNC, {
+                environmentId: String(environmentId),
+                connectionId,
+                providerConfigKey,
+                delta: String(delta),
+                sort,
+                model
+            });
 
             break;
         }
         case 'created_at': {
             sort = 'created_at';
-            await metricsManager.capture(
-                MetricTypes.SYNC_GET_RECORDS_SORT_BY_USED,
-                `Sort by used in get records with a sort value of ${sort}`,
-                LogActionEnum.SYNC,
-                {
-                    environmentId: String(environmentId),
-                    connectionId,
-                    providerConfigKey,
-                    delta: String(delta),
-                    sort,
-                    model
-                }
-            );
+            await telemetry.log(LogTypes.SYNC_GET_RECORDS_SORT_BY_USED, `Sort by used in get records with a sort value of ${sort}`, LogActionEnum.SYNC, {
+                environmentId: String(environmentId),
+                connectionId,
+                providerConfigKey,
+                delta: String(delta),
+                sort,
+                model
+            });
             break;
         }
         case 'id': {
-            await metricsManager.capture(
-                MetricTypes.SYNC_GET_RECORDS_SORT_BY_USED,
-                `Sort by used in get records with a sort value of ${sort}`,
-                LogActionEnum.SYNC,
-                {
-                    environmentId: String(environmentId),
-                    connectionId,
-                    providerConfigKey,
-                    delta: String(delta),
-                    sort,
-                    model
-                }
-            );
+            await telemetry.log(LogTypes.SYNC_GET_RECORDS_SORT_BY_USED, `Sort by used in get records with a sort value of ${sort}`, LogActionEnum.SYNC, {
+                environmentId: String(environmentId),
+                connectionId,
+                providerConfigKey,
+                delta: String(delta),
+                sort,
+                model
+            });
         }
     }
 
@@ -205,18 +190,13 @@ export async function getDataRecords(
             return { success: false, error, response: null };
         }
 
-        await metricsManager.capture(
-            MetricTypes.SYNC_GET_RECORDS_OFFSET_USED,
-            `Offset used in get records with an offset value of ${offset}`,
-            LogActionEnum.SYNC,
-            {
-                environmentId: String(environmentId),
-                connectionId,
-                providerConfigKey,
-                delta: String(delta),
-                model
-            }
-        );
+        await telemetry.log(LogTypes.SYNC_GET_RECORDS_OFFSET_USED, `Offset used in get records with an offset value of ${offset}`, LogActionEnum.SYNC, {
+            environmentId: String(environmentId),
+            connectionId,
+            providerConfigKey,
+            delta: String(delta),
+            model
+        });
 
         query = query.offset(Number(offset));
     }
@@ -278,7 +258,7 @@ export async function getDataRecords(
     let result;
 
     if (includeMetaData) {
-        await metricsManager.capture(MetricTypes.SYNC_GET_RECORDS_INCLUDE_METADATA_USED, `Include Nango metadata used in get records`, LogActionEnum.SYNC, {
+        await telemetry.log(LogTypes.SYNC_GET_RECORDS_INCLUDE_METADATA_USED, `Include Nango metadata used in get records`, LogActionEnum.SYNC, {
             environmentId: String(environmentId),
             connectionId,
             providerConfigKey,
@@ -486,7 +466,7 @@ export async function getAllDataRecords(
         }
     } catch (e: any) {
         const errorMessage = 'List records error';
-        await metricsManager.capture(MetricTypes.SYNC_GET_RECORDS_QUERY_TIMEOUT, errorMessage, LogActionEnum.SYNC, {
+        await telemetry.log(LogTypes.SYNC_GET_RECORDS_QUERY_TIMEOUT, errorMessage, LogActionEnum.SYNC, {
             environmentId: String(environmentId),
             connectionId,
             providerConfigKey,

--- a/packages/shared/lib/services/sync/run.service.ts
+++ b/packages/shared/lib/services/sync/run.service.ts
@@ -15,7 +15,7 @@ import webhookService from '../notification/webhook.service.js';
 import { isCloud, getApiUrl, JAVASCRIPT_PRIMITIVES } from '../../utils/utils.js';
 import errorManager, { ErrorSourceEnum } from '../../utils/error.manager.js';
 import { NangoError } from '../../utils/error.js';
-import metricsManager, { MetricTypes } from '../../utils/metrics.manager.js';
+import telemetry, { LogTypes, MetricTypes } from '../../utils/telemetry.js';
 import type { NangoIntegrationData, NangoIntegration } from '../../models/NangoConfig.js';
 import type { UpsertSummary } from '../../models/Data.js';
 import { LogActionEnum } from '../../models/Activity.js';
@@ -191,7 +191,7 @@ export default class SyncRun {
             const secretKey = optionalSecretKey || (environment ? (environment?.secret_key as string) : '');
 
             const providerConfigKey = this.nangoConnection.provider_config_key;
-            const syncObject = integrations[providerConfigKey] as unknown as { [key: string]: NangoIntegration };
+            const syncObject = integrations[providerConfigKey] as unknown as Record<string, NangoIntegration>;
 
             let syncData: NangoIntegrationData;
 
@@ -348,7 +348,7 @@ export default class SyncRun {
                 const endTime = Date.now();
                 const totalRunTime = (endTime - startTime) / 1000;
 
-                await metricsManager.captureMetric(MetricTypes.SYNC_TRACK_RUNTIME, this.syncId as string, this.syncType, totalRunTime);
+                await telemetry.duration(MetricTypes.SYNC_TRACK_RUNTIME, totalRunTime);
 
                 if (this.isAction) {
                     const content = `${this.syncName} action was run successfully and results are being sent synchronously.`;
@@ -547,8 +547,8 @@ export default class SyncRun {
             });
         }
 
-        await metricsManager.capture(
-            MetricTypes.SYNC_SUCCESS,
+        await telemetry.log(
+            LogTypes.SYNC_SUCCESS,
             content,
             LogActionEnum.SYNC,
             {
@@ -631,8 +631,8 @@ export default class SyncRun {
             }
         });
 
-        await metricsManager.capture(
-            MetricTypes.SYNC_FAILURE,
+        await telemetry.log(
+            LogTypes.SYNC_FAILURE,
             content,
             LogActionEnum.SYNC,
             {

--- a/packages/shared/lib/utils/telemetry.ts
+++ b/packages/shared/lib/utils/telemetry.ts
@@ -1,7 +1,8 @@
 import { v2, client } from '@datadog/datadog-api-client';
 import { isCloud } from './utils.js';
+import tracer from 'dd-trace';
 
-export enum MetricTypes {
+export enum LogTypes {
     AUTH_TOKEN_REFRESH_START = 'auth_token_refresh_start',
     AUTH_TOKEN_REFRESH_SUCCESS = 'auth_token_refresh_success',
     AUTH_TOKEN_REFRESH_FAILURE = 'auth_token_refresh_failure',
@@ -11,7 +12,6 @@ export enum MetricTypes {
     AUTH_TOKEN_REQUEST_FAILURE = 'auth_token_request_failure',
     ACTION_SUCCESS = 'action_success',
     ACTION_FAILURE = 'action_failure',
-    ACTION_TRACK_RUNTIME = 'action_track_runtime',
     SYNC_OVERLAP = 'sync_overlap',
     SYNC_FAILURE = 'sync_failure',
     SYNC_SUCCESS = 'sync_success',
@@ -20,7 +20,6 @@ export enum MetricTypes {
     GET_CONNECTION_SUCCESS = 'get_connection_success',
     SYNC_DEPLOY_SUCCESS = 'sync_deploy_success',
     SYNC_DEPLOY_FAILURE = 'sync_deploy_failure',
-    SYNC_TRACK_RUNTIME = 'sync_script_track_runtime',
     SYNC_GET_RECORDS_OFFSET_USED = 'sync_get_records_offset_used',
     SYNC_GET_RECORDS_SORT_BY_USED = 'sync_get_records_sort_by_used',
     SYNC_GET_RECORDS_ORDER_USED = 'sync_get_records_order_used',
@@ -29,7 +28,6 @@ export enum MetricTypes {
     SYNC_GET_RECORDS_QUERY_TIMEOUT = 'sync_get_records_query_timeout',
     FLOW_JOB_TIMEOUT_FAILURE = 'flow_job_failure',
     POST_CONNECTION_SCRIPT_FAILURE = 'post_connection_script_failure',
-    WEBHOOK_TRACK_RUNTIME = 'webhook_track_runtime',
     INCOMING_WEBHOOK_RECEIVED = 'incoming_webhook_received',
     INCOMING_WEBHOOK_ISSUE_WRONG_CONNECTION_IDENTIFIER = 'incoming_webhook_issue_wrong_connection_identifier',
     INCOMING_WEBHOOK_ISSUE_CONNECTION_NOT_FOUND = 'incoming_webhook_issue_connection_not_found',
@@ -38,15 +36,20 @@ export enum MetricTypes {
     INCOMING_WEBHOOK_FAILED_PROCESSING = 'incoming_webhook_failed_processing'
 }
 
+export enum MetricTypes {
+    ACTION_TRACK_RUNTIME = 'action_track_runtime',
+    SYNC_TRACK_RUNTIME = 'sync_script_track_runtime',
+    WEBHOOK_TRACK_RUNTIME = 'webhook_track_runtime'
+}
+
 export enum SpanTypes {
     CONNECTION_TEST = 'nango.server.hooks.connectionTest',
     JOBS_CLEAN_ACTIVITY_LOGS = 'nango.jobs.cron.cleanActivityLogs',
     JOBS_IDLE_DEMO = 'nango.jobs.cron.idleDemos'
 }
 
-class MetricsManager {
+class Telemetry {
     private logInstance: v2.LogsApi | undefined;
-    private metricsInstance: v2.MetricsApi | undefined;
     constructor() {
         try {
             if (isCloud() && process.env['DD_API_KEY'] && process.env['DD_APP_KEY']) {
@@ -55,14 +58,13 @@ class MetricsManager {
                     site: 'us3.datadoghq.com'
                 });
                 this.logInstance = new v2.LogsApi(configuration);
-                this.metricsInstance = new v2.MetricsApi(configuration);
             }
         } catch (_) {
             return;
         }
     }
 
-    public async capture(eventId: string, message: string, operation: string, context: Record<string, string> = {}, additionalTags = '') {
+    public async log(eventId: string, message: string, operation: string, context: Record<string, string> = {}, additionalTags = '') {
         const params: v2.LogsApiSubmitLogRequest = {
             body: [
                 {
@@ -78,34 +80,17 @@ class MetricsManager {
         await this.logInstance?.submitLog(params);
     }
 
-    public async captureMetric(metricName: string, metricId: string, metricCategory: string, value: number) {
-        const currentTime = Math.floor(Date.now() / 1000);
-        const params: v2.MetricsApiSubmitMetricsRequest = {
-            body: {
-                series: [
-                    {
-                        metric: metricName,
-                        points: [
-                            {
-                                timestamp: currentTime,
-                                value
-                            }
-                        ],
-                        unit: 'seconds',
-                        resources: [
-                            {
-                                name: metricId,
-                                type: metricCategory
-                            }
-                        ],
-                        type: 3
-                    }
-                ]
-            }
-        };
+    public async increment(metricName: MetricTypes, value?: number) {
+        tracer.dogstatsd.increment(metricName, value || 1);
+    }
 
-        await this.metricsInstance?.submitMetrics(params);
+    public async decrement(metricName: MetricTypes, value?: number) {
+        tracer.dogstatsd.decrement(metricName, value || 1);
+    }
+
+    public async duration(metricName: MetricTypes, value: number) {
+        tracer.dogstatsd.distribution(metricName, value);
     }
 }
 
-export default new MetricsManager();
+export default new Telemetry();


### PR DESCRIPTION
## Describe your changes

- Proposing to rename metricsManager to Telemetry because it's doing log + metrics. 
  Feel free to propose a new name or oppose this change
- Use dd-trace for metrics to avoid using the HTTP pool to send metrics
  One "drawback" is that we no longer can't send the metrics definition, it should be done in the UI (which is standard practice but just wanted to warm)
- Renamed and split `captureMetric` to 3 different functions.
  In Datadog you have multiple metrics types and we might at some point use more than just duration
- Renamed the Enums to fit their usage
- Removed the tags from metrics (namely `syncId` and `actionName` that could make the billing go up a lot)


Closes NAN-344
