### PR TITLE
Tbonnin/package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27425,7 +27425,7 @@
             "version": "1.0.0",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@nangohq/shared": "^0.38.0",
+                "@nangohq/shared": "^0.38.5",
                 "dd-trace": "5.2.0",
                 "express": "^4.18.2",
                 "zod": "^3.22.4",
@@ -27552,7 +27552,7 @@
                 "@aws-sdk/client-s3": "^3.348.0",
                 "@datadog/datadog-api-client": "^1.16.0",
                 "@hapi/boom": "^10.0.1",
-                "@nangohq/node": "^0.37.26",
+                "@nangohq/node": "^0.38.5",
                 "@sentry/node": "^7.37.2",
                 "@temporalio/client": "^1.9.1",
                 "amqplib": "^0.10.3",
@@ -27603,17 +27603,6 @@
             "engines": {
                 "node": ">=16.7",
                 "npm": ">=6.14.11"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/node": {
-            "version": "0.37.26",
-            "resolved": "https://registry.npmjs.org/@nangohq/node/-/node-0.37.26.tgz",
-            "integrity": "sha512-tdSk6N3Im6jJWnDXqixQnDKo9IvujHksnXTB+LkD9ulPw9Iopy6NzxR4RjKDmdKP9vl/JP1ObZJ8rcoQCU3vQg==",
-            "dependencies": {
-                "axios": "^1.2.0"
-            },
-            "engines": {
-                "node": ">=16.7"
             }
         },
         "packages/shared/node_modules/@types/uuid": {

--- a/packages/persist/package.json
+++ b/packages/persist/package.json
@@ -18,7 +18,7 @@
     },
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
-        "@nangohq/shared": "^0.38.0",
+        "@nangohq/shared": "^0.38.5",
         "dd-trace": "5.2.0",
         "express": "^4.18.2",
         "zod": "^3.22.4",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,7 +20,7 @@
         "@aws-sdk/client-s3": "^3.348.0",
         "@datadog/datadog-api-client": "^1.16.0",
         "@hapi/boom": "^10.0.1",
-        "@nangohq/node": "^0.37.26",
+        "@nangohq/node": "^0.38.5",
         "@sentry/node": "^7.37.2",
         "@temporalio/client": "^1.9.1",
         "amqplib": "^0.10.3",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -29,12 +29,16 @@ npm install
 
 # Node client
 bump_and_npm_publish "@nangohq/node" "$VERSION"
-npm install "@nangohq/node@$VERSION" -w @nangohq/shared
+pushd "./packages/shared"; npm install "@nangohq/node@$VERSION"; popd;
 
 # Shared
 node scripts/flows.js
 bump_and_npm_publish "@nangohq/shared" "$VERSION"
-npm install "@nangohq/shared@$VERSION" -w nango -w @nangohq/nango-server -w @nangohq/nango-jobs -w @nangohq/nango-runner -w @nangohq/persist
+# Update all packages to use the new shared version
+package_dirs=("cli" "server" "runner" "jobs" "persist")
+for dir in "${package_dirs[@]}"; do
+  pushd "./packages/$dir"; npm install "@nangohq/shared@$VERSION"; popd;
+done
 
 # CLI
 bump_and_npm_publish "nango" "$VERSION"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,6 +2,7 @@
 
 # exit when any command fails
 set -e
+set -x
 
 # function to bump and publish a package
 # $1: package name
@@ -46,3 +47,6 @@ bump_and_npm_publish "nango" "$VERSION"
 # Frontend
 bump_and_npm_publish "@nangohq/frontend" "$VERSION"
 pushd ./packages/webapp; npm install "@nangohq/frontend@$VERSION"; popd
+
+# DEBUG: show changes in CI
+git diff


### PR DESCRIPTION
## Describe your changes

We ran several times into a situation where `shared` version was not
upgraded properly when publishing a new version.
I (Thomas) suspect the -w option might be buggy and causes some of the
packages not to upgrade the shared version properly.
This commit gets rid of the -w option in favor of navigating into the
package folder and running npm install there directly.
I am not sure this would fix our problem but it is worth trying imho