### PR TITLE
[nan-439] match syncs based on the sync id + model combo to prevent multiple dropdowns being open

### DIFF
--- a/packages/webapp/src/pages/Connection/Syncs.tsx
+++ b/packages/webapp/src/pages/Connection/Syncs.tsx
@@ -212,10 +212,7 @@ export default function Syncs(props: SyncsProps) {
                                         )}
                                     </div>
                                     <div className="relative interact-with-sync">
-                                        <EllipsisHorizontalIcon
-                                            className="flex h-5 w-5 cursor-pointer"
-                                            onClick={() => toggleDropdown(hashSync(sync))}
-                                        />
+                                        <EllipsisHorizontalIcon className="flex h-5 w-5 cursor-pointer" onClick={() => toggleDropdown(hashSync(sync))} />
                                         {openDropdownHash === hashSync(sync) && (
                                             <div className="text-gray-400 absolute z-10 -top-15 right-1 bg-black rounded border border-neutral-700 items-center">
                                                 <div className="flex flex-col w-full">

--- a/packages/webapp/src/pages/Connection/Syncs.tsx
+++ b/packages/webapp/src/pages/Connection/Syncs.tsx
@@ -37,6 +37,10 @@ export default function Syncs(props: SyncsProps) {
         }
     };
 
+    const hashSync = (sync: SyncResponse) => {
+        return `${sync.id}${JSON.stringify(sync.models)}`;
+    };
+
     useEffect(() => {
         const closeSyncWindow = (e: MouseEvent) => {
             if (!(e.target as HTMLElement).closest('.interact-with-sync')) {
@@ -210,9 +214,9 @@ export default function Syncs(props: SyncsProps) {
                                     <div className="relative interact-with-sync">
                                         <EllipsisHorizontalIcon
                                             className="flex h-5 w-5 cursor-pointer"
-                                            onClick={() => toggleDropdown(`${sync.id}${JSON.stringify(sync.models)}`)}
+                                            onClick={() => toggleDropdown(hashSync(sync))}
                                         />
-                                        {openDropdownHash === `${sync.id}${JSON.stringify(sync.models)}` && (
+                                        {openDropdownHash === hashSync(sync) && (
                                             <div className="text-gray-400 absolute z-10 -top-15 right-1 bg-black rounded border border-neutral-700 items-center">
                                                 <div className="flex flex-col w-full">
                                                     <div

--- a/packages/webapp/src/pages/Connection/Syncs.tsx
+++ b/packages/webapp/src/pages/Connection/Syncs.tsx
@@ -26,21 +26,21 @@ interface SyncsProps {
 
 export default function Syncs(props: SyncsProps) {
     const { syncs, connection, setSyncLoaded, loaded, syncLoaded, env } = props;
-    const [openDropdownId, setOpenDropdownId] = useState<string | null>(null);
+    const [openDropdownHash, setOpenDropdownHash] = useState<string | null>(null);
     const runCommandSyncAPI = useRunSyncAPI();
 
-    const toggleDropdown = (id: string) => {
-        if (openDropdownId === id) {
-            setOpenDropdownId(null);
+    const toggleDropdown = (hash: string) => {
+        if (openDropdownHash === hash) {
+            setOpenDropdownHash(null);
         } else {
-            setOpenDropdownId(id);
+            setOpenDropdownHash(hash);
         }
     };
 
     useEffect(() => {
         const closeSyncWindow = (e: MouseEvent) => {
             if (!(e.target as HTMLElement).closest('.interact-with-sync')) {
-                setOpenDropdownId(null);
+                setOpenDropdownHash(null);
             }
         };
 
@@ -208,8 +208,11 @@ export default function Syncs(props: SyncsProps) {
                                         )}
                                     </div>
                                     <div className="relative interact-with-sync">
-                                        <EllipsisHorizontalIcon className="flex h-5 w-5 cursor-pointer" onClick={() => toggleDropdown(sync.id)} />
-                                        {openDropdownId === sync.id && (
+                                        <EllipsisHorizontalIcon
+                                            className="flex h-5 w-5 cursor-pointer"
+                                            onClick={() => toggleDropdown(`${sync.id}${JSON.stringify(sync.models)}`)}
+                                        />
+                                        {openDropdownHash === `${sync.id}${JSON.stringify(sync.models)}` && (
                                             <div className="text-gray-400 absolute z-10 -top-15 right-1 bg-black rounded border border-neutral-700 items-center">
                                                 <div className="flex flex-col w-full">
                                                     <div


### PR DESCRIPTION
## Describe your changes
In a multi model scenario the sync id will be the same so the dropdown might show more than once. Use a combination of the model return which has to be unique and the sync id to correctly identify the sync

## Issue ticket number and link
NAN-439

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
