### PR TITLE
[NAN-461] records pagination default ordering should be based on

### DIFF
--- a/packages/shared/lib/db/migrations/20240301111115_records_updated_at_composite.cjs
+++ b/packages/shared/lib/db/migrations/20240301111115_records_updated_at_composite.cjs
@@ -1,4 +1,3 @@
-const tableName = '_nango_sync_data_records';
 
 exports.config = { transaction: false };
 

--- a/packages/shared/lib/services/sync/data/records.service.ts
+++ b/packages/shared/lib/services/sync/data/records.service.ts
@@ -456,7 +456,7 @@ export async function getAllDataRecords(
             const cursorRawElement = rawResult[rawResult.length - 1] as SyncDataRecord;
             const cursorElement = customerResult[customerResult.length - 1] as unknown as CustomerFacingDataRecord;
 
-            nextCursor = cursorElement['_nango_metadata']['first_seen_at'] as unknown as string;
+            nextCursor = cursorElement['_nango_metadata']['last_modified_at'] as unknown as string;
             const encodedCursorValue = Buffer.from(`${nextCursor}||${cursorRawElement.id}`).toString('base64');
 
             return { success: true, error: null, response: { records: customerResult as CustomerFacingDataRecord[], next_cursor: encodedCursorValue } };

--- a/packages/shared/lib/services/sync/data/records.service.ts
+++ b/packages/shared/lib/services/sync/data/records.service.ts
@@ -344,7 +344,7 @@ export async function getAllDataRecords(
                 model
             })
             .orderBy([
-                { column: 'created_at', order: 'asc' },
+                { column: 'updated_at', order: 'asc' },
                 { column: 'id', order: 'asc' }
             ]);
 
@@ -360,8 +360,8 @@ export async function getAllDataRecords(
 
             query = query.where((builder) =>
                 builder
-                    .where('created_at', '>', cursorSort)
-                    .orWhere((builder) => builder.where('created_at' as string, '=', cursorSort).andWhere('id', '>', cursorId))
+                    .where('updated_at', '>', cursorSort)
+                    .orWhere((builder) => builder.where('updated_at' as string, '=', cursorSort).andWhere('id', '>', cursorId))
             );
         }
 

--- a/packages/shared/lib/services/sync/data/records.service.ts
+++ b/packages/shared/lib/services/sync/data/records.service.ts
@@ -359,9 +359,7 @@ export async function getAllDataRecords(
             }
 
             query = query.where((builder) =>
-                builder
-                    .where('updated_at', '>', cursorSort)
-                    .orWhere((builder) => builder.where('updated_at' as string, '=', cursorSort).andWhere('id', '>', cursorId))
+                builder.where('updated_at', '>', cursorSort).orWhere((builder) => builder.where('updated_at', '=', cursorSort).andWhere('id', '>', cursorId))
             );
         }
 


### PR DESCRIPTION
## Describe your changes
Records pagination should be based on `updated_at` instead of `created_at`

## Issue ticket number and link
NAN-461

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 


Note: see https://github.com/NangoHQ/nango/pull/1792 to test all the pagination updates in aggregate