### PR TITLE
fix(ui): always identify to posthog

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -56,6 +56,7 @@
         "@typescript-eslint/no-invalid-void-type": "warn",
         "@typescript-eslint/no-base-to-string": "warn",
         "@typescript-eslint/restrict-plus-operands": "warn",
+        "@typescript-eslint/consistent-type-exports": "error",
         "react/prop-types": "off",
         "@typescript-eslint/no-unused-vars": [
             "error",

--- a/packages/server/lib/controllers/user.controller.ts
+++ b/packages/server/lib/controllers/user.controller.ts
@@ -3,8 +3,17 @@ import type { Request, Response, NextFunction } from 'express';
 import EmailClient from '../clients/email.client.js';
 import { errorManager, userService, getBaseUrl, isCloud, isEnterprise } from '@nangohq/shared';
 
+export interface GetUser {
+    user: {
+        id: number;
+        accountId: number;
+        email: string;
+        name: string;
+    };
+}
+
 class UserController {
-    async getUser(req: Request, res: Response, next: NextFunction) {
+    async getUser(req: Request, res: Response<GetUser>, next: NextFunction) {
         try {
             const { success, error, response } = await getUserAccountAndEnvironmentFromSession(req);
             if (!success || response === null) {

--- a/packages/server/lib/index.ts
+++ b/packages/server/lib/index.ts
@@ -1,1 +1,2 @@
-export { GetMeta } from './controllers/environment.controller.js';
+export type { GetMeta } from './controllers/environment.controller.js';
+export type { GetUser } from './controllers/user.controller.js';

--- a/packages/webapp/src/components/PrivateRoute.tsx
+++ b/packages/webapp/src/components/PrivateRoute.tsx
@@ -2,9 +2,13 @@ import { Outlet, Navigate } from 'react-router-dom';
 import { useMeta } from '../hooks/useMeta';
 import { useEffect } from 'react';
 import { useStore } from '../store';
+import { useAnalyticsIdentify } from '../utils/analytics';
+import { useUser } from '../hooks/useUser';
 
 const PrivateRoute: React.FC = () => {
     const { meta, error, loading } = useMeta();
+    const { user } = useUser();
+    const identify = useAnalyticsIdentify();
 
     const setStoredEnvs = useStore((state) => state.setEnvs);
     const setBaseUrl = useStore((state) => state.setBaseUrl);
@@ -22,6 +26,12 @@ const PrivateRoute: React.FC = () => {
         setDebugMode(meta.debugMode);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [meta, error]);
+
+    useEffect(() => {
+        if (user) {
+            identify(user);
+        }
+    }, [user, identify]);
 
     if (loading) {
         return null;

--- a/packages/webapp/src/hooks/useUser.tsx
+++ b/packages/webapp/src/hooks/useUser.tsx
@@ -1,9 +1,9 @@
 import useSWR from 'swr';
-import type { User } from '../types';
 import { swrFetcher } from '../utils/api';
+import type { GetUser } from '@nangohq/server';
 
 export function useUser() {
-    const { data, error, mutate } = useSWR<{ user: User }>('/api/v1/user', swrFetcher);
+    const { data, error, mutate } = useSWR<GetUser>('/api/v1/user', swrFetcher);
 
     const loading = !data && !error;
 

--- a/packages/webapp/src/hooks/useUser.tsx
+++ b/packages/webapp/src/hooks/useUser.tsx
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { User } from '../types';
+import type { User } from '../types';
 import { swrFetcher } from '../utils/api';
 
 export function useUser() {

--- a/packages/webapp/src/types.ts
+++ b/packages/webapp/src/types.ts
@@ -150,7 +150,6 @@ export interface ApiKeyCredentials {
 
 export interface User {
     id: number;
-    accountId: number;
     email: string;
     name: string;
     suspended: boolean;

--- a/packages/webapp/src/types.ts
+++ b/packages/webapp/src/types.ts
@@ -150,6 +150,7 @@ export interface ApiKeyCredentials {
 
 export interface User {
     id: number;
+    accountId: number;
     email: string;
     name: string;
     suspended: boolean;

--- a/packages/webapp/src/utils/analytics.tsx
+++ b/packages/webapp/src/utils/analytics.tsx
@@ -1,5 +1,5 @@
 import { usePostHog } from 'posthog-js/react';
-import { User } from './user';
+import type { User } from './user';
 
 export function useAnalyticsTrack() {
     const posthog = usePostHog();


### PR DESCRIPTION
## Describe your changes

Fixes NAN-636

- Always call identify 
Some users are not identified correctly in PostHog. Looking at their session it seems that they didn't go through sign-in, so I might be due to the posthog cookie being deleted but not the nango session one. 

- Fix inconsistent types

- Catch export types error