### PR TITLE
fix(connection): upsert return full connection, logs

### DIFF
--- a/packages/jobs/lib/crons/autoIdleDemo.integration.test.ts
+++ b/packages/jobs/lib/crons/autoIdleDemo.integration.test.ts
@@ -66,7 +66,7 @@ describe('Auto Idle Demo', async () => {
             })
             .returning('id');
         const conn = await connectionService.upsertConnection(connName, DEMO_GITHUB_CONFIG_KEY, 'github', {} as any, {}, env.id, 0);
-        const connId = conn[0]!.id;
+        const connId = conn[0]!.connection.id!;
         const sync = (await createSync(connId, DEMO_SYNC_NAME))!;
         await createSchedule(sync.id, '86400', 0, ScheduleStatus.RUNNING, nanoid());
         const schedBefore = await getSchedule(sync.id);

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -301,7 +301,7 @@ const initDb = async () => {
     );
 
     const connectionRes = await connectionService.upsertConnection(`conn-test`, `provider-test`, 'google', {} as AuthCredentials, {}, env.id, 0);
-    const connectionId = connectionRes[0]?.id;
+    const connectionId = connectionRes[0]?.connection.id;
     if (!connectionId) throw new Error('Connection not created');
 
     const connection = (await connectionService.getConnectionById(connectionId)) as Connection;

--- a/packages/server/lib/controllers/apiAuth.controller.ts
+++ b/packages/server/lib/controllers/apiAuth.controller.ts
@@ -208,11 +208,10 @@ class ApiAuthController {
             );
 
             if (updatedConnection) {
+                await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
                 void connectionCreatedHook(
                     {
-                        id: updatedConnection.id,
-                        connection_id: connectionId,
-                        provider_config_key: providerConfigKey,
+                        connection: updatedConnection.connection,
                         environment,
                         account,
                         auth_mode: AuthModes.ApiKey,
@@ -240,9 +239,7 @@ class ApiAuthController {
             if (logCtx) {
                 void connectionCreationFailedHook(
                     {
-                        id: -1,
-                        connection_id: connectionId as string,
-                        provider_config_key: providerConfigKey as string,
+                        connection: { connection_id: connectionId!, provider_config_key: providerConfigKey! },
                         environment,
                         account,
                         auth_mode: AuthModes.ApiKey,
@@ -366,6 +363,8 @@ class ApiAuthController {
                 return;
             }
 
+            await logCtx.enrichOperation({ integrationId: config.id!, integrationName: config.unique_key, providerName: config.provider });
+
             const template = configService.getTemplate(config.provider);
 
             if (template.auth_mode !== AuthModes.Basic) {
@@ -418,7 +417,6 @@ class ApiAuthController {
             }
 
             await updateProviderActivityLog(activityLogId as number, String(config.provider));
-            await logCtx.enrichOperation({ integrationId: config.id!, integrationName: config.unique_key, providerName: config.provider });
 
             await createActivityLogMessage({
                 level: 'info',
@@ -443,11 +441,10 @@ class ApiAuthController {
             );
 
             if (updatedConnection) {
+                await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
                 void connectionCreatedHook(
                     {
-                        id: updatedConnection.id,
-                        connection_id: connectionId,
-                        provider_config_key: providerConfigKey,
+                        connection: updatedConnection.connection,
                         environment,
                         account,
                         auth_mode: AuthModes.Basic,
@@ -475,9 +472,7 @@ class ApiAuthController {
             if (logCtx) {
                 void connectionCreationFailedHook(
                     {
-                        id: -1,
-                        connection_id: connectionId as string,
-                        provider_config_key: providerConfigKey as string,
+                        connection: { connection_id: connectionId!, provider_config_key: providerConfigKey! },
                         environment,
                         account,
                         auth_mode: AuthModes.ApiKey,

--- a/packages/server/lib/controllers/appAuth.controller.ts
+++ b/packages/server/lib/controllers/appAuth.controller.ts
@@ -99,6 +99,8 @@ class AppAuthController {
                 return;
             }
 
+            await logCtx.enrichOperation({ integrationId: config.id!, integrationName: config.unique_key, providerName: config.provider });
+
             const template = configService.getTemplate(config.provider);
             const tokenUrl = typeof template.token_url === 'string' ? template.token_url : (template.token_url?.[AuthModes.App] as string);
 
@@ -202,9 +204,7 @@ class AppAuthController {
 
                 void connectionCreationFailedHook(
                     {
-                        id: -1,
-                        connection_id: connectionId,
-                        provider_config_key: providerConfigKey,
+                        connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
                         environment,
                         account,
                         auth_mode: AuthModes.App,
@@ -232,11 +232,10 @@ class AppAuthController {
             );
 
             if (updatedConnection) {
+                await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
                 void connectionCreatedHook(
                     {
-                        id: updatedConnection.id,
-                        connection_id: connectionId,
-                        provider_config_key: providerConfigKey,
+                        connection: updatedConnection.connection,
                         environment,
                         account,
                         auth_mode: AuthModes.App,
@@ -295,9 +294,7 @@ class AppAuthController {
 
             void connectionCreationFailedHook(
                 {
-                    id: -1,
-                    connection_id: connectionId,
-                    provider_config_key: providerConfigKey,
+                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
                     environment,
                     account,
                     auth_mode: AuthModes.App,

--- a/packages/server/lib/controllers/appStoreAuth.controller.ts
+++ b/packages/server/lib/controllers/appStoreAuth.controller.ts
@@ -169,9 +169,7 @@ class AppStoreAuthController {
             if (!success || !credentials) {
                 void connectionCreationFailedHook(
                     {
-                        id: -1,
-                        connection_id: connectionId,
-                        provider_config_key: providerConfigKey,
+                        connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
                         environment,
                         account,
                         auth_mode: AuthModes.AppStore,
@@ -210,11 +208,10 @@ class AppStoreAuthController {
             );
 
             if (updatedConnection) {
+                await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
                 void connectionCreatedHook(
                     {
-                        id: updatedConnection.id,
-                        connection_id: connectionId,
-                        provider_config_key: providerConfigKey,
+                        connection: updatedConnection.connection,
                         environment,
                         account,
                         auth_mode: AuthModes.AppStore,
@@ -242,9 +239,7 @@ class AppStoreAuthController {
             if (logCtx) {
                 void connectionCreationFailedHook(
                     {
-                        id: -1,
-                        connection_id: connectionId as string,
-                        provider_config_key: providerConfigKey as string,
+                        connection: { connection_id: connectionId!, provider_config_key: providerConfigKey! },
                         environment,
                         account,
                         auth_mode: AuthModes.AppStore,

--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -580,9 +580,7 @@ class ConnectionController {
                 const connCreatedHook = async (res: ConnectionUpsertResponse) => {
                     void connectionCreatedHook(
                         {
-                            id: res.id,
-                            connection_id,
-                            provider_config_key,
+                            connection: res.connection,
                             environment,
                             account,
                             auth_mode: ProviderAuthModes.OAuth2,
@@ -630,9 +628,7 @@ class ConnectionController {
                 const connCreatedHook = async (res: ConnectionUpsertResponse) => {
                     void connectionCreatedHook(
                         {
-                            id: res.id,
-                            connection_id,
-                            provider_config_key,
+                            connection: res.connection,
                             environment,
                             account,
                             auth_mode: ProviderAuthModes.OAuth2,
@@ -674,9 +670,7 @@ class ConnectionController {
                 const connCreatedHook = async (res: ConnectionUpsertResponse) => {
                     void connectionCreatedHook(
                         {
-                            id: res.id,
-                            connection_id,
-                            provider_config_key,
+                            connection: res.connection,
                             environment,
                             account,
                             auth_mode: ProviderAuthModes.ApiKey,
@@ -716,9 +710,7 @@ class ConnectionController {
                 const connCreatedHook = async (res: ConnectionUpsertResponse) => {
                     void connectionCreatedHook(
                         {
-                            id: res.id,
-                            connection_id,
-                            provider_config_key,
+                            connection: res.connection,
                             environment,
                             account,
                             auth_mode: ProviderAuthModes.ApiKey,
@@ -801,12 +793,10 @@ class ConnectionController {
                 return;
             }
 
-            if (updatedConnection && updatedConnection.id && runHook) {
+            if (updatedConnection && updatedConnection.connection.id && runHook) {
                 void connectionCreatedHook(
                     {
-                        id: updatedConnection.id,
-                        connection_id,
-                        provider_config_key,
+                        connection: updatedConnection.connection,
                         environment,
                         account,
                         auth_mode: template.auth_mode,

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -540,11 +540,10 @@ class OAuthController {
             );
 
             if (updatedConnection) {
+                await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
                 void connectionCreatedHook(
                     {
-                        id: updatedConnection.id,
-                        connection_id: connectionId,
-                        provider_config_key: providerConfigKey,
+                        connection: updatedConnection.connection,
                         environment,
                         account,
                         auth_mode: ProviderAuthModes.None,
@@ -572,9 +571,7 @@ class OAuthController {
             if (logCtx) {
                 void connectionCreationFailedHook(
                     {
-                        id: -1,
-                        connection_id: connectionId as string,
-                        provider_config_key: providerConfigKey as string,
+                        connection: { connection_id: connectionId!, provider_config_key: providerConfigKey! },
                         environment,
                         account,
                         auth_mode: ProviderAuthModes.OAuth2CC,
@@ -1202,9 +1199,7 @@ class OAuthController {
 
             void connectionCreationFailedHook(
                 {
-                    id: -1,
-                    connection_id: connectionId,
-                    provider_config_key: providerConfigKey,
+                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
                     environment,
                     account,
                     auth_mode: template.auth_mode,
@@ -1367,9 +1362,7 @@ class OAuthController {
 
                 void connectionCreationFailedHook(
                     {
-                        id: -1,
-                        connection_id: connectionId,
-                        provider_config_key: providerConfigKey,
+                        connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
                         environment,
                         account,
                         auth_mode: template.auth_mode,
@@ -1457,7 +1450,6 @@ class OAuthController {
             );
 
             await updateProviderActivityLog(activityLogId, session.provider);
-            await logCtx.enrichOperation({ integrationId: config.id!, integrationName: config.unique_key, providerName: config.provider });
 
             await createActivityLogMessageAndEnd({
                 level: 'debug',
@@ -1490,14 +1482,13 @@ class OAuthController {
             );
 
             if (updatedConnection) {
+                await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
                 // don't initiate a sync if custom because this is the first step of the oauth flow
                 const initiateSync = template.auth_mode === ProviderAuthModes.Custom ? false : true;
                 const runPostConnectionScript = true;
                 void connectionCreatedHook(
                     {
-                        id: updatedConnection.id,
-                        connection_id: connectionId,
-                        provider_config_key: providerConfigKey,
+                        connection: updatedConnection.connection,
                         environment,
                         account,
                         auth_mode: template.auth_mode,
@@ -1516,9 +1507,7 @@ class OAuthController {
                 const connCreatedHook = async (res: ConnectionUpsertResponse) => {
                     void connectionCreatedHook(
                         {
-                            id: res.id,
-                            connection_id: connectionId,
-                            provider_config_key: providerConfigKey,
+                            connection: res.connection,
                             environment,
                             account,
                             auth_mode: ProviderAuthModes.App,
@@ -1588,9 +1577,7 @@ class OAuthController {
 
             void connectionCreationFailedHook(
                 {
-                    id: -1,
-                    connection_id: connectionId,
-                    provider_config_key: providerConfigKey,
+                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
                     environment,
                     account,
                     auth_mode: template.auth_mode,
@@ -1637,9 +1624,7 @@ class OAuthController {
 
             void connectionCreationFailedHook(
                 {
-                    id: -1,
-                    connection_id: connectionId,
-                    provider_config_key: providerConfigKey,
+                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
                     environment,
                     account,
                     auth_mode: template.auth_mode,
@@ -1694,14 +1679,16 @@ class OAuthController {
                 });
 
                 if (updatedConnection) {
+                    await logCtx.enrichOperation({
+                        connectionId: updatedConnection.connection.id!,
+                        connectionName: updatedConnection.connection.connection_id
+                    });
                     // syncs not support for oauth1
                     const initiateSync = false;
                     const runPostConnectionScript = true;
                     void connectionCreatedHook(
                         {
-                            id: updatedConnection.id,
-                            connection_id: connectionId,
-                            provider_config_key: providerConfigKey,
+                            connection: updatedConnection.connection,
                             environment,
                             account,
                             auth_mode: template.auth_mode,
@@ -1753,9 +1740,7 @@ class OAuthController {
 
                 void connectionCreationFailedHook(
                     {
-                        id: -1,
-                        connection_id: connectionId,
-                        provider_config_key: providerConfigKey,
+                        connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
                         environment,
                         account,
                         auth_mode: template.auth_mode,

--- a/packages/server/lib/controllers/unauth.controller.ts
+++ b/packages/server/lib/controllers/unauth.controller.ts
@@ -159,11 +159,10 @@ class UnAuthController {
             );
 
             if (updatedConnection) {
+                await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
                 void connectionCreatedHook(
                     {
-                        id: updatedConnection.id,
-                        connection_id: connectionId,
-                        provider_config_key: providerConfigKey,
+                        connection: updatedConnection.connection,
                         environment,
                         account,
                         auth_mode: AuthModes.None,
@@ -191,9 +190,7 @@ class UnAuthController {
             if (logCtx) {
                 void connectionCreationFailedHook(
                     {
-                        id: -1,
-                        connection_id: connectionId as string,
-                        provider_config_key: providerConfigKey as string,
+                        connection: { connection_id: connectionId!, provider_config_key: providerConfigKey! },
                         environment,
                         account,
                         auth_mode: AuthModes.None,

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -20,7 +20,8 @@ import type {
     Connection,
     ConnectionConfig,
     Template as ProviderTemplate,
-    HTTP_VERB
+    HTTP_VERB,
+    RecentlyFailedConnection
 } from '@nangohq/shared';
 
 import { getLogger, Ok, Err, isHosted } from '@nangohq/utils';
@@ -72,7 +73,7 @@ export const connectionCreated = async (
 ): Promise<void> => {
     if (options.initiateSync === true && !isHosted) {
         const syncClient = await SyncClient.getInstance();
-        await syncClient?.initiate(connection.id as number, logContextGetter);
+        await syncClient?.initiate(connection.connection.id as number, logContextGetter);
     }
 
     if (options.runPostConnectionScript === true) {
@@ -83,7 +84,7 @@ export const connectionCreated = async (
 };
 
 export const connectionCreationFailed = async (
-    connection: RecentlyCreatedConnection,
+    connection: RecentlyFailedConnection,
     provider: string,
     activityLogId: number | null,
     logCtx: LogContext

--- a/packages/server/lib/webhook/github-app-oauth-webhook-routing.ts
+++ b/packages/server/lib/webhook/github-app-oauth-webhook-routing.ts
@@ -90,9 +90,7 @@ async function handleCreateWebhook(integration: ProviderConfig, body: any, logCo
         const connCreatedHook = async (res: ConnectionUpsertResponse) => {
             void connectionCreatedHook(
                 {
-                    id: res.id,
-                    connection_id: connection.connection_id,
-                    provider_config_key: integration.unique_key,
+                    connection: res.connection,
                     environment,
                     account,
                     auth_mode: ProviderAuthModes.App,

--- a/packages/shared/lib/db/seeders/connection.seeder.ts
+++ b/packages/shared/lib/db/seeders/connection.seeder.ts
@@ -10,7 +10,7 @@ export const createConnectionSeeds = async (env: Environment): Promise<number[]>
     for (let i = 0; i < 4; i++) {
         const name = Math.random().toString(36).substring(7);
         const result = await connectionService.upsertConnection(`conn-${name}`, `provider-${name}`, 'google', {} as AuthCredentials, {}, env.id, 0);
-        connectionIds.push(...result.map((res) => res.id));
+        connectionIds.push(...result.map((res) => res.connection.id!));
     }
     return connectionIds;
 };
@@ -23,7 +23,7 @@ export const createConnectionSeed = async (env: Environment, provider: string): 
         throw new Error('Could not create connection seed');
     }
 
-    return { id: result[0].id, connection_id: name, provider_config_key: provider, environment_id: env.id };
+    return { id: result[0].connection.id!, connection_id: name, provider_config_key: provider, environment_id: env.id };
 };
 
 export const deleteAllConnectionSeeds = async (): Promise<void> => {

--- a/packages/shared/lib/models/Auth.ts
+++ b/packages/shared/lib/models/Auth.ts
@@ -1,6 +1,6 @@
 import type { ServiceResponse } from './Generic.js';
 import type { Template } from './Provider.js';
-import type { BaseConnection } from './Connection.js';
+import type { BaseConnection, StoredConnection } from './Connection.js';
 
 export enum AuthModes {
     OAuth1 = 'OAUTH1',
@@ -31,7 +31,7 @@ export enum OAuthBodyFormat {
 }
 
 export interface ConnectionUpsertResponse {
-    id: number;
+    connection: StoredConnection;
     operation: AuthOperation;
 }
 

--- a/packages/shared/lib/models/Connection.ts
+++ b/packages/shared/lib/models/Connection.ts
@@ -36,13 +36,22 @@ export interface Connection extends BaseConnection {
     credentials: AuthCredentials | ApiKeyCredentials | BasicApiCredentials | AppCredentials | AppStoreCredentials | UnauthCredentials;
 }
 
-export type RecentlyCreatedConnection = Pick<StoredConnection, 'id' | 'connection_id' | 'provider_config_key'> & {
+export interface RecentlyCreatedConnection {
+    connection: StoredConnection;
     auth_mode: AuthModes;
     error?: string;
     operation: AuthOperation;
     environment: Environment;
     account: Account;
-};
+}
+export interface RecentlyFailedConnection {
+    connection: Pick<StoredConnection, 'connection_id' | 'provider_config_key'>;
+    auth_mode: AuthModes;
+    error?: string;
+    operation: AuthOperation;
+    environment: Environment;
+    account: Account;
+}
 
 export interface ApiConnection {
     id?: number;

--- a/packages/shared/lib/services/notification/webhook.service.ts
+++ b/packages/shared/lib/services/notification/webhook.service.ts
@@ -5,7 +5,7 @@ import utc from 'dayjs/plugin/utc.js';
 import { backOff } from 'exponential-backoff';
 import crypto from 'crypto';
 import { SyncType } from '../../models/Sync.js';
-import type { NangoConnection, RecentlyCreatedConnection } from '../../models/Connection.js';
+import type { NangoConnection, RecentlyCreatedConnection, RecentlyFailedConnection } from '../../models/Connection.js';
 import type { Account, Config, Environment, SyncResult } from '../../models/index.js';
 import type { LogLevel } from '../../models/Activity.js';
 import { LogActionEnum } from '../../models/Activity.js';
@@ -229,7 +229,7 @@ class WebhookService {
     }
 
     async sendAuthUpdate(
-        connection: RecentlyCreatedConnection,
+        connection: RecentlyCreatedConnection | RecentlyFailedConnection,
         provider: string,
         success: boolean,
         activityLogId: number | null,
@@ -246,8 +246,8 @@ class WebhookService {
         const body: NangoAuthWebhookBody = {
             from: 'nango',
             type: WebhookType.AUTH,
-            connectionId: connection.connection_id,
-            providerConfigKey: connection.provider_config_key,
+            connectionId: connection.connection.connection_id,
+            providerConfigKey: connection.connection.provider_config_key,
             authMode: connection.auth_mode,
             provider,
             environment: environmentName,

--- a/packages/shared/lib/services/notification/webhook.service.unit.test.ts
+++ b/packages/shared/lib/services/notification/webhook.service.unit.test.ts
@@ -2,7 +2,7 @@
 import { vi, expect, describe, it, beforeEach } from 'vitest';
 import axios from 'axios';
 import { SyncType } from '../../models/Sync.js';
-import type { RecentlyCreatedConnection, NangoConnection } from '../../models/Connection.js';
+import type { RecentlyCreatedConnection, NangoConnection, StoredConnection } from '../../models/Connection.js';
 import WebhookService from './webhook.service.js';
 import type { Environment } from '../../models/Environment.js';
 import { mockCreateActivityLog } from '../activity/mocks.js';
@@ -18,6 +18,14 @@ vi.mock('axios', () => ({
 
 const integration: Config = { id: 1, unique_key: 'providerKey', provider: 'provider', environment_id: 1, oauth_client_id: '', oauth_client_secret: '' };
 const account: Account = { id: 1, name: 'account', secret_key: '', uuid: 'uuid' };
+const connection: StoredConnection = {
+    id: 1,
+    connection_id: '1',
+    provider_config_key: 'providerkey',
+    connection_config: {},
+    credentials: {},
+    environment_id: 1
+};
 
 describe('Webhook notification tests', () => {
     beforeEach(() => {
@@ -30,7 +38,7 @@ describe('Webhook notification tests', () => {
 
         await WebhookService.sendAuthUpdate(
             {
-                connection_id: 'foo',
+                connection,
                 environment: { name: 'dev', id: 1, secret_key: 'secret', send_auth_webhook: false, webhook_url: null, always_send_webhook: true } as Environment
             } as RecentlyCreatedConnection,
             'hubspot',
@@ -47,7 +55,7 @@ describe('Webhook notification tests', () => {
 
         await WebhookService.sendAuthUpdate(
             {
-                connection_id: 'foo',
+                connection,
                 environment: {
                     name: 'dev',
                     id: 1,
@@ -72,7 +80,7 @@ describe('Webhook notification tests', () => {
 
         await WebhookService.sendAuthUpdate(
             {
-                connection_id: 'foo',
+                connection,
                 environment: {
                     name: 'dev',
                     id: 1,
@@ -97,7 +105,7 @@ describe('Webhook notification tests', () => {
 
         await WebhookService.sendAuthUpdate(
             {
-                connection_id: 'foo',
+                connection,
                 environment: {
                     name: 'dev',
                     id: 1,
@@ -123,7 +131,7 @@ describe('Webhook notification tests', () => {
 
         await WebhookService.sendAuthUpdate(
             {
-                connection_id: 'foo',
+                connection,
                 environment: {
                     name: 'dev',
                     id: 1,
@@ -147,7 +155,7 @@ describe('Webhook notification tests', () => {
         const logCtx = new LogContext({ parentId: '1' }, { dryRun: true, logToConsole: false });
         await WebhookService.sendAuthUpdate(
             {
-                connection_id: 'foo',
+                connection,
                 environment: {
                     name: 'dev',
                     id: 1,


### PR DESCRIPTION
## Describe your changes

Fixes NAN-1041

- Upserting connection now returns full row 
Some part of the code still query connection again after that, ideally we would reuse the object but I tried to limit the number of changes

- Add missing context for logs where needed
