### PR TITLE
fix(server): [nan-990] hosted logic for sync tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "jobs:dev:watch": "npm run dev -w @nangohq/nango-jobs",
         "persist:dev:watch": "npm run dev -w @nangohq/nango-persist",
         "orchestrator:dev:watch": "npm run dev -w @nangohq/nango-orchestrator",
-        "webapp:dev:watch": "cd ./packages/webapp && npm run start:hosted",
+        "webapp:dev:watch": "cd ./packages/webapp && npm run start:local",
         "prepare": "husky install",
         "build:watch": "tsc -b -w --preserveWatchOutput tsconfig.build.json",
         "dev:watch": "npm run -w nango copy:files && npm run build:watch",

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -45,6 +45,7 @@ import {
 import type { LogContext } from '@nangohq/logs';
 import { logContextGetter } from '@nangohq/logs';
 import type { LastAction } from '@nangohq/records';
+import { isHosted } from '@nangohq/utils';
 import { records as recordsService } from '@nangohq/records';
 import type { RequestLocals } from '../utils/express.js';
 
@@ -203,6 +204,11 @@ class SyncController {
                 const error = new NangoError('unknown_connection', { connection_id, provider_config_key, environmentName: environment.name });
                 errorManager.errResFromNangoErr(res, error);
 
+                return;
+            }
+
+            if (isHosted) {
+                res.send([]);
                 return;
             }
 

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -8,6 +8,7 @@
         "test": "DISABLE_ESLINT_PLUGIN=true react-scripts test",
         "eject": "DISABLE_ESLINT_PLUGIN=true react-scripts eject",
         "start:hosted": "env-cmd -f .env.hosted npm run start",
+        "start:local": "env-cmd -f .env.local npm run start",
         "start:staging": "env-cmd -f .env.staging npm run start",
         "start:prod": "env-cmd -f .env.prod npm run start",
         "build:hosted": "env-cmd -f .env.hosted npm run build",

--- a/packages/webapp/src/pages/Connection/Show.tsx
+++ b/packages/webapp/src/pages/Connection/Show.tsx
@@ -17,6 +17,7 @@ import Syncs from './Syncs';
 import Authorization from './Authorization';
 import type { SyncResponse, Connection } from '../../types';
 import PageNotFound from '../PageNotFound';
+import { isHosted } from '../../utils/utils';
 
 import { useStore } from '../../store';
 
@@ -65,7 +66,7 @@ export default function ShowIntegration() {
         if (location.hash === '#models' || location.hash === '#syncs') {
             setActiveTab(Tabs.Syncs);
         }
-        if (location.hash === '#authorization') {
+        if (location.hash === '#authorization' || isHosted()) {
             setActiveTab(Tabs.Authorization);
         }
     }, [location]);


### PR DESCRIPTION
## Describe your changes
With https://github.com/NangoHQ/nango/commit/79545622929aa4c3dca94ffb2aa64468e00460ad not having a temporal address throws and on the connection page that causes issues for self hosted. Don't route to that query if running self hosted. Also load the Auth tab if on self hosted since there will be no syncs

## Issue ticket number and link
NAN-990

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
