### PR TITLE
Increase temporal worker max concurrency to 500

### DIFF
--- a/packages/jobs/lib/temporal.ts
+++ b/packages/jobs/lib/temporal.ts
@@ -5,6 +5,8 @@ import { createRequire } from 'module';
 import * as activities from './activities.js';
 import { SYNC_TASK_QUEUE, WEBHOOK_TASK_QUEUE, isProd, isEnterprise } from '@nangohq/shared';
 
+const TEMPORAL_WORKER_MAX_CONCURRENCY = parseInt(process.env['TEMPORAL_WORKER_MAX_CONCURRENCY'] || '0') || 500;
+
 export class Temporal {
     namespace: string;
     workers: Worker[] | null;
@@ -48,7 +50,7 @@ export class Temporal {
                 namespace: this.namespace,
                 workflowsPath: createRequire(import.meta.url).resolve('./workflows'),
                 activities,
-                maxConcurrentWorkflowTaskExecutions: 50,
+                maxConcurrentWorkflowTaskExecutions: TEMPORAL_WORKER_MAX_CONCURRENCY,
                 taskQueue: SYNC_TASK_QUEUE
             };
 


### PR DESCRIPTION
In case a backlog of Temporal activities forms we want jobs to be able to process more than 50 at a time

## Issue ticket number and link
https://linear.app/nango/issue/NAN-389/increase-temporal-worker-max-concurrency-to-500

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
