### PR TITLE
fix(yaml): handle optional connectionConfig parameters in provider URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@
 # NANGO_DB_POOL_MIN=<PICK-INT-OR-SKIP>
 # NANGO_DB_POOL_MAX=<PICK-INT-OR-SKIP>
 #
+# RECORDS_DATABASE_URL=${RECORDS_DATABASE_URL:-postgresql://nango:nango@nango-db:5432/nango}
 #
 # - Configure server and worker port (current value is the default for running Nango locally).
 #

--- a/packages/server/lib/utils/utils.unit.test.ts
+++ b/packages/server/lib/utils/utils.unit.test.ts
@@ -1,7 +1,7 @@
 import { expect, describe, it } from 'vitest';
 import { getConnectionMetadataFromTokenResponse, parseConnectionConfigParamsFromTemplate, getAdditionalAuthorizationParams } from './utils.js';
 import type { Template as ProviderTemplate } from '@nangohq/shared';
-import { AuthModes } from '@nangohq/shared';
+import { AuthModes, interpolateString } from '@nangohq/shared';
 
 describe('Utils unit tests', () => {
     it('Should parse config params in authorization_url', () => {
@@ -221,5 +221,13 @@ describe('Utils unit tests', () => {
         expect(result).toEqual({});
         result = getAdditionalAuthorizationParams(undefined);
         expect(result).toEqual({});
+    });
+
+    it('Should place params to string with domain dot awareness', () => {
+        const url = interpolateString('https://${subdomain ?? "hello"}.service.com/oauth/authorize', { subdomain: 'myaccount' });
+        expect(url).toEqual('https://myaccount.service.com/oauth/authorize');
+
+        const url2 = interpolateString('https://${subdomain}.service.com/oauth/authorize', { subdomain: '' });
+        expect(url2).toEqual('https://service.com/oauth/authorize');
     });
 });

--- a/packages/server/lib/utils/utils.unit.test.ts
+++ b/packages/server/lib/utils/utils.unit.test.ts
@@ -224,7 +224,7 @@ describe('Utils unit tests', () => {
     });
 
     it('Should place params to string with domain dot awareness', () => {
-        const url = interpolateString('https://${subdomain ?? "hello"}.service.com/oauth/authorize', { subdomain: 'myaccount' });
+        const url = interpolateString('https://${subdomain}.service.com/oauth/authorize', { subdomain: 'myaccount' });
         expect(url).toEqual('https://myaccount.service.com/oauth/authorize');
 
         const url2 = interpolateString('https://${subdomain}.service.com/oauth/authorize', { subdomain: '' });

--- a/packages/shared/lib/utils/utils.ts
+++ b/packages/shared/lib/utils/utils.ts
@@ -207,9 +207,17 @@ export function getWebsocketsPath(): string {
  * Copied from https://stackoverflow.com/a/1408373/250880
  */
 export function interpolateString(str: string, replacers: Record<string, any>) {
-    return str.replace(/\${([^{}]*)}/g, (a, b) => {
+    return str.replace(/\${([^{}]*)}\.?/g, (a, b) => {
         const r = replacers[b];
-        return typeof r === 'string' || typeof r === 'number' ? (r as string) : a; // Typecast needed to make TypeScript happy
+        if ((typeof r === 'string' && r.length > 0) || typeof r === 'number') {
+            if (a.endsWith('.') && (r as string).endsWith('.')) {
+                return r as string; // Typecast needed to make TypeScript happy
+            } else {
+                return (r as string) + '.'; // Typecast needed to make TypeScript happy
+            }
+        } else {
+            return '';
+        }
     });
 }
 


### PR DESCRIPTION
## Describe your changes
Providers can be configured with connectionConfig parameters, such as:
`authorization_url: https://${connectionConfig.subdomain}.api.accelo.com/oauth2/v0/authorize`

However, these connectionConfig parameters are seamingly required and not optional. This PR aims to make the string replacement of these parameters optional and `dot` / `.` aware for subdomain cases.

The UI still considers these parameters required, but at least you can use the params optionally in your authorization URL constructions via SDK or backend.

Also see tests. Here are some examples:

Given URL: `https://${subdomain}.service.com/oauth/authorize`
Given params: `{ subdomain: 'myaccount' }`
Resulting URL: `https://myaccount.service.com/oauth/authorize`

Given params: `{ subdomain: null }`
Resulting URL: `https://service.com/oauth/authorize`

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x ] I added tests, otherwise the reason is: 
- [?] I added observability, otherwise the reason is:
- [?] I added analytics, otherwise the reason is: 
