### PR TITLE
fix(getSyncs): should not join on action

### DIFF
--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -259,6 +259,7 @@ export const getSyncs = async (nangoConnection: Connection): Promise<(Sync & { s
             this.on(`${SYNC_CONFIG_TABLE}.sync_name`, `${TABLE}.name`)
                 .andOn(`${SYNC_CONFIG_TABLE}.deleted`, '=', db.knex.raw('FALSE'))
                 .andOn(`${SYNC_CONFIG_TABLE}.active`, '=', db.knex.raw('TRUE'))
+                .andOn(`${SYNC_CONFIG_TABLE}.type`, '=', db.knex.raw('?', 'sync'))
                 .andOn(`${SYNC_CONFIG_TABLE}.nango_config_id`, '=', db.knex.raw('?', [nangoConnection.config_id]));
         })
         .join('_nango_connections', '_nango_connections.id', `${TABLE}.nango_connection_id`)


### PR DESCRIPTION
## Describe your changes

Fixes NAN-959

When you have an a sync and an action with the same name the join is invalid. Not sure why we don't have a column `sync_config_id` in `_nango_syncs`