### PR TITLE
fix(db): add index for getAddedKeys()

### DIFF
--- a/packages/shared/lib/db/migrations/20240223150547_data_records-index.cjs
+++ b/packages/shared/lib/db/migrations/20240223150547_data_records-index.cjs
@@ -1,0 +1,14 @@
+exports.config = { transaction: false };
+
+exports.up = async function (knex) {
+    // Drop test index that was indeed not useful enough
+    await knex.schema.raw('DROP INDEX CONCURRENTLY idx_records_created_id_connection_model');
+
+    await knex.schema.raw(
+        'CREATE INDEX CONCURRENTLY "idx_records_connection_model_externalid" ON "nango"."_nango_sync_data_records" USING BTREE ("nango_connection_id","model","external_id")'
+    );
+};
+
+exports.down = async function (knex) {
+    await knex.schema.raw('DROP INDEX CONCURRENTLY idx_records_connection_model_externalid');
+};


### PR DESCRIPTION
## Describe your changes

Fixes NAN-416

- The index created in #1719 was a just a test, it did work but it is not used enough to be worth the slowness it can create on write
- Create an index for `getAddedKeys()`.
This index allows the method to do an index only scan, meaning PG can reply without ever loading the table in memory.
Since it's called on `upsert()` it should make persist a bit faster.
Note that it's the same index as the unique key but for some reason it does not use it, maybe it's not stored the same way.
From **0.9ms** to **0.092 ms** (10x faster)

## SQL
```sql
EXPLAIN ANALYZE SELECT
	"external_id"
FROM
	"nango"."_nango_sync_data_records"
WHERE
	"nango_connection_id" = 2
	AND "model" = 'GithubIssue'
	AND "external_id" in('470723537', '385642199', '427035762');
```

## Before
```sql
Index Scan using idx_nango_records_composite on _nango_sync_data_records  (cost=0.14..8.16 rows=1 width=516) (actual time=0.751..0.755 rows=3 loops=1)
"  Index Cond: ((nango_connection_id = 2) AND ((model)::text = 'GithubIssue'::text))"
"  Filter: ((external_id)::text = ANY ('{470723537,385642199,427035762}'::text[]))"
  Rows Removed by Filter: 7
Planning Time: 0.230 ms
Execution Time: 0.934 ms
```

## Before
```sql

Index Only Scan using idx_records_connection_model_externalid on _nango_sync_data_records  (cost=0.14..8.16 rows=1 width=516) (actual time=0.065..0.069 rows=3 loops=1)
"  Index Cond: ((nango_connection_id = 2) AND (model = 'GithubIssue'::text))"
"  Filter: ((external_id)::text = ANY ('{470723537,385642199,427035762}'::text[]))"
  Rows Removed by Filter: 7
  Heap Fetches: 10
Planning Time: 0.205 ms
Execution Time: 0.092 ms
```