### PR TITLE
feat(webapp):improve field values on refresh

### DIFF
--- a/packages/webapp/src/pages/Connection/Authorization.tsx
+++ b/packages/webapp/src/pages/Connection/Authorization.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Prism } from '@mantine/prism';
 import { Loading } from '@geist-ui/core';
 
@@ -18,8 +18,6 @@ interface AuthorizationProps {
 export default function Authorization(props: AuthorizationProps) {
     const { connection, forceRefresh, loaded } = props;
     const [refreshing, setRefreshing] = useState(false);
-
-    useEffect(() => {}, [refreshing]);
 
     const handleForceRefresh = async () => {
         setRefreshing(true);

--- a/packages/webapp/src/pages/Connection/Authorization.tsx
+++ b/packages/webapp/src/pages/Connection/Authorization.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { Prism } from '@mantine/prism';
 import { Loading } from '@geist-ui/core';
 
@@ -16,6 +17,15 @@ interface AuthorizationProps {
 
 export default function Authorization(props: AuthorizationProps) {
     const { connection, forceRefresh, loaded } = props;
+    const [refreshing, setRefreshing] = useState(false);
+
+    useEffect(() => {}, [refreshing]);
+
+    const handleForceRefresh = async () => {
+        setRefreshing(true);
+        await forceRefresh();
+        setRefreshing(false);
+    };
 
     if (!loaded) return <Loading spaceRatio={2.5} className="top-24" />;
 
@@ -71,7 +81,7 @@ export default function Authorization(props: AuthorizationProps) {
             {connection?.accessToken && (
                 <div className="flex flex-col">
                     <span className="text-gray-400 text-xs uppercase mb-1">Access Token</span>
-                    <SecretInput disabled defaultValue={connection?.accessToken} copy={true} refresh={() => forceRefresh()} />
+                    <SecretInput disabled value={refreshing ? 'Refreshing...' : connection.accessToken} copy={true} refresh={handleForceRefresh} />
                 </div>
             )}
             {connection?.oauthToken && (
@@ -89,7 +99,7 @@ export default function Authorization(props: AuthorizationProps) {
             {connection?.refreshToken && (
                 <div className="flex flex-col">
                     <span className="text-gray-400 text-xs uppercase mb-1">Refresh Token</span>
-                    <SecretInput disabled defaultValue={connection?.refreshToken} copy={true} refresh={() => forceRefresh()} />
+                    <SecretInput disabled value={refreshing ? 'Refreshing...' : connection.refreshToken} copy={true} refresh={handleForceRefresh} />
                 </div>
             )}
             <div className="flex flex-col">


### PR DESCRIPTION
## Describe your changes
Improve access token and refresh token fields to display a small message when refreshing tokens and update the values with the new tokens afterward. Revoked these displayed access tokens as well.
![improve_oauth2](https://github.com/NangoHQ/nango/assets/85742599/72fe10aa-d3dd-435c-8caf-894c3af4636b)
