### PR TITLE
fix(db): missing index on records

### DIFF
--- a/packages/jobs/lib/crons/deleteSyncsData.ts
+++ b/packages/jobs/lib/crons/deleteSyncsData.ts
@@ -5,7 +5,7 @@ import tracer from '../tracer.js';
 const limitJobs = 100;
 const limitSchedules = 100;
 const limitSyncs = 100;
-const limitRecords = 5000;
+const limitRecords = 1000;
 
 export async function deleteSyncsData(): Promise<void> {
     /**

--- a/packages/jobs/lib/crons/deleteSyncsData.ts
+++ b/packages/jobs/lib/crons/deleteSyncsData.ts
@@ -4,7 +4,7 @@ import tracer from '../tracer.js';
 
 const limitJobs = 100;
 const limitSchedules = 100;
-const limitSyncs = 100;
+const limitSyncs = 10;
 const limitRecords = 1000;
 
 export async function deleteSyncsData(): Promise<void> {

--- a/packages/shared/lib/db/migrations/20240229220040_records_id-index.cjs
+++ b/packages/shared/lib/db/migrations/20240229220040_records_id-index.cjs
@@ -1,9 +1,9 @@
 exports.config = { transaction: false };
 
-exports.up = function(knex) {
-  await knex.schema.raw('CREATE UNIQUE INDEX CONCURRENTLY "idx_records_id_pkey" ON "nango"."_nango_sync_data_records" USING BTREE ("id")');
+exports.up = async function (knex) {
+    await knex.schema.raw('CREATE UNIQUE INDEX CONCURRENTLY "idx_records_id_pkey" ON "_nango_sync_data_records" USING BTREE ("id")');
 };
 
-exports.down = function(knex) {
-  await knex.schema.raw('DROP INDEX CONCURRENTLY idx_records_id_pkey');
+exports.down = async function (knex) {
+    await knex.schema.raw('DROP INDEX CONCURRENTLY idx_records_id_pkey');
 };

--- a/packages/shared/lib/db/migrations/20240229220040_records_id-index.cjs
+++ b/packages/shared/lib/db/migrations/20240229220040_records_id-index.cjs
@@ -1,0 +1,9 @@
+exports.config = { transaction: false };
+
+exports.up = function(knex) {
+  await knex.schema.raw('CREATE UNIQUE INDEX CONCURRENTLY "idx_records_id_pkey" ON "nango"."_nango_sync_data_records" USING BTREE ("id")');
+};
+
+exports.down = function(knex) {
+  await knex.schema.raw('DROP INDEX CONCURRENTLY idx_records_id_pkey');
+};


### PR DESCRIPTION
## Describe your changes

With the introduction of async delete in #1745 I noticed that the queries were taking a long time (+60sec), way too much for a select by id. Turns out we don't have an index on the primary key. 
(This could also help GET /records but not sure)

- Add unique index on pkey
- Still reduce the amount of deletion per loop because it could still take +10seconds 