### PR TITLE
records: return new upsert result + retry upsert

### DIFF
--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -14,6 +14,7 @@ import {
     db
 } from '@nangohq/shared';
 import { logContextGetter } from '@nangohq/logs';
+import { migrate as migrateRecords } from '@nangohq/records';
 
 const mockSecretKey = 'secret-key';
 
@@ -30,6 +31,7 @@ describe('Persist API', () => {
 
     beforeAll(async () => {
         await multipleMigrations();
+        await migrateRecords();
         seed = await initDb();
         server.listen(port);
 

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -14,7 +14,7 @@ import { decryptRecord, decryptRecords, encryptRecords } from '../utils/encrypti
 import { RECORDS_TABLE } from '../constants.js';
 import { removeDuplicateKey, getUniqueId } from '../helpers/uniqueKey.js';
 import { logger } from '../utils/logger.js';
-import { retry, resultErr, resultOk } from '@nangohq/utils';
+import { resultErr, resultOk, retry } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
 import type { Knex } from 'knex';
 
@@ -198,32 +198,33 @@ export async function upsert(records: FormattedRecord[], connectionId: number, m
 
     let summary: UpsertSummary = { addedKeys: [], updatedKeys: [], deletedKeys: [], nonUniqueKeys };
     try {
-        const upserting = async () =>
-            await db.transaction(async (trx) => {
-                for (let i = 0; i < recordsWithoutDuplicates.length; i += BATCH_SIZE) {
-                    const chunk = recordsWithoutDuplicates.slice(i, i + BATCH_SIZE);
-                    const chunkSummary = await getUpsertSummary(chunk, connectionId, model, nonUniqueKeys, softDelete, trx);
-                    summary = {
-                        addedKeys: [...summary.addedKeys, ...chunkSummary.addedKeys],
-                        updatedKeys: [...summary.updatedKeys, ...chunkSummary.updatedKeys],
-                        deletedKeys: [...(summary.deletedKeys || []), ...(chunkSummary.deletedKeys || [])],
-                        nonUniqueKeys: nonUniqueKeys
-                    };
-                    const encryptedRecords = encryptRecords(chunk);
-                    await trx.from<FormattedRecord>(RECORDS_TABLE).insert(encryptedRecords).onConflict(['connection_id', 'external_id', 'model']).merge();
-                }
-            });
-        // Retry upserting if deadlock detected
-        // https://www.postgresql.org/docs/current/mvcc-serialization-failure-handling.html
-        await retry(upserting, {
-            maxAttempts: 3,
-            delayMs: 500,
-            retryIf: (error) => {
-                if ('code' in error) {
-                    const errorCode = (error as { code: string }).code;
-                    return errorCode === '40P01'; // deadlock_detected                    }
-                }
-                return false;
+        await db.transaction(async (trx) => {
+            for (let i = 0; i < recordsWithoutDuplicates.length; i += BATCH_SIZE) {
+                const chunk = recordsWithoutDuplicates.slice(i, i + BATCH_SIZE);
+                const chunkSummary = await getUpsertSummary(chunk, connectionId, model, nonUniqueKeys, softDelete, trx);
+                summary = {
+                    addedKeys: [...summary.addedKeys, ...chunkSummary.addedKeys],
+                    updatedKeys: [...summary.updatedKeys, ...chunkSummary.updatedKeys],
+                    deletedKeys: [...(summary.deletedKeys || []), ...(chunkSummary.deletedKeys || [])],
+                    nonUniqueKeys: nonUniqueKeys
+                };
+                const encryptedRecords = encryptRecords(chunk);
+
+                // Retry upserting if deadlock detected
+                // https://www.postgresql.org/docs/current/mvcc-serialization-failure-handling.html
+                const upserting = () =>
+                    trx.from<FormattedRecord>(RECORDS_TABLE).insert(encryptedRecords).onConflict(['connection_id', 'external_id', 'model']).merge();
+                await retry(upserting, {
+                    maxAttempts: 3,
+                    delayMs: 500,
+                    retryIf: (error: Error) => {
+                        if ('code' in error) {
+                            const errorCode = (error as { code: string }).code;
+                            return errorCode === '40P01'; // deadlock_detected
+                        }
+                        return false;
+                    }
+                });
             }
         });
 


### PR DESCRIPTION
## Describe your changes

This PR contains 2 commits:
- intermediary step before removing the legacy records logic: still double writing but now returning the result of the upsert to new db
- retrying the entire upsert transaction didn't solve the deadlock_detected error. I am still not sure what's going on, making an attempt at only retrying the upsert query inside the transaction