### PR TITLE
fix(webapp): [nan-968] when success if null it has a specific status

### DIFF
--- a/packages/webapp/src/pages/Activity.tsx
+++ b/packages/webapp/src/pages/Activity.tsx
@@ -590,7 +590,7 @@ export default function Activity() {
                                                                         <CheckInCircle className="stroke-green-500" size="32" />
                                                                     </Link>
                                                                 )}
-                                                                {!activity.success && (
+                                                                {activity.success === false && (
                                                                     <Link
                                                                         to={
                                                                             activity.action === 'sync deploy'

--- a/packages/webapp/src/types.ts
+++ b/packages/webapp/src/types.ts
@@ -18,7 +18,7 @@ export interface ActivityResponse {
         | 'cancel sync'
         | 'action'
         | 'webhook';
-    success: boolean;
+    success: boolean | null;
     timestamp: number;
     start: number;
     end: number;


### PR DESCRIPTION
## Describe your changes
Introduced by https://github.com/NangoHQ/nango/pull/2058/files#diff-161c31ba257cb7eb1000e9f12a039daf622daf838493f93cab7e07f5efa55ff4L573

![image](https://github.com/NangoHQ/nango/assets/1724137/5cf4e22d-91bc-4445-8739-590558357d0a)


Fix incorrect status indicator. Adjust type to be correct. 

## Issue ticket number and link
NAN-968

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
