### PR TITLE
debug(persist): differentiate environment not found and not matching in auth middleware

### DIFF
--- a/packages/persist/lib/middleware/auth.middleware.ts
+++ b/packages/persist/lib/middleware/auth.middleware.ts
@@ -25,8 +25,11 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
     environmentService
         .getAccountAndEnvironmentBySecretKey(secret)
         .then((result) => {
-            if (!result || result.environment.id !== environmentId) {
-                throw new Error('Cannot find matching environment');
+            if (!result) {
+                throw new Error('Cannot find environment');
+            }
+            if (result.environment.id !== environmentId) {
+                throw new Error(`Environment is not matching (expected: ${environmentId}, actual: ${result.environment.id})`);
             }
             next();
         })


### PR DESCRIPTION
Still investigating the persist auth error when running nango enterprise.
The commit differentiate the two different errors when environment is not matching in persist auth middleware
