### PR TITLE
chore(pkg): missing private

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5257,7 +5257,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14123,7 +14122,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14140,7 +14138,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14157,7 +14154,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14174,7 +14170,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14191,7 +14186,6 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14208,7 +14202,6 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14225,7 +14218,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14242,7 +14234,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14259,7 +14250,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14276,7 +14266,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14293,7 +14282,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14310,7 +14298,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14327,7 +14314,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14344,7 +14330,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14361,7 +14346,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14378,7 +14362,6 @@
             "os": [
                 "netbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14395,7 +14378,6 @@
             "os": [
                 "openbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14412,7 +14394,6 @@
             "os": [
                 "sunos"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14429,7 +14410,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14446,7 +14426,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14463,7 +14442,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -14526,7 +14504,6 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -29749,9 +29726,9 @@
             "dependencies": {
                 "@nangohq/data-ingestion": "file:../data-ingestion",
                 "@nangohq/logs": "file:../logs",
-                "@nangohq/nango-runner": "^1.0.0",
+                "@nangohq/nango-runner": "file:../shared",
                 "@nangohq/records": "file:../records",
-                "@nangohq/shared": "^0.39.18",
+                "@nangohq/shared": "file:../shared",
                 "@nangohq/utils": "file:../utils",
                 "@temporalio/activity": "^1.9.1",
                 "@temporalio/client": "^1.9.1",
@@ -30132,6 +30109,10 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "packages/jobs/node_modules/@nangohq/nango-runner": {
+            "resolved": "packages/shared",
+            "link": true
         },
         "packages/jobs/node_modules/@vitest/expect": {
             "version": "1.4.0",
@@ -32053,7 +32034,7 @@
             "dependencies": {
                 "@nangohq/logs": "file:../logs",
                 "@nangohq/records": "file:../records",
-                "@nangohq/shared": "^0.39.18",
+                "@nangohq/shared": "file:../shared",
                 "@nangohq/utils": "file:../utils",
                 "dd-trace": "5.2.0",
                 "express": "^4.19.2",
@@ -34503,7 +34484,7 @@
             "version": "1.0.0",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@nangohq/shared": "^0.39.18",
+                "@nangohq/shared": "file:../shared",
                 "@nangohq/utils": "file:../utils",
                 "@trpc/client": "^10.45.1",
                 "@trpc/server": "^10.45.1",
@@ -35892,7 +35873,7 @@
                 "@hapi/boom": "^10.0.1",
                 "@nangohq/logs": "file:../logs",
                 "@nangohq/records": "file:../records",
-                "@nangohq/shared": "^0.39.18",
+                "@nangohq/shared": "file:../shared",
                 "@nangohq/utils": "file:../utils",
                 "@workos-inc/node": "^6.2.0",
                 "axios": "^1.3.4",

--- a/packages/data-ingestion/package.json
+++ b/packages/data-ingestion/package.json
@@ -5,6 +5,7 @@
     "type": "module",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",
+    "private": true,
     "scripts": {},
     "keywords": [],
     "repository": {

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -3,6 +3,7 @@
     "version": "1.0.0",
     "type": "module",
     "main": "dist/index.js",
+    "private": true,
     "scripts": {
         "start": "tsc && node dist/app.js",
         "dev": "nodemon"
@@ -16,8 +17,8 @@
     "dependencies": {
         "@nangohq/data-ingestion": "file:../data-ingestion",
         "@nangohq/logs": "file:../logs",
-        "@nangohq/nango-runner": "^1.0.0",
-        "@nangohq/shared": "^0.39.18",
+        "@nangohq/nango-runner": "file:../shared",
+        "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",
         "@nangohq/records": "file:../records",
         "@temporalio/activity": "^1.9.1",

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -4,6 +4,7 @@
     "type": "module",
     "main": "./dist/index.js",
     "types": "./dist/index.js",
+    "private": true,
     "scripts": {
         "build": "rimraf ./dist && tsc"
     },

--- a/packages/persist/package.json
+++ b/packages/persist/package.json
@@ -5,6 +5,7 @@
     "type": "module",
     "main": "dist/app.js",
     "typings": "dist/index.d.ts",
+    "private": true,
     "scripts": {
         "start": "node dist/app.js",
         "dev": "nodemon"
@@ -18,7 +19,7 @@
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
         "@nangohq/logs": "file:../logs",
-        "@nangohq/shared": "^0.39.18",
+        "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",
         "@nangohq/records": "file:../records",
         "dd-trace": "5.2.0",

--- a/packages/records/package.json
+++ b/packages/records/package.json
@@ -3,6 +3,7 @@
     "version": "1.0.0",
     "type": "module",
     "main": "dist/index.js",
+    "private": true,
     "scripts": {
         "dev:migration:create": "npm run knex -- migrate:make",
         "dev:migration:run": "npm run knex -- migrate:latest",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -5,6 +5,7 @@
     "type": "module",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",
+    "private": true,
     "scripts": {
         "start": "node dist/app.js",
         "dev": "nodemon"
@@ -17,7 +18,7 @@
     },
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
-        "@nangohq/shared": "^0.39.18",
+        "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",
         "@trpc/client": "^10.45.1",
         "@trpc/server": "^10.45.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,6 +5,7 @@
     "type": "module",
     "main": "dist/server.js",
     "typings": "dist/index.d.ts",
+    "private": true,
     "scripts": {
         "start": "tsc && node dist/server.js",
         "dev": "nodemon",
@@ -25,7 +26,7 @@
         "@hapi/boom": "^10.0.1",
         "@nangohq/logs": "file:../logs",
         "@nangohq/records": "file:../records",
-        "@nangohq/shared": "^0.39.18",
+        "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",
         "@workos-inc/node": "^6.2.0",
         "axios": "^1.3.4",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,6 +5,7 @@
     "type": "module",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",
+    "private": true,
     "scripts": {},
     "keywords": [],
     "repository": {

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -49,7 +49,7 @@ popd
 # Shared
 bump_and_npm_publish "@nangohq/shared" "$VERSION"
 # Update all packages to use the new shared version
-package_dirs=("cli" "server" "runner" "jobs" "persist")
+package_dirs=("cli")
 for dir in "${package_dirs[@]}"; do
     pushd "$GIT_ROOT_DIR/packages/$dir"
     npm install @nangohq/shared@^$VERSION


### PR DESCRIPTION
## Describe your changes

- Missing `private` field
- Use local pkg instead of remote 
Since we load the code and packages there is no point of going through an install or limit the possibilities of de-sync.
