### PR TITLE
[nan-560] add tests and support array

### DIFF
--- a/packages/shared/lib/utils/utils.ts
+++ b/packages/shared/lib/utils/utils.ts
@@ -36,20 +36,23 @@ export enum NodeEnv {
 
 export const JAVASCRIPT_AND_TYPESCRIPT_TYPES = {
     primitives: ['string', 'number', 'boolean', 'bigint', 'symbol', 'undefined', 'null'],
+    aliases: ['String', 'Number', 'Boolean', 'BigInt', 'Symbol', 'Undefined', 'Null', 'bool', 'char', 'integer', 'int', 'date', 'object'],
     builtInObjects: ['Object', 'Array', 'Function', 'Date', 'RegExp', 'Map', 'Set', 'WeakMap', 'WeakSet', 'Promise', 'Symbol', 'Error'],
     utilityTypes: ['Record', 'Partial', 'Readonly', 'Pick']
 };
 
 export function isJsOrTsType(type: string): boolean {
+    const baseType = type.replace(/\[\]$/, '');
+
     const simpleTypes = Object.values(JAVASCRIPT_AND_TYPESCRIPT_TYPES).flat();
-    if (simpleTypes.includes(type)) {
+    if (simpleTypes.includes(baseType)) {
         return true;
     }
 
     const typesWithGenerics = [...JAVASCRIPT_AND_TYPESCRIPT_TYPES.builtInObjects, ...JAVASCRIPT_AND_TYPESCRIPT_TYPES.utilityTypes];
     const genericTypeRegex = new RegExp(`^(${typesWithGenerics.join('|')})<.+>$`);
 
-    return genericTypeRegex.test(type);
+    return genericTypeRegex.test(baseType);
 }
 
 export function getEnv() {

--- a/packages/shared/lib/utils/utils.unit.test.ts
+++ b/packages/shared/lib/utils/utils.unit.test.ts
@@ -12,3 +12,88 @@ describe('Proxy service Construct Header Tests', () => {
         expect(utils.isValidHttpUrl('/api/v2/tickets?per_page=100&include=requester,description&page=3')).toBe(false);
     });
 });
+
+describe('utils.isJsOrTsType function tests', () => {
+    it('recognizes primitive types', () => {
+        expect(utils.isJsOrTsType('string')).toBe(true);
+        expect(utils.isJsOrTsType('number')).toBe(true);
+        expect(utils.isJsOrTsType('boolean')).toBe(true);
+    });
+
+    it('recognizes null and undefined', () => {
+        expect(utils.isJsOrTsType('null')).toBe(true);
+        expect(utils.isJsOrTsType('undefined')).toBe(true);
+    });
+
+    it('recognizes function types', () => {
+        expect(utils.isJsOrTsType('Function')).toBe(true);
+    });
+
+    it('recognizes symbol types', () => {
+        expect(utils.isJsOrTsType('Symbol')).toBe(true);
+        expect(utils.isJsOrTsType('symbol')).toBe(true);
+    });
+
+    it('recognizes object types', () => {
+        expect(utils.isJsOrTsType('object')).toBe(true);
+        expect(utils.isJsOrTsType('Object')).toBe(true);
+    });
+
+    it('recognizes array types', () => {
+        expect(utils.isJsOrTsType('Array')).toBe(true);
+        expect(utils.isJsOrTsType('Array<string>')).toBe(true);
+        expect(utils.isJsOrTsType('Array<number>')).toBe(true);
+        expect(utils.isJsOrTsType('Array<boolean>')).toBe(true);
+    });
+
+    it('recognizes primitive alias types', () => {
+        expect(utils.isJsOrTsType('String')).toBe(true);
+        expect(utils.isJsOrTsType('Number')).toBe(true);
+        expect(utils.isJsOrTsType('Boolean')).toBe(true);
+        expect(utils.isJsOrTsType('integer')).toBe(true);
+        expect(utils.isJsOrTsType('int')).toBe(true);
+        expect(utils.isJsOrTsType('bool')).toBe(true);
+        expect(utils.isJsOrTsType('char')).toBe(true);
+    });
+
+    it('recognizes built-in object types', () => {
+        expect(utils.isJsOrTsType('Object')).toBe(true);
+        expect(utils.isJsOrTsType('Array')).toBe(true);
+        expect(utils.isJsOrTsType('Date')).toBe(true);
+    });
+
+    it('recognizes utility types', () => {
+        expect(utils.isJsOrTsType('Record')).toBe(true);
+        expect(utils.isJsOrTsType('Partial')).toBe(true);
+        expect(utils.isJsOrTsType('Readonly')).toBe(true);
+    });
+
+    it('handles array shorthand notation', () => {
+        expect(utils.isJsOrTsType('string[]')).toBe(true);
+        expect(utils.isJsOrTsType('number[]')).toBe(true);
+        expect(utils.isJsOrTsType('Array<string>')).toBe(true); // Testing generic array type
+    });
+
+    it('handles generic types', () => {
+        expect(utils.isJsOrTsType('Map<string, number>')).toBe(true);
+        expect(utils.isJsOrTsType('Set<boolean>')).toBe(true);
+        expect(utils.isJsOrTsType('Promise<Date>')).toBe(true);
+    });
+
+    it('returns false for unrecognized types', () => {
+        expect(utils.isJsOrTsType('UnrecognizedType')).toBe(false);
+        expect(utils.isJsOrTsType('AnotherType')).toBe(false);
+        expect(utils.isJsOrTsType('string{}')).toBe(false); // Invalid syntax
+    });
+
+    it('recognizes array types', () => {
+        expect(utils.isJsOrTsType('string[]')).toBe(true);
+        expect(utils.isJsOrTsType('number[]')).toBe(true);
+        expect(utils.isJsOrTsType('boolean[]')).toBe(true);
+        expect(utils.isJsOrTsType('bool[]')).toBe(true);
+        expect(utils.isJsOrTsType('Map<string, string>[]')).toBe(true);
+        expect(utils.isJsOrTsType('Set<number>[]')).toBe(true);
+        expect(utils.isJsOrTsType('Promise<boolean>[]')).toBe(true);
+        expect(utils.isJsOrTsType('Map<Person>[]')).toBe(true);
+    });
+});


### PR DESCRIPTION
## Describe your changes
* Support alias types that we support in models.service.ts
```
switch (field) {
                case 'boolean':
                case 'bool':
                    tsType = 'boolean';
                    break;
                case 'string':
                    tsType = 'string';
                    break;
                case 'char':
                    tsType = 'string';
                    break;
                case 'integer':
                case 'int':
                case 'number':
                    tsType = 'number';
                    break;
                case 'date':
                    tsType = 'Date';
                    break;
                default:
                    tsType = field;
            }
```
* Support array types
* Add tests to harden

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
