### PR TITLE
fix(auth): add span and cache 🙈

### DIFF
--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -70,7 +70,7 @@ export class AccessMiddleware {
 
     async publicKeyAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
         const active = tracer.scope().active();
-        const span = tracer.startSpan('secretKeyAuth', {
+        const span = tracer.startSpan('publicKeyAuth', {
             childOf: active!
         });
 
@@ -108,7 +108,7 @@ export class AccessMiddleware {
 
     async sessionAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
         const active = tracer.scope().active();
-        const span = tracer.startSpan('secretKeyAuth', {
+        const span = tracer.startSpan('sessionAuth', {
             childOf: active!
         });
 

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -12,24 +12,29 @@ const ignoreEnvPaths = ['/api/v1/meta', '/api/v1/user', '/api/v1/user/name', '/a
 
 export class AccessMiddleware {
     async secretKeyAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
-        const authorizationHeader = req.get('authorization');
-
-        if (!authorizationHeader) {
-            return errorManager.errRes(res, 'missing_auth_header');
-        }
-
-        const secret = authorizationHeader.split('Bearer ').pop();
-
-        if (!secret) {
-            return errorManager.errRes(res, 'malformed_auth_header');
-        }
-
-        if (!keyRegex.test(secret)) {
-            return errorManager.errRes(res, 'invalid_secret_key_format');
-        }
+        const active = tracer.scope().active();
+        const span = tracer.startSpan('secretKeyAuth', {
+            childOf: active!
+        });
 
         const start = Date.now();
         try {
+            const authorizationHeader = req.get('authorization');
+
+            if (!authorizationHeader) {
+                return errorManager.errRes(res, 'missing_auth_header');
+            }
+
+            const secret = authorizationHeader.split('Bearer ').pop();
+
+            if (!secret) {
+                return errorManager.errRes(res, 'malformed_auth_header');
+            }
+
+            if (!keyRegex.test(secret)) {
+                return errorManager.errRes(res, 'invalid_secret_key_format');
+            }
+
             const result = await environmentService.getAccountAndEnvironmentBySecretKey(secret);
             if (!result) {
                 res.status(401).send({ error: { code: 'unknown_user_account' } });
@@ -46,6 +51,7 @@ export class AccessMiddleware {
             return errorManager.errRes(res, 'malformed_auth_header');
         } finally {
             metrics.duration(metrics.Types.AUTH_GET_ENV_BY_SECRET_KEY, Date.now() - start);
+            span.finish();
         }
     }
 
@@ -63,17 +69,23 @@ export class AccessMiddleware {
     }
 
     async publicKeyAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
-        const publicKey = req.query['public_key'] as string;
+        const active = tracer.scope().active();
+        const span = tracer.startSpan('secretKeyAuth', {
+            childOf: active!
+        });
 
-        if (!publicKey) {
-            return errorManager.errRes(res, 'missing_public_key');
-        }
-
-        if (!keyRegex.test(publicKey)) {
-            return errorManager.errRes(res, 'invalid_public_key');
-        }
-
+        const start = Date.now();
         try {
+            const publicKey = req.query['public_key'] as string;
+
+            if (!publicKey) {
+                return errorManager.errRes(res, 'missing_public_key');
+            }
+
+            if (!keyRegex.test(publicKey)) {
+                return errorManager.errRes(res, 'invalid_public_key');
+            }
+
             const result = await environmentService.getAccountAndEnvironmentByPublicKey(publicKey);
             if (!result) {
                 res.status(401).send({ error: { code: 'unknown_user_account' } });
@@ -88,22 +100,36 @@ export class AccessMiddleware {
         } catch (e) {
             errorManager.report(e, { source: ErrorSourceEnum.PLATFORM, operation: LogActionEnum.INTERNAL_AUTHORIZATION });
             return errorManager.errRes(res, 'unknown_account');
+        } finally {
+            metrics.duration(metrics.Types.AUTH_PUBLIC_KEY, Date.now() - start);
+            span.finish();
         }
     }
 
     async sessionAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
-        if (!req.isAuthenticated()) {
-            res.status(401).send({ error: { code: 'unauthorized' } });
-            return;
-        }
+        const active = tracer.scope().active();
+        const span = tracer.startSpan('secretKeyAuth', {
+            childOf: active!
+        });
 
-        if (ignoreEnvPaths.includes(req.route.path)) {
-            next();
-            return;
-        }
+        const start = Date.now();
+        try {
+            if (!req.isAuthenticated()) {
+                res.status(401).send({ error: { code: 'unauthorized' } });
+                return;
+            }
 
-        res.locals['authType'] = 'session';
-        await fillLocalsFromSession(req, res, next);
+            if (ignoreEnvPaths.includes(req.route.path)) {
+                next();
+                return;
+            }
+
+            res.locals['authType'] = 'session';
+            await fillLocalsFromSession(req, res, next);
+        } finally {
+            metrics.duration(metrics.Types.AUTH_SESSION, Date.now() - start);
+            span.finish();
+        }
     }
 
     async noAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -14,6 +14,8 @@ export enum Types {
     PERSIST_RECORDS_COUNT = 'nango.persist.records.count',
     PERSIST_RECORDS_SIZE_IN_BYTES = 'nango.persist.records.sizeInBytes',
     AUTH_GET_ENV_BY_SECRET_KEY = 'nango.auth.getEnvBySecretKey',
+    AUTH_PUBLIC_KEY = 'nango.auth.publicKey',
+    AUTH_SESSION = 'nango.auth.session',
     LOGS_LOG = 'nango.logs.log',
     REFRESH_TOKENS = 'nango.jobs.cron.refreshTokens',
     REFRESH_TOKENS_SUCCESS = 'nango.jobs.cron.refreshTokens.success',


### PR DESCRIPTION
## Describe your changes

I bet the cache was useless, turns it wasn't BUT not for the same reason. When I introduced secretKey hash I picked the best hashing algo to not compromise on security, I forgot that its unbearably slow even on modern hardware. So each query to the public api would take 500ms-2s just to hash the query. The rest was smooth.

- **Add very minimalistic cache** to store hashing results
I could have gone for Redis, but I don't think we are sure to make it a mandatory part of the infra. It does not compromise on security nor caching too much since we still do the query. If an hacker manage to dump or access this memory, then we have bigger problems anyway. Using a less CPU intensive hashing algo could be a liability in security so I'm a bit stuck in between and it seems caching is the recommended way to go around those issues ([interesting read](https://tedspence.com/caching-strategies-for-authentication-8346a040234d))

- Add span on auth methods
That will help us see the auth time in Traces, that was the main thing missing during our debugging session.

