### PR TITLE
Update authorization_url for tiktok-accounts

### DIFF
--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -1377,7 +1377,7 @@ teamwork:
         base_url: https://api.surveymonkey.com
 tiktok-accounts:
     auth_mode: OAUTH2
-    authorization_url: https://open-api.tiktok.com/platform/oauth/connect/
+    authorization_url: https://www.tiktok.com/v2/auth/authorize/
     token_url: https://business-api.tiktok.com/open_api/v1.3/tt_user/oauth2/token/
     refresh_url: https://business-api.tiktok.com/open_api/v1.3/tt_user/oauth2/refresh_token/
     proxy:


### PR DESCRIPTION
## Describe your changes
It seems that the authorization_url is not good for tiktok-accounts: https://business-api.tiktok.com/portal/docs?id=1766042058952706