### PR TITLE
Khaliq/nan 525 upfort logs filter bug

### DIFF
--- a/packages/server/lib/controllers/activity.controller.ts
+++ b/packages/server/lib/controllers/activity.controller.ts
@@ -73,7 +73,7 @@ class ActivityController {
             const { environment } = response;
 
             const scripts = await getAllSyncAndActionNames(environment.id);
-            const integrations = await activityFilter(environment.id, 'provider');
+            const integrations = await activityFilter(environment.id, 'provider_config_key');
             const connections = await activityFilter(environment.id, 'connection_id');
             res.send({ scripts, integrations, connections });
         } catch (error) {

--- a/packages/shared/lib/services/activity/activity.service.ts
+++ b/packages/shared/lib/services/activity/activity.service.ts
@@ -248,7 +248,7 @@ export async function getTopLevelLogByEnvironment(
     return logs || [];
 }
 
-export async function activityFilter(environment_id: number, filterColumn: 'connection_id' | 'provider'): Promise<string[]> {
+export async function activityFilter(environment_id: number, filterColumn: 'connection_id' | 'provider_config_key'): Promise<string[]> {
     const logsQuery = db.knex
         .from<ActivityLog>('_nango_activity_logs')
         .where({ environment_id })

--- a/packages/shared/lib/services/activity/activity.service.ts
+++ b/packages/shared/lib/services/activity/activity.service.ts
@@ -255,6 +255,7 @@ export async function activityFilter(environment_id: number, filterColumn: 'conn
             environment_id
         })
         .andWhereNot({
+            [filterColumn]: '',
             action: 'sync deploy'
         })
         .whereNotNull(filterColumn)
@@ -266,7 +267,7 @@ export async function activityFilter(environment_id: number, filterColumn: 'conn
 
     const distinctValues: string[] = logs
         .map((log: Record<string, string>) => log[filterColumn] as string)
-        .filter((value: string | undefined): value is string => typeof value === 'string' && value !== '');
+        .filter((value: string | undefined): value is string => typeof value === 'string');
 
     return distinctValues;
 }

--- a/packages/shared/lib/services/activity/activity.service.ts
+++ b/packages/shared/lib/services/activity/activity.service.ts
@@ -251,7 +251,12 @@ export async function getTopLevelLogByEnvironment(
 export async function activityFilter(environment_id: number, filterColumn: 'connection_id' | 'provider_config_key'): Promise<string[]> {
     const logsQuery = db.knex
         .from<ActivityLog>('_nango_activity_logs')
-        .where({ environment_id })
+        .where({
+            environment_id
+        })
+        .andWhereNot({
+            action: 'sync deploy'
+        })
         .whereNotNull(filterColumn)
         .groupBy(filterColumn)
         .select(filterColumn)
@@ -261,7 +266,7 @@ export async function activityFilter(environment_id: number, filterColumn: 'conn
 
     const distinctValues: string[] = logs
         .map((log: Record<string, string>) => log[filterColumn] as string)
-        .filter((value: string | undefined): value is string => typeof value === 'string');
+        .filter((value: string | undefined): value is string => typeof value === 'string' && value !== '');
 
     return distinctValues;
 }


### PR DESCRIPTION
## Describe your changes
Integration filter should use the provider config key instead of the provider. This bug was introduced by https://github.com/NangoHQ/nango/pull/1648

## Issue ticket number and link
NAN-525

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
