### PR TITLE
fix(logs): ui feedback

### DIFF
--- a/packages/webapp/src/components/LeftNavBar.tsx
+++ b/packages/webapp/src/components/LeftNavBar.tsx
@@ -163,7 +163,7 @@ export default function LeftNavBar(props: LeftNavBarProps) {
                             <QueueListIcon className={`flex h-5 w-5 ${props.selectedItem === LeftNavBarItems.Activity ? 'text-white' : 'text-gray-400'}`} />
                             <p>Activity</p>
                         </Link>
-                        {/* <Link
+                        <Link
                             to={`/${env}/logs`}
                             className={`flex h-9 p-2 gap-x-3 items-center rounded-md text-sm ${navTextColor} ${
                                 props.selectedItem === LeftNavBarItems.Logs ? `${navActiveBg} text-white` : `text-gray-400 ${navHoverBg}`
@@ -173,7 +173,7 @@ export default function LeftNavBar(props: LeftNavBarProps) {
                             <p className="flex gap-4 items-center">
                                 Logs <span className="text-xs text-green-400">beta</span>
                             </p>
-                        </Link> */}
+                        </Link>
                         <Link
                             to={`/${env}/environment-settings`}
                             className={`flex h-9 p-2 gap-x-3 items-center rounded-md text-sm ${navTextColor} ${

--- a/packages/webapp/src/components/MultiSelect.tsx
+++ b/packages/webapp/src/components/MultiSelect.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from 'react';
 import { CrossCircledIcon } from '@radix-ui/react-icons';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/Popover';
 import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList, CommandCheck } from './ui/Command';
+import { cn } from '../utils/utils';
 
 export interface MultiSelectArgs<T> {
     label: string;
@@ -49,11 +50,11 @@ export const MultiSelect: React.FC<MultiSelectArgs<any>> = ({ label, options, se
     return (
         <Popover open={open} onOpenChange={setOpen}>
             <PopoverTrigger asChild>
-                <Button variant="zombieGray" size={'xs'}>
+                <Button variant="zombieGray" size={'xs'} className={cn('text-text-light-gray', isDirty && 'text-white')}>
                     {label}
                     {isDirty && (
                         <button
-                            className="bg-pure-black text-white flex gap-1 items-center px-1.5 rounded-xl"
+                            className="bg-pure-black text-text-light-gray flex gap-1 items-center px-1.5 rounded-xl"
                             onPointerDown={reset}
                             onKeyDown={(e) => {
                                 if (['Enter', ' '].includes(e.key)) {
@@ -67,7 +68,7 @@ export const MultiSelect: React.FC<MultiSelectArgs<any>> = ({ label, options, se
                     )}
                 </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-56 p-0 text-white bg-active-gray">
+            <PopoverContent className="w-56 p-0 text-white bg-active-gray" align="end">
                 <Command>
                     <CommandList>
                         <CommandEmpty>No framework found.</CommandEmpty>

--- a/packages/webapp/src/components/ui/Command.tsx
+++ b/packages/webapp/src/components/ui/Command.tsx
@@ -89,7 +89,7 @@ const CommandItem = React.forwardRef<React.ElementRef<typeof CommandPrimitive.It
         <CommandPrimitive.Item
             ref={ref}
             className={cn(
-                'px-2 data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 text-gray-400 relative flex cursor-pointer rounded select-none items-center py-1.5 pl-8 pr-2 text-xs outline-none transition-colors aria-selected:bg-pure-black aria-selected:text-white',
+                'px-2 data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 text-gray-400 relative flex cursor-pointer rounded select-none items-center py-1.5 pl-8 pr-2 text-sm outline-none transition-colors aria-selected:bg-pure-black aria-selected:text-white',
                 className
             )}
             {...props}

--- a/packages/webapp/src/components/ui/Table.tsx
+++ b/packages/webapp/src/components/ui/Table.tsx
@@ -37,7 +37,7 @@ const Head = forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCe
     <th
         ref={ref}
         className={cn(
-            'bg-active-gray border-t border-b border-border-gray-400 first-of-type:border-l last-of-type:border-r first-of-type:rounded-l last-of-type:rounded-r px-3 py-1 pt-1.5 text-xs leading-5 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+            'bg-active-gray first-of-type:rounded-l last-of-type:rounded-r px-3 py-1 pt-1.5 text-xs leading-5 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
             className
         )}
         {...props}

--- a/packages/webapp/src/components/ui/button/Button.tsx
+++ b/packages/webapp/src/components/ui/button/Button.tsx
@@ -20,7 +20,7 @@ export const buttonStyles = cva('disabled:pointer-events-none disabled:opacity-5
             zinc: 'bg-active-gray hover:bg-neutral-800 text-gray-400 border border-neutral-700'
         },
         size: {
-            xs: 'h-8 py-1 px-2',
+            xs: 'h-8 py-1 px-3',
             sm: 'h-9 px-2 ',
             md: 'h-9 py-2 px-4',
             lg: 'h-11 px-8'

--- a/packages/webapp/src/pages/Logs/Search.tsx
+++ b/packages/webapp/src/pages/Logs/Search.tsx
@@ -300,7 +300,7 @@ export const LogsSearch: React.FC = () => {
                                     <Table.Head
                                         key={header.id}
                                         style={{
-                                            width: header.getSize()
+                                            width: header.getSize() !== 0 ? header.getSize() : undefined
                                         }}
                                     >
                                         {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
@@ -315,8 +315,11 @@ export const LogsSearch: React.FC = () => {
                         table.getRowModel().rows.map((row) => <OperationRow key={row.original.id} row={row} />)
                     ) : operations.length <= 0 && !loading && readyToDisplay ? (
                         <Table.Row>
-                            <Table.Cell colSpan={columns.length} className="h-24 text-center">
-                                No results.
+                            <Table.Cell colSpan={columns.length} className="h-24 text-center p-0 pt-4">
+                                <div className="flex gap-2 flex-col border border-border-gray rounded-md items-center text-white text-center p-10 py-20">
+                                    <div className="text-center">No logs found</div>
+                                    <div className="text-gray-400">Note that logs older than 15 days are automatically cleared.</div>
+                                </div>
                             </Table.Cell>
                         </Table.Row>
                     ) : (

--- a/packages/webapp/src/pages/Logs/components/DatePicker.tsx
+++ b/packages/webapp/src/pages/Logs/components/DatePicker.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { CalendarIcon, LightningBoltIcon } from '@radix-ui/react-icons';
-import { addDays, format } from 'date-fns';
+import { addDays, addMonths, format } from 'date-fns';
 import type { DateRange } from 'react-day-picker';
 import { Popover, PopoverContent, PopoverTrigger } from '../../../components/ui/Popover';
 import { cn } from '../../../utils/utils';
@@ -59,9 +59,9 @@ export const DatePicker: React.FC<{
     const [date, setDate] = useState<DateRange | undefined>();
     const [tmpDate, setTmpDate] = useState<DateRange | undefined>();
 
-    const months = useMemo(() => {
+    const defaultMonth = useMemo(() => {
         const today = new Date();
-        return today.getDate() < 24 ? 2 : 1;
+        return today.getDate() > 15 ? today : addMonths(today, -1);
     }, []);
 
     const disabledBefore = useMemo(() => {
@@ -109,16 +109,16 @@ export const DatePicker: React.FC<{
     return (
         <Popover>
             <PopoverTrigger asChild>
-                <Button variant="zombieGray" size={'xs'} className={cn('flex-grow truncate w-[230px]')}>
+                <Button variant="zombieGray" size={'xs'} className={cn('flex-grow truncate text-text-light-gray', period && 'text-white')}>
                     <CalendarIcon />
                     {display}
                 </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-auto p-0 text-white bg-active-gray">
+            <PopoverContent className="w-auto p-0 text-white bg-active-gray" align="end">
                 <div className="flex gap-6">
                     <Calendar
                         mode="range"
-                        defaultMonth={date?.from}
+                        defaultMonth={defaultMonth}
                         selected={tmpDate}
                         onSelect={(e) => {
                             setSelectedPreset(undefined);
@@ -131,9 +131,10 @@ export const DatePicker: React.FC<{
                             setTmpDate(e);
                         }}
                         initialFocus
-                        numberOfMonths={months}
+                        numberOfMonths={2}
                         disabled={{ before: disabledBefore, after: disabledAfter }}
                         weekStartsOn={1}
+                        showOutsideDays={false}
                     />
                     <div className="flex flex-col mt-6">
                         <Button

--- a/packages/webapp/src/pages/Logs/components/MessageRow.tsx
+++ b/packages/webapp/src/pages/Logs/components/MessageRow.tsx
@@ -6,13 +6,23 @@ import { Drawer, DrawerContent, DrawerTrigger, DrawerClose } from '../../../comp
 import * as Table from '../../../components/ui/Table';
 import { ShowMessage } from '../ShowMessage';
 import { ArrowLeftIcon } from '@radix-ui/react-icons';
+import { cn } from '../../../utils/utils';
 
 const drawerWidth = '834px';
 export const MessageRow: React.FC<{ row: Row<SearchOperationsData> }> = ({ row }) => {
     return (
         <Drawer direction="right" snapPoints={[drawerWidth]} handleOnly={true} noBodyStyles={true} nested>
             <DrawerTrigger asChild type={null as unknown as 'button'}>
-                <Table.Row data-state={row.getIsSelected() && 'selected'} className="hover:cursor-pointer border-b-border-gray-400 table table-fixed w-full ">
+                <Table.Row
+                    data-state={row.getIsSelected() && 'selected'}
+                    className={cn(
+                        'hover:cursor-pointer border-b-border-gray-400 !border-l-2 table table-fixed w-full',
+                        row.original.level === 'error' && 'hover:border-l-red-500',
+                        row.original.level === 'warn' && 'hover:border-l-yellow-400',
+                        row.original.level === 'info' && 'hover:border-l-blue-400',
+                        row.original.level === 'debug' && 'hover:border-l-gray-400'
+                    )}
+                >
                     {row.getVisibleCells().map((cell) => (
                         <Table.Cell key={cell.id} style={{ width: cell.column.columnDef.size }}>
                             {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/packages/webapp/src/pages/Logs/components/ProviderTag.tsx
+++ b/packages/webapp/src/pages/Logs/components/ProviderTag.tsx
@@ -3,7 +3,7 @@ import IntegrationLogo from '../../../components/ui/IntegrationLogo';
 
 export const ProviderTag: React.FC<{ msg: SearchMessagesData }> = ({ msg }) => {
     if (!msg.integrationId || !msg.providerName) {
-        return null;
+        return <>-</>;
     }
 
     return (

--- a/packages/webapp/src/pages/Logs/components/SearchInOperation.tsx
+++ b/packages/webapp/src/pages/Logs/components/SearchInOperation.tsx
@@ -107,7 +107,9 @@ export const SearchInOperation: React.FC<{ operationId: string; isLive: boolean 
         if (data?.pagination.cursorBefore) {
             cursorBefore.current = data?.pagination.cursorBefore;
         }
-        setReadyToDisplay(true);
+        if (data?.data) {
+            setReadyToDisplay(true);
+        }
     }, [data?.data]);
     useEffect(() => {
         if (data?.pagination.cursorAfter && !hasLoadedMore) {

--- a/packages/webapp/src/pages/Logs/components/SearchableMultiSelect.tsx
+++ b/packages/webapp/src/pages/Logs/components/SearchableMultiSelect.tsx
@@ -8,6 +8,7 @@ import Spinner from '../../../components/ui/Spinner';
 import { Popover, PopoverContent, PopoverTrigger } from '../../../components/ui/Popover';
 import { Command, CommandCheck, CommandEmpty, CommandGroup, CommandItem, CommandList } from '../../../components/ui/Command';
 import { useDebounce } from 'react-use';
+import { cn } from '../../../utils/utils';
 
 export interface SearchableMultiSelectArgs<T> {
     label: string;
@@ -70,7 +71,7 @@ export const SearchableMultiSelect: React.FC<SearchableMultiSelectArgs<any>> = (
     return (
         <Popover open={open} onOpenChange={setOpen}>
             <PopoverTrigger asChild>
-                <Button variant="zombieGray" size={'xs'}>
+                <Button variant="zombieGray" size={'xs'} className={cn('text-text-light-gray', isDirty && 'text-white')}>
                     {label}
                     {isDirty && (
                         <button
@@ -88,7 +89,7 @@ export const SearchableMultiSelect: React.FC<SearchableMultiSelectArgs<any>> = (
                     )}
                 </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-56 p-0 text-white bg-active-gray">
+            <PopoverContent className="p-0 text-white bg-active-gray w-80" align="end">
                 <Command>
                     <Input
                         before={<MagnifyingGlassIcon className="w-4 h-4" />}
@@ -111,9 +112,16 @@ export const SearchableMultiSelect: React.FC<SearchableMultiSelectArgs<any>> = (
                                         onSelect={() => {
                                             select(option.value, !checked);
                                         }}
+                                        className="group"
                                     >
                                         <CommandCheck checked={checked} />
-                                        {option.name}
+                                        <div className="overflow-hidden">
+                                            <div className="whitespace-pre w-fit">
+                                                <div className={cn(option.name.length > 39 && 'duration-[2000ms] group-hover:translate-x-[calc(-100%+258px)]')}>
+                                                    {option.name}
+                                                </div>
+                                            </div>
+                                        </div>
                                     </CommandItem>
                                 );
                             })}

--- a/packages/webapp/src/pages/Logs/components/TypesSelect.tsx
+++ b/packages/webapp/src/pages/Logs/components/TypesSelect.tsx
@@ -5,6 +5,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '../../../components/ui/
 import { Command, CommandCheck, CommandEmpty, CommandGroup, CommandItem, CommandList } from '../../../components/ui/Command';
 import { typesOptions } from '../constants';
 import { Input } from '../../../components/ui/input/Input';
+import { cn } from '../../../utils/utils';
 
 export interface SearchableMultiSelectArgs<T> {
     selected: string[];
@@ -48,7 +49,7 @@ export const TypesSelect: React.FC<SearchableMultiSelectArgs<any>> = ({ selected
     return (
         <Popover open={open} onOpenChange={setOpen}>
             <PopoverTrigger asChild>
-                <Button variant="zombieGray" size={'xs'}>
+                <Button variant="zombieGray" size={'xs'} className={cn('text-text-light-gray', isDirty && 'text-white')}>
                     Type
                     {isDirty && (
                         <button
@@ -66,7 +67,7 @@ export const TypesSelect: React.FC<SearchableMultiSelectArgs<any>> = ({ selected
                     )}
                 </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-60 p-0 text-white bg-active-gray">
+            <PopoverContent className="w-72 p-0 text-white bg-active-gray">
                 <Command>
                     <CommandList className="max-h-none h-[415px]">
                         <CommandEmpty>No framework found.</CommandEmpty>

--- a/packages/webapp/src/pages/Logs/constants.tsx
+++ b/packages/webapp/src/pages/Logs/constants.tsx
@@ -18,7 +18,7 @@ export const columns: ColumnDef<SearchOperationsData>[] = [
     {
         accessorKey: 'createdAt',
         header: 'Timestamp',
-        size: 170,
+        size: 180,
         cell: ({ row }) => {
             return <div className="font-code text-s">{formatDateToLogFormat(row.original.createdAt)}</div>;
         }
@@ -42,7 +42,7 @@ export const columns: ColumnDef<SearchOperationsData>[] = [
     {
         accessorKey: 'integrationId',
         header: 'Integration',
-        size: 200,
+        minSize: 280,
         cell: ({ row }) => {
             return <ProviderTag msg={row.original} />;
         }
@@ -50,17 +50,18 @@ export const columns: ColumnDef<SearchOperationsData>[] = [
     {
         accessorKey: 'syncConfigId',
         header: 'Script',
-        size: 180,
+        minSize: 280,
         cell: ({ row }) => {
-            return <div className="truncate font-code text-s">{row.original.syncConfigName}</div>;
+            return <div className="truncate font-code text-s">{row.original.syncConfigName || '-'}</div>;
         }
     },
     {
         accessorKey: 'connectionId',
         header: 'Connection',
-        size: 200,
+        minSize: 0,
+        size: 0,
         cell: ({ row }) => {
-            return <div className="truncate font-code text-s">{row.original.connectionName}</div>;
+            return <div className="truncate font-code text-s">{row.original.connectionName || '-'}</div>;
         }
     },
     {


### PR DESCRIPTION
## Describe your changes

Fixes NAN-1066

Logs:
- Hover on logs message should show a border-left related to the level
- Calendar should always show 2 months and the previous one not the next
- Column size should be fixed and connection should take the remaining width
- Enable nav button for logs

General:
- Removed table header white border
- Filters button should be text-gray until a filter is active
- Filters tooltip should be aligned to the end of the button
- Filters items should be text:14px
- Button horizontal padding should be bigger


## Test
![Screenshot 2024-06-03 at 17 40 27](https://github.com/NangoHQ/nango/assets/1637651/2f946937-5626-4612-8000-35cb18907d96)
<img width="1507" alt="Screenshot 2024-06-03 at 17 39 53" src="https://github.com/NangoHQ/nango/assets/1637651/e200d4ce-6673-43b0-8bb0-8a5e5addcf2d">



https://github.com/NangoHQ/nango/assets/1637651/264494b2-4c4c-4409-99ee-31d2fa4b4e8a

