### PR TITLE
fix(db): add index for connections

### DIFF
--- a/packages/shared/lib/db/migrations/20240223162238_connections-index.cjs
+++ b/packages/shared/lib/db/migrations/20240223162238_connections-index.cjs
@@ -2,15 +2,10 @@ exports.config = { transaction: false };
 
 exports.up = async function (knex) {
     await knex.schema.raw(
-        'CREATE INDEX CONCURRENTLY "idx_connections_connectionid_envid_provider_where_deleted" ON "nango"."_nango_connections" USING BTREE ("connection_id","environment_id","provider_config_key") WHERE deleted=false'
-    );
-
-    await knex.schema.raw(
-        'CREATE INDEX CONCURRENTLY "idx_connections_envid_where_deleted" ON "nango"."_nango_connections" USING BTREE ("environment_id") WHERE deleted=false'
+        'CREATE INDEX "idx_connections_envid_connectionid_provider_where_deleted" ON "nango"."_nango_connections" USING BTREE ("environment_id","connection_id","provider_config_key") WHERE deleted=false'
     );
 };
 
 exports.down = async function (knex) {
-    await knex.schema.raw('DROP INDEX CONCURRENTLY idx_connections_connectionid_envid_provider_where_deleted');
-    await knex.schema.raw('DROP INDEX CONCURRENTLY idx_connections_envid_where_deleted');
+    await knex.schema.raw('DROP INDEX CONCURRENTLY idx_connections_envid_connectionid_provider_where_deleted');
 };

--- a/packages/shared/lib/db/migrations/20240223162238_connections-index.cjs
+++ b/packages/shared/lib/db/migrations/20240223162238_connections-index.cjs
@@ -1,0 +1,16 @@
+exports.config = { transaction: false };
+
+exports.up = async function (knex) {
+    await knex.schema.raw(
+        'CREATE INDEX CONCURRENTLY "idx_connections_connectionid_envid_provider_where_deleted" ON "nango"."_nango_connections" USING BTREE ("connection_id","environment_id","provider_config_key") WHERE deleted=false'
+    );
+
+    await knex.schema.raw(
+        'CREATE INDEX CONCURRENTLY "idx_connections_envid_where_deleted" ON "nango"."_nango_connections" USING BTREE ("environment_id") WHERE deleted=false'
+    );
+};
+
+exports.down = async function (knex) {
+    await knex.schema.raw('DROP INDEX CONCURRENTLY idx_connections_connectionid_envid_provider_where_deleted');
+    await knex.schema.raw('DROP INDEX CONCURRENTLY idx_connections_envid_where_deleted');
+};


### PR DESCRIPTION
## Context 

Almost all queries on `connection.service.ts` are using:
- `{ environment_id, deleted: false }`
OR
- `{ connection_id: connection.connection_id, provider_config_key: providerConfigKey, environment_id, deleted: false}`
OR
- `{ id, deleted: false }` (not relevant here)

The first one, even tho is the simplest, is also the slowest. 

## Describe your changes

Fixes NAN-434


- Add one index to fasten `listConnections()` and an other to fix almost all others queries.
I don't have enough connections locally to provide before and after, but I'm hopeful on 10x faster

## Before

```sql
# listConnections() not good
Bitmap Heap Scan on _nango_connections  (cost=19.06..1341.77 rows=816 width=885) (actual time=0.449..2.843 rows=668 loops=1)
  Recheck Cond: (environment_id = 835)
  Filter: (NOT deleted)
  Rows Removed by Filter: 781
  Heap Blocks: exact=1167
  ->  Bitmap Index Scan on _nango_connections_environment_id_index  (cost=0.00..18.86 rows=1449 width=0) (actual time=0.274..0.275 rows=1450 loops=1)
        Index Cond: (environment_id = 835)
Planning Time: 0.083 ms
Execution Time: 2.900 ms  
```


```sql
# everything else
Index Scan using _nango_connections_provider_config_key_connection_id_environmen on _nango_connections  (cost=0.41..2.64 rows=1 width=885) (actual time=0.077..0.078 rows=0 loops=1)
"  Index Cond: (((provider_config_key)::text = 'github'::text) AND ((connection_id)::text = 'connection-id'::text) AND (environment_id = 2))"
  Filter: (NOT deleted)
Planning Time: 1.001 ms
Execution Time: 0.102 ms
```