### PR TITLE
chore(persist): make NANGO_ENCRYPTION_KEY required in persist service

### DIFF
--- a/docs-v2/host/self-host/self-hosting-instructions.mdx
+++ b/docs-v2/host/self-host/self-hosting-instructions.mdx
@@ -74,11 +74,16 @@ NANGO_DASHBOARD_PASSWORD=<PICK-A-PASSWORD>
 ### Encrypt sensitive data[](#encrypt-sensitive-data 'Direct link to Encrypt sensitive data')
 
 You can enforce encryption of sensitive data (tokens, secret key, app secret)
-using the AES-GCM encryption algorithm. To do so, set the following environment
-variable to a randomly generated 256-bit base64-encoded key:
+using the AES-GCM encryption algorithm. To do so, generate a 256-bit base64-encoded key:
 
 ```
-NANGO_ENCRYPTION_KEY=<ADD-BASE64-256BIT-KEY>
+openssl rand -base64 32
+```
+
+And set the `NANGO_ENCRYPTION_KEY` environment variable to the generated key:
+
+```
+NANGO_ENCRYPTION_KEY=<BASE64-256BIT-KEY>
 ```
 
 Once you restart the Nango server, the encryption of the database will happen

--- a/packages/persist/lib/app.ts
+++ b/packages/persist/lib/app.ts
@@ -2,11 +2,12 @@ import './tracer.js';
 import { getLogger } from '@nangohq/utils';
 import { server } from './server.js';
 import { db } from '@nangohq/shared';
+import { envs } from './env.js';
 
 const logger = getLogger('Persist');
 
 try {
-    const port = parseInt(process.env['NANGO_PERSIST_PORT'] || '') || 3007;
+    const port = envs.NANGO_PERSIST_PORT;
     server.listen(port, () => {
         logger.info(`🚀 API ready at http://localhost:${port}`);
 

--- a/packages/persist/lib/env.ts
+++ b/packages/persist/lib/env.ts
@@ -1,0 +1,4 @@
+import { ENVS, parseEnvs } from '@nangohq/utils';
+
+// Encryption key is required for persist to store/retrieve records
+export const envs = parseEnvs(ENVS.required({ NANGO_ENCRYPTION_KEY: true }));

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -83,7 +83,12 @@ export const ENVS = z.object({
     NANGO_DB_PASSWORD: z.string().optional().default('nango'),
     NANGO_DB_SSL: bool,
     NANGO_DB_CLIENT: z.string().optional(),
-    NANGO_ENCRYPTION_KEY: z.string().optional(),
+    NANGO_ENCRYPTION_KEY: z
+        .string({
+            required_error:
+                'To learn more about NANGO_ENCRYPTION_KEY, please read the doc at https://docs.nango.dev/host/self-host/self-hosting-instructions#encrypt-sensitive-data'
+        })
+        .optional(),
     NANGO_DB_MIGRATION_FOLDER: z.string().optional(),
     NANGO_DB_SCHEMA: z.string().optional().default('nango'),
     NANGO_DB_ADDITIONAL_SCHEMAS: z.string().optional(),


### PR DESCRIPTION
Instead of failing when persisting records, persist will fail to start if the encryption key is not setup (with a error message mentioning the doc url)
Also adding to the docs how to generate a encryption key
![Screenshot 2024-05-30 at 10 23 52](https://github.com/NangoHQ/nango/assets/233326/70933c96-49c3-4768-a5ba-7299f832fb2c)

https://linear.app/nango/issue/NAN-922/improve-error-when-no-encryption-key

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
