### PR TITLE
[nan-600] pass in a generic

### DIFF
--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -204,11 +204,11 @@ interface Connection {
     credentials: AuthCredentials;
 }
 
-export class ActionError extends Error {
+export class ActionError<T = Record<string, unknown>> extends Error {
     type: string;
     payload?: Record<string, unknown>;
 
-    constructor(payload?: Record<string, unknown>) {
+    constructor(payload?: T) {
         super();
         this.type = 'action_script_runtime_error';
         if (payload) {
@@ -512,7 +512,7 @@ export class NangoAction {
 
         const lastArg = args[args.length - 1];
 
-        const isUserDefinedLevel = (object: UserLogParameters | any): boolean => {
+        const isUserDefinedLevel = (object: UserLogParameters): boolean => {
             return typeof lastArg === 'object' && 'level' in object;
         };
 


### PR DESCRIPTION
## Describe your changes
Allows a user to pass a generic to the ActionError, like so:

```
import type { NangoAction } from './models';

interface CustomError {
    code: number;
    key1: string;
}

export default async function runAction(nango: NangoAction): Promise<undefined> {
    await nango.get({
        baseUrlOverride: 'http://localhost:3009',
        endpoint: '/'
    });

    const { ActionError } = nango;

    throw new ActionError<CustomError>({
        code: 12345,
        key1: 'value1'
    });
}

```

## Issue ticket number and link
NAN-600

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
