### PR TITLE
fix(node): expose all types

### DIFF
--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -24,6 +24,8 @@ import { validateProxyConfiguration, validateSyncRecordConfiguration } from './u
 export const stagingHost = 'https://api-staging.nango.dev';
 export const prodHost = 'https://api.nango.dev';
 
+export * from './types.js';
+
 interface NangoProps {
     host?: string;
     secretKey: string;

--- a/packages/node-client/lib/types.ts
+++ b/packages/node-client/lib/types.ts
@@ -54,8 +54,8 @@ export interface ProxyConfiguration {
     retryOn?: number[] | null;
 }
 
-type FilterAction = 'added' | 'updated' | 'deleted' | 'ADDED' | 'UPDATED' | 'DELETED';
-type CombinedFilterAction = `${FilterAction},${FilterAction}`;
+export type FilterAction = 'added' | 'updated' | 'deleted' | 'ADDED' | 'UPDATED' | 'DELETED';
+export type CombinedFilterAction = `${FilterAction},${FilterAction}`;
 
 export interface GetRecordsRequestConfig {
     providerConfigKey: string;
@@ -127,7 +127,7 @@ export interface IntegrationWithCreds extends Integration {
     webhook_url?: string;
 }
 
-interface Timestamps {
+export interface Timestamps {
     created_at: string;
     updated_at: string;
 }
@@ -148,7 +148,7 @@ export interface Action extends Timestamps {
     name: string;
 }
 
-type SyncType = 'INCREMENTAL' | 'INITIAL';
+export type SyncType = 'INCREMENTAL' | 'INITIAL';
 
 export interface Integration {
     unique_key: string;


### PR DESCRIPTION
## Describe your changes

Fixes NAN-446

Node client was not exporting the types, making some comparison with enums impossible, and other stuff a bit annoying (pre-creating objects, reusing types in functions, etc...)

- Export all used types