### PR TITLE
fix(api): wrong join for getSyncs

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -188,7 +188,8 @@ class ConnectionService {
                 provider_config_key: providerConfigKey,
                 credentials: {},
                 connection_config: {},
-                environment_id
+                environment_id,
+                config_id: config_id!
             },
             ['id']
         );

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -218,7 +218,7 @@ export const getSyncs = async (nangoConnection: Connection): Promise<(Sync & { s
         ) as thirty_day_timestamps`
     );
 
-    const result = await schema()
+    const result = await db.knex
         .from<Sync>(TABLE)
         .select(
             `${TABLE}.*`,
@@ -227,7 +227,18 @@ export const getSyncs = async (nangoConnection: Connection): Promise<(Sync & { s
             `${SYNC_SCHEDULE_TABLE}.frequency`,
             `${SYNC_SCHEDULE_TABLE}.offset`,
             `${SYNC_SCHEDULE_TABLE}.status as schedule_status`,
-            `${SYNC_CONFIG_TABLE}.models`,
+            db.knex.raw(
+                `(
+                    SELECT models
+                    FROM
+                        _nango_connections
+                        JOIN _nango_configs ON _nango_configs.id = _nango_connections.config_id
+                        JOIN _nango_sync_configs ON _nango_sync_configs.nango_config_id = _nango_configs.id
+                            AND _nango_sync_configs.deleted = FALSE
+                            AND _nango_sync_configs.active = TRUE
+                    WHERE _nango_connections.id = _nango_syncs.nango_connection_id AND _nango_sync_configs.sync_name = _nango_syncs.name
+                ) as models`
+            ),
             db.knex.raw(
                 `(
                     SELECT json_build_object(
@@ -257,14 +268,11 @@ export const getSyncs = async (nangoConnection: Connection): Promise<(Sync & { s
         )
         .leftJoin(SYNC_JOB_TABLE, `${SYNC_JOB_TABLE}.sync_id`, '=', `${TABLE}.id`)
         .join(SYNC_SCHEDULE_TABLE, `${SYNC_SCHEDULE_TABLE}.sync_id`, `${TABLE}.id`)
-        .join(SYNC_CONFIG_TABLE, `${SYNC_CONFIG_TABLE}.sync_name`, `${TABLE}.name`)
         .where({
             nango_connection_id: nangoConnection.id,
             [`${SYNC_SCHEDULE_TABLE}.deleted`]: false,
             [`${SYNC_JOB_TABLE}.deleted`]: false,
-            [`${TABLE}.deleted`]: false,
-            [`${SYNC_CONFIG_TABLE}.deleted`]: false,
-            [`${SYNC_CONFIG_TABLE}.active`]: true
+            [`${TABLE}.deleted`]: false
         })
         .orderBy(`${TABLE}.name`, 'asc')
         .groupBy(
@@ -273,7 +281,7 @@ export const getSyncs = async (nangoConnection: Connection): Promise<(Sync & { s
             `${SYNC_SCHEDULE_TABLE}.offset`,
             `${SYNC_SCHEDULE_TABLE}.status`,
             `${SYNC_SCHEDULE_TABLE}.schedule_id`,
-            `${SYNC_CONFIG_TABLE}.models`
+            'models'
         );
 
     const syncsWithSchedule = result.map(async (sync) => {


### PR DESCRIPTION
## Describe your changes

Fixes NAN-776

Page `http://localhost:3000/dev/connections/<Integration>/<id>` was sometimes showing foreign models in the table. After investigating it seems we were joining on name which matched random data on the table.

- Fix join by using sub-select 
Not entirely sure what was the expected output for multi model sync (cf: screenshot) but seems correct like this, (tbh I find this view quite confusing)

- Bonus: missing `config_id` for new unauthenticated connection 

---

<img width="1167" alt="Screenshot 2024-04-22 at 17 17 30" src="https://github.com/NangoHQ/nango/assets/1637651/47b83572-eea8-4de6-abe2-65f90e986af5">
