### PR TITLE
fix(server): handle undefined status code

### DIFF
--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -624,7 +624,7 @@ class SyncController {
             );
 
             if (isErr(result)) {
-                errorManager.errResFromNangoErr(res, result.err as NangoError);
+                errorManager.handleGenericError(result.err, req, res, tracer);
                 return;
             }
 

--- a/packages/shared/lib/utils/error.manager.ts
+++ b/packages/shared/lib/utils/error.manager.ts
@@ -126,9 +126,9 @@ class ErrorManager {
         if (err) {
             logger.error(`Response error: ${JSON.stringify({ statusCode: err.status, type: err.type, payload: err.payload, message: err.message })}`);
             if (!err.message) {
-                res.status(err.status).send({ type: err.type, payload: err.payload });
+                res.status(err.status || 500).send({ type: err.type, payload: err.payload });
             } else {
-                res.status(err.status).send({ error: err.message, type: err.type, payload: err.payload });
+                res.status(err.status || 500).send({ error: err.message, type: err.type, payload: err.payload });
             }
         }
     }


### PR DESCRIPTION
## Describe your changes

The function is not returning a NangoError but it was masked with the type casting.
The actual error that lead to this is yet to be fixed.

- Use generic error handling
- always put a default status just in case (it's the only place where we fully trusted the payload)
