### PR TITLE
fix(orchestrator): harden type safety of orchestrator client execute function

### DIFF
--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -199,7 +199,10 @@ class DryRunService {
         };
         // dry-run is not scheduling any tasks so we can safely mock the orchestrator client
         const orchestratorClient = {
-            execute: () => {
+            executeAction: () => {
+                return Promise.resolve({}) as any;
+            },
+            executeWebhook: () => {
                 return Promise.resolve({}) as any;
             }
         };

--- a/packages/shared/lib/services/sync/run.service.integration.test.ts
+++ b/packages/shared/lib/services/sync/run.service.integration.test.ts
@@ -29,7 +29,10 @@ class integrationServiceMock implements IntegrationServiceInterface {
 }
 
 const orchestratorClient = {
-    execute: () => {
+    executeAction: () => {
+        return Promise.resolve({}) as any;
+    },
+    executeWebhook: () => {
         return Promise.resolve({}) as any;
     }
 };

--- a/packages/shared/lib/services/sync/run.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/run.service.unit.test.ts
@@ -39,7 +39,10 @@ const recordsService = {
 };
 
 const orchestratorClient = {
-    execute: () => {
+    executeAction: () => {
+        return Promise.resolve({}) as any;
+    },
+    executeWebhook: () => {
         return Promise.resolve({}) as any;
     }
 };


### PR DESCRIPTION
This commit is adding a `type: 'webhook' | 'action' | 'sync'` to the task args so the processors knows what kind of processing must happens.
It also make the orchestrator aware of Nango concepts like webhook, actions, etc... making the interface types more specific (instead of having `args: JsonValue`, partially addressing the issue with Temporal where everything input/output are `any`). This also keeps the translation between nango concepts and nango-agnostic scheduler contained within the orchestrator. When dequeing tasks the orchestrator will also translate task into `TaskAction`, `TaskWebhook`, etc...

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
