### PR TITLE
fix(version): store version in a file instead of reading package.json

### DIFF
--- a/packages/cli/lib/cli.ts
+++ b/packages/cli/lib/cli.ts
@@ -26,7 +26,7 @@ export const version = (debug: boolean) => {
     if (debug) {
         printDebug('Looking up the version first for a local path first then globally');
     }
-    const version = getPkgVersion(debug);
+    const version = getPkgVersion();
 
     console.log(chalk.green('Nango CLI version:'), version);
 };

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -11,7 +11,7 @@ import { exec, spawn } from 'child_process';
 import promptly from 'promptly';
 import chalk from 'chalk';
 import type { NangoModel, NangoIntegrationData, NangoIntegration } from '@nangohq/shared';
-import { SyncConfigType, cloudHost, stagingHost } from '@nangohq/shared';
+import { SyncConfigType, cloudHost, stagingHost, NANGO_VERSION } from '@nangohq/shared';
 import * as dotenv from 'dotenv';
 import { state } from './state.js';
 import https from 'node:https';
@@ -112,15 +112,8 @@ export function checkEnvVars(optionalHostport?: string) {
     }
 }
 
-let pkgVersion: string | undefined = undefined;
-export function getPkgVersion(debug = false) {
-    if (pkgVersion && !debug) {
-        return pkgVersion;
-    }
-
-    const pkg = JSON.parse(fs.readFileSync(path.resolve(getNangoRootPath(debug) as string, 'package.json'), 'utf8')) as { version: string };
-    pkgVersion = pkg.version;
-    return pkg.version;
+export function getPkgVersion() {
+    return NANGO_VERSION;
 }
 
 export async function upgradeAction(debug = false) {
@@ -152,7 +145,7 @@ export async function upgradeAction(debug = false) {
 
     try {
         const resolved = npa('nango');
-        const version = getPkgVersion(debug);
+        const version = getPkgVersion();
         if (debug) {
             printDebug(`Version ${version} of nango is installed.`);
         }
@@ -271,7 +264,7 @@ export const http = axios.create({
 });
 
 export function getUserAgent(): string {
-    const clientVersion = getPkgVersion(false);
+    const clientVersion = getPkgVersion();
     const nodeVersion = process.versions.node;
 
     const osName = os.platform().replace(' ', '_');

--- a/packages/node-client/lib/utils.ts
+++ b/packages/node-client/lib/utils.ts
@@ -1,9 +1,7 @@
 import os from 'os';
 
 import type { ProxyConfiguration, GetRecordsRequestConfig } from './types.js';
-import path from 'node:path';
-import fs from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import { NANGO_VERSION } from './version.js';
 
 /**
  * Validates the configuration for a proxy call
@@ -36,12 +34,9 @@ export const validateSyncRecordConfiguration = (config: GetRecordsRequestConfig)
 };
 
 export function getUserAgent(userAgent?: string): string {
-    const dir = path.dirname(fileURLToPath(import.meta.url));
-    const packageJson = JSON.parse(fs.readFileSync(path.resolve(dir, '../package.json'), 'utf8'));
-    const clientVersion: string = packageJson.version; // eslint-disable-line
     const nodeVersion = process.versions.node;
 
     const osName = os.platform().replace(' ', '_');
     const osVersion = os.release().replace(' ', '_');
-    return `nango-node-client/${clientVersion} (${osName}/${osVersion}; node.js/${nodeVersion})${userAgent ? `; ${userAgent}` : ''}`;
+    return `nango-node-client/${NANGO_VERSION} (${osName}/${osVersion}; node.js/${nodeVersion})${userAgent ? `; ${userAgent}` : ''}`;
 }

--- a/packages/node-client/lib/version.ts
+++ b/packages/node-client/lib/version.ts
@@ -1,0 +1,1 @@
+export const NANGO_VERSION = '0.39.40';

--- a/packages/node-client/lib/version.ts
+++ b/packages/node-client/lib/version.ts
@@ -1,1 +1,1 @@
-export const NANGO_VERSION = '0.39.40';
+export const NANGO_VERSION = '0.39.30';

--- a/packages/server/lib/controllers/environment.controller.ts
+++ b/packages/server/lib/controllers/environment.controller.ts
@@ -11,10 +11,10 @@ import {
     getWebsocketsPath,
     getOauthCallbackUrl,
     getGlobalWebhookReceiveUrl,
-    packageJsonFile,
     getOnboardingProgress,
     userService,
-    generateSlackConnectionId
+    generateSlackConnectionId,
+    NANGO_VERSION
 } from '@nangohq/shared';
 import { NANGO_ADMIN_UUID } from './account.controller.js';
 import type { RequestLocals } from '../utils/express.js';
@@ -53,11 +53,10 @@ class EnvironmentController {
             }
 
             const environments = await environmentService.getEnvironmentsByAccountId(user.account_id);
-            const version = packageJsonFile().version;
             const onboarding = await getOnboardingProgress(sessionUser.id);
             res.status(200).send({
                 environments,
-                version,
+                version: NANGO_VERSION,
                 email: sessionUser.email,
                 baseUrl,
                 debugMode: req.session.debugMode === true,

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -4,7 +4,7 @@ import './utils/config.js';
 import type { WebSocket } from 'ws';
 import { WebSocketServer } from 'ws';
 import http from 'http';
-import { db, getGlobalOAuthCallbackUrl, getPort, getWebsocketsPath, packageJsonFile } from '@nangohq/shared';
+import { NANGO_VERSION, db, getGlobalOAuthCallbackUrl, getPort, getWebsocketsPath } from '@nangohq/shared';
 import { getLogger } from '@nangohq/utils';
 import oAuthSessionService from './services/oauth-session.service.js';
 import migrate from './utils/migrate.js';
@@ -47,7 +47,7 @@ refreshTokens();
 
 const port = getPort();
 server.listen(port, () => {
-    logger.info(`✅ Nango Server with version ${packageJsonFile().version} is listening on port ${port}. OAuth callback URL: ${getGlobalOAuthCallbackUrl()}`);
+    logger.info(`✅ Nango Server with version ${NANGO_VERSION} is listening on port ${port}. OAuth callback URL: ${getGlobalOAuthCallbackUrl()}`);
     logger.info(
         `\n   |     |     |     |     |     |     |\n   |     |     |     |     |     |     |\n   |     |     |     |     |     |     |  \n \\ | / \\ | / \\ | / \\ | / \\ | / \\ | / \\ | /\n  \\|/   \\|/   \\|/   \\|/   \\|/   \\|/   \\|/\n------------------------------------------\nLaunch Nango at http://localhost:${port}\n------------------------------------------\n  /|\\   /|\\   /|\\   /|\\   /|\\   /|\\   /|\\\n / | \\ / | \\ / | \\ / | \\ / | \\ / | \\ / | \\\n   |     |     |     |     |     |     |\n   |     |     |     |     |     |     |\n   |     |     |     |     |     |     |`
     );

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -48,6 +48,8 @@ export * from './utils/kvstore/RedisStore.js';
 
 export * from './sdk/sync.js';
 
+export { NANGO_VERSION } from './version.js';
+
 export {
     db,
     seeders,

--- a/packages/shared/lib/utils/analytics.ts
+++ b/packages/shared/lib/utils/analytics.ts
@@ -1,6 +1,6 @@
 import { PostHog } from 'posthog-node';
 import { localhostUrl, isCloud, isStaging, baseUrl } from '@nangohq/utils';
-import { UserType, packageJsonFile } from '../utils/utils.js';
+import { UserType } from '../utils/utils.js';
 import ip from 'ip';
 import errorManager, { ErrorSourceEnum } from './error.manager.js';
 import accountService from '../services/account.service.js';
@@ -8,6 +8,7 @@ import environmentService from '../services/environment.service.js';
 import userService from '../services/user.service.js';
 import type { Account, User } from '../models/Admin.js';
 import { LogActionEnum } from '../models/Activity.js';
+import { NANGO_VERSION } from '../version.js';
 
 export enum AnalyticsTypes {
     ACCOUNT_CREATED = 'server:account_created',
@@ -64,7 +65,7 @@ class Analytics {
             if (process.env['TELEMETRY']?.toLowerCase() !== 'false' && !isStaging) {
                 this.client = new PostHog('phc_4S2pWFTyPYT1i7zwC8YYQqABvGgSAzNHubUkdEFvcTl');
                 this.client.enable();
-                this.packageVersion = packageJsonFile().version;
+                this.packageVersion = NANGO_VERSION;
             }
         } catch (e) {
             errorManager.report(e, {

--- a/packages/shared/lib/utils/error.manager.ts
+++ b/packages/shared/lib/utils/error.manager.ts
@@ -6,10 +6,10 @@ import type { ErrorEvent } from '@sentry/types';
 import { NangoError } from './error.js';
 import type { Response, Request } from 'express';
 import { getLogger, isCloud, stringifyError } from '@nangohq/utils';
-import { packageJsonFile } from './utils.js';
 import environmentService from '../services/environment.service.js';
 import accountService from '../services/account.service.js';
 import userService from '../services/user.service.js';
+import { NANGO_VERSION } from '../version.js';
 
 const logger = getLogger('ErrorManager');
 
@@ -33,7 +33,7 @@ class ErrorManager {
     constructor() {
         try {
             if (isCloud && process.env['SENTRY_DNS']) {
-                const packageVersion = packageJsonFile().version;
+                const packageVersion = NANGO_VERSION;
                 sentry.init({
                     dsn: process.env['SENTRY_DNS'],
                     beforeSend(event: ErrorEvent, _: EventHint) {

--- a/packages/shared/lib/utils/utils.ts
+++ b/packages/shared/lib/utils/utils.ts
@@ -1,14 +1,9 @@
-import path, { resolve } from 'path';
-import { readFileSync } from 'fs';
+import path from 'path';
 import { fileURLToPath } from 'url';
 import { isEnterprise, isStaging, isProd, localhostUrl, cloudHost, stagingHost } from '@nangohq/utils';
 import type { Environment } from '../models/Environment.js';
 import environmentService from '../services/environment.service.js';
 import type { Connection } from '../models/Connection.js';
-
-interface PackageJson {
-    version: string;
-}
 
 export { cloudHost, stagingHost };
 
@@ -256,17 +251,6 @@ export function interpolateIfNeeded(str: string, replacers: Record<string, any>)
 export function getConnectionConfig(queryParams: any): Record<string, string> {
     const arr = Object.entries(queryParams).filter(([, v]) => typeof v === 'string'); // Filter strings
     return Object.fromEntries(arr) as Record<string, string>;
-}
-
-let packageJsonCache: PackageJson | undefined;
-export function packageJsonFile(): PackageJson {
-    if (packageJsonCache) {
-        return packageJsonCache;
-    }
-
-    const localPath = '../../package.json';
-    packageJsonCache = JSON.parse(readFileSync(resolve(dirname(), localPath)).toString('utf-8')) as PackageJson;
-    return packageJsonCache;
 }
 
 export function safeStringify(obj: any): string {

--- a/packages/shared/lib/version.ts
+++ b/packages/shared/lib/version.ts
@@ -1,0 +1,1 @@
+export const NANGO_VERSION = '0.39.40';

--- a/packages/shared/lib/version.ts
+++ b/packages/shared/lib/version.ts
@@ -1,1 +1,1 @@
-export const NANGO_VERSION = '0.39.40';
+export const NANGO_VERSION = '0.39.30';

--- a/scripts/gitrelease.mjs
+++ b/scripts/gitrelease.mjs
@@ -23,7 +23,7 @@ echo`Generating changelog`;
 await $`npx git-cliff -o CHANGELOG.md -t ${nextTag}`;
 
 echo`Adding file`;
-await $`git add -A package.json package-lock.json packages/**/package.json CHANGELOG.md`;
+await $`git add -A package.json package-lock.json packages/**/package.json CHANGELOG.md packages/**/lib/version.ts`;
 
 echo`Creating commit`;
 await $`git -c user.name="Release Bot" -c user.email="contact@nango.dev" commit --allow-empty --author="Release Bot <contact@nango.dev>" -m ${releaseMessage} `;

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -34,6 +34,9 @@ if [[ ! "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+|0\.0\.1-[0-9a-fA-F]{40})$ ]]; the
     exit 1
 fi
 
+sed -E -i '' "s/NANGO_VERSION = '[0-9.]+/NANGO_VERSION = '$VERSION/" "$GIT_ROOT_DIR/packages/shared/lib/version.ts"
+sed -E -i '' "s/NANGO_VERSION = '[0-9.]+/NANGO_VERSION = '$VERSION/" "$GIT_ROOT_DIR/packages/node-client/lib/version.ts"
+
 npm ci
 npm run ts-build
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -34,9 +34,16 @@ if [[ ! "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+|0\.0\.1-[0-9a-fA-F]{40})$ ]]; the
     exit 1
 fi
 
-sed -E -i '' "s/NANGO_VERSION = '[0-9.]+/NANGO_VERSION = '$VERSION/" "$GIT_ROOT_DIR/packages/shared/lib/version.ts"
-sed -E -i '' "s/NANGO_VERSION = '[0-9.]+/NANGO_VERSION = '$VERSION/" "$GIT_ROOT_DIR/packages/node-client/lib/version.ts"
+# increment stored version
+# NB: macos and linux have different "sed" that don't edit in place the same way
+pushd "$GIT_ROOT_DIR/packages"
+sed -E "s/NANGO_VERSION = '[0-9a-fA-F.-]+/NANGO_VERSION = '$VERSION/" ./shared/lib/version.ts >tmp
+mv tmp ./shared/lib/version.ts
+sed -E "s/NANGO_VERSION = '[0-9a-fA-F.-]+/NANGO_VERSION = '$VERSION/" ./node-client/lib/version.ts >tmp
+mv tmp ./node-client/lib/version.ts
+popd
 
+# build codebase
 npm ci
 npm run ts-build
 


### PR DESCRIPTION
## Describe your changes

Fixes NAN-1020

I have done it I don't know how many times, and everytime I think it's going to be different. Reading from package.json is clunky and not portable as soon as you bundle, use an exotic install, use a serveless host, etc. We had two reports last week, after many tries I could not reproduce so instead of wasting time I implemented this regular solution. You can find this way of doing things in many libs (i.e: [stripe](https://github.com/stripe/stripe-node/blob/162ba379ee32801762a3f0f74ee4cd18f99566b5/src/stripe.core.ts#L52), [algolia](https://github.com/algolia/algoliasearch-client-javascript/blob/5828389d96c7d8b416ee4bd3017b980d3927bee4/packages/client-common/src/version.ts), etc.)

- Store version in file to secure fast and stable loading across env
Once again I had to do the work two times, using shared right now would be a mistake but as soon as we clean it up I hope we can use it.
