### PR TITLE
fix(orchestratorClient): race condition in dequeue

### DIFF
--- a/packages/orchestrator/lib/clients/processor.integration.test.ts
+++ b/packages/orchestrator/lib/clients/processor.integration.test.ts
@@ -103,10 +103,10 @@ async function processN(handler: (task: TaskAction | TaskWebhook | TaskPostConne
         handler,
         opts: { orchestratorClient, groupKey, maxConcurrency: n, checkForTerminatedInterval: 100 }
     });
+    processor.start();
     for (let i = 0; i < n; i++) {
         await scheduleTask({ groupKey });
     }
-    processor.start();
     // Wait so the processor can process all tasks
     await new Promise((resolve) => setTimeout(resolve, 1000));
     return processor;

--- a/packages/orchestrator/lib/routes/v1/postDequeue.ts
+++ b/packages/orchestrator/lib/routes/v1/postDequeue.ts
@@ -69,14 +69,13 @@ const handler = (scheduler: Scheduler, eventEmitter: EventEmitter) => {
             cleanupAndRespond((res) => res.status(200).send([]));
         }, longPollingTimeoutMs);
 
-        eventEmitter.once(eventId, onTaskStarted);
-
         const getTasks = await scheduler.dequeue({ groupKey, limit });
         if (getTasks.isErr()) {
             cleanupAndRespond((res) => res.status(500).json({ error: { code: 'dequeue_failed', message: getTasks.error.message } }));
             return;
         }
         if (longPolling && getTasks.value.length === 0) {
+            eventEmitter.once(eventId, onTaskStarted);
             await new Promise((resolve) => resolve(timeout));
         } else {
             cleanupAndRespond((res) => res.status(200).json(getTasks.value));


### PR DESCRIPTION
A race condition would happen in dequeue long polling if tasks are being created while tasks are being dequeued. Those newly created tasks would be dequeued as well but never returned to the processor, hence ending up being expired.
The solution to avoid the race condition is simple: only listen to the task creation event if no tasks have been dequeued

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
