### PR TITLE
new session param: final_redirect_url

### DIFF
--- a/packages/server/lib/clients/publisher.client.ts
+++ b/packages/server/lib/clients/publisher.client.ts
@@ -187,7 +187,7 @@ export class Publisher {
         providerConfigKey: string | undefined,
         connectionId: string | undefined,
         wsErr: WSErr,
-        finalRedirectUrl: string | undefined
+        finalRedirectUrl?: string | undefined
     ) {
         logger.debug(`OAuth flow error for provider config "${providerConfigKey}" and connectionId "${connectionId}": ${wsErr.type} - ${wsErr.message}`);
         if (wsClientId) {

--- a/packages/server/lib/utils/utils.ts
+++ b/packages/server/lib/utils/utils.ts
@@ -359,7 +359,11 @@ export function resetPasswordSecret() {
 export function constructFinalRedirectUrl(finalRedirectUrl: string, queryParams: Record<string, any>) {
     const url = new URL(finalRedirectUrl);
     for (const queryKey in queryParams) {
-        url.searchParams.append(queryKey, queryParams[queryKey]);
+        let value = queryParams[queryKey];
+        if (typeof value !== 'string' && typeof value !== 'number') {
+            value = JSON.stringify(value);
+        }
+        url.searchParams.append(queryKey, value);
     }
     return url.toString();
 }

--- a/packages/server/lib/utils/utils.ts
+++ b/packages/server/lib/utils/utils.ts
@@ -355,3 +355,11 @@ Nango OAuth flow callback. Read more about how to use it at: https://github.com/
 export function resetPasswordSecret() {
     return process.env['NANGO_ADMIN_KEY'] || 'nango';
 }
+
+export function constructFinalRedirectUrl(finalRedirectUrl: string, queryParams: Record<string, any>) {
+    const url = new URL(finalRedirectUrl);
+    for (const queryKey in queryParams) {
+        url.searchParams.append(queryKey, queryParams[queryKey]);
+    }
+    return url.toString();
+}

--- a/packages/server/lib/utils/utils.unit.test.ts
+++ b/packages/server/lib/utils/utils.unit.test.ts
@@ -1,5 +1,10 @@
 import { expect, describe, it } from 'vitest';
-import { getConnectionMetadataFromTokenResponse, parseConnectionConfigParamsFromTemplate, getAdditionalAuthorizationParams } from './utils.js';
+import {
+    getConnectionMetadataFromTokenResponse,
+    parseConnectionConfigParamsFromTemplate,
+    getAdditionalAuthorizationParams,
+    constructFinalRedirectUrl
+} from './utils.js';
 import type { Template as ProviderTemplate } from '@nangohq/shared';
 import { AuthModes } from '@nangohq/shared';
 
@@ -221,5 +226,19 @@ describe('Utils unit tests', () => {
         expect(result).toEqual({});
         result = getAdditionalAuthorizationParams(undefined);
         expect(result).toEqual({});
+    });
+
+    it('Should construct final redirect URL', () => {
+        const url = 'https://external-website.com/confirm-connection?externalSession=dummy';
+        const result = constructFinalRedirectUrl(url, { providerConfigKey: 'provider-key', connectionId: 'test-connection-id', error: 'failed' });
+        expect(result).toEqual(
+            'https://external-website.com/confirm-connection?externalSession=dummy&providerConfigKey=provider-key&connectionId=test-connection-id&error=failed'
+        );
+
+        // error can be an object, serialized into JSON
+        const result2 = constructFinalRedirectUrl(url, { providerConfigKey: 'provider-key', connectionId: 'test-connection-id', error: { message: 'failed' } });
+        expect(result2).toEqual(
+            'https://external-website.com/confirm-connection?externalSession=dummy&providerConfigKey=provider-key&connectionId=test-connection-id&error=%7B%22message%22%3A%22failed%22%7D'
+        );
     });
 });

--- a/packages/shared/lib/db/migrations/20240426100946_add_final_redirect_url_oauth_sessions.cjs
+++ b/packages/shared/lib/db/migrations/20240426100946_add_final_redirect_url_oauth_sessions.cjs
@@ -1,0 +1,13 @@
+const tableName = '_nango_oauth_sessions';
+
+exports.up = function(knex) {
+  return knex.schema.alterTable(tableName, function (table) {
+    table.string('final_redirect_url');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(tableName, function (table) {
+    table.dropColumn('final_redirect_url');
+  });
+};

--- a/packages/shared/lib/models/Auth.ts
+++ b/packages/shared/lib/models/Auth.ts
@@ -51,6 +51,11 @@ export interface OAuthSession {
 
     // Needed for oAuth 1.0a
     requestTokenSecret?: string;
+
+    // URL to redirect the user at the end of the authorization flow.
+    // URL will contain in query parameters the connection ID, provider config key and connection status.
+    // This can be used in cases where you don't want to follow the frontend flows via websocket communication.
+    finalRedirectUrl: string | undefined;
 }
 
 export interface TemplateOAuth2 extends Template {


### PR DESCRIPTION
New parameter for connection sessions: final_redirect_url

This param enables starting a new connection creation that finalizes with redirecting to `final_redirect_url` with error or success result. It especially frees developers from frontend SDK dependency to create connections.

Frontend SDK typically builds connection initialization URLs like this: `http://127.0.0.1:3003/oauth/connect/my-service?connection_id=test-connection-id1&public_key=b9ad10b6-4283-4f7e-a377-82279ad54a4f`

Nango users can also use this URL to initiate connection sessions without using frontend SDK, however, there isn't an easy for them to finalize the connection process without using websockets or popup windows (to be notified via `window.parent.message`).

You can now build connection initialization URLs like this: `http://127.0.0.1:3003/oauth/connect/my-service?connection_id=test-connection-id1&public_key=b9ad10b6-4283-4f7e-a377-82279ad54a4f&final_redirect_url=http%3A%2F%2Flocalhost%3A5678%2Fwebhook%2F217fd5a6-190e-4659-95df-e78ff7fd48f8%3Fmy-external-param%3Dyes-correct`

See the last `final_redirect_url` parameter. That can be any URL and can include query params. Once the connection process finalizes with error or success, the authorizing user will be redirected to this URL, at which point you can continue using the newly established connection (or handle error experience).


## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [X] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is: not sure what to do about this
- [ ] I added analytics, otherwise the reason is: not sure what to do about this
