### PR TITLE
[NAN-532] Update docs because modifiedAfter isn't null for an initial sync

### DIFF
--- a/docs-v2/integrate/guides/receive-webhooks-from-nango.mdx
+++ b/docs-v2/integrate/guides/receive-webhooks-from-nango.mdx
@@ -28,7 +28,7 @@ Webhooks from Nango are POST requests with the following body:
     "model": "<string>",
     "responseResults": { "<DataModel>": { "added": 123, "updated": 123, "deleted": 123 } },
     "syncType": "INITIAL" | "INCREMENTAL",
-    "modifiedAfter": "<timestamp>" // Null on the sync's first execution.
+    "modifiedAfter": "<timestamp>"
 }
 ```
 </Tab>

--- a/docs-v2/integrate/guides/sync-data-from-an-api.mdx
+++ b/docs-v2/integrate/guides/sync-data-from-an-api.mdx
@@ -37,7 +37,7 @@ The webhook from Nango is a POST request with the following body ([reference](/r
     "model": "<string>",
     "responseResults": { "<DataModel>": { "added": 123, "updated": 123, "deleted": 123 } },
     "syncType": "INITIAL" | "INCREMENTAL",
-    "modifiedAfter": "<timestamp>" // Null on the sync's first execution.
+    "modifiedAfter": "<timestamp>"
 }
 ```
 

--- a/packages/shared/lib/services/notification/webhook.service.ts
+++ b/packages/shared/lib/services/notification/webhook.service.ts
@@ -150,12 +150,13 @@ class WebhookService {
                 deleted: 0
             },
             syncType,
-            modifiedAfter: now ? dayjs(now).toDate().toISOString() : null,
+            modifiedAfter: dayjs(now).toDate().toISOString(),
             queryTimeStamp: now as unknown as string
         };
 
         if (syncType === SyncType.INITIAL) {
             body.queryTimeStamp = null;
+            body.modifiedAfter = null;
         }
 
         if (responseResults.deleted && responseResults.deleted > 0) {

--- a/packages/shared/lib/services/notification/webhook.service.ts
+++ b/packages/shared/lib/services/notification/webhook.service.ts
@@ -150,7 +150,7 @@ class WebhookService {
                 deleted: 0
             },
             syncType,
-            modifiedAfter: dayjs(now).toDate().toISOString(),
+            modifiedAfter: now ? dayjs(now).toDate().toISOString() : null,
             queryTimeStamp: now as unknown as string
         };
 

--- a/packages/shared/lib/services/notification/webhook.service.ts
+++ b/packages/shared/lib/services/notification/webhook.service.ts
@@ -156,7 +156,6 @@ class WebhookService {
 
         if (syncType === SyncType.INITIAL) {
             body.queryTimeStamp = null;
-            body.modifiedAfter = null;
         }
 
         if (responseResults.deleted && responseResults.deleted > 0) {


### PR DESCRIPTION
## Describe your changes
Since modifiedAfter is set at the beginning of the sync this value can always be used to fetch records. Update docs accordingly

## Issue ticket number and link
NAN-532

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
