### PR TITLE
fix: Error unable to get local issuer certificate

### DIFF
--- a/packages/records/lib/db/config.ts
+++ b/packages/records/lib/db/config.ts
@@ -9,7 +9,8 @@ const config: Knex.Config = {
     client: 'postgres',
     connection: {
         connectionString: envs.RECORDS_DATABASE_URL,
-        statement_timeout: 60000
+        statement_timeout: 60000,
+        ssl: 'no-verify' // RDS CA cert is self-signed and not in the CA store
     },
     searchPath: schema,
     pool: { min: 2, max: 20 },


### PR DESCRIPTION
RDS certificate is self-sign and therefore rejected when trying to connect with sslmode=required
This change prevents the cert verification to fail the ssl connection
