### PR TITLE
fix(db): slow query getSyncs

### DIFF
--- a/packages/shared/lib/db/migrations/20240502171723_index_syncs.cjs
+++ b/packages/shared/lib/db/migrations/20240502171723_index_syncs.cjs
@@ -1,0 +1,11 @@
+exports.up = async function (knex, _) {
+    await knex.schema.raw(
+        'CREATE INDEX "idx_connectionid_name_where_deleted" ON "_nango_syncs" USING BTREE ("nango_connection_id", "name") WHERE deleted = false'
+    );
+    await knex.schema.raw('CREATE INDEX "idx_id_where_deleted" ON "_nango_syncs" USING BTREE ("id") WHERE deleted = false');
+};
+
+exports.down = async function (knex, _) {
+    await knex.schema.raw('DROP INDEX CONCURRENTLY idx_connectionid_name_where_deleted');
+    await knex.schema.raw('DROP INDEX CONCURRENTLY idx_id_where_deleted');
+};

--- a/packages/shared/lib/db/migrations/20240502171723_index_syncs.cjs
+++ b/packages/shared/lib/db/migrations/20240502171723_index_syncs.cjs
@@ -1,8 +1,8 @@
 exports.up = async function (knex, _) {
     await knex.schema.raw(
-        'CREATE INDEX "idx_connectionid_name_where_deleted" ON "_nango_syncs" USING BTREE ("nango_connection_id", "name") WHERE deleted = false'
+        'CREATE INDEX CONCURRENTLY "idx_connectionid_name_where_deleted" ON "_nango_syncs" USING BTREE ("nango_connection_id", "name") WHERE deleted = false'
     );
-    await knex.schema.raw('CREATE INDEX "idx_id_where_deleted" ON "_nango_syncs" USING BTREE ("id") WHERE deleted = false');
+    await knex.schema.raw('CREATE INDEX CONCURRENTLY "idx_id_where_deleted" ON "_nango_syncs" USING BTREE ("id") WHERE deleted = false');
 };
 
 exports.down = async function (knex, _) {

--- a/packages/shared/lib/db/migrations/20240502171723_index_syncs.cjs
+++ b/packages/shared/lib/db/migrations/20240502171723_index_syncs.cjs
@@ -1,3 +1,5 @@
+exports.config = { transaction: false };
+
 exports.up = async function (knex, _) {
     await knex.schema.raw(
         'CREATE INDEX CONCURRENTLY "idx_connectionid_name_where_deleted" ON "_nango_syncs" USING BTREE ("nango_connection_id", "name") WHERE deleted = false'

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -266,7 +266,7 @@ export const getSyncs = async (nangoConnection: Connection): Promise<(Sync & { s
             ),
             syncJobTimestampsSubQuery
         )
-        .leftJoin(SYNC_SCHEDULE_TABLE, function () {
+        .join(SYNC_SCHEDULE_TABLE, function () {
             this.on(`${SYNC_SCHEDULE_TABLE}.sync_id`, `${TABLE}.id`).andOn(`${SYNC_SCHEDULE_TABLE}.deleted`, '=', db.knex.raw('FALSE'));
         })
         .where({

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -201,7 +201,7 @@ export const getSyncs = async (nangoConnection: Connection): Promise<(Sync & { s
         return [];
     }
 
-    const scheduleResponse = await syncClient?.listSchedules();
+    const scheduleResponse = await syncClient.listSchedules();
     if (scheduleResponse?.schedules.length === 0) {
         await markAllAsStopped();
     }
@@ -219,7 +219,7 @@ export const getSyncs = async (nangoConnection: Connection): Promise<(Sync & { s
         ) as thirty_day_timestamps`
     );
 
-    const result = await db.knex
+    const q = db.knex
         .from<Sync>(TABLE)
         .select(
             `${TABLE}.*`,
@@ -255,11 +255,10 @@ export const getSyncs = async (nangoConnection: Connection): Promise<(Sync & { s
                         'activity_log_id', ${ACTIVITY_LOG_TABLE}.id
                     )
                     FROM ${SYNC_JOB_TABLE}
-                    JOIN ${SYNC_CONFIG_TABLE} ON ${SYNC_CONFIG_TABLE}.id = ${SYNC_JOB_TABLE}.sync_config_id
+                    JOIN ${SYNC_CONFIG_TABLE} ON ${SYNC_CONFIG_TABLE}.id = ${SYNC_JOB_TABLE}.sync_config_id AND ${SYNC_CONFIG_TABLE}.deleted = false
                     LEFT JOIN ${ACTIVITY_LOG_TABLE} ON ${ACTIVITY_LOG_TABLE}.session_id = ${SYNC_JOB_TABLE}.id::text
                     WHERE ${SYNC_JOB_TABLE}.sync_id = ${TABLE}.id
-                    AND ${SYNC_JOB_TABLE}.deleted = false
-                    AND ${SYNC_CONFIG_TABLE}.deleted = false
+                        AND ${SYNC_JOB_TABLE}.deleted = false
                     ORDER BY ${SYNC_JOB_TABLE}.updated_at DESC
                     LIMIT 1
                 ) as latest_sync
@@ -267,12 +266,11 @@ export const getSyncs = async (nangoConnection: Connection): Promise<(Sync & { s
             ),
             syncJobTimestampsSubQuery
         )
-        .leftJoin(SYNC_JOB_TABLE, `${SYNC_JOB_TABLE}.sync_id`, '=', `${TABLE}.id`)
-        .join(SYNC_SCHEDULE_TABLE, `${SYNC_SCHEDULE_TABLE}.sync_id`, `${TABLE}.id`)
+        .leftJoin(SYNC_SCHEDULE_TABLE, function () {
+            this.on(`${SYNC_SCHEDULE_TABLE}.sync_id`, `${TABLE}.id`).andOn(`${SYNC_SCHEDULE_TABLE}.deleted`, '=', db.knex.raw('FALSE'));
+        })
         .where({
             nango_connection_id: nangoConnection.id,
-            [`${SYNC_SCHEDULE_TABLE}.deleted`]: false,
-            [`${SYNC_JOB_TABLE}.deleted`]: false,
             [`${TABLE}.deleted`]: false
         })
         .orderBy(`${TABLE}.name`, 'asc')
@@ -285,6 +283,8 @@ export const getSyncs = async (nangoConnection: Connection): Promise<(Sync & { s
             'models'
         );
 
+    // console.log(q.toQuery());
+    const result = await q;
     const syncsWithSchedule = result.map(async (sync) => {
         const { schedule_id } = sync;
         const schedule = scheduleResponse?.schedules.find((schedule) => schedule.scheduleId === schedule_id);
@@ -302,7 +302,7 @@ export const getSyncs = async (nangoConnection: Connection): Promise<(Sync & { s
             };
             await updateScheduleStatus(schedule_id, SyncCommand.UNPAUSE, null, nangoConnection.environment_id);
         }
-        const futureActionTimes = schedule?.info?.futureActionTimes?.map((long) => long?.seconds?.toNumber()) || [];
+        const futureActionTimes = schedule?.info?.futureActionTimes?.map((long) => long.seconds?.toNumber()) || [];
 
         return {
             ...sync,
@@ -647,7 +647,7 @@ export const getAndReconcileDifferences = async ({
                     deletedSyncs.push({
                         name: existingSync.sync_name,
                         providerConfigKey: existingSync.unique_key,
-                        connections: connections?.length
+                        connections: connections.length
                     });
                 } else {
                     deletedActions.push({


### PR DESCRIPTION
## Describe your changes

Fixes NAN-853

- Add missing index `where deleted = false` for table `nango_syncs`
Not sure how I missed that 2months ago 

- Fix query (or tentatively)

## Side notes
- Might be easier to manage with multiple queries
- `thirty_day_timestamps` might be huge for syncs running every 5minutes for no usage of this value it seems


## Query plan
### In production
It's huge but not crazy bad, we just scan too many rows basically 

```sql
Sort  (cost=4471341.64..4471342.15 rows=206 width=312)
  Sort Key: _nango_syncs.name
  ->  Group  (cost=654676.78..4471333.72 rows=206 width=312)
"        Group Key: _nango_syncs.id, _nango_sync_schedules.frequency, _nango_sync_schedules.""offset"", _nango_sync_schedules.status, _nango_sync_schedules.schedule_id, ((SubPlan 1))"
        ->  Sort  (cost=654676.78..654677.30 rows=206 width=238)
"              Sort Key: _nango_syncs.id, _nango_sync_schedules.frequency, _nango_sync_schedules.""offset"", _nango_sync_schedules.status, _nango_sync_schedules.schedule_id, ((SubPlan 1))"
              ->  Nested Loop Left Join  (cost=1.00..654668.86 rows=206 width=238)
                    ->  Nested Loop  (cost=0.57..5.01 rows=1 width=206)
                          ->  Index Scan using idx_connectionid_name_where_deleted on _nango_syncs  (cost=0.28..2.50 rows=1 width=87)
                                Index Cond: (nango_connection_id = 28673)
                          ->  Index Scan using nango_sync_schedules_sync_id_deleted_index on _nango_sync_schedules  (cost=0.29..2.50 rows=1 width=135)
                                Index Cond: ((sync_id = _nango_syncs.id) AND (deleted = false))
                    ->  Index Only Scan using idx_jobs_id_status_type_where_delete on _nango_sync_jobs  (cost=0.43..2250.49 rows=3437 width=16)
                          Index Cond: (sync_id = _nango_syncs.id)
                    SubPlan 1
                      ->  Nested Loop  (cost=0.57..3166.89 rows=1 width=46)
                            Join Filter: (_nango_connections.config_id = _nango_configs.id)
                            ->  Nested Loop  (cost=0.29..3164.74 rows=1 width=54)
                                  Join Filter: (_nango_connections.config_id = _nango_sync_configs.nango_config_id)
                                  ->  Index Scan using _nango_connections_pkey on _nango_connections  (cost=0.29..2.51 rows=1 width=4)
                                        Index Cond: (id = _nango_syncs.nango_connection_id)
                                  ->  Seq Scan on _nango_sync_configs  (cost=0.00..3162.20 rows=3 width=50)
                                        Filter: ((NOT deleted) AND active AND ((sync_name)::text = (_nango_syncs.name)::text))
                            ->  Index Only Scan using _nango_configs_pkey on _nango_configs  (cost=0.28..2.13 rows=1 width=4)
                                  Index Cond: (id = _nango_sync_configs.nango_config_id)
        SubPlan 2
          ->  Limit  (cost=14302.77..14302.77 rows=1 width=40)
                ->  Sort  (cost=14302.77..14310.30 rows=3012 width=40)
                      Sort Key: _nango_sync_jobs_1.updated_at DESC
                      ->  Nested Loop Left Join  (cost=1.29..14287.71 rows=3012 width=40)
                            ->  Nested Loop  (cost=0.73..6046.36 rows=3012 width=168)
                                  ->  Index Scan using idx_jobs_id_status_type_where_delete on _nango_sync_jobs _nango_sync_jobs_1  (cost=0.43..3840.94 rows=3437 width=119)
                                        Index Cond: (sync_id = _nango_syncs.id)
                                  ->  Memoize  (cost=0.30..1.36 rows=1 width=53)
                                        Cache Key: _nango_sync_jobs_1.sync_config_id
                                        Cache Mode: logical
                                        ->  Index Scan using _nango_sync_configs_pkey on _nango_sync_configs _nango_sync_configs_1  (cost=0.29..1.35 rows=1 width=53)
                                              Index Cond: (id = _nango_sync_jobs_1.sync_config_id)
                                              Filter: (NOT deleted)
                            ->  Index Scan using _nango_activity_logs_session_id_index on _nango_activity_logs  (cost=0.56..2.72 rows=1 width=13)
                                  Index Cond: ((session_id)::text = (_nango_sync_jobs_1.id)::text)
        SubPlan 3
          ->  Aggregate  (cost=1057.78..1057.79 rows=1 width=32)
                ->  Index Scan using idx_jobs_syncid_createdat_where_deleted on _nango_sync_jobs _nango_sync_jobs_2  (cost=0.56..1053.11 rows=932 width=16)
"                      Index Cond: ((sync_id = _nango_syncs.id) AND (created_at >= (CURRENT_DATE - '30 days'::interval)))"
```