### PR TITLE
fix: batchDelete returns incorrect sync result

### DIFF
--- a/packages/shared/lib/services/sync/data/data.service.ts
+++ b/packages/shared/lib/services/sync/data/data.service.ts
@@ -35,13 +35,18 @@ export async function upsert(
     try {
         const encryptedRecords = encryptionManager.encryptDataRecords(recordsWithoutDuplicates);
 
-        await schema().from(RECORDS_TABLE).insert(encryptedRecords).onConflict(['nango_connection_id', 'external_id', 'model']).merge();
+        const externalIds = await schema()
+            .from<DataRecord>(RECORDS_TABLE)
+            .insert(encryptedRecords)
+            .onConflict(['nango_connection_id', 'external_id', 'model'])
+            .merge()
+            .returning('external_id');
 
         if (softDelete) {
             return {
                 success: true,
                 summary: {
-                    deletedKeys: [...addedKeys, ...updatedKeys],
+                    deletedKeys: externalIds.map(({ external_id }) => external_id),
                     addedKeys: [],
                     updatedKeys: []
                 }

--- a/packages/shared/lib/services/sync/run.service.integration.test.ts
+++ b/packages/shared/lib/services/sync/run.service.integration.test.ts
@@ -164,7 +164,7 @@ describe('Running sync', () => {
                 { id: '1', name: 'a' },
                 { id: '2', name: 'b' }
             ];
-            const expectedResult = { added: 0, updated: 0, deleted: 0 };
+            const expectedResult = { added: 0, updated: 0, deleted: 2 };
             const { records } = await verifySyncRun(rawRecords, rawRecords, false, expectedResult, softDelete);
             expect(records).lengthOf(2);
             records.forEach((record) => {


### PR DESCRIPTION
## Describe your changes
Sync can return incorrect deletion results. 
Fixing by getting directly getting the modified rows when `soft_delete = true`

## Issue ticket number and link
https://linear.app/nango/issue/NAN-641/batchdelete-doesnt-return-the-correct-result

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
