### PR TITLE
feat(pkgs): create kvstore 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY packages/shared/package.json ./packages/shared/package.json
 COPY packages/utils/package.json ./packages/utils/package.json
 COPY packages/webapp/package.json ./packages/webapp/package.json
 COPY packages/data-ingestion/package.json ./packages/data-ingestion/package.json
+COPY packages/kvstore/package.json ./packages/kvstore/package.json
 COPY packages/logs/package.json ./packages/logs/package.json
 COPY packages/records/package.json ./packages/records/package.json
 COPY packages/types/package.json ./packages/types/package.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
                 "packages/cli",
                 "packages/shared",
                 "packages/frontend",
+                "packages/kvstore",
                 "packages/logs",
                 "packages/node-client",
                 "packages/records",
@@ -6738,6 +6739,10 @@
         },
         "node_modules/@nangohq/frontend": {
             "resolved": "packages/frontend",
+            "link": true
+        },
+        "node_modules/@nangohq/kvstore": {
+            "resolved": "packages/kvstore",
             "link": true
         },
         "node_modules/@nangohq/logs": {
@@ -33419,6 +33424,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@nangohq/data-ingestion": "file:../data-ingestion",
+                "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/logs": "file:../logs",
                 "@nangohq/nango-orchestrator": "file:../orchestrator",
                 "@nangohq/nango-runner": "file:../runner",
@@ -33466,11 +33472,23 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "packages/kvstore": {
+            "name": "@nangohq/kvstore",
+            "version": "1.0.0",
+            "dependencies": {
+                "@nangohq/utils": "file:../utils",
+                "redis": "4.6.13"
+            },
+            "devDependencies": {
+                "vitest": "0.33.0"
+            }
+        },
         "packages/logs": {
             "name": "@nangohq/logs",
             "version": "1.0.0",
             "dependencies": {
                 "@elastic/elasticsearch": "8.13.1",
+                "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/utils": "file:../utils",
                 "zod": "3.22.4"
             },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "packages/cli",
         "packages/shared",
         "packages/frontend",
+        "packages/kvstore",
         "packages/logs",
         "packages/node-client",
         "packages/records",

--- a/packages/jobs/Dockerfile
+++ b/packages/jobs/Dockerfile
@@ -13,6 +13,7 @@ COPY packages/shared/ packages/shared/
 COPY packages/utils/ packages/utils/
 COPY packages/records/ packages/records/
 COPY packages/data-ingestion/ packages/data-ingestion/
+COPY packages/kvstore/ packages/kvstore/
 COPY packages/jobs/ packages/jobs/
 COPY packages/logs/ packages/logs/
 COPY packages/runner/ packages/runner/

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -16,6 +16,7 @@
     },
     "dependencies": {
         "@nangohq/data-ingestion": "file:../data-ingestion",
+        "@nangohq/kvstore": "file:../kvstore",
         "@nangohq/logs": "file:../logs",
         "@nangohq/nango-orchestrator": "file:../orchestrator",
         "@nangohq/nango-runner": "file:../runner",

--- a/packages/jobs/tsconfig.json
+++ b/packages/jobs/tsconfig.json
@@ -6,6 +6,9 @@
     },
     "references": [
         {
+            "path": "../kvstore"
+        },
+        {
             "path": "../logs"
         },
         {

--- a/packages/kvstore/lib/FeatureFlags.ts
+++ b/packages/kvstore/lib/FeatureFlags.ts
@@ -1,0 +1,39 @@
+import { getLogger } from '@nangohq/utils';
+import type { KVStore } from './KVStore.js';
+
+const logger = getLogger('FeatureFlags');
+
+export class FeatureFlags {
+    kvstore: KVStore | undefined;
+
+    constructor(kvstore: KVStore | undefined) {
+        if (!kvstore) {
+            logger.error('Feature flags not enabled');
+        }
+
+        this.kvstore = kvstore;
+    }
+
+    async isEnabled({
+        key,
+        distinctId,
+        fallback,
+        isExcludingFlag = false
+    }: {
+        key: string;
+        distinctId: string;
+        fallback: boolean;
+        isExcludingFlag?: boolean;
+    }): Promise<boolean> {
+        if (!this.kvstore) {
+            return fallback;
+        }
+
+        try {
+            const exists = await this.kvstore.exists(`flag:${key}:${distinctId}`);
+            return isExcludingFlag ? !exists : exists;
+        } catch {
+            return fallback;
+        }
+    }
+}

--- a/packages/kvstore/lib/InMemoryStore.ts
+++ b/packages/kvstore/lib/InMemoryStore.ts
@@ -1,0 +1,53 @@
+import type { KVStore } from './KVStore.js';
+
+interface Value {
+    value: string;
+    timestamp: number;
+    ttlInMs: number;
+}
+
+export class InMemoryKVStore implements KVStore {
+    private store: Map<string, Value>;
+
+    constructor() {
+        this.store = new Map();
+    }
+
+    public async get(key: string): Promise<string | null> {
+        const res = this.store.get(key);
+        if (res === undefined) {
+            return null;
+        }
+        if (this.isExpired(res)) {
+            this.store.delete(key);
+            return null;
+        }
+        return Promise.resolve(res.value);
+    }
+
+    public async set(key: string, value: string, opts?: { canOverride?: boolean; ttlInMs?: number }): Promise<void> {
+        const res = this.store.get(key);
+        const isExpired = res && this.isExpired(res);
+        if (isExpired || opts?.canOverride || res === undefined) {
+            this.store.set(key, { value: value, timestamp: Date.now(), ttlInMs: opts?.ttlInMs || 0 });
+            return Promise.resolve();
+        }
+        return Promise.reject(new Error('Key already exists'));
+    }
+
+    public async delete(key: string): Promise<void> {
+        this.store.delete(key);
+        return Promise.resolve();
+    }
+
+    public async exists(key: string): Promise<boolean> {
+        return Promise.resolve(this.store.has(key));
+    }
+
+    private isExpired(value: Value): boolean {
+        if (value.ttlInMs > 0 && value.timestamp + value.ttlInMs < Date.now()) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/packages/kvstore/lib/InMemoryStore.unit.test.ts
+++ b/packages/kvstore/lib/InMemoryStore.unit.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { InMemoryKVStore } from './InMemoryStore.js';
+
+describe('InMemoryKVStore', () => {
+    let store: InMemoryKVStore;
+    beforeEach(() => {
+        store = new InMemoryKVStore();
+    });
+
+    it('should set and get a value', async () => {
+        await store.set('key', 'value');
+        const value = await store.get('key');
+        expect(value).toEqual('value');
+    });
+
+    it('should return null for a non-existent key', async () => {
+        const value = await store.get('do-not-exist');
+        expect(value).toBeNull();
+    });
+
+    it('should allow overriding a key', async () => {
+        await store.set('key', 'value');
+        await store.set('key', 'value2', { canOverride: true });
+        const value = await store.get('key');
+        expect(value).toEqual('value2');
+    });
+
+    it('should not allow overriding a key', async () => {
+        await store.set('key', 'value');
+        await expect(store.set('key', 'value2', { canOverride: false })).rejects.toEqual(new Error('Key already exists'));
+    });
+
+    it('should return null for a key that has expired', async () => {
+        const ttlInMs = 1000;
+        await store.set('key', 'value', { canOverride: true, ttlInMs });
+        await new Promise((resolve) => setTimeout(resolve, ttlInMs * 2));
+        const value = await store.get('key');
+        expect(value).toBeNull();
+    });
+
+    it('should not return null for a key that has not expired', async () => {
+        const ttlInMs = 2000;
+        await store.set('key', 'value', { canOverride: true, ttlInMs });
+        await new Promise((resolve) => setTimeout(resolve, ttlInMs / 2));
+        const value = await store.get('key');
+        expect(value).toEqual('value');
+    });
+
+    it('should allow setting an expired key', async () => {
+        await store.set('key', 'value', { canOverride: false, ttlInMs: 10 });
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        await expect(store.set('key', 'value', { canOverride: false })).resolves.not.toThrow();
+    });
+
+    it('should allow setting a key with a TTL of 0', async () => {
+        await store.set('key', 'value', { canOverride: true, ttlInMs: 0 });
+        const value = await store.get('key');
+        expect(value).toEqual('value');
+    });
+
+    it('should allow deleting a key', async () => {
+        await store.delete('key');
+        const value = await store.get('key');
+        expect(value).toBeNull();
+    });
+    it('should allow checking if a key exists', async () => {
+        await expect(store.exists('key')).resolves.toEqual(false);
+        await store.set('key', 'value');
+        await expect(store.exists('key')).resolves.toEqual(true);
+    });
+});

--- a/packages/kvstore/lib/KVStore.ts
+++ b/packages/kvstore/lib/KVStore.ts
@@ -1,0 +1,6 @@
+export interface KVStore {
+    set(key: string, value: string, options?: { canOverride?: boolean; ttlInMs?: number }): Promise<void>;
+    get(key: string): Promise<string | null>;
+    delete(key: string): Promise<void>;
+    exists(key: string): Promise<boolean>;
+}

--- a/packages/kvstore/lib/RedisStore.ts
+++ b/packages/kvstore/lib/RedisStore.ts
@@ -1,0 +1,47 @@
+import type { KVStore } from './KVStore.js';
+import { createClient } from 'redis';
+import type { RedisClientType } from 'redis';
+
+export class RedisKVStore implements KVStore {
+    private client: RedisClientType;
+
+    constructor(url: string) {
+        this.client = createClient({ url: url });
+
+        this.client.on('error', (err) => {
+            console.error(`Redis (kvstore) error: ${err}`);
+        });
+    }
+
+    public async connect(): Promise<void> {
+        return this.client.connect().then(() => {});
+    }
+
+    public async get(key: string): Promise<string | null> {
+        return this.client.get(key);
+    }
+
+    public async set(key: string, value: string, opts?: { canOverride?: boolean; ttlInMs?: number }): Promise<void> {
+        const options: any = {};
+        if (opts) {
+            if (opts.ttlInMs && opts.ttlInMs > 0) {
+                options['PX'] = opts.ttlInMs;
+            }
+            if (opts.canOverride === false) {
+                options['NX'] = true;
+            }
+        }
+        const res = await this.client.set(key, value, options);
+        if (res !== 'OK') {
+            throw new Error(`Failed to set key: ${key}, value: ${value}, ${JSON.stringify(options)}`);
+        }
+    }
+
+    public async exists(key: string): Promise<boolean> {
+        return (await this.client.exists(key)) > 0;
+    }
+
+    public async delete(key: string): Promise<void> {
+        await this.client.del(key);
+    }
+}

--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -1,0 +1,17 @@
+import { InMemoryKVStore } from './InMemoryStore.js';
+import { RedisKVStore } from './RedisStore.js';
+
+export { InMemoryKVStore } from './InMemoryStore.js';
+export { RedisKVStore } from './RedisStore.js';
+export type { KVStore } from './KVStore.js';
+
+export async function createKVStore() {
+    const url = process.env['NANGO_REDIS_URL'];
+    if (url) {
+        const store = new RedisKVStore(url);
+        await store.connect();
+        return store;
+    }
+
+    return new InMemoryKVStore();
+}

--- a/packages/kvstore/package.json
+++ b/packages/kvstore/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@nangohq/logs",
+    "name": "@nangohq/kvstore",
     "version": "1.0.0",
     "type": "module",
     "main": "./dist/index.js",
@@ -14,16 +14,11 @@
         "directory": "packages/logs"
     },
     "dependencies": {
-        "@elastic/elasticsearch": "8.13.1",
-        "@nangohq/kvstore": "file:../kvstore",
         "@nangohq/utils": "file:../utils",
-        "zod": "3.22.4"
+        "redis": "4.6.13"
     },
     "devDependencies": {
-        "@nangohq/types": "file:../types",
-        "type-fest": "4.14.0",
-        "vitest": "0.33.0",
-        "winston": "3.8.2"
+        "vitest": "0.33.0"
     },
     "files": [
         "dist/**/*"

--- a/packages/kvstore/tsconfig.json
+++ b/packages/kvstore/tsconfig.json
@@ -6,12 +6,6 @@
     },
     "references": [
         {
-            "path": "../kvstore"
-        },
-        {
-            "path": "../types"
-        },
-        {
             "path": "../utils"
         }
     ],

--- a/packages/logs/lib/models/messages.ts
+++ b/packages/logs/lib/models/messages.ts
@@ -36,14 +36,15 @@ export const ResponseError = errors.ResponseError;
 /**
  * Create one message
  */
-export async function createMessage(row: MessageRow): Promise<void> {
-    await client.create<MessageRow>({
+export async function createMessage(row: MessageRow): Promise<{ index: string }> {
+    const res = await client.create<MessageRow>({
         index: indexMessages.index,
         id: row.id,
         document: row,
         refresh: row.operation ? true : isTest,
         pipeline: `daily.${indexMessages.index}`
     });
+    return { index: res._index };
 }
 
 /**
@@ -161,10 +162,16 @@ export async function listOperations(opts: {
 /**
  * Get a single operation
  */
-export async function getOperation(opts: { id: MessageRow['id'] }): Promise<MessageRow> {
+export async function getOperation(opts: { id: MessageRow['id']; indexName?: string | null }): Promise<MessageRow> {
+    if (opts.indexName) {
+        const res = await client.get<OperationRow>({ index: opts.indexName, id: opts.id });
+        return res._source!;
+    }
+
     // Can't perform a getById because we don't know in which index the operation is in
     const res = await client.search<OperationRow>({
         index: indexMessages.index,
+        size: 1,
         query: {
             term: { id: opts.id }
         }

--- a/packages/logs/lib/utils.ts
+++ b/packages/logs/lib/utils.ts
@@ -1,5 +1,16 @@
 import { getLogger } from '@nangohq/utils';
+import { createKVStore } from '@nangohq/kvstore';
+import type { KVStore } from '@nangohq/kvstore';
 
 export const logger = getLogger('elasticsearch');
 
 export const isCli = process.argv.find((value) => value.includes('/bin/nango') || value.includes('cli/dist/index'));
+
+let kvstore: KVStore;
+export async function getKVStore() {
+    if (!kvstore) {
+        kvstore = await createKVStore();
+    }
+
+    return kvstore;
+}

--- a/packages/persist/Dockerfile
+++ b/packages/persist/Dockerfile
@@ -12,6 +12,7 @@ COPY packages/node-client/ packages/node-client/
 COPY packages/shared/ packages/shared/
 COPY packages/persist/ packages/persist/
 COPY packages/utils/ packages/utils/
+COPY packages/kvstore/ packages/kvstore/
 COPY packages/logs/ packages/logs/
 COPY packages/records/ packages/records/
 COPY package*.json ./

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -14,6 +14,7 @@ COPY package*.json ./
 COPY packages/webapp/build/ packages/webapp/build/
 COPY packages/shared/ packages/shared/
 COPY packages/utils/ packages/utils/
+COPY packages/kvstore/ packages/kvstore/
 COPY packages/logs/ packages/logs/
 COPY packages/node-client/ packages/node-client/
 COPY packages/records/ packages/records/

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -42,9 +42,6 @@ export * from './utils/utils.js';
 export * from './utils/error.js';
 export * from './db/database.js';
 export * from './constants.js';
-export * from './utils/kvstore/KVStore.js';
-export * from './utils/kvstore/InMemoryStore.js';
-export * from './utils/kvstore/RedisStore.js';
 
 export * from './sdk/sync.js';
 

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -4,5 +4,10 @@
         "rootDir": "lib",
         "outDir": "dist"
     },
-    "include": ["lib/**/*"]
+    "include": ["lib/**/*"],
+    "references": [
+        {
+            "path": "../types"
+        }
+    ]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -14,6 +14,9 @@
             "path": "packages/jobs"
         },
         {
+            "path": "packages/kvstore"
+        },
+        {
             "path": "packages/logs"
         },
         {

--- a/tsconfig.docker.json
+++ b/tsconfig.docker.json
@@ -11,6 +11,9 @@
             "path": "packages/frontend"
         },
         {
+            "path": "packages/kvstore"
+        },
+        {
             "path": "packages/jobs"
         },
         {


### PR DESCRIPTION
## Describe your changes

Fixes NAN-1071

- Create a reusable package for KVStore
Duplicated for now, can't remove it entirely from `shared` because FeatureFlags and Locking, but it's a first step. I stopped exporting it so it's no longer used by external package and I'll do a second pass to remove it entirely.
Note: I did that because logs can't depend on shared


- Use it in Jobs


- Use it in Logs
As discussed orally, the main id is to be able to retrieve the indexName quickly without doing a full search on the cluster. Maybe it's the fix maybe not.
