### PR TITLE
[nan-526] for OAauth2 force an expiration unless explicitly stated

### DIFF
--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -362,7 +362,7 @@ paths:
                                     description: (OAuth 2, optional) In seconds.
                                 no_expiration:
                                     type: boolean
-                                    description: (OAuth2, optional) If the provider gives access tokens that don't expire pass in true for this parameter to avoid passing an expiration for the access token.
+                                    description: (OAuth2, optional) If the provider gives access tokens that don't expire, pass in `true` to avoid an import validation error.
                                 oauth_token:
                                     type: string
                                     description: (OAuth 1, required) The client token to be attached to the connection.

--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -360,6 +360,9 @@ paths:
                                 expires_in:
                                     type: integer
                                     description: (OAuth 2, optional) In seconds.
+                                no_expiration:
+                                    type: boolean
+                                    description: (OAuth2, optional) If the provider gives access tokens that don't expire pass in true for this parameter to avoid passing an expiration for the access token.
                                 oauth_token:
                                     type: string
                                     description: (OAuth 1, required) The client token to be attached to the connection.

--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -535,7 +535,7 @@ class ConnectionController {
                     return;
                 }
 
-                if (!parsedExpiresAt && noExpiration && noExpiration !== true) {
+                if (!parsedExpiresAt && noExpiration !== true) {
                     errorManager.errRes(res, 'missing_expires_at');
                     return;
                 }

--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -523,7 +523,7 @@ class ConnectionController {
             let runHook = false;
 
             if (template.auth_mode === ProviderAuthModes.OAuth2) {
-                const { access_token, refresh_token, expires_at, expires_in, metadata, connection_config } = req.body;
+                const { access_token, refresh_token, expires_at, expires_in, metadata, connection_config, no_expiration: noExpiration } = req.body;
 
                 const { expires_at: parsedExpiresAt } = connectionService.parseRawCredentials(
                     { access_token, refresh_token, expires_at, expires_in },
@@ -534,6 +534,12 @@ class ConnectionController {
                     errorManager.errRes(res, 'missing_access_token');
                     return;
                 }
+
+                if (!parsedExpiresAt && noExpiration && noExpiration !== true) {
+                    errorManager.errRes(res, 'missing_expires_at');
+                    return;
+                }
+
                 oAuthCredentials = {
                     type: template.auth_mode,
                     access_token,

--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -540,6 +540,11 @@ class ConnectionController {
                     return;
                 }
 
+                if (parsedExpiresAt && isNaN(parsedExpiresAt.getTime())) {
+                    errorManager.errRes(res, 'invalid_expires_at');
+                    return;
+                }
+
                 oAuthCredentials = {
                     type: template.auth_mode,
                     access_token,

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -202,7 +202,12 @@ export class NangoError extends Error {
 
             case 'missing_expires_at':
                 this.status = 400;
-                this.message = `Importing an OAuth2 token requires the 'expires_at' parameter. If the token doesn't expire pass in the noExpiration parameter`;
+                this.message = `Importing an OAuth2 token requires the 'expires_at' parameter. If the token doesn't expire pass in the 'no_expiration' parameter`;
+                break;
+
+            case 'invalid_expires_at':
+                this.status = 400;
+                this.message = `The provided 'expires_at' parameter is invalid. It should be a valid date`;
                 break;
 
             case 'missing_hmac':

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -200,6 +200,11 @@ export class NangoError extends Error {
                 this.message = `Missing param 'access_token'.`;
                 break;
 
+            case 'missing_expires_at':
+                this.status = 400;
+                this.message = `Importing an OAuth2 token requires the 'expires_at' parameter. If the token doesn't expire pass in the noExpiration parameter`;
+                break;
+
             case 'missing_hmac':
                 this.status = 400;
                 this.message = `Missing param 'hmac'.`;


### PR DESCRIPTION
## Describe your changes
A customer imported connections and didn't import the expiration date. Then one day the connections stopped working because the system never know when to refresh their access token. Unless a provider provides tokens that never expire force on import an expires_at or expires_in parameter

## Issue ticket number and link
NAN-526

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
