### PR TITLE
chore: actions and webhooks can be executed by orchestrator

### DIFF
--- a/packages/jobs/lib/activities.ts
+++ b/packages/jobs/lib/activities.ts
@@ -32,30 +32,16 @@ import {
     isInitialSyncStillRunning,
     getSyncByIdAndName,
     getLastSyncDate,
-    getSyncConfigRaw,
-    getOrchestratorUrl,
-    SlackService
+    getSyncConfigRaw
 } from '@nangohq/shared';
 import { records as recordsService } from '@nangohq/records';
-import { getLogger, env, stringifyError, errorToObject } from '@nangohq/utils';
-import { BigQueryClient } from '@nangohq/data-ingestion/dist/index.js';
+import { getLogger, stringifyError, errorToObject } from '@nangohq/utils';
 import integrationService from './integration.service.js';
 import type { LogContext } from '@nangohq/logs';
 import { logContextGetter } from '@nangohq/logs';
-import { OrchestratorClient } from '@nangohq/nango-orchestrator';
+import { bigQueryClient, slackService } from './clients.js';
 
 const logger = getLogger('Jobs');
-
-const bigQueryClient = await BigQueryClient.createInstance({
-    datasetName: 'raw',
-    tableName: `${env}_script_runs`
-});
-
-const orchestratorClient = new OrchestratorClient({ baseUrl: getOrchestratorUrl() });
-const slackService = new SlackService({
-    orchestratorClient: orchestratorClient,
-    logContextGetter: logContextGetter
-});
 
 export async function routeSync(args: InitialSyncArgs): Promise<boolean | object | null> {
     const { syncId, syncJobId, syncName, nangoConnection, debug } = args;

--- a/packages/jobs/lib/clients.ts
+++ b/packages/jobs/lib/clients.ts
@@ -1,0 +1,17 @@
+import { BigQueryClient } from '@nangohq/data-ingestion';
+import { logContextGetter } from '@nangohq/logs';
+import { OrchestratorClient } from '@nangohq/nango-orchestrator';
+import { SlackService, getOrchestratorUrl } from '@nangohq/shared';
+import { env } from '@nangohq/utils';
+
+export const bigQueryClient = await BigQueryClient.createInstance({
+    datasetName: 'raw',
+    tableName: `${env}_script_runs`
+});
+
+export const orchestratorClient = new OrchestratorClient({ baseUrl: getOrchestratorUrl() });
+
+export const slackService = new SlackService({
+    orchestratorClient: orchestratorClient,
+    logContextGetter: logContextGetter
+});

--- a/packages/jobs/lib/processor/processor.ts
+++ b/packages/jobs/lib/processor/processor.ts
@@ -24,7 +24,7 @@ export class Processor {
             const actionWorker = new ProcessorWorker({
                 orchestratorUrl: this.orchestratorServiceUrl,
                 groupKey: 'action',
-                maxConcurrency: 100
+                maxConcurrency: 500
             });
             actionWorker.start();
 

--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -43,9 +43,10 @@ describe('OrchestratorClient', async () => {
                 timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
                 args: {
                     type: 'action',
-                    name: rndStr(),
+                    actionName: rndStr(),
                     connection: {
                         id: 123,
+                        connection_id: 'C',
                         provider_config_key: 'P',
                         environment_id: 456
                     },
@@ -79,9 +80,10 @@ describe('OrchestratorClient', async () => {
                     name: 'Task',
                     groupKey: groupKey,
                     args: {
-                        name: 'Action',
+                        actionName: 'Action',
                         connection: {
                             id: 1234,
+                            connection_id: 'C',
                             provider_config_key: 'P',
                             environment_id: 5678
                         },
@@ -109,9 +111,10 @@ describe('OrchestratorClient', async () => {
                     name: 'Task',
                     groupKey: groupKey,
                     args: {
-                        name: 'Action',
+                        actionName: 'Action',
                         connection: {
                             id: 1234,
+                            connection_id: 'C',
                             provider_config_key: 'P',
                             environment_id: 5678
                         },
@@ -144,10 +147,11 @@ describe('OrchestratorClient', async () => {
                     name: 'Task',
                     groupKey: groupKey,
                     args: {
-                        name: 'Action',
+                        webhookName: 'W',
                         parentSyncName: 'parent',
                         connection: {
                             id: 1234,
+                            connection_id: 'C',
                             provider_config_key: 'P',
                             environment_id: 5678
                         },
@@ -175,10 +179,11 @@ describe('OrchestratorClient', async () => {
                     name: 'Task',
                     groupKey: groupKey,
                     args: {
-                        name: 'Action',
+                        webhookName: 'W',
                         parentSyncName: rndStr(),
                         connection: {
                             id: 1234,
+                            connection_id: 'C',
                             provider_config_key: 'P',
                             environment_id: 5678
                         },
@@ -205,9 +210,10 @@ describe('OrchestratorClient', async () => {
                 timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
                 args: {
                     type: 'action',
-                    name: `action-a`,
+                    actionName: `A`,
                     connection: {
                         id: 123,
+                        connection_id: 'C',
                         provider_config_key: 'P',
                         environment_id: 456
                     },
@@ -222,9 +228,10 @@ describe('OrchestratorClient', async () => {
                 timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
                 args: {
                     type: 'action',
-                    name: `action-b`,
+                    actionName: `A`,
                     connection: {
                         id: 123,
+                        connection_id: 'C',
                         provider_config_key: 'P',
                         environment_id: 456
                     },
@@ -252,9 +259,10 @@ describe('OrchestratorClient', async () => {
                 timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
                 args: {
                     type: 'action',
-                    name: `action-a`,
+                    actionName: `A`,
                     connection: {
                         id: 123,
+                        connection_id: 'C',
                         provider_config_key: 'P',
                         environment_id: 456
                     },
@@ -269,10 +277,11 @@ describe('OrchestratorClient', async () => {
                 timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
                 args: {
                     type: 'webhook',
-                    name: `webhook-a`,
+                    webhookName: `webhook-a`,
                     parentSyncName: 'parent',
                     connection: {
                         id: 123,
+                        connection_id: 'C',
                         provider_config_key: 'P',
                         environment_id: 456
                     },

--- a/packages/orchestrator/lib/clients/processor.integration.test.ts
+++ b/packages/orchestrator/lib/clients/processor.integration.test.ts
@@ -126,9 +126,10 @@ async function scheduleTask({ groupKey }: { groupKey: string }) {
             payload: {
                 type: 'action',
                 activityLogId: 1234,
-                name: 'Task',
+                actionName: 'Task',
                 connection: {
                     id: 1234,
+                    connection_id: 'C',
                     provider_config_key: 'P',
                     environment_id: 5678
                 },

--- a/packages/orchestrator/lib/clients/processor.ts
+++ b/packages/orchestrator/lib/clients/processor.ts
@@ -105,6 +105,7 @@ export class OrchestratorProcessor {
                 } else {
                     await this.orchestratorClient.succeed({ taskId: task.id, output: res.value });
                 }
+                //TODO what to do if failed/success fails?
             } catch (err: unknown) {
                 const error = new Error(stringifyError(err));
                 await this.orchestratorClient.failed({ taskId: task.id, error });

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -5,30 +5,32 @@ import type { TaskState } from '@nangohq/scheduler';
 
 export type SchedulingProps = Omit<PostSchedule['Body'], 'scheduling'>;
 
-export interface ActionArgs {
-    name: string;
+interface ActionArgs {
+    actionName: string;
     connection: {
         id: number;
+        provider_config_key: string;
+        environment_id: number;
+        connection_id: string;
+    };
+    activityLogId: number;
+    input: JsonValue;
+}
+interface WebhookArgs {
+    webhookName: string;
+    parentSyncName: string;
+    connection: {
+        id: number;
+        connection_id: string;
         provider_config_key: string;
         environment_id: number;
     };
     activityLogId: number;
     input: JsonValue;
 }
-export interface WebhookArgs {
-    name: string;
-    parentSyncName: string;
-    connection: {
-        id: number;
-        provider_config_key: string;
-        environment_id: number;
-    };
-    activityLogId: number | null;
-    input: JsonValue;
-}
 
-export interface PostConnectionArgs {
-    name: string;
+interface PostConnectionArgs {
+    postConnectionName: string;
     connection: {
         id: number;
         provider_config_key: string;
@@ -46,29 +48,24 @@ export type ExecutePostConnectionProps = Omit<ExecuteProps, 'args'> & { args: Po
 
 export type OrchestratorTask = TaskAction | TaskWebhook | TaskPostConnection;
 
-export interface TaskAction extends ActionArgs {
+interface TaskCommonFields {
     id: string;
+    name: string;
     state: TaskState;
-    abortController: AbortController;
+}
+interface TaskCommon extends TaskCommonFields {
     isWebhook(this: OrchestratorTask): this is TaskWebhook;
     isAction(this: OrchestratorTask): this is TaskAction;
     isPostConnection(this: OrchestratorTask): this is TaskPostConnection;
+    abortController: AbortController;
 }
-export function TaskAction(props: {
-    id: string;
-    state: TaskState;
-    name: string;
-    connection: {
-        id: number;
-        provider_config_key: string;
-        environment_id: number;
-    };
-    activityLogId: number;
-    input: JsonValue;
-}): TaskAction {
+
+export interface TaskAction extends TaskCommon, ActionArgs {}
+export function TaskAction(props: TaskCommonFields & ActionArgs): TaskAction {
     return {
         id: props.id,
         name: props.name,
+        actionName: props.actionName,
         state: props.state,
         connection: props.connection,
         activityLogId: props.activityLogId,
@@ -80,31 +77,13 @@ export function TaskAction(props: {
     };
 }
 
-export interface TaskWebhook extends WebhookArgs {
-    id: string;
-    state: TaskState;
-    abortController: AbortController;
-    isWebhook(this: OrchestratorTask): this is TaskWebhook;
-    isAction(this: OrchestratorTask): this is TaskAction;
-    isPostConnection(this: OrchestratorTask): this is TaskPostConnection;
-}
-export function TaskWebhook(props: {
-    id: string;
-    state: TaskState;
-    name: string;
-    parentSyncName: string;
-    connection: {
-        id: number;
-        provider_config_key: string;
-        environment_id: number;
-    };
-    activityLogId: number | null;
-    input: JsonValue;
-}): TaskWebhook {
+export interface TaskWebhook extends TaskCommon, WebhookArgs {}
+export function TaskWebhook(props: TaskCommonFields & WebhookArgs): TaskWebhook {
     return {
         id: props.id,
-        state: props.state,
         name: props.name,
+        state: props.state,
+        webhookName: props.webhookName,
         parentSyncName: props.parentSyncName,
         connection: props.connection,
         activityLogId: props.activityLogId,
@@ -116,30 +95,13 @@ export function TaskWebhook(props: {
     };
 }
 
-export interface TaskPostConnection extends PostConnectionArgs {
-    id: string;
-    state: TaskState;
-    abortController: AbortController;
-    isWebhook(this: OrchestratorTask): this is TaskWebhook;
-    isAction(this: OrchestratorTask): this is TaskAction;
-    isPostConnection(this: OrchestratorTask): this is TaskPostConnection;
-}
-export function TaskPostConnection(props: {
-    id: string;
-    state: TaskState;
-    name: string;
-    connection: {
-        id: number;
-        provider_config_key: string;
-        environment_id: number;
-    };
-    fileLocation: string;
-    activityLogId: number;
-}): TaskPostConnection {
+export interface TaskPostConnection extends TaskCommon, PostConnectionArgs {}
+export function TaskPostConnection(props: TaskCommonFields & PostConnectionArgs): TaskPostConnection {
     return {
         id: props.id,
         state: props.state,
         name: props.name,
+        postConnectionName: props.postConnectionName,
         connection: props.connection,
         fileLocation: props.fileLocation,
         activityLogId: props.activityLogId,

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -33,6 +33,7 @@ export function validateTask(task: Task): Result<TaskAction | TaskWebhook | Task
                 state: action.data.state,
                 id: action.data.id,
                 name: action.data.name,
+                actionName: action.data.payload.actionName,
                 connection: action.data.payload.connection,
                 activityLogId: action.data.payload.activityLogId,
                 input: action.data.payload.input
@@ -46,6 +47,7 @@ export function validateTask(task: Task): Result<TaskAction | TaskWebhook | Task
                 id: webhook.data.id,
                 state: webhook.data.state,
                 name: webhook.data.name,
+                webhookName: webhook.data.payload.webhookName,
                 parentSyncName: webhook.data.payload.parentSyncName,
                 connection: webhook.data.payload.connection,
                 activityLogId: webhook.data.payload.activityLogId,
@@ -60,11 +62,12 @@ export function validateTask(task: Task): Result<TaskAction | TaskWebhook | Task
                 id: postConnection.data.id,
                 state: postConnection.data.state,
                 name: postConnection.data.name,
+                postConnectionName: postConnection.data.payload.postConnectionName,
                 connection: postConnection.data.payload.connection,
                 fileLocation: postConnection.data.payload.fileLocation,
                 activityLogId: postConnection.data.payload.activityLogId
             })
         );
     }
-    return Err(`Cannot validate task: ${task}`);
+    return Err(`Cannot validate task ${JSON.stringify(task)}: ${action.error || webhook.error || postConnection.error}`);
 }

--- a/packages/orchestrator/lib/index.ts
+++ b/packages/orchestrator/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './clients/types.js';
 export * from './clients/client.js';
 export * from './clients/processor.js';
+export * from './utils/validation.js';

--- a/packages/orchestrator/lib/routes/v1/postSchedule.ts
+++ b/packages/orchestrator/lib/routes/v1/postSchedule.ts
@@ -33,30 +33,31 @@ export type PostSchedule = Endpoint<{
 }>;
 
 const commonSchemaFields = {
-    name: z.string().min(1),
     connection: z.object({
         id: z.number().positive(),
+        connection_id: z.string().min(1),
         provider_config_key: z.string().min(1),
         environment_id: z.number().positive()
     }),
+    activityLogId: z.number().positive(),
     input: jsonSchema
 };
 
 export const actionArgsSchema = z.object({
     type: z.literal('action'),
-    activityLogId: z.number().positive(),
+    actionName: z.string().min(1),
     ...commonSchemaFields
 });
 export const webhookArgsSchema = z.object({
     type: z.literal('webhook'),
+    webhookName: z.string().min(1),
     parentSyncName: z.string().min(1),
-    activityLogId: z.number().positive().nullable(),
     ...commonSchemaFields
 });
 export const postConnectionArgsSchema = z.object({
     type: z.literal('post-connection-script'),
+    postConnectionName: z.string().min(1),
     fileLocation: z.string().min(1),
-    activityLogId: z.number().positive(),
     ...commonSchemaFields
 });
 

--- a/packages/orchestrator/lib/server.ts
+++ b/packages/orchestrator/lib/server.ts
@@ -24,7 +24,7 @@ export const getServer = (scheduler: Scheduler, eventEmmiter: EventEmitter): Exp
         const originalSend = res.send;
         res.send = function (body: any) {
             if (res.statusCode >= 400) {
-                logger.error(`${req.method} ${req.path} ${res.statusCode} -> ${body}`);
+                logger.error(`${req.method} ${req.path} ${res.statusCode} -> ${JSON.stringify(body)}`);
             }
             originalSend.call(this, body) as any;
             return this;

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -151,6 +151,13 @@ describe('Task', () => {
         expect(l5.length).toBe(2);
         expect(l5.map((t) => t.id)).toStrictEqual([t1.id, t2.id]);
     });
+    it('should be successfully saving json output', async () => {
+        const outputs = [1, 'one', true, null, ['a', 'b'], { a: 1, b: 2, s: 'two', arr: ['a', 'b'] }, [{ id: 'a' }, { id: 'b' }]];
+        for (const output of outputs) {
+            const task = await createTaskWithState(db, 'STARTED');
+            (await tasks.transitionState(db, { taskId: task.id, newState: 'SUCCEEDED', output })).unwrap();
+        }
+    });
 });
 
 async function createTaskWithState(db: knex.Knex, state: TaskState): Promise<Task> {

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -184,6 +184,23 @@ export async function transitionState(
     }
 
     const output = 'output' in props ? props.output : null;
+    const asPostgresJson = (val: JsonValue) => {
+        if (val === null) {
+            return null;
+        }
+        if (Array.isArray(val)) {
+            // https://github.com/brianc/node-postgres/issues/442
+            return JSON.stringify(val);
+        }
+        switch (typeof val) {
+            case 'string': {
+                return db.raw(`to_json(?::text)`, [val]);
+            }
+            default:
+                return db.raw(`to_json(?::json)`, [val]);
+        }
+    };
+
     const updated = await db
         .from<DbTask>(TASKS_TABLE)
         .where('id', props.taskId)
@@ -191,12 +208,13 @@ export async function transitionState(
             state: transition.value.to,
             last_state_transition_at: new Date(),
             terminated: validToStates.includes(transition.value.to),
-            output
+            output: asPostgresJson(output)
         })
         .returning('*');
     if (!updated?.[0]) {
         return Err(new Error(`Task with id '${props.taskId}' not found`));
     }
+
     return Ok(DbTask.from(updated[0]));
 }
 

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -1,5 +1,5 @@
 import type { LogContext, LogContextGetter } from '@nangohq/logs';
-import { Err, Ok, stringifyError, metrics, getLogger } from '@nangohq/utils';
+import { Err, Ok, stringifyError, metrics } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
 import { NangoError } from '../utils/error.js';
 import telemetry, { LogTypes } from '../utils/telemetry.js';
@@ -20,20 +20,11 @@ import type { LogLevel } from '@nangohq/types';
 import SyncClient from './sync.client.js';
 import type { Client as TemporalClient } from '@temporalio/client';
 import { LogActionEnum } from '../models/Activity.js';
-import type {
-    ExecuteReturn,
-    ExecuteActionProps,
-    ExecuteWebhookProps,
-    ExecutePostConnectionProps,
-    ActionArgs,
-    WebhookArgs,
-    PostConnectionArgs
-} from '@nangohq/nango-orchestrator';
+import type { ExecuteReturn, ExecuteActionProps, ExecuteWebhookProps, ExecutePostConnectionProps } from '@nangohq/nango-orchestrator';
 import type { Account } from '../models/Admin.js';
 import type { Environment } from '../models/Environment.js';
 import type { SyncConfig } from '../models/index.js';
-
-const logger = getLogger('orchestrator.client');
+import tracer from 'dd-trace';
 
 async function getTemporal(): Promise<TemporalClient> {
     const instance = await SyncClient.getInstance();
@@ -86,86 +77,108 @@ export class Orchestrator {
             });
             await logCtx.info(`Starting action workflow ${workflowId} in the task queue: ${SYNC_TASK_QUEUE}`, { input: JSON.stringify(input, null, 2) });
 
-            const isOchestratorEnabled = await featureFlags.isEnabled('orchestrator:dryrun', 'global', false, false);
-            if (isOchestratorEnabled) {
+            let res: Result<any, NangoError>;
+
+            const isGloballyEnabled = await featureFlags.isEnabled('orchestrator:immediate', 'global', false);
+            const isEnvEnabled = await featureFlags.isEnabled('orchestrator:immediate', `${environment_id}`, false);
+            const activeSpan = tracer.scope().active();
+            const spanTags = {
+                'action.name': actionName,
+                'connection.id': connection.id,
+                'connection.connection_id': connection.connection_id,
+                'connection.provider_config_key': connection.provider_config_key,
+                'connection.environment_id': connection.environment_id
+            };
+            if (isGloballyEnabled || isEnvEnabled) {
+                const span = tracer.startSpan('execute.action', {
+                    tags: spanTags,
+                    ...(activeSpan ? { childOf: activeSpan } : {})
+                });
                 try {
                     const groupKey: string = 'action';
                     const executionId = `${groupKey}:environment:${connection.environment_id}:connection:${connection.id}:action:${actionName}:at:${new Date().toISOString()}:${uuid()}`;
                     const parsedInput = JSON.parse(JSON.stringify(input));
-                    const args: ActionArgs = {
-                        name: actionName,
+                    const args = {
+                        actionName,
                         connection: {
                             id: connection.id!,
+                            connection_id: connection.connection_id,
                             provider_config_key: connection.provider_config_key,
                             environment_id: connection.environment_id
                         },
                         activityLogId,
                         input: parsedInput
                     };
-                    // Execute dry-mode: no await for now
-                    void this.client
-                        .executeAction({
-                            name: executionId,
-                            groupKey,
-                            args,
-                            timeoutSettingsInSecs: {
-                                createdToStarted: 5,
-                                startedToCompleted: 5,
-                                heartbeat: 10
-                            }
-                        })
-                        .then(
-                            (res) => {
-                                if (res.isErr()) {
-                                    logger.error(`Error: Execution '${executionId}' failed: ${stringifyError(res.error)}`);
-                                } else {
-                                    logger.info(`Execution '${executionId}' executed successfully with result: ${JSON.stringify(res.value)}`);
-                                }
-                            },
-                            (error) => {
-                                logger.error(`Error: Action '${executionId}' failed: ${stringifyError(error)}`);
-                            }
-                        );
+                    const actionResult = await this.client.executeAction({
+                        name: executionId,
+                        groupKey,
+                        args
+                    });
+                    res = actionResult.mapError((e) => new NangoError('action_failure', e.payload ?? { error: e.message }));
+                    if (res.isErr()) {
+                        span.setTag('error', res.error);
+                    }
                 } catch (e: unknown) {
-                    const errorMsg = `Execute: Failed to parse input object ${JSON.stringify(input)} to JsonValue: ${stringifyError(e)}`;
-                    logger.error(errorMsg);
+                    const errorMsg = `Execute: Failed to parse input '${JSON.stringify(input)}': ${stringifyError(e)}`;
+                    const error = new NangoError('action_failure', { error: errorMsg });
+                    span.setTag('error', e);
+                    return Err(error);
+                } finally {
+                    span.finish();
+                }
+            } else {
+                const span = tracer.startSpan('execute.actionTemporal', {
+                    tags: spanTags,
+                    ...(activeSpan ? { childOf: activeSpan } : {})
+                });
+                try {
+                    const temporal = await getTemporal();
+                    const actionHandler = await temporal.workflow.execute('action', {
+                        taskQueue: SYNC_TASK_QUEUE,
+                        workflowId,
+                        args: [
+                            {
+                                actionName,
+                                nangoConnection: {
+                                    id: connection.id,
+                                    connection_id: connection.connection_id,
+                                    provider_config_key: connection.provider_config_key,
+                                    environment_id: connection.environment_id
+                                },
+                                input,
+                                activityLogId
+                            }
+                        ]
+                    });
+
+                    const { error: rawError, response }: RunnerOutput = actionHandler;
+                    if (rawError) {
+                        // Errors received from temporal are raw objects not classes
+                        const error = new NangoError(rawError['type'], rawError['payload'], rawError['status']);
+                        res = Err(error);
+                        await logCtx.error(`Failed with error ${rawError['type']} ${JSON.stringify(rawError['payload'])}`);
+                    } else {
+                        res = Ok(response);
+                    }
+                    if (res.isErr()) {
+                        span.setTag('error', res.error);
+                    }
+                } catch (e: unknown) {
+                    span.setTag('error', e);
+                    throw e;
+                } finally {
+                    span.finish();
                 }
             }
 
-            const temporal = await getTemporal();
-            const actionHandler = await temporal.workflow.execute('action', {
-                taskQueue: SYNC_TASK_QUEUE,
-                workflowId,
-                args: [
-                    {
-                        actionName,
-                        nangoConnection: {
-                            id: connection.id,
-                            connection_id: connection.connection_id,
-                            provider_config_key: connection.provider_config_key,
-                            environment_id: connection.environment_id
-                        },
-                        input,
-                        activityLogId
-                    }
-                ]
-            });
-
-            const { success, error: rawError, response }: RunnerOutput = actionHandler;
-
-            // Errors received from temporal are raw objects not classes
-            const error = rawError ? new NangoError(rawError['type'], rawError['payload'], rawError['status']) : rawError;
-            if (!success || error) {
-                if (rawError) {
-                    await createActivityLogMessageAndEnd({
-                        level: 'error',
-                        environment_id,
-                        activity_log_id: activityLogId,
-                        timestamp: Date.now(),
-                        content: `Failed with error ${rawError['type']} ${JSON.stringify(rawError['payload'])}`
-                    });
-                    await logCtx.error(`Failed with error ${rawError['type']} ${JSON.stringify(rawError['payload'])}`);
-                }
+            if (res.isErr()) {
+                await createActivityLogMessageAndEnd({
+                    level: 'error',
+                    environment_id,
+                    activity_log_id: activityLogId,
+                    timestamp: Date.now(),
+                    content: `Failed with error ${res.error.type} ${JSON.stringify(res.error.payload)}`
+                });
                 await createActivityLogMessageAndEnd({
                     level: 'error',
                     environment_id,
@@ -174,11 +187,10 @@ export class Orchestrator {
                     content: `The action workflow ${workflowId} did not complete successfully`
                 });
                 await logCtx.error(`The action workflow ${workflowId} did not complete successfully`);
-
-                return Err(error!);
+                return res;
             }
 
-            const content = `The action workflow ${workflowId} was successfully run. A truncated response is: ${JSON.stringify(response, null, 2)?.slice(0, 100)}`;
+            const content = `The action workflow ${workflowId} was successfully run. A truncated response is: ${JSON.stringify(res.value, null, 2)?.slice(0, 100)}`;
 
             await createActivityLogMessageAndEnd({
                 level: 'info',
@@ -203,7 +215,7 @@ export class Orchestrator {
                 `actionName:${actionName}`
             );
 
-            return Ok(response);
+            return res;
         } catch (err) {
             const errorMessage = stringifyError(err, { pretty: true });
             const error = new NangoError('action_failure', { errorMessage });
@@ -315,71 +327,96 @@ export class Orchestrator {
             const { credentials, credentials_iv, credentials_tag, deleted, deleted_at, ...nangoConnectionWithoutCredentials } =
                 connection as unknown as NangoFullConnection;
 
-            const isOchestratorEnabled = await featureFlags.isEnabled('orchestrator:dryrun', 'global', false, false);
-            if (isOchestratorEnabled) {
+            const activeSpan = tracer.scope().active();
+            const spanTags = {
+                'webhook.name': webhookName,
+                'connection.id': connection.id,
+                'connection.connection_id': connection.connection_id,
+                'connection.provider_config_key': connection.provider_config_key,
+                'connection.environment_id': connection.environment_id
+            };
+
+            let res: Result<any, NangoError>;
+
+            const isGloballyEnabled = await featureFlags.isEnabled('orchestrator:immediate', 'global', false);
+            const isEnvEnabled = await featureFlags.isEnabled('orchestrator:immediate', `${integration.environment_id}`, false);
+            if (isGloballyEnabled || isEnvEnabled) {
+                const span = tracer.startSpan('execute.webhook', {
+                    tags: spanTags,
+                    ...(activeSpan ? { childOf: activeSpan } : {})
+                });
                 try {
                     const groupKey: string = 'webhook';
                     const executionId = `${groupKey}:environment:${connection.environment_id}:connection:${connection.id}:webhook:${webhookName}:at:${new Date().toISOString()}:${uuid()}`;
                     const parsedInput = JSON.parse(JSON.stringify(input));
-                    const args: WebhookArgs = {
-                        name: webhookName,
+                    const args = {
+                        webhookName,
                         parentSyncName: syncConfig.sync_name,
                         connection: {
                             id: connection.id!,
+                            connection_id: connection.connection_id,
                             provider_config_key: connection.provider_config_key,
                             environment_id: connection.environment_id
                         },
                         input: parsedInput,
-                        activityLogId
+                        activityLogId: activityLogId!
                     };
-                    // Execute dry-mode: no await for now
-                    void this.client
-                        .executeWebhook({
-                            name: executionId,
-                            groupKey,
-                            args,
-                            timeoutSettingsInSecs: {
-                                createdToStarted: 5,
-                                startedToCompleted: 5,
-                                heartbeat: 10
-                            }
-                        })
-                        .then(
-                            (res) => {
-                                if (res.isErr()) {
-                                    logger.error(`Error: Execution '${executionId}' failed: ${stringifyError(res.error)}`);
-                                } else {
-                                    logger.info(`Execution '${executionId}' executed successfully with result: ${JSON.stringify(res.value)}`);
-                                }
-                            },
-                            (error) => {
-                                logger.error(`Error: Action '${executionId}' failed: ${stringifyError(error)}`);
-                            }
-                        );
+                    const webhookResult = await this.client.executeWebhook({
+                        name: executionId,
+                        groupKey,
+                        args
+                    });
+                    res = webhookResult.mapError((e) => new NangoError('action_failure', e.payload ?? { error: e.message }));
+                    if (res.isErr()) {
+                        span.setTag('error', res.error);
+                    }
                 } catch (e: unknown) {
-                    const errorMsg = `Execute: Failed to parse input object ${JSON.stringify(input)} to JsonValue: ${stringifyError(e)}`;
-                    logger.error(errorMsg);
+                    const errorMsg = `Execute: Failed to parse input '${JSON.stringify(input)}': ${stringifyError(e)}`;
+                    const error = new NangoError('action_failure', { error: errorMsg });
+                    span.setTag('error', e);
+                    return Err(error);
+                } finally {
+                    span.finish();
+                }
+            } else {
+                const span = tracer.startSpan('execute.webhookTemporal', {
+                    tags: spanTags,
+                    ...(activeSpan ? { childOf: activeSpan } : {})
+                });
+                try {
+                    const temporal = await getTemporal();
+                    const webhookHandler = await temporal.workflow.execute('webhook', {
+                        taskQueue: WEBHOOK_TASK_QUEUE,
+                        workflowId,
+                        args: [
+                            {
+                                name: webhookName,
+                                parentSyncName: syncConfig.sync_name,
+                                nangoConnection: nangoConnectionWithoutCredentials,
+                                input,
+                                activityLogId
+                            }
+                        ]
+                    });
+
+                    const { error, response } = webhookHandler;
+                    if (error) {
+                        res = Err(error);
+                    } else {
+                        res = Ok(response);
+                    }
+                    if (res.isErr()) {
+                        span.setTag('error', res.error);
+                    }
+                } catch (e: unknown) {
+                    span.setTag('error', e);
+                    throw e;
+                } finally {
+                    span.finish();
                 }
             }
 
-            const temporal = await getTemporal();
-            const webhookHandler = await temporal.workflow.execute('webhook', {
-                taskQueue: WEBHOOK_TASK_QUEUE,
-                workflowId,
-                args: [
-                    {
-                        name: webhookName,
-                        parentSyncName: syncConfig.sync_name,
-                        nangoConnection: nangoConnectionWithoutCredentials,
-                        input,
-                        activityLogId
-                    }
-                ]
-            });
-
-            const { success, error, response } = webhookHandler;
-
-            if (success === false || error) {
+            if (res.isErr()) {
                 await createActivityLogMessageAndEnd({
                     level: 'error',
                     environment_id: integration.environment_id,
@@ -390,7 +427,7 @@ export class Orchestrator {
                 await logCtx.error('The webhook workflow did not complete successfully');
                 await logCtx.failed();
 
-                return Err(error);
+                return res;
             }
 
             await createActivityLogMessageAndEnd({
@@ -405,7 +442,7 @@ export class Orchestrator {
 
             await updateSuccessActivityLog(activityLogId as number, true);
 
-            return Ok(response);
+            return res;
         } catch (e) {
             const errorMessage = stringifyError(e, { pretty: true });
             const error = new NangoError('webhook_script_failure', { errorMessage });
@@ -461,80 +498,105 @@ export class Orchestrator {
             });
             await logCtx.info(`Starting post connection script workflow ${workflowId} in the task queue: ${SYNC_TASK_QUEUE}`);
 
-            const isOchestratorEnabled = await featureFlags.isEnabled('orchestrator:dryrun', 'global', false, false);
-            if (isOchestratorEnabled) {
-                const groupKey: string = 'post-connection-script';
-                const executionId = `${groupKey}:environment:${connection.environment_id}:connection:${connection.id}:post-connection-script:${name}:at:${new Date().toISOString()}:${uuid()}`;
-                const args: PostConnectionArgs = {
-                    name,
-                    connection: {
-                        id: connection.id!,
-                        provider_config_key: connection.provider_config_key,
-                        environment_id: connection.environment_id
-                    },
-                    activityLogId,
-                    fileLocation
-                };
+            let res: Result<any, NangoError>;
 
-                void this.client
-                    .executePostConnection({
-                        name: executionId,
-                        groupKey,
-                        args,
-                        timeoutSettingsInSecs: {
-                            createdToStarted: 5,
-                            startedToCompleted: 5,
-                            heartbeat: 10
-                        }
-                    })
-                    .then(
-                        (res) => {
-                            if (res.isErr()) {
-                                logger.error(`Error: Execution '${executionId}' failed: ${stringifyError(res.error)}`);
-                            } else {
-                                logger.info(`Execution '${executionId}' executed successfully with result: ${res.value}`);
-                            }
-                        },
-                        (error) => {
-                            logger.error(`Error: Post connection script '${executionId}' failed: ${stringifyError(error)}`);
-                        }
-                    );
-            }
-
-            const temporal = await getTemporal();
-            const postConnectionScriptHandler = await temporal.workflow.execute('postConnectionScript', {
-                taskQueue: SYNC_TASK_QUEUE,
-                workflowId,
-                args: [
-                    {
-                        name,
-                        nangoConnection: {
-                            id: connection.id,
-                            connection_id: connection.connection_id,
+            const isGloballyEnabled = await featureFlags.isEnabled('orchestrator:immediate', 'global', false);
+            const isEnvEnabled = await featureFlags.isEnabled('orchestrator:immediate', `${connection.environment_id}`, false);
+            const activeSpan = tracer.scope().active();
+            const spanTags = {
+                'postConnection.name': name,
+                'connection.id': connection.id,
+                'connection.connection_id': connection.connection_id,
+                'connection.provider_config_key': connection.provider_config_key,
+                'connection.environment_id': connection.environment_id
+            };
+            if (isGloballyEnabled || isEnvEnabled) {
+                const span = tracer.startSpan('execute.action', {
+                    tags: spanTags,
+                    ...(activeSpan ? { childOf: activeSpan } : {})
+                });
+                try {
+                    const groupKey: string = 'post-connection-script';
+                    const executionId = `${groupKey}:environment:${connection.environment_id}:connection:${connection.id}:post-connection-script:${name}:at:${new Date().toISOString()}:${uuid()}`;
+                    const args = {
+                        postConnectionName: name,
+                        connection: {
+                            id: connection.id!,
                             provider_config_key: connection.provider_config_key,
                             environment_id: connection.environment_id
                         },
-                        fileLocation,
-                        activityLogId
-                    }
-                ]
-            });
-
-            const { success, error: rawError, response }: RunnerOutput = postConnectionScriptHandler;
-
-            // Errors received from temporal are raw objects not classes
-            const error = rawError ? new NangoError(rawError['type'], rawError['payload'], rawError['status']) : rawError;
-            if (!success || error) {
-                if (rawError) {
-                    await createActivityLogMessageAndEnd({
-                        level: 'error',
-                        environment_id: connection.environment_id,
-                        activity_log_id: activityLogId,
-                        timestamp: Date.now(),
-                        content: `Failed with error ${rawError['type']} ${JSON.stringify(rawError['payload'])}`
+                        activityLogId,
+                        fileLocation
+                    };
+                    const result = await this.client.executePostConnection({
+                        name: executionId,
+                        groupKey,
+                        args
                     });
-                    await logCtx.error(`Failed with error ${rawError['type']} ${JSON.stringify(rawError['payload'])}`);
+                    res = result.mapError((e) => new NangoError('post_connection_failure', e.payload ?? { error: e.message }));
+                    if (res.isErr()) {
+                        span.setTag('error', res.error);
+                    }
+                } catch (e: unknown) {
+                    span.setTag('error', e);
+                    throw e;
+                } finally {
+                    span.finish();
                 }
+            } else {
+                const span = tracer.startSpan('execute.postConnectionTemporal', {
+                    tags: spanTags,
+                    ...(activeSpan ? { childOf: activeSpan } : {})
+                });
+                try {
+                    const temporal = await getTemporal();
+                    const postConnectionScriptHandler = await temporal.workflow.execute('postConnectionScript', {
+                        taskQueue: SYNC_TASK_QUEUE,
+                        workflowId,
+                        args: [
+                            {
+                                name,
+                                nangoConnection: {
+                                    id: connection.id,
+                                    connection_id: connection.connection_id,
+                                    provider_config_key: connection.provider_config_key,
+                                    environment_id: connection.environment_id
+                                },
+                                fileLocation,
+                                activityLogId
+                            }
+                        ]
+                    });
+
+                    const { error: rawError, response }: RunnerOutput = postConnectionScriptHandler;
+                    if (rawError) {
+                        // Errors received from temporal are raw objects not classes
+                        const error = new NangoError(rawError['type'], rawError['payload'], rawError['status']);
+                        res = Err(error);
+                        await logCtx.error(`Failed with error ${rawError['type']} ${JSON.stringify(rawError['payload'])}`);
+                    } else {
+                        res = Ok(response);
+                    }
+                    if (res.isErr()) {
+                        span.setTag('error', res.error);
+                    }
+                } catch (e: unknown) {
+                    span.setTag('error', e);
+                    throw e;
+                } finally {
+                    span.finish();
+                }
+            }
+
+            if (res.isErr()) {
+                await createActivityLogMessageAndEnd({
+                    level: 'error',
+                    environment_id: connection.environment_id,
+                    activity_log_id: activityLogId,
+                    timestamp: Date.now(),
+                    content: `Failed with error ${res.error.type} ${JSON.stringify(res.error.payload)}`
+                });
+                await logCtx.error(`Failed with error ${res.error.type} ${JSON.stringify(res.error.payload)}`);
                 await createActivityLogMessageAndEnd({
                     level: 'error',
                     environment_id: connection.environment_id,
@@ -544,10 +606,10 @@ export class Orchestrator {
                 });
                 await logCtx.error(`The post connection script workflow ${workflowId} did not complete successfully`);
 
-                return Err(error!);
+                return res;
             }
 
-            const content = `The post connection script workflow ${workflowId} was successfully run. A truncated response is: ${JSON.stringify(response, null, 2)?.slice(0, 100)}`;
+            const content = `The post connection script workflow ${workflowId} was successfully run. A truncated response is: ${JSON.stringify(res.value, null, 2)?.slice(0, 100)}`;
 
             await createActivityLogMessageAndEnd({
                 level: 'info',
@@ -572,7 +634,7 @@ export class Orchestrator {
                 `postConnectionScript:${name}`
             );
 
-            return Ok(response);
+            return res;
         } catch (err) {
             const errorMessage = stringifyError(err, { pretty: true });
             const error = new NangoError('post_connection_script_failure', { errorMessage });

--- a/packages/utils/lib/result.ts
+++ b/packages/utils/lib/result.ts
@@ -8,7 +8,7 @@ export interface Left<T, E extends Error> {
     isOk(this: Result<T, E>): this is Right<T, E>;
     unwrap(): T;
     map<U>(fn: (value: T) => U): Result<T, E>;
-    mapError<U extends Error>(fn: (error: E | string) => U): Result<T, U>;
+    mapError<U extends Error>(fn: (error: E) => U): Result<T, U>;
 }
 
 export interface Right<T, E extends Error> {
@@ -17,7 +17,7 @@ export interface Right<T, E extends Error> {
     isOk(this: Result<T, E>): this is Right<T, E>;
     unwrap(): T;
     map<U>(fn: (value: T) => U): Result<U, E>;
-    mapError<U extends Error>(fn: (error: E | string) => U): Result<T, U>;
+    mapError<U extends Error>(fn: (error: E) => U): Result<T, U>;
 }
 
 export type Result<T, E extends Error = Error> = Left<T, E> | Right<T, E>;
@@ -35,7 +35,7 @@ export function Ok<T, E extends Error>(value: T): Result<T, E> {
                 return Err(error as E);
             }
         },
-        mapError: <U extends Error>(_fn: (error: E | string) => U): Result<T, U> => {
+        mapError: <U extends Error>(_fn: (error: E) => U): Result<T, U> => {
             return Ok(value);
         }
     };
@@ -52,9 +52,9 @@ export function Err<T, E extends Error>(error: E | string): Result<T, E> {
         map: <U>(_fn: (value: T) => U): Result<T, E> => {
             return Err(error);
         },
-        mapError: <U extends Error>(fn: (error: E | string) => U): Result<T, U> => {
+        mapError: <U extends Error>(fn: (error: E) => U): Result<T, U> => {
             try {
-                return Err(fn(error));
+                return Err(fn(typeof error === 'string' ? (new Error(error) as E) : error));
             } catch (error) {
                 return Err(error as U);
             }


### PR DESCRIPTION
The feature is behind 2 flags:
- orchestrator:immediate:ENVIRONMENT_ID to ramp up by environment
- orchestrator:immediate:global to enable it to everybody

In addition to add calls to the run.service in jobs.processor.handler this commit:
- adds the missing connection_id to the tasks payload (I had missed it)
- adds some tracing to be able to compare the execution via temporal/orchestrator
- deal with some postgres weirdness wrt json

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
