### PR TITLE
fix(demo): incorrect token used to oauth

### DIFF
--- a/packages/webapp/src/pages/InteractiveDemo/index.tsx
+++ b/packages/webapp/src/pages/InteractiveDemo/index.tsx
@@ -170,7 +170,7 @@ export const InteractiveDemo: React.FC = () => {
                                 connectionId={connectionId}
                                 hostUrl={environmentAndAccount.host}
                                 providerConfigKey={providerConfigKey}
-                                publicKey={environmentAndAccount.environment.secret_key}
+                                publicKey={environmentAndAccount.environment.public_key}
                                 onProgress={onAuthorize}
                             />
 


### PR DESCRIPTION
## Describe your changes

Fixes NAN-1029

- Incorrect token used
Just slipped during reviews, in previous [PR regarding slack banner](https://github.com/NangoHQ/nango/pull/2184)