### PR TITLE
feat(orchestrator): add long polling option for /output endpoint

### DIFF
--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -2,7 +2,9 @@ import './tracer.js';
 import { getLogger, stringifyError } from '@nangohq/utils';
 import { getServer } from './server.js';
 import { envs } from './env.js';
+import type { Task } from '@nangohq/scheduler';
 import { Scheduler, DatabaseClient } from '@nangohq/scheduler';
+import { EventsHandler } from './events.js';
 
 const logger = getLogger('Orchestrator');
 
@@ -17,19 +19,20 @@ try {
     await dbClient.migrate();
 
     // TODO: add logic to update syncs and syncs jobs in the database
+    const eventsHandler = new EventsHandler({
+        CREATED: (task: Task) => console.log(`Task created: ${JSON.stringify(task)}`),
+        STARTED: (task: Task) => console.log(`Task started: ${JSON.stringify(task)}`),
+        SUCCEEDED: (task: Task) => console.log(`Task succeeded: ${JSON.stringify(task)}`),
+        FAILED: (task: Task) => console.log(`Task failed: ${JSON.stringify(task)}`),
+        EXPIRED: (task: Task) => console.log(`Task expired: ${JSON.stringify(task)}`),
+        CANCELLED: (task: Task) => console.log(`Task cancelled: ${JSON.stringify(task)}`)
+    });
     const scheduler = new Scheduler({
         dbClient,
-        on: {
-            CREATED: (task) => console.log(`Task created: ${JSON.stringify(task)}`),
-            STARTED: (task) => console.log(`Task started: ${JSON.stringify(task)}`),
-            SUCCEEDED: (task) => console.log(`Task succeeded: ${JSON.stringify(task)}`),
-            FAILED: (task) => console.log(`Task failed: ${JSON.stringify(task)}`),
-            EXPIRED: (task) => console.log(`Task expired: ${JSON.stringify(task)}`),
-            CANCELLED: (task) => console.log(`Task cancelled: ${JSON.stringify(task)}`)
-        }
+        on: eventsHandler.onCallbacks
     });
 
-    const server = getServer({ scheduler });
+    const server = getServer(scheduler, eventsHandler);
     const port = envs.NANGO_ORCHESTRATOR_PORT;
     server.listen(port, () => {
         logger.info(`🚀 Orchestrator API ready at http://localhost:${port}`);

--- a/packages/orchestrator/lib/events.ts
+++ b/packages/orchestrator/lib/events.ts
@@ -1,0 +1,58 @@
+import type { Task } from '@nangohq/scheduler';
+import EventEmitter from 'node:events';
+
+type TaskEvent = 'completed';
+
+export function getEventId(event: TaskEvent, taskId: string) {
+    return `task:${event}:${taskId}`;
+}
+
+export class EventsHandler extends EventEmitter {
+    public readonly onCallbacks: {
+        CREATED: (task: Task) => void;
+        STARTED: (task: Task) => void;
+        SUCCEEDED: (task: Task) => void;
+        FAILED: (task: Task) => void;
+        EXPIRED: (task: Task) => void;
+        CANCELLED: (task: Task) => void;
+    };
+
+    constructor(on: {
+        CREATED: (task: Task) => void;
+        STARTED: (task: Task) => void;
+        SUCCEEDED: (task: Task) => void;
+        FAILED: (task: Task) => void;
+        EXPIRED: (task: Task) => void;
+        CANCELLED: (task: Task) => void;
+    }) {
+        super();
+        this.onCallbacks = {
+            CREATED: (task: Task) => {
+                on.CREATED(task);
+            },
+            STARTED: (task: Task) => {
+                on.STARTED(task);
+            },
+            SUCCEEDED: (task: Task) => {
+                on.SUCCEEDED(task);
+                this.emitEvent('completed', task);
+            },
+            FAILED: (task: Task) => {
+                on.FAILED(task);
+                this.emitEvent('completed', task);
+            },
+            EXPIRED: (task: Task) => {
+                on.EXPIRED(task);
+                this.emitEvent('completed', task);
+            },
+            CANCELLED: (task: Task) => {
+                on.CANCELLED(task);
+                this.emitEvent('completed', task);
+            }
+        };
+    }
+
+    private emitEvent(event: TaskEvent, task: Task) {
+        this.emit(getEventId(event, task.id), task);
+    }
+}

--- a/packages/orchestrator/lib/routes/v1/task/taskId/output.ts
+++ b/packages/orchestrator/lib/routes/v1/task/taskId/output.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
 import type { JsonValue } from 'type-fest';
-import type { Scheduler, TaskTerminalState } from '@nangohq/scheduler';
+import type { Scheduler, Task, TaskState } from '@nangohq/scheduler';
 import type { ApiError, Endpoint } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, RouteHandler, Route } from '@nangohq/utils';
 import { validateRequest } from '@nangohq/utils';
+import type { EventEmitter } from 'node:events';
+import { getEventId } from '../../../../events.js';
 
 type Output = Endpoint<{
     Method: typeof method;
@@ -11,42 +13,74 @@ type Output = Endpoint<{
     Params: {
         taskId: string;
     };
-    Error: ApiError<'fetching_failed'>;
-    Success: { state: TaskTerminalState; output: JsonValue };
+    Querystring: {
+        waitForCompletion?: boolean;
+    };
+    Error: ApiError<'task_not_found'>;
+    Success: { state: TaskState; output: JsonValue };
 }>;
 
 const path = '/v1/task/:taskId/output';
 const method = 'GET';
 
 const validate = validateRequest<Output>({
+    parseQuery: (data) =>
+        z
+            .object({
+                waitForCompletion: z
+                    .string()
+                    .optional()
+                    .default('false')
+                    .transform((val) => val === 'true')
+            })
+            .parse(data),
     parseParams: (data) => z.object({ taskId: z.string().uuid() }).parse(data)
 });
 
-const getHandler = (scheduler: Scheduler) => {
+const getHandler = (scheduler: Scheduler, eventEmitter: EventEmitter) => {
     return async (req: EndpointRequest<Output>, res: EndpointResponse<Output>) => {
+        const waitForCompletionTimeoutMs = 120_000;
+        const eventId = getEventId('completed', req.params.taskId);
+        const cleanupAndRespond = (respond: (res: EndpointResponse<Output>) => void) => {
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+            if (onCompletion) {
+                eventEmitter.removeListener(eventId, onCompletion);
+            }
+            if (!res.writableEnded) {
+                respond(res);
+            }
+        };
+        const onCompletion = (completedTask: Task) => {
+            cleanupAndRespond((res) => res.status(200).json({ state: completedTask.state, output: completedTask.output }));
+        };
+        const timeout = setTimeout(() => {
+            cleanupAndRespond((res) => res.status(204).send());
+        }, waitForCompletionTimeoutMs);
+
+        eventEmitter.once(eventId, onCompletion);
+
         const task = await scheduler.get({ taskId: req.params.taskId });
         if (task.isErr()) {
-            return res.status(500).json({ error: { code: 'fetching_failed', message: task.error.message } });
+            cleanupAndRespond((res) => res.status(404).json({ error: { code: 'task_not_found', message: task.error.message } }));
+            return;
         }
-        switch (task.value.state) {
-            case 'CREATED':
-            case 'STARTED':
-                return res.status(204).send(); // No content yet
-            case 'SUCCEEDED':
-            case 'FAILED':
-            case 'EXPIRED':
-            case 'CANCELLED':
-                return res.status(200).json({ state: task.value.state, output: task.value.output });
+        if (req.query.waitForCompletion && (task.value.state === 'CREATED' || task.value.state === 'STARTED')) {
+            await new Promise((resolve) => resolve(timeout));
+        } else {
+            cleanupAndRespond((res) => res.status(200).json({ state: task.value.state, output: task.value.output }));
         }
+        return;
     };
 };
 
 export const route: Route<Output> = { path, method };
 
-export const getRouteHandler = (scheduler: Scheduler): RouteHandler<Output> => {
+export const getRouteHandler = (scheduler: Scheduler, eventEmmiter: EventEmitter): RouteHandler<Output> => {
     return {
         ...route,
         validate,
-        handler: getHandler(scheduler)
+        handler: getHandler(scheduler, eventEmmiter)
     };
 };

--- a/packages/orchestrator/lib/server.ts
+++ b/packages/orchestrator/lib/server.ts
@@ -6,10 +6,11 @@ import { getRouteHandler as outputHandler } from './routes/v1/task/taskId/output
 import { getLogger, createRoute } from '@nangohq/utils';
 import type { Scheduler } from '@nangohq/scheduler';
 import type { ApiError } from '@nangohq/types';
+import type EventEmitter from 'node:events';
 
 const logger = getLogger('Orchestrator.server');
 
-export const getServer = ({ scheduler }: { scheduler: Scheduler }): Express => {
+export const getServer = (scheduler: Scheduler, eventEmmiter: EventEmitter): Express => {
     const server = express();
 
     server.use(express.json({ limit: '100kb' }));
@@ -34,7 +35,7 @@ export const getServer = ({ scheduler }: { scheduler: Scheduler }): Express => {
 
     createRoute(server, healthHandler);
     createRoute(server, scheduleHandler(scheduler));
-    createRoute(server, outputHandler(scheduler));
+    createRoute(server, outputHandler(scheduler, eventEmmiter));
 
     server.use((err: unknown, _req: Request, res: Response, next: NextFunction) => {
         res.status(500).json({ error: `Internal server error: '${err}'` });

--- a/packages/utils/lib/express/validate.ts
+++ b/packages/utils/lib/express/validate.ts
@@ -14,17 +14,17 @@ export const validateRequest =
     (req: EndpointRequest<E>, res: EndpointResponse<E>, next: NextFunction) => {
         try {
             if (parser.parseBody) {
-                parser.parseBody(req.body);
+                req.body = parser.parseBody(req.body);
             } else {
                 z.object({}).strict('Body is not allowed').parse(req.body);
             }
             if (parser.parseQuery) {
-                parser.parseQuery(req.query);
+                req.query = parser.parseQuery(req.query);
             } else {
                 z.object({}).strict('Query string parameters are not allowed').parse(req.query);
             }
             if (parser.parseParams) {
-                parser.parseParams(req.params);
+                req.params = parser.parseParams(req.params);
             } else {
                 z.object({}).strict('Url parameters are not allowed').parse(req.params);
             }


### PR DESCRIPTION
## Describe your changes

Right now the orchestrator client, when executing a task, loops indefinitely until the task completes, fetching the output repeatedly, which leads to a ton of http requests and db queries. 
This commit adds a "longpolling" option for the `output` endpoint where the server keeps the connection opens and waits for the completion event to be emitted (or timeout to be reached).
Code is more complicated since we now rely on on event being emitted by an eventEmitter but the benefit is a less naive and less request/query hungry logic

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
