### PR TITLE
fix: ensure secret_key_hashed is updated when needed

### DIFF
--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -235,10 +235,7 @@ class EnvironmentService {
                 return null;
             }
 
-            const encryptedEnvironment = encryptionManager.encryptEnvironment({
-                ...environment,
-                secret_key_hashed: await hashSecretKey(environment.secret_key)
-            });
+            const encryptedEnvironment = await encryptionManager.encryptEnvironment(environment);
             await db.knex.from<Environment>(TABLE).where({ id: environmentId }).update(encryptedEnvironment);
 
             const env = encryptionManager.decryptEnvironment(encryptedEnvironment)!;
@@ -401,7 +398,7 @@ class EnvironmentService {
 
         environment.pending_secret_key = pending_secret_key;
 
-        const encryptedEnvironment = encryptionManager.encryptEnvironment(environment);
+        const encryptedEnvironment = await encryptionManager.encryptEnvironment(environment);
         await db.knex.from<Environment>(TABLE).where({ id }).update(encryptedEnvironment);
 
         return pending_secret_key;


### PR DESCRIPTION
secret_key_hashed must be set and kept up to date when secret key or NANGO_ENCRYPTION_KEY rotate

## Issue ticket number and link
https://linear.app/nango/issue/NAN-895/secret-key-hashed-was-empty-for-customer-running-enterprise

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
