### PR TITLE
fix(cron): delete old activities safely

### DIFF
--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -2,6 +2,7 @@ import './tracer.js';
 import { Temporal } from './temporal.js';
 import { server } from './server.js';
 import { cronAutoIdleDemo } from './crons/autoIdleDemo.js';
+import { deleteOldActivityLogs } from './crons/deleteOldActivities.js';
 
 try {
     const port = parseInt(process.env['NANGO_JOBS_PORT'] || '') || 3005;
@@ -13,6 +14,7 @@ try {
 
     // Register recurring tasks
     cronAutoIdleDemo();
+    deleteOldActivityLogs();
 
     // handle SIGTERM
     process.on('SIGTERM', async () => {

--- a/packages/jobs/lib/crons/autoIdleDemo.ts
+++ b/packages/jobs/lib/crons/autoIdleDemo.ts
@@ -62,7 +62,7 @@ export async function exec(): Promise<void> {
             continue;
         }
 
-        logger.info('[autoidle] pausing', { sync });
+        logger.info(`[autoidle] pausing ${sync.id}`);
 
         const resTemporal = await syncClient.runSyncCommand(sync.schedule_id, sync.id, SyncCommand.PAUSE, activityLogId, sync.environment_id);
         if (isErr(resTemporal)) {

--- a/packages/jobs/lib/crons/deleteOldActivities.ts
+++ b/packages/jobs/lib/crons/deleteOldActivities.ts
@@ -1,0 +1,55 @@
+import * as cron from 'node-cron';
+import { deleteLog, deleteLogsMessages, errorManager, ErrorSourceEnum, findOldActivities, logger } from '@nangohq/shared';
+import { SpanTypes } from '@nangohq/shared';
+import tracer from '../tracer.js';
+import { setTimeout } from 'node:timers/promises';
+
+// Retention in days
+const retention = parseInt(process.env['NANGO_CLEAR_ACTIVIES_RETENTION'] || '', 10) || 15;
+const limitLog = parseInt(process.env['NANGO_CLEAR_ACTIVIES_LIMIT'] || '', 10) || 1000;
+const limitMsg = parseInt(process.env['NANGO_CLEAR_ACTIVIES_MSG_LIMIT'] || '', 10) || 5000;
+
+export async function deleteOldActivityLogs(): Promise<void> {
+    /**
+     * Delete all activity logs older than 15 days
+     */
+    cron.schedule('*/15 * * * *', async () => {
+        const span = tracer.startSpan(SpanTypes.JOBS_CLEAN_ACTIVITY_LOGS);
+        tracer.scope().activate(span, async () => {
+            try {
+                await exec();
+            } catch (err: unknown) {
+                const e = new Error('failed_to_clean_activity_logs_table', { cause: err instanceof Error ? err.message : err });
+                errorManager.report(e, { source: ErrorSourceEnum.PLATFORM }, tracer);
+            }
+
+            span.finish();
+        });
+    });
+}
+
+/**
+ * Postgres does not allow DELETE LIMIT so we batch ourself to limit the memory footprint of this query.
+ */
+export async function exec(): Promise<void> {
+    logger.info('[oldActivity] starting');
+
+    const logs = await findOldActivities({ retention, limit: limitLog });
+    logger.info(`[oldActivity] found ${logs.length} syncs`);
+
+    for (const log of logs) {
+        logger.info(`[oldActivity] deleting syncId: ${log.id}`);
+        let count = 0;
+        do {
+            count = await deleteLogsMessages({ activityLogId: log.id, limit: limitMsg });
+            logger.info(`[oldActivity] deleted ${count} rows`);
+        } while (count >= limitMsg);
+
+        await deleteLog({ activityLogId: log.id });
+
+        // Free the CPU for a while
+        await setTimeout(5000);
+    }
+
+    logger.info('[oldActivity] done');
+}

--- a/packages/jobs/lib/crons/deleteOldActivities.ts
+++ b/packages/jobs/lib/crons/deleteOldActivities.ts
@@ -43,12 +43,12 @@ export async function exec(): Promise<void> {
         do {
             count = await deleteLogsMessages({ activityLogId: log.id, limit: limitMsg });
             logger.info(`[oldActivity] deleted ${count} rows`);
+
+            // Free the CPU
+            await setTimeout(250);
         } while (count >= limitMsg);
 
         await deleteLog({ activityLogId: log.id });
-
-        // Free the CPU for a while
-        await setTimeout(5000);
     }
 
     logger.info('[oldActivity] done');

--- a/packages/server/lib/jobs/index.ts
+++ b/packages/server/lib/jobs/index.ts
@@ -1,32 +1,4 @@
-import * as cron from 'node-cron';
-import { isCloud, db, encryptionManager, errorManager, ErrorSourceEnum, logger } from '@nangohq/shared';
-import { SpanTypes } from '@nangohq/shared';
-import tracer from '../tracer.js';
-
-export async function deleteOldActivityLogs(): Promise<void> {
-    /**
-     * Delete all activity logs older than 15 days
-     */
-    cron.schedule('*/1 * * * *', async () => {
-        const activityLogTableName = 'nango._nango_activity_logs';
-        const span = tracer.startSpan(SpanTypes.JOBS_CLEAN_ACTIVITY_LOGS);
-        tracer.scope().activate(span, async () => {
-            logger.info('[oldActivity] starting');
-            try {
-                // Postgres does not allow DELETE LIMIT so we batch ourself to limit the memory footprint of this query.
-                await db.knex.raw(
-                    `DELETE FROM ${activityLogTableName} WHERE id IN (SELECT id FROM ${activityLogTableName} WHERE created_at < NOW() - interval '15 days' LIMIT 5000)`
-                );
-            } catch (err: unknown) {
-                const e = new Error('failed_to_clean_activity_logs_table', { cause: err instanceof Error ? err.message : err });
-                errorManager.report(e, { source: ErrorSourceEnum.PLATFORM }, tracer);
-            }
-
-            span.finish();
-            logger.info('[oldActivity] done');
-        });
-    });
-}
+import { isCloud, encryptionManager } from '@nangohq/shared';
 
 export async function encryptDataRecords(): Promise<void> {
     if (isCloud()) {

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -44,7 +44,6 @@ import {
     packageJsonFile
 } from '@nangohq/shared';
 import oAuthSessionService from './services/oauth-session.service.js';
-import { deleteOldActivityLogs } from './jobs/index.js';
 import migrate from './utils/migrate.js';
 
 const { NANGO_MIGRATE_AT_START = 'true' } = process.env;
@@ -232,9 +231,6 @@ const wss = new WebSocketServer({ server, path: getWebsocketsPath() });
 wss.on('connection', async (ws: WebSocket) => {
     await publisher.subscribe(ws);
 });
-
-// kick off any job
-deleteOldActivityLogs();
 
 const port = getPort();
 server.listen(port, () => {

--- a/packages/shared/lib/services/activity/activity.service.ts
+++ b/packages/shared/lib/services/activity/activity.service.ts
@@ -354,8 +354,10 @@ export async function deleteLog({ activityLogId }: { activityLogId: number }): P
 }
 
 export async function deleteLogsMessages({ activityLogId, limit }: { activityLogId: number; limit: number }): Promise<number> {
-    const del = await db.knex.raw(
-        `DELETE FROM nango._nango_activity_log_messages WHERE id IN (SELECT id FROM nango._nango_activity_log_messages WHERE activity_log_id = ${activityLogId} LIMIT ${limit})`
-    );
-    return del.rowCount;
+    const del = await db.knex
+        .withSchema(db.schema())
+        .from('_nango_activity_log_messages')
+        .whereIn('id', db.knex.queryBuilder().select('id').from('_nango_activity_log_messages').where({ activity_log_id: activityLogId }).limit(limit))
+        .del();
+    return del;
 }

--- a/packages/shared/lib/services/activity/activity.service.ts
+++ b/packages/shared/lib/services/activity/activity.service.ts
@@ -266,7 +266,7 @@ export async function activityFilter(environment_id: number, filterColumn: 'conn
     const logs = await logsQuery;
 
     const distinctValues: string[] = logs
-        .map((log: { [key: string]: string }) => log[filterColumn] as string)
+        .map((log: Record<string, string>) => log[filterColumn] as string)
         .filter((value: string | undefined): value is string => typeof value === 'string');
 
     return distinctValues;
@@ -334,4 +334,28 @@ export async function createActivityLogDatabaseErrorMessageAndEnd(baseMessage: s
         timestamp: Date.now(),
         content: errorMessage
     });
+}
+
+export async function findOldActivities({ retention, limit }: { retention: number; limit: number }): Promise<{ id: number }[]> {
+    const q = db.knex
+        .queryBuilder()
+        .withSchema(db.schema())
+        .from('_nango_activity_logs')
+        .select('id')
+        .where(db.knex.raw(`_nango_activity_logs.updated_at <  NOW() - INTERVAL '${retention} days'`))
+        .limit(limit);
+    const logs: { id: number }[] = await q;
+
+    return logs;
+}
+
+export async function deleteLog({ activityLogId }: { activityLogId: number }): Promise<void> {
+    await db.knex.withSchema(db.schema()).from('_nango_activity_logs').where({ id: activityLogId }).del();
+}
+
+export async function deleteLogsMessages({ activityLogId, limit }: { activityLogId: number; limit: number }): Promise<number> {
+    const del = await db.knex.raw(
+        `DELETE FROM nango._nango_activity_log_messages WHERE id IN (SELECT id FROM nango._nango_activity_log_messages WHERE activity_log_id = ${activityLogId} LIMIT ${limit})`
+    );
+    return del.rowCount;
 }


### PR DESCRIPTION
## Describe your changes

Following #1616 
Fixes NAN-394

Current clear was working but it was a naive implementation wrote quickly. We needed a long term fix that do not lock the table; especially in case where activityLogId would be > 10K messages.
Here we split the scripts to select/delete in batch:
- Select N log id
- Delete in small batch all the messages of this id
- Delete the log id
- Repeat

It's verbose on purpose because on production it's hard to know if something is locking or slow 

![Screenshot 2024-02-19 at 14 56 27](https://github.com/NangoHQ/nango/assets/1637651/4dd3fa41-c0ec-412f-9ac9-129bfe7711f4)
