### PR TITLE
fix(utils): parse env with zod

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,8 +74,5 @@ DEFAULT_GITHUB_CLIENT_SECRET=
 WORKOS_API_KEY=
 WORKOS_CLIENT_ID=
 
-# Encryption key for secrets / records stored in database
-NANGO_ENCRYPTION_KEY=
-
 # Enable or disable environment keys cache
 NANGO_CACHE_ENV_KEYS=

--- a/.env.example
+++ b/.env.example
@@ -76,3 +76,6 @@ WORKOS_CLIENT_ID=
 
 # Enable or disable environment keys cache
 NANGO_CACHE_ENV_KEYS=
+
+# Key to send email
+MAILGUN_API_KEY=

--- a/package-lock.json
+++ b/package-lock.json
@@ -34222,7 +34222,8 @@
             "version": "1.0.0",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "winston": "3.8.2"
+                "winston": "3.8.2",
+                "zod": "3.22.4"
             },
             "devDependencies": {}
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7120,12 +7120,38 @@
                 "linux"
             ]
         },
+        "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.13.2.tgz",
+            "integrity": "sha512-zvXvAUGGEYi6tYhcDmb9wlOckVbuD+7z3mzInCSTACJ4DQrdSLPNUeDIcAQW39M3q6PDquqLWu7pnO39uSMRzQ==",
+            "cpu": [
+                "ppc64le"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.13.0.tgz",
             "integrity": "sha512-Oq90dtMHvthFOPMl7pt7KmxzX7E71AfyIhh+cPhLY9oko97Zf2C9tt/XJD4RgxhaGeAraAXDtqxvKE1y/j35lA==",
             "cpu": [
                 "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.13.2.tgz",
+            "integrity": "sha512-l4U0KDFwzD36j7HdfJ5/TveEQ1fUTjFFQP5qIt9gBqBgu1G8/kCaq5Ok05kd5TG9F8Lltf3MoYsUMw3rNlJ0Yg==",
+            "cpu": [
+                "s390x"
             ],
             "dev": true,
             "optional": true,
@@ -24499,8 +24525,9 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.0.2",
-            "license": "BSD-3-Clause",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -34225,7 +34252,1070 @@
                 "winston": "3.8.2",
                 "zod": "3.22.4"
             },
-            "devDependencies": {}
+            "devDependencies": {
+                "vitest": "1.4.0"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+            "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/android-arm": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+            "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/android-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+            "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/android-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+            "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+            "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/darwin-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+            "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+            "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+            "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/linux-arm": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+            "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/linux-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+            "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/linux-ia32": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+            "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/linux-loong64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+            "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+            "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+            "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+            "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/linux-s390x": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+            "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/linux-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+            "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+            "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+            "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/sunos-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+            "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/win32-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+            "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/win32-ia32": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+            "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@esbuild/win32-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+            "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.13.2.tgz",
+            "integrity": "sha512-3XFIDKWMFZrMnao1mJhnOT1h2g0169Os848NhhmGweEcfJ4rCi+3yMCOLG4zA61rbJdkcrM/DjVZm9Hg5p5w7g==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "packages/utils/node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.13.2.tgz",
+            "integrity": "sha512-GdxxXbAuM7Y/YQM9/TwwP+L0omeE/lJAR1J+olu36c3LqqZEBdsIWeQ91KBe6nxwOnb06Xh7JS2U5ooWU5/LgQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "packages/utils/node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.13.2.tgz",
+            "integrity": "sha512-mCMlpzlBgOTdaFs83I4XRr8wNPveJiJX1RLfv4hggyIVhfB5mJfN4P8Z6yKh+oE4Luz+qq1P3kVdWrCKcMYrrA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "packages/utils/node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.13.2.tgz",
+            "integrity": "sha512-yUoEvnH0FBef/NbB1u6d3HNGyruAKnN74LrPAfDQL3O32e3k3OSfLrPgSJmgb3PJrBZWfPyt6m4ZhAFa2nZp2A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "packages/utils/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.13.2.tgz",
+            "integrity": "sha512-GYbLs5ErswU/Xs7aGXqzc3RrdEjKdmoCrgzhJWyFL0r5fL3qd1NPcDKDowDnmcoSiGJeU68/Vy+OMUluRxPiLQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "packages/utils/node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.13.2.tgz",
+            "integrity": "sha512-L1+D8/wqGnKQIlh4Zre9i4R4b4noxzH5DDciyahX4oOz62CphY7WDWqJoQ66zNR4oScLNOqQJfNSIAe/6TPUmQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "packages/utils/node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.13.2.tgz",
+            "integrity": "sha512-tK5eoKFkXdz6vjfkSTCupUzCo40xueTOiOO6PeEIadlNBkadH1wNOH8ILCPIl8by/Gmb5AGAeQOFeLev7iZDOA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "packages/utils/node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.13.2.tgz",
+            "integrity": "sha512-C3GSKvMtdudHCN5HdmAMSRYR2kkhgdOfye4w0xzyii7lebVr4riCgmM6lRiSCnJn2w1Xz7ZZzHKuLrjx5620kw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "packages/utils/node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.13.2.tgz",
+            "integrity": "sha512-xXMLUAMzrtsvh3cZ448vbXqlUa7ZL8z0MwHp63K2IIID2+DeP5iWIT6g1SN7hg1VxPzqx0xZdiDM9l4n9LRU1A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "packages/utils/node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.13.2.tgz",
+            "integrity": "sha512-M/JYAWickafUijWPai4ehrjzVPKRCyDb1SLuO+ZyPfoXgeCEAlgPkNXewFZx0zcnoIe3ay4UjXIMdXQXOZXWqA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "packages/utils/node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.13.2.tgz",
+            "integrity": "sha512-2YWwoVg9KRkIKaXSh0mz3NmfurpmYoBBTAXA9qt7VXk0Xy12PoOP40EFuau+ajgALbbhi4uTj3tSG3tVseCjuA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "packages/utils/node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.13.2.tgz",
+            "integrity": "sha512-2FSsE9aQ6OWD20E498NYKEQLneShWes0NGMPQwxWOdws35qQXH+FplabOSP5zEe1pVjurSDOGEVCE2agFwSEsw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "packages/utils/node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.13.2.tgz",
+            "integrity": "sha512-7h7J2nokcdPePdKykd8wtc8QqqkqxIrUz7MHj6aNr8waBRU//NLDVnNjQnqQO6fqtjrtCdftpbTuOKAyrAQETQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "packages/utils/node_modules/@vitest/expect": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.4.0.tgz",
+            "integrity": "sha512-Jths0sWCJZ8BxjKe+p+eKsoqev1/T8lYcrjavEaz8auEJ4jAVY0GwW3JKmdVU4mmNPLPHixh4GNXP7GFtAiDHA==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/spy": "1.4.0",
+                "@vitest/utils": "1.4.0",
+                "chai": "^4.3.10"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "packages/utils/node_modules/@vitest/runner": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.4.0.tgz",
+            "integrity": "sha512-EDYVSmesqlQ4RD2VvWo3hQgTJ7ZrFQ2VSJdfiJiArkCerDAGeyF1i6dHkmySqk573jLp6d/cfqCN+7wUB5tLgg==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/utils": "1.4.0",
+                "p-limit": "^5.0.0",
+                "pathe": "^1.1.1"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "packages/utils/node_modules/@vitest/snapshot": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.4.0.tgz",
+            "integrity": "sha512-saAFnt5pPIA5qDGxOHxJ/XxhMFKkUSBJmVt5VgDsAqPTX6JP326r5C/c9UuCMPoXNzuudTPsYDZCoJ5ilpqG2A==",
+            "dev": true,
+            "dependencies": {
+                "magic-string": "^0.30.5",
+                "pathe": "^1.1.1",
+                "pretty-format": "^29.7.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "packages/utils/node_modules/@vitest/spy": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.4.0.tgz",
+            "integrity": "sha512-Ywau/Qs1DzM/8Uc+yA77CwSegizMlcgTJuYGAi0jujOteJOUf1ujunHThYo243KG9nAyWT3L9ifPYZ5+As/+6Q==",
+            "dev": true,
+            "dependencies": {
+                "tinyspy": "^2.2.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "packages/utils/node_modules/@vitest/utils": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.4.0.tgz",
+            "integrity": "sha512-mx3Yd1/6e2Vt/PUC98DcqTirtfxUyAZ32uK82r8rZzbtBeBo+nqgnjx/LvqQdWsrvNtm14VmurNgcf4nqY5gJg==",
+            "dev": true,
+            "dependencies": {
+                "diff-sequences": "^29.6.3",
+                "estree-walker": "^3.0.3",
+                "loupe": "^2.3.7",
+                "pretty-format": "^29.7.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "packages/utils/node_modules/esbuild": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+            "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+            "dev": true,
+            "hasInstallScript": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.20.2",
+                "@esbuild/android-arm": "0.20.2",
+                "@esbuild/android-arm64": "0.20.2",
+                "@esbuild/android-x64": "0.20.2",
+                "@esbuild/darwin-arm64": "0.20.2",
+                "@esbuild/darwin-x64": "0.20.2",
+                "@esbuild/freebsd-arm64": "0.20.2",
+                "@esbuild/freebsd-x64": "0.20.2",
+                "@esbuild/linux-arm": "0.20.2",
+                "@esbuild/linux-arm64": "0.20.2",
+                "@esbuild/linux-ia32": "0.20.2",
+                "@esbuild/linux-loong64": "0.20.2",
+                "@esbuild/linux-mips64el": "0.20.2",
+                "@esbuild/linux-ppc64": "0.20.2",
+                "@esbuild/linux-riscv64": "0.20.2",
+                "@esbuild/linux-s390x": "0.20.2",
+                "@esbuild/linux-x64": "0.20.2",
+                "@esbuild/netbsd-x64": "0.20.2",
+                "@esbuild/openbsd-x64": "0.20.2",
+                "@esbuild/sunos-x64": "0.20.2",
+                "@esbuild/win32-arm64": "0.20.2",
+                "@esbuild/win32-ia32": "0.20.2",
+                "@esbuild/win32-x64": "0.20.2"
+            }
+        },
+        "packages/utils/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "packages/utils/node_modules/execa": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^8.0.1",
+                "human-signals": "^5.0.0",
+                "is-stream": "^3.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^5.1.0",
+                "onetime": "^6.0.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "packages/utils/node_modules/get-stream": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+            "dev": true,
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/utils/node_modules/human-signals": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=16.17.0"
+            }
+        },
+        "packages/utils/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/utils/node_modules/js-tokens": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-8.0.3.tgz",
+            "integrity": "sha512-UfJMcSJc+SEXEl9lH/VLHSZbThQyLpw1vLO1Lb+j4RWDvG3N2f7yj3PVQA3cmkTBNldJ9eFnM+xEXxHIXrYiJw==",
+            "dev": true
+        },
+        "packages/utils/node_modules/local-pkg": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.0.tgz",
+            "integrity": "sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==",
+            "dev": true,
+            "dependencies": {
+                "mlly": "^1.4.2",
+                "pkg-types": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "packages/utils/node_modules/mimic-fn": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/utils/node_modules/npm-run-path": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+            "dev": true,
+            "dependencies": {
+                "path-key": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/utils/node_modules/onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
+            "dependencies": {
+                "mimic-fn": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/utils/node_modules/p-limit": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+            "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+            "dev": true,
+            "dependencies": {
+                "yocto-queue": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/utils/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/utils/node_modules/postcss": {
+            "version": "8.4.38",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+            "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "dependencies": {
+                "nanoid": "^3.3.7",
+                "picocolors": "^1.0.0",
+                "source-map-js": "^1.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "packages/utils/node_modules/rollup": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.13.2.tgz",
+            "integrity": "sha512-MIlLgsdMprDBXC+4hsPgzWUasLO9CE4zOkj/u6j+Z6j5A4zRY+CtiXAdJyPtgCsc42g658Aeh1DlrdVEJhsL2g==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "1.0.5"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.13.2",
+                "@rollup/rollup-android-arm64": "4.13.2",
+                "@rollup/rollup-darwin-arm64": "4.13.2",
+                "@rollup/rollup-darwin-x64": "4.13.2",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.13.2",
+                "@rollup/rollup-linux-arm64-gnu": "4.13.2",
+                "@rollup/rollup-linux-arm64-musl": "4.13.2",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.13.2",
+                "@rollup/rollup-linux-riscv64-gnu": "4.13.2",
+                "@rollup/rollup-linux-s390x-gnu": "4.13.2",
+                "@rollup/rollup-linux-x64-gnu": "4.13.2",
+                "@rollup/rollup-linux-x64-musl": "4.13.2",
+                "@rollup/rollup-win32-arm64-msvc": "4.13.2",
+                "@rollup/rollup-win32-ia32-msvc": "4.13.2",
+                "@rollup/rollup-win32-x64-msvc": "4.13.2",
+                "fsevents": "~2.3.2"
+            }
+        },
+        "packages/utils/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/utils/node_modules/strip-final-newline": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/utils/node_modules/strip-literal": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.0.0.tgz",
+            "integrity": "sha512-f9vHgsCWBq2ugHAkGMiiYY+AYG0D/cbloKKg0nhaaaSNsujdGIpVXCNsrJpCKr5M0f4aI31mr13UjY6GAuXCKA==",
+            "dev": true,
+            "dependencies": {
+                "js-tokens": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "packages/utils/node_modules/tinypool": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.3.tgz",
+            "integrity": "sha512-Ud7uepAklqRH1bvwy22ynrliC7Dljz7Tm8M/0RBUW+YRa4YHhZ6e4PpgE+fu1zr/WqB1kbeuVrdfeuyIBpy4tw==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/utils/node_modules/vite": {
+            "version": "5.2.6",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.6.tgz",
+            "integrity": "sha512-FPtnxFlSIKYjZ2eosBQamz4CbyrTizbZ3hnGJlh/wMtCrlp1Hah6AzBLjGI5I2urTfNnpovpHdrL6YRuBOPnCA==",
+            "dev": true,
+            "dependencies": {
+                "esbuild": "^0.20.1",
+                "postcss": "^8.4.36",
+                "rollup": "^4.13.0"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "less": "*",
+                "lightningcss": "^1.21.0",
+                "sass": "*",
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/utils/node_modules/vite-node": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.4.0.tgz",
+            "integrity": "sha512-VZDAseqjrHgNd4Kh8icYHWzTKSCZMhia7GyHfhtzLW33fZlG9SwsB6CEhgyVOWkJfJ2pFLrp/Gj1FSfAiqH9Lw==",
+            "dev": true,
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.3.4",
+                "pathe": "^1.1.1",
+                "picocolors": "^1.0.0",
+                "vite": "^5.0.0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "packages/utils/node_modules/vitest": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.4.0.tgz",
+            "integrity": "sha512-gujzn0g7fmwf83/WzrDTnncZt2UiXP41mHuFYFrdwaLRVQ6JYQEiME2IfEjU3vcFL3VKa75XhI3lFgn+hfVsQw==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/expect": "1.4.0",
+                "@vitest/runner": "1.4.0",
+                "@vitest/snapshot": "1.4.0",
+                "@vitest/spy": "1.4.0",
+                "@vitest/utils": "1.4.0",
+                "acorn-walk": "^8.3.2",
+                "chai": "^4.3.10",
+                "debug": "^4.3.4",
+                "execa": "^8.0.1",
+                "local-pkg": "^0.5.0",
+                "magic-string": "^0.30.5",
+                "pathe": "^1.1.1",
+                "picocolors": "^1.0.0",
+                "std-env": "^3.5.0",
+                "strip-literal": "^2.0.0",
+                "tinybench": "^2.5.1",
+                "tinypool": "^0.8.2",
+                "vite": "^5.0.0",
+                "vite-node": "1.4.0",
+                "why-is-node-running": "^2.2.2"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "@vitest/browser": "1.4.0",
+                "@vitest/ui": "1.4.0",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/utils/node_modules/yocto-queue": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+            "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "packages/webapp": {
             "name": "@nangohq/webapp",

--- a/packages/utils/lib/environment/helpers.ts
+++ b/packages/utils/lib/environment/helpers.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+export function envErrorToString(issues: z.ZodIssue[]) {
+    return issues
+        .map((issue) => {
+            return `${issue.path.join('')} (${issue.code} ${issue.message})`;
+        })
+        .join(', ');
+}
+
+export function initGlobalEnv() {
+    const schema = z.object({
+        // Database
+        NANGO_DATABASE_URL: z.string().url().optional(),
+        NANGO_DB_HOST: z.string().optional().default('localhost'),
+        NANGO_DB_PORT: z.coerce.number().optional().default(5432),
+        NANGO_DB_USER: z.string().optional().default('nango'),
+        NANGO_DB_NAME: z.string().optional().default('nango'),
+        NANGO_DB_PASSWORD: z.string().optional().default('nango'),
+        NANGO_DB_SSL: z.coerce.boolean().default(false),
+        NANGO_ENCRYPTION_KEY: z.string().optional(),
+
+        // env
+        NODE_ENV: z.enum(['production', 'development', 'test']).default('development'),
+        CI: z.coerce.boolean().default(false),
+        VITEST: z.coerce.boolean().default(false),
+
+        // demo
+        DEFAULT_GITHUB_CLIENT_ID: z.string().optional(),
+        DEFAULT_GITHUB_CLIENT_SECRET: z.string().optional(),
+
+        // auth
+        WORKOS_API_KEY: z.string().optional(),
+        WORKOS_CLIENT_ID: z.string().optional(),
+        NANGO_DASHBOARD_USERNAME: z.string().optional(),
+        NANGO_DASHBOARD_PASSWORD: z.string().optional(),
+
+        // aws
+        AWS_REGION: z.string().optional(),
+        AWS_BUCKET_NAME: z.string().optional(),
+
+        // others
+        SERVER_RUN_MODE: z.enum(['DOCKERIZED', '']).optional(),
+        NANGO_CLOUD: z.coerce.boolean().optional().default(false),
+        NANGO_ENTERPRISE: z.coerce.boolean().optional().default(false),
+        NANGO_SERVER_URL: z.string().url().optional(),
+        NANGO_TELEMETRY_SDK: z.coerce.boolean().default(false).optional(),
+        LOG_LEVEL: z.enum(['info', 'debug', 'warn', 'error']).optional().default('info')
+    });
+
+    const res = schema.safeParse(process.env);
+    if (!res.success) {
+        throw new Error(`Missing or invalid env vars: ${envErrorToString(res.error.issues)}`);
+    }
+
+    return res.data;
+}

--- a/packages/utils/lib/environment/helpers.ts
+++ b/packages/utils/lib/environment/helpers.ts
@@ -1,52 +1,70 @@
 import { z } from 'zod';
 
-export function envErrorToString(issues: z.ZodIssue[]) {
-    return issues
-        .map((issue) => {
-            return `${issue.path.join('')} (${issue.code} ${issue.message})`;
-        })
-        .join(', ');
-}
+const ENVS = {
+    // Node ecosystem
+    NODE_ENV: z.enum(['production', 'development', 'test']).default('development'),
+    CI: z.coerce.boolean().default(false),
+    VITEST: z.coerce.boolean().default(false),
+    TZ: z.string().default('UTC'),
 
-export function initGlobalEnv() {
-    const schema = z.object({
-        // Database
-        NANGO_DATABASE_URL: z.string().url().optional(),
-        NANGO_DB_HOST: z.string().optional().default('localhost'),
-        NANGO_DB_PORT: z.coerce.number().optional().default(5432),
-        NANGO_DB_USER: z.string().optional().default('nango'),
-        NANGO_DB_NAME: z.string().optional().default('nango'),
-        NANGO_DB_PASSWORD: z.string().optional().default('nango'),
-        NANGO_DB_SSL: z.coerce.boolean().default(false),
-        NANGO_ENCRYPTION_KEY: z.string().optional(),
+    // Postgres
+    NANGO_DATABASE_URL: z.string().url().optional(),
+    NANGO_DB_HOST: z.string().optional().default('localhost'),
+    NANGO_DB_PORT: z.coerce.number().optional().default(5432),
+    NANGO_DB_USER: z.string().optional().default('nango'),
+    NANGO_DB_NAME: z.string().optional().default('nango'),
+    NANGO_DB_PASSWORD: z.string().optional().default('nango'),
+    NANGO_DB_SSL: z.coerce.boolean().default(false),
+    NANGO_DB_CLIENT: z.string().optional(),
+    NANGO_ENCRYPTION_KEY: z.string().optional(),
+    NANGO_DB_MIGRATION_FOLDER: z.string().optional(),
 
-        // env
-        NODE_ENV: z.enum(['production', 'development', 'test']).default('development'),
-        CI: z.coerce.boolean().default(false),
-        VITEST: z.coerce.boolean().default(false),
+    // Redis
+    NANGO_REDIS_URL: z.string().url().optional(),
 
-        // demo
-        DEFAULT_GITHUB_CLIENT_ID: z.string().optional(),
-        DEFAULT_GITHUB_CLIENT_SECRET: z.string().optional(),
+    // Render
+    RENDER_API_KEY: z.string().optional(),
+    IS_RENDER: z.coerce.boolean().default(false),
 
-        // auth
-        WORKOS_API_KEY: z.string().optional(),
-        WORKOS_CLIENT_ID: z.string().optional(),
-        NANGO_DASHBOARD_USERNAME: z.string().optional(),
-        NANGO_DASHBOARD_PASSWORD: z.string().optional(),
+    // Slack
+    NANGO_ADMIN_CONNECTION_ID: z.string().optional(),
+    NANGO_SLACK_INTEGRATION_KEY: z.string().optional(),
+    NANGO_ADMIN_UUID: z.string().uuid().optional(),
 
-        // aws
-        AWS_REGION: z.string().optional(),
-        AWS_BUCKET_NAME: z.string().optional(),
+    // Sentry
+    SENTRY_DNS: z.string().url().optional(),
 
-        // others
-        SERVER_RUN_MODE: z.enum(['DOCKERIZED', '']).optional(),
-        NANGO_CLOUD: z.coerce.boolean().optional().default(false),
-        NANGO_ENTERPRISE: z.coerce.boolean().optional().default(false),
-        NANGO_SERVER_URL: z.string().url().optional(),
-        NANGO_TELEMETRY_SDK: z.coerce.boolean().default(false).optional(),
-        LOG_LEVEL: z.enum(['info', 'debug', 'warn', 'error']).optional().default('info')
-    });
+    // Temporal
+    TEMPORAL_NAMESPACE: z.string().optional(),
+    TEMPORAL_ADDRESS: z.string().optional(),
+    TEMPORAL_WORKER_MAX_CONCURRENCY: z.coerce.number().default(500),
+
+    // ----- Others
+    SERVER_RUN_MODE: z.enum(['DOCKERIZED', '']).optional(),
+    NANGO_CLOUD: z.coerce.boolean().optional().default(false),
+    NANGO_ENTERPRISE: z.coerce.boolean().optional().default(false),
+    NANGO_TELEMETRY_SDK: z.coerce.boolean().default(false).optional(),
+    NANGO_ADMIN_KEY: z.string().optional(),
+    NANGO_INTEGRATIONS_FULL_PATH: z.string().optional(),
+    TELEMETRY: z.coerce.boolean().default(true),
+    LOG_LEVEL: z.enum(['info', 'debug', 'warn', 'error']).optional().default('info')
+};
+
+type EnvKeys = keyof typeof ENVS;
+
+/**
+ * Parse and type process.env
+ */
+export function getEnvs<const TKey extends EnvKeys[]>({ required }: { required: TKey }) {
+    const schema = z.object({ ...ENVS }).required(
+        required.reduce(
+            (prev, curr) => {
+                prev[curr as TKey[0]] = true;
+                return prev;
+            },
+            {} as Record<TKey[0], true>
+        )
+    );
 
     const res = schema.safeParse(process.env);
     if (!res.success) {
@@ -55,3 +73,15 @@ export function initGlobalEnv() {
 
     return res.data;
 }
+
+export function envErrorToString(issues: z.ZodIssue[]) {
+    return issues
+        .map((issue) => {
+            return `${issue.path.join('')} (${issue.code} ${issue.message})`;
+        })
+        .join(', ');
+}
+
+const envs = getEnvs({ required: ['NANGO_DATABASE_URL'] });
+envs.NANGO_ENCRYPTION_KEY;
+envs.NANGO_DATABASE_URL;

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { ENVS, parseEnvs } from './parse.js';
+
+describe('parse', () => {
+    it('should parse correctly', () => {
+        const res = parseEnvs(ENVS.required({ NANGO_DATABASE_URL: true }), { NANGO_DATABASE_URL: 'http://example.com' });
+        expect(res).toMatchObject({ NANGO_DATABASE_URL: 'http://example.com' });
+    });
+
+    it('should throw on error', () => {
+        expect(() => {
+            parseEnvs(ENVS.required({ NANGO_DATABASE_URL: true }), {});
+        }).toThrowError();
+    });
+
+    it('should have some default', () => {
+        const res = parseEnvs(ENVS, {});
+        expect(res).toMatchObject({ NANGO_DB_SSL: false, NANGO_PERSIST_PORT: 3007 });
+    });
+
+    it('should coerce boolean and number', () => {
+        const res = parseEnvs(ENVS, { NANGO_DB_SSL: 'true', NANGO_PERSIST_PORT: '3008' });
+        expect(res).toMatchObject({ NANGO_DB_SSL: true, NANGO_PERSIST_PORT: 3008 });
+    });
+});

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,7 +16,8 @@
     },
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
-        "winston": "3.8.2"
+        "winston": "3.8.2",
+        "zod": "3.22.4"
     },
     "devDependencies": {}
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,5 +19,7 @@
         "winston": "3.8.2",
         "zod": "3.22.4"
     },
-    "devDependencies": {}
+    "devDependencies": {
+        "vitest": "1.4.0"
+    }
 }


### PR DESCRIPTION
## Context

Fixes NAN-662

Currently we are using `process.env` everywhere but it's untyped and always a pain to deal with `any`. The idea with this function is that each service can call it when they launch and combine it with their own set of required env vars. 
For example in logs I need Elasticsearch env but I can't make it globally required. (I'm sure it will be handy for @TBonnin too)
You can find an usage example here: https://github.com/NangoHQ/nango/blob/1085b3149239da8c2bd050fffc1021e39c34f061/packages/logs/lib/env.ts#L1-L4


The main drawback is that it can't be used for floating constants like we have in `detection.ts`. I guess **we need to decide** wether it's fine to have this function run directly or make the detection constants also an object in a function. I will say it's a bit less convenient for sure, but with less side-effects
```ts
function initDetection(envs) {
  return { isCloud: envs.NANGO_CLOUD }
}
export const { isCloud } = initDetection(initGlobalEnv());
```

## Changes

- Expose a way to parse process.env with Zod (not exhaustive) 