### PR TITLE
fix(envs): allow empty string

### DIFF
--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 const bool = z
-    .enum(['true', 'false'])
+    .enum(['true', 'false', ''])
     .optional()
     .default('false')
     .transform((value) => value === 'true');

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -19,7 +19,7 @@ describe('parse', () => {
     });
 
     it('should coerce boolean and number', () => {
-        const res = parseEnvs(ENVS, { NANGO_DB_SSL: 'true', NANGO_LOGS_ENABLED: 'false', NANGO_PERSIST_PORT: '3008' });
-        expect(res).toMatchObject({ NANGO_DB_SSL: true, NANGO_PERSIST_PORT: 3008, NANGO_LOGS_ENABLED: false, NANGO_CLOUD: false });
+        const res = parseEnvs(ENVS, { NANGO_DB_SSL: 'true', NANGO_LOGS_ENABLED: 'false', NANGO_PERSIST_PORT: '3008', NANGO_CACHE_ENV_KEYS: '' });
+        expect(res).toMatchObject({ NANGO_DB_SSL: true, NANGO_PERSIST_PORT: 3008, NANGO_LOGS_ENABLED: false, NANGO_CLOUD: false, NANGO_CACHE_ENV_KEYS: false });
     });
 });


### PR DESCRIPTION
## Describe your changes

Follow up of #2046 

- Since it's no longer a boolean type we should manually allow empty string