### PR TITLE
fix(cli): compiler should skip project

### DIFF
--- a/packages/cli/lib/cli.ts
+++ b/packages/cli/lib/cli.ts
@@ -324,11 +324,11 @@ export const tscWatch = async (debug = false) => {
         compileFile(filePath);
     });
 
+    const compiler = tsNode.create({
+        skipProject: true, // when installed locally we don't want ts-node to pick up the package tsconfig.json file
+        compilerOptions: JSON.parse(tsconfig).compilerOptions
+    });
     function compileFile(filePath: string) {
-        const compiler = tsNode.create({
-            compilerOptions: JSON.parse(tsconfig).compilerOptions
-        });
-
         try {
             const providerConfiguration = config?.find((config) =>
                 [...config.syncs, ...config.actions].find((sync) => sync.name === path.basename(filePath, '.ts'))


### PR DESCRIPTION
## Describe your changes

Fixes NAN-449

We were not ignoring ambient tsconfig when doing `nango dev` like we do on `nango deploy dev` 

- Skip project to avoid loading any `tsconfig.json`
- Do not redeclare a compiler each time we compile a file