### PR TITLE
fix: set secret_key_hashed when creating environment

### DIFF
--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -235,7 +235,10 @@ class EnvironmentService {
                 return null;
             }
 
-            const encryptedEnvironment = await encryptionManager.encryptEnvironment(environment);
+            const encryptedEnvironment = await encryptionManager.encryptEnvironment({
+                ...environment,
+                secret_key_hashed: await hashSecretKey(environment.secret_key)
+            });
             await db.knex.from<Environment>(TABLE).where({ id: environmentId }).update(encryptedEnvironment);
 
             const env = encryptionManager.decryptEnvironment(encryptedEnvironment)!;


### PR DESCRIPTION
followup of https://github.com/NangoHQ/nango/pull/2119

Not doing so will lead to empty secret_key_hashed if NANGO_ENCRYPTION_KEY is empty
