### PR TITLE
[nan-903] add optional integration-id

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -116,10 +116,14 @@ program
         '-m, --metadata [metadata]',
         'Optional (for syncs only): metadata to stub for the sync script supplied in JSON format, for example --metadata \'{"foo": "bar"}\''
     )
+    .option(
+        '--integration-id [integrationId]',
+        'Optional: The integration id to use for the dryrun. If not provided, the integration id will be retrieved from the nango.yaml file. This is useful using nested directories and script name are repeated'
+    )
     .action(async function (this: Command, sync: string, connectionId: string) {
-        const { autoConfirm, debug, e: environment } = this.opts();
+        const { autoConfirm, debug, e: environment, integrationId } = this.opts();
         await verificationService.necessaryFilesExist(autoConfirm, debug);
-        dryrunService.run({ ...this.opts(), sync, connectionId }, environment, debug);
+        dryrunService.run({ ...this.opts(), sync, connectionId }, environment, integrationId, debug);
     });
 
 program

--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -123,7 +123,7 @@ program
     .action(async function (this: Command, sync: string, connectionId: string) {
         const { autoConfirm, debug, e: environment, integrationId } = this.opts();
         await verificationService.necessaryFilesExist(autoConfirm, debug);
-        dryrunService.run({ ...this.opts(), sync, connectionId }, environment, integrationId, debug);
+        dryrunService.run({ ...this.opts(), sync, connectionId, optionalEnvironment: environment, optionalProviderConfigKey: integrationId }, debug);
     });
 
 program

--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -30,7 +30,7 @@ class DryRunService {
 
         this.returnOutput = returnOutput;
     }
-    public async run(options: RunArgs, optionalEnvironment?: string, debug = false): Promise<string | void> {
+    public async run(options: RunArgs, optionalEnvironment?: string, optionalProviderConfigKey?: string, debug = false): Promise<string | void> {
         let syncName = '';
         let connectionId, suppliedLastSyncDate, actionInput, rawStubbedMetadata;
 
@@ -75,11 +75,15 @@ class DryRunService {
             return;
         }
 
-        const providerConfigKey = config.find((config) => [...config.syncs, ...config.actions].find((sync) => sync.name === syncName))?.providerConfigKey;
+        let providerConfigKey = optionalProviderConfigKey;
 
         if (!providerConfigKey) {
-            console.log(chalk.red(`Provider config key not found, please check that the provider exists for this sync name: ${syncName}`));
-            return;
+            providerConfigKey = config.find((config) => [...config.syncs, ...config.actions].find((sync) => sync.name === syncName))?.providerConfigKey;
+
+            if (!providerConfigKey) {
+                console.log(chalk.red(`Provider config key not found, please check that the provider exists for this sync name: ${syncName}`));
+                return;
+            }
         }
 
         const foundConfig = config.find((configItem) => {

--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -17,6 +17,8 @@ interface RunArgs extends GlobalOptions {
     useServerLastSyncDate?: boolean;
     input?: object;
     metadata?: Metadata;
+    optionalEnvironment?: string;
+    optionalProviderConfigKey?: string;
 }
 
 class DryRunService {
@@ -30,11 +32,11 @@ class DryRunService {
 
         this.returnOutput = returnOutput;
     }
-    public async run(options: RunArgs, optionalEnvironment?: string, optionalProviderConfigKey?: string, debug = false): Promise<string | void> {
+    public async run(options: RunArgs, debug = false): Promise<string | void> {
         let syncName = '';
         let connectionId, suppliedLastSyncDate, actionInput, rawStubbedMetadata;
 
-        const environment = optionalEnvironment || this.environment;
+        const environment = options.optionalEnvironment || this.environment;
 
         if (!environment) {
             console.log(chalk.red('Environment is required'));
@@ -75,13 +77,17 @@ class DryRunService {
             return;
         }
 
-        let providerConfigKey = optionalProviderConfigKey;
+        let providerConfigKey = options.optionalProviderConfigKey;
 
         if (!providerConfigKey) {
             providerConfigKey = config.find((config) => [...config.syncs, ...config.actions].find((sync) => sync.name === syncName))?.providerConfigKey;
 
             if (!providerConfigKey) {
-                console.log(chalk.red(`Provider config key not found, please check that the provider exists for this sync name: ${syncName}`));
+                console.log(
+                    chalk.red(
+                        `Provider config key not found, please check that the provider exists for this sync name: ${syncName} by going to the Nango dashboard.`
+                    )
+                );
                 return;
             }
         }

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -228,10 +228,12 @@ interface RunArgs {
     metadata?: Metadata;
     autoConfirm: boolean;
     debug: boolean;
+    optionalEnvironment?: string;
+    optionalProviderConfigKey?: string;
 }
 
 export interface DryRunServiceInterface {
-    run: (options: RunArgs, environment?: string, optionalLoadLocation?: string, debug?: boolean) => Promise<string | void>;
+    run: (options: RunArgs, debug?: boolean) => Promise<string | void>;
 }
 
 export interface NangoProps {

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -231,7 +231,7 @@ interface RunArgs {
 }
 
 export interface DryRunServiceInterface {
-    run: (options: RunArgs, environment?: string, debug?: boolean) => Promise<string | void>;
+    run: (options: RunArgs, environment?: string, optionalLoadLocation?: string, debug?: boolean) => Promise<string | void>;
 }
 
 export interface NangoProps {


### PR DESCRIPTION
## Describe your changes
If a user has repeated sync names then we (nango) might not know how to resolve the script to run in a dry run

```
integrations:
  provider-1:
   syncs:
     foo:
  provider-2:
    syncs:
      foo:
```

This allows a user to pass in an optional flag of `integration-id` to identify `provider-1` or `provider-2`

```
nango dryrun foo unique-connection --integration-id provider-2
```

## Issue ticket number and link
NAN-903

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
