### PR TITLE
[nan-668] add verification bash script to publish packages

### DIFF
--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -45,9 +45,10 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  npx nango version
                   GIT_HASH=$(git rev-parse HEAD)
-                  cd ../ && mkdir nango-cli-test && cd nango-cli-test
+                  mkdir nango-cli-test && cd nango-cli-test
                   npm init -y
                   npm -g install @nangohq/cli@0.0.1-$GIT_HASH
                   nango version --debug
+                  nango init --debug
+                  nango generate --debug

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -41,7 +41,9 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
+                  echo "attempting install"
                   npm install @nangohq/shared@0.0.1-$GIT_HASH
+                  echo "building"
                   npm run build
                   npm version 0.0.1-$GIT_HASH --workspaces-update=false
                   npm publish --ignore-scripts

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -32,16 +32,7 @@ jobs:
               shell: bash
               run: |
                   GIT_HASH=$(git rev-parse --short HEAD)
-                  npm run build:hosted
-                  # publish all before bumping to an alternate version
-                  npm publish -w packages/node-client
-                  npm i
-                  npm publish -w packages/shared
-                  npm i
-                  npm publish -w packages/cli
-                  npm i
-                  npm publish -w packages/frontend
-                  bash ./scripts/publish.sh 0.0.1-$GIT_HASH true
+                  bash ./scripts/publish.sh 0.0.1-$GIT_HASH
             - name: Install the cli from the github package registry
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -31,12 +31,12 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               shell: bash
               run: |
-                  GIT_HASH=$(git rev-parse --short HEAD)
+                  GIT_HASH=$(git rev-parse HEAD)
                   bash ./scripts/publish.sh 0.0.1-$GIT_HASH
             - name: Install the cli from the github package registry
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  GIT_HASH=$(git rev-parse --short HEAD)
+                  GIT_HASH=$(git rev-parse HEAD)
                   npm install nango@0.0.1-$GIT_HASH
                   npx nango version --debug

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -31,16 +31,18 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
-                  npm version 0.0.1-$GIT_HASH
-                  npm publish
+                  npm run build
+                  npm version 0.0.1-$GIT_HASH --ignore-scripts
+                  npm publish --ignore-scripts
             - name: Publish the cli
               working-directory: packages/cli
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
-                  npm version 0.0.1-$GIT_HASH
-                  npm publish
+                  npm run build
+                  npm version 0.0.1-$GIT_HASH --ignore-scripts
+                  npm publish --ignore-scripts
             - name: Install the cli from the github package registry
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -28,14 +28,17 @@ jobs:
             - name: Publish npm packages to the github registry
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  # we don't want to try and install from the github registry
+                  npm_config_ignore_scripts: true
               shell: bash
               run: |
-                  GIT_HASH=$(git rev-parse --short HEAD)
+                  GIT_HASH=$(git rev-parse HEAD)
+                  npm run build:hosted
                   bash ./scripts/publish.sh 0.0.1-$GIT_HASH true
             - name: Install the cli from the github package registry
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  GIT_HASH=$(git rev-parse --short HEAD)
+                  GIT_HASH=$(git rev-parse HEAD)
                   npm install nango@0.0.1-$GIT_HASH
                   npx nango version --debug

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -46,8 +46,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
-                  mkdir nango-cli-test
-                  cd nango-cli-test
+                  mkdir nango-cli-test && cd nango-cli-test
                   npm init -y
-                  npm install nangohq/cli@0.0.1-$GIT_HASH
+                  npm install @nangohq/cli@0.0.1-$GIT_HASH
                   npx nango version --debug

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -53,4 +53,5 @@ jobs:
                   npm install @nangohq/cli@0.0.1-$GIT_HASH
                   npx nango version --debug
                   npx nango init --debug
+                  cd nango-integrations
                   npx nango generate --debug

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -52,7 +52,7 @@ jobs:
                   npm init -y
                   npm install @nangohq/cli@0.0.1-$GIT_HASH
                   VERSION_OUTPUT=$(npx nango version)
-                  EXPECTED_VERSION="Nango CLI version: 0.0.2-$GIT_HASH"
+                  EXPECTED_VERSION="Nango CLI version: 0.0.1-$GIT_HASH"
                   [ "$VERSION_OUTPUT" = "$EXPECTED_VERSION" ] || { echo "Version mismatch. Expected: $EXPECTED_VERSION, got: $VERSION_OUTPUT"; exit 1; }
                   npx nango version --debug
                   npx nango init --debug

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -51,6 +51,9 @@ jobs:
                   mkdir nango-cli-test && cd nango-cli-test
                   npm init -y
                   npm install @nangohq/cli@0.0.1-$GIT_HASH
+                  VERSION_OUTPUT=$(npx nango version)
+                  EXPECTED_VERSION="Nango CLI version: 0.0.1-$GIT_HASH"
+                  [ "$VERSION_OUTPUT" = "$EXPECTED_VERSION" ] || { echo "Version mismatch. Expected: $EXPECTED_VERSION, got: $VERSION_OUTPUT"; exit 1; }
                   npx nango version --debug
                   npx nango init --debug
                   cd nango-integrations

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -25,6 +25,7 @@ jobs:
                   node-version: '18.x'
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@nangohq'
+                  always-auth: true
             - run: npm run build:hosted
             - name: Publish the shared package
               working-directory: packages/shared
@@ -41,9 +42,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
-                  echo "attempting install"
                   npm install @nangohq/shared@0.0.1-$GIT_HASH
-                  echo "building"
                   npm run build
                   npm version 0.0.1-$GIT_HASH --workspaces-update=false
                   npm publish --ignore-scripts

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -41,6 +41,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
+                  npm install @nangohq/shared@0.0.1-$GIT_HASH
                   npm run build
                   npm version 0.0.1-$GIT_HASH --workspaces-update=false
                   npm publish --ignore-scripts

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -48,7 +48,7 @@ jobs:
                   GIT_HASH=$(git rev-parse HEAD)
                   mkdir nango-cli-test && cd nango-cli-test
                   npm init -y
-                  npm -g install @nangohq/cli@0.0.1-$GIT_HASH
-                  nango version --debug
-                  nango init --debug
-                  nango generate --debug
+                  npm install @nangohq/cli@0.0.1-$GIT_HASH
+                  npx nango version --debug
+                  npx nango init --debug
+                  npx nango generate --debug

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -25,16 +25,22 @@ jobs:
                   node-version: '18.x'
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@nangohq'
-            - name: Publish npm packages to the github registry
+            - name: Publish the shared package
+              working-directory: packages/shared
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  # we don't want to try and install from the github registry
-                  npm_config_ignore_scripts: true
-              shell: bash
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
-                  npm run build:hosted
-                  bash ./scripts/publish.sh 0.0.1-$GIT_HASH true
+                  npm version 0.0.1-$GIT_HASH
+                  npm publish
+            - name: Publish the cli
+              working-directory: packages/cli
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  GIT_HASH=$(git rev-parse HEAD)
+                  npm version 0.0.1-$GIT_HASH
+                  npm publish
             - name: Install the cli from the github package registry
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -35,8 +35,11 @@ jobs:
                   npm run build:hosted
                   # publish all before bumping to an alternate version
                   npm publish -w packages/node-client
+                  npm i
                   npm publish -w packages/shared
+                  npm i
                   npm publish -w packages/cli
+                  npm i
                   npm publish -w packages/frontend
                   bash ./scripts/publish.sh 0.0.1-$GIT_HASH true
             - name: Install the cli from the github package registry

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -1,0 +1,40 @@
+name: CLI Publish & Verify
+
+on:
+    push:
+        branches:
+            - master
+            - staging/**
+    pull_request:
+
+concurrency:
+    group: verify-cli-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    publish-and-test:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '18.x'
+                  registry-url: 'https://npm.pkg.github.com'
+
+            - name: Publish npm packages to the github registry
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              shell: bash
+              run: |
+                  GIT_HASH=$(git rev-parse --short HEAD)
+                  bash ./scripts/publish.sh 0.0.1-$GIT_HASH
+            - name: Install the cli from the github package registry
+              run: |
+                  GIT_HASH=$(git rev-parse --short HEAD)
+                  npm install -g nango@$0.0.1-$GIT_HASH
+                  nango version --debug

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -14,6 +14,8 @@ concurrency:
 jobs:
     publish-and-test:
         runs-on: ubuntu-latest
+        env:
+            NANGO_CLI_UPGRADE_MODE: ignore
         permissions:
             contents: read
             packages: write

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -42,9 +42,11 @@ jobs:
                   jq '.name = "@nangohq/cli"' package.json > temp.json && mv temp.json package.json
                   npm publish --access public
             - name: Install the cli from the github package registry
+              working-directory: tmp
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
+                  npm init -y
                   npm install nangohq/cli@0.0.1-$GIT_HASH
                   npx nango version --debug

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -40,8 +40,6 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   jq '.name = "@nangohq/cli"' package.json > temp.json && mv temp.json package.json
-                  GIT_HASH=$(git rev-parse HEAD)
-                  npm version 0.0.1-$GIT_HASH
                   npm publish --access public
             - name: Install the cli from the github package registry
               env:

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -46,5 +46,5 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
-                  npm install nangohq@cli@0.0.1-$GIT_HASH
+                  npm install nangohq/cli@0.0.1-$GIT_HASH
                   npx nango version --debug

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -26,6 +26,12 @@ jobs:
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@nangohq'
             - run: npm run build:hosted
+            - name: Configure npmrc
+              working-directory: packages/shared
+              run: |
+                  cat << EOF > .npmrc
+                  @nangohq:registry=https://npm.pkg.github.com/
+                  //npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
             - name: Publish the shared package
               working-directory: packages/shared
               env:
@@ -35,6 +41,12 @@ jobs:
                   npm run build
                   npm version 0.0.1-$GIT_HASH --ignore-scripts
                   npm publish --ignore-scripts
+            - name: Configure npmrc
+              working-directory: packages/cli
+              run: |
+                  cat << EOF > .npmrc
+                  @nangohq:registry=https://npm.pkg.github.com/
+                  //npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
             - name: Publish the cli
               working-directory: packages/cli
               env:

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -31,8 +31,8 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               shell: bash
               run: |
+                  GIT_HASH=$(git rev-parse --short HEAD)
                   bash ./scripts/publish.sh 0.0.1-$GIT_HASH true
-                  bash ./scripts/publish.sh 0.0.1-$GIT_HASH
             - name: Install the cli from the github package registry
               run: |
                   GIT_HASH=$(git rev-parse --short HEAD)

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -25,12 +25,6 @@ jobs:
                   node-version: '18.x'
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@nangohq'
-            - name: Configure npmrc
-              run: |
-                  cat << EOF > .npmrc
-                  @nangohq:registry=https://npm.pkg.github.com/
-                  //npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
-                  EOF
             - name: Publish npm packages to the github registry
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -43,6 +43,7 @@ jobs:
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
                   jq '.dependencies["@nangohq/shared"] = "0.0.1-'$GIT_HASH'"' package.json > temp.json && mv temp.json package.json
+                  npm install
                   npm run build
                   npm version 0.0.1-$GIT_HASH --workspaces-update=false
                   npm publish --ignore-scripts

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -42,7 +42,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
-                  jq '.dependencies["@nangohq/shared"] = "0.0.1-'$GIT_HASH'"' packages/cli/package.json > temp.json && mv temp.json packages/cli/package.json
+                  jq '.dependencies["@nangohq/shared"] = "0.0.1-'$GIT_HASH'"' package.json > temp.json && mv temp.json package.json
                   npm run build
                   npm version 0.0.1-$GIT_HASH --workspaces-update=false
                   npm publish --ignore-scripts

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -25,6 +25,12 @@ jobs:
                   node-version: '18.x'
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@nangohq'
+            - name: Configure npmrc
+              run: |
+                  cat << EOF > .npmrc
+                  @nangohq:registry=https://npm.pkg.github.com/
+                  //npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
+                  EOF
             - name: Publish npm packages to the github registry
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -33,7 +33,7 @@ jobs:
               run: |
                   GIT_HASH=$(git rev-parse --short HEAD)
                   # publish all before bumping to an alternate version
-                  npm publish -w packages/node
+                  npm publish -w packages/node-client
                   npm publish -w packages/shared
                   npm publish -w packages/cli
                   npm publish -w packages/frontend

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -52,7 +52,7 @@ jobs:
                   npm init -y
                   npm install @nangohq/cli@0.0.1-$GIT_HASH
                   VERSION_OUTPUT=$(npx nango version)
-                  EXPECTED_VERSION="Nango CLI version: 0.0.1-$GIT_HASH"
+                  EXPECTED_VERSION="Nango CLI version: 0.0.2-$GIT_HASH"
                   [ "$VERSION_OUTPUT" = "$EXPECTED_VERSION" ] || { echo "Version mismatch. Expected: $EXPECTED_VERSION, got: $VERSION_OUTPUT"; exit 1; }
                   npx nango version --debug
                   npx nango init --debug

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -17,7 +17,6 @@ jobs:
         permissions:
             contents: read
             packages: write
-
         steps:
             - uses: actions/checkout@v4
 
@@ -25,7 +24,7 @@ jobs:
               with:
                   node-version: '18.x'
                   registry-url: 'https://npm.pkg.github.com'
-
+                  scope: '@nangohq'
             - name: Publish npm packages to the github registry
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -34,7 +33,9 @@ jobs:
                   GIT_HASH=$(git rev-parse --short HEAD)
                   bash ./scripts/publish.sh 0.0.1-$GIT_HASH true
             - name: Install the cli from the github package registry
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   GIT_HASH=$(git rev-parse --short HEAD)
-                  npm install -g nango@$0.0.1-$GIT_HASH
-                  nango version --debug
+                  npm install nango@0.0.1-$GIT_HASH
+                  npx nango version --debug

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -26,31 +26,22 @@ jobs:
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@nangohq'
                   always-auth: true
-            - run: npm run build:hosted
-            - name: Publish the shared package
-              working-directory: packages/shared
+            - name: Publish npm packages to the github registry
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              shell: bash
               run: |
-                  GIT_HASH=$(git rev-parse HEAD)
-                  npm run build
-                  npm version 0.0.1-$GIT_HASH --workspaces-update=false
-                  npm publish --ignore-scripts
-            - name: Publish the cli
-              working-directory: packages/cli
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  GIT_HASH=$(git rev-parse HEAD)
-                  jq '.dependencies["@nangohq/shared"] = "0.0.1-'$GIT_HASH'"' package.json > temp.json && mv temp.json package.json
-                  npm install
-                  npm run build
-                  npm version 0.0.1-$GIT_HASH --workspaces-update=false
-                  npm publish --ignore-scripts
+                  GIT_HASH=$(git rev-parse --short HEAD)
+                  # publish all before bumping to an alternate version
+                  npm publish -w packages/node
+                  npm publish -w packages/shared
+                  npm publish -w packages/cli
+                  npm publish -w packages/frontend
+                  bash ./scripts/publish.sh 0.0.1-$GIT_HASH true
             - name: Install the cli from the github package registry
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  GIT_HASH=$(git rev-parse HEAD)
+                  GIT_HASH=$(git rev-parse --short HEAD)
                   npm install nango@0.0.1-$GIT_HASH
                   npx nango version --debug

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -45,8 +45,9 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
+                  npx nango version
                   GIT_HASH=$(git rev-parse HEAD)
                   cd ../ && mkdir nango-cli-test && cd nango-cli-test
                   npm init -y
-                  npm install @nangohq/cli@0.0.1-$GIT_HASH
-                  npx nango version --debug
+                  npm -g install @nangohq/cli@0.0.1-$GIT_HASH
+                  nango version --debug

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -30,13 +30,23 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               shell: bash
+              continue-on-error: true
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
                   bash ./scripts/publish.sh 0.0.1-$GIT_HASH
+            - name: Publish the cli privately under the correct scope
+              working-directory: packages/cli
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  jq '.name = "@nangohq/cli"' package.json > temp.json && mv temp.json package.json
+                  GIT_HASH=$(git rev-parse HEAD)
+                  npm version 0.0.1-$GIT_HASH
+                  npm publish --access public
             - name: Install the cli from the github package registry
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
-                  npm install nango@0.0.1-$GIT_HASH
+                  npm install nangohq@cli@0.0.1-$GIT_HASH
                   npx nango version --debug

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -25,6 +25,7 @@ jobs:
                   node-version: '18.x'
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@nangohq'
+            - run: npm run build:hosted
             - name: Publish the shared package
               working-directory: packages/shared
               env:

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -42,7 +42,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
-                  npm install @nangohq/shared@0.0.1-$GIT_HASH
+                  jq '.dependencies["@nangohq/shared"] = "0.0.1-'$GIT_HASH'"' packages/cli/package.json > temp.json && mv temp.json packages/cli/package.json
                   npm run build
                   npm version 0.0.1-$GIT_HASH --workspaces-update=false
                   npm publish --ignore-scripts

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -26,11 +26,6 @@ jobs:
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@nangohq'
             - run: npm run build:hosted
-            - name: Configure npmrc
-              run: |
-                  cat << EOF > .npmrc
-                  @nangohq:registry=https://npm.pkg.github.com/
-                  //npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
             - name: Publish the shared package
               working-directory: packages/shared
               env:
@@ -38,7 +33,7 @@ jobs:
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
                   npm run build
-                  npm version 0.0.1-$GIT_HASH --ignore-scripts
+                  npm version 0.0.1-$GIT_HASH --workspaces-update=false
                   npm publish --ignore-scripts
             - name: Publish the cli
               working-directory: packages/cli
@@ -47,7 +42,7 @@ jobs:
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
                   npm run build
-                  npm version 0.0.1-$GIT_HASH --ignore-scripts
+                  npm version 0.0.1-$GIT_HASH --workspaces-update=false
                   npm publish --ignore-scripts
             - name: Install the cli from the github package registry
               env:

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -31,7 +31,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               shell: bash
               run: |
-                  GIT_HASH=$(git rev-parse --short HEAD)
+                  bash ./scripts/publish.sh 0.0.1-$GIT_HASH true
                   bash ./scripts/publish.sh 0.0.1-$GIT_HASH
             - name: Install the cli from the github package registry
               run: |

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -27,7 +27,6 @@ jobs:
                   scope: '@nangohq'
             - run: npm run build:hosted
             - name: Configure npmrc
-              working-directory: packages/shared
               run: |
                   cat << EOF > .npmrc
                   @nangohq:registry=https://npm.pkg.github.com/
@@ -41,12 +40,6 @@ jobs:
                   npm run build
                   npm version 0.0.1-$GIT_HASH --ignore-scripts
                   npm publish --ignore-scripts
-            - name: Configure npmrc
-              working-directory: packages/cli
-              run: |
-                  cat << EOF > .npmrc
-                  @nangohq:registry=https://npm.pkg.github.com/
-                  //npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
             - name: Publish the cli
               working-directory: packages/cli
               env:

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -42,11 +42,12 @@ jobs:
                   jq '.name = "@nangohq/cli"' package.json > temp.json && mv temp.json package.json
                   npm publish --access public
             - name: Install the cli from the github package registry
-              working-directory: tmp
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
+                  mkdir nango-cli-test
+                  cd nango-cli-test
                   npm init -y
                   npm install nangohq/cli@0.0.1-$GIT_HASH
                   npx nango version --debug

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -46,7 +46,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   GIT_HASH=$(git rev-parse HEAD)
-                  mkdir nango-cli-test && cd nango-cli-test
+                  cd ../ && mkdir nango-cli-test && cd nango-cli-test
                   npm init -y
                   npm install @nangohq/cli@0.0.1-$GIT_HASH
                   npx nango version --debug

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -32,6 +32,7 @@ jobs:
               shell: bash
               run: |
                   GIT_HASH=$(git rev-parse --short HEAD)
+                  npm run build:hosted
                   # publish all before bumping to an alternate version
                   npm publish -w packages/node-client
                   npm publish -w packages/shared

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -20,9 +20,9 @@ function bump_and_npm_publish {
 GIT_ROOT_DIR=$(git rev-parse --show-toplevel)
 VERSION=$1
 
-# ensure version is of format x.y.z
-if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "VERSION '$VERSION' is not of format x.y.z"
+# ensure version is of format x.y.z or 0.0.1-<commit hash>
+if [[ ! "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+|0\.0\.1-[0-9a-fA-F]{40})$ ]]; then
+    echo "VERSION '$VERSION' is not of format x.y.z or 0.0.1-<commit hash>"
     exit 1
 fi
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -14,21 +14,16 @@ function bump_and_npm_publish {
         echo "Publishing '$1@$2'"
         npm version "$2" -w "$1"
         npm publish --access public -w "$1"
-        echo "Published '$1@$2'"
     fi
 }
 
 GIT_ROOT_DIR=$(git rev-parse --show-toplevel)
 VERSION=$1
-BY_PASS_VERSION_CHECK=$2
 
-# ensure version is of format x.y.z
-if [[ "$BY_PASS_VERSION_CHECK" != "true" ]]; then
-    # ensure version is of format x.y.z
-    if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        echo "VERSION '$VERSION' is not of format x.y.z"
-        exit 1
-    fi
+# ensure version is of format x.y.z or 0.0.1-<commit hash>
+if [[ ! "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+|0\.0\.1-[0-9a-fA-F]{40})$ ]]; then
+    echo "VERSION '$VERSION' is not of format x.y.z or 0.0.1-<commit hash>"
+    exit 1
 fi
 
 npm install
@@ -36,7 +31,6 @@ npm install
 # Node client
 bump_and_npm_publish "@nangohq/node" "$VERSION"
 pushd "$GIT_ROOT_DIR/packages/shared"
-echo $VERSION
 npm install @nangohq/node@^$VERSION
 popd
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -19,11 +19,15 @@ function bump_and_npm_publish {
 
 GIT_ROOT_DIR=$(git rev-parse --show-toplevel)
 VERSION=$1
+BY_PASS_VERSION_CHECK=$2
 
 # ensure version is of format x.y.z
-if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "VERSION '$VERSION' is not of format x.y.z"
-    exit 1
+if [[ "$BY_PASS_VERSION_CHECK" != "true" ]]; then
+    # ensure version is of format x.y.z
+    if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "VERSION '$VERSION' is not of format x.y.z"
+        exit 1
+    fi
 fi
 
 npm install

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -20,9 +20,9 @@ function bump_and_npm_publish {
 GIT_ROOT_DIR=$(git rev-parse --show-toplevel)
 VERSION=$1
 
-# ensure version is of format x.y.z or 0.0.1-<commit hash>
-if [[ ! "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+|0\.0\.1-[0-9a-fA-F]{40})$ ]]; then
-    echo "VERSION '$VERSION' is not of format x.y.z or 0.0.1-<commit hash>"
+# ensure version is of format x.y.z
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "VERSION '$VERSION' is not of format x.y.z"
     exit 1
 fi
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -14,6 +14,7 @@ function bump_and_npm_publish {
         echo "Publishing '$1@$2'"
         npm version "$2" -w "$1"
         npm publish --access public -w "$1"
+        echo "Published '$1@$2'"
     fi
 }
 
@@ -35,6 +36,7 @@ npm install
 # Node client
 bump_and_npm_publish "@nangohq/node" "$VERSION"
 pushd "$GIT_ROOT_DIR/packages/shared"
+echo $VERSION
 npm install @nangohq/node@^$VERSION
 popd
 


### PR DESCRIPTION
## Describe your changes
The goal with this PR is to mimic a publish process of the cli with the code that is in review to ensure a working cli that is in a remote source. This is accomplished by building and publishing the packages to the Github registry and finally using the cli to verify that it works expected. This will protect against instances where a faulty cli is published. This will be especially useful to verify that this PR: https://github.com/NangoHQ/nango/pull/1918 works as expected with packaging the utils package. Additionally, as we refactor the cli to move code out of shared and reduce the package size of the cli this will ensure things still work as expected.

## Issue ticket number and link
NAN-668

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
