### PR TITLE
fix(db): add index to configs

### DIFF
--- a/packages/shared/lib/db/migrations/20240222182357_configs-index.cjs
+++ b/packages/shared/lib/db/migrations/20240222182357_configs-index.cjs
@@ -1,0 +1,11 @@
+exports.config = { transaction: false };
+
+exports.up = function (knex) {
+    return knex.schema.raw(
+        'CREATE INDEX "idx_configs_environmentid_uniquekey_deleted" ON "nango"."_nango_configs" USING BTREE ("environment_id","unique_key") WHERE deleted = false'
+    );
+};
+
+exports.down = function (knex) {
+    return knex.schema.raw('DROP INDEX CONCURRENTLY idx_configs_environmentid_uniquekey_deleted');
+};


### PR DESCRIPTION
## Describe your changes

Every queries touching `_nango_configs` is using `where({ environment_id, deleted: false })`.
Current query plan filter out but we can improve this by using a partial index. None of them are slow but those are the most executed queries --after the logs.
Locally, from **0.1ms** to **0.04** (60% faster); in prod we can expect from 7ms to 3ms, it's a few minutes of CPU over a day because of the volume.

<img width="660" alt="Screenshot 2024-02-22 at 19 28 15" src="https://github.com/NangoHQ/nango/assets/1637651/40f39953-720f-46d1-b74f-01b252316e7d">
 
## SQL
```sql
EXPLAIN ANALYZE SELECT
	*
FROM
	nango._nango_configs
WHERE
	unique_key = 'test'
	AND environment_id = 1
	AND deleted = false;
```

## Before
```sql
Index Scan using _nango_configs_unique_key_environment_id_deleted_at_unique on _nango_configs  (cost=0.14..8.16 rows=1 width=3225) (actual time=0.030..0.031 rows=0 loops=1)
"  Index Cond: (((unique_key)::text = 'test'::text) AND (environment_id = 1))"
  Filter: (NOT deleted)
Planning Time: 0.144 ms
Execution Time: 0.106 ms
```

## After
```sql
Index Scan using idx_configs_environmentid_uniquekey_deleted on _nango_configs  (cost=0.13..8.15 rows=1 width=3225) (actual time=0.017..0.017 rows=0 loops=1)
"  Index Cond: ((environment_id = 1) AND ((unique_key)::text = 'test'::text))"
Planning Time: 0.135 ms
Execution Time: 0.042 ms
```