### PR TITLE
fix(dd): correctly load tracer

### DIFF
--- a/packages/jobs/lib/index.ts
+++ b/packages/jobs/lib/index.ts
@@ -1,1 +1,4 @@
+/**
+ * This file SHOULD just export types and getJobsClient
+ */
 export { getJobsClient } from './client.js';

--- a/packages/jobs/lib/tracer.ts
+++ b/packages/jobs/lib/tracer.ts
@@ -1,13 +1,10 @@
 import tracer from 'dd-trace';
-import { isCloud } from '@nangohq/shared';
 
-if (isCloud()) {
-    tracer.init({
-        service: 'nango-jobs'
-    });
-    tracer.use('pg', {
-        service: 'nango-postgres'
-    });
-}
+tracer.init({
+    service: 'nango-jobs'
+});
+tracer.use('pg', {
+    service: 'nango-postgres'
+});
 
 export default tracer;

--- a/packages/persist/lib/app.ts
+++ b/packages/persist/lib/app.ts
@@ -1,3 +1,4 @@
+import './tracer.js';
 import { server } from './server.js';
 
 try {

--- a/packages/persist/lib/server.ts
+++ b/packages/persist/lib/server.ts
@@ -1,4 +1,3 @@
-import './tracer.js';
 import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import { validateRequest } from 'zod-express';

--- a/packages/persist/lib/tracer.ts
+++ b/packages/persist/lib/tracer.ts
@@ -1,14 +1,11 @@
 import tracer from 'dd-trace';
-import { isCloud } from '@nangohq/shared';
 
-if (isCloud()) {
-    tracer.init({
-        service: 'nango-persist'
-    });
-    tracer.use('pg', {
-        service: 'nango-postgres'
-    });
-    tracer.use('express');
-}
+tracer.init({
+    service: 'nango-persist'
+});
+tracer.use('pg', {
+    service: 'nango-postgres'
+});
+tracer.use('express');
 
 export default tracer;

--- a/packages/runner/lib/app.ts
+++ b/packages/runner/lib/app.ts
@@ -1,3 +1,4 @@
+import './tracer.js';
 import { server } from './server.js';
 
 try {

--- a/packages/runner/lib/index.ts
+++ b/packages/runner/lib/index.ts
@@ -1,2 +1,6 @@
-export { getRunnerClient, ProxyAppRouter } from './client.js';
-export { AppRouter } from './server.js';
+/**
+ * This file SHOULD just export types and getRunnerClient
+ */
+export { getRunnerClient } from './client.js';
+export type { ProxyAppRouter } from './client.js';
+export type { AppRouter } from './server.js';


### PR DESCRIPTION
## Describe your changes

We had a mixup in the tracer because jobs was loading the runner's tracer through a barrel file mistake (linter should have picked up missing `export types`).

- Add comments to barrel file to clarify expectation, not bulletproof but better than nothing
- Correctly load the tracer at the beginning of the entry points 
  Note that it shouldn't be useful to load the tracer after it has been instantiated; since the config is global we could import `dd-trace` and avoid this mistake. 
- Remove `isCloud()` that was annoying locally
 


