### PR TITLE
[nan-905] fix revert key and allow public keys to be able to be rotated

### DIFF
--- a/packages/webapp/src/pages/EnvironmentSettings.tsx
+++ b/packages/webapp/src/pages/EnvironmentSettings.tsx
@@ -75,7 +75,7 @@ export const EnvironmentSettings: React.FC = () => {
         }
 
         setSecretKey(environment.pending_secret_key || environment.secret_key);
-        setSecretKeyRotatable(environment.secret_key_rotatable);
+        setSecretKeyRotatable(!environment.secret_key_rotatable);
         setHasPendingSecretKey(Boolean(environment.pending_secret_key));
 
         setPublicKey(environment.pending_public_key || environment.public_key);
@@ -270,7 +270,7 @@ export const EnvironmentSettings: React.FC = () => {
     };
 
     const onRevertKey = async (publicKey = true) => {
-        const res = await fetch(`/api/v1/environment/?env=${env}`, {
+        const res = await fetch(`/api/v1/environment/revert-key?env=${env}`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'

--- a/packages/webapp/src/pages/EnvironmentSettings.tsx
+++ b/packages/webapp/src/pages/EnvironmentSettings.tsx
@@ -75,7 +75,7 @@ export const EnvironmentSettings: React.FC = () => {
         }
 
         setSecretKey(environment.pending_secret_key || environment.secret_key);
-        setSecretKeyRotatable(!environment.secret_key_rotatable);
+        setSecretKeyRotatable(environment.secret_key_rotatable !== false);
         setHasPendingSecretKey(Boolean(environment.pending_secret_key));
 
         setPublicKey(environment.pending_public_key || environment.public_key);

--- a/packages/webapp/src/types.ts
+++ b/packages/webapp/src/types.ts
@@ -264,7 +264,7 @@ export interface Account {
     always_send_webhook: boolean;
     slack_notifications: boolean;
     websockets_path: string;
-    secret_key_rotatable: boolean;
+    secret_key_rotatable?: boolean;
     env_variables: { id?: number; name: string; value: string }[];
     host: string;
     uuid: string;


### PR DESCRIPTION
## Describe your changes
Rotateable might not be set. Fixes incorrect route introduced by https://github.com/NangoHQ/nango/pull/1987/files#diff-0199d9c354e383165f793ac468f1114e575c42728bf2a704dce1bb153e9c8288L275

## Issue ticket number and link
NAN-905

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
