### PR TITLE
fix wave accounting token url

### DIFF
--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -2133,7 +2133,7 @@ wave-accounting:
         - accounting
     auth_mode: OAUTH2
     authorization_url: https://api.waveapps.com/oauth2/authorize
-    token_url: https://api.waveapps.com/oauth2/token
+    token_url: https://api.waveapps.com/oauth2/token/
     proxy:
         base_url: https://gql.waveapps.com
     docs: https://docs.nango.dev/integrations/all/wave-accounting


### PR DESCRIPTION
## Describe your changes
Fixing Wave Accounting configuration

Exchange code with url https://api.waveapps.com/oauth2/token - 405
![image](https://github.com/NangoHQ/nango/assets/30033017/3606a694-4787-483d-8ce6-46ba81ec3590)

Exchange the same code with url https://api.waveapps.com/oauth2/token/ - 200
![image](https://github.com/NangoHQ/nango/assets/30033017/69001c49-acf5-41e5-a9a9-93ce3641f140)


## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
