### PR TITLE
[NAN-751] Add migrate command to make migration easier

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -18,6 +18,7 @@ import compileService from './services/compile.service.js';
 import verificationService from './services/verification.service.js';
 import dryrunService from './services/dryrun.service.js';
 import configService from './services/config.service.js';
+import { v1toV2Migration, directoryMigration } from './services/migration.service.js';
 import { upgradeAction, NANGO_INTEGRATIONS_LOCATION, printDebug } from './utils.js';
 import type { ENV, DeployOptions } from './types.js';
 
@@ -156,7 +157,14 @@ program
     .command('migrate-config')
     .description('Migrate the nango.yaml from v1 (deprecated) to v2')
     .action(async function (this: Command) {
-        await verificationService.runMigration(path.resolve(process.cwd(), NANGO_INTEGRATIONS_LOCATION));
+        await v1toV2Migration(path.resolve(process.cwd(), NANGO_INTEGRATIONS_LOCATION));
+    });
+
+program
+    .command('migrate-to-directories')
+    .description('Migrate the script files from root level to structured directories.')
+    .action(async function (this: Command) {
+        await directoryMigration(path.resolve(process.cwd(), NANGO_INTEGRATIONS_LOCATION));
     });
 
 // Hidden commands //

--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -164,7 +164,8 @@ program
     .command('migrate-to-directories')
     .description('Migrate the script files from root level to structured directories.')
     .action(async function (this: Command) {
-        await directoryMigration(path.resolve(process.cwd(), NANGO_INTEGRATIONS_LOCATION));
+        const { debug } = this.opts();
+        await directoryMigration(path.resolve(process.cwd(), NANGO_INTEGRATIONS_LOCATION), debug);
     });
 
 // Hidden commands //

--- a/packages/cli/lib/services/migration.service.ts
+++ b/packages/cli/lib/services/migration.service.ts
@@ -1,0 +1,103 @@
+import fs from 'fs';
+import path from 'path';
+import chalk from 'chalk';
+import { exec } from 'child_process';
+
+import { nangoConfigFile, loadLocalNangoConfig, determineVersion } from '@nangohq/shared';
+import { getNangoRootPath } from '../utils.js';
+
+export const v1toV2Migration = async (loadLocation: string): Promise<void> => {
+    if (process.env['NANGO_CLI_UPGRADE_MODE'] === 'ignore') {
+        return;
+    }
+    const localConfig = await loadLocalNangoConfig(loadLocation);
+
+    if (!localConfig) {
+        return;
+    }
+
+    const version = determineVersion(localConfig);
+    if (version === 'v2') {
+        console.log(chalk.blue(`nango.yaml is already at v2.`));
+    }
+    if (version === 'v1' && localConfig.integrations) {
+        exec(`node ${getNangoRootPath()}/scripts/v1-v2.js ./${nangoConfigFile}`, (error) => {
+            if (error) {
+                console.log(chalk.red(`There was an issue migrating your nango.yaml to v2.`));
+                console.error(error);
+                return;
+            }
+            console.log(chalk.blue(`Migrated to v2 of nango.yaml!`));
+        });
+    }
+};
+
+async function createDirectory(dirPath: string): Promise<void> {
+    try {
+        await fs.promises.mkdir(dirPath, { recursive: true });
+        console.log(chalk.green(`Created directory at ${dirPath}.`));
+    } catch (error) {
+        console.error(chalk.red(`There was an issue creating the directory at ${dirPath}.`), error);
+    }
+}
+
+async function moveFile(source: string, destination: string): Promise<void> {
+    try {
+        await fs.promises.rename(source, destination);
+        console.log(chalk.green(`Moved file from ${source} to ${destination}.`));
+    } catch (error) {
+        console.error(chalk.red(`There was an issue moving the file from ${source} to ${destination}.`), error);
+    }
+}
+
+async function updateImports(filePath: string): Promise<void> {
+    try {
+        const data = await fs.promises.readFile(filePath, 'utf8');
+        const updatedData = data.replace(/from '\.\//g, "from '../../");
+        await fs.promises.writeFile(filePath, updatedData, 'utf8');
+        console.log(chalk.green(`Updated imports in ${filePath}.`));
+    } catch (error) {
+        console.error(chalk.red(`There was an issue updating the imports in ${filePath}.`), error);
+    }
+}
+
+export const directoryMigration = async (loadLocation: string): Promise<void> => {
+    const localConfig = await loadLocalNangoConfig(loadLocation);
+
+    if (!localConfig) {
+        return;
+    }
+
+    const version = determineVersion(localConfig);
+    if (version !== 'v2') {
+        console.log(chalk.red(`nango.yaml is not at v2. Nested directories are not supported in v1.`));
+        return;
+    }
+
+    for (const integration of Object.keys(localConfig.integrations)) {
+        const integrationPath = `${loadLocation}/${integration}`;
+        await createDirectory(integrationPath);
+
+        const scripts = localConfig.integrations[integration];
+
+        if (scripts?.syncs) {
+            const syncsPath: string = path.join(integrationPath, 'syncs');
+            await createDirectory(syncsPath);
+            for (const sync of Object.keys(scripts.syncs)) {
+                const syncPath: string = path.join(syncsPath, `${sync}.ts`);
+                await moveFile(path.join(loadLocation, `${sync}.ts`), syncPath);
+                await updateImports(syncPath);
+            }
+        }
+
+        if (scripts?.actions) {
+            const actionsPath: string = path.join(integrationPath, 'actions');
+            await createDirectory(actionsPath);
+            for (const action of Object.keys(scripts.actions)) {
+                const actionPath: string = path.join(actionsPath, `${action}.ts`);
+                await moveFile(path.join(loadLocation, `${action}.ts`), actionPath);
+                await updateImports(actionPath);
+            }
+        }
+    }
+};

--- a/packages/cli/lib/services/migration.service.ts
+++ b/packages/cli/lib/services/migration.service.ts
@@ -34,6 +34,9 @@ export const v1toV2Migration = async (loadLocation: string): Promise<void> => {
 
 async function createDirectory(dirPath: string, debug = false): Promise<void> {
     if (fs.existsSync(dirPath)) {
+        if (debug) {
+            printDebug(`Directory already exists at ${dirPath}.`);
+        }
         return;
     }
     try {
@@ -48,6 +51,9 @@ async function createDirectory(dirPath: string, debug = false): Promise<void> {
 
 async function moveFile(source: string, destination: string, debug = false): Promise<boolean> {
     if (fs.existsSync(destination)) {
+        if (debug) {
+            printDebug(`File already exists at ${destination}.`);
+        }
         return false;
     }
     try {

--- a/packages/cli/lib/services/migration.service.ts
+++ b/packages/cli/lib/services/migration.service.ts
@@ -39,13 +39,10 @@ async function createDirectory(dirPath: string, debug = false): Promise<void> {
         }
         return;
     }
-    try {
-        await fs.promises.mkdir(dirPath, { recursive: true });
-        if (debug) {
-            printDebug(`Created directory at ${dirPath}.`);
-        }
-    } catch (error) {
-        console.error(chalk.red(`There was an issue creating the directory at ${dirPath}.`), error);
+
+    await fs.promises.mkdir(dirPath, { recursive: true });
+    if (debug) {
+        printDebug(`Created directory at ${dirPath}.`);
     }
 }
 
@@ -56,18 +53,13 @@ async function moveFile(source: string, destination: string, debug = false): Pro
         }
         return false;
     }
-    try {
-        await fs.promises.rename(source, destination);
-        if (debug) {
-            printDebug(`Moved file from ${source} to ${destination}.`);
-        }
 
-        return true;
-    } catch (error) {
-        console.error(chalk.red(`There was an issue moving the file from ${source} to ${destination}.`), error);
+    await fs.promises.rename(source, destination);
+    if (debug) {
+        printDebug(`Moved file from ${source} to ${destination}.`);
     }
 
-    return false;
+    return true;
 }
 
 async function updateModelImport(filePath: string, debug = false): Promise<void> {

--- a/packages/cli/lib/services/verification.service.ts
+++ b/packages/cli/lib/services/verification.service.ts
@@ -1,12 +1,11 @@
 import fs from 'fs';
 import chalk from 'chalk';
 import promptly from 'promptly';
-import { exec } from 'child_process';
 
-import { nangoConfigFile, loadLocalNangoConfig, determineVersion } from '@nangohq/shared';
+import { nangoConfigFile } from '@nangohq/shared';
 import configService from './config.service.js';
 import compileService, { listFilesToCompile } from './compile.service.js';
-import { printDebug, getNangoRootPath } from '../utils.js';
+import { printDebug } from '../utils.js';
 import { NANGO_INTEGRATIONS_NAME } from '../constants.js';
 import { init, generate } from '../cli.js';
 
@@ -89,32 +88,6 @@ class VerificationService {
                     await compileService.run({ debug });
                 }
             }
-        }
-    }
-
-    public async runMigration(loadLocation: string): Promise<void> {
-        if (process.env['NANGO_CLI_UPGRADE_MODE'] === 'ignore') {
-            return;
-        }
-        const localConfig = await loadLocalNangoConfig(loadLocation);
-
-        if (!localConfig) {
-            return;
-        }
-
-        const version = determineVersion(localConfig);
-        if (version === 'v2') {
-            console.log(chalk.blue(`nango.yaml is already at v2.`));
-        }
-        if (version === 'v1' && localConfig.integrations) {
-            exec(`node ${getNangoRootPath()}/scripts/v1-v2.js ./${nangoConfigFile}`, (error) => {
-                if (error) {
-                    console.log(chalk.red(`There was an issue migrating your nango.yaml to v2.`));
-                    console.error(error);
-                    return;
-                }
-                console.log(chalk.blue(`Migrated to v2 of nango.yaml!`));
-            });
         }
     }
 

--- a/packages/logs/lib/es/helpers.ts
+++ b/packages/logs/lib/es/helpers.ts
@@ -27,7 +27,7 @@ export async function migrateMapping() {
         );
     } catch (err) {
         logger.error(err);
-        //throw new Error('failed_to_init_opensearch');
+        throw new Error('failed_to_init_opensearch');
     }
 }
 

--- a/packages/logs/lib/es/helpers.ts
+++ b/packages/logs/lib/es/helpers.ts
@@ -27,7 +27,7 @@ export async function migrateMapping() {
         );
     } catch (err) {
         logger.error(err);
-        throw new Error('failed_to_init_opensearch');
+        //throw new Error('failed_to_init_opensearch');
     }
 }
 


### PR DESCRIPTION
## Describe your changes
Adds a cli migration command `nango migrate-to-directories` to easily change to the nested cli directory structure

## Issue ticket number and link
NAN-751

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
