### PR TITLE
fix server error logging: stringify logged object

### DIFF
--- a/packages/shared/lib/utils/error.manager.ts
+++ b/packages/shared/lib/utils/error.manager.ts
@@ -124,7 +124,7 @@ class ErrorManager {
 
     public errResFromNangoErr(res: Response, err: NangoError | null) {
         if (err) {
-            logger.error(`Error: ${{ statusCode: err.status, type: err.type, payload: err.payload, message: err.message }}`);
+            logger.error('Response error:', JSON.stringify({ statusCode: err.status, type: err.type, payload: err.payload, message: err.message }));
             if (!err.message) {
                 res.status(err.status).send({ type: err.type, payload: err.payload });
             } else {


### PR DESCRIPTION
## Describe your changes

Fixing error response logging, I forgot to stringify the logged object

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
