### PR TITLE
fix: use GET /config/KEY to obtain provider in cli dryrun

### DIFF
--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import type { Metadata, NangoConnection } from '@nangohq/shared';
 import { SyncConfigType, SyncType, syncRunService, cloudHost, stagingHost } from '@nangohq/shared';
 import type { GlobalOptions } from '../types.js';
-import { parseSecretKey, printDebug, hostport, getConnection, getProviderBySyncName } from '../utils.js';
+import { parseSecretKey, printDebug, hostport, getConnection, getConfig } from '../utils.js';
 import configService from './config.service.js';
 import compileService from './compile.service.js';
 import integrationService from './local-integration.service.js';
@@ -98,7 +98,9 @@ class DryRunService {
             printDebug(`Connection found with ${JSON.stringify(nangoConnection, null, 2)}`);
         }
 
-        const provider = await getProviderBySyncName({ syncName }, debug);
+        const {
+            config: { provider }
+        } = await getConfig(providerConfigKey, debug);
         if (!provider) {
             console.log(chalk.red('Provider not found'));
             return;

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -214,20 +214,14 @@ export async function getConnection(providerConfigKey: string, connectionId: str
         });
 }
 
-export async function getProviderBySyncName(params: Record<string, string>, debug = false) {
-    const url = process.env['NANGO_HOSTPORT'] + `/sync/provider`;
+export async function getConfig(providerConfigKey: string, debug = false) {
+    const url = process.env['NANGO_HOSTPORT'] + `/config/${providerConfigKey}`;
     const headers = enrichHeaders();
     if (debug) {
-        printDebug(
-            `getProviderBySyncName endpoint to the URL: ${url} with headers: ${JSON.stringify(headers, null, 2)} with params: ${JSON.stringify(
-                params,
-                null,
-                2
-            )}`
-        );
+        printDebug(`getConfig endpoint to the URL: ${url} with headers: ${JSON.stringify(headers, null, 2)}`);
     }
     return await axios
-        .get(url, { params, headers, httpsAgent: httpsAgent() })
+        .get(url, { headers, httpsAgent: httpsAgent() })
         .then((res) => {
             return res.data;
         })


### PR DESCRIPTION
We cannot use the /sync/provider endpoint in CLI dryrun because the sync might have not be deployed yet and therefore doesn't exist.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
