### PR TITLE
fix(logs): handle buffered activities

### DIFF
--- a/packages/jobs/lib/integration.service.ts
+++ b/packages/jobs/lib/integration.service.ts
@@ -180,7 +180,7 @@ class IntegrationService implements IntegrationServiceInterface {
                         content: error.message,
                         timestamp: Date.now()
                     });
-                    await logCtx?.error(`Failed`, { error });
+                    await logCtx?.error(error.message, { error });
                 }
                 return { success, error, response };
             } finally {

--- a/packages/persist/lib/server.ts
+++ b/packages/persist/lib/server.ts
@@ -41,11 +41,14 @@ server.post(
         params: z.object({
             environmentId: z.string().transform(Number).pipe(z.number().int().positive()) as unknown as z.ZodNumber
         }),
-        body: z.object({
-            activityLogId: z.number(),
-            level: z.enum(logLevelValues),
-            msg: z.string()
-        })
+        body: z
+            .object({
+                activityLogId: z.number(),
+                level: z.enum(logLevelValues),
+                msg: z.string(),
+                timestamp: z.number().optional() // Optional until fully deployed
+            })
+            .strict()
     }),
     persistController.saveActivityLog.bind(persistController)
 );

--- a/packages/shared/lib/sdk/sync.integration.test.ts
+++ b/packages/shared/lib/sdk/sync.integration.test.ts
@@ -9,7 +9,7 @@ import { createConfigSeeds } from '../seeders/config.seeder.js';
 import { createEnvironmentSeed } from '../seeders/environment.seeder.js';
 import type { Environment } from '../models/Environment.js';
 
-describe('Connection service integration tests', async () => {
+describe('Connection service integration tests', () => {
     let env: Environment;
     beforeAll(async () => {
         await multipleMigrations();

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -574,8 +574,8 @@ export class NangoAction {
      * http = green
      * silly = light green
      */
-    public async log(s: any, a?: { level: LogLevel }): Promise<void>;
-    public async log(s: string, ...args: [any, { level: LogLevel }]): Promise<void>;
+    public async log(message: any, options?: { level?: LogLevel } | { [key: string]: any; level?: never }): Promise<void>;
+    public async log(message: string, ...args: [any, { level?: LogLevel }]): Promise<void>;
     public async log(...args: [...any]): Promise<void> {
         this.exitSyncIfAborted();
         if (args.length === 0) {

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -3,6 +3,7 @@ import { Nango, getUserAgent } from '@nangohq/node';
 import configService from '../services/config.service.js';
 import paginateService from '../services/paginate.service.js';
 import proxyService from '../services/proxy.service.js';
+import type { AxiosInstance } from 'axios';
 import axios from 'axios';
 import { getPersistAPIUrl, safeStringify } from '../utils/utils.js';
 import type { IntegrationWithCreds } from '@nangohq/node';
@@ -272,9 +273,21 @@ interface EnvironmentVariable {
 
 const MEMOIZED_CONNECTION_TTL = 60000;
 
+export const defaultPersistApi = axios.create({
+    baseURL: getPersistAPIUrl(),
+    httpsAgent: new https.Agent({ keepAlive: true }),
+    headers: {
+        'User-Agent': getUserAgent('sdk')
+    },
+    validateStatus: (_status) => {
+        return true;
+    }
+});
+
 export class NangoAction {
     protected nango: Nango;
     private attributes = {};
+    protected persistApi: AxiosInstance;
     activityLogId?: number | undefined;
     syncId?: string;
     nangoConnectionId?: number;
@@ -296,9 +309,10 @@ export class NangoAction {
     >();
     private memoizedIntegration: IntegrationWithCreds | undefined;
 
-    constructor(config: NangoProps) {
+    constructor(config: NangoProps, { persistApi }: { persistApi: AxiosInstance } = { persistApi: defaultPersistApi }) {
         this.connectionId = config.connectionId;
         this.providerConfigKey = config.providerConfigKey;
+        this.persistApi = persistApi;
 
         if (config.activityLogId) {
             this.activityLogId = config.activityLogId;
@@ -414,21 +428,16 @@ export class NangoAction {
             });
 
             if (activityLogs) {
+                // Save buffered logs
                 for (const log of activityLogs) {
-                    if (log.level === 'debug') continue;
-                    await this.log(log.content, { level: log.level });
-                    switch (log.level) {
-                        case 'error':
-                            logger.error(log.content);
-                            break;
-                        case 'warn':
-                            logger.warn(log.content);
-                            break;
-                        case 'info':
-                            logger.info(log.content);
-                            break;
-                        default:
-                            logger.debug(log.content);
+                    if (log.level === 'debug') {
+                        continue;
+                    }
+
+                    if (!this.dryRun) {
+                        await this.sendLogToPersist(log.content, { level: log.level, timestamp: log.timestamp });
+                    } else {
+                        logger[log.level in logger ? log.level : 'debug'](log.content);
                     }
                 }
             }
@@ -565,7 +574,9 @@ export class NangoAction {
      * http = green
      * silly = light green
      */
-    public async log(...args: any[]): Promise<void> {
+    public async log(s: any, a?: { level: LogLevel }): Promise<void>;
+    public async log(s: string, ...args: [any, { level: LogLevel }]): Promise<void>;
+    public async log(...args: [...any]): Promise<void> {
         this.exitSyncIfAborted();
         if (args.length === 0) {
             return;
@@ -590,25 +601,7 @@ export class NangoAction {
             return;
         }
 
-        const response = await persistApi({
-            method: 'POST',
-            url: `/environment/${this.environmentId}/log`,
-            headers: {
-                Authorization: `Bearer ${this.nango.secretKey}`
-            },
-            data: {
-                activityLogId: this.activityLogId,
-                level: userDefinedLevel?.level ?? 'info',
-                msg: content
-            }
-        });
-
-        if (response.status > 299) {
-            logger.error(`Request to persist API (log) failed: errorCode=${response.status} response='${JSON.stringify(response.data)}'`, this.stringify());
-            throw new Error(`Failed to log: ${JSON.stringify(response.data)}`);
-        }
-
-        return;
+        await this.sendLogToPersist(content, { level: userDefinedLevel?.level ?? 'info', timestamp: Date.now() });
     }
 
     public async getEnvironmentVariables(): Promise<EnvironmentVariable[] | null> {
@@ -695,6 +688,27 @@ export class NangoAction {
             return this.nango.triggerSync(providerConfigKey, [syncName], connectionId, fullResync);
         }
     }
+
+    private async sendLogToPersist(content: string, options: { level: LogLevel; timestamp: number }) {
+        const response = await this.persistApi({
+            method: 'POST',
+            url: `/environment/${this.environmentId}/log`,
+            headers: {
+                Authorization: `Bearer ${this.nango.secretKey}`
+            },
+            data: {
+                activityLogId: this.activityLogId,
+                level: options.level ?? 'info',
+                timestamp: options.timestamp,
+                msg: content
+            }
+        });
+
+        if (response.status > 299) {
+            logger.error(`Request to persist API (log) failed: errorCode=${response.status} response='${JSON.stringify(response.data)}'`, this.stringify());
+            throw new Error(`Failed to log: ${JSON.stringify(response.data)}`);
+        }
+    }
 }
 
 export class NangoSync extends NangoAction {
@@ -763,7 +777,7 @@ export class NangoSync extends NangoAction {
 
         for (let i = 0; i < results.length; i += this.batchSize) {
             const batch = results.slice(i, i + this.batchSize);
-            const response = await persistApi({
+            const response = await this.persistApi({
                 method: 'POST',
                 url: `/environment/${this.environmentId}/connection/${this.nangoConnectionId}/sync/${this.syncId}/job/${this.syncJobId}/records`,
                 headers: {
@@ -814,7 +828,7 @@ export class NangoSync extends NangoAction {
 
         for (let i = 0; i < results.length; i += this.batchSize) {
             const batch = results.slice(i, i + this.batchSize);
-            const response = await persistApi({
+            const response = await this.persistApi({
                 method: 'DELETE',
                 url: `/environment/${this.environmentId}/connection/${this.nangoConnectionId}/sync/${this.syncId}/job/${this.syncJobId}/records`,
                 headers: {
@@ -865,7 +879,7 @@ export class NangoSync extends NangoAction {
 
         for (let i = 0; i < results.length; i += this.batchSize) {
             const batch = results.slice(i, i + this.batchSize);
-            const response = await persistApi({
+            const response = await this.persistApi({
                 method: 'PUT',
                 url: `/environment/${this.environmentId}/connection/${this.nangoConnectionId}/sync/${this.syncId}/job/${this.syncJobId}/records`,
                 headers: {
@@ -899,17 +913,6 @@ export class NangoSync extends NangoAction {
         return super.getMetadata<T>();
     }
 }
-
-const persistApi = axios.create({
-    baseURL: getPersistAPIUrl(),
-    httpsAgent: new https.Agent({ keepAlive: true }),
-    headers: {
-        'User-Agent': getUserAgent('sdk')
-    },
-    validateStatus: (_status) => {
-        return true;
-    }
-});
 
 const TELEMETRY_ALLOWED_METHODS: (keyof NangoSync)[] = [
     'batchDelete',

--- a/packages/shared/lib/sdk/sync.unit.test.ts
+++ b/packages/shared/lib/sdk/sync.unit.test.ts
@@ -451,9 +451,9 @@ describe('Log', () => {
         // @ts-expect-error Level is wrong on purpose, if it's not breaking anymore the type is broken
         await nangoAction.log('hello', { level: 'foobar' });
     });
+
     it('should enforce type: log message + object', async () => {
         const nangoAction = new NangoAction({ ...nangoProps, dryRun: true });
-        // @ts-expect-error Level is wrong on purpose, if it's not breaking anymore the type is broken
         await nangoAction.log('hello', { foo: 'bar' });
     });
 });

--- a/packages/webapp/src/pages/Logs/Search.tsx
+++ b/packages/webapp/src/pages/Logs/Search.tsx
@@ -337,7 +337,7 @@ export const LogsSearch: React.FC = () => {
                     ))}
                 </Table.Header>
                 <Table.Body>
-                    {loading && (
+                    {loading && !readyToDisplay && (
                         <Table.Row>
                             {table.getAllColumns().map((col, i) => {
                                 return (


### PR DESCRIPTION
## Describe your changes

Fixes NAN-944

- Allow buffered activities in proxy to send their timestamp to Persist
- Fix: finally managed to find a type for `log()` and its weird signature 
- Pass PersistAPI to Nango() as dependency for mocking purpose