### PR TITLE
Split stripe-app into 2 providers for live and sandbox

### DIFF
--- a/docs-v2/integrations/all/stripe-app.mdx
+++ b/docs-v2/integrations/all/stripe-app.mdx
@@ -1,9 +1,9 @@
 ---
-title: Stripe
-sidebarTitle: Stripe
+title: Stripe App
+sidebarTitle: Stripe App
 ---
 
-API configuration: [`stripe`](https://nango.dev/providers.yaml)
+API configuration: [`stripe-app`](https://nango.dev/providers.yaml)
 
 ## Features
 
@@ -25,12 +25,12 @@ API configuration: [`stripe`](https://nango.dev/providers.yaml)
 
 <Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
 
-## Connection configuration in Nango
+## Connection configuration in Nango for external test apps
 
-Stripe requires you to use either the application domain or a temporary id (in test mode) to identify your application. See the [docs](https://stripe.com/docs/stripe-apps/api-authentication/oauth#install-app) for more information.
+If you are using the "External Test" version of your app, Stripe requires you to use a temporary id to identify your application. See the [docs](https://stripe.com/docs/stripe-apps/api-authentication/oauth#install-app) for more information.
 
-You should add your app domain to the `appDomain` field in the connection params.
+In this case, you must use the `stripe-app-sandbox` integration in Nango, and add the temporary ID to the `appDomain` field in the connection params.
 
 ```js
-nango.auth('stripe-app', '<CONNECTION-ID>', {params: {appDomain: '<stripe-app-domain>'}});
+nango.auth('stripe-app-sandbox', '<CONNECTION-ID>', {params: {appDomain: '<stripe-app-domain>'}});
 ```

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -1358,6 +1358,15 @@ stripe-express:
         base_url: https://api.stripe.com
 stripe-app:
     auth_mode: OAUTH2
+    authorization_url: https://marketplace.stripe.com/oauth/v2/authorize
+    token_url: https://api.stripe.com/v1/oauth/token
+    disable_pkce: true
+    proxy:
+        base_url: https://api.stripe.com
+    refresh_params:
+        grant_type: refresh_token
+stripe-app-sandbox:
+    auth_mode: OAUTH2
     authorization_url: https://marketplace.stripe.com/oauth/v2/${connectionConfig.appDomain}/authorize
     token_url: https://api.stripe.com/v1/oauth/token
     disable_pkce: true


### PR DESCRIPTION
## Describe your changes
As it was, the stripe-app provider only worked for "External test" apps, and not for production apps (apps approved by Stripe).
This PR splits the provider into 2, adding a "stripe-app-sandox" provider, because the URL is formed differently in test and live.
Stripe-app docs are updated to reflect this change.

## Issue ticket number and link
N/A

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
