### PR TITLE
fix(cli): glob change of behavior

### DIFF
--- a/packages/cli/lib/cli.ts
+++ b/packages/cli/lib/cli.ts
@@ -299,7 +299,7 @@ export const tscWatch = async (debug = false) => {
         if (filePath === nangoConfigFile) {
             return;
         }
-        compileFile(listFile(`./${filePath}`));
+        compileFile(listFile(filePath));
     });
 
     watcher.on('unlink', (filePath: string) => {

--- a/packages/cli/lib/cli.ts
+++ b/packages/cli/lib/cli.ts
@@ -5,7 +5,6 @@ import yaml from 'js-yaml';
 import chalk from 'chalk';
 import chokidar from 'chokidar';
 import * as tsNode from 'ts-node';
-import { glob } from 'glob';
 import ejs from 'ejs';
 import * as dotenv from 'dotenv';
 import { spawn } from 'child_process';
@@ -18,6 +17,8 @@ import configService from './services/config.service.js';
 import modelService from './services/model.service.js';
 import parserService from './services/parser.service.js';
 import { NangoSyncTypesFileLocation, TYPES_FILE_NAME, exampleSyncName } from './constants.js';
+import type { ListedFile } from './services/compile.service.js';
+import { listFile, listFiles } from './services/compile.service.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -298,7 +299,7 @@ export const tscWatch = async (debug = false) => {
         if (filePath === nangoConfigFile) {
             return;
         }
-        compileFile(filePath);
+        compileFile(listFile(`./${filePath}`));
     });
 
     watcher.on('unlink', (filePath: string) => {
@@ -313,43 +314,38 @@ export const tscWatch = async (debug = false) => {
     watcher.on('change', (filePath: string) => {
         if (filePath === nangoConfigFile) {
             // config file changed, re-compile each ts file
-            const integrationFiles = glob.sync(`./*.ts`);
+            const integrationFiles = listFiles({});
             for (const file of integrationFiles) {
-                // strip the file to just the last part
-                const strippedFile = file.replace(/^.*[\\/]/, '');
-                compileFile(strippedFile);
+                compileFile(file);
             }
             return;
         }
-        compileFile(filePath);
+        compileFile(listFile(filePath));
     });
 
     const compiler = tsNode.create({
         skipProject: true, // when installed locally we don't want ts-node to pick up the package tsconfig.json file
         compilerOptions: JSON.parse(tsconfig).compilerOptions
     });
-    function compileFile(filePath: string) {
+    function compileFile(file: ListedFile) {
         try {
-            const providerConfiguration = config?.find((config) =>
-                [...config.syncs, ...config.actions].find((sync) => sync.name === path.basename(filePath, '.ts'))
-            );
+            const providerConfiguration = config?.find((config) => [...config.syncs, ...config.actions].find((sync) => sync.name === file.baseName));
             if (!providerConfiguration) {
                 return;
             }
-            const syncConfig = [...providerConfiguration.syncs, ...providerConfiguration.actions].find((sync) => sync.name === path.basename(filePath, '.ts'));
+            const syncConfig = [...providerConfiguration.syncs, ...providerConfiguration.actions].find((sync) => sync.name === file.baseName);
 
             const type = syncConfig?.type || SyncConfigType.SYNC;
 
-            if (!parserService.callsAreUsedCorrectly(filePath, type, modelNames)) {
+            if (!parserService.callsAreUsedCorrectly(file.inputPath, type, modelNames)) {
                 return;
             }
-            const result = compiler.compile(fs.readFileSync(filePath, 'utf8'), filePath);
-            const jsFilePath = `./dist/${path.basename(filePath.replace('.ts', '.js'))}`;
+            const result = compiler.compile(fs.readFileSync(file.inputPath, 'utf8'), file.inputPath);
 
-            fs.writeFileSync(jsFilePath, result);
-            console.log(chalk.green(`Compiled ${filePath} successfully`));
+            fs.writeFileSync(file.outputPath, result);
+            console.log(chalk.green(`Compiled ${file.inputPath} successfully`));
         } catch (error) {
-            console.error(`Error compiling ${filePath}:`);
+            console.error(`Error compiling ${file.inputPath}:`);
             console.error(error);
             return;
         }

--- a/packages/cli/lib/services/compile.service.ts
+++ b/packages/cli/lib/services/compile.service.ts
@@ -86,15 +86,27 @@ class CompileService {
     }
 }
 
-export function listFiles({ cwd, syncName }: { cwd?: string; syncName?: string | undefined }): { inputPath: string; outputPath: string; baseName: string }[] {
+export interface ListedFile {
+    inputPath: string;
+    outputPath: string;
+    baseName: string;
+}
+
+export function listFile(filePath: string): ListedFile {
+    if (!filePath.startsWith('./')) {
+        filePath = `./${filePath}`;
+    }
+    return {
+        inputPath: filePath,
+        outputPath: filePath.replace(/\/[^/]*$/, `/dist/${path.basename(filePath.replace('.ts', '.js'))}`),
+        baseName: path.basename(filePath, '.ts')
+    };
+}
+export function listFiles({ cwd, syncName }: { cwd?: string; syncName?: string | undefined }): ListedFile[] {
     const files = syncName ? [`./${syncName}.ts`] : glob.sync(`./*.ts`, { dotRelative: true, cwd: cwd || process.cwd() });
 
     return files.map((filePath) => {
-        return {
-            inputPath: filePath,
-            outputPath: filePath.replace(/\/[^/]*$/, `/dist/${path.basename(filePath.replace('.ts', '.js'))}`),
-            baseName: path.basename(filePath, '.ts')
-        };
+        return listFile(filePath);
     });
 }
 

--- a/packages/cli/lib/services/compile.service.ts
+++ b/packages/cli/lib/services/compile.service.ts
@@ -40,7 +40,7 @@ class CompileService {
             printDebug(`Compiler options: ${JSON.stringify(compilerOptions, null, 2)}`);
         }
 
-        const integrationFiles = syncName ? [`./${syncName}.ts`] : glob.sync(`./*.ts`);
+        const integrationFiles = listFiles({ cwd: './', syncName });
         let success = true;
 
         const { success: loadSuccess, error, response: config } = await configService.load('', debug);
@@ -52,34 +52,31 @@ class CompileService {
 
         const modelNames = configService.getModelNames(config);
 
-        for (const filePath of integrationFiles) {
+        for (const file of integrationFiles) {
             try {
-                const providerConfiguration = config.find((config) =>
-                    [...config.syncs, ...config.actions].find((sync) => sync.name === path.basename(filePath, '.ts'))
-                );
+                const providerConfiguration = config.find((config) => [...config.syncs, ...config.actions].find((sync) => sync.name === file.baseName));
 
                 if (!providerConfiguration) {
                     continue;
                 }
 
                 const syncConfig = [...(providerConfiguration?.syncs || []), ...(providerConfiguration?.actions || [])].find(
-                    (sync) => sync.name === path.basename(filePath, '.ts')
+                    (sync) => sync.name === file.baseName
                 );
                 const type = syncConfig?.type || SyncConfigType.SYNC;
 
-                if (!parserService.callsAreUsedCorrectly(filePath, type, modelNames)) {
-                    if (syncName && filePath.includes(syncName)) {
+                if (!parserService.callsAreUsedCorrectly(file.inputPath, type, modelNames)) {
+                    if (syncName && file.inputPath.includes(syncName)) {
                         success = false;
                     }
                     continue;
                 }
-                const result = compiler.compile(fs.readFileSync(filePath, 'utf8'), filePath);
-                const jsFilePath = filePath.replace(/\/[^/]*$/, `/dist/${path.basename(filePath.replace('.ts', '.js'))}`);
+                const result = compiler.compile(fs.readFileSync(file.inputPath, 'utf8'), file.inputPath);
 
-                fs.writeFileSync(jsFilePath, result);
-                console.log(chalk.green(`Compiled "${filePath}" successfully`));
+                fs.writeFileSync(file.outputPath, result);
+                console.log(chalk.green(`Compiled "${file.inputPath}" successfully`));
             } catch (error) {
-                console.error(`Error compiling "${filePath}":`);
+                console.error(`Error compiling "${file.inputPath}":`);
                 console.error(error);
                 success = false;
             }
@@ -87,6 +84,18 @@ class CompileService {
 
         return success;
     }
+}
+
+export function listFiles({ cwd, syncName }: { cwd?: string; syncName?: string | undefined }): { inputPath: string; outputPath: string; baseName: string }[] {
+    const files = syncName ? [`./${syncName}.ts`] : glob.sync(`./*.ts`, { dotRelative: true, cwd: cwd || process.cwd() });
+
+    return files.map((filePath) => {
+        return {
+            inputPath: filePath,
+            outputPath: filePath.replace(/\/[^/]*$/, `/dist/${path.basename(filePath.replace('.ts', '.js'))}`),
+            baseName: path.basename(filePath, '.ts')
+        };
+    });
 }
 
 const compileService = new CompileService();

--- a/packages/cli/lib/services/compile.service.ts
+++ b/packages/cli/lib/services/compile.service.ts
@@ -40,7 +40,7 @@ class CompileService {
             printDebug(`Compiler options: ${JSON.stringify(compilerOptions, null, 2)}`);
         }
 
-        const integrationFiles = listFiles({ cwd: './', syncName });
+        const integrationFiles = listFilesToCompile({ syncName });
         let success = true;
 
         const { success: loadSuccess, error, response: config } = await configService.load('', debug);
@@ -92,7 +92,7 @@ export interface ListedFile {
     baseName: string;
 }
 
-export function listFile(filePath: string): ListedFile {
+export function getFileToCompile(filePath: string): ListedFile {
     if (!filePath.startsWith('./')) {
         filePath = `./${filePath}`;
     }
@@ -102,11 +102,11 @@ export function listFile(filePath: string): ListedFile {
         baseName: path.basename(filePath, '.ts')
     };
 }
-export function listFiles({ cwd, syncName }: { cwd?: string; syncName?: string | undefined }): ListedFile[] {
+export function listFilesToCompile({ cwd, syncName }: { cwd?: string; syncName?: string | undefined } = {}): ListedFile[] {
     const files = syncName ? [`./${syncName}.ts`] : glob.sync(`./*.ts`, { dotRelative: true, cwd: cwd || process.cwd() });
 
     return files.map((filePath) => {
-        return listFile(filePath);
+        return getFileToCompile(filePath);
     });
 }
 

--- a/packages/cli/lib/services/compile.service.unit.test.ts
+++ b/packages/cli/lib/services/compile.service.unit.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { listFiles } from './compile.service';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const thisFolder = path.dirname(fileURLToPath(import.meta.url));
+
+describe('listFiles', () => {
+    it('should list files with glob', () => {
+        const files = listFiles({ cwd: thisFolder });
+        expect(files.length).toBeGreaterThan(1);
+        expect(files[0]).toStrictEqual({
+            baseName: 'verification.service',
+            inputPath: './verification.service.ts',
+            outputPath: './dist/verification.service.js'
+        });
+    });
+
+    it('should list files with syncName', () => {
+        const files = listFiles({ syncName: 'compile.service', cwd: thisFolder });
+        expect(files.length).toBe(1);
+        expect(files[0]).toStrictEqual({
+            baseName: 'compile.service',
+            inputPath: './compile.service.ts',
+            outputPath: './dist/compile.service.js'
+        });
+    });
+});

--- a/packages/cli/lib/services/compile.service.unit.test.ts
+++ b/packages/cli/lib/services/compile.service.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { listFiles } from './compile.service';
+import { listFile, listFiles } from './compile.service';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
@@ -23,6 +23,15 @@ describe('listFiles', () => {
             baseName: 'compile.service',
             inputPath: './compile.service.ts',
             outputPath: './dist/compile.service.js'
+        });
+    });
+
+    it('should add correct invalid path ', () => {
+        const file = listFile('foobar.ts');
+        expect(file).toStrictEqual({
+            baseName: 'foobar',
+            inputPath: './foobar.ts',
+            outputPath: './dist/foobar.js'
         });
     });
 });

--- a/packages/cli/lib/services/compile.service.unit.test.ts
+++ b/packages/cli/lib/services/compile.service.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { listFile, listFiles } from './compile.service';
+import { getFileToCompile, listFilesToCompile } from './compile.service';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
@@ -7,7 +7,7 @@ const thisFolder = path.dirname(fileURLToPath(import.meta.url));
 
 describe('listFiles', () => {
     it('should list files with glob', () => {
-        const files = listFiles({ cwd: thisFolder });
+        const files = listFilesToCompile({ cwd: thisFolder });
         expect(files.length).toBeGreaterThan(1);
         expect(files[0]).toStrictEqual({
             baseName: 'verification.service',
@@ -17,7 +17,7 @@ describe('listFiles', () => {
     });
 
     it('should list files with syncName', () => {
-        const files = listFiles({ syncName: 'compile.service', cwd: thisFolder });
+        const files = listFilesToCompile({ syncName: 'compile.service', cwd: thisFolder });
         expect(files.length).toBe(1);
         expect(files[0]).toStrictEqual({
             baseName: 'compile.service',
@@ -27,7 +27,7 @@ describe('listFiles', () => {
     });
 
     it('should add correct invalid path ', () => {
-        const file = listFile('foobar.ts');
+        const file = getFileToCompile('foobar.ts');
         expect(file).toStrictEqual({
             baseName: 'foobar',
             inputPath: './foobar.ts',

--- a/packages/cli/lib/services/verification.service.ts
+++ b/packages/cli/lib/services/verification.service.ts
@@ -1,13 +1,11 @@
 import fs from 'fs';
-import { glob } from 'glob';
 import chalk from 'chalk';
-import path from 'path';
 import promptly from 'promptly';
 import { exec } from 'child_process';
 
 import { nangoConfigFile, loadLocalNangoConfig, determineVersion } from '@nangohq/shared';
 import configService from './config.service.js';
-import compileService from './compile.service.js';
+import compileService, { listFiles } from './compile.service.js';
 import { printDebug, getNangoRootPath } from '../utils.js';
 import { NANGO_INTEGRATIONS_NAME } from '../constants.js';
 import { init, generate } from '../cli.js';
@@ -132,9 +130,9 @@ class VerificationService {
         const actionNames = config.map((provider) => provider.actions.map((action) => action.name)).flat();
         const flows = [...syncNames, ...actionNames].filter((name) => name);
 
-        const tsFiles = glob.sync(`./*.ts`, { dotRelative: true });
+        const tsFiles = listFiles({});
 
-        const tsFileNames = tsFiles.filter((file) => !file.includes('models.ts')).map((file) => path.basename(file, '.ts'));
+        const tsFileNames = tsFiles.filter((file) => !file.inputPath.includes('models.ts')).map((file) => file.baseName);
 
         const missingSyncsAndActions = flows.filter((syncOrActionName) => !tsFileNames.includes(syncOrActionName));
 

--- a/packages/cli/lib/services/verification.service.ts
+++ b/packages/cli/lib/services/verification.service.ts
@@ -132,7 +132,7 @@ class VerificationService {
         const actionNames = config.map((provider) => provider.actions.map((action) => action.name)).flat();
         const flows = [...syncNames, ...actionNames].filter((name) => name);
 
-        const tsFiles = glob.sync(`./*.ts`);
+        const tsFiles = glob.sync(`./*.ts`, { dotRelative: true });
 
         const tsFileNames = tsFiles.filter((file) => !file.includes('models.ts')).map((file) => path.basename(file, '.ts'));
 

--- a/packages/cli/lib/services/verification.service.ts
+++ b/packages/cli/lib/services/verification.service.ts
@@ -5,7 +5,7 @@ import { exec } from 'child_process';
 
 import { nangoConfigFile, loadLocalNangoConfig, determineVersion } from '@nangohq/shared';
 import configService from './config.service.js';
-import compileService, { listFiles } from './compile.service.js';
+import compileService, { listFilesToCompile } from './compile.service.js';
 import { printDebug, getNangoRootPath } from '../utils.js';
 import { NANGO_INTEGRATIONS_NAME } from '../constants.js';
 import { init, generate } from '../cli.js';
@@ -130,7 +130,7 @@ class VerificationService {
         const actionNames = config.map((provider) => provider.actions.map((action) => action.name)).flat();
         const flows = [...syncNames, ...actionNames].filter((name) => name);
 
-        const tsFiles = listFiles({});
+        const tsFiles = listFilesToCompile();
 
         const tsFileNames = tsFiles.filter((file) => !file.inputPath.includes('models.ts')).map((file) => file.baseName);
 


### PR DESCRIPTION
## Describe your changes

Followup of #1874 

When I did this eslint pass, I found undeclared usage of packages. It was the case for glob, so I had to pick a version. After testing, I picked the last one. 
While `nango cli dev` worked,  it turns out it had a slightly different logic than `nango deploy dev` which hide a change in behavior.

- Share a single unified way to listFiles
- Add tests

## How to test?

- npm run dw
- `node ../nango/packages/cli/dist/index.js dev`
- modify a sync
- `node ../nango/packages/cli/dist/index.js deploy dev`
- check that your file are still there and compiled