### PR TITLE
fix(docker): change Postgres version for public docker-compose

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -19,7 +19,7 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Build the docker-compose stack
-              run: docker-compose -f ./packages/cli/docker/docker-compose.yaml --project-directory . up -d
+              run: docker compose -f ./packages/cli/docker/docker-compose.yaml --project-directory . up -d
 
             - name: Sleep
               uses: jakejarvis/wait-action@master

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
     nango-db:
-        image: postgres:15.5-alpine
+        image: postgres:16.0-alpine
         container_name: nango-db
         environment:
             POSTGRES_PASSWORD: nango
@@ -73,7 +73,6 @@ services:
 
 networks:
     nango:
-
 
 volumes:
     esdata1:

--- a/packages/cli/docker/docker-compose.yaml
+++ b/packages/cli/docker/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
     nango-db:
-        image: postgres:15.5-alpine
+        image: postgres:16.0-alpine
         container_name: nango-db
         environment:
             POSTGRES_PASSWORD: nango


### PR DESCRIPTION
## Describe your changes

~I honestly don't know but seems to fix it.~
Also I realised I have pinned Postgres but if you are not part of this repo and do rely on the docker-compose.yml then it will scream at you that your data is not the same version as the docker image, so we have to leave those one as v16 unfortunately.