### PR TITLE
dynamic ddtrace pg.service 

### DIFF
--- a/packages/jobs/lib/tracer.ts
+++ b/packages/jobs/lib/tracer.ts
@@ -4,7 +4,7 @@ tracer.init({
     service: 'nango-jobs'
 });
 tracer.use('pg', {
-    service: 'nango-postgres'
+    service: (params: { database: string }) => `postgres-${params.database}`
 });
 tracer.use('opensearch', {
     service: 'nango-opensearch'

--- a/packages/persist/lib/tracer.ts
+++ b/packages/persist/lib/tracer.ts
@@ -4,7 +4,7 @@ tracer.init({
     service: 'nango-persist'
 });
 tracer.use('pg', {
-    service: 'nango-postgres'
+    service: (params: { database: string }) => `postgres-${params.database}`
 });
 tracer.use('opensearch', {
     service: 'nango-opensearch'

--- a/packages/server/lib/tracer.ts
+++ b/packages/server/lib/tracer.ts
@@ -4,7 +4,7 @@ tracer.init({
     service: 'nango'
 });
 tracer.use('pg', {
-    service: 'nango-postgres'
+    service: (params: { database: string }) => `postgres-${params.database}`
 });
 tracer.use('opensearch', {
     service: 'nango-opensearch'


### PR DESCRIPTION
## Describe your changes
Making the ddtrace pg.service depend on the database name in order to be able to differentiate apm metrics between main and records dbs. ex: `postgres-nango_tbvo` or `postgres-records`

https://datadoghq.dev/dd-trace-js/interfaces/export_.plugins.pg.html#service

Note: requires changing the DD dashboard db widget

## Issue ticket number and link
https://linear.app/nango/issue/NAN-746/datadog-apm-graphs-for-records-db-datadog-database-monitoring
