### PR TITLE
feat(integrations): add support for highlevel white-label

### DIFF
--- a/docs-v2/integrations/all/highlevel.mdx
+++ b/docs-v2/integrations/all/highlevel.mdx
@@ -3,7 +3,7 @@ title: HighLevel
 sidebarTitle: HighLevel
 ---
 
-API configuration: [`highlevel`](https://nango.dev/providers.yaml)
+API configuration: [`highlevel`](https://nango.dev/providers.yaml), [`highlevel-white-label`](https://nango.dev/providers.yaml)
 
 ## Features
 
@@ -19,10 +19,17 @@ API configuration: [`highlevel`](https://nango.dev/providers.yaml)
 
 ## Getting started
 
--   [API Documentation](https://highlevel.stoplight.io/docs/integrations/0443d7d1a4bd0-overview)
+-   [How to register an Application](https://highlevel.stoplight.io/docs/integrations/a04191c0fabf9-authorization#1-register-an-oauth-app)
+-   [OAuth related docs](https://highlevel.stoplight.io/docs/integrations/a04191c0fabf9-authorization)
+-   [List of OAuth scopes](https://highlevel.stoplight.io/docs/integrations/vcctp9t1w8hja-scopes)
+-   [HighLevel REST API docs](https://highlevel.stoplight.io/docs/integrations/0443d7d1a4bd0-overview)
 
 <Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
 
 ## API gotchas
+-   HighLevel offers two different authorization flows for their users. The `standard` option allows for general OAuth2 authentication, while the `highlevel-white-label` option allows users to generate access tokens, enabling them to white-label the platform. This means users can rebrand the platform with their own branding elements and customize it to match their brand identity
+-   HighLevel enforces rate limits for its public V2 APIs. For more details check [HighLevel rate limits](https://highlevel.stoplight.io/docs/integrations/a04191c0fabf9-authorization#what-are-current-rate-limits-for-api-20).
+-   When creating an app, there are 2 types of access: Location Level Access (also known as Sub-Account) and Agency Level Access (also known as Company). These access levels provide comprehensive control over location data at either the individual location or agency-wide level.
+-   The App Type determines the accessibility and visibility of your application. A public app is available for anyone to use and access, while a private app is restricted to a specific group or individuals and is not publicly listed in the marketplace. For more details check [profile information](https://help.gohighlevel.com/support/solutions/articles/155000000136-how-to-get-started-with-the-developer-s-marketplace#How-to-use-the-oAuth-V2-to-configure-Webhooks-for-your-apps?)
 
 <Note>Add Getting Started links and Gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/highlevel.mdx)</Note>

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -1081,6 +1081,22 @@ highlevel:
     auth_mode: OAUTH2
     authorization_url: https://marketplace.gohighlevel.com/oauth/chooselocation
     token_url: https://services.leadconnectorhq.com/oauth/token
+    scope_separator: ' '
+    proxy:
+        base_url: https://services.leadconnectorhq.com
+    disable_pkce: true
+    token_params:
+        grant_type: authorization_code
+    refresh_params:
+        grant_type: refresh_token
+    docs: https://docs.nango.dev/integrations/all/highlevel
+highlevel-white-label:
+    categories:
+        - marketing
+    auth_mode: OAUTH2
+    authorization_url: https://marketplace.leadconnectorhq.com/oauth/chooselocation
+    token_url: https://services.leadconnectorhq.com/oauth/token
+    scope_separator: ' '
     proxy:
         base_url: https://services.leadconnectorhq.com
     disable_pkce: true
@@ -1702,6 +1718,7 @@ pingboard:
     proxy:
         base_url: https://app.pingboard.com/api/v2
     authorization_url: https://app.pingboard.com/oauth/token
+    scope_separator: ' '
     authorization_params:
         grant_type: client_credentials
     docs: https://docs.nango.dev/integrations/all/pingboard

--- a/packages/webapp/public/images/template-logos/highlevel-white-label.svg
+++ b/packages/webapp/public/images/template-logos/highlevel-white-label.svg
@@ -1,0 +1,1 @@
+highlevel.svg


### PR DESCRIPTION
## Describe your changes

- Added configuration for highlevel white-label in providers.yaml
- Added highlevel white-label SVG file in template-logos folder.
- Consolidate highlevel white-label docs pages
## Issue ticket number and link
[Slack](https://nango-community.slack.com/archives/C04ABR352H0/p1717108445509399)
## Test
This provider has been used successfully in local development to connect to highlevel white-label after authorizing using Nango.
The documentation update was reviewed using `npm run docs` and verifying on localhost.