### PR TITLE
fix(sdk): logging null should not throw an error

### DIFF
--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -533,7 +533,7 @@ export class NangoAction {
         const lastArg = args[args.length - 1];
 
         const isUserDefinedLevel = (object: UserLogParameters): boolean => {
-            return typeof lastArg === 'object' && 'level' in object;
+            return lastArg && typeof lastArg === 'object' && 'level' in object;
         };
 
         const userDefinedLevel: UserLogParameters | undefined = isUserDefinedLevel(lastArg) ? lastArg : undefined;

--- a/packages/shared/lib/sdk/sync.unit.test.ts
+++ b/packages/shared/lib/sdk/sync.unit.test.ts
@@ -365,3 +365,27 @@ describe('Pagination', () => {
         };
     };
 });
+
+describe('Log', () => {
+    it('should not log if no activityLogId', async () => {
+        const nangoAction = new NangoAction({
+            secretKey: '***',
+            providerConfigKey: 'github',
+            connectionId: 'connection-1'
+        });
+        await expect(async () => {
+            await nangoAction.log('top');
+        }).rejects.toThrowError(new Error('There is no current activity log stream to log to'));
+    });
+
+    it('should not fail on null', async () => {
+        const nangoAction = new NangoAction({
+            secretKey: '***',
+            providerConfigKey: 'github',
+            connectionId: 'connection-1',
+            dryRun: true,
+            activityLogId: 1
+        });
+        await nangoAction.log(null);
+    });
+});


### PR DESCRIPTION
## Describe your changes

Fixes NAN-909

- Fix logging null should not throw an error
Added a test but `persistApi` is hard to mock so I had to use dryRun