### PR TITLE
fix: logs don't show the context when detecting records differences

### DIFF
--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -221,16 +221,21 @@ class SyncController {
                     logger.error('Error fetching records from new records service', newResponse.err);
                 } else {
                     // Compare legacy and new records
-                    // dates are set by the database and may differ
+                    // Dates are set by the database and may differ
                     // so we need to remove them before comparing
-                    const oldRecords = response.records.map((r) => {
-                        const { _nango_metadata: _ignored, ...rest } = r;
-                        return rest;
-                    });
-                    const newRecords = newResponse.res.records.map((r) => {
-                        const { _nango_metadata: _ignored, ...rest } = r;
-                        return rest;
-                    });
+                    // Also sorting the records by id since the order depends on updatedAt
+                    const oldRecords = response.records
+                        .map((r) => {
+                            const { _nango_metadata: _ignored, ...rest } = r;
+                            return rest;
+                        })
+                        .sort(({ id: a }, { id: b }) => (a as string).localeCompare(b as string));
+                    const newRecords = newResponse.res.records
+                        .map((r) => {
+                            const { _nango_metadata: _ignored, ...rest } = r;
+                            return rest;
+                        })
+                        .sort(({ id: a }, { id: b }) => (a as string).localeCompare(b as string));
                     const oldRecordsJson = JSON.stringify(oldRecords);
                     const newRecordsJson = JSON.stringify(newRecords);
                     if (oldRecordsJson !== newRecordsJson) {

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -234,14 +234,19 @@ class SyncController {
                     const oldRecordsJson = JSON.stringify(oldRecords);
                     const newRecordsJson = JSON.stringify(newRecords);
                     if (oldRecordsJson !== newRecordsJson) {
-                        logger.error(`[RECORDS MIGRATION] Differences between legacy and new records: ${oldRecordsJson} <<<>>> ${newRecordsJson}`, {
+                        const context = {
+                            environmentId,
+                            providerConfigKey,
                             connectionId,
                             model,
                             modifiedAfter: delta || modified_after,
                             limit,
                             filter,
                             cursor
-                        });
+                        };
+                        logger.error(
+                            `[RECORDS MIGRATION] Differences between legacy and new records (${JSON.stringify(context)}): ${oldRecordsJson} <<<>>> ${newRecordsJson}`
+                        );
                     } else {
                         logger.info('[RECORDS MIGRATION] No differences between legacy and new records');
                     }


### PR DESCRIPTION
logs in render don't show extra info like environment, connectionId, etc... which makes it harder to debug

tested locally