### PR TITLE
Fix/cron delete syncs perf

### DIFF
--- a/packages/jobs/lib/crons/deleteSyncsData.ts
+++ b/packages/jobs/lib/crons/deleteSyncsData.ts
@@ -1,8 +1,8 @@
 import * as cron from 'node-cron';
-import { errorManager, ErrorSourceEnum, logger, MetricTypes, softDeleteJobs, softDeleteSchedules, telemetry, syncDataService, db } from '@nangohq/shared';
+import { errorManager, ErrorSourceEnum, logger, MetricTypes, softDeleteSchedules, telemetry, syncDataService, db } from '@nangohq/shared';
 import tracer from '../tracer.js';
 
-const limitJobs = 5;
+// const limitJobs = 100;
 const limitSchedules = 100;
 const limitSyncs = 10;
 const limitRecords = 1000;
@@ -10,7 +10,7 @@ const limitRecords = 1000;
 export async function deleteSyncsData(): Promise<void> {
     /**
      * Clean data from soft deleted syncs.
-     * This cron is to be remove at some point, we need a queue to delete specific provider/connection/sync
+     * This cron needs to be removed at some point, we need a queue to delete specific provider/connection/sync
      */
     cron.schedule('*/20 * * * *', async () => {
         const start = Date.now();
@@ -39,12 +39,14 @@ export async function exec(): Promise<void> {
         }
 
         // -----
+        // It simply is not possible right now, table is too big
+
         // Soft delete jobs
-        let countJobs = 0;
-        do {
-            countJobs = await softDeleteJobs(limitJobs);
-            logger.info(`[deleteSyncs] soft deleted ${countJobs} jobs`);
-        } while (countJobs >= limitJobs);
+        // let countJobs = 0;
+        // do {
+        //     countJobs = await softDeleteJobs(limitJobs);
+        //     logger.info(`[deleteSyncs] soft deleted ${countJobs} jobs`);
+        // } while (countJobs >= limitJobs);
 
         // -----
         // Soft delete schedules

--- a/packages/jobs/lib/crons/deleteSyncsData.ts
+++ b/packages/jobs/lib/crons/deleteSyncsData.ts
@@ -1,8 +1,8 @@
 import * as cron from 'node-cron';
-import { errorManager, ErrorSourceEnum, logger, MetricTypes, softDeleteJobs, softDeleteSchedules, telemetry, syncDataService } from '@nangohq/shared';
+import { errorManager, ErrorSourceEnum, logger, MetricTypes, softDeleteJobs, softDeleteSchedules, telemetry, syncDataService, db } from '@nangohq/shared';
 import tracer from '../tracer.js';
 
-const limitJobs = 100;
+const limitJobs = 5;
 const limitSchedules = 100;
 const limitSyncs = 10;
 const limitRecords = 1000;
@@ -10,6 +10,7 @@ const limitRecords = 1000;
 export async function deleteSyncsData(): Promise<void> {
     /**
      * Clean data from soft deleted syncs.
+     * This cron is to be remove at some point, we need a queue to delete specific provider/connection/sync
      */
     cron.schedule('*/20 * * * *', async () => {
         const start = Date.now();
@@ -21,35 +22,47 @@ export async function deleteSyncsData(): Promise<void> {
         }
         telemetry.duration(MetricTypes.JOBS_DELETE_SYNCS_DATA, Date.now() - start);
     });
+
+    Promise.all([exec(), exec()]);
 }
 
 export async function exec(): Promise<void> {
     logger.info('[deleteSyncs] starting');
 
-    // -----
-    // Soft delete jobs
-    let countJobs = 0;
-    do {
-        countJobs = await softDeleteJobs(limitJobs);
-        logger.info(`[deleteSyncs] soft deleted ${countJobs} jobs`);
-    } while (countJobs >= limitJobs);
+    await db.knex.transaction(async (trx) => {
+        // Because it's slow and create deadlocks
+        // we need to acquire a Lock that prevents any other duplicate cron to execute the same thing
+        const { rows } = await trx.raw(`SELECT pg_try_advisory_xact_lock(?);`, [123456789]);
+        if (!rows || rows.lengt <= 0 || rows[0].pg_try_advisory_xact_lock === false) {
+            logger.info(`[deleteSyncs] could not acquire lock, skipping`);
+            return;
+        }
 
-    // -----
-    // Soft delete schedules
-    let countSchedules = 0;
-    do {
-        countSchedules = await softDeleteSchedules(limitSchedules);
-        logger.info(`[deleteSyncs] soft deleted ${countSchedules} schedules`);
-    } while (countSchedules >= limitSchedules);
+        // -----
+        // Soft delete jobs
+        let countJobs = 0;
+        do {
+            countJobs = await softDeleteJobs(limitJobs);
+            logger.info(`[deleteSyncs] soft deleted ${countJobs} jobs`);
+        } while (countJobs >= limitJobs);
 
-    // ----
-    // hard delete records
-    const syncs = await syncDataService.findSyncsWithDeletableRecords(limitSyncs);
-    logger.info(`[deleteSyncs] found ${syncs.length} syncs for records`);
-    for (const sync of syncs) {
-        logger.info(`[oldActivity] deleting syncId: ${sync.id}`);
-        await syncDataService.deleteRecordsBySyncId(sync.id!, limitRecords);
-    }
+        // -----
+        // Soft delete schedules
+        let countSchedules = 0;
+        do {
+            countSchedules = await softDeleteSchedules(limitSchedules);
+            logger.info(`[deleteSyncs] soft deleted ${countSchedules} schedules`);
+        } while (countSchedules >= limitSchedules);
+
+        // ----
+        // hard delete records
+        const syncs = await syncDataService.findSyncsWithDeletableRecords(limitSyncs);
+        logger.info(`[deleteSyncs] found ${syncs.length} syncs for records`);
+        for (const sync of syncs) {
+            logger.info(`[deleteSyncs] deleting syncId: ${sync.id}`);
+            await syncDataService.deleteRecordsBySyncId(sync.id!, limitRecords);
+        }
+    });
 
     logger.info('[deleteSyncs] ✅ done');
 }

--- a/packages/shared/lib/clients/sync.client.ts
+++ b/packages/shared/lib/clients/sync.client.ts
@@ -414,7 +414,7 @@ class SyncClient {
                         await this.cancelSync(syncId);
 
                         await clearLastSyncDate(syncId);
-                        await deleteRecordsBySyncId(syncId);
+                        await deleteRecordsBySyncId({ syncId });
                         await createActivityLogMessage({
                             level: 'info',
                             environment_id: environmentId,

--- a/packages/shared/lib/services/sync/data/records.service.ts
+++ b/packages/shared/lib/services/sync/data/records.service.ts
@@ -8,8 +8,7 @@ import type {
     CustomerFacingDataRecord,
     DataRecordWithMetadata,
     GetRecordsResponse,
-    LastAction,
-    Sync
+    LastAction
 } from '../../../models/Sync.js';
 import type { DataResponse } from '../../../models/Data.js';
 import type { ServiceResponse } from '../../../models/Generic.js';
@@ -546,17 +545,7 @@ export async function getRecordsByExternalIds(external_ids: string[], nango_conn
     return result as unknown as SyncDataRecord[];
 }
 
-export async function findSyncsWithDeletableRecords(limit: number): Promise<Pick<Sync, 'id'>[]> {
-    return db.knex
-        .select<Pick<Sync, 'id'>[]>('syncs.id')
-        .from('_nango_sync_data_records AS rec')
-        .join('_nango_syncs AS syncs', 'syncs.id', '=', 'rec.sync_id')
-        .where('syncs.deleted', true)
-        .groupBy('syncs.id')
-        .limit(limit);
-}
-
-export async function deleteRecordsBySyncId(syncId: string, limit: number = 5000): Promise<void> {
+export async function deleteRecordsBySyncId({ syncId, limit = 5000 }: { syncId: string; limit?: number }): Promise<void> {
     let countRecords = 0;
     do {
         countRecords = await db

--- a/packages/shared/lib/services/sync/job.service.ts
+++ b/packages/shared/lib/services/sync/job.service.ts
@@ -172,7 +172,7 @@ export const isInitialSyncStillRunning = async (sync_id: string): Promise<boolea
     return false;
 };
 
-export async function softDeleteJobs(limit: number): Promise<number> {
+export async function softDeleteJobs({ syncId, limit }: { syncId: string; limit: number }): Promise<number> {
     return db
         .knex('_nango_sync_jobs')
         .update({
@@ -180,11 +180,6 @@ export async function softDeleteJobs(limit: number): Promise<number> {
             deleted_at: db.knex.fn.now()
         })
         .whereIn('id', function (sub) {
-            sub.select('jobs.id')
-                .from('_nango_sync_jobs AS jobs')
-                .join('_nango_syncs AS syncs', 'syncs.id', '=', 'jobs.sync_id')
-                .where('syncs.deleted', true)
-                .andWhere('jobs.deleted', false)
-                .limit(limit);
+            sub.select('id').from('_nango_sync_jobs').where({ deleted: false, sync_id: syncId }).limit(limit);
         });
 }

--- a/packages/shared/lib/services/sync/schedule.service.ts
+++ b/packages/shared/lib/services/sync/schedule.service.ts
@@ -117,7 +117,7 @@ export const updateOffset = async (schedule_id: string, offset: number): Promise
     await schema().update({ offset }).from<SyncSchedule>(TABLE).where({ schedule_id, deleted: false });
 };
 
-export async function softDeleteSchedules(limit: number): Promise<number> {
+export async function softDeleteSchedules({ syncId, limit }: { syncId: string; limit: number }): Promise<number> {
     return db
         .knex('_nango_sync_schedules')
         .update({
@@ -125,11 +125,6 @@ export async function softDeleteSchedules(limit: number): Promise<number> {
             deleted_at: db.knex.fn.now()
         })
         .whereIn('id', function (sub) {
-            sub.select('schedules.id')
-                .from('_nango_sync_schedules AS schedules')
-                .join('_nango_syncs AS syncs', 'syncs.id', '=', 'schedules.sync_id')
-                .where('syncs.deleted', true)
-                .andWhere('schedules.deleted', false)
-                .limit(limit);
+            sub.select('id').from('_nango_sync_schedules').where({ deleted: false, sync_id: syncId }).limit(limit);
         });
 }

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -739,3 +739,10 @@ export async function findPausableDemoSyncs(): Promise<PausableSyncs[]> {
 
     return syncs;
 }
+
+export async function findRecentlyDeletedSync(): Promise<{ id: string }[]> {
+    const q = db.knex.from('_nango_syncs').select('_nango_syncs.id').where(db.knex.raw("_nango_syncs.deleted_at >  NOW() - INTERVAL '6h'"));
+    const syncs: { id: string }[] = await q;
+
+    return syncs;
+}


### PR DESCRIPTION
## Describe your changes

This cron has proven much more complicated than anticipated. It's not easy to say to PG finds me what should be deleted but not is not. Basically it has to do a seq-scan on all the tables, which is not good. 

- Revert to a naive approach, select every sync that has recently been deleted and iterate over them. 
That means more useless work but at least it should be much faster

- Use advisory lock to prevent other cron to trigger at the same time


This change the fact if the cron didn't work for a moment it will not catch up, but since it's impossible I prefer to focus on the best case scenario until we have a queue to manage jobs.