### PR TITLE
fix(cron): fine tune delete old activities

### DIFF
--- a/packages/jobs/lib/crons/deleteOldActivities.ts
+++ b/packages/jobs/lib/crons/deleteOldActivities.ts
@@ -1,30 +1,26 @@
 import * as cron from 'node-cron';
-import { deleteLog, deleteLogsMessages, errorManager, ErrorSourceEnum, findOldActivities, logger } from '@nangohq/shared';
-import { SpanTypes } from '@nangohq/shared';
+import { deleteLog, deleteLogsMessages, errorManager, ErrorSourceEnum, findOldActivities, logger, MetricTypes, telemetry } from '@nangohq/shared';
 import tracer from '../tracer.js';
 import { setTimeout } from 'node:timers/promises';
 
 // Retention in days
 const retention = parseInt(process.env['NANGO_CLEAR_ACTIVIES_RETENTION'] || '', 10) || 15;
-const limitLog = parseInt(process.env['NANGO_CLEAR_ACTIVIES_LIMIT'] || '', 10) || 1000;
+const limitLog = parseInt(process.env['NANGO_CLEAR_ACTIVIES_LIMIT'] || '', 10) || 2000;
 const limitMsg = parseInt(process.env['NANGO_CLEAR_ACTIVIES_MSG_LIMIT'] || '', 10) || 5000;
 
 export async function deleteOldActivityLogs(): Promise<void> {
     /**
      * Delete all activity logs older than 15 days
      */
-    cron.schedule('*/15 * * * *', async () => {
-        const span = tracer.startSpan(SpanTypes.JOBS_CLEAN_ACTIVITY_LOGS);
-        tracer.scope().activate(span, async () => {
-            try {
-                await exec();
-            } catch (err: unknown) {
-                const e = new Error('failed_to_clean_activity_logs_table', { cause: err instanceof Error ? err.message : err });
-                errorManager.report(e, { source: ErrorSourceEnum.PLATFORM }, tracer);
-            }
-
-            span.finish();
-        });
+    cron.schedule('*/10 * * * *', async () => {
+        const start = Date.now();
+        try {
+            await exec();
+        } catch (err: unknown) {
+            const e = new Error('failed_to_clean_activity_logs_table', { cause: err instanceof Error ? err.message : err });
+            errorManager.report(e, { source: ErrorSourceEnum.PLATFORM }, tracer);
+        }
+        telemetry.duration(MetricTypes.JOBS_CLEAN_ACTIVITY_LOGS, Date.now() - start);
     });
 }
 
@@ -45,7 +41,7 @@ export async function exec(): Promise<void> {
             logger.info(`[oldActivity] deleted ${count} rows`);
 
             // Free the CPU
-            await setTimeout(250);
+            await setTimeout(200);
         } while (count >= limitMsg);
 
         await deleteLog({ activityLogId: log.id });

--- a/packages/shared/lib/utils/telemetry.ts
+++ b/packages/shared/lib/utils/telemetry.ts
@@ -40,12 +40,12 @@ export enum MetricTypes {
     ACTION_TRACK_RUNTIME = 'action_track_runtime',
     SYNC_TRACK_RUNTIME = 'sync_script_track_runtime',
     WEBHOOK_TRACK_RUNTIME = 'webhook_track_runtime',
-    RUNNER_SDK = 'nango.runner.sdk'
+    RUNNER_SDK = 'nango.runner.sdk',
+    JOBS_CLEAN_ACTIVITY_LOGS = 'nango.jobs.cron.cleanActivityLogs'
 }
 
 export enum SpanTypes {
     CONNECTION_TEST = 'nango.server.hooks.connectionTest',
-    JOBS_CLEAN_ACTIVITY_LOGS = 'nango.jobs.cron.cleanActivityLogs',
     JOBS_IDLE_DEMO = 'nango.jobs.cron.idleDemos',
     RUNNER_EXEC = 'nango.runner.exec'
 }


### PR DESCRIPTION
## Describe your changes

We are producing ~300k logs per day, the current pace is not enough to clear everything in a timely fashion
It's clear that we will need to rethink this table in a near future wether by using partition or by changing the storage entirely.

- Increase the pace
- Remove span that is too big to be sent to Datadog

