### PR TITLE
fix: TypeError: request.headers.split is not a function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7392,59 +7392,59 @@
             "integrity": "sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA==",
             "dev": true
         },
-        "node_modules/@sentry/core": {
-            "version": "7.105.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.105.0.tgz",
-            "integrity": "sha512-5xsaTG6jZincTeJUmZomlv20mVRZUEF1U/g89lmrSOybyk2+opEnB1JeBn4ODwnvmSik8r2QLr6/RiYlaxRJCg==",
+        "node_modules/@sentry-internal/tracing": {
+            "version": "7.109.0",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.109.0.tgz",
+            "integrity": "sha512-PzK/joC5tCuh2R/PRh+7dp+uuZl7pTsBIjPhVZHMTtb9+ls65WkdZJ1/uKXPouyz8NOo9Xok7aEvEo9seongyw==",
             "dependencies": {
-                "@sentry/types": "7.105.0",
-                "@sentry/utils": "7.105.0"
+                "@sentry/core": "7.109.0",
+                "@sentry/types": "7.109.0",
+                "@sentry/utils": "7.109.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@sentry/core": {
+            "version": "7.109.0",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.109.0.tgz",
+            "integrity": "sha512-xwD4U0IlvvlE/x/g/W1I8b4Cfb16SsCMmiEuBf6XxvAa3OfWBxKoqLifb3GyrbxMC4LbIIZCN/SvLlnGJPgszA==",
+            "dependencies": {
+                "@sentry/types": "7.109.0",
+                "@sentry/utils": "7.109.0"
             },
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@sentry/node": {
-            "version": "7.105.0",
-            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.105.0.tgz",
-            "integrity": "sha512-b0QwZ7vT4hcJi6LmNRh3dcaYpLtXnkYXkL0rfhMb8hN8sUx8zuOWFMI7j0cfAloVThUeJVwGyv9dERfzGS2r2w==",
+            "version": "7.109.0",
+            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.109.0.tgz",
+            "integrity": "sha512-tqMNAES4X/iBl1eZRCmc29p//0id01FBLEiesNo5nk6ECl6/SaGMFAEwu1gsn90h/Bjgr04slwFOS4cR45V2PQ==",
             "dependencies": {
-                "@sentry-internal/tracing": "7.105.0",
-                "@sentry/core": "7.105.0",
-                "@sentry/types": "7.105.0",
-                "@sentry/utils": "7.105.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@sentry/node/node_modules/@sentry-internal/tracing": {
-            "version": "7.105.0",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.105.0.tgz",
-            "integrity": "sha512-b+AFYB7Bc9vmyxl2jbmuT4esX5G0oPfpz35A0sxFzmJIhvMg1YMDNio2c81BtKN+VSPORCnKMLhfk3kyKKvWMQ==",
-            "dependencies": {
-                "@sentry/core": "7.105.0",
-                "@sentry/types": "7.105.0",
-                "@sentry/utils": "7.105.0"
+                "@sentry-internal/tracing": "7.109.0",
+                "@sentry/core": "7.109.0",
+                "@sentry/types": "7.109.0",
+                "@sentry/utils": "7.109.0"
             },
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@sentry/types": {
-            "version": "7.105.0",
-            "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.105.0.tgz",
-            "integrity": "sha512-80o0KMVM+X2Ym9hoQxvJetkJJwkpCg7o6tHHFXI+Rp7fawc2iCMTa0IRQMUiSkFvntQLYIdDoNNuKdzz2PbQGA==",
+            "version": "7.109.0",
+            "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.109.0.tgz",
+            "integrity": "sha512-egCBnDv3YpVFoNzRLdP0soVrxVLCQ+rovREKJ1sw3rA2/MFH9WJ+DZZexsX89yeAFzy1IFsCp7/dEqudusml6g==",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@sentry/utils": {
-            "version": "7.105.0",
-            "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.105.0.tgz",
-            "integrity": "sha512-YVAV0c2KLM8+VZCicQ/E/P2+J9Vs0hGhrXwV7w6ZEAtvxrg4oF270toL1WRhvcaf8JO4J1v4V+LuU6Txs4uEeQ==",
+            "version": "7.109.0",
+            "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.109.0.tgz",
+            "integrity": "sha512-3RjxMOLMBwZ5VSiH84+o/3NY2An4Zldjz0EbfEQNRY9yffRiCPJSQiCJID8EoylCFOh/PAhPimBhqbtWJxX6iw==",
             "dependencies": {
-                "@sentry/types": "7.105.0"
+                "@sentry/types": "7.109.0"
             },
             "engines": {
                 "node": ">=8"
@@ -37318,7 +37318,7 @@
                 "@datadog/datadog-api-client": "^1.16.0",
                 "@hapi/boom": "^10.0.1",
                 "@nangohq/node": "^0.39.16",
-                "@sentry/node": "^7.105.0",
+                "@sentry/node": "^7.106.0",
                 "@temporalio/client": "^1.9.1",
                 "amqplib": "^0.10.3",
                 "archiver": "^6.0.1",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -21,7 +21,7 @@
         "@datadog/datadog-api-client": "^1.16.0",
         "@hapi/boom": "^10.0.1",
         "@nangohq/node": "^0.39.16",
-        "@sentry/node": "^7.105.0",
+        "@sentry/node": "^7.106.0",
         "@temporalio/client": "^1.9.1",
         "amqplib": "^0.10.3",
         "archiver": "^6.0.1",


### PR DESCRIPTION
undici version was bumped yesterday but the sentry lib version 7.105 doesn't support it. Bumping sentry to 7.106 where the issue was fixed.

https://github.com/getsentry/sentry-javascript/releases/tag/7.106.0 

https://github.com/getsentry/sentry-javascript/pull/10938

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
