### PR TITLE
server: add logging when returning error in auth middleware

### DIFF
--- a/packages/jobs/lib/integration.service.ts
+++ b/packages/jobs/lib/integration.service.ts
@@ -146,12 +146,14 @@ class IntegrationService implements IntegrationServiceInterface {
 
                 if (res && res.response && res.response.cancelled) {
                     const error = new NangoError('script_cancelled');
+                    runSpan.setTag('error', error);
                     return { success: false, error, response: null };
                 }
 
                 // TODO handle errors from the runner more gracefully and this service doesn't have to handle them
                 if (res && !res.success && res.error) {
                     const { error } = res;
+                    runSpan.setTag('error', error);
 
                     const err = new NangoError(error.type, error.payload, error.status);
 

--- a/packages/shared/lib/utils/error.manager.ts
+++ b/packages/shared/lib/utils/error.manager.ts
@@ -124,6 +124,7 @@ class ErrorManager {
 
     public errResFromNangoErr(res: Response, err: NangoError | null) {
         if (err) {
+            logger.error(`Error: ${{ statusCode: err.status, type: err.type, payload: err.payload, message: err.message }}`);
             if (!err.message) {
                 res.status(err.status).send({ type: err.type, payload: err.payload });
             } else {


### PR DESCRIPTION
Investigating an issue where the node client from runner is returning 401 when getting connection/provider details
