### PR TITLE
record id should not change between script executions

### DIFF
--- a/packages/shared/lib/services/sync/data/records.service.ts
+++ b/packages/shared/lib/services/sync/data/records.service.ts
@@ -33,6 +33,13 @@ export const formatDataRecords = (
     trackDeletes = false,
     softDelete = false
 ): ServiceResponse<SyncDataRecord[]> => {
+    // hashing unique composite key (connection, model, external_id)
+    // to generate stable record ids across script executions
+    const stableId = (rawRecord: DataResponse): string => {
+        const namespace = uuid.v5(`${nango_connection_id}${model}`, uuid.NIL);
+        return uuid.v5(`${nango_connection_id}${model}${rawRecord.id}`, namespace);
+    };
+
     const formattedRecords: SyncDataRecord[] = [] as SyncDataRecord[];
 
     const deletedAtKey = 'deletedAt';
@@ -66,11 +73,10 @@ export const formatDataRecords = (
             }
         }
 
-        const external_id = record['id'];
         formattedRecords[i] = {
-            id: uuid.v4(),
+            id: stableId(record),
             json: record,
-            external_id,
+            external_id: record['id'],
             data_hash,
             model,
             nango_connection_id,


### PR DESCRIPTION
## Describe your changes

Currently the record internal id is modified every time a record is updated which is counter intuitive and makes debugging harder

With this commit a record id is now a uuid v5 generated from the unique composite key (connection, model, external id)

