### PR TITLE
fix cap logic

### DIFF
--- a/packages/server/lib/controllers/flow.controller.ts
+++ b/packages/server/lib/controllers/flow.controller.ts
@@ -234,7 +234,6 @@ class FlowController {
                 return;
             }
 
-            console.log(account);
             if (account.is_capped && flow?.providerConfigKey) {
                 const isCapped = await connectionService.shouldCapUsage({ providerConfigKey: flow?.providerConfigKey, environmentId: environment.id });
 

--- a/packages/server/lib/controllers/flow.controller.ts
+++ b/packages/server/lib/controllers/flow.controller.ts
@@ -122,7 +122,7 @@ class FlowController {
             }
 
             if (account.is_capped && firstConfig?.providerConfigKey) {
-                const isCapped = await connectionService.shouldCapUsage({ providerConfigKey: firstConfig?.providerConfigKey, environmentId });
+                const isCapped = await connectionService.shouldCapUsage({ providerConfigKey: firstConfig?.providerConfigKey, environmentId, type: 'activate' });
 
                 if (isCapped) {
                     errorManager.errRes(res, 'resource_capped');
@@ -235,7 +235,11 @@ class FlowController {
             }
 
             if (account.is_capped && flow?.providerConfigKey) {
-                const isCapped = await connectionService.shouldCapUsage({ providerConfigKey: flow?.providerConfigKey, environmentId: environment.id });
+                const isCapped = await connectionService.shouldCapUsage({
+                    providerConfigKey: flow?.providerConfigKey,
+                    environmentId: environment.id,
+                    type: 'activate'
+                });
 
                 if (isCapped) {
                     errorManager.errRes(res, 'resource_capped');

--- a/packages/shared/lib/constants.ts
+++ b/packages/shared/lib/constants.ts
@@ -1,6 +1,5 @@
-//import { isEnterprise } from '@nangohq/utils';
+import { isEnterprise } from '@nangohq/utils';
 
 export const SYNC_TASK_QUEUE = 'nango-syncs';
 export const WEBHOOK_TASK_QUEUE = 'nango-webhooks';
-//export const CONNECTIONS_WITH_SCRIPTS_CAP_LIMIT = isEnterprise ? Infinity : 3;
-export const CONNECTIONS_WITH_SCRIPTS_CAP_LIMIT = Infinity;
+export const CONNECTIONS_WITH_SCRIPTS_CAP_LIMIT = isEnterprise ? Infinity : 3;

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1042,7 +1042,15 @@ class ConnectionService {
         }
     }
 
-    public async shouldCapUsage({ providerConfigKey, environmentId }: { providerConfigKey: string; environmentId: number }): Promise<boolean> {
+    public async shouldCapUsage({
+        providerConfigKey,
+        environmentId,
+        type
+    }: {
+        providerConfigKey: string;
+        environmentId: number;
+        type: 'activate' | 'deploy';
+    }): Promise<boolean> {
         const connections = await this.getConnectionsByEnvironmentAndConfig(environmentId, providerConfigKey);
 
         if (!connections) {
@@ -1051,7 +1059,11 @@ class ConnectionService {
 
         if (connections.length > CONNECTIONS_WITH_SCRIPTS_CAP_LIMIT) {
             logger.info(`Reached cap for providerConfigKey: ${providerConfigKey} and environmentId: ${environmentId}`);
-            void analytics.trackByEnvironmentId(AnalyticsTypes.RESOURCE_CAPPED_SCRIPT_ACTIVATE, environmentId);
+            if (type === 'deploy') {
+                void analytics.trackByEnvironmentId(AnalyticsTypes.RESOURCE_CAPPED_SCRIPT_DEPLOY_IS_DISABLED, environmentId);
+            } else {
+                void analytics.trackByEnvironmentId(AnalyticsTypes.RESOURCE_CAPPED_SCRIPT_ACTIVATE, environmentId);
+            }
             return true;
         }
 

--- a/packages/shared/lib/services/sync/config/config.service.ts
+++ b/packages/shared/lib/services/sync/config/config.service.ts
@@ -257,6 +257,7 @@ export async function getSyncConfigsByConfigId(environment_id: number, nango_con
             environment_id,
             nango_config_id,
             active: true,
+            enabled: true,
             type: isAction ? SyncConfigType.ACTION : SyncConfigType.SYNC,
             deleted: false
         });
@@ -449,6 +450,7 @@ export async function getSyncConfigByParams(
                 sync_name,
                 nango_config_id: config.id as number,
                 active: true,
+                enabled: true,
                 type: isAction ? SyncConfigType.ACTION : SyncConfigType.SYNC,
                 deleted: false
             })

--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -767,7 +767,7 @@ async function compileDeployInfo({
     if (account && account.is_capped) {
         // if there are too many connections for this sync then we need to also
         // mark it as disabled
-        shouldCap = await connectionService.shouldCapUsage({ providerConfigKey, environmentId: environment_id });
+        shouldCap = await connectionService.shouldCapUsage({ providerConfigKey, environmentId: environment_id, type: 'deploy' });
     }
 
     insertData.push({

--- a/packages/shared/lib/utils/analytics.ts
+++ b/packages/shared/lib/utils/analytics.ts
@@ -43,6 +43,7 @@ export enum AnalyticsTypes {
     RESOURCE_CAPPED_CONNECTION_CREATED = 'server:resource_capped:connection_creation',
     RESOURCE_CAPPED_CONNECTION_IMPORTED = 'server:resource_capped:connection_imported',
     RESOURCE_CAPPED_SCRIPT_ACTIVATE = 'server:resource_capped:script_activate',
+    RESOURCE_CAPPED_SCRIPT_DEPLOY_IS_DISABLED = 'server:resource_capped:script_deploy_is_disabled',
     SYNC_DEPLOY_SUCCESS = 'sync:deploy_succeeded',
     SYNC_PAUSE = 'sync:command_pause',
     SYNC_RUN = 'sync:command_run',


### PR DESCRIPTION
## Describe your changes
On deploy the cap was being applied but only to disable the sync config which if a sync was already had no impact. This update fixes the cap application and adds an event for deploy so we know it isn't an active cap but rather a passive one. A passive cap in this case means that it doesn't disrupt any operation but if a new connection is created the sync won't initiate because it is disabled.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
