### PR TITLE
fix(records): transaction not reusing opened connection

### DIFF
--- a/packages/records/lib/db/config.ts
+++ b/packages/records/lib/db/config.ts
@@ -12,7 +12,7 @@ const config: Knex.Config = {
         statement_timeout: 60000
     },
     searchPath: schema,
-    pool: { min: 2, max: 20 },
+    pool: { min: 2, max: 50 },
     migrations: {
         extension: isJS ? 'js' : 'ts',
         directory: 'migrations',

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -15,6 +15,7 @@ import { RECORDS_TABLE } from '../constants.js';
 import { removeDuplicateKey, getUniqueId } from '../helpers/uniqueKey.js';
 import { logger } from '../utils/logger.js';
 import { resultErr, resultOk, type Result } from '@nangohq/utils';
+import type { Knex } from 'knex';
 
 dayjs.extend(utc);
 
@@ -199,7 +200,7 @@ export async function upsert(records: FormattedRecord[], connectionId: number, m
         await db.transaction(async (trx) => {
             for (let i = 0; i < recordsWithoutDuplicates.length; i += BATCH_SIZE) {
                 const chunk = recordsWithoutDuplicates.slice(i, i + BATCH_SIZE);
-                const chunkSummary = await getUpsertSummary(chunk, connectionId, model, nonUniqueKeys, softDelete);
+                const chunkSummary = await getUpsertSummary(chunk, connectionId, model, nonUniqueKeys, softDelete, trx);
                 summary = {
                     addedKeys: [...summary.addedKeys, ...chunkSummary.addedKeys],
                     updatedKeys: [...summary.updatedKeys, ...chunkSummary.updatedKeys],
@@ -251,10 +252,10 @@ export async function update(records: FormattedRecord[], connectionId: number, m
             for (let i = 0; i < recordsWithoutDuplicates.length; i += BATCH_SIZE) {
                 const chunk = recordsWithoutDuplicates.slice(i, i + BATCH_SIZE);
 
-                updatedKeys.push(...(await getUpdatedKeys(chunk, connectionId, model)));
+                updatedKeys.push(...(await getUpdatedKeys(chunk, connectionId, model, trx)));
 
                 const recordsToUpdate: FormattedRecord[] = [];
-                const rawOldRecords = await getRecordsByExternalIds(updatedKeys, connectionId, model);
+                const rawOldRecords = await getRecordsByExternalIds(updatedKeys, connectionId, model, trx);
                 for (const rawOldRecord of rawOldRecords) {
                     if (!rawOldRecord) {
                         continue;
@@ -341,11 +342,11 @@ export async function markNonCurrentGenerationRecordsAsDeleted(connectionId: num
  * getUpdatedKeys
  * @desc returns a list of the keys that exist in the records tables but have a different data_hash
  */
-async function getUpdatedKeys(records: FormattedRecord[], connectionId: number, model: string): Promise<string[]> {
+async function getUpdatedKeys(records: FormattedRecord[], connectionId: number, model: string, trx: Knex.Transaction): Promise<string[]> {
     const keys: string[] = records.map((record: FormattedRecord) => getUniqueId(record));
     const keysWithHash: [string, string][] = records.map((record: FormattedRecord) => [getUniqueId(record), record.data_hash]);
 
-    const rowsToUpdate = (await db
+    const rowsToUpdate = (await trx
         .from(RECORDS_TABLE)
         .pluck('external_id')
         .where({
@@ -363,10 +364,11 @@ async function getUpsertSummary(
     connectionId: number,
     model: string,
     nonUniqueKeys: string[],
-    softDelete: boolean
+    softDelete: boolean,
+    trx: Knex.Transaction
 ): Promise<UpsertSummary> {
     const keys: string[] = records.map((record: FormattedRecord) => getUniqueId(record));
-    const nonDeletedKeys: string[] = await db
+    const nonDeletedKeys: string[] = await trx
         .from(RECORDS_TABLE)
         .where({
             connection_id: connectionId,
@@ -385,7 +387,7 @@ async function getUpsertSummary(
         };
     } else {
         const addedKeys = keys?.filter((key: string) => !nonDeletedKeys.includes(key));
-        const updatedKeys = await getUpdatedKeys(records, connectionId, model);
+        const updatedKeys = await getUpdatedKeys(records, connectionId, model, trx);
         return {
             addedKeys,
             updatedKeys,
@@ -395,8 +397,8 @@ async function getUpsertSummary(
     }
 }
 
-async function getRecordsByExternalIds(external_ids: string[], connection_id: number, model: string): Promise<UnencryptedRecord[]> {
-    const encryptedRecords = await db
+async function getRecordsByExternalIds(external_ids: string[], connection_id: number, model: string, trx: Knex.Transaction): Promise<UnencryptedRecord[]> {
+    const encryptedRecords = await trx
         .from<FormattedRecord>(RECORDS_TABLE)
         .where({
             connection_id,


### PR DESCRIPTION
## Describe your changes

Contributes to NAN-796

There is discrepancy is the new records storage, we have a lot of error in production related to pool exhaustion which is probably due do the fact that the transactions were not reusing the connection correctly.  Not entirely sure it's the full fix but maybe

- Fix transaction usage
- Still increase the pool since we have a better DB

```logs
2024-04-25T08:58:41.431Z [ERROR] [records] Failed to upsert records to table records.
Model: ***, Nango Connection ID: ***.
Attempted to insert/update/delete: 100 records
KnexTimeoutError: Knex: Timeout acquiring a connection. The pool is probably full. Are you missing a .transacting(trx) call?
2024-04-25T08:58:41.431Z [ERROR] [PersistController] Failed to save records: Error: Failed to upsert records to table records.
```