### PR TITLE
fix(shared): specify published files

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -75,5 +75,10 @@
         "@types/uuid": "^9.0.0",
         "typescript": "^5.3.3",
         "vitest": "1.4.0"
-    }
+    },
+    "files": [
+        "dist/**/*",
+        "flows.yaml",
+        "providers.yaml"
+    ]
 }


### PR DESCRIPTION
## Describe your changes

Follow up of #1887 

Obviously it wasn't going to be easy. For some reason changing the path also lead to npm not publishing the dist folder 
[0.39.5](https://www.npmjs.com/package/@nangohq/shared/v/0.39.5?activeTab=code) vs [0.39.6](https://www.npmjs.com/package/@nangohq/shared/v/0.39.6?activeTab=code)


- Explicitly list published files