### PR TITLE
fix(db): add index for data_records

### DIFF
--- a/packages/shared/lib/db/migrations/20240222111223_data_records_index.cjs
+++ b/packages/shared/lib/db/migrations/20240222111223_data_records_index.cjs
@@ -1,0 +1,11 @@
+exports.config = { transaction: false };
+
+exports.up = function (knex) {
+    return knex.schema.raw(
+        'CREATE INDEX CONCURRENTLY "idx_records_created_id_connection_model" ON "nango"."_nango_sync_data_records" USING BTREE ("created_at","id","nango_connection_id","model");'
+    );
+};
+
+exports.down = function (knex) {
+    return knex.schema.raw('DROP INDEX CONCURRENTLY idx_records_created_id_connection_model');
+};


### PR DESCRIPTION
## Describe your changes

Contributes to NAN-419

This query is not the slowest but can be rather slow there is static part and a big moving part. Having partition or something would help reduce the need of an large index.
It's more a test to see it could perform better than the current index `idx_nango_records_composite` by putting the order first.

