### PR TITLE
[NAN-478] update runner logic to allow to connect to a remote instance

### DIFF
--- a/packages/jobs/lib/runner/remote.runner.ts
+++ b/packages/jobs/lib/runner/remote.runner.ts
@@ -1,0 +1,30 @@
+import type { Runner } from './runner.js';
+import { RunnerType } from './runner.js';
+import { getRunnerClient } from '@nangohq/nango-runner';
+
+export class RemoteRunner implements Runner {
+    public client: any;
+    public runnerType: RunnerType = RunnerType.Remote;
+    constructor(
+        public readonly id: string,
+        public readonly url: string
+    ) {
+        this.client = getRunnerClient(this.url);
+    }
+
+    async suspend(): Promise<void> {
+        console.warn('cannot suspend a remote runner');
+    }
+
+    toJSON() {
+        return { runnerType: this.runnerType, id: this.id, url: this.url };
+    }
+
+    static fromJSON(obj: any): RemoteRunner {
+        throw new Error(`'fromJSON(${obj})' not implemented`);
+    }
+
+    static async getOrStart(runnerId: string): Promise<RemoteRunner> {
+        return new RemoteRunner(runnerId, process.env['RUNNER_SERVICE_URL'] || 'http://nango-runner');
+    }
+}

--- a/packages/shared/lib/services/file/remote.service.ts
+++ b/packages/shared/lib/services/file/remote.service.ts
@@ -13,8 +13,8 @@ import localFileService from './local.service.js';
 let client: S3Client | null = null;
 let useS3 = !isLocal();
 
-if (isEnterprise() && !(process.env['AWS_PUBLIC_ACCESS_KEY_ID'] && process.env['AWS_PUBLIC_SECRET_ACCESS'])) {
-    useS3 = false;
+if (isEnterprise()) {
+    useS3 = Boolean(process.env['AWS_REGION'] && process.env['AWS_BUCKET_NAME']);
     client = new S3Client({
         region: (process.env['AWS_REGION'] as string) || 'us-west-2'
     });


### PR DESCRIPTION
## Describe your changes
* Add a remote instance runner so jobs doesn't need to spawn a process. In some cases I saw that a sync failed because spawning a process took too long. For enterprise customers they can setup a runner instance and so in that case jobs will connect to that remote instance instead. Customers can set this using the `RUNNER_SERVICE_URL` env variable
* Best practice is to use an AWS role for connecting to a bucket so this update allows customers to configure bucket connection using the role as long as they have `AWS_REGION` and `AWS_BUCKET_NAME` set

## Issue ticket number and link
NAN-478

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
