### PR TITLE
sdk/sync: remove unecessary call to API (/config)

### DIFF
--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import type { Metadata, NangoConnection } from '@nangohq/shared';
 import { SyncConfigType, SyncType, syncRunService, cloudHost, stagingHost } from '@nangohq/shared';
 import type { GlobalOptions } from '../types.js';
-import { parseSecretKey, printDebug, hostport, getConnection } from '../utils.js';
+import { parseSecretKey, printDebug, hostport, getConnection, getProviderBySyncName } from '../utils.js';
 import configService from './config.service.js';
 import compileService from './compile.service.js';
 import integrationService from './local-integration.service.js';
@@ -98,6 +98,15 @@ class DryRunService {
             printDebug(`Connection found with ${JSON.stringify(nangoConnection, null, 2)}`);
         }
 
+        const provider = await getProviderBySyncName({ syncName }, debug);
+        if (!provider) {
+            console.log(chalk.red('Provider not found'));
+            return;
+        }
+        if (debug) {
+            printDebug(`Provider found: ${provider}`);
+        }
+
         if (process.env['NANGO_HOSTPORT'] === cloudHost || process.env['NANGO_HOSTPORT'] === stagingHost) {
             process.env['NANGO_CLOUD'] = 'true';
         }
@@ -138,6 +147,7 @@ class DryRunService {
             integrationService,
             writeToDb: false,
             nangoConnection,
+            provider,
             input: normalizedInput as object,
             isAction: syncInfo?.type === SyncConfigType.ACTION,
             syncId: 'abc',

--- a/packages/shared/lib/services/sync/run.service.ts
+++ b/packages/shared/lib/services/sync/run.service.ts
@@ -272,6 +272,7 @@ export default class SyncRun {
                 connectionId: String(this.nangoConnection?.connection_id),
                 environmentId: this.nangoConnection?.environment_id as number,
                 providerConfigKey: String(this.nangoConnection?.provider_config_key),
+                provider: this.provider as string,
                 activityLogId: this.activityLogId as number,
                 secretKey,
                 nangoConnectionId: this.nangoConnection?.id as number,


### PR DESCRIPTION
## Describe your changes
@bodinsamuel  noticed last week that when proxying/paginating we were making a call to `/config` to obtain the provider name (which mean that any nango.proxy call in scripts triggers 2 requests to our API, one to get connection credentials and one to get provider name) 
This PR is removing this request in favor of passing the provider as part of the NangoProps.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
