### PR TITLE
refactor: better Result types

### DIFF
--- a/packages/jobs/lib/crons/autoIdleDemo.integration.test.ts
+++ b/packages/jobs/lib/crons/autoIdleDemo.integration.test.ts
@@ -15,7 +15,7 @@ import {
     DEMO_SYNC_NAME
 } from '@nangohq/shared';
 import { exec } from './autoIdleDemo.js';
-import { nanoid, resultOk } from '@nangohq/utils';
+import { nanoid, Ok } from '@nangohq/utils';
 
 describe('Auto Idle Demo', async () => {
     let env: Environment;
@@ -28,7 +28,7 @@ describe('Auto Idle Demo', async () => {
     it('should delete syncs', async () => {
         const syncClient = (await SyncClient.getInstance())!;
         vi.spyOn(syncClient, 'runSyncCommand').mockImplementation(() => {
-            return Promise.resolve(resultOk(true));
+            return Promise.resolve(Ok(true));
         });
 
         const connName = nanoid();

--- a/packages/jobs/lib/crons/autoIdleDemo.ts
+++ b/packages/jobs/lib/crons/autoIdleDemo.ts
@@ -12,7 +12,7 @@ import {
     findPausableDemoSyncs,
     SpanTypes
 } from '@nangohq/shared';
-import { getLogger, isErr } from '@nangohq/utils';
+import { getLogger } from '@nangohq/utils';
 import tracer from 'dd-trace';
 import { logContextGetter } from '@nangohq/logs';
 import { records as recordsService } from '@nangohq/records';
@@ -90,13 +90,13 @@ export async function exec(): Promise<void> {
             recordsService,
             initiator: 'auto_idle_demo'
         });
-        if (isErr(resTemporal)) {
+        if (resTemporal.isErr()) {
             await logCtx.failed();
             continue;
         }
 
         const resDb = await updateScheduleStatus(sync.schedule_id, SyncCommand.PAUSE, activityLogId, sync.environment_id, logCtx);
-        if (isErr(resDb)) {
+        if (resDb.isErr()) {
             await logCtx.failed();
             continue;
         }

--- a/packages/jobs/lib/integration.service.ts
+++ b/packages/jobs/lib/integration.service.ts
@@ -1,6 +1,6 @@
 import type { Context } from '@temporalio/activity';
 import type { IntegrationServiceInterface, RunScriptOptions, ServiceResponse } from '@nangohq/shared';
-import { integrationFilesAreRemote, isCloud, isProd, getLogger, isOk, stringifyError } from '@nangohq/utils';
+import { integrationFilesAreRemote, isCloud, isProd, getLogger, stringifyError } from '@nangohq/utils';
 import { createActivityLogMessage, localFileService, remoteFileService, NangoError, formatScriptError } from '@nangohq/shared';
 import type { Runner } from './runner/runner.js';
 import { getOrStartRunner, getRunnerId } from './runner/runner.js';
@@ -37,7 +37,7 @@ class IntegrationService implements IntegrationServiceInterface {
             syncId
         });
 
-        if (isOk(res)) {
+        if (res.isOk()) {
             this.runningScripts.set(syncId, { ...scriptObject, cancelled: true });
         } else {
             if (activityLogId && environmentId) {

--- a/packages/persist/lib/controllers/persist.controller.ts
+++ b/packages/persist/lib/controllers/persist.controller.ts
@@ -221,7 +221,7 @@ class PersistController {
 
         const syncConfig = await getSyncConfigByJobId(syncJobId);
         if (syncConfig && !syncConfig?.models.includes(model)) {
-            const err = Error(`The model '${model}' is not included in the declared sync models: ${syncConfig.models}.`);
+            const err = new Error(`The model '${model}' is not included in the declared sync models: ${syncConfig.models}.`);
             await logCtx.error('The model is not included in the declared sync models', { model });
 
             span.setTag('error', err).finish();

--- a/packages/persist/lib/controllers/persist.controller.ts
+++ b/packages/persist/lib/controllers/persist.controller.ts
@@ -213,7 +213,7 @@ class PersistController {
                 timestamp: Date.now()
             });
             await logCtx.error('There was an issue with the batch', { error: formatting.error, persistType });
-            const err = Error(`Failed to ${persistType} records ${activityLogId}`);
+            const err = new Error(`Failed to ${persistType} records ${activityLogId}`);
 
             span.setTag('error', err).finish();
             return Err(err);

--- a/packages/records/lib/helpers/format.ts
+++ b/packages/records/lib/helpers/format.ts
@@ -3,7 +3,7 @@ import * as uuid from 'uuid';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc.js';
 import type { FormattedRecord, UnencryptedRecordData } from '../types.js';
-import { resultErr, resultOk } from '@nangohq/utils';
+import { Err, Ok } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
 
 dayjs.extend(utc);
@@ -40,7 +40,7 @@ export const formatRecords = ({
 
         if (!datum['id']) {
             const error = new Error(`Missing id field in record: ${JSON.stringify(datum)}. Model: ${model}`);
-            return resultErr(error);
+            return Err(error);
         }
 
         const formattedRecord: FormattedRecord = {
@@ -63,5 +63,5 @@ export const formatRecords = ({
         }
         formattedRecords.push(formattedRecord);
     }
-    return resultOk(formattedRecords);
+    return Ok(formattedRecords);
 };

--- a/packages/runner/lib/cancel.ts
+++ b/packages/runner/lib/cancel.ts
@@ -1,4 +1,4 @@
-import { resultOk, resultErr } from '@nangohq/utils';
+import { Ok, Err } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
 import { syncAbortControllers } from './state.js';
 
@@ -6,8 +6,8 @@ export const cancel = (syncId: string): Result<string> => {
     const abortController = syncAbortControllers.get(syncId);
     if (abortController) {
         abortController.abort();
-        return resultOk('cancelled');
+        return Ok('cancelled');
     } else {
-        return resultErr('child process not found');
+        return Err('child process not found');
     }
 };

--- a/packages/server/lib/controllers/apiAuth.controller.ts
+++ b/packages/server/lib/controllers/apiAuth.controller.ts
@@ -24,7 +24,7 @@ import {
 } from '@nangohq/shared';
 import type { LogContext } from '@nangohq/logs';
 import { logContextGetter } from '@nangohq/logs';
-import { isErr, stringifyError } from '@nangohq/utils';
+import { stringifyError } from '@nangohq/utils';
 import type { RequestLocals } from '../utils/express.js';
 
 class ApiAuthController {
@@ -168,7 +168,7 @@ class ApiAuthController {
                 tracer
             );
 
-            if (isErr(connectionResponse)) {
+            if (connectionResponse.isErr()) {
                 await createActivityLogMessageAndEnd({
                     level: 'error',
                     environment_id: environmentId,
@@ -179,7 +179,7 @@ class ApiAuthController {
                 await logCtx.error('Provided credentials are invalid', { provider: config.provider });
                 await logCtx.failed();
 
-                errorManager.errResFromNangoErr(res, connectionResponse.err);
+                errorManager.errResFromNangoErr(res, connectionResponse.error);
 
                 return;
             }
@@ -399,7 +399,7 @@ class ApiAuthController {
                 tracer
             );
 
-            if (isErr(connectionResponse)) {
+            if (connectionResponse.isErr()) {
                 await createActivityLogMessageAndEnd({
                     level: 'error',
                     environment_id: environmentId,
@@ -410,7 +410,7 @@ class ApiAuthController {
                 await logCtx.error('Provided credentials are invalid', { provider: config.provider });
                 await logCtx.failed();
 
-                errorManager.errResFromNangoErr(res, connectionResponse.err);
+                errorManager.errResFromNangoErr(res, connectionResponse.error);
 
                 return;
             }

--- a/packages/server/lib/controllers/onboarding.controller.ts
+++ b/packages/server/lib/controllers/onboarding.controller.ts
@@ -28,7 +28,7 @@ import {
     AnalyticsTypes
 } from '@nangohq/shared';
 import type { IncomingPreBuiltFlowConfig } from '@nangohq/shared';
-import { getLogger, isErr } from '@nangohq/utils';
+import { getLogger } from '@nangohq/utils';
 import type { LogContext } from '@nangohq/logs';
 import { logContextGetter } from '@nangohq/logs';
 import { records as recordsService } from '@nangohq/records';
@@ -146,11 +146,11 @@ class OnboardingController {
                 connectionId: connectionExists.id,
                 model: DEMO_MODEL
             });
-            if (isErr(getRecords)) {
+            if (getRecords.isErr()) {
                 res.status(400).json({ error: { code: 'failed_to_get_records' } });
                 return;
             } else {
-                payload.records = getRecords.res.records;
+                payload.records = getRecords.value.records;
             }
             if (payload.records.length > 0) {
                 payload.progress = status.progress > 4 ? status.progress : 4;
@@ -429,17 +429,17 @@ class OnboardingController {
                 logCtx
             });
 
-            if (isErr(actionResponse)) {
+            if (actionResponse.isErr()) {
                 void analytics.track(AnalyticsTypes.DEMO_5_ERR, account.id, { user_id: user.id });
-                errorManager.errResFromNangoErr(res, actionResponse.err);
-                await logCtx.error('Failed to trigger action', { error: actionResponse.err });
+                errorManager.errResFromNangoErr(res, actionResponse.error);
+                await logCtx.error('Failed to trigger action', { error: actionResponse.error });
                 await logCtx.failed();
                 return;
             }
 
             await logCtx.success();
             void analytics.track(AnalyticsTypes.DEMO_5_SUCCESS, account.id, { user_id: user.id });
-            res.status(200).json({ action: actionResponse.res });
+            res.status(200).json({ action: actionResponse.value });
         } catch (err) {
             if (logCtx) {
                 await logCtx.error('Failed to trigger action', { error: err });

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -44,7 +44,6 @@ import {
 } from '@nangohq/shared';
 import type { LogContext } from '@nangohq/logs';
 import { logContextGetter } from '@nangohq/logs';
-import { isErr, isOk } from '@nangohq/utils';
 import type { LastAction } from '@nangohq/records';
 import { records as recordsService } from '@nangohq/records';
 import type { RequestLocals } from '../utils/express.js';
@@ -172,12 +171,12 @@ class SyncController {
                 cursor: cursor as string
             });
 
-            if (isErr(result)) {
-                errorManager.errResFromNangoErr(res, new NangoError('pass_through_error', result.err));
+            if (result.isErr()) {
+                errorManager.errResFromNangoErr(res, new NangoError('pass_through_error', result.error));
                 return;
             }
             await trackFetch(connection.id as number);
-            res.send(result.res);
+            res.send(result.value);
         } catch (e) {
             next(e);
         }
@@ -413,16 +412,16 @@ class SyncController {
                 logCtx
             });
 
-            if (isOk(actionResponse)) {
+            if (actionResponse.isOk()) {
                 span.finish();
                 await logCtx.success();
-                res.send(actionResponse.res);
+                res.send(actionResponse.value);
 
                 return;
             } else {
-                span.setTag('nango.error', actionResponse.err);
-                errorManager.errResFromNangoErr(res, actionResponse.err);
-                await logCtx.error('Failed to trigger action', { err: actionResponse.err });
+                span.setTag('nango.error', actionResponse.error);
+                errorManager.errResFromNangoErr(res, actionResponse.error);
+                await logCtx.error('Failed to trigger action', { err: actionResponse.error });
                 await logCtx.failed();
                 span.finish();
 
@@ -676,8 +675,8 @@ class SyncController {
                 initiator: 'UI'
             });
 
-            if (isErr(result)) {
-                errorManager.handleGenericError(result.err, req, res, tracer);
+            if (result.isErr()) {
+                errorManager.handleGenericError(result.error, req, res, tracer);
                 await logCtx.failed();
                 return;
             }

--- a/packages/server/lib/controllers/user.controller.ts
+++ b/packages/server/lib/controllers/user.controller.ts
@@ -1,7 +1,7 @@
 import { getUserFromSession } from '../utils/utils.js';
 import type { Request, Response, NextFunction } from 'express';
 import EmailClient from '../clients/email.client.js';
-import { isCloud, isEnterprise, basePublicUrl, isErr } from '@nangohq/utils';
+import { isCloud, isEnterprise, basePublicUrl } from '@nangohq/utils';
 import { errorManager, userService } from '@nangohq/shared';
 import type { RequestLocals } from '../utils/express.js';
 
@@ -18,12 +18,12 @@ class UserController {
     async getUser(req: Request, res: Response<GetUser, never>, next: NextFunction) {
         try {
             const getUser = await getUserFromSession(req);
-            if (isErr(getUser)) {
-                errorManager.errResFromNangoErr(res, getUser.err);
+            if (getUser.isErr()) {
+                errorManager.errResFromNangoErr(res, getUser.error);
                 return;
             }
 
-            const user = getUser.res;
+            const user = getUser.value;
             res.status(200).send({
                 user: {
                     id: user.id,
@@ -40,12 +40,12 @@ class UserController {
     async editName(req: Request, res: Response<any, never>, next: NextFunction) {
         try {
             const getUser = await getUserFromSession(req);
-            if (isErr(getUser)) {
-                errorManager.errResFromNangoErr(res, getUser.err);
+            if (getUser.isErr()) {
+                errorManager.errResFromNangoErr(res, getUser.error);
                 return;
             }
 
-            const user = getUser.res;
+            const user = getUser.value;
             const name = req.body['name'];
 
             if (!name) {
@@ -63,12 +63,12 @@ class UserController {
     async editPassword(req: Request, res: Response<any, never>, next: NextFunction) {
         try {
             const getUser = await getUserFromSession(req);
-            if (isErr(getUser)) {
-                errorManager.errResFromNangoErr(res, getUser.err);
+            if (getUser.isErr()) {
+                errorManager.errResFromNangoErr(res, getUser.error);
                 return;
             }
 
-            const user = getUser.res;
+            const user = getUser.value;
             const oldPassword = req.body['old_password'];
             const newPassword = req.body['new_password'];
 

--- a/packages/server/lib/utils/utils.ts
+++ b/packages/server/lib/utils/utils.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import type { Request } from 'express';
 import type { User, Template as ProviderTemplate } from '@nangohq/shared';
 import type { Result } from '@nangohq/utils';
-import { getLogger, resultErr, resultOk } from '@nangohq/utils';
+import { getLogger, Err, Ok } from '@nangohq/utils';
 import type { WSErr } from './web-socket-error.js';
 import { NangoError, userService, interpolateString } from '@nangohq/shared';
 
@@ -14,17 +14,17 @@ export async function getUserFromSession(req: Request<any>): Promise<Result<User
     if (!sessionUser) {
         const error = new NangoError('user_not_found');
 
-        return resultErr(error);
+        return Err(error);
     }
 
     const user = await userService.getUserById(sessionUser.id);
 
     if (!user) {
         const error = new NangoError('user_not_found');
-        return resultErr(error);
+        return Err(error);
     }
 
-    return resultOk(user);
+    return Ok(user);
 }
 
 export function dirname() {

--- a/packages/shared/lib/clients/sync.client.ts
+++ b/packages/shared/lib/clients/sync.client.ts
@@ -30,7 +30,7 @@ import errorManager, { ErrorSourceEnum } from '../utils/error.manager.js';
 import { NangoError } from '../utils/error.js';
 import type { RunnerOutput } from '../models/Runner.js';
 import type { LogContext, LogContextGetter } from '@nangohq/logs';
-import { isTest, isProd, getLogger, metrics, isErr, resultOk, resultErr, stringifyError } from '@nangohq/utils';
+import { isTest, isProd, getLogger, metrics, Ok, Err, stringifyError } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
 
 const logger = getLogger('Sync.Client');
@@ -417,8 +417,8 @@ class SyncClient {
                     {
                         const result = await this.cancelSync(syncId);
 
-                        if (isErr(result)) {
-                            return resultErr(result.err);
+                        if (result.isErr()) {
+                            return result;
                         }
                     }
                     break;
@@ -473,7 +473,7 @@ class SyncClient {
                     break;
             }
 
-            return resultOk(true);
+            return Ok(true);
         } catch (err) {
             const errorMessage = stringifyError(err, { pretty: true });
 
@@ -486,7 +486,7 @@ class SyncClient {
             });
             await logCtx.error('Sync command failed', { error: err, command });
 
-            return resultErr(err as Error);
+            return Err(err as Error);
         }
     }
 
@@ -496,13 +496,13 @@ class SyncClient {
             const { job_id, run_id } = jobIsRunning;
             if (!run_id) {
                 const error = new NangoError('run_id_not_found');
-                return resultErr(error);
+                return Err(error);
             }
 
             const workflowHandle = this.client?.workflow.getHandle(job_id, run_id);
             if (!workflowHandle) {
                 const error = new NangoError('run_id_not_found');
-                return resultErr(error);
+                return Err(error);
             }
 
             try {
@@ -510,14 +510,14 @@ class SyncClient {
                 // We await the results otherwise it might not be cancelled yet
                 await workflowHandle.result();
             } catch (err) {
-                return resultErr(new NangoError('failed_to_cancel_sync', err as any));
+                return Err(new NangoError('failed_to_cancel_sync', err as any));
             }
         } else {
             const error = new NangoError('sync_job_not_running');
-            return resultErr(error);
+            return Err(error);
         }
 
-        return resultOk(true);
+        return Ok(true);
     }
 
     async triggerSyncs(syncs: SyncWithSchedule[], environmentId: number) {
@@ -608,7 +608,7 @@ class SyncClient {
                     await logCtx.error(`The action workflow ${workflowId} did not complete successfully`);
                 }
 
-                return resultErr(error!);
+                return Err(error!);
             }
 
             const content = `The action workflow ${workflowId} was successfully run. A truncated response is: ${JSON.stringify(response, null, 2)?.slice(
@@ -641,7 +641,7 @@ class SyncClient {
                 `actionName:${actionName}`
             );
 
-            return resultOk(response);
+            return Ok(response);
         } catch (e) {
             const errorMessage = stringifyError(e, { pretty: true });
             const error = new NangoError('action_failure', { errorMessage });
@@ -684,7 +684,7 @@ class SyncClient {
                 `actionName:${actionName}`
             );
 
-            return resultErr(error);
+            return Err(error);
         } finally {
             const endTime = Date.now();
             const totalRunTime = (endTime - startTime) / 1000;

--- a/packages/shared/lib/hooks/hooks.ts
+++ b/packages/shared/lib/hooks/hooks.ts
@@ -11,7 +11,7 @@ import integrationPostConnectionScript from '../integrations/scripts/connection/
 import webhookService from '../services/notification/webhook.service.js';
 import { SpanTypes } from '../utils/telemetry.js';
 import { getSyncConfigsWithConnections } from '../services/sync/config/config.service.js';
-import { isCloud, isLocal, isEnterprise, getLogger, resultOk, resultErr } from '@nangohq/utils';
+import { isCloud, isLocal, isEnterprise, getLogger, Ok, Err } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
 import { NangoError } from '../utils/error.js';
 import type { LogContext, LogContextGetter } from '@nangohq/logs';
@@ -96,7 +96,7 @@ export const connectionTest = async (
     const providerVerification = template?.proxy?.verification;
 
     if (!providerVerification) {
-        return resultOk(true);
+        return Ok(true);
     }
     const active = tracer.scope().active();
     const span = tracer.startSpan(SpanTypes.CONNECTION_TEST, {
@@ -152,26 +152,26 @@ export const connectionTest = async (
         if (axios.isAxiosError(response)) {
             span.setTag('nango.error', response);
             const error = new NangoError('connection_test_failed', response, response.response?.status);
-            return resultErr(error);
+            return Err(error);
         }
 
         if (!response) {
             const error = new NangoError('connection_test_failed');
             span.setTag('nango.error', response);
-            return resultErr(error);
+            return Err(error);
         }
 
         if (response.status && (response?.status < 200 || response?.status > 300)) {
             const error = new NangoError('connection_test_failed');
             span.setTag('nango.error', response);
-            return resultErr(error);
+            return Err(error);
         }
 
-        return resultOk(true);
+        return Ok(true);
     } catch (e) {
         const error = new NangoError('connection_test_failed');
         span.setTag('nango.error', e);
-        return resultErr(error);
+        return Err(error);
     } finally {
         span.finish();
     }

--- a/packages/shared/lib/services/notification/slack.service.ts
+++ b/packages/shared/lib/services/notification/slack.service.ts
@@ -7,7 +7,7 @@ import environmentService from '../environment.service.js';
 import type { LogLevel } from '../../models/Activity.js';
 import { LogActionEnum } from '../../models/Activity.js';
 import { updateSuccess as updateSuccessActivityLog, createActivityLogMessage, createActivityLog } from '../activity/activity.service.js';
-import { basePublicUrl, isOk } from '@nangohq/utils';
+import { basePublicUrl } from '@nangohq/utils';
 import connectionService from '../connection.service.js';
 import accountService from '../account.service.js';
 import SyncClient from '../../clients/sync.client.js';
@@ -152,8 +152,8 @@ class SlackService {
             logCtx
         });
 
-        if (id && isOk(actionResponse) && actionResponse.res.ts) {
-            await this.updateNotificationWithAdminTimestamp(id, actionResponse.res.ts);
+        if (id && actionResponse.isOk() && actionResponse.value.ts) {
+            await this.updateNotificationWithAdminTimestamp(id, actionResponse.value.ts);
         }
     }
 
@@ -304,8 +304,8 @@ class SlackService {
             logCtx
         });
 
-        if (isOk(actionResponse) && actionResponse.res.ts) {
-            await this.updateNotificationWithTimestamp(slackNotificationStatus.id, actionResponse.res.ts);
+        if (actionResponse.isOk() && actionResponse.value.ts) {
+            await this.updateNotificationWithTimestamp(slackNotificationStatus.id, actionResponse.value.ts);
         }
 
         await this.sendDuplicateNotificationToNangoAdmins(
@@ -317,12 +317,12 @@ class SlackService {
             slackNotificationStatus.admin_slack_timestamp
         );
 
-        const content = isOk(actionResponse)
+        const content = actionResponse.isOk()
             ? `The action ${this.actionName} was successfully triggered for the ${flowType} ${syncName} for environment ${slackConnection?.environment_id} for account ${account.uuid}.`
-            : `The action ${this.actionName} failed to trigger for the ${flowType} ${syncName} with the error: ${actionResponse.err.message} for environment ${slackConnection?.environment_id} for account ${account.uuid}.`;
+            : `The action ${this.actionName} failed to trigger for the ${flowType} ${syncName} with the error: ${actionResponse.error.message} for environment ${slackConnection?.environment_id} for account ${account.uuid}.`;
 
         await createActivityLogMessage({
-            level: isOk(actionResponse) ? 'info' : 'error',
+            level: actionResponse.isOk() ? 'info' : 'error',
             activity_log_id: activityLogId as number,
             environment_id: slackConnection?.environment_id,
             timestamp: Date.now(),
@@ -330,9 +330,9 @@ class SlackService {
             params: payload as unknown as Record<string, unknown>
         });
 
-        await updateSuccessActivityLog(activityLogId as number, isOk(actionResponse));
+        await updateSuccessActivityLog(activityLogId as number, actionResponse.isOk());
 
-        if (isOk(actionResponse)) {
+        if (actionResponse.isOk()) {
             await logCtx.info(
                 `The action ${this.actionName} was successfully triggered for the ${flowType} ${syncName} for environment ${slackConnection?.environment_id} for account ${account.uuid}.`,
                 { payload }
@@ -340,8 +340,8 @@ class SlackService {
             await logCtx.success();
         } else {
             await logCtx.error(
-                `The action ${this.actionName} failed to trigger for the ${flowType} ${syncName} with the error: ${actionResponse.err.message} for environment ${slackConnection?.environment_id} for account ${account.uuid}.`,
-                { error: actionResponse.err, payload }
+                `The action ${this.actionName} failed to trigger for the ${flowType} ${syncName} with the error: ${actionResponse.error.message} for environment ${slackConnection?.environment_id} for account ${account.uuid}.`,
+                { error: actionResponse.error, payload }
             );
             await logCtx.failed();
         }
@@ -447,12 +447,12 @@ class SlackService {
 
         await this.sendDuplicateNotificationToNangoAdmins(payload, activityLogId as number, environment_id, logCtx, undefined, admin_slack_timestamp);
 
-        const content = isOk(actionResponse)
+        const content = actionResponse.isOk()
             ? `The action ${this.actionName} was successfully triggered for the ${syncType} ${syncName} for environment ${slackConnection?.environment_id} for account ${account.uuid}.`
-            : `The action ${this.actionName} failed to trigger for the ${syncType} ${syncName} with the error: ${actionResponse.err.message} for environment ${slackConnection?.environment_id} for account ${account.uuid}.`;
+            : `The action ${this.actionName} failed to trigger for the ${syncType} ${syncName} with the error: ${actionResponse.error.message} for environment ${slackConnection?.environment_id} for account ${account.uuid}.`;
 
         await createActivityLogMessage({
-            level: isOk(actionResponse) ? 'info' : 'error',
+            level: actionResponse.isOk() ? 'info' : 'error',
             activity_log_id: activityLogId as number,
             environment_id: slackConnection?.environment_id,
             timestamp: Date.now(),
@@ -460,12 +460,12 @@ class SlackService {
             params: payload as unknown as Record<string, unknown>
         });
 
-        await updateSuccessActivityLog(activityLogId as number, isOk(actionResponse));
-        if (isOk(actionResponse)) {
+        await updateSuccessActivityLog(activityLogId as number, actionResponse.isOk());
+        if (actionResponse.isOk()) {
             await logCtx.info(content, payload);
             await logCtx.success();
         } else {
-            await logCtx.error(content, { error: actionResponse.err });
+            await logCtx.error(content, { error: actionResponse.error });
             await logCtx.failed();
         }
     }

--- a/packages/shared/lib/services/sync/schedule.service.ts
+++ b/packages/shared/lib/services/sync/schedule.service.ts
@@ -6,7 +6,7 @@ import { getInterval } from '../nango-config.service.js';
 import SyncClient from '../../clients/sync.client.js';
 import { createActivityLogDatabaseErrorMessageAndEnd } from '../activity/activity.service.js';
 import type { LogContext } from '@nangohq/logs';
-import { resultOk, resultErr } from '@nangohq/utils';
+import { Ok, Err } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
 
 const TABLE = dbNamespace + 'sync_schedules';
@@ -70,7 +70,7 @@ export const updateScheduleStatus = async (
 ): Promise<Result<boolean>> => {
     try {
         await schema().update({ status: SyncCommandToScheduleStatus[status] }).from<SyncSchedule>(TABLE).where({ schedule_id, deleted: false });
-        return resultOk(true);
+        return Ok(true);
     } catch (error) {
         if (activityLogId) {
             await createActivityLogDatabaseErrorMessageAndEnd(
@@ -82,7 +82,7 @@ export const updateScheduleStatus = async (
             await logCtx?.error(`Failed to update schedule status to ${status} for schedule_id: ${schedule_id}`, { error });
         }
 
-        return resultErr(error as Error);
+        return Err(error as Error);
     }
 };
 


### PR DESCRIPTION
- Making Result types returns an instance of the interface so we can use dot notation `res.isOk()/res.isErr()` instead of `isOk(res)/isErr(res)`, avoiding to import the functions every time.
- It also allows us to extends Ok and Err with functions like `.unwrap()` that is very useful in tests. I also needed a `.map()` function recently.
- Shortening `resultOk/resultErr` to `Ok/Err`. imho result prefix doesn't add much and since Result is now used across the codebase adding more context isn't adding much value.
- Renaming `ok.res` to `ok.value` (all the `res.res` were a bit weird) and `err.err` to `err.error`

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
