### PR TITLE
feat(scheduler): all terminated tasks can have an output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33945,6 +33945,7 @@
                 "zod": "3.22.4"
             },
             "devDependencies": {
+                "@nangohq/types": "file:../types",
                 "rimraf": "3.0.2",
                 "vitest": "0.33.0"
             }

--- a/packages/orchestrator/lib/client.integration.test.ts
+++ b/packages/orchestrator/lib/client.integration.test.ts
@@ -33,94 +33,102 @@ describe('OrchestratorClient', async () => {
         await dbClient.clearDatabase();
     });
 
-    it('should schedule immediate task', async () => {
-        const groupKey = 'groupA';
-        const res = (
-            await client.schedule({
-                name: 'Task',
-                groupKey: groupKey,
-                retry: { count: 3, max: 5 },
-                timeoutSettingsInSecs: {
-                    createdToStarted: 10,
-                    startedToCompleted: 10,
-                    heartbeat: 10
-                },
-                args: {
-                    name: 'Action',
-                    connection: {
-                        id: 1234,
-                        provider_config_key: 'P',
-                        environment_id: 5678
+    describe('schedule', () => {
+        it('should schedule immediate task', async () => {
+            const groupKey = 'groupA';
+            const res = (
+                await client.schedule({
+                    name: 'Task',
+                    groupKey: groupKey,
+                    retry: { count: 3, max: 5 },
+                    timeoutSettingsInSecs: {
+                        createdToStarted: 10,
+                        startedToCompleted: 10,
+                        heartbeat: 10
                     },
-                    activityLogId: 9876,
-                    input: { foo: 'bar' }
-                }
-            })
-        ).unwrap();
-        const tasks = (await scheduler.list({ groupKey })).unwrap();
-        expect(tasks.length).toBe(1);
-        expect(tasks[0]?.id).toBe(res.taskId);
-        expect(tasks[0]?.state).toBe('CREATED');
+                    args: {
+                        name: 'Action',
+                        connection: {
+                            id: 1234,
+                            provider_config_key: 'P',
+                            environment_id: 5678
+                        },
+                        activityLogId: 9876,
+                        input: { foo: 'bar' }
+                    }
+                })
+            ).unwrap();
+            const tasks = (await scheduler.list({ groupKey })).unwrap();
+            expect(tasks.length).toBe(1);
+            expect(tasks[0]?.id).toBe(res.taskId);
+            expect(tasks[0]?.state).toBe('CREATED');
+        });
     });
 
-    it('should execute', async () => {
-        const groupKey = 'groupB';
-        const output = { count: 9 };
+    describe('execute', () => {
+        it('should be successful when task succeed', async () => {
+            const groupKey = 'groupB';
+            const output = { count: 9 };
 
-        const processor = new MockProcessor({
-            groupKey,
-            process: async (task) => {
-                await scheduler.succeed({ taskId: task.id, output });
-            }
-        });
-        try {
-            const res = await client.execute({
-                name: 'Task',
-                groupKey: groupKey,
-                args: {
-                    name: 'Action',
-                    connection: {
-                        id: 1234,
-                        provider_config_key: 'P',
-                        environment_id: 5678
-                    },
-                    activityLogId: 9876,
-                    input: { foo: 'bar' }
+            const processor = new MockProcessor({
+                groupKey,
+                process: async (task) => {
+                    await scheduler.succeed({ taskId: task.id, output });
                 }
             });
-            expect(res.unwrap()).toEqual(output);
-        } finally {
-            processor.stop();
-        }
-    });
-    it('should return an error if execute fails', async () => {
-        const groupKey = 'groupC';
-
-        const processor = new MockProcessor({
-            groupKey,
-            process: async (task) => {
-                await scheduler.fail({ taskId: task.id });
+            try {
+                const res = await client.execute({
+                    name: 'Task',
+                    groupKey: groupKey,
+                    args: {
+                        name: 'Action',
+                        connection: {
+                            id: 1234,
+                            provider_config_key: 'P',
+                            environment_id: 5678
+                        },
+                        activityLogId: 9876,
+                        input: { foo: 'bar' }
+                    }
+                });
+                expect(res.unwrap()).toEqual(output);
+            } finally {
+                processor.stop();
             }
         });
-        try {
-            const res = await client.execute({
-                name: 'Task',
-                groupKey: groupKey,
-                args: {
-                    name: 'Action',
-                    connection: {
-                        id: 1234,
-                        provider_config_key: 'P',
-                        environment_id: 5678
-                    },
-                    activityLogId: 9876,
-                    input: { foo: 'bar' }
+        it('should return an error if task fails', async () => {
+            const groupKey = 'groupC';
+
+            const errorPayload = { message: 'something bad happened' };
+            const processor = new MockProcessor({
+                groupKey,
+                process: async (task) => {
+                    await scheduler.fail({ taskId: task.id, error: errorPayload });
                 }
             });
-            expect(res.isErr()).toBe(true);
-        } finally {
-            processor.stop();
-        }
+            try {
+                const res = await client.execute({
+                    name: 'Task',
+                    groupKey: groupKey,
+                    args: {
+                        name: 'Action',
+                        connection: {
+                            id: 1234,
+                            provider_config_key: 'P',
+                            environment_id: 5678
+                        },
+                        activityLogId: 9876,
+                        input: { foo: 'bar' }
+                    }
+                });
+                expect(res.isOk()).toBe(false);
+                if (res.isErr()) {
+                    expect(res.error.payload).toBe(res.error.payload);
+                }
+            } finally {
+                processor.stop();
+            }
+        });
     });
 });
 

--- a/packages/scheduler/lib/monitor.worker.ts
+++ b/packages/scheduler/lib/monitor.worker.ts
@@ -96,11 +96,13 @@ export class MonitorChild {
         if (expired.isErr()) {
             logger.error(`Error expiring tasks: ${stringifyError(expired.error)}`);
         } else {
-            const taskIds = expired.value.map((t) => t.id);
-            if (taskIds.length > 0 && !this.cancelled) {
-                this.send({ ids: taskIds });
+            if (expired.value.length > 0) {
+                const taskIds = expired.value.map((t) => t.id);
+                if (taskIds.length > 0 && !this.cancelled) {
+                    this.send({ ids: taskIds });
+                }
+                logger.info(`Expired tasks: ${JSON.stringify(expired.value.map((t) => t.id))} `);
             }
-            logger.info(`Expired tasks: ${JSON.stringify(expired.value.map((t) => t.id))} `);
         }
     }
 

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -45,14 +45,14 @@ describe('Scheduler', () => {
     it('should retry failed task if max retries is not reached', async () => {
         const task = await scheduleTask(scheduler, { taskProps: { retryMax: 2, retryCount: 1 } });
         await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 });
-        (await scheduler.fail({ taskId: task.id })).unwrap();
+        (await scheduler.fail({ taskId: task.id, error: { message: 'failure happened' } })).unwrap();
         const retried = (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
         expect(retried.length).toBe(1);
     });
     it('should not retry failed task if reached max retries', async () => {
         const task = await scheduleTask(scheduler, { taskProps: { retryMax: 2, retryCount: 2 } });
         (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
-        (await scheduler.fail({ taskId: task.id })).unwrap();
+        (await scheduler.fail({ taskId: task.id, error: { message: 'failure happened' } })).unwrap();
         const retried = (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
         expect(retried.length).toBe(0);
     });
@@ -73,7 +73,7 @@ describe('Scheduler', () => {
     it('should call callback when task is failed', async () => {
         const task = await scheduleTask(scheduler);
         (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
-        (await scheduler.fail({ taskId: task.id })).unwrap();
+        (await scheduler.fail({ taskId: task.id, error: { message: 'failure happend' } })).unwrap();
         expect(callbacks.FAILED).toHaveBeenCalledOnce();
     });
     it('should call callback when task is succeeded', async () => {
@@ -85,7 +85,7 @@ describe('Scheduler', () => {
     it('should call callback when task is cancelled', async () => {
         const task = await scheduleTask(scheduler);
         (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
-        (await scheduler.cancel({ taskId: task.id })).unwrap();
+        (await scheduler.cancel({ taskId: task.id, reason: 'cancelled by user' })).unwrap();
         expect(callbacks.CANCELLED).toHaveBeenCalledOnce();
     });
     it('should call callback when task is expired', async () => {

--- a/packages/scheduler/lib/types.ts
+++ b/packages/scheduler/lib/types.ts
@@ -2,6 +2,8 @@ import type { TaskProps, taskStates } from './models/tasks';
 import type { JsonValue } from 'type-fest';
 
 export type TaskState = (typeof taskStates)[number];
+export type TaskTerminalState = Exclude<TaskState, 'CREATED' | 'STARTED'>;
+export type TaskNonTerminalState = Exclude<TaskState, TaskTerminalState>;
 
 export interface Task {
     readonly id: string;

--- a/packages/utils/lib/result.ts
+++ b/packages/utils/lib/result.ts
@@ -38,7 +38,7 @@ export function Ok<T, E extends Error>(value: T): Result<T, E> {
 
 export function Err<T, E extends Error>(error: E | string): Result<T, E> {
     return {
-        error: error instanceof Error ? error : (new Error(error) as E),
+        error: typeof error === 'string' ? (new Error(error) as E) : error,
         unwrap: () => {
             throw error as Error;
         },


### PR DESCRIPTION
## Describe your changes

I started with the idea to add an `output` for failed task (the error that caused the failure) but I realized all terminated tasks can have an output. Ex: reason for cancellation, etc...
This commit ensures it is required to set an output when terminating a non successful task

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
