### PR TITLE
fix: integration should be unique per environment

### DIFF
--- a/packages/shared/lib/db/migrations/20240320184257_integration-unique-constraint-nulls-not-distinct.cjs
+++ b/packages/shared/lib/db/migrations/20240320184257_integration-unique-constraint-nulls-not-distinct.cjs
@@ -1,0 +1,17 @@
+exports.up = async function (knex) {
+    return knex
+        .raw('ALTER TABLE _nango_configs DROP CONSTRAINT IF EXISTS _nango_configs_unique_key_environment_id_deleted_at_unique')
+        .then(() =>
+            knex.raw(
+                'ALTER TABLE _nango_configs ADD CONSTRAINT _nango_configs_unique_key_environment_id_deleted_at_unique UNIQUE NULLS NOT DISTINCT (unique_key, environment_id, deleted_at)'
+            )
+        )
+        .then(() => knex.raw('ALTER TABLE _nango_connections DROP CONSTRAINT IF EXISTS _nango_connections_provider_config_key_connection_id_environmen'))
+        .then(() =>
+            knex.raw(
+                'ALTER TABLE _nango_connections ADD CONSTRAINT _nango_connections_provider_config_key_connection_id_environmen UNIQUE NULLS NOT DISTINCT (provider_config_key, connection_id, environment_id, deleted_at)'
+            )
+        );
+};
+
+exports.down = async function () {};


### PR DESCRIPTION
The unique constraint for integration is for unique_key, environment_id and deleted_at which can be null. However null values are not considered equal by default by postgres. 🤯 

from postgres doc at https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-UNIQUE-CONSTRAINTS
> By default, two null values are not considered equal in this
comparison. That means even in the presence of a unique constraint it is possible to store duplicate rows that contain a null value in at least one of the constrained columns. This behavior can be changed by adding the clause NULLS NOT DISTINCT

With this constraint, editing a integration with a name that already exists shows an error

## Issue ticket number and link
https://linear.app/nango/issue/NAN-615/user-managed-to-create-two-integrations-with-the-same-integration-id

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
