### PR TITLE
fix(deps): pin aws-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -154,588 +154,1024 @@
                 "tslib": "^1.11.1"
             }
         },
-        "node_modules/@aws-sdk/client-s3": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/abort-controller": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
+            "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
             "dependencies": {
-                "@aws-crypto/sha1-browser": "3.0.0",
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.428.0",
-                "@aws-sdk/credential-provider-node": "3.428.0",
-                "@aws-sdk/middleware-bucket-endpoint": "3.428.0",
-                "@aws-sdk/middleware-expect-continue": "3.428.0",
-                "@aws-sdk/middleware-flexible-checksums": "3.428.0",
-                "@aws-sdk/middleware-host-header": "3.428.0",
-                "@aws-sdk/middleware-location-constraint": "3.428.0",
-                "@aws-sdk/middleware-logger": "3.428.0",
-                "@aws-sdk/middleware-recursion-detection": "3.428.0",
-                "@aws-sdk/middleware-sdk-s3": "3.428.0",
-                "@aws-sdk/middleware-signing": "3.428.0",
-                "@aws-sdk/middleware-ssec": "3.428.0",
-                "@aws-sdk/middleware-user-agent": "3.428.0",
-                "@aws-sdk/region-config-resolver": "3.428.0",
-                "@aws-sdk/signature-v4-multi-region": "3.428.0",
-                "@aws-sdk/types": "3.428.0",
-                "@aws-sdk/util-endpoints": "3.428.0",
-                "@aws-sdk/util-user-agent-browser": "3.428.0",
-                "@aws-sdk/util-user-agent-node": "3.428.0",
-                "@aws-sdk/xml-builder": "3.310.0",
-                "@smithy/config-resolver": "^2.0.14",
-                "@smithy/eventstream-serde-browser": "^2.0.11",
-                "@smithy/eventstream-serde-config-resolver": "^2.0.11",
-                "@smithy/eventstream-serde-node": "^2.0.11",
-                "@smithy/fetch-http-handler": "^2.2.3",
-                "@smithy/hash-blob-browser": "^2.0.11",
-                "@smithy/hash-node": "^2.0.11",
-                "@smithy/hash-stream-node": "^2.0.11",
-                "@smithy/invalid-dependency": "^2.0.11",
-                "@smithy/md5-js": "^2.0.11",
-                "@smithy/middleware-content-length": "^2.0.13",
-                "@smithy/middleware-endpoint": "^2.1.0",
-                "@smithy/middleware-retry": "^2.0.16",
-                "@smithy/middleware-serde": "^2.0.11",
-                "@smithy/middleware-stack": "^2.0.5",
-                "@smithy/node-config-provider": "^2.1.1",
-                "@smithy/node-http-handler": "^2.1.7",
-                "@smithy/protocol-http": "^3.0.7",
-                "@smithy/smithy-client": "^2.1.11",
-                "@smithy/types": "^2.3.5",
-                "@smithy/url-parser": "^2.0.11",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-body-length-browser": "^2.0.0",
-                "@smithy/util-body-length-node": "^2.1.0",
-                "@smithy/util-defaults-mode-browser": "^2.0.15",
-                "@smithy/util-defaults-mode-node": "^2.0.19",
-                "@smithy/util-retry": "^2.0.4",
-                "@smithy/util-stream": "^2.0.16",
-                "@smithy/util-utf8": "^2.0.0",
-                "@smithy/util-waiter": "^2.0.11",
-                "fast-xml-parser": "4.2.5",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-s3/node_modules/tslib": {
-            "version": "2.5.3",
-            "license": "0BSD"
+        "node_modules/@aws-sdk/abort-controller/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
-        "node_modules/@aws-sdk/client-sso": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/abort-controller/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/chunked-blob-reader": {
+            "version": "3.310.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.310.0.tgz",
+            "integrity": "sha512-CrJS3exo4mWaLnWxfCH+w88Ou0IcAZSIkk4QbmxiHl/5Dq705OLoxf4385MVyExpqpeVJYOYQ2WaD8i/pQZ2fg==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/chunked-blob-reader/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/client-sso-oidc": {
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.348.0.tgz",
+            "integrity": "sha512-tvHpcycx4EALvk38I9rAOdPeHvBDezqIB4lrE7AvnOJljlvCcdQ2gXa9GDrwrM7zuYBIZMBRE/njTMrCwoOdAA==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/middleware-host-header": "3.428.0",
-                "@aws-sdk/middleware-logger": "3.428.0",
-                "@aws-sdk/middleware-recursion-detection": "3.428.0",
-                "@aws-sdk/middleware-user-agent": "3.428.0",
-                "@aws-sdk/region-config-resolver": "3.428.0",
-                "@aws-sdk/types": "3.428.0",
-                "@aws-sdk/util-endpoints": "3.428.0",
-                "@aws-sdk/util-user-agent-browser": "3.428.0",
-                "@aws-sdk/util-user-agent-node": "3.428.0",
-                "@smithy/config-resolver": "^2.0.14",
-                "@smithy/fetch-http-handler": "^2.2.3",
-                "@smithy/hash-node": "^2.0.11",
-                "@smithy/invalid-dependency": "^2.0.11",
-                "@smithy/middleware-content-length": "^2.0.13",
-                "@smithy/middleware-endpoint": "^2.1.0",
-                "@smithy/middleware-retry": "^2.0.16",
-                "@smithy/middleware-serde": "^2.0.11",
-                "@smithy/middleware-stack": "^2.0.5",
-                "@smithy/node-config-provider": "^2.1.1",
-                "@smithy/node-http-handler": "^2.1.7",
-                "@smithy/protocol-http": "^3.0.7",
-                "@smithy/smithy-client": "^2.1.11",
-                "@smithy/types": "^2.3.5",
-                "@smithy/url-parser": "^2.0.11",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-body-length-browser": "^2.0.0",
-                "@smithy/util-body-length-node": "^2.1.0",
-                "@smithy/util-defaults-mode-browser": "^2.0.15",
-                "@smithy/util-defaults-mode-node": "^2.0.19",
-                "@smithy/util-retry": "^2.0.4",
-                "@smithy/util-utf8": "^2.0.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
+                "@aws-sdk/util-base64": "3.310.0",
+                "@aws-sdk/util-body-length-browser": "3.310.0",
+                "@aws-sdk/util-body-length-node": "3.310.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "@smithy/protocol-http": "^1.0.1",
+                "@smithy/types": "^1.0.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sso/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@aws-sdk/client-sts": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
+            "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/credential-provider-node": "3.428.0",
-                "@aws-sdk/middleware-host-header": "3.428.0",
-                "@aws-sdk/middleware-logger": "3.428.0",
-                "@aws-sdk/middleware-recursion-detection": "3.428.0",
-                "@aws-sdk/middleware-sdk-sts": "3.428.0",
-                "@aws-sdk/middleware-signing": "3.428.0",
-                "@aws-sdk/middleware-user-agent": "3.428.0",
-                "@aws-sdk/region-config-resolver": "3.428.0",
-                "@aws-sdk/types": "3.428.0",
-                "@aws-sdk/util-endpoints": "3.428.0",
-                "@aws-sdk/util-user-agent-browser": "3.428.0",
-                "@aws-sdk/util-user-agent-node": "3.428.0",
-                "@smithy/config-resolver": "^2.0.14",
-                "@smithy/fetch-http-handler": "^2.2.3",
-                "@smithy/hash-node": "^2.0.11",
-                "@smithy/invalid-dependency": "^2.0.11",
-                "@smithy/middleware-content-length": "^2.0.13",
-                "@smithy/middleware-endpoint": "^2.1.0",
-                "@smithy/middleware-retry": "^2.0.16",
-                "@smithy/middleware-serde": "^2.0.11",
-                "@smithy/middleware-stack": "^2.0.5",
-                "@smithy/node-config-provider": "^2.1.1",
-                "@smithy/node-http-handler": "^2.1.7",
-                "@smithy/protocol-http": "^3.0.7",
-                "@smithy/smithy-client": "^2.1.11",
-                "@smithy/types": "^2.3.5",
-                "@smithy/url-parser": "^2.0.11",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-body-length-browser": "^2.0.0",
-                "@smithy/util-body-length-node": "^2.1.0",
-                "@smithy/util-defaults-mode-browser": "^2.0.15",
-                "@smithy/util-defaults-mode-node": "^2.0.19",
-                "@smithy/util-retry": "^2.0.4",
-                "@smithy/util-utf8": "^2.0.0",
-                "fast-xml-parser": "4.2.5",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
+            "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
             "dependencies": {
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/types": "^2.3.5",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
+            "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.428.0",
-                "@aws-sdk/credential-provider-process": "3.428.0",
-                "@aws-sdk/credential-provider-sso": "3.428.0",
-                "@aws-sdk/credential-provider-web-identity": "3.428.0",
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/credential-provider-imds": "^2.0.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/shared-ini-file-loader": "^2.0.6",
-                "@smithy/types": "^2.3.5",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.347.0.tgz",
+            "integrity": "sha512-wJbGN3OE1/daVCrwk49whhIr9E0j1N4gWwN/wi4WuyYIA+5lMUfVp0aGIOvZR+878DxuFz2hQ4XcZVT4K2WvQw==",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.428.0",
-                "@aws-sdk/credential-provider-ini": "3.428.0",
-                "@aws-sdk/credential-provider-process": "3.428.0",
-                "@aws-sdk/credential-provider-sso": "3.428.0",
-                "@aws-sdk/credential-provider-web-identity": "3.428.0",
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/credential-provider-imds": "^2.0.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/shared-ini-file-loader": "^2.0.6",
-                "@smithy/types": "^2.3.5",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
             "dependencies": {
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/shared-ini-file-loader": "^2.0.6",
-                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.347.0.tgz",
+            "integrity": "sha512-/WUkirizeNAqwVj0zkcrqdQ9pUm1HY5kU+qy7xTR0OebkuJauglkmSTMD+56L1JPunWqHhlwCMVRaz5eaJdSEQ==",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.428.0",
-                "@aws-sdk/token-providers": "3.428.0",
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/shared-ini-file-loader": "^2.0.6",
-                "@smithy/types": "^2.3.5",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
+            "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
             "dependencies": {
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/types": "^2.3.5",
+                "@aws-sdk/types": "3.347.0",
+                "bowser": "^2.11.0",
                 "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.347.0.tgz",
+            "integrity": "sha512-6X0b9qGsbD1s80PmbaB6v1/ZtLfSx6fjRX8caM7NN0y/ObuLoX8LhYnW6WlB2f1+xb4EjaCNgpP/zCf98MXosw==",
             "dependencies": {
-                "@aws-sdk/types": "3.428.0",
-                "@aws-sdk/util-arn-parser": "3.310.0",
-                "@smithy/node-config-provider": "^2.1.1",
-                "@smithy/protocol-http": "^3.0.7",
-                "@smithy/types": "^2.3.5",
-                "@smithy/util-config-provider": "^2.0.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
             }
         },
-        "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@aws-sdk/middleware-expect-continue": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/protocol-http": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+            "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
             "dependencies": {
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/protocol-http": "^3.0.7",
-                "@smithy/types": "^2.3.5",
+                "@smithy/types": "^1.2.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-expect-continue/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/types": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+            "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
-        "node_modules/@aws-sdk/middleware-flexible-checksums": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/config-resolver": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.347.0.tgz",
+            "integrity": "sha512-2ja+Sf/VnUO7IQ3nKbDQ5aumYKKJUaTm/BuVJ29wNho8wYHfuf7wHZV0pDTkB8RF5SH7IpHap7zpZAj39Iq+EA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-config-provider": "3.310.0",
+                "@aws-sdk/util-middleware": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/config-resolver/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/config-resolver/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/credential-provider-imds": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.347.0.tgz",
+            "integrity": "sha512-7scCy/DCDRLIhlqTxff97LQWDnRwRXji3bxxMg+xWOTTaJe7PWx+etGSbBWaL42vsBHFShQjSLvJryEgoBktpw==",
+            "dependencies": {
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-imds/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-imds/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/eventstream-codec": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
+            "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
             "dependencies": {
                 "@aws-crypto/crc32": "3.0.0",
-                "@aws-crypto/crc32c": "3.0.0",
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/is-array-buffer": "^2.0.0",
-                "@smithy/protocol-http": "^3.0.7",
-                "@smithy/types": "^2.3.5",
-                "@smithy/util-utf8": "^2.0.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-hex-encoding": "3.310.0",
                 "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/eventstream-codec/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
             "dependencies": {
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/protocol-http": "^3.0.7",
-                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
+        "node_modules/@aws-sdk/eventstream-codec/node_modules/tslib": {
             "version": "2.6.2",
-            "license": "0BSD"
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
-        "node_modules/@aws-sdk/middleware-location-constraint": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/eventstream-serde-browser": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.347.0.tgz",
+            "integrity": "sha512-9BLVTHWgpiTo/hl+k7qt7E9iYu43zVwJN+4TEwA9ZZB3p12068t1Hay6HgCcgJC3+LWMtw/OhvypV6vQAG4UBg==",
             "dependencies": {
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/types": "^2.3.5",
+                "@aws-sdk/eventstream-serde-universal": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-location-constraint/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/eventstream-serde-browser/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
             "dependencies": {
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
+        "node_modules/@aws-sdk/eventstream-serde-browser/node_modules/tslib": {
             "version": "2.6.2",
-            "license": "0BSD"
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
-        "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.347.0.tgz",
+            "integrity": "sha512-RcXQbNVq0PFmDqfn6+MnjCUWbbobcYVxpimaF6pMDav04o6Mcle+G2Hrefp5NlFr/lZbHW2eUKYsp1sXPaxVlQ==",
             "dependencies": {
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/protocol-http": "^3.0.7",
-                "@smithy/types": "^2.3.5",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/eventstream-serde-config-resolver/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
             "dependencies": {
-                "@aws-sdk/types": "3.428.0",
-                "@aws-sdk/util-arn-parser": "3.310.0",
-                "@smithy/protocol-http": "^3.0.7",
-                "@smithy/smithy-client": "^2.1.11",
-                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/tslib": {
+        "node_modules/@aws-sdk/eventstream-serde-config-resolver/node_modules/tslib": {
             "version": "2.6.2",
-            "license": "0BSD"
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
-        "node_modules/@aws-sdk/middleware-sdk-sts": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/eventstream-serde-node": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.347.0.tgz",
+            "integrity": "sha512-pgQCWH0PkHjcHs04JE7FoGAD3Ww45ffV8Op0MSLUhg9OpGa6EDoO3EOpWi9l/TALtH4f0KRV35PVyUyHJ/wEkA==",
             "dependencies": {
-                "@aws-sdk/middleware-signing": "3.428.0",
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/types": "^2.3.5",
+                "@aws-sdk/eventstream-serde-universal": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@aws-sdk/middleware-signing": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/eventstream-serde-node/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
             "dependencies": {
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/protocol-http": "^3.0.7",
-                "@smithy/signature-v4": "^2.0.0",
-                "@smithy/types": "^2.3.5",
-                "@smithy/util-middleware": "^2.0.4",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-signing/node_modules/tslib": {
+        "node_modules/@aws-sdk/eventstream-serde-node/node_modules/tslib": {
             "version": "2.6.2",
-            "license": "0BSD"
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
-        "node_modules/@aws-sdk/middleware-ssec": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/eventstream-serde-universal": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.347.0.tgz",
+            "integrity": "sha512-4wWj6bz6lOyDIO/dCCjwaLwRz648xzQQnf89R29sLoEqvAPP5XOB7HL+uFaQ/f5tPNh49gL6huNFSVwDm62n4Q==",
             "dependencies": {
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/types": "^2.3.5",
+                "@aws-sdk/eventstream-codec": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-ssec/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/eventstream-serde-universal/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
             "dependencies": {
-                "@aws-sdk/types": "3.428.0",
-                "@aws-sdk/util-endpoints": "3.428.0",
-                "@smithy/protocol-http": "^3.0.7",
-                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
+        "node_modules/@aws-sdk/eventstream-serde-universal/node_modules/tslib": {
             "version": "2.6.2",
-            "license": "0BSD"
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
-        "node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/fetch-http-handler": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.347.0.tgz",
+            "integrity": "sha512-sQ5P7ivY8//7wdxfA76LT1sF6V2Tyyz1qF6xXf9sihPN5Q1Y65c+SKpMzXyFSPqWZ82+SQQuDliYZouVyS6kQQ==",
             "dependencies": {
-                "@smithy/node-config-provider": "^2.1.1",
-                "@smithy/types": "^2.3.5",
-                "@smithy/util-config-provider": "^2.0.0",
-                "@smithy/util-middleware": "^2.0.4",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/querystring-builder": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-base64": "3.310.0",
                 "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/region-config-resolver/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@aws-sdk/signature-v4-multi-region": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
             "dependencies": {
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/protocol-http": "^3.0.7",
-                "@smithy/signature-v4": "^2.0.0",
-                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/tslib": {
+        "node_modules/@aws-sdk/fetch-http-handler/node_modules/tslib": {
             "version": "2.6.2",
-            "license": "0BSD"
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
-        "node_modules/@aws-sdk/token-providers": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/hash-blob-browser": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.347.0.tgz",
+            "integrity": "sha512-RxgstIldLsdJKN5UHUwSI9PMiatr0xKmKxS4+tnWZ1/OOg6wuWqqpDpWdNOVSJSpxpUaP6kRrvG5Yo5ZevoTXw==",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/middleware-host-header": "3.428.0",
-                "@aws-sdk/middleware-logger": "3.428.0",
-                "@aws-sdk/middleware-recursion-detection": "3.428.0",
-                "@aws-sdk/middleware-user-agent": "3.428.0",
-                "@aws-sdk/types": "3.428.0",
-                "@aws-sdk/util-endpoints": "3.428.0",
-                "@aws-sdk/util-user-agent-browser": "3.428.0",
-                "@aws-sdk/util-user-agent-node": "3.428.0",
-                "@smithy/config-resolver": "^2.0.14",
-                "@smithy/fetch-http-handler": "^2.2.3",
-                "@smithy/hash-node": "^2.0.11",
-                "@smithy/invalid-dependency": "^2.0.11",
-                "@smithy/middleware-content-length": "^2.0.13",
-                "@smithy/middleware-endpoint": "^2.1.0",
-                "@smithy/middleware-retry": "^2.0.16",
-                "@smithy/middleware-serde": "^2.0.11",
-                "@smithy/middleware-stack": "^2.0.5",
-                "@smithy/node-config-provider": "^2.1.1",
-                "@smithy/node-http-handler": "^2.1.7",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/protocol-http": "^3.0.7",
-                "@smithy/shared-ini-file-loader": "^2.0.6",
-                "@smithy/smithy-client": "^2.1.11",
-                "@smithy/types": "^2.3.5",
-                "@smithy/url-parser": "^2.0.11",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-body-length-browser": "^2.0.0",
-                "@smithy/util-body-length-node": "^2.1.0",
-                "@smithy/util-defaults-mode-browser": "^2.0.15",
-                "@smithy/util-defaults-mode-node": "^2.0.19",
-                "@smithy/util-retry": "^2.0.4",
-                "@smithy/util-utf8": "^2.0.0",
+                "@aws-sdk/chunked-blob-reader": "3.310.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/hash-blob-browser/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/token-providers/node_modules/tslib": {
+        "node_modules/@aws-sdk/hash-blob-browser/node_modules/tslib": {
             "version": "2.6.2",
-            "license": "0BSD"
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/hash-node": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
+            "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
+            "dependencies": {
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-buffer-from": "3.310.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/hash-node/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/hash-node/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/hash-stream-node": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.347.0.tgz",
+            "integrity": "sha512-tOBfcvELyt1GVuAlQ4d0mvm3QxoSSmvhH15SWIubM9RP4JWytBVzaFAn/aC02DBAWyvp0acMZ5J+47mxrWJElg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/hash-stream-node/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/hash-stream-node/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/invalid-dependency": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
+            "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
+            "dependencies": {
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/invalid-dependency/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/invalid-dependency/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/is-array-buffer": {
+            "version": "3.310.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+            "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/is-array-buffer/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/md5-js": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.347.0.tgz",
+            "integrity": "sha512-mChE+7DByTY9H4cQ6fnWp2x5jf8e6OZN+AdLp6WQ+W99z35zBeqBxVmgm8ziJwkMIrkSTv9j3Y7T9Ve3RIcSfg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/md5-js/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/md5-js/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/middleware-content-length": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
+            "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-content-length/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-content-length/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/middleware-endpoint": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+            "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
+            "dependencies": {
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
+                "@aws-sdk/util-middleware": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-endpoint/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/middleware-retry": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.347.0.tgz",
+            "integrity": "sha512-CpdM+8dCSbX96agy4FCzOfzDmhNnGBM/pxrgIVLm5nkYTLuXp/d7ubpFEUHULr+4hCd5wakHotMt7yO29NFaVw==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/service-error-classification": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-middleware": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "tslib": "^2.5.0",
+                "uuid": "^8.3.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-retry/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-retry/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-serde": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+            "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-serde/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-serde/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/middleware-stack": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+            "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-stack/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/node-config-provider": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.347.0.tgz",
+            "integrity": "sha512-faU93d3+5uTTUcotGgMXF+sJVFjrKh+ufW+CzYKT4yUHammyaIab/IbTPWy2hIolcEGtuPeVoxXw8TXbkh/tuw==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/node-config-provider/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/node-config-provider/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/node-http-handler": {
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.348.0.tgz",
+            "integrity": "sha512-wxdgc4tO5F6lN4wHr0CZ4TyIjDW/ORp4SJZdWYNs2L5J7+/SwqgJY2lxRlGi0i7Md+apAdE3sT3ukVQ/9pVfPg==",
+            "dependencies": {
+                "@aws-sdk/abort-controller": "3.347.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/querystring-builder": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/node-http-handler/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/node-http-handler/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/property-provider": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.347.0.tgz",
+            "integrity": "sha512-t3nJ8CYPLKAF2v9nIHOHOlF0CviQbTvbFc2L4a+A+EVd/rM4PzL3+3n8ZJsr0h7f6uD04+b5YRFgKgnaqLXlEg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/property-provider/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/property-provider/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/protocol-http": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+            "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
+            "dependencies": {
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/protocol-http/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/protocol-http/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/querystring-builder": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+            "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-uri-escape": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/querystring-builder/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/querystring-builder/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/querystring-parser": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+            "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/querystring-parser/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/querystring-parser/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/service-error-classification": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
+            "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/shared-ini-file-loader": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.347.0.tgz",
+            "integrity": "sha512-Xw+zAZQVLb+xMNHChXQ29tzzLqm3AEHsD8JJnlkeFjeMnWQtXdUfOARl5s8NzAppcKQNlVe2gPzjaKjoy2jz1Q==",
+            "dependencies": {
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/shared-ini-file-loader/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/shared-ini-file-loader/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/signature-v4": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
+            "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
+            "dependencies": {
+                "@aws-sdk/eventstream-codec": "3.347.0",
+                "@aws-sdk/is-array-buffer": "3.310.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-hex-encoding": "3.310.0",
+                "@aws-sdk/util-middleware": "3.347.0",
+                "@aws-sdk/util-uri-escape": "3.310.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/smithy-client": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+            "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
+            "dependencies": {
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/smithy-client/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/smithy-client/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@aws-sdk/types": {
             "version": "3.428.0",
@@ -752,6 +1188,32 @@
             "version": "2.5.3",
             "license": "0BSD"
         },
+        "node_modules/@aws-sdk/url-parser": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+            "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
+            "dependencies": {
+                "@aws-sdk/querystring-parser": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/url-parser/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/url-parser/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
         "node_modules/@aws-sdk/util-arn-parser": {
             "version": "3.310.0",
             "license": "Apache-2.0",
@@ -766,20 +1228,162 @@
             "version": "2.6.2",
             "license": "0BSD"
         },
-        "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/util-base64": {
+            "version": "3.310.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+            "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
             "dependencies": {
-                "@aws-sdk/types": "3.428.0",
+                "@aws-sdk/util-buffer-from": "3.310.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
+        "node_modules/@aws-sdk/util-base64/node_modules/tslib": {
             "version": "2.6.2",
-            "license": "0BSD"
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/util-body-length-browser": {
+            "version": "3.310.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+            "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-body-length-browser/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/util-body-length-node": {
+            "version": "3.310.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+            "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-body-length-node/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/util-buffer-from": {
+            "version": "3.310.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+            "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+            "dependencies": {
+                "@aws-sdk/is-array-buffer": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-buffer-from/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/util-config-provider": {
+            "version": "3.310.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+            "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-config-provider/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-browser": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.347.0.tgz",
+            "integrity": "sha512-+JHFA4reWnW/nMWwrLKqL2Lm/biw/Dzi/Ix54DAkRZ08C462jMKVnUlzAI+TfxQE3YLm99EIa0G7jiEA+p81Qw==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-node": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.347.0.tgz",
+            "integrity": "sha512-A8BzIVhAAZE5WEukoAN2kYebzTc99ZgncbwOmgCCbvdaYlk5tzguR/s+uoT4G0JgQGol/4hAMuJEl7elNgU6RQ==",
+            "dependencies": {
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-imds": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/util-hex-encoding": {
+            "version": "3.310.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+            "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-hex-encoding/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@aws-sdk/util-locate-window": {
             "version": "3.310.0",
@@ -795,44 +1399,125 @@
             "version": "2.5.3",
             "license": "0BSD"
         },
-        "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
+        "node_modules/@aws-sdk/util-middleware": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+            "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
             "dependencies": {
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/types": "^2.3.5",
-                "bowser": "^2.11.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.428.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.428.0",
-                "@smithy/node-config-provider": "^2.1.1",
-                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "aws-crt": ">=1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "aws-crt": {
-                    "optional": true
-                }
             }
         },
-        "node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
+        "node_modules/@aws-sdk/util-middleware/node_modules/tslib": {
             "version": "2.6.2",
-            "license": "0BSD"
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/util-retry": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
+            "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
+            "dependencies": {
+                "@aws-sdk/service-error-classification": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-retry/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/util-stream-browser": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.347.0.tgz",
+            "integrity": "sha512-pIbmzIJfyX26qG622uIESOmJSMGuBkhmNU7I98bzhYCet5ctC0ow9L5FZw9ljOE46P/HkEcsOhh+qTHyCXlCEQ==",
+            "dependencies": {
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-base64": "3.310.0",
+                "@aws-sdk/util-hex-encoding": "3.310.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-stream-browser/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/util-stream-node": {
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.348.0.tgz",
+            "integrity": "sha512-MFXyMUWA2oD0smBZf+sdnuyxLw8nCqyMEgYbos+6grvF1Szxn5+zbYTZrEBYiICqD1xJRLbWTzFLJU7oYm6pUg==",
+            "dependencies": {
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-buffer-from": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-stream-node/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/util-uri-escape": {
+            "version": "3.310.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+            "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-uri-escape/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/util-utf8": {
+            "version": "3.310.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+            "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
+            "dependencies": {
+                "@aws-sdk/util-buffer-from": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
         "node_modules/@aws-sdk/util-utf8-browser": {
             "version": "3.259.0",
@@ -844,6 +1529,40 @@
         "node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
             "version": "2.5.3",
             "license": "0BSD"
+        },
+        "node_modules/@aws-sdk/util-utf8/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/@aws-sdk/util-waiter": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.347.0.tgz",
+            "integrity": "sha512-3ze/0PkwkzUzLncukx93tZgGL0JX9NaP8DxTi6WzflnL/TEul5Z63PCruRNK0om17iZYAWKrf8q2mFoHYb4grA==",
+            "dependencies": {
+                "@aws-sdk/abort-controller": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-waiter/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-waiter/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@aws-sdk/xml-builder": {
             "version": "3.310.0",
@@ -5557,511 +6276,6 @@
                 "@sinonjs/commons": "^1.7.0"
             }
         },
-        "node_modules/@smithy/abort-controller": {
-            "version": "2.0.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/abort-controller/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/chunked-blob-reader": {
-            "version": "2.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@smithy/chunked-blob-reader-native": {
-            "version": "2.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-base64": "^2.0.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@smithy/chunked-blob-reader-native/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/chunked-blob-reader/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/config-resolver": {
-            "version": "2.0.14",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^2.1.1",
-                "@smithy/types": "^2.3.5",
-                "@smithy/util-config-provider": "^2.0.0",
-                "@smithy/util-middleware": "^2.0.4",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/config-resolver/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/credential-provider-imds": {
-            "version": "2.0.16",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^2.1.1",
-                "@smithy/property-provider": "^2.0.12",
-                "@smithy/types": "^2.3.5",
-                "@smithy/url-parser": "^2.0.11",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/credential-provider-imds/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/eventstream-codec": {
-            "version": "2.0.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/crc32": "3.0.0",
-                "@smithy/types": "^2.3.5",
-                "@smithy/util-hex-encoding": "^2.0.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@smithy/eventstream-codec/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/eventstream-serde-browser": {
-            "version": "2.0.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/eventstream-serde-universal": "^2.0.11",
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/eventstream-serde-browser/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/eventstream-serde-config-resolver": {
-            "version": "2.0.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/eventstream-serde-config-resolver/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/eventstream-serde-node": {
-            "version": "2.0.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/eventstream-serde-universal": "^2.0.11",
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/eventstream-serde-node/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/eventstream-serde-universal": {
-            "version": "2.0.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/eventstream-codec": "^2.0.11",
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/eventstream-serde-universal/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/fetch-http-handler": {
-            "version": "2.2.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/protocol-http": "^3.0.7",
-                "@smithy/querystring-builder": "^2.0.11",
-                "@smithy/types": "^2.3.5",
-                "@smithy/util-base64": "^2.0.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@smithy/fetch-http-handler/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/hash-blob-browser": {
-            "version": "2.0.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/chunked-blob-reader": "^2.0.0",
-                "@smithy/chunked-blob-reader-native": "^2.0.0",
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@smithy/hash-blob-browser/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/hash-node": {
-            "version": "2.0.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.3.5",
-                "@smithy/util-buffer-from": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/hash-node/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/hash-stream-node": {
-            "version": "2.0.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.3.5",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/hash-stream-node/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/invalid-dependency": {
-            "version": "2.0.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@smithy/invalid-dependency/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/is-array-buffer": {
-            "version": "2.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/is-array-buffer/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/md5-js": {
-            "version": "2.0.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.3.5",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@smithy/md5-js/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/middleware-content-length": {
-            "version": "2.0.13",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/protocol-http": "^3.0.7",
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/middleware-content-length/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/middleware-endpoint": {
-            "version": "2.1.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/middleware-serde": "^2.0.11",
-                "@smithy/node-config-provider": "^2.1.1",
-                "@smithy/shared-ini-file-loader": "^2.2.0",
-                "@smithy/types": "^2.3.5",
-                "@smithy/url-parser": "^2.0.11",
-                "@smithy/util-middleware": "^2.0.4",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/middleware-endpoint/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/middleware-retry": {
-            "version": "2.0.16",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^2.1.1",
-                "@smithy/protocol-http": "^3.0.7",
-                "@smithy/service-error-classification": "^2.0.4",
-                "@smithy/types": "^2.3.5",
-                "@smithy/util-middleware": "^2.0.4",
-                "@smithy/util-retry": "^2.0.4",
-                "tslib": "^2.5.0",
-                "uuid": "^8.3.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/middleware-retry/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/middleware-retry/node_modules/uuid": {
-            "version": "8.3.2",
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
-        "node_modules/@smithy/middleware-serde": {
-            "version": "2.0.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/middleware-serde/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/middleware-stack": {
-            "version": "2.0.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/middleware-stack/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/node-config-provider": {
-            "version": "2.1.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^2.0.12",
-                "@smithy/shared-ini-file-loader": "^2.2.0",
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/node-config-provider/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/node-http-handler": {
-            "version": "2.1.7",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^2.0.11",
-                "@smithy/protocol-http": "^3.0.7",
-                "@smithy/querystring-builder": "^2.0.11",
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/node-http-handler/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/property-provider": {
-            "version": "2.0.12",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/property-provider/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/protocol-http": {
-            "version": "3.0.7",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/protocol-http/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/querystring-builder": {
-            "version": "2.0.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.3.5",
-                "@smithy/util-uri-escape": "^2.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/querystring-builder/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/querystring-parser": {
-            "version": "2.0.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/querystring-parser/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/service-error-classification": {
-            "version": "2.0.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.3.5"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/shared-ini-file-loader": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/shared-ini-file-loader/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/signature-v4": {
-            "version": "2.0.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/eventstream-codec": "^2.0.11",
-                "@smithy/is-array-buffer": "^2.0.0",
-                "@smithy/types": "^2.3.5",
-                "@smithy/util-hex-encoding": "^2.0.0",
-                "@smithy/util-middleware": "^2.0.4",
-                "@smithy/util-uri-escape": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/signature-v4/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/smithy-client": {
-            "version": "2.1.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/middleware-stack": "^2.0.5",
-                "@smithy/types": "^2.3.5",
-                "@smithy/util-stream": "^2.0.16",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/smithy-client/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/types": {
             "version": "2.3.5",
             "license": "Apache-2.0",
@@ -6073,237 +6287,6 @@
             }
         },
         "node_modules/@smithy/types/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/url-parser": {
-            "version": "2.0.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/querystring-parser": "^2.0.11",
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@smithy/url-parser/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/util-base64": {
-            "version": "2.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^2.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/util-base64/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/util-body-length-browser": {
-            "version": "2.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@smithy/util-body-length-browser/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/util-body-length-node": {
-            "version": "2.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/util-body-length-node/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/util-buffer-from": {
-            "version": "2.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^2.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/util-buffer-from/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/util-config-provider": {
-            "version": "2.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/util-config-provider/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "2.0.15",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^2.0.12",
-                "@smithy/smithy-client": "^2.1.11",
-                "@smithy/types": "^2.3.5",
-                "bowser": "^2.11.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@smithy/util-defaults-mode-browser/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "2.0.19",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/config-resolver": "^2.0.14",
-                "@smithy/credential-provider-imds": "^2.0.16",
-                "@smithy/node-config-provider": "^2.1.1",
-                "@smithy/property-provider": "^2.0.12",
-                "@smithy/smithy-client": "^2.1.11",
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@smithy/util-defaults-mode-node/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/util-hex-encoding": {
-            "version": "2.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/util-hex-encoding/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/util-middleware": {
-            "version": "2.0.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/util-middleware/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/util-retry": {
-            "version": "2.0.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/service-error-classification": "^2.0.4",
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@smithy/util-retry/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/util-stream": {
-            "version": "2.0.16",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/fetch-http-handler": "^2.2.3",
-                "@smithy/node-http-handler": "^2.1.7",
-                "@smithy/types": "^2.3.5",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-buffer-from": "^2.0.0",
-                "@smithy/util-hex-encoding": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/util-stream/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/util-uri-escape": {
-            "version": "2.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/util-uri-escape/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/util-utf8": {
-            "version": "2.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^2.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/util-utf8/node_modules/tslib": {
-            "version": "2.6.2",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/util-waiter": {
-            "version": "2.0.11",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^2.0.11",
-                "@smithy/types": "^2.3.5",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/util-waiter/node_modules/tslib": {
             "version": "2.6.2",
             "license": "0BSD"
         },
@@ -14103,26 +14086,6 @@
             "version": "2.0.6",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/fast-xml-parser": {
-            "version": "4.2.5",
-            "funding": [
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/naturalintelligence"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/NaturalIntelligence"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "strnum": "^1.0.5"
-            },
-            "bin": {
-                "fxparser": "src/cli/cli.js"
-            }
         },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
@@ -26846,7 +26809,7 @@
             "version": "0.39.0",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@aws-sdk/client-s3": "^3.348.0",
+                "@aws-sdk/client-s3": "3.348.0",
                 "@datadog/datadog-api-client": "^1.16.0",
                 "@hapi/boom": "^10.0.1",
                 "@nangohq/node": "^0.39.0",
@@ -26902,6 +26865,534 @@
             "engines": {
                 "node": ">=16.7",
                 "npm": ">=6.14.11"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/client-s3": {
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.348.0.tgz",
+            "integrity": "sha512-19ShUJL/Kqol4pW2S6axD85oL2JIh91ctUgqPEuu5BzGyEgq5s+HP/DDNzcdsTKl7gfCfaIULf01yWU6RwY1EA==",
+            "dependencies": {
+                "@aws-crypto/sha1-browser": "3.0.0",
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sts": "3.348.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/eventstream-serde-browser": "3.347.0",
+                "@aws-sdk/eventstream-serde-config-resolver": "3.347.0",
+                "@aws-sdk/eventstream-serde-node": "3.347.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-blob-browser": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/hash-stream-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/md5-js": "3.347.0",
+                "@aws-sdk/middleware-bucket-endpoint": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-expect-continue": "3.347.0",
+                "@aws-sdk/middleware-flexible-checksums": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-location-constraint": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-sdk-s3": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/middleware-ssec": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/signature-v4-multi-region": "3.347.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
+                "@aws-sdk/util-base64": "3.310.0",
+                "@aws-sdk/util-body-length-browser": "3.310.0",
+                "@aws-sdk/util-body-length-node": "3.310.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-stream-browser": "3.347.0",
+                "@aws-sdk/util-stream-node": "3.348.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "@aws-sdk/util-waiter": "3.347.0",
+                "@aws-sdk/xml-builder": "3.310.0",
+                "@smithy/protocol-http": "^1.0.1",
+                "@smithy/types": "^1.0.0",
+                "fast-xml-parser": "4.2.4",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/client-sso": {
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.348.0.tgz",
+            "integrity": "sha512-5S23gVKBl0fhZ96RD8LdPhMKeh8E5fmebyZxMNZuWliSXz++Q9ZCrwPwQbkks3duPOTcKKobs3IoqP82HoXMvQ==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
+                "@aws-sdk/util-base64": "3.310.0",
+                "@aws-sdk/util-body-length-browser": "3.310.0",
+                "@aws-sdk/util-body-length-node": "3.310.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "@smithy/protocol-http": "^1.0.1",
+                "@smithy/types": "^1.0.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/client-sts": {
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.348.0.tgz",
+            "integrity": "sha512-4iaQlWAOHMEF4xjR/FB/ws3aUjXjJHwbsIcqbdYAxsKijDYYTZYCPc/gM0NE1yi28qlNYNhMzHipe5xTYbU2Eg==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/config-resolver": "3.347.0",
+                "@aws-sdk/credential-provider-node": "3.348.0",
+                "@aws-sdk/fetch-http-handler": "3.347.0",
+                "@aws-sdk/hash-node": "3.347.0",
+                "@aws-sdk/invalid-dependency": "3.347.0",
+                "@aws-sdk/middleware-content-length": "3.347.0",
+                "@aws-sdk/middleware-endpoint": "3.347.0",
+                "@aws-sdk/middleware-host-header": "3.347.0",
+                "@aws-sdk/middleware-logger": "3.347.0",
+                "@aws-sdk/middleware-recursion-detection": "3.347.0",
+                "@aws-sdk/middleware-retry": "3.347.0",
+                "@aws-sdk/middleware-sdk-sts": "3.347.0",
+                "@aws-sdk/middleware-serde": "3.347.0",
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/middleware-stack": "3.347.0",
+                "@aws-sdk/middleware-user-agent": "3.347.0",
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/node-http-handler": "3.348.0",
+                "@aws-sdk/smithy-client": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/url-parser": "3.347.0",
+                "@aws-sdk/util-base64": "3.310.0",
+                "@aws-sdk/util-body-length-browser": "3.310.0",
+                "@aws-sdk/util-body-length-node": "3.310.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+                "@aws-sdk/util-defaults-mode-node": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "@aws-sdk/util-retry": "3.347.0",
+                "@aws-sdk/util-user-agent-browser": "3.347.0",
+                "@aws-sdk/util-user-agent-node": "3.347.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "@smithy/protocol-http": "^1.0.1",
+                "@smithy/types": "^1.0.0",
+                "fast-xml-parser": "4.2.4",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.347.0.tgz",
+            "integrity": "sha512-UnEM+LKGpXKzw/1WvYEQsC6Wj9PupYZdQOE+e2Dgy2dqk/pVFy4WueRtFXYDT2B41ppv3drdXUuKZRIDVqIgNQ==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.348.0.tgz",
+            "integrity": "sha512-0IEH5mH/cz2iLyr/+pSa3sCsQcGADiLSEn6yivsXdfz1zDqBiv+ffDoL0+Pvnp+TKf8sA6OlX8PgoMoEBvBdKw==",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.347.0",
+                "@aws-sdk/credential-provider-imds": "3.347.0",
+                "@aws-sdk/credential-provider-process": "3.347.0",
+                "@aws-sdk/credential-provider-sso": "3.348.0",
+                "@aws-sdk/credential-provider-web-identity": "3.347.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.348.0.tgz",
+            "integrity": "sha512-ngRWphm9e36i58KqVi7Z8WOub+k0cSl+JZaAmgfFm0+dsfBG5uheo598OeiwWV0DqlilvaQZFaMVQgG2SX/tHg==",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.347.0",
+                "@aws-sdk/credential-provider-imds": "3.347.0",
+                "@aws-sdk/credential-provider-ini": "3.348.0",
+                "@aws-sdk/credential-provider-process": "3.347.0",
+                "@aws-sdk/credential-provider-sso": "3.348.0",
+                "@aws-sdk/credential-provider-web-identity": "3.347.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.347.0.tgz",
+            "integrity": "sha512-yl1z4MsaBdXd4GQ2halIvYds23S67kElyOwz7g8kaQ4kHj+UoYWxz3JVW/DGusM6XmQ9/F67utBrUVA0uhQYyw==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.348.0.tgz",
+            "integrity": "sha512-5cQao705376KgGkLv9xgkQ3T5H7KdNddWuyoH2wDcrHd1BA2Lnrell3Yyh7R6jQeV7uCQE/z0ugUOKhDqNKIqQ==",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.348.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/token-providers": "3.348.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.347.0.tgz",
+            "integrity": "sha512-DxoTlVK8lXjS1zVphtz/Ab+jkN/IZor9d6pP2GjJHNoAIIzXfRwwj5C8vr4eTayx/5VJ7GRP91J8GJ2cKly8Qw==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/middleware-bucket-endpoint": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.347.0.tgz",
+            "integrity": "sha512-i9n4ylkGmGvizVcTfN4L+oN10OCL2DKvyMa4cCAVE1TJrsnaE0g7IOOyJGUS8p5KJYQrKVR7kcsa2L1S0VeEcA==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-arn-parser": "3.310.0",
+                "@aws-sdk/util-config-provider": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/middleware-expect-continue": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.347.0.tgz",
+            "integrity": "sha512-95M1unD1ENL0tx35dfyenSfx0QuXBSKtOi/qJja6LfX5771C5fm5ZTOrsrzPFJvRg/wj8pCOVWRZk+d5+jvfOQ==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/middleware-flexible-checksums": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.347.0.tgz",
+            "integrity": "sha512-Pda7VMAIyeHw9nMp29rxdFft3EF4KP/tz/vLB6bqVoBNbLujo5rxn3SGOgStgIz7fuMLQQfoWIsmvxUm+Fp+Dw==",
+            "dependencies": {
+                "@aws-crypto/crc32": "3.0.0",
+                "@aws-crypto/crc32c": "3.0.0",
+                "@aws-sdk/is-array-buffer": "3.310.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
+            "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/middleware-location-constraint": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.347.0.tgz",
+            "integrity": "sha512-x5fcEV7q8fQ0OmUO+cLhN5iPqGoLWtC3+aKHIfRRb2BpOO1khyc1FKzsIAdeQz2hfktq4j+WsrmcPvFKv51pSg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
+            "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
+            "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/middleware-sdk-s3": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.347.0.tgz",
+            "integrity": "sha512-TLr92+HMvamrhJJ0VDhA/PiUh4rTNQz38B9dB9ikohTaRgm+duP+mRiIv16tNPZPGl8v82Thn7Ogk2qPByNDtg==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-arn-parser": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/middleware-sdk-sts": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.347.0.tgz",
+            "integrity": "sha512-38LJ0bkIoVF3W97x6Jyyou72YV9Cfbml4OaDEdnrCOo0EssNZM5d7RhjMvQDwww7/3OBY/BzeOcZKfJlkYUXGw==",
+            "dependencies": {
+                "@aws-sdk/middleware-signing": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/middleware-signing": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.347.0.tgz",
+            "integrity": "sha512-zVBF/4MGKnvhAE/J+oAL/VAehiyv+trs2dqSQXwHou9j8eA8Vm8HS2NdOwpkZQchIxTuwFlqSusDuPEdYFbvGw==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/signature-v4": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-middleware": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/middleware-ssec": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.347.0.tgz",
+            "integrity": "sha512-467VEi2elPmUGcHAgTmzhguZ3lwTpwK+3s+pk312uZtVsS9rP1MAknYhpS3ZvssiqBUVPx8m29cLcC6Tx5nOJg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.347.0.tgz",
+            "integrity": "sha512-wJbGN3OE1/daVCrwk49whhIr9E0j1N4gWwN/wi4WuyYIA+5lMUfVp0aGIOvZR+878DxuFz2hQ4XcZVT4K2WvQw==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/util-endpoints": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/signature-v4-multi-region": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.347.0.tgz",
+            "integrity": "sha512-838h7pbRCVYWlTl8W+r5+Z5ld7uoBObgAn7/RB1MQ4JjlkfLdN7emiITG6ueVL+7gWZNZc/4dXR/FJSzCgrkxQ==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.347.0",
+                "@aws-sdk/signature-v4": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/signature-v4-crt": "^3.118.0"
+            },
+            "peerDependenciesMeta": {
+                "@aws-sdk/signature-v4-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/token-providers": {
+            "version": "3.348.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.348.0.tgz",
+            "integrity": "sha512-nTjoJkUsJUrJTZuqaeMD9PW2//Rdg2HgfDjiyC4jmAXtayWYCi11mqauurMaUHJ3p5qJ8f5xzxm6vBTbrftPag==",
+            "dependencies": {
+                "@aws-sdk/client-sso-oidc": "3.348.0",
+                "@aws-sdk/property-provider": "3.347.0",
+                "@aws-sdk/shared-ini-file-loader": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/types": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.347.0.tgz",
+            "integrity": "sha512-/WUkirizeNAqwVj0zkcrqdQ9pUm1HY5kU+qy7xTR0OebkuJauglkmSTMD+56L1JPunWqHhlwCMVRaz5eaJdSEQ==",
+            "dependencies": {
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
+            "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.347.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "packages/shared/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.347.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.347.0.tgz",
+            "integrity": "sha512-6X0b9qGsbD1s80PmbaB6v1/ZtLfSx6fjRX8caM7NN0y/ObuLoX8LhYnW6WlB2f1+xb4EjaCNgpP/zCf98MXosw==",
+            "dependencies": {
+                "@aws-sdk/node-config-provider": "3.347.0",
+                "@aws-sdk/types": "3.347.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/shared/node_modules/@smithy/protocol-http": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+            "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+            "dependencies": {
+                "@smithy/types": "^1.2.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/shared/node_modules/@smithy/types": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+            "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "packages/shared/node_modules/@types/uuid": {
@@ -27009,6 +27500,27 @@
                 "node": ">= 12.0.0"
             }
         },
+        "packages/shared/node_modules/fast-xml-parser": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+            "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+            "funding": [
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "dependencies": {
+                "strnum": "^1.0.5"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
+        },
         "packages/shared/node_modules/glob": {
             "version": "10.3.0",
             "license": "ISC",
@@ -27088,6 +27600,11 @@
                 "fast-fifo": "^1.2.0",
                 "streamx": "^2.15.0"
             }
+        },
+        "packages/shared/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "packages/shared/node_modules/zip-stream": {
             "version": "5.0.1",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,7 +17,7 @@
     },
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
-        "@aws-sdk/client-s3": "^3.348.0",
+        "@aws-sdk/client-s3": "3.348.0",
         "@datadog/datadog-api-client": "^1.16.0",
         "@hapi/boom": "^10.0.1",
         "@nangohq/node": "^0.39.0",


### PR DESCRIPTION
## Describe your changes

Fixes NAN-530

AWS upgraded their sdk with a broken version, it's usually better to have a `^` for libraries but in that case it's a side-effect and this library is not used by the CLI. Ultimately, the CLI should not import this package at all but in the meantime it's safer to pin back to something that was working.

- Pin dependency to last working version 
