### PR TITLE
fix(db): add index for isSyncJobRunning

### DIFF
--- a/packages/shared/lib/db/migrations/20240304130200_jobs-index-order.cjs
+++ b/packages/shared/lib/db/migrations/20240304130200_jobs-index-order.cjs
@@ -1,0 +1,11 @@
+exports.config = { transaction: false };
+
+exports.up = async function (knex) {
+    await knex.schema.raw(
+        'CREATE INDEX CONCURRENTLY "idx_jobs_syncid_createdat_where_deleted" ON "_nango_sync_jobs" USING BTREE ("sync_id", "created_at" DESC) WHERE deleted = false'
+    );
+};
+
+exports.down = async function (knex) {
+    await knex.schema.raw('DROP INDEX CONCURRENTLY idx_jobs_syncid_createdat_where_deleted');
+};


### PR DESCRIPTION
## Describe your changes

Fixes NAN-433


isSyncJobRunning() and getLatestSyncJob() both use an inefficient way to query the DB to avoid returning the wrong job in case of multiples are running (which needs to be fixed but we don't know why at the moment).

- Add an index to help both queries
It is a magnitude times faster, from **66s** to **0.5ms**

## Query 

```sql
select * 
from _nango_sync_jobs 
where sync_id = '00831e7a-dce3-40c3-bce0-c5cf02d7b3a1' and deleted = FALSE 
order by created_at desc
LIMIT 1
```

## Before

```sql
Limit  (cost=0.43..555.70 rows=1 width=312) (actual time=66492.393..66492.394 rows=1 loops=1)
  ->  Index Scan Backward using _nango_sync_jobs_created_at_index on _nango_sync_jobs  (cost=0.43..746830.79 rows=1345 width=312) (actual time=66492.392..66492.393 rows=1 loops=1)
"        Filter: ((NOT deleted) AND (sync_id = '00831e7a-dce3-40c3-bce0-35cf02d7b3a1'::uuid))"
        Rows Removed by Filter: 2032442
Planning Time: 0.101 ms
Execution Time: 66492.412 ms
```

## After

```sql
Limit  (cost=0.43..1.55 rows=1 width=312) (actual time=0.524..0.524 rows=1 loops=1)
  ->  Index Scan using idx_jobs_syncid_createdat_where_deleted on _nango_sync_jobs  (cost=0.43..1510.05 rows=1345 width=312) (actual time=0.523..0.523 rows=1 loops=1)
"        Index Cond: (sync_id = '00831e7a-dce3-40c3-bce0-35cf02d7b3a1'::uuid)"
Planning Time: 0.165 ms
Execution Time: 0.537 ms
```