### PR TITLE
fix(db): add index for sync_jobs

### DIFF
--- a/packages/shared/lib/db/migrations/20240222091347_sync-jobs-index.cjs
+++ b/packages/shared/lib/db/migrations/20240222091347_sync-jobs-index.cjs
@@ -1,0 +1,11 @@
+exports.config = { transaction: false };
+
+exports.up = function (knex) {
+    return knex.schema.raw(
+        'CREATE INDEX CONCURRENTLY "idx_jobs_id_status_type_where_delete" ON "nango"."_nango_sync_jobs" USING BTREE ("sync_id","status","type") WHERE deleted = false'
+    );
+};
+
+exports.down = function (knex) {
+    return knex.schema.raw('DROP INDEX CONCURRENTLY idx_jobs_id_status_type_where_delete');
+};


### PR DESCRIPTION
## Describe your changes

Fixes NAN-412

Impact two queries, not the slowest ones but executed quite often.
This index should make the query in prod go from average 60-100ms to 0-10ms, and obviously avoid the slow ones (currently topping a few seconds)


## Results

```sql
EXPLAIN ANALYSE SELECT
	*
FROM
	"nango"."_nango_sync_jobs"
WHERE
	"sync_id" = 'aa037132-403f-465f-b9d4-5b7a21eadbd4'
	AND "deleted" = FALSE
	AND "type" = 'INITIAL'
	AND "status" = 'RUNNING'
LIMIT 100;
```

### Before
```sql
# In prod 
Limit  (cost=162.77..165.01 rows=1 width=312) (actual time=94.953..94.956 rows=0 loops=1)
  ->  Bitmap Heap Scan on _nango_sync_jobs  (cost=162.77..165.01 rows=1 width=312) (actual time=94.952..94.954 rows=0 loops=1)
"        Recheck Cond: ((sync_id = 'd744f9ba-e823-42db-a3c2-22e905d2c2c7'::uuid) AND (status = 'RUNNING'::text))"
"        Filter: ((NOT deleted) AND ((type)::text = 'INITIAL'::text))"
        Rows Removed by Filter: 2
        Heap Blocks: exact=2
        ->  BitmapAnd  (cost=162.77..162.77 rows=2 width=0) (actual time=91.580..91.582 rows=0 loops=1)
              ->  Bitmap Index Scan on _nango_sync_jobs_sync_id_deleted_index  (cost=0.00..17.03 rows=1330 width=0) (actual time=0.270..0.270 rows=1330 loops=1)
"                    Index Cond: ((sync_id = 'd744f9ba-e823-42db-a3c2-22e905d2c2c7'::uuid) AND (deleted = false))"
              ->  Bitmap Index Scan on _nango_sync_jobs_status_index  (cost=0.00..145.49 rows=15381 width=0) (actual time=89.058..89.058 rows=502597 loops=1)
"                    Index Cond: (status = 'RUNNING'::text)"
Planning Time: 0.209 ms
Execution Time: 95.003 ms
```


### After
```sql
# In dev
Limit  (cost=0.14..8.16 rows=1 width=231) (actual time=0.021..0.022 rows=0 loops=1)
  ->  Index Scan using _nango_sync_jobs_sync_id_wherenotdeleted_index on _nango_sync_jobs  (cost=0.14..8.16 rows=1 width=231) (actual time=0.020..0.020 rows=0 loops=1)
"        Index Cond: ((sync_id = 'aa037132-403f-465f-b9d4-5b7a21eadbd4'::uuid) AND (status = 'RUNNING'::text) AND ((type)::text = 'INITIAL'::text))"
Planning Time: 0.211 ms
Execution Time: 0.052 ms
```
