### PR TITLE
fix(datadog): incorrect metric for sync 

### DIFF
--- a/packages/shared/lib/services/sync/run.service.ts
+++ b/packages/shared/lib/services/sync/run.service.ts
@@ -369,6 +369,7 @@ export default class SyncRun {
                     return { success: true, error: null, response: userDefinedResults };
                 }
 
+                const totalRunTime = (Date.now() - startTime) / 1000;
                 await this.finishSync(models, syncStartDate, syncData.version as string, totalRunTime, trackDeletes);
 
                 return { success: true, error: null, response: true };

--- a/packages/shared/lib/services/sync/run.service.ts
+++ b/packages/shared/lib/services/sync/run.service.ts
@@ -300,12 +300,12 @@ export default class SyncRun {
                 }
             }
 
+            const startTime = Date.now();
             try {
                 result = true;
 
                 const syncStartDate = new Date();
 
-                const startTime = Date.now();
                 const {
                     success,
                     error,
@@ -343,11 +343,6 @@ export default class SyncRun {
                 if (!this.writeToDb) {
                     return userDefinedResults;
                 }
-
-                const endTime = Date.now();
-                const totalRunTime = (endTime - startTime) / 1000;
-
-                await telemetry.duration(MetricTypes.SYNC_TRACK_RUNTIME, totalRunTime);
 
                 if (this.isAction) {
                     const content = `${this.syncName} action was run successfully and results are being sent synchronously.`;
@@ -389,6 +384,11 @@ export default class SyncRun {
                 const errorType = this.determineErrorType();
 
                 return { success: false, error: new NangoError(errorType, errorMessage), response: result };
+            } finally {
+                if (!this.isAction) {
+                    const totalRunTime = (Date.now() - startTime) / 1000;
+                    await telemetry.duration(MetricTypes.SYNC_TRACK_RUNTIME, totalRunTime);
+                }
             }
         }
 

--- a/packages/shared/lib/services/sync/run.service.ts
+++ b/packages/shared/lib/services/sync/run.service.ts
@@ -386,7 +386,7 @@ export default class SyncRun {
 
                 return { success: false, error: new NangoError(errorType, errorMessage), response: result };
             } finally {
-                if (!this.isAction) {
+                if (!this.isInvokedImmediately) {
                     const totalRunTime = (Date.now() - startTime) / 1000;
                     await telemetry.duration(MetricTypes.SYNC_TRACK_RUNTIME, totalRunTime);
                 }


### PR DESCRIPTION
## Describe your changes

Fixes NAN-393

- The metric was also tracking action, Im not sure it was intended since there is a dedicated metric for that
- It wasnt tracking failure

