### PR TITLE
persist: add authentication

### DIFF
--- a/packages/persist/lib/controllers/persist.controller.ts
+++ b/packages/persist/lib/controllers/persist.controller.ts
@@ -28,7 +28,7 @@ type RecordRequest = Request<
         syncId: string;
         syncJobId: number;
     },
-    any,
+    void,
     {
         model: string;
         records: Record<string, any>[];
@@ -36,12 +36,12 @@ type RecordRequest = Request<
         connectionId: string;
         activityLogId: number;
     },
-    any
+    void
 >;
 
 class PersistController {
     public async saveActivityLog(
-        req: Request<{ environmentId: number }, any, { activityLogId: number; level: LogLevel; msg: string }, any>,
+        req: Request<{ environmentId: number }, void, { activityLogId: number; level: LogLevel; msg: string }, void>,
         res: Response,
         next: NextFunction
     ) {

--- a/packages/persist/lib/middleware/auth.middleware.ts
+++ b/packages/persist/lib/middleware/auth.middleware.ts
@@ -1,0 +1,34 @@
+import type { Request, Response, NextFunction } from 'express';
+import { environmentService } from '@nangohq/shared';
+
+export const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
+    const authorizationHeader = req.get('authorization');
+
+    if (!authorizationHeader) {
+        res.status(401).json({ error: 'Missing authorization header' });
+        return;
+    }
+
+    const secret = authorizationHeader.split('Bearer ').pop();
+    if (!secret) {
+        res.status(401).json({ error: 'Malformed authorization header. Expected `Bearer SECRET_KEY`' });
+        return;
+    }
+
+    const environmentId = parseInt(req.params['environmentId'] || '');
+    if (!environmentId) {
+        res.status(401).json({ error: 'Missing environmentId' });
+        return;
+    }
+    environmentService
+        .getAccountIdAndEnvironmentIdBySecretKey(secret)
+        .then((result) => {
+            if (!result || result.environmentId !== environmentId) {
+                throw new Error('Unauthorized');
+            }
+            next();
+        })
+        .catch(() => {
+            res.status(401).json({ error: 'Unauthorized' });
+        });
+};

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -1,4 +1,4 @@
-import { expect, describe, it, beforeAll, afterAll } from 'vitest';
+import { expect, describe, it, beforeAll, afterAll, vi } from 'vitest';
 import { server } from './server.js';
 import fetch from 'node-fetch';
 import type { AuthCredentials, Connection, Sync, Job as SyncJob, Environment } from '@nangohq/shared';
@@ -15,6 +15,8 @@ import {
 } from '@nangohq/shared';
 import { logContextGetter } from '@nangohq/logs';
 
+const mockSecretKey = 'secret-key';
+
 describe('Persist API', () => {
     const port = 3096;
     const serverUrl = `http://localhost:${port}`;
@@ -30,6 +32,13 @@ describe('Persist API', () => {
         await multipleMigrations();
         seed = await initDb();
         server.listen(port);
+
+        vi.spyOn(environmentService, 'getAccountIdAndEnvironmentIdBySecretKey').mockImplementation((secretKey) => {
+            if (secretKey === mockSecretKey) {
+                return Promise.resolve({ accountId: seed.env.account_id, environmentId: seed.env.id });
+            }
+            return Promise.resolve(null);
+        });
     });
 
     afterAll(async () => {
@@ -47,6 +56,7 @@ describe('Persist API', () => {
             method: 'POST',
             body: JSON.stringify({ activityLogId: seed.activityLogId, level: 'info', msg: 'Hello, world!' }),
             headers: {
+                Authorization: `Bearer ${mockSecretKey}`,
                 'Content-Type': 'application/json'
             }
         });
@@ -70,6 +80,7 @@ describe('Persist API', () => {
                         activityLogId: seed.activityLogId
                     }),
                     headers: {
+                        Authorization: `Bearer ${mockSecretKey}`,
                         'Content-Type': 'application/json'
                     }
                 }
@@ -115,6 +126,7 @@ describe('Persist API', () => {
                         trackDeletes: false
                     }),
                     headers: {
+                        Authorization: `Bearer ${mockSecretKey}`,
                         'Content-Type': 'application/json'
                     }
                 }
@@ -143,6 +155,7 @@ describe('Persist API', () => {
                     trackDeletes: false
                 }),
                 headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
                     'Content-Type': 'application/json'
                 }
             }
@@ -171,11 +184,30 @@ describe('Persist API', () => {
                     softDelete: true
                 }),
                 headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
                     'Content-Type': 'application/json'
                 }
             }
         );
         expect(response.status).toEqual(201);
+    });
+
+    it('should fail if passing incorrect authorization header ', async () => {
+        const recordsUrl = `${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/sync/${seed.sync.id}/job/${seed.syncJob.id}/records`;
+        const reqs = [`POST ${serverUrl}/environment/${seed.env.id}/log`, `POST ${recordsUrl}`, `PUT ${recordsUrl}`, `DELETE ${recordsUrl}`];
+
+        for (const req of reqs) {
+            const [method, url] = req.split(' ');
+            if (method && url) {
+                const res = await fetch(url, {
+                    method,
+                    headers: { Authorization: `Bearer WRONG_SECRET_KEY` }
+                });
+                expect(res.status).toEqual(401);
+            } else {
+                throw new Error('Invalid request');
+            }
+        }
     });
 });
 

--- a/packages/persist/lib/server.ts
+++ b/packages/persist/lib/server.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { getLogger } from '@nangohq/utils';
 import persistController from './controllers/persist.controller.js';
 import { logLevelValues } from '@nangohq/shared';
+import { authMiddleware } from './middleware/auth.middleware.js';
 
 const logger = getLogger('Persist');
 
@@ -25,6 +26,8 @@ server.use((req: Request, res: Response, next: NextFunction) => {
         logger.info(`${req.method} ${req.path} ${res.statusCode}`);
     }
 });
+
+server.use('/environment/:environmentId/*', authMiddleware);
 
 server.get('/health', (_req: Request, res: Response) => {
     res.json({ status: 'ok' });

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -264,7 +264,7 @@ interface EnvironmentVariable {
 const MEMOIZED_CONNECTION_TTL = 60000;
 
 export class NangoAction {
-    private nango: Nango;
+    protected nango: Nango;
     private attributes = {};
     activityLogId?: number;
     syncId?: string;
@@ -554,6 +554,9 @@ export class NangoAction {
         const response = await persistApi({
             method: 'POST',
             url: `/environment/${this.environmentId}/log`,
+            headers: {
+                Authorization: `Bearer ${this.nango.secretKey}`
+            },
             data: {
                 activityLogId: this.activityLogId,
                 level: userDefinedLevel?.level ?? 'info',
@@ -731,6 +734,9 @@ export class NangoSync extends NangoAction {
             const response = await persistApi({
                 method: 'POST',
                 url: `/environment/${this.environmentId}/connection/${this.nangoConnectionId}/sync/${this.syncId}/job/${this.syncJobId}/records`,
+                headers: {
+                    Authorization: `Bearer ${this.nango.secretKey}`
+                },
                 data: {
                     model,
                     records: batch,
@@ -779,6 +785,9 @@ export class NangoSync extends NangoAction {
             const response = await persistApi({
                 method: 'DELETE',
                 url: `/environment/${this.environmentId}/connection/${this.nangoConnectionId}/sync/${this.syncId}/job/${this.syncJobId}/records`,
+                headers: {
+                    Authorization: `Bearer ${this.nango.secretKey}`
+                },
                 data: {
                     model,
                     records: batch,
@@ -827,6 +836,9 @@ export class NangoSync extends NangoAction {
             const response = await persistApi({
                 method: 'PUT',
                 url: `/environment/${this.environmentId}/connection/${this.nangoConnectionId}/sync/${this.syncId}/job/${this.syncJobId}/records`,
+                headers: {
+                    Authorization: `Bearer ${this.nango.secretKey}`
+                },
                 data: {
                     model,
                     records: batch,


### PR DESCRIPTION
persist is now verifying that the environment of a request matches the secretKey, making it harder to impersonate runners

## Issue ticket number and link

https://linear.app/nango/issue/NAN-689/add-secret-key-authentication-for-persist-api

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
