### PR TITLE
[NAN-698] Add the ability to call a sync from an action

### DIFF
--- a/packages/cli/lib/templates/action.ejs
+++ b/packages/cli/lib/templates/action.ejs
@@ -36,7 +36,7 @@
 
     if (formattedInputs) {
         const formattedInputsArray = formattedInputs.split(',').map(input => input.trim());
-        if (isArrayInterfaceNames) {
+        if (isArrayInterfaceNames && formattedInterfaceNames) {
             formattedInterfaceNames = formattedInterfaceNames.filter(interfaceName => !formattedInputsArray.includes(interfaceName));
         } else {
             formattedInterfaceNames = formattedInterfaceNames === formattedInputs ? '' : formattedInterfaceNames;

--- a/packages/jobs/lib/runner/local.runner.ts
+++ b/packages/jobs/lib/runner/local.runner.ts
@@ -51,7 +51,7 @@ export class LocalRunner implements Runner {
                 env: {
                     ...process.env,
                     RUNNER_ID: runnerId,
-                    IDLE_MAX_DURATION_MS: '60000'
+                    IDLE_MAX_DURATION_MS: '0'
                 }
             });
 

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -80,7 +80,11 @@ export async function exec(
                     throw new Error(`Default exports is not a function but a ${typeof scriptExports.default}`);
                 }
                 if (isAction) {
-                    return await scriptExports.default(nango, codeParams);
+                    let inputParams = codeParams;
+                    if (typeof codeParams === 'object' && Object.keys(codeParams).length === 0) {
+                        inputParams = undefined;
+                    }
+                    return await scriptExports.default(nango, inputParams);
                 } else {
                     return await scriptExports.default(nango);
                 }

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -224,10 +224,10 @@ export interface NangoProps {
     host?: string;
     secretKey: string;
     accountId?: number;
-    connectionId?: string;
+    connectionId: string;
     environmentId?: number;
     activityLogId?: number;
-    providerConfigKey?: string;
+    providerConfigKey: string;
     provider?: string;
     lastSyncDate?: Date;
     syncId?: string | undefined;
@@ -259,8 +259,8 @@ export class NangoAction {
     dryRun?: boolean;
     abortSignal?: AbortSignal;
 
-    public connectionId?: string;
-    public providerConfigKey?: string;
+    public connectionId: string;
+    public providerConfigKey: string;
     public provider?: string;
 
     public ActionError = ActionError;
@@ -271,6 +271,9 @@ export class NangoAction {
     >();
 
     constructor(config: NangoProps) {
+        this.connectionId = config.connectionId;
+        this.providerConfigKey = config.providerConfigKey;
+
         if (config.activityLogId) {
             this.activityLogId = config.activityLogId;
         }
@@ -294,14 +297,6 @@ export class NangoAction {
 
         if (config.dryRun) {
             this.dryRun = config.dryRun;
-        }
-
-        if (config.connectionId) {
-            this.connectionId = config.connectionId;
-        }
-
-        if (config.providerConfigKey) {
-            this.providerConfigKey = config.providerConfigKey;
         }
 
         if (config.environmentId) {
@@ -841,7 +836,9 @@ const TELEMETRY_ALLOWED_METHODS: (keyof NangoSync)[] = [
     'getEnvironmentVariables',
     'getMetadata',
     'proxy',
-    'log'
+    'log',
+    'triggerAction',
+    'triggerSync'
 ];
 
 /* eslint-disable no-inner-declarations */

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -625,6 +625,10 @@ export class NangoAction {
     public async triggerAction<T = object>(providerConfigKey: string, connectionId: string, actionName: string, input?: unknown): Promise<T> {
         return this.nango.triggerAction(providerConfigKey, connectionId, actionName, input) as T;
     }
+
+    public async triggerSync(providerConfigKey: string, connectionId: string, syncName: string, fullResync?: boolean): Promise<void> {
+        return this.nango.triggerSync(providerConfigKey, [syncName], connectionId, fullResync);
+    }
 }
 
 export class NangoSync extends NangoAction {

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -136,7 +136,7 @@ class EnvironmentService {
             .select<Account>('_nango_accounts.*')
             .from(TABLE)
             .join('_nango_accounts', '_nango_accounts.id', '_nango_environments.account_id')
-            .where({ id: environment_id })
+            .where('_nango_environments.id', environment_id)
             .first();
 
         return result || null;


### PR DESCRIPTION
## Describe your changes
This allows a user to have a coordinating action that tells sync when to start based on input from other syncs. As a proof of concept example:

- coordinating action
```
import type { NangoAction } from './models';

export default async function runAction(nango: NangoAction, input?: string): Promise<boolean> {
    await nango.log('starting action');
    await nango.log(input);
    const order = [
        'first-sync',
        'second-sync'
    ];

    if (!input && order[0] && typeof order[0] === 'string') {
        await nango.log('running first sync');
        await nango.triggerSync(nango.providerConfigKey, nango.connectionId, order[0] as string)
    } else {
        if (!order.includes(input as string)) {
            throw new Error(`Invalid input: ${input}`);
        }

        const index = order.indexOf(input as string);
        const nextIndex = index + 1;

        if (order[nextIndex] && typeof order[nextIndex] === 'string') {
            await nango.log('running next sync');
            await nango.triggerSync(nango.providerConfigKey, nango.connectionId, order[nextIndex] as string);
        }
    }
    return true;
}
```
- first-sync
```
import type { NangoSync } from './models';

export default async function fetchData(nango: NangoSync): Promise<void> {
    await nango.log('First sync ran');
    await nango.triggerAction(nango.providerConfigKey, nango.connectionId, 'sync-coordinator', 'first-sync')
}

```
- second-sync
```
import type { NangoSync } from './models';

export default async function fetchData(nango: NangoSync): Promise<void> {
    await nango.log('Second sync ran');
}
```

## Issue ticket number and link
NAN-698

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
