### PR TITLE
feat: allow upsert existing basic connection

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -251,12 +251,6 @@ class ConnectionService {
         credentials: BasicApiCredentials | ApiKeyCredentials,
         logContextGetter: LogContextGetter
     ) {
-        const connection = await this.checkIfConnectionExists(connection_id, provider_config_key, environmentId);
-
-        if (connection) {
-            throw new NangoError('connection_already_exists');
-        }
-
         const [importedConnection] = await this.upsertApiConnection(connection_id, provider_config_key, provider, credentials, {}, environmentId, accountId);
 
         if (importedConnection) {


### PR DESCRIPTION
## Describe your changes

Following our conversation with Thomas, we agree that we can allow upsert existing basic connection.

It is already allowed for Oauth2 and ApiKey connection but not for basic credentials.

This PR remove the check which disallow the import of an existing connection with basic credentials.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
