### PR TITLE
fix(jobs): local runner for enterprise

### DIFF
--- a/packages/jobs/lib/runner/runner.ts
+++ b/packages/jobs/lib/runner/runner.ts
@@ -29,7 +29,7 @@ export function getRunnerId(suffix: string): string {
 
 export async function getOrStartRunner(runnerId: string): Promise<Runner> {
     const waitForRunner = async function (runner: Runner): Promise<void> {
-        const timeoutMs = 5000;
+        const timeoutMs = isEnterprise ? 60000 : 5000;
         let healthCheck = false;
         const startTime = Date.now();
         while (!healthCheck && Date.now() - startTime < timeoutMs) {
@@ -56,9 +56,7 @@ export async function getOrStartRunner(runnerId: string): Promise<Runner> {
     }
     const isRender = process.env['IS_RENDER'] === 'true';
     let runner: Runner;
-    if (isEnterprise) {
-        runner = await RemoteRunner.getOrStart(runnerId);
-    } else if (isRender) {
+    if (isRender) {
         runner = await RenderRunner.getOrStart(runnerId);
     } else {
         runner = await LocalRunner.getOrStart(runnerId);


### PR DESCRIPTION
## Describe your changes
Issues with the runner failing health checks for enterprise. Using a a remote runner requires the API call from jobs to the runner stay open for the duration of the sync. This can be problematic as the connection can drop or be terminated for a number of reasons. This piece of [code](https://github.com/NangoHQ/nango/blob/master/packages/jobs/lib/integration.service.ts#L124-L133] should be refactored soon so that this logic is more portable across different cloud providers besides just our own.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
