### PR TITLE
[nan-529] fix bug in syncstatus endpoint

### DIFF
--- a/packages/cli/lib/nango.yaml.schema.v2.json
+++ b/packages/cli/lib/nango.yaml.schema.v2.json
@@ -52,6 +52,12 @@
                                                 "enum": "nango yaml schema validation error: sync_type must be either 'incremental' or 'full'."
                                             }
                                         },
+                                        "track_deletes": {
+                                            "type": "boolean",
+                                            "errorMessage": {
+                                                "type": "nango yaml schema validation error: track_deletes must be a boolean."
+                                            }
+                                        },
                                         "auto_start": {
                                             "type": "boolean",
                                             "errorMessage": {

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -549,7 +549,8 @@ class SyncController {
             const environmentId = getEnvironmentId(res);
 
             if (syncNames === '*') {
-                syncNames = await getSyncsByProviderConfigKey(environmentId, provider_config_key as string).then((syncs) => syncs.map((sync) => sync.name));
+                const syncs = await getSyncsByProviderConfigKey(environmentId, provider_config_key as string);
+                syncNames = syncs.filter((sync) => (connection_id ? sync.connection_id === connection_id : true)).map((sync) => sync.name);
             } else {
                 syncNames = (syncNames as string).split(',');
             }

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -5,6 +5,7 @@ import type { LogLevel, NangoConnection, HTTP_VERB } from '@nangohq/shared';
 import tracer from 'dd-trace';
 import { getUserAccountAndEnvironmentFromSession } from '../utils/utils.js';
 import {
+    Connection,
     getEnvironmentId,
     deploy as deploySyncConfig,
     syncDataService,
@@ -12,6 +13,7 @@ import {
     getSyncs,
     verifyOwnership,
     isSyncValid,
+    getSyncNamesByConnectionId,
     getSyncsByProviderConfigKey,
     SyncClient,
     updateScheduleStatus,
@@ -548,9 +550,26 @@ class SyncController {
 
             const environmentId = getEnvironmentId(res);
 
+            let connection: Connection | null = null;
+
+            if (connection_id) {
+                const connectionResult = await connectionService.getConnection(connection_id as string, provider_config_key as string, environmentId);
+                const { success: connectionSuccess, error: connectionError } = connectionResult;
+                if (!connectionSuccess || !connectionResult.response) {
+                    errorManager.errResFromNangoErr(res, connectionError);
+                    return;
+                }
+
+                connection = connectionResult.response;
+            }
+
             if (syncNames === '*') {
-                const syncs = await getSyncsByProviderConfigKey(environmentId, provider_config_key as string);
-                syncNames = syncs.filter((sync) => (connection_id ? sync.connection_id === connection_id : true)).map((sync) => sync.name);
+                if (connection && connection.id) {
+                    syncNames = await getSyncNamesByConnectionId(connection.id);
+                } else {
+                    const syncs = await getSyncsByProviderConfigKey(environmentId, provider_config_key as string);
+                    syncNames = syncs.map((sync) => sync.name);
+                }
             } else {
                 syncNames = (syncNames as string).split(',');
             }
@@ -559,7 +578,7 @@ class SyncController {
                 success,
                 error,
                 response: syncsWithStatus
-            } = await syncOrchestrator.getSyncStatus(environmentId, provider_config_key as string, syncNames as string[], connection_id as string);
+            } = await syncOrchestrator.getSyncStatus(environmentId, provider_config_key as string, syncNames, connection_id as string, false, connection);
 
             if (!success || !syncsWithStatus) {
                 errorManager.errResFromNangoErr(res, error);

--- a/packages/shared/lib/services/sync/orchestrator.service.ts
+++ b/packages/shared/lib/services/sync/orchestrator.service.ts
@@ -400,7 +400,9 @@ export class Orchestrator {
         if (syncSchedule) {
             if (syncSchedule?.schedule?.state?.paused && status !== SyncStatus.PAUSED) {
                 await updateScheduleStatus(schedule?.id as string, SyncCommand.PAUSE, null, environmentId);
-                status = SyncStatus.PAUSED;
+                if (status !== SyncStatus.RUNNING) {
+                    status = SyncStatus.PAUSED;
+                }
             } else if (!syncSchedule?.schedule?.state?.paused && status === SyncStatus.PAUSED) {
                 await updateScheduleStatus(schedule?.id as string, SyncCommand.UNPAUSE, null, environmentId);
                 status = SyncStatus.STOPPED;

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -327,9 +327,11 @@ export const getSyncsByConnectionId = async (nangoConnectionId: number): Promise
     return null;
 };
 
-export const getSyncsByProviderConfigKey = async (environment_id: number, providerConfigKey: string): Promise<Sync[]> => {
+type SyncWithConnectionId = Sync & { connection_id: string };
+
+export const getSyncsByProviderConfigKey = async (environment_id: number, providerConfigKey: string): Promise<SyncWithConnectionId[]> => {
     const results = await db.knex
-        .select(`${TABLE}.id`, `${TABLE}.name`, `_nango_connections.connection_id`, `${TABLE}.created_at`, `${TABLE}.updated_at`, `${TABLE}.last_sync_date`)
+        .select(`${TABLE}.*`, `${TABLE}.name`, `_nango_connections.connection_id`, `${TABLE}.created_at`, `${TABLE}.updated_at`, `${TABLE}.last_sync_date`)
         .from<Sync>(TABLE)
         .join('_nango_connections', '_nango_connections.id', `${TABLE}.nango_connection_id`)
         .where({


### PR DESCRIPTION
## Describe your changes
* Adds `track_deletes` to the nango.yaml schema
* Fixes issue with mismatch of the UI vs. the API when a sync is running
* Remove duplicated syncs when a connection id is passed to the status endpoint 

## Issue ticket number and link
NAN-529

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
