### PR TITLE
fix: batchDelete counts already deleted records or non-existing ones as deleted

### DIFF
--- a/packages/shared/lib/services/sync/data/data.service.ts
+++ b/packages/shared/lib/services/sync/data/data.service.ts
@@ -33,11 +33,12 @@ export async function upsert(
 
     const addedKeys = await getAddedKeys(recordsWithoutDuplicates, nangoConnectionId, model);
     const updatedKeys = await getUpdatedKeys(recordsWithoutDuplicates, nangoConnectionId, model);
+    const deletedKeys = await getDeletedKeys(recordsWithoutDuplicates, nangoConnectionId, model);
 
     try {
         const encryptedRecords = encryptionManager.encryptDataRecords(recordsWithoutDuplicates);
 
-        const externalIds = await schema()
+        await schema()
             .from<DataRecord>(RECORDS_TABLE)
             .insert(encryptedRecords)
             .onConflict(['nango_connection_id', 'external_id', 'model'])
@@ -48,7 +49,7 @@ export async function upsert(
             return {
                 success: true,
                 summary: {
-                    deletedKeys: externalIds.map(({ external_id }) => external_id),
+                    deletedKeys: deletedKeys,
                     addedKeys: [],
                     updatedKeys: []
                 }
@@ -230,4 +231,17 @@ export async function getUpdatedKeys(response: DataRecord[], nangoConnectionId: 
         .whereNotIn(['external_id', 'data_hash'], keysWithHash);
 
     return rowsToUpdate;
+}
+
+export async function getDeletedKeys(response: DataRecord[], nangoConnectionId: number, model: string): Promise<string[]> {
+    const keys: string[] = response.map((data: DataRecord) => String(data[RECORD_UNIQUE_KEY]));
+    return await schema()
+        .from(RECORDS_TABLE)
+        .where({
+            nango_connection_id: nangoConnectionId,
+            model,
+            external_deleted_at: null
+        })
+        .whereIn('external_id', keys)
+        .pluck('external_id');
 }


### PR DESCRIPTION
## Describe your changes
Upsert summary would count already deleted records or non-existing ones as deleted

## Issue ticket number and link
https://linear.app/nango/issue/NAN-727/sync-logs-always-return-all-deleted-records-even-when-they-were

Tested locally
