### PR TITLE
fix(temporal): handle error outside the scripts

### DIFF
--- a/packages/jobs/lib/activities.ts
+++ b/packages/jobs/lib/activities.ts
@@ -23,7 +23,7 @@ import {
     getLastSyncDate
 } from '@nangohq/shared';
 import { records as recordsService } from '@nangohq/records';
-import { getLogger, env, stringifyError } from '@nangohq/utils';
+import { getLogger, env, stringifyError, errorToObject } from '@nangohq/utils';
 import { BigQueryClient } from '@nangohq/data-ingestion/dist/index.js';
 import integrationService from './integration.service.js';
 import type { ContinuousSyncArgs, InitialSyncArgs, ActionArgs, WebhookArgs } from './models/worker';
@@ -430,7 +430,7 @@ export async function reportFailure(
         name,
         connectionId: nangoConnection?.connection_id,
         providerConfigKey: nangoConnection?.provider_config_key,
-        error: stringifyError(error),
+        error: JSON.stringify(errorToObject(error)), // temporal is wrapping error with an exotic class that is not Error
         info: JSON.stringify(context.info),
         workflowId: context.info.workflowExecution.workflowId,
         runId: context.info.workflowExecution.runId,

--- a/packages/jobs/lib/workflows.ts
+++ b/packages/jobs/lib/workflows.ts
@@ -1,6 +1,8 @@
+import type { ActivityFailure } from '@temporalio/workflow';
 import { CancellationScope, proxyActivities, isCancellation } from '@temporalio/workflow';
 import type * as activities from './activities.js';
 import type { WebhookArgs, ContinuousSyncArgs, InitialSyncArgs, ActionArgs } from './models/worker';
+import type { RunnerOutput } from '@nangohq/shared';
 
 const SYNC_TIMEOUT = '24h';
 const SYNC_MAX_ATTEMPTS = 3;
@@ -19,7 +21,7 @@ const { routeSync, scheduleAndRouteSync } = proxyActivities<typeof activities>({
     },
     heartbeatTimeout: '30m'
 });
-const { runAction } = proxyActivities<typeof activities>({
+const { runAction, reportFailure: reportActionFailure } = proxyActivities<typeof activities>({
     // actions are more time sensitive, hence shorter timeout
     // actions are synchronous so no retry and fast eviction from the queue
     scheduleToStartTimeout: '1m',
@@ -79,21 +81,29 @@ export async function continuousSync(args: ContinuousSyncArgs): Promise<boolean 
     }
 }
 
-export async function action(args: ActionArgs): Promise<object> {
+export async function action(args: ActionArgs): Promise<RunnerOutput> {
     try {
         return await runAction(args);
-    } catch (e) {
-        await reportFailure(e, args, ACTION_TIMEOUT, ACTION_MAX_ATTEMPTS);
+    } catch (err) {
+        await reportActionFailure(err, args, ACTION_TIMEOUT, ACTION_MAX_ATTEMPTS);
 
-        return { success: false };
+        return {
+            success: false,
+            error: {
+                type: 'nango_internal_error',
+                status: 500,
+                payload: { message: (err as ActivityFailure).cause?.message }
+            },
+            response: null
+        };
     }
 }
 
 export async function webhook(args: WebhookArgs): Promise<boolean> {
     try {
         return await runWebhook(args);
-    } catch (e) {
-        await reportFailure(e, args, WEBHOOK_TIMEOUT, WEBHOOK_MAX_ATTEMPTS);
+    } catch (err) {
+        await reportFailure(err, args, WEBHOOK_TIMEOUT, WEBHOOK_MAX_ATTEMPTS);
 
         return false;
     }

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -425,12 +425,11 @@ class SyncController {
                 return;
             } else {
                 span.setTag('nango.error', actionResponse.error);
-                errorManager.errResFromNangoErr(res, actionResponse.error);
                 await logCtx.error('Failed to trigger action', { error: actionResponse.error });
                 await logCtx.failed();
-                span.finish();
 
-                next(actionResponse.error);
+                errorManager.errResFromNangoErr(res, actionResponse.error);
+                span.finish();
                 return;
             }
         } catch (err) {

--- a/packages/shared/lib/clients/sync.client.ts
+++ b/packages/shared/lib/clients/sync.client.ts
@@ -588,7 +588,6 @@ class SyncClient {
 
             // Errors received from temporal are raw objects not classes
             const error = rawError ? new NangoError(rawError['type'], rawError['payload'], rawError['status']) : rawError;
-
             if (!success || error) {
                 if (writeLogs) {
                     if (rawError) {
@@ -606,11 +605,9 @@ class SyncClient {
                         environment_id,
                         activity_log_id: activityLogId,
                         timestamp: Date.now(),
-                        content: `The action workflow ${workflowId} did not complete successfully ${JSON.stringify(response, null, 2)} ${JSON.stringify(rawError, null, 2)}`
+                        content: `The action workflow ${workflowId} did not complete successfully`
                     });
-                    await logCtx.error(
-                        `The action workflow ${workflowId} did not complete successfully ${JSON.stringify(response, null, 2)} ${JSON.stringify(rawError, null, 2)}`
-                    );
+                    await logCtx.error(`The action workflow ${workflowId} did not complete successfully`);
                 }
 
                 return Err(error!);
@@ -647,11 +644,11 @@ class SyncClient {
             );
 
             return Ok(response);
-        } catch (e) {
-            const errorMessage = stringifyError(e, { pretty: true });
+        } catch (err) {
+            const errorMessage = stringifyError(err, { pretty: true });
             const error = new NangoError('action_failure', { errorMessage });
 
-            const content = `The action workflow ${workflowId} failed with error: ${e}`;
+            const content = `The action workflow ${workflowId} failed with error: ${err}`;
 
             if (writeLogs) {
                 await createActivityLogMessageAndEnd({
@@ -664,7 +661,7 @@ class SyncClient {
                 await logCtx.error(content);
             }
 
-            errorManager.report(e, {
+            errorManager.report(err, {
                 source: ErrorSourceEnum.PLATFORM,
                 operation: LogActionEnum.SYNC_CLIENT,
                 environmentId: connection.environment_id,

--- a/packages/shared/lib/utils/error.manager.ts
+++ b/packages/shared/lib/utils/error.manager.ts
@@ -127,10 +127,12 @@ class ErrorManager {
         if (err) {
             logger.error(`Response error: ${JSON.stringify({ statusCode: err.status, type: err.type, payload: err.payload, message: err.message })}`);
             if (!err.message) {
-                res.status(err.status || 500).send({ type: err.type, payload: err.payload });
+                res.status(err.status || 500).send({ type: err.type || 'unknown_error', payload: err.payload });
             } else {
                 res.status(err.status || 500).send({ error: err.message, type: err.type, payload: err.payload });
             }
+        } else {
+            res.status(500).json({ error: { code: 'unknown_empty_error' } });
         }
     }
 


### PR DESCRIPTION
## Context

Fixes NAN-929

There are multiple combined errors that lead to a painful investigation:
- Temporal is wrapping all function in `activities.ts` and try/catch them to report failure but because we added an other layer of try/catch, all tasks are marked as successful. This prevent retry (which is a good thing or not I don't even know anymore) but most importantly it broke the expected return in sync.client.ts
- Sync.client.ts expected `actionHandler` to always have a shape of `{success, error, response}` which was not the case as mentioned. Natively Temporal is re-throwing at the place you wait for a workflow but because of our try/catch it was just returning false (**note**: all our workflows are broken this way but only action and webhooks are awaited like this, I only fixed action because we are replacing everything soon)
- The error should have at least been sent to Datadog, but because of the foreign Temporal object it wasn't stringified properly
- The error that started this investigation `model_schema` in db being broken somehow for this customer (it was missing `field`), I could not reproduce, and a redeploy fixed it.

### Addition Notes
- All our workflows are somewhat broken because we have only partial try/catch (@TBonnin you probably need to think about that with your work)
- In a sync, if any errors happen before the activity log is created (`activities.ts:241`) we have absolutely no trace of a sync execution except in datadog, it should probably be the first step in any task execution. And there are a lot of stuff that can fail.
- Error reporting is unmanageable, we have multiple telemetry.log, errorManager, activities reporting different stuff at different place, in `jobs` and in `server`. We should have --ideally-- one single report in a global try/catch.
- Because we don't have a proper sentry setup, and our Datadog setup only reports Error in span, it's simply impossible to be warned automatically of those errors. 

## Changes

- Correctly stringify the error that is sent to Datadog
- Correctly output foreign error in action 
- Fix double headers sent sync.controller
- Fix errResFromNangoErr not handling error being null
- Remove temp logging

## Test

- Throw an error in `activities.ts:runAction`
- Trigger an action

<img width="1193" alt="Screenshot 2024-05-15 at 18 55 07" src="https://github.com/NangoHQ/nango/assets/1637651/d3cdcf5c-d7a5-4b5e-97ea-2e67e22f1e19">

<img width="1150" alt="Screenshot 2024-05-15 at 18 56 09" src="https://github.com/NangoHQ/nango/assets/1637651/60b85703-3f69-4712-8c3f-be8251eae5b2">

