### PR TITLE
fix(jobs): [nan-1010] use void

### DIFF
--- a/packages/shared/lib/services/notification/webhook.service.ts
+++ b/packages/shared/lib/services/notification/webhook.service.ts
@@ -18,7 +18,7 @@ import { stringifyError } from '@nangohq/utils';
 
 dayjs.extend(utc);
 
-const RETRY_ATTEMPTS = 7;
+const RETRY_ATTEMPTS = 10;
 
 const NON_FORWARDABLE_HEADERS = [
     'host',

--- a/packages/shared/lib/services/notification/webhook.service.ts
+++ b/packages/shared/lib/services/notification/webhook.service.ts
@@ -18,7 +18,7 @@ import { stringifyError } from '@nangohq/utils';
 
 dayjs.extend(utc);
 
-const RETRY_ATTEMPTS = 10;
+const RETRY_ATTEMPTS = 7;
 
 const NON_FORWARDABLE_HEADERS = [
     'host',

--- a/packages/shared/lib/services/sync/run.service.ts
+++ b/packages/shared/lib/services/sync/run.service.ts
@@ -648,7 +648,7 @@ export default class SyncRun {
             deleted
         };
 
-        await webhookService.sendSyncUpdate(
+        void webhookService.sendSyncUpdate(
             this.nangoConnection,
             this.syncName,
             model,


### PR DESCRIPTION
## Describe your changes
As explained by Thomas:
![image](https://github.com/NangoHQ/nango/assets/1724137/49464765-394f-4bdc-8c15-388f72704980)

Use void since we're not explicitly handling the promise resolution of the webhook sending

Tested this against returning a 504 (what the customer is returning from their webhook) from a webhook with Temporal and the task execution completes even as the webhook continues to retry. With `async` usage, the temporal activity is still in running state while the webhook retries.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
