### PR TITLE
[NAN-461] records pagination default ordering should be based on

### DIFF
--- a/packages/shared/lib/services/sync/data/records.service.ts
+++ b/packages/shared/lib/services/sync/data/records.service.ts
@@ -344,7 +344,7 @@ export async function getAllDataRecords(
                 model
             })
             .orderBy([
-                { column: 'created_at', order: 'asc' },
+                { column: 'updated_at', order: 'asc' },
                 { column: 'id', order: 'asc' }
             ]);
 
@@ -360,8 +360,8 @@ export async function getAllDataRecords(
 
             query = query.where((builder) =>
                 builder
-                    .where('created_at', '>', cursorSort)
-                    .orWhere((builder) => builder.where('created_at' as string, '=', cursorSort).andWhere('id', '>', cursorId))
+                    .where('updated_at', '>', cursorSort)
+                    .orWhere((builder) => builder.where('updated_at' as string, '=', cursorSort).andWhere('id', '>', cursorId))
             );
         }
 

--- a/packages/shared/lib/services/sync/data/records.service.ts
+++ b/packages/shared/lib/services/sync/data/records.service.ts
@@ -359,9 +359,7 @@ export async function getAllDataRecords(
             }
 
             query = query.where((builder) =>
-                builder
-                    .where('updated_at', '>', cursorSort)
-                    .orWhere((builder) => builder.where('updated_at' as string, '=', cursorSort).andWhere('id', '>', cursorId))
+                builder.where('updated_at', '>', cursorSort).orWhere((builder) => builder.where('updated_at', '=', cursorSort).andWhere('id', '>', cursorId))
             );
         }
 


### PR DESCRIPTION
## Describe your changes
Records pagination should be based on `updated_at` instead of `created_at`

## Issue ticket number and link
NAN-461

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
