### PR TITLE
Add Support for Microsoft Ads API

### DIFF
--- a/docs-v2/integrations/all/microsoft-ads.mdx
+++ b/docs-v2/integrations/all/microsoft-ads.mdx
@@ -1,0 +1,34 @@
+---
+title: Microsoft Ads
+sidebarTitle: Microsoft Ads
+---
+
+API configuration: [`microsoft-ads`](https://nango.dev/providers.yaml)
+
+## Features
+
+| Features | Status |
+| - | - |
+| [Auth (OAuth)](/integrate/guides/authorize-an-api) | ✅ |
+| [Sync data](/integrate/guides/sync-data-from-an-api) | 🚫 (see API gotchas) |
+| [Perform workflows](/integrate/guides/perform-workflows-with-an-api) | 🚫 (see API gotchas) |
+| [Proxy requests](/integrate/guides/proxy-requests-to-an-api) | 🚫 (see API gotchas) |
+| [Receive webhooks](/integrate/guides/receive-webhooks-from-an-api) | 🚫 |
+
+<Tip>We can implement missing features in &lt;48h, just ask for it in the [community](https://nango.dev/slack).</Tip>
+
+## Getting started
+
+-   [Microsoft Ads Authentication with OAuth](https://learn.microsoft.com/en-us/advertising/guides/authentication-oauth?view=bingads-13)
+
+<Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
+
+## API gotchas
+
+-   The Microsoft Advertising API doesn't offer a REST API, which means certain Nango functionalities won't be accessible, including syncs, workflows, and proxy requests.  
+    To engage with the Microsoft Advertising API, developers must initially retrieve the access token utilizing the [backend API](https://docs.nango.dev/reference/api/connection/get). This token should then be utilized with [official client libraries](https://learn.microsoft.com/en-us/advertising/guides/client-libraries?view=bingads-13) or a [SOAP Client](https://learn.microsoft.com/en-us/advertising/guides/authentication-oauth-quick-start?view=bingads-13) for further interaction.
+
+<Note>
+    Add Getting Started links and Gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft-ads.mdx)
+</Note>
+

--- a/docs-v2/integrations/marketing.mdx
+++ b/docs-v2/integrations/marketing.mdx
@@ -27,4 +27,5 @@ sidebarTitle: Marketing
     <Card title="Sendgrid" href="/integrations/all/sendgrid" color="#68a063" />
     <Card title="Twitter" href="/integrations/all/twitter" color="#68a063" />
     <Card title="Zoho Bigin" href="/integrations/all/zoho-bigin" color="#68a063" />
+    <Card title="Microsoft Ads" href="/integrations/all/microsoft-ads" color="#68a063" />
 </CardGroup>

--- a/docs-v2/mint.json
+++ b/docs-v2/mint.json
@@ -394,6 +394,7 @@
                         "integrations/all/linear",
                         "integrations/all/linkedin",
                         "integrations/all/mailchimp",
+                        "integrations/all/microsoft-ads",
                         "integrations/all/microsoft-teams",
                         "integrations/all/microsoft-tenant-specific",
                         "integrations/all/miro",

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -1328,7 +1328,8 @@ microsoft-ads:
     default_scopes:
         - https://ads.microsoft.com/msads.manage
         - offline_access
-    proxy: null
+    proxy:
+        base_url: https://clientcenter.api.bingads.microsoft.com/Api
     refresh_params:
         grant_type: refresh_token
         scope: https://ads.microsoft.com/msads.manage

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -1321,6 +1321,18 @@ microsoft-tenant-specific:
     refresh_params:
         grant_type: refresh_token
     docs: https://docs.nango.dev/integrations/all/microsoft-tenant-specific
+microsoft-ads:
+    alias: microsoft-teams
+    categories:
+        - marketing
+    default_scopes:
+        - https://ads.microsoft.com/msads.manage
+        - offline_access
+    proxy: null
+    refresh_params:
+        grant_type: refresh_token
+        scope: https://ads.microsoft.com/msads.manage
+    docs: https://docs.nango.dev/integrations/all/microsoft-ads
 mixpanel:
     categories:
         - analytics


### PR DESCRIPTION
## Describe your changes

- Added configuration for microsoft-ads in providers.yaml
- Added microsoft-ads to docs-v2.
- Added microsoft-ads pages for Pre-Configured APIs group in mint.json.
- Consolidate microsoft-ads docs pages

## Test

This provider has been used successfully in local development to connect to Microsoft Ads and successfully call those endpoints after authorizing using Nango.

The documentation update was reviewed using npm run docs and verifying on localhost.

## Issue ticket number and link

Related to [this thread](https://nango-community.slack.com/archives/C04ABR352H0/p1712349133436789) in the Slack channel.