### PR TITLE
feat(orchestrator): dry run execute action/webhook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32996,6 +32996,7 @@
             "dependencies": {
                 "@nangohq/data-ingestion": "file:../data-ingestion",
                 "@nangohq/logs": "file:../logs",
+                "@nangohq/nango-orchestrator": "file:../orchestrator",
                 "@nangohq/nango-runner": "file:../runner",
                 "@nangohq/records": "file:../records",
                 "@nangohq/shared": "file:../shared",
@@ -33259,6 +33260,7 @@
             "dependencies": {
                 "@hapi/boom": "^10.0.1",
                 "@nangohq/logs": "file:../logs",
+                "@nangohq/nango-orchestrator": "file:../orchestrator",
                 "@nangohq/records": "file:../records",
                 "@nangohq/shared": "file:../shared",
                 "@nangohq/types": "^0.39.30",
@@ -33386,6 +33388,7 @@
             },
             "devDependencies": {
                 "@nangohq/logs": "file:../logs",
+                "@nangohq/nango-orchestrator": "file:../orchestrator",
                 "@nangohq/records": "file:../records",
                 "@nangohq/types": "^0.39.30",
                 "@octokit/types": "^9.2.1",

--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -197,6 +197,13 @@ class DryRunService {
                 return Promise.resolve([]);
             }
         };
+        // dry-run is not scheduling any tasks so we can safely mock the orchestrator client
+        const orchestratorClient = {
+            execute: () => {
+                return Promise.resolve({}) as any;
+            }
+        };
+
         const logContextGetter = {
             create: () => {
                 return Promise.resolve({}) as any;
@@ -209,6 +216,7 @@ class DryRunService {
         const syncRun = new syncRunService({
             integrationService,
             recordsService,
+            orchestratorClient,
             dryRunService: new DryRunService(environment, true),
             logContextGetter,
             writeToDb: false,

--- a/packages/jobs/Dockerfile
+++ b/packages/jobs/Dockerfile
@@ -16,6 +16,7 @@ COPY packages/data-ingestion/ packages/data-ingestion/
 COPY packages/jobs/ packages/jobs/
 COPY packages/logs/ packages/logs/
 COPY packages/runner/ packages/runner/
+COPY packages/orchestrator/ packages/orchestrator/
 COPY package*.json ./
 
 RUN npm pkg delete scripts.prepare

--- a/packages/jobs/lib/activities.ts
+++ b/packages/jobs/lib/activities.ts
@@ -20,7 +20,8 @@ import {
     LogTypes,
     isInitialSyncStillRunning,
     getSyncByIdAndName,
-    getLastSyncDate
+    getLastSyncDate,
+    getOrchestratorUrl
 } from '@nangohq/shared';
 import { records as recordsService } from '@nangohq/records';
 import { getLogger, env, stringifyError, errorToObject } from '@nangohq/utils';
@@ -29,6 +30,7 @@ import integrationService from './integration.service.js';
 import type { ContinuousSyncArgs, InitialSyncArgs, ActionArgs, WebhookArgs } from './models/worker';
 import type { LogContext } from '@nangohq/logs';
 import { logContextGetter } from '@nangohq/logs';
+import { OrchestratorClient } from '@nangohq/nango-orchestrator';
 
 const logger = getLogger('Jobs');
 
@@ -36,6 +38,8 @@ const bigQueryClient = await BigQueryClient.createInstance({
     datasetName: 'raw',
     tableName: `${env}_script_runs`
 });
+
+const orchestratorClient = new OrchestratorClient({ baseUrl: getOrchestratorUrl() });
 
 export async function routeSync(args: InitialSyncArgs): Promise<boolean | object | null> {
     const { syncId, syncJobId, syncName, nangoConnection, debug } = args;
@@ -65,6 +69,7 @@ export async function runAction(args: ActionArgs): Promise<ServiceResponse> {
         bigQueryClient,
         integrationService,
         recordsService,
+        orchestratorClient,
         logContextGetter,
         writeToDb: true,
         nangoConnection,
@@ -274,6 +279,7 @@ export async function syncProvider(
             integrationService,
             recordsService,
             logContextGetter,
+            orchestratorClient,
             writeToDb: true,
             syncId,
             syncJobId,
@@ -368,6 +374,7 @@ export async function runWebhook(args: WebhookArgs): Promise<boolean> {
         integrationService,
         recordsService,
         logContextGetter,
+        orchestratorClient,
         writeToDb: true,
         nangoConnection,
         syncJobId: syncJobId?.id as number,
@@ -463,6 +470,7 @@ export async function cancelActivity(workflowArguments: InitialSyncArgs | Contin
             bigQueryClient,
             integrationService,
             recordsService,
+            orchestratorClient,
             logContextGetter,
             writeToDb: true,
             syncId,

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -17,6 +17,7 @@
     "dependencies": {
         "@nangohq/data-ingestion": "file:../data-ingestion",
         "@nangohq/logs": "file:../logs",
+        "@nangohq/nango-orchestrator": "file:../orchestrator",
         "@nangohq/nango-runner": "file:../runner",
         "@nangohq/shared": "file:../shared",
         "@nangohq/records": "file:../records",

--- a/packages/jobs/tsconfig.json
+++ b/packages/jobs/tsconfig.json
@@ -22,6 +22,9 @@
         },
         {
             "path": "../data-ingestion"
+        },
+        {
+            "path": "../orchestrator"
         }
     ],
     "include": ["lib/**/*"]

--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -20,17 +20,17 @@ try {
     const scheduler = new Scheduler({
         dbClient,
         on: {
-            CREATED: (task) => console.log(`Task ${task.id} created`),
-            STARTED: (task) => console.log(`Task ${task.id} started`),
-            SUCCEEDED: (task) => console.log(`Task ${task.id} succeeded`),
-            FAILED: (task) => console.log(`Task ${task.id} failed`),
-            EXPIRED: (task) => console.log(`Task ${task.id} expired`),
-            CANCELLED: (task) => console.log(`Task ${task.id} cancelled`)
+            CREATED: (task) => console.log(`Task created: ${JSON.stringify(task)}`),
+            STARTED: (task) => console.log(`Task started: ${JSON.stringify(task)}`),
+            SUCCEEDED: (task) => console.log(`Task succeeded: ${JSON.stringify(task)}`),
+            FAILED: (task) => console.log(`Task failed: ${JSON.stringify(task)}`),
+            EXPIRED: (task) => console.log(`Task expired: ${JSON.stringify(task)}`),
+            CANCELLED: (task) => console.log(`Task cancelled: ${JSON.stringify(task)}`)
         }
     });
 
-    const port = envs.NANGO_ORCHESTRATOR_PORT;
     const server = getServer({ scheduler });
+    const port = envs.NANGO_ORCHESTRATOR_PORT;
     server.listen(port, () => {
         logger.info(`🚀 Orchestrator API ready at http://localhost:${port}`);
     });

--- a/packages/orchestrator/lib/routes/v1/schedule.ts
+++ b/packages/orchestrator/lib/routes/v1/schedule.ts
@@ -22,16 +22,7 @@ type Schedule = Endpoint<{
             startedToCompleted: number;
             heartbeat: number;
         };
-        args: {
-            name: string;
-            connection: {
-                id: number;
-                provider_config_key: string;
-                environment_id: number;
-            };
-            activityLogId: number;
-            input: JsonValue;
-        };
+        args: JsonValue;
     };
     Error: ApiError<'schedule_failed'>;
     Success: { taskId: string };

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -17,6 +17,7 @@ COPY packages/utils/ packages/utils/
 COPY packages/logs/ packages/logs/
 COPY packages/node-client/ packages/node-client/
 COPY packages/records/ packages/records/
+COPY packages/orchestrator/ packages/orchestrator/
 
 RUN npm pkg delete scripts.prepare
 RUN npm ci --omit=dev

--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -24,13 +24,14 @@ import {
     NangoError,
     createActivityLogAndLogMessage,
     accountService,
-    slackNotificationService
+    SlackService
 } from '@nangohq/shared';
 import { NANGO_ADMIN_UUID } from './account.controller.js';
 import { metrics } from '@nangohq/utils';
 import { logContextGetter } from '@nangohq/logs';
 import type { RequestLocals } from '../utils/express.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationStartCapCheck as connectionCreationStartCapCheckHook } from '../hooks/hooks.js';
+import { getOrchestratorClient } from '../utils/utils.js';
 
 class ConnectionController {
     /**
@@ -431,6 +432,7 @@ class ConnectionController {
 
             await connectionService.deleteConnection(connection, integration_key, info?.environmentId as number);
 
+            const slackNotificationService = new SlackService(getOrchestratorClient());
             await slackNotificationService.closeAllOpenNotifications(environment.id);
 
             res.status(204).send();

--- a/packages/server/lib/controllers/onboarding.controller.ts
+++ b/packages/server/lib/controllers/onboarding.controller.ts
@@ -25,7 +25,9 @@ import {
     createActivityLog,
     LogActionEnum,
     analytics,
-    AnalyticsTypes
+    AnalyticsTypes,
+    getOrchestratorUrl,
+    Orchestrator
 } from '@nangohq/shared';
 import type { IncomingPreBuiltFlowConfig } from '@nangohq/shared';
 import { getLogger } from '@nangohq/utils';
@@ -34,6 +36,7 @@ import { logContextGetter } from '@nangohq/logs';
 import { records as recordsService } from '@nangohq/records';
 import type { GetOnboardingStatus } from '@nangohq/types';
 import type { RequestLocals } from '../utils/express.js';
+import { OrchestratorClient } from '@nangohq/nango-orchestrator';
 
 const logger = getLogger('Server.Onboarding');
 
@@ -426,7 +429,8 @@ class OnboardingController {
                     connection: { id: connection.id!, name: connection.connection_id }
                 }
             );
-            const actionResponse = await syncClient.triggerAction({
+            const orchestrator = new Orchestrator(new OrchestratorClient({ baseUrl: getOrchestratorUrl() }));
+            const actionResponse = await orchestrator.triggerAction({
                 connection,
                 actionName: DEMO_ACTION_NAME,
                 input: { title: req.body.title },

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -48,6 +48,7 @@ import type { LastAction } from '@nangohq/records';
 import { isHosted } from '@nangohq/utils';
 import { records as recordsService } from '@nangohq/records';
 import type { RequestLocals } from '../utils/express.js';
+import { getOrchestrator } from '../utils/utils.js';
 
 class SyncController {
     public async deploySync(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
@@ -414,7 +415,7 @@ class SyncController {
                 throw new NangoError('failed_to_get_sync_client');
             }
 
-            const actionResponse = await syncClient.triggerAction({
+            const actionResponse = await getOrchestrator().triggerAction({
                 connection,
                 actionName: action_name,
                 input,

--- a/packages/server/lib/utils/utils.ts
+++ b/packages/server/lib/utils/utils.ts
@@ -5,7 +5,8 @@ import type { User, Template as ProviderTemplate } from '@nangohq/shared';
 import type { Result } from '@nangohq/utils';
 import { getLogger, Err, Ok } from '@nangohq/utils';
 import type { WSErr } from './web-socket-error.js';
-import { NangoError, userService, interpolateString } from '@nangohq/shared';
+import { NangoError, userService, interpolateString, Orchestrator, getOrchestratorUrl } from '@nangohq/shared';
+import { OrchestratorClient } from '@nangohq/nango-orchestrator';
 
 const logger = getLogger('Server.Utils');
 
@@ -332,4 +333,12 @@ Nango OAuth flow callback. Read more about how to use it at: https://github.com/
 
 export function resetPasswordSecret() {
     return process.env['NANGO_ADMIN_KEY'] || 'nango';
+}
+
+export function getOrchestratorClient() {
+    return new OrchestratorClient({ baseUrl: getOrchestratorUrl() });
+}
+
+export function getOrchestrator() {
+    return new Orchestrator(getOrchestratorClient());
 }

--- a/packages/server/lib/webhook/internal-nango.ts
+++ b/packages/server/lib/webhook/internal-nango.ts
@@ -1,7 +1,8 @@
 import get from 'lodash-es/get.js';
-import { environmentService, connectionService, telemetry, getSyncConfigsByConfigIdForWebhook, SyncClient, LogActionEnum, LogTypes } from '@nangohq/shared';
+import { environmentService, connectionService, telemetry, getSyncConfigsByConfigIdForWebhook, LogActionEnum, LogTypes } from '@nangohq/shared';
 import type { Config as ProviderConfig, SyncConfig, Connection } from '@nangohq/shared';
 import type { LogContextGetter } from '@nangohq/logs';
+import { getOrchestrator } from '../utils/utils.js';
 
 export interface InternalNango {
     getWebhooks: (environment_id: number, nango_config_id: number) => Promise<SyncConfig[]>;
@@ -98,7 +99,6 @@ export const internalNango: InternalNango = {
             connectionIds: connections.map((connection) => connection.connection_id).join(',')
         });
 
-        const syncClient = await SyncClient.getInstance();
         const type = get(body, webhookType);
 
         for (const syncConfig of syncConfigsWithWebhooks) {
@@ -111,7 +111,7 @@ export const internalNango: InternalNango = {
             for (const webhook of webhook_subscriptions) {
                 if (type === webhook) {
                     for (const connection of connections) {
-                        await syncClient?.triggerWebhook(integration, connection, webhook, syncConfig.sync_name, body, logContextGetter);
+                        await getOrchestrator().triggerWebhook(integration, connection, webhook, syncConfig.sync_name, body, logContextGetter);
                     }
                 }
             }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,6 +25,7 @@
     "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@nangohq/logs": "file:../logs",
+        "@nangohq/nango-orchestrator": "file:../orchestrator",
         "@nangohq/records": "file:../records",
         "@nangohq/shared": "file:../shared",
         "@nangohq/types": "^0.39.30",

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -22,6 +22,9 @@
         },
         {
             "path": "../records"
+        },
+        {
+            "path": "../orchestrator"
         }
     ],
     "include": ["lib/**/*", "../shared/lib/express.d.ts", "../utils/lib/vitest.d.ts"]

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -1,0 +1,406 @@
+import type { LogContext, LogContextGetter } from '@nangohq/logs';
+import { Err, Ok, stringifyError, metrics, getLogger } from '@nangohq/utils';
+import type { Result } from '@nangohq/utils';
+import { NangoError } from '../utils/error.js';
+import telemetry, { LogTypes } from '../utils/telemetry.js';
+import type { RunnerOutput } from '../models/Runner.js';
+import type { NangoConnection, Connection as NangoFullConnection } from '../models/Connection.js';
+import {
+    createActivityLog,
+    createActivityLogMessage,
+    createActivityLogMessageAndEnd,
+    updateSuccess as updateSuccessActivityLog
+} from '../services/activity/activity.service.js';
+import { SYNC_TASK_QUEUE, WEBHOOK_TASK_QUEUE } from '../constants.js';
+import { v4 as uuid } from 'uuid';
+import featureFlags from '../utils/featureflags.js';
+import errorManager, { ErrorSourceEnum } from '../utils/error.manager.js';
+import type { Config as ProviderConfig } from '../models/Provider.js';
+import type { LogLevel } from '@nangohq/types';
+import SyncClient from './sync.client.js';
+import type { Client as TemporalClient } from '@temporalio/client';
+import { LogActionEnum } from '../models/Activity.js';
+import type { TExecuteReturn, TExecuteProps } from '@nangohq/nango-orchestrator';
+
+const logger = getLogger('orchestrator.client');
+
+async function getTemporal(): Promise<TemporalClient> {
+    const instance = await SyncClient.getInstance();
+    if (!instance) {
+        throw new Error('Temporal client not initialized');
+    }
+    return instance.getClient() as TemporalClient;
+}
+
+export interface OrchestratorClientInterface {
+    execute(props: TExecuteProps): Promise<TExecuteReturn>;
+}
+
+export class Orchestrator {
+    private client: OrchestratorClientInterface;
+
+    public constructor(client: OrchestratorClientInterface) {
+        this.client = client;
+    }
+
+    async triggerAction<T = any>({
+        connection,
+        actionName,
+        input,
+        activityLogId,
+        environment_id,
+        writeLogs = true,
+        logCtx
+    }: {
+        connection: NangoConnection;
+        actionName: string;
+        input: object;
+        activityLogId: number;
+        environment_id: number;
+        writeLogs?: boolean;
+        logCtx: LogContext;
+    }): Promise<Result<T, NangoError>> {
+        const startTime = Date.now();
+        const workflowId = `${SYNC_TASK_QUEUE}.ACTION:${actionName}.${connection.connection_id}.${uuid()}`;
+        try {
+            if (writeLogs) {
+                await createActivityLogMessage({
+                    level: 'info',
+                    environment_id,
+                    activity_log_id: activityLogId,
+                    content: `Starting action workflow ${workflowId} in the task queue: ${SYNC_TASK_QUEUE}`,
+                    params: {
+                        input: JSON.stringify(input, null, 2)
+                    },
+                    timestamp: Date.now()
+                });
+                await logCtx.info(`Starting action workflow ${workflowId} in the task queue: ${SYNC_TASK_QUEUE}`, { input: JSON.stringify(input, null, 2) });
+            }
+
+            // Execute dry-mode: no await for now
+            const groupKey: string = 'action';
+            this.dryExecute({
+                executionId: `${groupKey}:environment:${connection.environment_id}:connection:${connection.id}:action:${actionName}:at:${new Date().toISOString()}:${uuid()}`,
+                groupKey,
+                args: {
+                    name: actionName,
+                    connection: {
+                        id: connection.id!,
+                        provider_config_key: connection.provider_config_key,
+                        environment_id: connection.environment_id
+                    },
+                    activityLogId,
+                    input: input
+                }
+            });
+
+            const temporal = await getTemporal();
+            const actionHandler = await temporal.workflow.execute('action', {
+                taskQueue: SYNC_TASK_QUEUE,
+                workflowId,
+                args: [
+                    {
+                        actionName,
+                        nangoConnection: {
+                            id: connection.id,
+                            connection_id: connection.connection_id,
+                            provider_config_key: connection.provider_config_key,
+                            environment_id: connection.environment_id
+                        },
+                        input,
+                        activityLogId: writeLogs ? activityLogId : undefined
+                    }
+                ]
+            });
+
+            const { success, error: rawError, response }: RunnerOutput = actionHandler;
+
+            // Errors received from temporal are raw objects not classes
+            const error = rawError ? new NangoError(rawError['type'], rawError['payload'], rawError['status']) : rawError;
+            if (!success || error) {
+                if (writeLogs) {
+                    if (rawError) {
+                        await createActivityLogMessageAndEnd({
+                            level: 'error',
+                            environment_id,
+                            activity_log_id: activityLogId,
+                            timestamp: Date.now(),
+                            content: `Failed with error ${rawError['type']} ${JSON.stringify(rawError['payload'])}`
+                        });
+                        await logCtx.error(`Failed with error ${rawError['type']} ${JSON.stringify(rawError['payload'])}`);
+                    }
+                    await createActivityLogMessageAndEnd({
+                        level: 'error',
+                        environment_id,
+                        activity_log_id: activityLogId,
+                        timestamp: Date.now(),
+                        content: `The action workflow ${workflowId} did not complete successfully`
+                    });
+                    await logCtx.error(`The action workflow ${workflowId} did not complete successfully`);
+                }
+
+                return Err(error!);
+            }
+
+            const content = `The action workflow ${workflowId} was successfully run. A truncated response is: ${JSON.stringify(response, null, 2)?.slice(0, 100)}`;
+
+            if (writeLogs) {
+                await createActivityLogMessageAndEnd({
+                    level: 'info',
+                    environment_id,
+                    activity_log_id: activityLogId,
+                    timestamp: Date.now(),
+                    content
+                });
+                await updateSuccessActivityLog(activityLogId, true);
+                await logCtx.info(content);
+            }
+
+            await telemetry.log(
+                LogTypes.ACTION_SUCCESS,
+                content,
+                LogActionEnum.ACTION,
+                {
+                    workflowId,
+                    input: JSON.stringify(input, null, 2),
+                    connection: JSON.stringify(connection),
+                    actionName
+                },
+                `actionName:${actionName}`
+            );
+
+            return Ok(response);
+        } catch (err) {
+            const errorMessage = stringifyError(err, { pretty: true });
+            const error = new NangoError('action_failure', { errorMessage });
+
+            const content = `The action workflow ${workflowId} failed with error: ${err}`;
+
+            if (writeLogs) {
+                await createActivityLogMessageAndEnd({
+                    level: 'error',
+                    environment_id,
+                    activity_log_id: activityLogId,
+                    timestamp: Date.now(),
+                    content
+                });
+                await logCtx.error(content);
+            }
+
+            errorManager.report(err, {
+                source: ErrorSourceEnum.PLATFORM,
+                operation: LogActionEnum.SYNC_CLIENT,
+                environmentId: connection.environment_id,
+                metadata: {
+                    actionName,
+                    connectionDetails: JSON.stringify(connection),
+                    input
+                }
+            });
+
+            await telemetry.log(
+                LogTypes.ACTION_FAILURE,
+                content,
+                LogActionEnum.ACTION,
+                {
+                    workflowId,
+                    input: JSON.stringify(input, null, 2),
+                    connection: JSON.stringify(connection),
+                    actionName,
+                    level: 'error'
+                },
+                `actionName:${actionName}`
+            );
+
+            return Err(error);
+        } finally {
+            const endTime = Date.now();
+            const totalRunTime = (endTime - startTime) / 1000;
+            metrics.duration(metrics.Types.ACTION_TRACK_RUNTIME, totalRunTime);
+        }
+    }
+
+    async triggerWebhook<T = any>(
+        integration: ProviderConfig,
+        connection: NangoConnection,
+        webhookName: string,
+        parentSyncName: string,
+        input: object,
+        logContextGetter: LogContextGetter
+    ): Promise<Result<T, NangoError>> {
+        const log = {
+            level: 'info' as LogLevel,
+            success: null,
+            action: LogActionEnum.WEBHOOK,
+            start: Date.now(),
+            end: Date.now(),
+            timestamp: Date.now(),
+            connection_id: connection.connection_id,
+            provider_config_key: connection.provider_config_key,
+            provider: integration.provider,
+            environment_id: connection.environment_id,
+            operation_name: webhookName
+        };
+
+        const activityLogId = await createActivityLog(log);
+        const logCtx = await logContextGetter.create(
+            { id: String(activityLogId), operation: { type: 'webhook', action: 'incoming' }, message: 'Received a webhook' },
+            {
+                account: { id: connection.account_id! },
+                environment: { id: integration.environment_id },
+                config: { id: integration.id!, name: integration.unique_key },
+                connection: { id: connection.id!, name: connection.connection_id }
+            }
+        );
+
+        const workflowId = `${WEBHOOK_TASK_QUEUE}.WEBHOOK:${parentSyncName}:${webhookName}.${connection.connection_id}.${Date.now()}`;
+
+        try {
+            await createActivityLogMessage({
+                level: 'info',
+                environment_id: integration.environment_id,
+                activity_log_id: activityLogId as number,
+                content: `Starting webhook workflow ${workflowId} in the task queue: ${WEBHOOK_TASK_QUEUE}`,
+                params: {
+                    input: JSON.stringify(input, null, 2)
+                },
+                timestamp: Date.now()
+            });
+            await logCtx.info('Starting webhook workflow', { workflowId, input });
+
+            const { credentials, credentials_iv, credentials_tag, deleted, deleted_at, ...nangoConnectionWithoutCredentials } =
+                connection as unknown as NangoFullConnection;
+
+            // Execute dry-mode: no await for now
+            const groupKey: string = 'webhook';
+            this.dryExecute({
+                executionId: `${groupKey}:environment:${connection.environment_id}:connection:${connection.id}:webhook:${webhookName}:at:${new Date().toISOString()}:${uuid()}`,
+                groupKey,
+                args: {
+                    name: webhookName,
+                    parentSyncName,
+                    connection: {
+                        id: connection.id!,
+                        provider_config_key: connection.provider_config_key,
+                        environment_id: connection.environment_id
+                    },
+                    input,
+                    activityLogId
+                }
+            });
+
+            const temporal = await getTemporal();
+            const webhookHandler = await temporal.workflow.execute('webhook', {
+                taskQueue: WEBHOOK_TASK_QUEUE,
+                workflowId,
+                args: [
+                    {
+                        name: webhookName,
+                        parentSyncName,
+                        nangoConnection: nangoConnectionWithoutCredentials,
+                        input,
+                        activityLogId
+                    }
+                ]
+            });
+
+            const { success, error, response } = webhookHandler;
+
+            if (success === false || error) {
+                await createActivityLogMessageAndEnd({
+                    level: 'error',
+                    environment_id: integration.environment_id,
+                    activity_log_id: activityLogId as number,
+                    timestamp: Date.now(),
+                    content: `The webhook workflow ${workflowId} did not complete successfully`
+                });
+                await logCtx.error('The webhook workflow did not complete successfully');
+                await logCtx.failed();
+
+                return Err(error);
+            }
+
+            await createActivityLogMessageAndEnd({
+                level: 'info',
+                environment_id: integration.environment_id,
+                activity_log_id: activityLogId as number,
+                timestamp: Date.now(),
+                content: `The webhook workflow ${workflowId} was successfully run.`
+            });
+            await logCtx.info('The webhook workflow was successfully run');
+            await logCtx.success();
+
+            await updateSuccessActivityLog(activityLogId as number, true);
+
+            return Ok(response);
+        } catch (e) {
+            const errorMessage = stringifyError(e, { pretty: true });
+            const error = new NangoError('webhook_script_failure', { errorMessage });
+
+            await createActivityLogMessageAndEnd({
+                level: 'error',
+                environment_id: integration.environment_id,
+                activity_log_id: activityLogId as number,
+                timestamp: Date.now(),
+                content: `The webhook workflow ${workflowId} failed with error: ${errorMessage}`
+            });
+            await logCtx.error('The webhook workflow failed', { error: e });
+            await logCtx.failed();
+
+            errorManager.report(e, {
+                source: ErrorSourceEnum.PLATFORM,
+                operation: LogActionEnum.SYNC_CLIENT,
+                environmentId: connection.environment_id,
+                metadata: {
+                    parentSyncName,
+                    webhookName,
+                    connectionDetails: JSON.stringify(connection),
+                    input
+                }
+            });
+
+            return Err(error);
+        }
+    }
+    // TODO: remove once Temporal has been removed
+    private async dryExecute({ executionId, groupKey, args }: { executionId: string; groupKey: string; args: Record<string, any> }): Promise<void> {
+        const isEnabled = await featureFlags.isEnabled('orchestrator:dryrun', 'global', false, false);
+        if (!isEnabled) {
+            return;
+        }
+
+        if ('input' in args) {
+            const { input, ...rest } = args;
+            try {
+                // TODO: make input a JsonValue once Temporal has been removed
+                args = { ...rest, input: JSON.parse(JSON.stringify(input)) };
+            } catch (e: unknown) {
+                const errorMsg = `Execute: Failed to parse input object ${JSON.stringify(input)} to JsonValue: ${stringifyError(e)}`;
+                logger.error(errorMsg);
+            }
+        }
+        return this.client
+            .execute({
+                name: executionId,
+                groupKey,
+                args,
+                timeoutSettingsInSecs: {
+                    createdToStarted: 5,
+                    startedToCompleted: 5,
+                    heartbeat: 10
+                }
+            })
+            .then(
+                (res) => {
+                    if (res.isErr()) {
+                        logger.error(`Error: Execution '${executionId}' failed: ${stringifyError(res.error)}`);
+                    } else {
+                        logger.info(`Execution '${executionId}' executed successfully with result: ${res.value}`);
+                    }
+                },
+                (error) => {
+                    logger.error(`Error: Action '${executionId}' failed: ${stringifyError(error)}`);
+                }
+            );
+    }
+}

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -17,10 +17,11 @@ import proxyService from './services/proxy.service.js';
 import syncRunService from './services/sync/run.service.js';
 import syncOrchestrator, { syncCommandToOperation } from './services/sync/orchestrator.service.js';
 import flowService from './services/flow.service.js';
-import slackNotificationService, { generateSlackConnectionId } from './services/notification/slack.service.js';
 import webhookService from './services/notification/webhook.service.js';
 import analytics, { AnalyticsTypes } from './utils/analytics.js';
 import featureFlags from './utils/featureflags.js';
+import { Orchestrator } from './clients/orchestrator.js';
+import { SlackService, generateSlackConnectionId } from './services/notification/slack.service.js';
 
 export * from './services/activity/activity.service.js';
 export * from './services/sync/sync.service.js';
@@ -70,11 +71,12 @@ export {
     hmacService,
     proxyService,
     flowService,
-    slackNotificationService,
-    generateSlackConnectionId,
     webhookService,
     analytics,
     AnalyticsTypes,
     featureFlags,
-    syncCommandToOperation
+    syncCommandToOperation,
+    Orchestrator,
+    SlackService,
+    generateSlackConnectionId
 };

--- a/packages/shared/lib/services/notification/slack.service.ts
+++ b/packages/shared/lib/services/notification/slack.service.ts
@@ -12,6 +12,8 @@ import connectionService from '../connection.service.js';
 import accountService from '../account.service.js';
 import SyncClient from '../../clients/sync.client.js';
 import type { LogContext, LogContextGetter } from '@nangohq/logs';
+import type { OrchestratorClientInterface } from '../../clients/orchestrator.js';
+import { Orchestrator } from '../../clients/orchestrator.js';
 
 const logger = getLogger('SlackService');
 const TABLE = dbNamespace + 'slack_notifications';
@@ -74,12 +76,17 @@ export const generateSlackConnectionId = (accountUUID: string, environmentName: 
  *      - name
  */
 
-class SlackService {
+export class SlackService {
+    private orchestrator: Orchestrator;
     private actionName = 'flow-result-notifier-action';
     private adminConnectionId = process.env['NANGO_ADMIN_CONNECTION_ID'] || 'admin-slack';
     private integrationKey = process.env['NANGO_SLACK_INTEGRATION_KEY'] || 'slack';
     private nangoAdminUUID = process.env['NANGO_ADMIN_UUID'];
     private env = 'prod';
+
+    constructor(orchestratorClient: OrchestratorClientInterface) {
+        this.orchestrator = new Orchestrator(orchestratorClient);
+    }
 
     /**
      * Get Nango Admin Connection
@@ -146,7 +153,7 @@ class SlackService {
             payload.ts = ts;
         }
 
-        const actionResponse = await syncClient.triggerAction<SlackActionResponse>({
+        const actionResponse = await this.orchestrator.triggerAction<SlackActionResponse>({
             connection: nangoAdminConnection,
             actionName: this.actionName,
             input: payload,
@@ -303,7 +310,7 @@ class SlackService {
             return;
         }
 
-        const actionResponse = await syncClient.triggerAction<SlackActionResponse>({
+        const actionResponse = await this.orchestrator.triggerAction<SlackActionResponse>({
             connection: slackConnection as NangoConnection,
             actionName: this.actionName,
             input: payload,
@@ -449,7 +456,7 @@ class SlackService {
             }
         );
 
-        const actionResponse = await syncClient.triggerAction<SlackActionResponse>({
+        const actionResponse = await this.orchestrator.triggerAction<SlackActionResponse>({
             connection: slackConnection as NangoConnection,
             actionName: this.actionName,
             input: payload,
@@ -670,5 +677,3 @@ class SlackService {
             });
     }
 }
-
-export default new SlackService();

--- a/packages/shared/lib/services/sync/orchestrator.service.ts
+++ b/packages/shared/lib/services/sync/orchestrator.service.ts
@@ -59,7 +59,7 @@ interface CreateSyncArgs {
     syncName: string;
 }
 
-export class Orchestrator {
+export class OrchestratorService {
     public async create(
         connections: Connection[],
         syncName: string,
@@ -528,4 +528,4 @@ export class Orchestrator {
     }
 }
 
-export default new Orchestrator();
+export default new OrchestratorService();

--- a/packages/shared/lib/services/sync/run.service.integration.test.ts
+++ b/packages/shared/lib/services/sync/run.service.integration.test.ts
@@ -28,6 +28,12 @@ class integrationServiceMock implements IntegrationServiceInterface {
     }
 }
 
+const orchestratorClient = {
+    execute: () => {
+        return Promise.resolve({}) as any;
+    }
+};
+
 const integrationService = new integrationServiceMock();
 
 describe('Running sync', () => {
@@ -183,7 +189,8 @@ describe('SyncRun', () => {
     it('should initialize correctly', () => {
         const config: SyncRunConfig = {
             integrationService: integrationService as unknown as IntegrationServiceInterface,
-            recordsService: recordsService,
+            recordsService,
+            orchestratorClient,
             logContextGetter,
             writeToDb: true,
             nangoConnection: {
@@ -243,8 +250,9 @@ const runJob = async (
 
     const config: SyncRunConfig = {
         integrationService: integrationService,
-        recordsService: recordsService,
-        logContextGetter: logContextGetter,
+        recordsService,
+        orchestratorClient,
+        logContextGetter,
         writeToDb: true,
         nangoConnection: connection,
         syncName: sync.name,

--- a/packages/shared/lib/services/sync/run.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/run.service.unit.test.ts
@@ -39,11 +39,18 @@ const recordsService = {
     }
 };
 
+const orchestratorClient = {
+    execute: () => {
+        return Promise.resolve({}) as any;
+    }
+};
+
 describe('SyncRun', () => {
     const dryRunConfig: SyncRunConfig = {
         integrationService: integrationService as unknown as IntegrationServiceInterface,
         recordsService,
-        logContextGetter: logContextGetter,
+        orchestratorClient,
+        logContextGetter,
         writeToDb: false,
         nangoConnection: {
             id: 1,
@@ -62,7 +69,8 @@ describe('SyncRun', () => {
         const config: SyncRunConfig = {
             integrationService: integrationService as unknown as IntegrationServiceInterface,
             recordsService,
-            logContextGetter: logContextGetter,
+            orchestratorClient,
+            logContextGetter,
             writeToDb: true,
             nangoConnection: {
                 id: 1,

--- a/packages/shared/lib/utils/utils.ts
+++ b/packages/shared/lib/utils/utils.ts
@@ -93,6 +93,10 @@ export function getRedisUrl() {
     return process.env['NANGO_REDIS_URL'] || undefined;
 }
 
+export function getOrchestratorUrl() {
+    return process.env['ORCHESTRATOR_SERVICE_URL'] || `http://localhost:${process.env['NANGO_ORCHESTRATOR_PORT'] || 3008}`;
+}
+
 export function isValidHttpUrl(str: string) {
     try {
         new URL(str);

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -63,6 +63,7 @@
     "devDependencies": {
         "@nangohq/logs": "file:../logs",
         "@nangohq/records": "file:../records",
+        "@nangohq/nango-orchestrator": "file:../orchestrator",
         "@nangohq/types": "^0.39.30",
         "@octokit/types": "^9.2.1",
         "@types/amqplib": "^0.8.2",

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -19,6 +19,9 @@
         },
         {
             "path": "../records"
+        },
+        {
+            "path": "../orchestrator"
         }
     ],
     "include": ["lib/**/*", "../utils/lib/vitest.d.ts"]


### PR DESCRIPTION
## Describe your changes
With this commit, tasks will be scheduled in the background for each action/webhook. There is no task processor yet so the tasks will end up being expired. The result of the execution is not used, only logged.
The goal is to verify orchestrator is correctly setup

I have moved `triggerAction` and `triggerWebhook` into their own `orchestrator` file. Eventually `SyncClient` and `OrchestratorService` will go away since that's where the logic to deal with temporal is.
I initially though triggering sync could be moved to the server entirely but `triggerAction` is actually used in `run.service` to send Slack notification. I therefore had to inject the orchestratorClient and pass yet another interface in `SyncRunConfig`. We are gonna need to at some point (soon?) rethink `run.service`. I know it is in shared because it is also used by the CLI for dry runs but it has a lot of dependencies and most of them aren't used when running a dry-run (no records writing, no slack notification, no reporting, ...)

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
