### PR TITLE
fix(server): [nan-1037] allow an override connection to be refreshed properly

### DIFF
--- a/packages/shared/lib/clients/oauth2.client.ts
+++ b/packages/shared/lib/clients/oauth2.client.ts
@@ -52,6 +52,13 @@ export async function getFreshOAuth2Credentials(
     template: ProviderTemplateOAuth2
 ): Promise<ServiceResponse<OAuth2Credentials>> {
     const credentials = connection.credentials as OAuth2Credentials;
+    if (credentials.config_override && credentials.config_override.client_id && credentials.config_override.client_secret) {
+        config = {
+            ...config,
+            oauth_client_id: credentials.config_override.client_id,
+            oauth_client_secret: credentials.config_override.client_secret
+        };
+    }
     const simpleOAuth2ClientConfig = getSimpleOAuth2ClientConfig(config, template, connection.connection_config);
     if (template.token_request_auth_method === 'basic') {
         const headers = {


### PR DESCRIPTION
## Describe your changes
A overriden connection wouldn't refresh properly due to the refresh using the incorrect client id and secret combo.

## Issue ticket number and link
NAN-1037

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
