### PR TITLE
feat: hn demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "webapp:dev:watch": "cd ./packages/webapp && npm run start:hosted",
         "prepare": "husky install",
         "build:watch": "tsc -b -w --preserveWatchOutput tsconfig.build.json",
-        "dev:watch": "npm run -w nango copyfiles && npm run build:watch",
+        "dev:watch": "npm run -w nango copy:files && npm run build:watch",
         "watch:dev": "npm run dev:watch",
         "dev:watch:apps": "concurrently --kill-others \"npm run server:dev:watch\" \"npm run webapp:dev:watch\" \"npm run jobs:dev:watch\" \"npm run persist:dev:watch\"",
         "watch:dev:apps": "npm run dev:watch:apps",

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -50,12 +50,11 @@ const app = express();
 const apiAuth = [authMiddleware.secretKeyAuth.bind(authMiddleware), rateLimiterMiddleware];
 const adminAuth = [authMiddleware.secretKeyAuth.bind(authMiddleware), authMiddleware.adminKeyAuth.bind(authMiddleware), rateLimiterMiddleware];
 const apiPublicAuth = [authMiddleware.publicKeyAuth.bind(authMiddleware), authCheck, rateLimiterMiddleware];
-const webAuth =
-    isCloud || isEnterprise
-        ? [passport.authenticate('session'), authMiddleware.sessionAuth.bind(authMiddleware), rateLimiterMiddleware]
-        : isBasicAuthEnabled
-          ? [passport.authenticate('basic', { session: false }), authMiddleware.basicAuth.bind(authMiddleware), rateLimiterMiddleware]
-          : [authMiddleware.noAuth.bind(authMiddleware), rateLimiterMiddleware];
+const webAuth = AUTH_ENABLED
+    ? [passport.authenticate('session'), authMiddleware.sessionAuth.bind(authMiddleware), rateLimiterMiddleware]
+    : isBasicAuthEnabled
+      ? [passport.authenticate('basic', { session: false }), authMiddleware.basicAuth.bind(authMiddleware), rateLimiterMiddleware]
+      : [authMiddleware.noAuth.bind(authMiddleware), rateLimiterMiddleware];
 
 app.use(
     express.json({

--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -30,6 +30,7 @@ import AccountSettings from './pages/AccountSettings';
 import UserSettings from './pages/UserSettings';
 import { Homepage } from './pages/Homepage';
 import { NotFound } from './pages/NotFound';
+import { HNDemo } from './pages/HNDemo';
 
 Sentry.init({
     dsn: process.env.REACT_APP_PUBLIC_SENTRY_KEY,
@@ -113,6 +114,7 @@ const App = () => {
                         )}
                     </Route>
                     <Route path="/auth-link" element={<AuthLink />} />
+                    {true && <Route path="/hn-demo" element={<HNDemo />} />}
                     {AUTH_ENABLED && (
                         <>
                             <Route path="/signin" element={<Signin />} />

--- a/packages/webapp/src/components/TopNavBar.tsx
+++ b/packages/webapp/src/components/TopNavBar.tsx
@@ -1,9 +1,34 @@
 import { ChatBubbleBottomCenterIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
+import { useStore } from '../store';
+import { useMemo } from 'react';
+import { useSignout } from '../utils/user';
+import Info from './ui/Info';
 
 export default function NavBar() {
+    const signout = useSignout();
+    const email = useStore((state) => state.email);
+    const isHNDemo = useMemo(() => {
+        return Boolean(email.match(/demo-[a-z0-9]+@example.com/));
+    }, [email]);
+
+    const onCreateAccount = () => {
+        signout();
+    };
+
     return (
         <div className="w-full fixed bg-pure-black z-50 left-[15.8rem]">
-            <div className="flex justify-end border-b border-border-gray py-3 mr-[15.8rem]">
+            <div className="flex justify-between border-b border-border-gray py-3 mr-[15.8rem]">
+                <div className="text-white px-6 text-sm">
+                    {isHNDemo && (
+                        <Info padding={'px-3 py-1.5'} size={15}>
+                            This is a test account. Click{' '}
+                            <button className="font-bold" onClick={onCreateAccount}>
+                                here
+                            </button>{' '}
+                            to create a real account.
+                        </Info>
+                    )}
+                </div>
                 <div className="flex items-center pr-6">
                     <a
                         href="https://nango.dev/slack"

--- a/packages/webapp/src/pages/HNDemo.tsx
+++ b/packages/webapp/src/pages/HNDemo.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import Spinner from '../components/ui/Spinner';
+import { Navigate, useNavigate } from 'react-router-dom';
+import { useSignupAPI } from '../utils/api';
+import { useAnalyticsTrack } from '../utils/analytics';
+import { useSignin, type User } from '../utils/user';
+
+export const HNDemo: React.FC = () => {
+    const [isAnUser, setIsAnUser] = useState<null | boolean>(null);
+    const navigate = useNavigate();
+    const signupAPI = useSignupAPI();
+    const signin = useSignin();
+    const analyticsTrack = useAnalyticsTrack();
+
+    useEffect(() => {
+        async function getMeta() {
+            const res = await fetch('/api/v1/meta');
+            if (res.status !== 200) {
+                setIsAnUser(false);
+                return;
+            }
+            setIsAnUser(true);
+        }
+        void getMeta();
+    }, []);
+
+    useEffect(() => {
+        if (isAnUser === null || isAnUser) {
+            return;
+        }
+        async function signup() {
+            const id = Math.random().toString(36).replace('0.', '');
+            const res = await signupAPI(`demo-${id}`, `demo-${id}@example.com`, Math.random().toString(36));
+
+            if (res?.status === 200) {
+                const { user } = (await res.json()) as { user: User };
+                analyticsTrack('web:account_signup', {
+                    user_id: user.id,
+                    email: user.email,
+                    name: user.name,
+                    accountId: user.accountId
+                });
+                signin(user);
+                navigate('/');
+            }
+        }
+
+        void signup();
+    }, [isAnUser, signin, navigate, analyticsTrack, signupAPI]);
+
+    if (isAnUser) {
+        return <Navigate to="/dev/interactive-demo" replace />;
+    }
+
+    return (
+        <div className="w-screen h-screen flex justify-center items-center">
+            <div className="text-white">
+                {String(isAnUser)}
+                <Spinner size={1} />
+                ahllo
+            </div>
+        </div>
+    );
+};

--- a/packages/webapp/src/pages/HNDemo.tsx
+++ b/packages/webapp/src/pages/HNDemo.tsx
@@ -55,9 +55,7 @@ export const HNDemo: React.FC = () => {
     return (
         <div className="w-screen h-screen flex justify-center items-center">
             <div className="text-white">
-                {String(isAnUser)}
                 <Spinner size={1} />
-                ahllo
             </div>
         </div>
     );


### PR DESCRIPTION
## Describe your changes

fixes NAN-788

- Introduce a temporary frontend endpoint to automatically create an account and redirect to the interactive demo. 
It detects if we are connected to avoid creating new accounts for nothing otherwise it will create an account with a random id and email `demo-<id>@example.com`.
- Banner is displayed when connected to a demo account 
- Bonus: fix the broken script to compile

---

<img width="1443" alt="Screenshot 2024-04-24 at 12 38 03" src="https://github.com/NangoHQ/nango/assets/1637651/214c6d9f-9277-4a2d-ac0d-9da800f68d41">
