### PR TITLE
fix(server): [nan-1037] on refresh keep the overrides

### DIFF
--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -260,6 +260,27 @@ class OAuthController {
                         oauth_client_secret_override: config.oauth_client_secret
                     };
                 }
+
+                const obfuscatedClientSecret = config.oauth_client_secret ? config.oauth_client_secret.slice(0, 4) + '***' : '';
+
+                await createActivityLogMessage({
+                    level: 'info',
+                    environment_id: environmentId,
+                    activity_log_id: activityLogId as number,
+                    content: 'Credentials override',
+                    timestamp: Date.now(),
+                    auth_mode: template.auth_mode,
+                    url: callbackUrl,
+                    params: {
+                        oauth_client_id: config.oauth_client_id,
+                        oauth_client_secret: obfuscatedClientSecret
+                    }
+                });
+
+                await logCtx.info('Credentials override', {
+                    oauth_client_id: config.oauth_client_id,
+                    oauth_client_secret: obfuscatedClientSecret
+                });
             }
 
             if (connectionConfig['oauth_scopes_override']) {

--- a/packages/shared/lib/clients/oauth2.client.ts
+++ b/packages/shared/lib/clients/oauth2.client.ts
@@ -121,6 +121,13 @@ export async function getFreshOAuth2Credentials(
             newCredentials.refresh_token = credentials.refresh_token;
         }
 
+        if (credentials.config_override && credentials.config_override.client_id && credentials.config_override.client_secret) {
+            newCredentials.config_override = {
+                client_id: credentials.config_override.client_id,
+                client_secret: credentials.config_override.client_secret
+            };
+        }
+
         return { success: true, error: null, response: newCredentials };
     } catch (err) {
         const error = new NangoError(`refresh_token_parsing_error`, { cause: err });


### PR DESCRIPTION
## Describe your changes
When refreshing the override goes away. Keep it around. Also adds in activity logs for an override.

## Issue ticket number and link
NAN-1037

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
