### PR TITLE
[nan-544] allow optional params to be passed in and used

### DIFF
--- a/packages/shared/lib/sdk/sync.integration.test.ts
+++ b/packages/shared/lib/sdk/sync.integration.test.ts
@@ -16,7 +16,7 @@ describe('Connection service integration tests', () => {
     });
 
     describe('Nango object tests', () => {
-        it('Should replace existing metadata, overwriting anything existing', async () => {
+        it('Should retrieve connections correctly if different connection credentials are passed in', async () => {
             const connections = await createConnectionSeeds(environmentName);
 
             const [nangoConnectionId, secondNangoConnectionId]: number[] = connections;

--- a/packages/shared/lib/sdk/sync.integration.test.ts
+++ b/packages/shared/lib/sdk/sync.integration.test.ts
@@ -1,0 +1,77 @@
+import { expect, describe, it, beforeAll } from 'vitest';
+import { multipleMigrations } from '../db/database.js';
+import type { Connection } from '../models/Connection.js';
+import { NangoAction } from './sync.js';
+import connectionService from '../services/connection.service.js';
+import environmentService from '../services/environment.service.js';
+import { createConnectionSeeds } from '../db/seeders/connection.seeder.js';
+import { createConfigSeeds } from '../db/seeders/config.seeder.js';
+
+const environmentName = 'sdk-test';
+
+describe('Connection service integration tests', () => {
+    beforeAll(async () => {
+        await multipleMigrations();
+        await createConfigSeeds();
+    });
+
+    describe('Nango object tests', () => {
+        it('Should replace existing metadata, overwriting anything existing', async () => {
+            const connections = await createConnectionSeeds(environmentName);
+
+            const [nangoConnectionId, secondNangoConnectionId]: number[] = connections;
+            const establishedConnection = await connectionService.getConnectionById(nangoConnectionId as number);
+
+            if (!establishedConnection) {
+                throw new Error('Connection not established');
+            }
+
+            const environment = await environmentService.getById(establishedConnection.environment_id);
+
+            if (!environment) {
+                throw new Error('Environment not found');
+            }
+
+            const nangoProps = {
+                host: 'http://localhost:3003',
+                accountId: environment.account_id,
+                connectionId: String(establishedConnection.connection_id),
+                environmentId: environment.id,
+                providerConfigKey: String(establishedConnection?.provider_config_key),
+                provider: 'hubspot',
+                activityLogId: 1,
+                secretKey: '****',
+                nangoConnectionId: nangoConnectionId as number,
+                syncId: 'aaa-bbb-ccc',
+                syncJobId: 2,
+                lastSyncDate: new Date()
+            };
+
+            const nango = new NangoAction(nangoProps);
+
+            // @ts-expect-error we are overriding a private method here
+            nango.nango.getConnection = async (providerConfigKey: string, connectionId: string) => {
+                const { response } = await connectionService.getConnection(connectionId, providerConfigKey, environment.id);
+                return response as Connection;
+            };
+
+            const connection = await nango.getConnection();
+            expect(connection).toBeDefined();
+            expect(connection.connection_id).toBe(establishedConnection.connection_id);
+            expect(connection.provider_config_key).toBe(establishedConnection.provider_config_key);
+
+            const secondEstablishedConnection = await connectionService.getConnectionById(secondNangoConnectionId as number);
+            if (!secondEstablishedConnection) {
+                throw new Error('Connection not established');
+            }
+
+            const secondConnection = await nango.getConnection(
+                secondEstablishedConnection.provider_config_key,
+                String(secondEstablishedConnection.connection_id)
+            );
+            expect(secondConnection).toBeDefined();
+            expect(secondConnection.connection_id).toBe(secondEstablishedConnection.connection_id);
+            expect(secondConnection.provider_config_key).toBe(secondEstablishedConnection.provider_config_key);
+        });
+    });
+});

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -338,7 +338,9 @@ export class NangoAction {
         if (this.dryRun) {
             return this.nango.proxy(config);
         } else {
-            const connection = await this.getConnection();
+            const { connectionId, providerConfigKey } = config;
+            console.log(config);
+            const connection = await this.getConnection(providerConfigKey, connectionId);
             if (!connection) {
                 throw new Error(`Connection not found using the provider config key ${this.providerConfigKey} and connection id ${this.connectionId}`);
             }
@@ -418,10 +420,14 @@ export class NangoAction {
         return this.nango.getToken(this.providerConfigKey as string, this.connectionId as string);
     }
 
-    public async getConnection(): Promise<Connection> {
+    public async getConnection(optionalProviderConfigKey?: string, optionalConnectionId?: string): Promise<Connection> {
         this.exitSyncIfAborted();
+
+        const providerConfigKey = optionalProviderConfigKey || this.providerConfigKey;
+        const connectionId = optionalConnectionId || this.connectionId;
+
         if (!this.memoizedConnection || Date.now() - this.memoizedConnection.timestamp > MEMOIZED_CONNECTION_TTL) {
-            const connection = await this.nango.getConnection(this.providerConfigKey as string, this.connectionId as string);
+            const connection = await this.nango.getConnection(providerConfigKey as string, connectionId as string);
             this.memoizedConnection = { connection, timestamp: Date.now() };
             return connection;
         }

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -445,16 +445,16 @@ export class NangoAction {
         const providerConfigKey = providerConfigKeyOverride || this.providerConfigKey;
         const connectionId = connectionIdOverride || this.connectionId;
 
-        if (
-            !this.memoizedConnections.get(`${providerConfigKey}${connectionId}`) ||
-            Date.now() - this.memoizedConnections.get(`${providerConfigKey}${connectionId}`)!.timestamp > MEMOIZED_CONNECTION_TTL
-        ) {
+        const credentialsPair = `${providerConfigKey}${connectionId}`;
+        const cachedConnection = this.memoizedConnections.get(credentialsPair);
+
+        if (!cachedConnection || Date.now() - cachedConnection.timestamp > MEMOIZED_CONNECTION_TTL) {
             const connection = await this.nango.getConnection(providerConfigKey as string, connectionId as string);
-            this.memoizedConnections.set(`${providerConfigKey}${connectionId}`, { connection, timestamp: Date.now() });
+            this.memoizedConnections.set(credentialsPair, { connection, timestamp: Date.now() });
             return connection;
         }
 
-        return this.memoizedConnections.get(`${providerConfigKey}${connectionId}`)!.connection;
+        return cachedConnection.connection;
     }
 
     public async setMetadata(metadata: Record<string, any>): Promise<AxiosResponse<void>> {


### PR DESCRIPTION
## Describe your changes
See the community reported issue: https://nango-community.slack.com/archives/C04ABR352H0/p1710132351607969

The user is triggering an action from a sync in an effort to abstract out logic. This used to work until optional parameters were not allowed to be passed into a getConnection call with the changes in https://github.com/NangoHQ/nango/pull/1764/files#diff-f52f0d61cd6802499f5a31aca89d3aec3df278a751065390c02b6bbdb24c0840L337-R341

This update allows optional params to be passed into a getConnection call. The ideal case is that the caching of a connection call is keyed by a `providerConfigKey` and `connectionId` combination but I feel that is an edge case that is out of scope of the immediate user reported issue and this update resolves their blocking issue.

## Issue ticket number and link
NAN-544

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
