### PR TITLE
[nan-520] if more than 25 hours then let the incremental sync run

### DIFF
--- a/packages/shared/lib/services/sync/job.service.ts
+++ b/packages/shared/lib/services/sync/job.service.ts
@@ -6,6 +6,8 @@ import { Job as SyncJob, SyncStatus, SyncType, SyncResultByModel } from '../../m
 
 const SYNC_JOB_TABLE = dbNamespace + 'sync_jobs';
 
+const SYNC_TIMEOUT_HOURS = 25;
+
 export const createSyncJob = async (
     sync_id: string,
     type: SyncType,
@@ -165,7 +167,11 @@ export const isInitialSyncStillRunning = async (sync_id: string): Promise<boolea
         })
         .first();
 
-    if (result) {
+    // if it has been running for more than 24 hours then we should assume it is stuck
+    const moreThan24Hours =
+        result && result.updated_at ? new Date(result.updated_at).getTime() < new Date().getTime() - SYNC_TIMEOUT_HOURS * 60 * 60 * 1000 : false;
+
+    if (result && !moreThan24Hours) {
         return true;
     }
 


### PR DESCRIPTION
## Describe your changes
Situation came up for two customers. One self hosted there was issues in their setup and so the initial sync didn't complete so was still in a running state. If an `INITIAL` sync has been running for more than 25 hours (1 hour grace period) then allow incremental syns to run since we can assume it is stuck

## Issue ticket number and link
NAN-520 

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
