### PR TITLE
sdk proxy: memoize connection to avoid request on every proxy call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9510,7 +9510,8 @@
         },
         "node_modules/api": {
             "version": "6.1.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/api/-/api-6.1.1.tgz",
+            "integrity": "sha512-we3fnLinpYWlKOHdX4S/Ky9gZvColCnht/qhtv04K2jQbrC/z4SxvZVAT8W8PCC5NLLU4H35r3u4Lt77ZaiY9w==",
             "dependencies": {
                 "@readme/oas-to-har": "^20.0.2",
                 "@readme/openapi-parser": "^2.4.0",
@@ -27384,6 +27385,7 @@
                 "@trpc/client": "^10.44.1",
                 "@trpc/server": "^10.44.1",
                 "@types/fs-extra": "^11.0.1",
+                "api": "^6.1.1",
                 "dd-trace": "5.2.0",
                 "dotenv": "^16.0.3",
                 "fs-extra": "^11.1.1",

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -27,6 +27,7 @@
         "@trpc/client": "^10.44.1",
         "@trpc/server": "^10.44.1",
         "@types/fs-extra": "^11.0.1",
+        "api": "^6.1.1",
         "dd-trace": "5.2.0",
         "dotenv": "^16.0.3",
         "fs-extra": "^11.1.1",

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -226,6 +226,8 @@ interface EnvironmentVariable {
     value: string;
 }
 
+const MEMOIZED_CONNECTION_TTL = 60000;
+
 export class NangoAction {
     private nango: Nango;
     private attributes = {};
@@ -418,7 +420,7 @@ export class NangoAction {
 
     public async getConnection(): Promise<Connection> {
         this.exitSyncIfAborted();
-        if (!this.memoizedConnection || Date.now() - this.memoizedConnection.timestamp > 60000) {
+        if (!this.memoizedConnection || Date.now() - this.memoizedConnection.timestamp > MEMOIZED_CONNECTION_TTL) {
             const connection = await this.nango.getConnection(this.providerConfigKey as string, this.connectionId as string);
             this.memoizedConnection = { connection, timestamp: Date.now() };
             return connection;

--- a/packages/shared/lib/sdk/sync.unit.test.ts
+++ b/packages/shared/lib/sdk/sync.unit.test.ts
@@ -6,10 +6,43 @@ import configService from '../services/config.service.js';
 import type { CursorPagination, LinkPagination, OffsetPagination } from '../models/Proxy.js';
 import { NangoAction } from './sync.js';
 import { isValidHttpUrl } from '../utils/utils.js';
+import proxyService from '../services/proxy.service.js';
+import type { AxiosResponse } from 'axios';
 
 vi.mock('@nangohq/node', () => {
     const Nango = vi.fn();
     return { Nango };
+});
+
+describe('Proxy', () => {
+    let nangoAction: NangoAction;
+    let nango: Nango;
+    beforeEach(async () => {
+        nangoAction = new NangoAction({
+            secretKey: '***',
+            providerConfigKey: 'github',
+            connectionId: 'connection-1'
+        });
+        nango = new Nango({ secretKey: '***' });
+        (await import('@nangohq/node')).Nango.prototype.getConnection = vi.fn().mockReturnValue({ credentials: {} });
+        vi.spyOn(proxyService, 'route').mockImplementation(() => Promise.resolve({ response: {} as AxiosResponse, activityLogs: [] }));
+    });
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('memoizes connection', async () => {
+        await nangoAction.proxy({ endpoint: '/issues' });
+        await nangoAction.proxy({ endpoint: '/issues' });
+        expect(nango.getConnection).toHaveBeenCalledTimes(1);
+    });
+    it('get connection if memoized connection is too old', async () => {
+        await nangoAction.proxy({ endpoint: '/issues' });
+        const later = Date.now() + 61000;
+        vi.spyOn(Date, 'now').mockReturnValue(later);
+        await nangoAction.proxy({ endpoint: '/issues' });
+        expect(nango.getConnection).toHaveBeenCalledTimes(2);
+    });
 });
 
 describe('Pagination', () => {


### PR DESCRIPTION
## Describe your changes
Right now each call to `nango.proxy` in scripts makes a request to the api to fetch the connection.
This change caches the connection for 1 minute to avoid all those unnecessary api requests.

The `shouldRefreshCredentials` logic used in connection service is quite complex and requires accessing the database so we are not using it in the sdk but only cache the connection for one minute (happy to discuss this arbitrary value), which is good enough to avoid calling /connection/... on every proxy call without running into expired credentials

https://linear.app/nango/issue/NAN-411/reduce-the-number-of-calls-made-to-connection-when-proxying-from

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
