### PR TITLE
fix: do not idle runner if idleMaxDurationMs is 0

### DIFF
--- a/packages/runner/lib/monitor.ts
+++ b/packages/runner/lib/monitor.ts
@@ -93,7 +93,7 @@ export class RunnerMonitor {
     private checkIdle(): NodeJS.Timeout {
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         return setInterval(async () => {
-            if (this.tracked.size == 0) {
+            if (this.idleMaxDurationMs > 0 && this.tracked.size == 0) {
                 const idleTimeMs = Date.now() - this.lastIdleTrackingDate;
                 if (idleTimeMs > this.idleMaxDurationMs) {
                     logger.info(`Runner '${this.runnerId}' idle for more than ${this.idleMaxDurationMs}ms`);


### PR DESCRIPTION
## Describe your changes
Introduced a bug in https://github.com/NangoHQ/nango/pull/1943/files which cause runner with max idle time set to zero like the default runner or paying customer to idle all the time.

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
