### PR TITLE
fix(oauth): [nan-934] fix public key lookup

### DIFF
--- a/packages/server/lib/controllers/environment.controller.ts
+++ b/packages/server/lib/controllers/environment.controller.ts
@@ -126,9 +126,22 @@ class EnvironmentController {
             const nangoAdminUUID = NANGO_ADMIN_UUID;
             const env = 'prod';
             const info = await accountService.getAccountAndEnvironmentIdByUUID(nangoAdminUUID as string, env);
-            const digest = await hmacService.digest(info?.environmentId as number, integration_key, connectionId as string);
 
-            res.status(200).send({ hmac_digest: digest, public_key: res.locals['environment'].public_key, integration_key });
+            if (!info) {
+                errorManager.errRes(res, 'account_not_found');
+                return;
+            }
+
+            const digest = await hmacService.digest(info?.environmentId, integration_key, connectionId as string);
+
+            const environment = await environmentService.getById(info?.environmentId);
+
+            if (!environment) {
+                errorManager.errRes(res, 'account_not_found');
+                return;
+            }
+
+            res.status(200).send({ hmac_digest: digest, public_key: environment.public_key, integration_key });
         } catch (err) {
             next(err);
         }

--- a/packages/server/lib/controllers/environment.controller.ts
+++ b/packages/server/lib/controllers/environment.controller.ts
@@ -132,9 +132,9 @@ class EnvironmentController {
                 return;
             }
 
-            const digest = await hmacService.digest(info?.environmentId, integration_key, connectionId as string);
+            const digest = await hmacService.digest(info.environmentId, integration_key, connectionId as string);
 
-            const environment = await environmentService.getById(info?.environmentId);
+            const environment = await environmentService.getById(info.environmentId);
 
             if (!environment) {
                 errorManager.errRes(res, 'account_not_found');


### PR DESCRIPTION
## Describe your changes
When creating a slack connection the hmac key needs to match the key of the Nango admin account not the current user's hmac account. 

This bug was introduced with https://github.com/NangoHQ/nango/pull/2097

## Issue ticket number and link
NAN-934

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
