### PR TITLE
[nan-439] fix improperly named const

### DIFF
--- a/packages/webapp/src/utils/language-snippets.tsx
+++ b/packages/webapp/src/utils/language-snippets.tsx
@@ -5,7 +5,7 @@ export const nodeSnippet = (models: string | NangoSyncModel[] | undefined, secre
     return `import { Nango } from '@nangohq/node';
 const nango = new Nango({ secretKey: '${secretKey}' });
 
-const issues = await nango.listRecords({
+const records = await nango.listRecords({
     providerConfigKey: '${providerConfigKey}',
     connectionId: '${connectionId}',
     model: '${model}'
@@ -36,7 +36,7 @@ ${JSON.stringify(input, null, 2)
     return `import Nango from '@nangohq/node';
 const nango = new Nango({ secretKey: '${secretKey}' });
 
-const issues = await nango.triggerAction(
+const response = await nango.triggerAction(
     '${providerConfigKey}',
     '${connectionId}',
     '${actionName}',


### PR DESCRIPTION
## Describe your changes
The name is misleading and previously was named to fit the getting started guide. Use a more appropriate name for the getting started and also the API Reference.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
