### PR TITLE
fix(db): add index for logs

### DIFF
--- a/packages/shared/lib/db/migrations/20240222135116_logs-index.cjs
+++ b/packages/shared/lib/db/migrations/20240222135116_logs-index.cjs
@@ -1,0 +1,11 @@
+exports.config = { transaction: false };
+
+exports.up = function (knex) {
+    return knex.schema.raw(
+        'CREATE INDEX CONCURRENTLY "idx_logs_environment_timestamp" ON "nango"."_nango_activity_logs" USING BTREE ("environment_id","timestamp" DESC NULLS LAST)'
+    );
+};
+
+exports.down = function (knex) {
+    return knex.schema.raw('DROP INDEX CONCURRENTLY idx_logs_environment_timestamp');
+};


### PR DESCRIPTION
## Describe your changes

Contributes to NAN-417

We are always ordering with the timestamp so it should make the default query faster. But because we have many filters it will be hard to optimize every queries. (in `getTopLevelLogByEnvironment()`) 
And it can take as much as 30s so it would help a lot.

I do wonder though Why `timestamp` is a `bigint`? It's weird and not optimized for time based filtering 
 
## Before

```sql
EXPLAIN ANALYZE SELECT
	_nango_activity_logs.*
FROM
	nango._nango_activity_logs
WHERE
	environment_id = '3002' 
GROUP BY 
	_nango_activity_logs.id
ORDER BY
	_nango_activity_logs.timestamp DESC
LIMIT 100;
```

```sql
# In prod
Limit  (cost=362484.08..362484.33 rows=100 width=202) (actual time=19250.301..19250.323 rows=100 loops=1)
  ->  Sort  (cost=362484.08..366085.24 rows=1440465 width=202) (actual time=19250.300..19250.310 rows=100 loops=1)
"        Sort Key: ""timestamp"" DESC"
        Sort Method: top-N heapsort  Memory: 78kB
        ->  Group  (cost=0.43..307430.54 rows=1440465 width=202) (actual time=3.366..18017.120 rows=1408794 loops=1)
              Group Key: id
              ->  Index Scan using _nango_activity_logs_pkey on _nango_activity_logs  (cost=0.43..303829.38 rows=1440465 width=202) (actual time=3.359..16944.672 rows=1408794 loops=1)
                    Filter: (environment_id = 3002)
                    Rows Removed by Filter: 3024554
Planning Time: 0.169 ms
Execution Time: 19250.393 ms
```