### PR TITLE
fix(logs): missing contextGetter in syncCommand

### DIFF
--- a/packages/server/lib/controllers/onboarding.controller.ts
+++ b/packages/server/lib/controllers/onboarding.controller.ts
@@ -297,24 +297,24 @@ class OnboardingController {
             if (!status || status.length <= 0) {
                 // If for any reason we don't have a sync, because of a partial state
                 logger.info(`[demo] no sync were found ${environment.id}`);
-                await syncOrchestrator.runSyncCommand(
+                await syncOrchestrator.runSyncCommand({
                     recordsService,
-                    environment.id,
-                    DEMO_GITHUB_CONFIG_KEY,
-                    [DEMO_SYNC_NAME],
-                    SyncCommand.RUN_FULL,
+                    environmentId: environment.id,
+                    providerConfigKey: DEMO_GITHUB_CONFIG_KEY,
+                    syncNames: [DEMO_SYNC_NAME],
+                    command: SyncCommand.RUN_FULL,
                     logContextGetter,
-                    req.body.connectionId
-                );
-                await syncOrchestrator.runSyncCommand(
+                    connectionId: req.body.connectionId
+                });
+                await syncOrchestrator.runSyncCommand({
                     recordsService,
-                    environment.id,
-                    DEMO_GITHUB_CONFIG_KEY,
-                    [DEMO_SYNC_NAME],
-                    SyncCommand.UNPAUSE,
+                    environmentId: environment.id,
+                    providerConfigKey: DEMO_GITHUB_CONFIG_KEY,
+                    syncNames: [DEMO_SYNC_NAME],
+                    command: SyncCommand.UNPAUSE,
                     logContextGetter,
-                    req.body.connectionId
-                );
+                    connectionId: req.body.connectionId
+                });
 
                 res.status(200).json({ retry: true });
                 return;
@@ -329,15 +329,15 @@ class OnboardingController {
             if (!job.nextScheduledSyncAt && job.jobStatus === SyncStatus.PAUSED) {
                 // If the sync has never run
                 logger.info(`[demo] no job were found ${environment.id}`);
-                await syncOrchestrator.runSyncCommand(
+                await syncOrchestrator.runSyncCommand({
                     recordsService,
-                    environment.id,
-                    DEMO_GITHUB_CONFIG_KEY,
-                    [DEMO_SYNC_NAME],
-                    SyncCommand.RUN_FULL,
+                    environmentId: environment.id,
+                    providerConfigKey: DEMO_GITHUB_CONFIG_KEY,
+                    syncNames: [DEMO_SYNC_NAME],
+                    command: SyncCommand.RUN_FULL,
                     logContextGetter,
-                    req.body.connectionId
-                );
+                    connectionId: req.body.connectionId
+                });
             }
 
             if (job.jobStatus === SyncStatus.SUCCESS) {

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -335,15 +335,15 @@ class SyncController {
 
             const environmentId = getEnvironmentId(res);
 
-            const { success, error } = await syncOrchestrator.runSyncCommand(
+            const { success, error } = await syncOrchestrator.runSyncCommand({
                 recordsService,
                 environmentId,
-                provider_config_key,
-                syncNames as string[],
-                full_resync ? SyncCommand.RUN_FULL : SyncCommand.RUN,
+                providerConfigKey: provider_config_key,
+                syncNames: syncNames as string[],
+                command: full_resync ? SyncCommand.RUN_FULL : SyncCommand.RUN,
                 logContextGetter,
-                connection_id
-            );
+                connectionId: connection_id!
+            });
 
             if (!success) {
                 errorManager.errResFromNangoErr(res, error);
@@ -549,14 +549,15 @@ class SyncController {
 
             const environmentId = getEnvironmentId(res);
 
-            await syncOrchestrator.runSyncCommand(
+            await syncOrchestrator.runSyncCommand({
                 recordsService,
                 environmentId,
-                provider_config_key as string,
-                syncNames as string[],
-                SyncCommand.PAUSE,
-                connection_id
-            );
+                providerConfigKey: provider_config_key as string,
+                syncNames: syncNames as string[],
+                command: SyncCommand.PAUSE,
+                logContextGetter,
+                connectionId: connection_id
+            });
 
             res.sendStatus(200);
         } catch (e) {
@@ -588,14 +589,15 @@ class SyncController {
 
             const environmentId = getEnvironmentId(res);
 
-            await syncOrchestrator.runSyncCommand(
+            await syncOrchestrator.runSyncCommand({
                 recordsService,
                 environmentId,
-                provider_config_key as string,
-                syncNames as string[],
-                SyncCommand.UNPAUSE,
-                connection_id
-            );
+                providerConfigKey: provider_config_key as string,
+                syncNames: syncNames as string[],
+                command: SyncCommand.UNPAUSE,
+                logContextGetter,
+                connectionId: connection_id
+            });
 
             res.sendStatus(200);
         } catch (e) {

--- a/packages/shared/lib/services/sync/orchestrator.service.ts
+++ b/packages/shared/lib/services/sync/orchestrator.service.ts
@@ -184,15 +184,23 @@ export class Orchestrator {
         }
     }
 
-    public async runSyncCommand(
-        recordsService: RecordsServiceInterface,
-        environmentId: number,
-        providerConfigKey: string,
-        syncNames: string[],
-        command: SyncCommand,
-        logContextGetter: LogContextGetter,
-        connectionId?: string
-    ): Promise<ServiceResponse<boolean>> {
+    public async runSyncCommand({
+        recordsService,
+        environmentId,
+        providerConfigKey,
+        syncNames,
+        command,
+        logContextGetter,
+        connectionId
+    }: {
+        recordsService: RecordsServiceInterface;
+        environmentId: number;
+        providerConfigKey: string;
+        syncNames: string[];
+        command: SyncCommand;
+        logContextGetter: LogContextGetter;
+        connectionId?: string;
+    }): Promise<ServiceResponse<boolean>> {
         const action = CommandToActivityLog[command];
         const provider = await configService.getProviderName(providerConfigKey);
 


### PR DESCRIPTION
## Describe your changes

- Fix missing logContextGetter in SyncCommand
It wasn't caught by TS because connection_id is `any`. Took the opportunity to move to a json object, this is handy and also prevent more of this kind of errors
