### PR TITLE
fix(env): unsafe getEnvByName

### DIFF
--- a/packages/server/lib/controllers/auth.controller.ts
+++ b/packages/server/lib/controllers/auth.controller.ts
@@ -181,7 +181,7 @@ class AuthController {
 
             if (isCloud() && !joinedWithToken) {
                 // On Cloud version, create default provider config to simplify onboarding.
-                const env = await environmentService.getByEnvironmentName('dev');
+                const env = await environmentService.getByEnvironmentName(account.id, 'dev');
                 if (env) {
                     await createOnboardingProvider({ envId: env.id });
                 }

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -81,9 +81,9 @@ class EnvironmentService {
 
                     if (envSecretKey === secretKey) {
                         const env = environmentVariable.replace('NANGO_SECRET_KEY_', '').toLowerCase();
-                        const environment = await this.getByEnvironmentName(env);
+                        const environment = await db.knex.select('*').from<Environment>(TABLE).where({ secret_key: secretKey, name: env }).first();
 
-                        if (environment === null) {
+                        if (!environment) {
                             return null;
                         }
 
@@ -96,7 +96,7 @@ class EnvironmentService {
         if (!this.environmentAccountSecrets[secretKey]) {
             // If the secret key is not in the cache, try to get it from the database
             const fromDb = await db.knex.select('*').from<Environment>(TABLE).where({ secret_key: secretKey }).first();
-            if (fromDb == null) {
+            if (!fromDb) {
                 return null;
             }
             this.addToEnvironmentSecretCache(fromDb);
@@ -154,9 +154,9 @@ class EnvironmentService {
 
                     if (envPublicKey === publicKey) {
                         const env = environmentVariable.replace('NANGO_PUBLIC_KEY_', '').toLowerCase();
-                        const environment = await this.getByEnvironmentName(env);
+                        const environment = await db.knex.select('*').from<Environment>(TABLE).where({ public_key: publicKey, name: env }).first();
 
-                        if (environment === null) {
+                        if (!environment) {
                             return null;
                         }
 
@@ -165,13 +165,13 @@ class EnvironmentService {
                 }
             }
         }
-        const result = await db.knex.select('*').from<Environment>(TABLE).where({ public_key: publicKey });
+        const result = await db.knex.select('*').from<Environment>(TABLE).where({ public_key: publicKey }).first();
 
-        if (result == null || result.length == 0 || result[0] == null) {
+        if (!result) {
             return null;
         }
 
-        return { accountId: result[0].account_id, environmentId: result[0].id };
+        return { accountId: result.account_id, environmentId: result.id };
     }
 
     async getByAccountIdAndEnvironment(id: number): Promise<Environment | null> {
@@ -267,8 +267,8 @@ class EnvironmentService {
         }
     }
 
-    async getByEnvironmentName(name: string): Promise<Environment | null> {
-        const result = await db.knex.select('*').from<Environment>(TABLE).where({ name });
+    async getByEnvironmentName(accountId: number, name: string): Promise<Environment | null> {
+        const result = await db.knex.select('*').from<Environment>(TABLE).where({ account_id: accountId, name });
 
         if (result == null || result.length == 0 || result[0] == null) {
             return null;
@@ -510,6 +510,7 @@ class EnvironmentService {
             });
 
         if (this.environmentAccountSecrets[environment.secret_key]) {
+            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
             delete this.environmentAccountSecrets[environment.secret_key];
         }
 


### PR DESCRIPTION
## Describe your changes

Fixes NAN-622

`getByEnvironmentName` is an unsafe function but until now it was only used outside cloud. During the deployment of the onboarding, I used this method to create the default provider without realising it wouldn't target the correct account.

- Enforce passing the accountId
- Other methods use their own stricter select 