### PR TITLE
Fix: temporal activities timeout

### DIFF
--- a/packages/jobs/lib/activities.ts
+++ b/packages/jobs/lib/activities.ts
@@ -340,8 +340,8 @@ export async function runWebhook(args: WebhookArgs): Promise<boolean> {
 export async function reportFailure(
     error: any,
     workflowArguments: InitialSyncArgs | ContinuousSyncArgs | ActionArgs | WebhookArgs,
-    DEFAULT_TIMEOUT: string,
-    MAXIMUM_ATTEMPTS: number
+    timeout: string,
+    max_attempts: number
 ): Promise<void> {
     const { nangoConnection } = workflowArguments;
     let type = 'webhook';
@@ -366,9 +366,9 @@ export async function reportFailure(
         content += `due to a termination.`;
     } else if (error.cause instanceof TimeoutFailure || error.cause?.name === 'TimeoutFailure') {
         if (error.cause.timeoutType === 3) {
-            content += `due to a timeout with respect to the max schedule length timeout of ${DEFAULT_TIMEOUT}.`;
+            content += `due to a timeout with respect to the max schedule length timeout of ${timeout}.`;
         } else {
-            content += `due to a timeout and a lack of heartbeat with ${MAXIMUM_ATTEMPTS} attempts.`;
+            content += `due to a timeout and a lack of heartbeat with ${max_attempts} attempts.`;
         }
     } else {
         content += `due to a unknown failure.`;

--- a/packages/jobs/lib/workflows.ts
+++ b/packages/jobs/lib/workflows.ts
@@ -2,17 +2,49 @@ import { CancellationScope, proxyActivities, isCancellation } from '@temporalio/
 import type * as activities from './activities.js';
 import type { WebhookArgs, ContinuousSyncArgs, InitialSyncArgs, ActionArgs } from './models/worker';
 
-const DEFAULT_TIMEOUT = '24 hours';
-const MAXIMUM_ATTEMPTS = 3;
+const SYNC_TIMEOUT = '24h';
+const SYNC_MAX_ATTEMPTS = 3;
+const ACTION_TIMEOUT = '15m';
+const ACTION_MAX_ATTEMPTS = 1; // no retry
+const WEBHOOK_TIMEOUT = '15m';
+const WEBHOOK_MAX_ATTEMPTS = 3;
 
-const { cancelActivity, reportFailure, routeSync, scheduleAndRouteSync, runAction, runWebhook } = proxyActivities<typeof activities>({
-    startToCloseTimeout: DEFAULT_TIMEOUT,
-    scheduleToCloseTimeout: DEFAULT_TIMEOUT,
+const { routeSync, scheduleAndRouteSync } = proxyActivities<typeof activities>({
+    // 1 hour to start so syncs are not evicted from the queue too soon
+    // 24 hours to complete to allow for long running syncs
+    scheduleToStartTimeout: '1h',
+    startToCloseTimeout: SYNC_TIMEOUT,
     retry: {
-        initialInterval: '5m',
-        maximumAttempts: MAXIMUM_ATTEMPTS
+        maximumAttempts: SYNC_MAX_ATTEMPTS
     },
     heartbeatTimeout: '30m'
+});
+const { runAction } = proxyActivities<typeof activities>({
+    // actions are more time sensitive, hence shorter timeout
+    // actions are synchronous so no retry and fast eviction from the queue
+    scheduleToStartTimeout: '1m',
+    startToCloseTimeout: ACTION_TIMEOUT,
+    retry: {
+        maximumAttempts: ACTION_MAX_ATTEMPTS
+    }
+});
+
+const { runWebhook } = proxyActivities<typeof activities>({
+    // webhook execution should be fast, hence shorter startToCloseTimeout
+    // but we allow for longer time to start so events are not evicted too soon if system is busy
+    scheduleToStartTimeout: '1h',
+    startToCloseTimeout: WEBHOOK_TIMEOUT,
+    retry: {
+        maximumAttempts: WEBHOOK_MAX_ATTEMPTS
+    }
+});
+
+const { cancelActivity, reportFailure } = proxyActivities<typeof activities>({
+    scheduleToStartTimeout: '5m',
+    startToCloseTimeout: '30s',
+    retry: {
+        maximumAttempts: 3
+    }
 });
 
 export async function initialSync(args: InitialSyncArgs): Promise<boolean | object | null> {
@@ -24,7 +56,7 @@ export async function initialSync(args: InitialSyncArgs): Promise<boolean | obje
 
             return false;
         }
-        await reportFailure(e, args, DEFAULT_TIMEOUT, MAXIMUM_ATTEMPTS);
+        await reportFailure(e, args, SYNC_TIMEOUT, SYNC_MAX_ATTEMPTS);
 
         return false;
     }
@@ -41,7 +73,7 @@ export async function continuousSync(args: ContinuousSyncArgs): Promise<boolean 
 
             return { cancelled: true };
         }
-        await reportFailure(e, args, DEFAULT_TIMEOUT, MAXIMUM_ATTEMPTS);
+        await reportFailure(e, args, SYNC_TIMEOUT, SYNC_MAX_ATTEMPTS);
 
         return false;
     }
@@ -51,7 +83,7 @@ export async function action(args: ActionArgs): Promise<object> {
     try {
         return await runAction(args);
     } catch (e: any) {
-        await reportFailure(e, args, DEFAULT_TIMEOUT, MAXIMUM_ATTEMPTS);
+        await reportFailure(e, args, ACTION_TIMEOUT, ACTION_MAX_ATTEMPTS);
 
         return { success: false };
     }
@@ -61,7 +93,7 @@ export async function webhook(args: WebhookArgs): Promise<boolean> {
     try {
         return await runWebhook(args);
     } catch (e: any) {
-        await reportFailure(e, args, DEFAULT_TIMEOUT, MAXIMUM_ATTEMPTS);
+        await reportFailure(e, args, WEBHOOK_TIMEOUT, WEBHOOK_MAX_ATTEMPTS);
 
         return false;
     }


### PR DESCRIPTION
Set more appropriate timeout for temporal activities Faster timeout for actions and webhooks as well as setting scheduleToStart timeouts

Syncs: 1h enqueued, 24h to execute
Actions: 1m enqueued, 15mins to execute
Webhook: 1h enqueued, 15mins to execute

## Issue ticket number and link
https://linear.app/nango/issue/NAN-388/[outage]-temporal-set-appropriate-timeouts-for-temporal-activities

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
