### PR TITLE
all functions in records takes struct with named params

### DIFF
--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -171,13 +171,18 @@ class DryRunService {
         // dry-run mode does not read or write to the records database
         // so we can safely mock the records service
         const recordsService: RecordsServiceInterface = {
-            markNonCurrentGenerationRecordsAsDeleted: (
-                _connectionId: number,
-                _model: string,
-                _syncId: string,
-                _generation: number
+            markNonCurrentGenerationRecordsAsDeleted: ({
+                connectionId: _connectionId,
+                model: _model,
+                syncId: _syncId,
+                generation: _generation
+            }: {
+                connectionId: number;
+                model: string;
+                syncId: string;
+                generation: number;
                 // eslint-disable-next-line @typescript-eslint/require-await
-            ): Promise<string[]> => {
+            }): Promise<string[]> => {
                 return Promise.resolve([]);
             }
         };

--- a/packages/persist/lib/controllers/persist.controller.ts
+++ b/packages/persist/lib/controllers/persist.controller.ts
@@ -77,7 +77,7 @@ class PersistController {
         } = req;
         const logCtx = logContextGetter.get({ id: String(activityLogId) });
         const persist = async (records: FormattedRecord[], legacyRecords: DataRecord[]) => {
-            const newUpsert = recordsService.upsert(records, nangoConnectionId, model, false);
+            const newUpsert = recordsService.upsert({ records, connectionId: nangoConnectionId, model, softDelete: false });
             const legacyUpsert = dataService.upsert(legacyRecords, nangoConnectionId, model, activityLogId, environmentId, false, logCtx);
             const [newRes] = await Promise.all([newUpsert, legacyUpsert]);
             return newRes;
@@ -110,7 +110,7 @@ class PersistController {
         } = req;
         const logCtx = logContextGetter.get({ id: String(activityLogId) });
         const persist = async (records: FormattedRecord[], legacyRecords: DataRecord[]) => {
-            const newUpsert = recordsService.upsert(records, nangoConnectionId, model, true);
+            const newUpsert = recordsService.upsert({ records, connectionId: nangoConnectionId, model, softDelete: true });
             const legacyUpsert = dataService.upsert(legacyRecords, nangoConnectionId, model, activityLogId, environmentId, true, logCtx);
             const [newRes] = await Promise.all([newUpsert, legacyUpsert]);
             return newRes;
@@ -143,7 +143,7 @@ class PersistController {
         } = req;
         const logCtx = logContextGetter.get({ id: String(activityLogId) });
         const persist = async (records: FormattedRecord[], legacyRecords: DataRecord[]) => {
-            const newUpsert = recordsService.update(records, nangoConnectionId, model);
+            const newUpsert = recordsService.update({ records, connectionId: nangoConnectionId, model });
             const legacyUpsert = dataService.update(legacyRecords, nangoConnectionId, model, activityLogId, environmentId, logCtx);
             const [newRes] = await Promise.all([newUpsert, legacyUpsert]);
             return newRes;
@@ -216,7 +216,14 @@ class PersistController {
         });
 
         let formattedRecords: FormattedRecord[] = [];
-        const formatting = recordsFormatter.formatRecords(records as UnencryptedRecordData[], nangoConnectionId, model, syncId, syncJobId, softDelete);
+        const formatting = recordsFormatter.formatRecords({
+            data: records as UnencryptedRecordData[],
+            connectionId: nangoConnectionId,
+            model,
+            syncId,
+            syncJobId,
+            softDelete
+        });
         if (isErr(formatting)) {
             logger.error('Failed to format records: ' + formatting.err.message);
         } else {

--- a/packages/records/lib/helpers/format.ts
+++ b/packages/records/lib/helpers/format.ts
@@ -8,19 +8,26 @@ import type { Result } from '@nangohq/utils';
 
 dayjs.extend(utc);
 
-export const formatRecords = (
-    data: UnencryptedRecordData[],
-    connection_id: number,
-    model: string,
-    syncId: string,
-    sync_job_id: number,
+export const formatRecords = ({
+    data,
+    connectionId,
+    model,
+    syncId,
+    syncJobId,
     softDelete = false
-): Result<FormattedRecord[]> => {
+}: {
+    data: UnencryptedRecordData[];
+    connectionId: number;
+    model: string;
+    syncId: string;
+    syncJobId: number;
+    softDelete?: boolean;
+}): Result<FormattedRecord[]> => {
     // hashing unique composite key (connection, model, external_id)
     // to generate stable record ids across script executions
     const stableId = (unencryptedData: UnencryptedRecordData): string => {
-        const namespace = uuid.v5(`${connection_id}${model}`, uuid.NIL);
-        return uuid.v5(`${connection_id}${model}${unencryptedData.id}`, namespace);
+        const namespace = uuid.v5(`${connectionId}${model}`, uuid.NIL);
+        return uuid.v5(`${connectionId}${model}${unencryptedData.id}`, namespace);
     };
     const formattedRecords: FormattedRecord[] = [];
     const now = new Date();
@@ -42,9 +49,9 @@ export const formatRecords = (
             external_id: datum['id'],
             data_hash,
             model,
-            connection_id,
+            connection_id: connectionId,
             sync_id: syncId,
-            sync_job_id
+            sync_job_id: syncJobId
         };
 
         if (softDelete) {

--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -181,23 +181,23 @@ async function upsertRecords(
     syncJobId: number,
     softDelete = false
 ): Promise<UpsertSummary> {
-    const formatRes = formatRecords(records, connectionId, model, syncId, syncJobId, softDelete);
+    const formatRes = formatRecords({ data: records, connectionId, model, syncId, syncJobId, softDelete });
     if (isErr(formatRes)) {
         throw new Error(`Failed to format records: ${formatRes.err.message}`);
     }
-    const updateRes = await Records.upsert(formatRes.res, connectionId, model, softDelete);
-    if (isErr(updateRes)) {
-        throw new Error(`Failed to update records: ${updateRes.err.message}`);
+    const upsertRes = await Records.upsert({ records: formatRes.res, connectionId, model, softDelete });
+    if (isErr(upsertRes)) {
+        throw new Error(`Failed to update records: ${upsertRes.err.message}`);
     }
-    return updateRes.res;
+    return upsertRes.res;
 }
 
 async function updateRecords(records: UnencryptedRecordData[], connectionId: number, model: string, syncId: string, syncJobId: number) {
-    const formatRes = formatRecords(records, connectionId, model, syncId, syncJobId);
+    const formatRes = formatRecords({ data: records, connectionId, model, syncId, syncJobId });
     if (isErr(formatRes)) {
         throw new Error(`Failed to format records: ${formatRes.err.message}`);
     }
-    const updateRes = await Records.update(formatRes.res, connectionId, model);
+    const updateRes = await Records.update({ records: formatRes.res, connectionId, model });
     if (isErr(updateRes)) {
         throw new Error(`Failed to update records: ${updateRes.err.message}`);
     }

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -187,7 +187,17 @@ export async function getRecords({
     }
 }
 
-export async function upsert(records: FormattedRecord[], connectionId: number, model: string, softDelete = false): Promise<Result<UpsertSummary>> {
+export async function upsert({
+    records,
+    connectionId,
+    model,
+    softDelete = false
+}: {
+    records: FormattedRecord[];
+    connectionId: number;
+    model: string;
+    softDelete?: boolean;
+}): Promise<Result<UpsertSummary>> {
     const { records: recordsWithoutDuplicates, nonUniqueKeys } = removeDuplicateKey(records);
 
     if (!recordsWithoutDuplicates || recordsWithoutDuplicates.length === 0) {
@@ -201,7 +211,7 @@ export async function upsert(records: FormattedRecord[], connectionId: number, m
         await db.transaction(async (trx) => {
             for (let i = 0; i < recordsWithoutDuplicates.length; i += BATCH_SIZE) {
                 const chunk = recordsWithoutDuplicates.slice(i, i + BATCH_SIZE);
-                const chunkSummary = await getUpsertSummary(chunk, connectionId, model, nonUniqueKeys, softDelete, trx);
+                const chunkSummary = await getUpsertSummary({ records: chunk, connectionId, model, nonUniqueKeys, softDelete, trx });
                 summary = {
                     addedKeys: [...summary.addedKeys, ...chunkSummary.addedKeys],
                     updatedKeys: [...summary.updatedKeys, ...chunkSummary.updatedKeys],
@@ -253,7 +263,15 @@ export async function upsert(records: FormattedRecord[], connectionId: number, m
     }
 }
 
-export async function update(records: FormattedRecord[], connectionId: number, model: string): Promise<Result<UpsertSummary>> {
+export async function update({
+    records,
+    connectionId,
+    model
+}: {
+    records: FormattedRecord[];
+    connectionId: number;
+    model: string;
+}): Promise<Result<UpsertSummary>> {
     const { records: recordsWithoutDuplicates, nonUniqueKeys } = removeDuplicateKey(records);
 
     if (!recordsWithoutDuplicates || recordsWithoutDuplicates.length === 0) {
@@ -268,10 +286,10 @@ export async function update(records: FormattedRecord[], connectionId: number, m
             for (let i = 0; i < recordsWithoutDuplicates.length; i += BATCH_SIZE) {
                 const chunk = recordsWithoutDuplicates.slice(i, i + BATCH_SIZE);
 
-                updatedKeys.push(...(await getUpdatedKeys(chunk, connectionId, model, trx)));
+                updatedKeys.push(...(await getUpdatedKeys({ records: chunk, connectionId, model, trx })));
 
                 const recordsToUpdate: FormattedRecord[] = [];
-                const rawOldRecords = await getRecordsByExternalIds(updatedKeys, connectionId, model, trx);
+                const rawOldRecords = await getRecordsByExternalIds({ externalIds: updatedKeys, connectionId, model, trx });
                 for (const rawOldRecord of rawOldRecords) {
                     if (!rawOldRecord) {
                         continue;
@@ -333,7 +351,17 @@ export async function deleteRecordsBySyncId({ syncId, limit = 5000 }: { syncId: 
 
 // Mark all non-deleted records that don't belong to currentGeneration as deleted
 // returns the ids of records being deleted
-export async function markNonCurrentGenerationRecordsAsDeleted(connectionId: number, model: string, syncId: string, generation: number): Promise<string[]> {
+export async function markNonCurrentGenerationRecordsAsDeleted({
+    connectionId,
+    model,
+    syncId,
+    generation
+}: {
+    connectionId: number;
+    model: string;
+    syncId: string;
+    generation: number;
+}): Promise<string[]> {
     const now = db.fn.now(6);
     return (await db
         .from<FormattedRecord>(RECORDS_TABLE)
@@ -358,7 +386,17 @@ export async function markNonCurrentGenerationRecordsAsDeleted(connectionId: num
  * getUpdatedKeys
  * @desc returns a list of the keys that exist in the records tables but have a different data_hash
  */
-async function getUpdatedKeys(records: FormattedRecord[], connectionId: number, model: string, trx: Knex.Transaction): Promise<string[]> {
+async function getUpdatedKeys({
+    records,
+    connectionId,
+    model,
+    trx
+}: {
+    records: FormattedRecord[];
+    connectionId: number;
+    model: string;
+    trx: Knex.Transaction;
+}): Promise<string[]> {
     const keys: string[] = records.map((record: FormattedRecord) => getUniqueId(record));
     const keysWithHash: [string, string][] = records.map((record: FormattedRecord) => [getUniqueId(record), record.data_hash]);
 
@@ -375,14 +413,21 @@ async function getUpdatedKeys(records: FormattedRecord[], connectionId: number, 
     return rowsToUpdate;
 }
 
-async function getUpsertSummary(
-    records: FormattedRecord[],
-    connectionId: number,
-    model: string,
-    nonUniqueKeys: string[],
-    softDelete: boolean,
-    trx: Knex.Transaction
-): Promise<UpsertSummary> {
+async function getUpsertSummary({
+    records,
+    connectionId,
+    model,
+    nonUniqueKeys,
+    softDelete,
+    trx
+}: {
+    records: FormattedRecord[];
+    connectionId: number;
+    model: string;
+    nonUniqueKeys: string[];
+    softDelete: boolean;
+    trx: Knex.Transaction;
+}): Promise<UpsertSummary> {
     const keys: string[] = records.map((record: FormattedRecord) => getUniqueId(record));
     const nonDeletedKeys: string[] = await trx
         .from(RECORDS_TABLE)
@@ -403,7 +448,7 @@ async function getUpsertSummary(
         };
     } else {
         const addedKeys = keys?.filter((key: string) => !nonDeletedKeys.includes(key));
-        const updatedKeys = await getUpdatedKeys(records, connectionId, model, trx);
+        const updatedKeys = await getUpdatedKeys({ records, connectionId, model, trx });
         return {
             addedKeys,
             updatedKeys,
@@ -413,14 +458,24 @@ async function getUpsertSummary(
     }
 }
 
-async function getRecordsByExternalIds(external_ids: string[], connection_id: number, model: string, trx: Knex.Transaction): Promise<UnencryptedRecord[]> {
+async function getRecordsByExternalIds({
+    externalIds,
+    connectionId,
+    model,
+    trx
+}: {
+    externalIds: string[];
+    connectionId: number;
+    model: string;
+    trx: Knex.Transaction;
+}): Promise<UnencryptedRecord[]> {
     const encryptedRecords = await trx
         .from<FormattedRecord>(RECORDS_TABLE)
         .where({
-            connection_id,
+            connection_id: connectionId,
             model
         })
-        .whereIn('external_id', external_ids);
+        .whereIn('external_id', externalIds);
 
     if (!encryptedRecords) {
         return [];

--- a/packages/shared/lib/services/sync/run.service.ts
+++ b/packages/shared/lib/services/sync/run.service.ts
@@ -84,7 +84,17 @@ export interface SyncRunConfig {
 }
 
 export interface RecordsServiceInterface {
-    markNonCurrentGenerationRecordsAsDeleted(connectionId: number, model: string, syncId: string, generation: number): Promise<string[]>;
+    markNonCurrentGenerationRecordsAsDeleted({
+        connectionId,
+        model,
+        syncId,
+        generation
+    }: {
+        connectionId: number;
+        model: string;
+        syncId: string;
+        generation: number;
+    }): Promise<string[]>;
 }
 
 export default class SyncRun {
@@ -498,7 +508,12 @@ export default class SyncRun {
                     this.syncJobId as number
                 );
                 this.recordsService
-                    .markNonCurrentGenerationRecordsAsDeleted(this.nangoConnection.id as number, model, this.syncId as string, this.syncJobId as number)
+                    .markNonCurrentGenerationRecordsAsDeleted({
+                        connectionId: this.nangoConnection.id as number,
+                        model,
+                        syncId: this.syncId as string,
+                        generation: this.syncJobId as number
+                    })
                     .catch((err: unknown) => {
                         logger.error(`Error marking non current generation records as deleted:`, err, {
                             connectionId: this.nangoConnection.id,

--- a/packages/shared/lib/services/sync/run.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/run.service.unit.test.ts
@@ -24,7 +24,17 @@ class integrationServiceMock implements IntegrationServiceInterface {
 
 const integrationService = new integrationServiceMock();
 const recordsService = {
-    markNonCurrentGenerationRecordsAsDeleted: (_connectionId: number, _model: string, _syncId: string, _generation: number): Promise<string[]> => {
+    markNonCurrentGenerationRecordsAsDeleted: ({
+        connectionId: _connectionId,
+        model: _model,
+        syncId: _syncId,
+        generation: _generation
+    }: {
+        connectionId: number;
+        model: string;
+        syncId: string;
+        generation: number;
+    }): Promise<string[]> => {
         return Promise.resolve([]);
     }
 };


### PR DESCRIPTION
## Describe your changes

Reading calls to records functions is more explicit and easier when using object/struct with named fields

```
// before
recordsService.upsert(records, connectionId, model, false);

// after
recordsService.upsert({ records, connectionId, model, softDelete: false });
```
