### PR TITLE
fix(persist): catch invalid payload early

### DIFF
--- a/packages/persist/lib/server.ts
+++ b/packages/persist/lib/server.ts
@@ -59,7 +59,7 @@ const validateRecordsRequest = validateRequest({
     }),
     body: z.object({
         model: z.string(),
-        records: z.any().array().nonempty(),
+        records: z.array(z.object({ id: z.string().max(255).min(1) })).nonempty(),
         providerConfigKey: z.string(),
         connectionId: z.string(),
         activityLogId: z.number()

--- a/packages/persist/lib/server.ts
+++ b/packages/persist/lib/server.ts
@@ -59,7 +59,7 @@ const validateRecordsRequest = validateRequest({
     }),
     body: z.object({
         model: z.string(),
-        records: z.array(z.object({ id: z.string().max(255).min(1) })).nonempty(),
+        records: z.array(z.object({ id: z.union([z.string().max(255).min(1), z.number()]) })).nonempty(),
         providerConfigKey: z.string(),
         connectionId: z.string(),
         activityLogId: z.number()


### PR DESCRIPTION
## Describe your changes

Fixes NAN-958

- **Catch invalid payload early** to prevent accidental crash on id too big


The display is suboptimal but at least is readable

**id too big**
<img width="1222" alt="Screenshot 2024-05-16 at 10 35 51" src="https://github.com/NangoHQ/nango/assets/1637651/3ae3820b-87d4-4cbf-ac02-da34fe35c9f6">


**invalid object**
<img width="1232" alt="Screenshot 2024-05-16 at 10 34 42" src="https://github.com/NangoHQ/nango/assets/1637651/9d4a9d1f-a71d-415a-bb40-dfa07dc78ef8">
 