### PR TITLE
chore: rename orchestrator waitForCompletion param to longPolling

### DIFF
--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -240,7 +240,7 @@ describe('OrchestratorClient', async () => {
     });
     describe('dequeue', () => {
         it('should returns nothing if no scheduled task', async () => {
-            const res = await client.dequeue({ groupKey: 'abc', limit: 1, waitForCompletion: false });
+            const res = await client.dequeue({ groupKey: 'abc', limit: 1, longPolling: false });
             expect(res.unwrap()).toEqual([]);
         });
         it('should return scheduled tasks', async () => {
@@ -280,7 +280,7 @@ describe('OrchestratorClient', async () => {
                     input: { foo: 'bar' }
                 }
             });
-            const res = await client.dequeue({ groupKey, limit: 2, waitForCompletion: false });
+            const res = await client.dequeue({ groupKey, limit: 2, longPolling: false });
             expect(res.unwrap().length).toBe(2);
             expect(res.unwrap()[0]?.isAction()).toBe(true);
             expect(res.unwrap()[1]?.isWebhook()).toBe(true);

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -17,7 +17,8 @@ import type {
     ExecutePostConnectionProps,
     TaskAction,
     TaskWebhook,
-    TaskPostConnection
+    TaskPostConnection,
+    OrchestratorTask
 } from './types.js';
 import { validateTask } from './validate.js';
 import type { JsonValue } from 'type-fest';
@@ -66,7 +67,7 @@ export class OrchestratorClient {
             return res;
         }
         const taskId = res.value.taskId;
-        const getOutput = await this.routeFetch(getOutputRoute)({ params: { taskId }, query: { waitForCompletion: true } });
+        const getOutput = await this.routeFetch(getOutputRoute)({ params: { taskId }, query: { longPolling: true } });
         if ('error' in getOutput) {
             return Err({
                 name: getOutput.error.code,
@@ -178,17 +179,17 @@ export class OrchestratorClient {
     public async dequeue({
         groupKey,
         limit,
-        waitForCompletion
+        longPolling
     }: {
         groupKey: string;
         limit: number;
-        waitForCompletion: boolean;
-    }): Promise<Result<(TaskWebhook | TaskAction | TaskPostConnection)[], ClientError>> {
+        longPolling: boolean;
+    }): Promise<Result<OrchestratorTask[], ClientError>> {
         const res = await this.routeFetch(postDequeueRoute)({
             body: {
                 groupKey,
                 limit,
-                waitForCompletion
+                longPolling
             }
         });
         if ('error' in res) {

--- a/packages/orchestrator/lib/clients/processor.ts
+++ b/packages/orchestrator/lib/clients/processor.ts
@@ -78,7 +78,7 @@ export class OrchestratorProcessor {
             await this.queue.onSizeLessThan(this.queue.concurrency);
             const available = this.queue.concurrency - this.queue.size;
             const limit = available + this.queue.concurrency; // fetching more than available to keep the queue full
-            const tasks = await this.orchestratorClient.dequeue({ groupKey: this.groupKey, limit, waitForCompletion: true });
+            const tasks = await this.orchestratorClient.dequeue({ groupKey: this.groupKey, limit, longPolling: true });
             if (tasks.isErr()) {
                 logger.error(`failed to dequeue tasks: ${stringifyError(tasks.error)}`);
                 await new Promise((resolve) => setTimeout(resolve, 1000)); // wait for a bit before retrying to avoid hammering the server in case of repetitive errors

--- a/packages/orchestrator/lib/routes/v1/postDequeue.ts
+++ b/packages/orchestrator/lib/routes/v1/postDequeue.ts
@@ -14,7 +14,7 @@ type PostDequeue = Endpoint<{
     Body: {
         groupKey: string;
         limit: number;
-        waitForCompletion: boolean;
+        longPolling: boolean;
     };
     Error: ApiError<'dequeue_failed'>;
     Success: Task[];
@@ -26,7 +26,7 @@ const validate = validateRequest<PostDequeue>({
             .object({
                 groupKey: z.string().min(1),
                 limit: z.coerce.number().positive(),
-                waitForCompletion: z.coerce.boolean()
+                longPolling: z.coerce.boolean()
             })
             .parse(data)
 });
@@ -43,8 +43,8 @@ export const routeHandler = (scheduler: Scheduler, eventEmitter: EventEmitter): 
 
 const handler = (scheduler: Scheduler, eventEmitter: EventEmitter) => {
     return async (req: EndpointRequest<PostDequeue>, res: EndpointResponse<PostDequeue>) => {
-        const { groupKey, limit, waitForCompletion } = req.body;
-        const waitForCompletionTimeoutMs = 60_000;
+        const { groupKey, limit, longPolling: longPolling } = req.body;
+        const longPollingTimeoutMs = 60_000;
         const eventId = `task:started:${groupKey}`;
         const cleanupAndRespond = (respond: (res: EndpointResponse<PostDequeue>) => void) => {
             if (timeout) {
@@ -67,7 +67,7 @@ const handler = (scheduler: Scheduler, eventEmitter: EventEmitter) => {
         };
         const timeout = setTimeout(() => {
             cleanupAndRespond((res) => res.status(200).send([]));
-        }, waitForCompletionTimeoutMs);
+        }, longPollingTimeoutMs);
 
         eventEmitter.once(eventId, onTaskStarted);
 
@@ -76,7 +76,7 @@ const handler = (scheduler: Scheduler, eventEmitter: EventEmitter) => {
             cleanupAndRespond((res) => res.status(500).json({ error: { code: 'dequeue_failed', message: getTasks.error.message } }));
             return;
         }
-        if (waitForCompletion && getTasks.value.length === 0) {
+        if (longPolling && getTasks.value.length === 0) {
             await new Promise((resolve) => resolve(timeout));
         } else {
             cleanupAndRespond((res) => res.status(200).json(getTasks.value));


### PR DESCRIPTION
waitForCompletion isn't a very good name for the dequeue endpoint but I wanted to keep consistency with the /output endpoint. Renaming it to longPolling so it is consistent but also works for different endpoints

Note: it would break at deploy time since either the client will use the new name but the orchestrator service isn't yet (or vice versa depending on which service get started first). I will deploy while we are still in dry run mode then.
