### PR TITLE
fix(integration):stripe-app access token refresh on expire

### DIFF
--- a/docs-v2/integrations/all/stripe-app.mdx
+++ b/docs-v2/integrations/all/stripe-app.mdx
@@ -27,10 +27,14 @@ API configuration: [`stripe-app`](https://nango.dev/providers.yaml)
 
 ## Connection configuration in Nango for external test apps
 
-If you are using the "External Test" version of your app, Stripe requires you to use a temporary id to identify your application. See the [docs](https://stripe.com/docs/stripe-apps/api-authentication/oauth#install-app) for more information.
+- If you are using the "External Test" version of your app, Stripe requires you to use a temporary id to identify your application. See the [docs](https://stripe.com/docs/stripe-apps/api-authentication/oauth#install-app) for more information.
 
-In this case, you must use the `stripe-app-sandbox` integration in Nango, and add the temporary ID to the `appDomain` field in the connection params.
+- In this case, you must use the `stripe-app-sandbox` integration in Nango, and add the temporary ID to the `appDomain` field in the connection params.
 
 ```js
 nango.auth('stripe-app-sandbox', '<CONNECTION-ID>', {params: {appDomain: '<stripe-app-domain>'}});
 ```
+
+## API gotchas
+
+- Stripe app does not return an `expire_at` or `expire_in` value during the exchange of a code for an access token. However, according to the [docs](https://docs.stripe.com/stripe-apps/api-authentication/oauth#refresh-access-token), access tokens expire in one hour, while refresh tokens expire in one year

--- a/packages/shared/lib/clients/provider.client.ts
+++ b/packages/shared/lib/clients/provider.client.ts
@@ -290,7 +290,7 @@ class ProviderClient {
                 };
             }
 
-            throw new NangoError('tiktok_token_request_error');
+            throw new NangoError('tiktok_token_request_error', response.data);
         } catch (e: any) {
             throw new NangoError('tiktok_token_request_error', e.message);
         }

--- a/packages/shared/lib/clients/provider.client.ts
+++ b/packages/shared/lib/clients/provider.client.ts
@@ -11,6 +11,7 @@ import axios from 'axios';
 import qs from 'qs';
 import { parseTokenExpirationDate, isTokenExpired } from '../utils/utils.js';
 import { NangoError } from '../utils/error.js';
+const stripeAppExpiresIn = 3600;
 
 class ProviderClient {
     public shouldUseProviderClient(provider: string): boolean {
@@ -222,7 +223,7 @@ class ProviderClient {
                     stripe_publishable_key: response.data['stripe_publishable_key'],
                     stripe_user_id: response.data['stripe_user_id'],
                     token_type: response.data['token_type'],
-                    expires_in: 3600
+                    expires_in: stripeAppExpiresIn
                 };
             }
 
@@ -255,7 +256,7 @@ class ProviderClient {
                     stripe_publishable_key: response.data['stripe_publishable_key'],
                     stripe_user_id: response.data['stripe_user_id'],
                     token_type: response.data['token_type'],
-                    expires_in: 3600
+                    expires_in: stripeAppExpiresIn
                 };
             }
             throw new NangoError('stripe_app_token_refresh_request_error');

--- a/packages/webapp/public/images/template-logos/stripe-app-sandbox.svg
+++ b/packages/webapp/public/images/template-logos/stripe-app-sandbox.svg
@@ -1,0 +1,1 @@
+stripe.svg


### PR DESCRIPTION
## Describe your changes
Nango was finding it hard to refresh `stripe-app`  access token upon expiration. This was because upon exchanging a code for an access token, there is no `expire_at` or `expire_in` value in the response. However, according to the [docs](https://docs.stripe.com/stripe-apps/api-authentication/oauth#refresh-access-token), the access token expires after an hour, which is equivalent to 3600 seconds. I added that value during the creation of the Stripe app token. This will help facilitate automatic refresh on access token expiration.  
