### PR TITLE
fix(logs): only require envs for cloud

### DIFF
--- a/packages/logs/lib/env.ts
+++ b/packages/logs/lib/env.ts
@@ -1,3 +1,8 @@
-import { parseEnvs, ENVS } from '@nangohq/utils';
+import { parseEnvs, ENVS, isLocal, isCloud } from '@nangohq/utils';
 
-export const envs = parseEnvs(ENVS.required({ NANGO_LOGS_OS_URL: true, NANGO_LOGS_OS_USER: true, NANGO_LOGS_OS_PWD: true }));
+// Do not require in community and enterprise right now
+const required = isCloud || isLocal;
+
+export const envs = parseEnvs(required ? ENVS.required({ NANGO_LOGS_OS_URL: true, NANGO_LOGS_OS_USER: true, NANGO_LOGS_OS_PWD: true }) : ENVS);
+
+envs.NANGO_LOGS_ENABLED = envs.NANGO_LOGS_ENABLED ? Boolean(envs.NANGO_LOGS_OS_URL && envs.NANGO_LOGS_OS_USER && envs.NANGO_LOGS_OS_PWD) : false;

--- a/packages/logs/lib/es/client.ts
+++ b/packages/logs/lib/es/client.ts
@@ -2,10 +2,9 @@ import { Client } from '@opensearch-project/opensearch';
 import { envs } from '../env.js';
 
 export const client = new Client({
-    // Because it's loaded in CLI and runner we can't required any envs
     nodes: envs.NANGO_LOGS_OS_URL || 'http://localhost:0',
     requestTimeout: 5000,
     maxRetries: 1,
-    auth: { username: envs.NANGO_LOGS_OS_USER, password: envs.NANGO_LOGS_OS_PWD },
+    auth: { username: envs.NANGO_LOGS_OS_USER!, password: envs.NANGO_LOGS_OS_PWD! },
     ssl: { rejectUnauthorized: false }
 });

--- a/packages/logs/lib/es/helpers.ts
+++ b/packages/logs/lib/es/helpers.ts
@@ -1,8 +1,14 @@
+import { envs } from '../env.js';
 import { logger } from '../utils.js';
 import { client } from './client.js';
 import { indices } from './schema.js';
 
 export async function start() {
+    if (!envs.NANGO_LOGS_ENABLED) {
+        logger.warning('OpenSearch is disabled, skipping');
+        return;
+    }
+
     logger.info('🔄 OpenSearch service starting...');
 
     await migrateMapping();


### PR DESCRIPTION
## Describe your changes

Fixes NAN-814

- Make opensearch not required until we figure out our strategy (= make logs optional or not for self-host). 
- Skip migration when opensearch is not set