### PR TITLE
feat(orchestrator): add support for schedules

### DIFF
--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -34,9 +34,34 @@ describe('OrchestratorClient', async () => {
         scheduler.stop();
         await dbClient.clearDatabase();
     });
+
+    describe('recurring schedule', () => {
+        it('should be created', async () => {
+            const res = await client.recurring({
+                name: 'Task',
+                startsAt: new Date(),
+                frequencyMs: 300_000,
+                args: {
+                    type: 'sync',
+                    syncId: 'sync-a',
+                    syncName: rndStr(),
+                    syncJobId: 5678,
+                    connection: {
+                        id: 123,
+                        connection_id: 'C',
+                        provider_config_key: 'P',
+                        environment_id: 456
+                    },
+                    debug: false
+                }
+            });
+            expect(res.isOk()).toBe(true);
+        });
+    });
+
     describe('heartbeat', () => {
         it('should be successful', async () => {
-            const scheduledTask = await client.schedule({
+            const scheduledTask = await client.immediate({
                 name: 'Task',
                 groupKey: rndStr(),
                 retry: { count: 0, max: 0 },
@@ -229,7 +254,7 @@ describe('OrchestratorClient', async () => {
     describe('search', () => {
         it('should returns task by ids', async () => {
             const groupKey = rndStr();
-            const actionA = await client.schedule({
+            const actionA = await client.immediate({
                 name: 'Task',
                 groupKey,
                 retry: { count: 0, max: 0 },
@@ -247,7 +272,7 @@ describe('OrchestratorClient', async () => {
                     input: { foo: 'bar' }
                 }
             });
-            const actionB = await client.schedule({
+            const actionB = await client.immediate({
                 name: 'Task',
                 groupKey,
                 retry: { count: 0, max: 0 },
@@ -278,7 +303,7 @@ describe('OrchestratorClient', async () => {
         });
         it('should return scheduled tasks', async () => {
             const groupKey = rndStr();
-            const scheduledAction = await client.schedule({
+            const scheduledAction = await client.immediate({
                 name: 'Task',
                 groupKey,
                 retry: { count: 0, max: 0 },
@@ -296,7 +321,7 @@ describe('OrchestratorClient', async () => {
                     input: { foo: 'bar' }
                 }
             });
-            const scheduledWebhook = await client.schedule({
+            const scheduledWebhook = await client.immediate({
                 name: 'Task',
                 groupKey,
                 retry: { count: 0, max: 0 },

--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -228,7 +228,7 @@ describe('OrchestratorClient', async () => {
     describe('succeed', () => {
         it('should support big output', async () => {
             const groupKey = rndStr();
-            const actionA = await client.schedule({
+            const actionA = await client.immediate({
                 name: 'Task',
                 groupKey,
                 retry: { count: 0, max: 0 },

--- a/packages/orchestrator/lib/clients/processor.integration.test.ts
+++ b/packages/orchestrator/lib/clients/processor.integration.test.ts
@@ -106,36 +106,33 @@ async function processN(handler: (task: OrchestratorTask) => Promise<Result<Json
     });
     processor.start({ tracer });
     for (let i = 0; i < n; i++) {
-        await scheduleTask({ groupKey });
+        await immediateTask({ groupKey });
     }
     // Wait so the processor can process all tasks
     await new Promise((resolve) => setTimeout(resolve, 1000));
     return processor;
 }
 
-async function scheduleTask({ groupKey }: { groupKey: string }) {
-    return scheduler.schedule({
-        scheduling: 'immediate',
-        taskProps: {
-            groupKey,
-            name: 'Task',
-            retryMax: 0,
-            retryCount: 0,
-            createdToStartedTimeoutSecs: 30,
-            startedToCompletedTimeoutSecs: 30,
-            heartbeatTimeoutSecs: 30,
-            payload: {
-                type: 'action',
-                activityLogId: 1234,
-                actionName: 'Task',
-                connection: {
-                    id: 1234,
-                    connection_id: 'C',
-                    provider_config_key: 'P',
-                    environment_id: 5678
-                },
-                input: { foo: 'bar' }
-            }
+async function immediateTask({ groupKey }: { groupKey: string }) {
+    return scheduler.immediate({
+        groupKey,
+        name: 'Task',
+        retryMax: 0,
+        retryCount: 0,
+        createdToStartedTimeoutSecs: 30,
+        startedToCompletedTimeoutSecs: 30,
+        heartbeatTimeoutSecs: 30,
+        payload: {
+            type: 'action',
+            activityLogId: 1234,
+            actionName: 'Task',
+            connection: {
+                id: 1234,
+                connection_id: 'C',
+                provider_config_key: 'P',
+                environment_id: 5678
+            },
+            input: { foo: 'bar' }
         }
     });
 }

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -1,9 +1,11 @@
 import type { JsonValue, SetOptional } from 'type-fest';
-import type { PostSchedule } from '../routes/v1/postSchedule.js';
+import type { PostImmediate } from '../routes/v1/postImmediate.js';
+import type { PostRecurring } from '../routes/v1/postRecurring.js';
 import type { Result } from '@nangohq/utils';
 import type { TaskState } from '@nangohq/scheduler';
 
-export type SchedulingProps = Omit<PostSchedule['Body'], 'scheduling'>;
+export type ImmediateProps = PostImmediate['Body'];
+export type RecurringProps = PostRecurring['Body'];
 
 interface SyncArgs {
     syncId: string;
@@ -52,7 +54,7 @@ interface PostConnectionArgs {
     activityLogId: number;
 }
 
-export type ExecuteProps = SetOptional<SchedulingProps, 'retry' | 'timeoutSettingsInSecs'>;
+export type ExecuteProps = SetOptional<ImmediateProps, 'retry' | 'timeoutSettingsInSecs'>;
 export type ExecuteReturn = Result<JsonValue, ClientError>;
 export type ExecuteActionProps = Omit<ExecuteProps, 'args'> & { args: ActionArgs };
 export type ExecuteWebhookProps = Omit<ExecuteProps, 'args'> & { args: WebhookArgs };

--- a/packages/orchestrator/lib/routes/v1/postRecurring.ts
+++ b/packages/orchestrator/lib/routes/v1/postRecurring.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import type { JsonValue } from 'type-fest';
+import type { Scheduler } from '@nangohq/scheduler';
+import type { ApiError, Endpoint } from '@nangohq/types';
+import type { EndpointRequest, EndpointResponse, RouteHandler, Route } from '@nangohq/utils';
+import { validateRequest } from '@nangohq/utils';
+import { syncArgsSchema } from '../../clients/validate.js';
+
+const path = '/v1/recurring';
+const method = 'POST';
+
+export type PostRecurring = Endpoint<{
+    Method: typeof method;
+    Path: typeof path;
+    Body: {
+        name: string;
+        startsAt: Date;
+        frequencyMs: number;
+        args: JsonValue;
+    };
+    Error: ApiError<'recurring_failed'>;
+    Success: { scheduleId: string };
+}>;
+
+const validate = validateRequest<PostRecurring>({
+    parseBody: (data: any) => {
+        return z
+            .object({
+                name: z.string().min(1),
+                startsAt: z.coerce.date(),
+                frequencyMs: z.number().int().positive(),
+                args: syncArgsSchema
+            })
+            .parse(data);
+    }
+});
+
+const handler = (scheduler: Scheduler) => {
+    return async (req: EndpointRequest<PostRecurring>, res: EndpointResponse<PostRecurring>) => {
+        const schedule = await scheduler.recurring({
+            name: req.body.name,
+            payload: req.body.args,
+            startsAt: req.body.startsAt,
+            frequencyMs: req.body.frequencyMs
+        });
+        if (schedule.isErr()) {
+            return res.status(500).json({ error: { code: 'recurring_failed', message: schedule.error.message } });
+        }
+        return res.status(201).json({ scheduleId: schedule.value.id });
+    };
+};
+
+export const route: Route<PostRecurring> = { path, method };
+
+export const routeHandler = (scheduler: Scheduler): RouteHandler<PostRecurring> => {
+    return {
+        ...route,
+        validate,
+        handler: handler(scheduler)
+    };
+};

--- a/packages/orchestrator/lib/server.ts
+++ b/packages/orchestrator/lib/server.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import type { Express, Request, Response, NextFunction } from 'express';
-import { routeHandler as postScheduleHandler } from './routes/v1/postSchedule.js';
+import { routeHandler as postImmediateHandler } from './routes/v1/postImmediate.js';
+import { routeHandler as postRecurringHandler } from './routes/v1/postRecurring.js';
 import { routeHandler as postSearchHandler } from './routes/v1/postSearch.js';
 import { routeHandler as postDequeueHandler } from './routes/v1/postDequeue.js';
 import { routeHandler as putTaskHandler } from './routes/v1/tasks/putTaskId.js';
@@ -38,7 +39,8 @@ export const getServer = (scheduler: Scheduler, eventEmmiter: EventEmitter): Exp
     //TODO: add auth middleware
 
     createRoute(server, getHealthHandler);
-    createRoute(server, postScheduleHandler(scheduler));
+    createRoute(server, postImmediateHandler(scheduler));
+    createRoute(server, postRecurringHandler(scheduler));
     createRoute(server, postSearchHandler(scheduler));
     createRoute(server, putTaskHandler(scheduler));
     createRoute(server, getOutputHandler(scheduler, eventEmmiter));

--- a/packages/scheduler/lib/db/migrations/20240506105059_initial_scheduler_models.ts
+++ b/packages/scheduler/lib/db/migrations/20240506105059_initial_scheduler_models.ts
@@ -33,7 +33,6 @@ export async function up(knex: Knex): Promise<void> {
                 terminated boolean
             );
         `);
-        // TODO: add indexes
     });
 }
 

--- a/packages/scheduler/lib/db/migrations/20240604135056_schedules_model.ts
+++ b/packages/scheduler/lib/db/migrations/20240604135056_schedules_model.ts
@@ -1,0 +1,39 @@
+import type { Knex } from 'knex';
+import { SCHEDULES_TABLE } from '../../models/schedules.js';
+import { TASKS_TABLE } from '../../models/tasks.js';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.transaction(async (trx) => {
+        await trx.raw(`
+            CREATE TYPE schedule_states AS ENUM (
+                'PAUSED',
+                'STARTED',
+                'DELETED'
+            );
+        `);
+        await trx.raw(`
+            CREATE TABLE IF NOT EXISTS ${SCHEDULES_TABLE} (
+                id uuid PRIMARY KEY,
+                name varchar(255) NOT NULL,
+                state schedule_states NOT NULL,
+                starts_at timestamp with time zone NOT NULL,
+                frequency interval NOT NULL,
+                payload json NOT NULL,
+                created_at timestamp with time zone NOT NULL,
+                updated_at timestamp with time zone NOT NULL,
+                deleted_at timestamp with time zone NULL
+            );
+        `);
+        // add foreign key schedule_id to tasks_table, cascade delete and nullable
+        await trx.raw(`
+            ALTER TABLE ${TASKS_TABLE}
+            ADD COLUMN IF NOT EXISTS schedule_id uuid REFERENCES ${SCHEDULES_TABLE}(id) ON DELETE CASCADE;
+        `);
+        // TODO: add indexes
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`DROP TABLE IF EXISTS ${SCHEDULES_TABLE}`);
+    await knex.raw(`DROP TYPE IF EXISTS schedule_states`);
+}

--- a/packages/scheduler/lib/models/schedules.integration.test.ts
+++ b/packages/scheduler/lib/models/schedules.integration.test.ts
@@ -1,0 +1,126 @@
+import { expect, describe, it, beforeEach, afterEach } from 'vitest';
+import * as schedules from './schedules.js';
+import { getTestDbClient } from '../db/helpers.test.js';
+
+describe('Schedules', () => {
+    const dbClient = getTestDbClient();
+    const db = dbClient.db;
+    beforeEach(async () => {
+        await dbClient.migrate();
+    });
+    afterEach(async () => {
+        await dbClient.clearDatabase();
+    });
+
+    it('should be successfully created', async () => {
+        const schedule = (
+            await schedules.create(db, {
+                name: 'Test Schedule',
+                payload: { foo: 'bar' },
+                startsAt: new Date(),
+                frequencyMs: 300_000
+            })
+        ).unwrap();
+        expect(schedule).toMatchObject({
+            id: expect.any(String) as string,
+            name: 'Test Schedule',
+            state: 'STARTED',
+            payload: { foo: 'bar' },
+            startsAt: expect.toBeIsoDateTimezone(),
+            frequencyMs: 300_000,
+            createdAt: expect.toBeIsoDateTimezone(),
+            updatedAt: expect.toBeIsoDateTimezone(),
+            deletedAt: null
+        });
+    });
+    it('should be successfully retrieved', async () => {
+        const schedule = (
+            await schedules.create(db, {
+                name: 'Test Schedule',
+                payload: { foo: 'bar' },
+                startsAt: new Date(),
+                frequencyMs: 300_000
+            })
+        ).unwrap();
+        const retrieved = (await schedules.get(db, schedule.id)).unwrap();
+        expect(retrieved).toMatchObject(schedule);
+    });
+    it('should be successfully deleted', async () => {
+        const schedule = (
+            await schedules.create(db, {
+                name: 'Test Schedule',
+                payload: { foo: 'bar' },
+                startsAt: new Date(),
+                frequencyMs: 300_000
+            })
+        ).unwrap();
+        const deleted = (await schedules.remove(db, schedule.id)).unwrap();
+        expect(deleted.state).toBe('DELETED');
+        expect(deleted.updatedAt.getTime()).toBeGreaterThan(schedule.updatedAt.getTime());
+        expect(deleted.deletedAt).toBeInstanceOf(Date);
+    });
+    it('should be successfully paused/unpaused', async () => {
+        const schedule = (
+            await schedules.create(db, {
+                name: 'Test Schedule',
+                payload: { foo: 'bar' },
+                startsAt: new Date(),
+                frequencyMs: 300_000
+            })
+        ).unwrap();
+        const paused = (await schedules.transitionState(db, schedule.id, 'PAUSED')).unwrap();
+        expect(paused.state).toBe('PAUSED');
+        expect(paused.updatedAt.getTime()).toBeGreaterThan(schedule.updatedAt.getTime());
+
+        const unpaused = (await schedules.transitionState(db, schedule.id, 'STARTED')).unwrap();
+        expect(unpaused.state).toBe('STARTED');
+        expect(unpaused.updatedAt.getTime()).toBeGreaterThan(schedule.updatedAt.getTime());
+    });
+    it('should fail when pausing/unpausing a deleted schedule', async () => {
+        const schedule = (
+            await schedules.create(db, {
+                name: 'Test Schedule',
+                payload: { foo: 'bar' },
+                startsAt: new Date(),
+                frequencyMs: 300_000
+            })
+        ).unwrap();
+        await schedules.remove(db, schedule.id);
+        const paused = await schedules.transitionState(db, schedule.id, 'PAUSED');
+        expect(paused.isErr()).toBe(true);
+        const unpaused = await schedules.transitionState(db, schedule.id, 'STARTED');
+        expect(unpaused.isErr()).toBe(true);
+    });
+    it('should be successfully updated', async () => {
+        const schedule = (
+            await schedules.create(db, {
+                name: 'Test Schedule',
+                payload: { foo: 'bar' },
+                startsAt: new Date(),
+                frequencyMs: 300_000
+            })
+        ).unwrap();
+        const updated = (await schedules.update(db, { id: schedule.id, frequencyMs: 600_000, payload: { i: 2 } })).unwrap();
+        expect(updated.frequencyMs).toBe(600_000);
+        expect(updated.payload).toMatchObject({ i: 2 });
+        expect(updated.updatedAt.getTime()).toBeGreaterThan(schedule.updatedAt.getTime());
+    });
+    it('should be searchable', async () => {
+        const schedule = (
+            await schedules.create(db, {
+                name: 'Test Schedule',
+                payload: { foo: 'bar' },
+                startsAt: new Date(),
+                frequencyMs: 300_000
+            })
+        ).unwrap();
+        const byName = (await schedules.search(db, { name: schedule.name, limit: 10 })).unwrap();
+        expect(byName).toEqual([schedule]);
+
+        const started = (await schedules.search(db, { state: 'STARTED', limit: 10 })).unwrap();
+        expect(started).toEqual([schedule]);
+
+        const deleted = (await schedules.search(db, { state: 'DELETED', limit: 10 })).unwrap();
+        expect(deleted).toEqual([]);
+    });
+});

--- a/packages/scheduler/lib/models/schedules.ts
+++ b/packages/scheduler/lib/models/schedules.ts
@@ -1,0 +1,196 @@
+import type { JsonValue } from 'type-fest';
+import { uuidv7 } from 'uuidv7';
+import type knex from 'knex';
+import { Err, Ok, stringifyError } from '@nangohq/utils';
+import type { Result } from '@nangohq/utils';
+import type { Schedule, ScheduleState } from '../types';
+
+export const SCHEDULES_TABLE = 'schedules';
+
+interface ScheduleStateTransition {
+    from: ScheduleState;
+    to: ScheduleState;
+}
+
+export const validScheduleStateTransitions = [
+    { from: 'STARTED', to: 'PAUSED' },
+    { from: 'STARTED', to: 'DELETED' },
+    { from: 'PAUSED', to: 'STARTED' }
+] as const;
+export type ValidScheduleStateTransitions = (typeof validScheduleStateTransitions)[number];
+
+const ScheduleStateTransition = {
+    validate({ from, to }: { from: ScheduleState; to: ScheduleState }): Result<ValidScheduleStateTransitions> {
+        const transition = validScheduleStateTransitions.find((t) => t.from === from && t.to === to);
+        if (transition) {
+            return Ok(transition);
+        } else {
+            return Err(new Error(`Invalid state transition from ${from} to ${to}`));
+        }
+    }
+};
+
+interface DbSchedule {
+    readonly id: string;
+    readonly name: string;
+    state: ScheduleState;
+    readonly starts_at: Date;
+    frequency: string;
+    payload: JsonValue;
+    readonly created_at: Date;
+    updated_at: Date;
+    deleted_at: Date | null;
+}
+
+// knex uses https://github.com/bendrucker/postgres-interval
+function postgresIntervalInMs(i: {
+    years?: number;
+    months?: number;
+    days?: number;
+    hours?: number;
+    minutes?: number;
+    seconds?: number;
+    milliseconds?: number;
+}): number {
+    return (
+        (i.years ?? 0) * 31536000000 +
+        (i.months ?? 0) * 2592000000 +
+        (i.days ?? 0) * 86400000 +
+        (i.hours ?? 0) * 3600000 +
+        (i.minutes ?? 0) * 60000 +
+        (i.seconds ?? 0) * 1000 +
+        (i.milliseconds ?? 0)
+    );
+}
+
+const DbSchedule = {
+    to: (schedule: Schedule): DbSchedule => ({
+        id: schedule.id.toString(),
+        name: schedule.name,
+        state: schedule.state,
+        starts_at: schedule.startsAt,
+        frequency: `${schedule.frequencyMs} milliseconds`,
+        payload: schedule.payload,
+        created_at: schedule.createdAt,
+        updated_at: schedule.updatedAt,
+        deleted_at: schedule.deletedAt
+    }),
+    from: (dbSchedule: DbSchedule): Schedule => ({
+        id: dbSchedule.id,
+        name: dbSchedule.name,
+        state: dbSchedule.state,
+        startsAt: dbSchedule.starts_at,
+        frequencyMs: postgresIntervalInMs(dbSchedule.frequency as any),
+        payload: dbSchedule.payload,
+        createdAt: dbSchedule.created_at,
+        updatedAt: dbSchedule.updated_at,
+        deletedAt: dbSchedule.deleted_at
+    })
+};
+
+export type ScheduleProps = Omit<Schedule, 'id' | 'state' | 'createdAt' | 'updatedAt' | 'deletedAt'>;
+export async function create(db: knex.Knex, props: ScheduleProps): Promise<Result<Schedule>> {
+    const now = new Date();
+    const newSchedule: Schedule = {
+        ...props,
+        id: uuidv7(),
+        state: 'STARTED',
+        payload: props.payload,
+        startsAt: now,
+        frequencyMs: props.frequencyMs,
+        createdAt: now,
+        updatedAt: now,
+        deletedAt: null
+    };
+    try {
+        const inserted = await db.from<DbSchedule>(SCHEDULES_TABLE).insert(DbSchedule.to(newSchedule)).returning('*');
+        if (!inserted?.[0]) {
+            return Err(new Error(`Error: no schedule '${props.name}' created`));
+        }
+        return Ok(DbSchedule.from(inserted[0]));
+    } catch (err: unknown) {
+        return Err(new Error(`Error creating schedule '${props.name}': ${stringifyError(err)}`));
+    }
+}
+
+export async function get(db: knex.Knex, scheduleId: string): Promise<Result<Schedule>> {
+    try {
+        const schedule = await db.from<DbSchedule>(SCHEDULES_TABLE).where('id', scheduleId).first();
+        if (!schedule) {
+            return Err(new Error(`Error: no schedule '${scheduleId}' found`));
+        }
+        return Ok(DbSchedule.from(schedule));
+    } catch (err: unknown) {
+        return Err(new Error(`Error getting schedule '${scheduleId}': ${stringifyError(err)}`));
+    }
+}
+
+export async function transitionState(db: knex.Knex, scheduleId: string, to: ScheduleState): Promise<Result<Schedule>> {
+    try {
+        const getSchedule = await get(db, scheduleId);
+        if (getSchedule.isErr()) {
+            return Err(new Error(`Error: no schedule '${scheduleId}' found`));
+        }
+        const transition = ScheduleStateTransition.validate({ from: getSchedule.value.state, to });
+        if (transition.isErr()) {
+            return Err(transition.error);
+        }
+        const updated = await db.from<DbSchedule>(SCHEDULES_TABLE).where('id', scheduleId).update({ state: to, updated_at: new Date() }).returning('*');
+        if (!updated?.[0]) {
+            return Err(new Error(`Error: no schedule '${scheduleId}' updated`));
+        }
+        return Ok(DbSchedule.from(updated[0]));
+    } catch (err: unknown) {
+        return Err(new Error(`Error transitioning schedule '${scheduleId}': ${stringifyError(err)}`));
+    }
+}
+
+export async function update(db: knex.Knex, props: Partial<Pick<ScheduleProps, 'frequencyMs' | 'payload'>> & { id: string }): Promise<Result<Schedule>> {
+    try {
+        const newValues = {
+            ...(props.frequencyMs ? { frequency: `${props.frequencyMs} milliseconds` } : {}),
+            ...(props.payload ? { payload: props.payload } : {}),
+            updated_at: new Date()
+        };
+        const updated = await db.from<DbSchedule>(SCHEDULES_TABLE).where('id', props.id).update(newValues).returning('*');
+        if (!updated?.[0]) {
+            return Err(new Error(`Error: no schedule '${props.id}' updated`));
+        }
+        return Ok(DbSchedule.from(updated[0]));
+    } catch (err: unknown) {
+        return Err(new Error(`Error updating schedule '${props.id}': ${stringifyError(err)}`));
+    }
+}
+
+export async function remove(db: knex.Knex, id: string): Promise<Result<Schedule>> {
+    try {
+        const now = new Date();
+        const deleted = await db
+            .from<DbSchedule>(SCHEDULES_TABLE)
+            .where('id', id)
+            .update({ state: 'DELETED', deleted_at: now, updated_at: now })
+            .returning('*');
+        if (!deleted?.[0]) {
+            return Err(new Error(`Error: no schedule '${id}' deleted`));
+        }
+        return Ok(DbSchedule.from(deleted[0]));
+    } catch (err: unknown) {
+        return Err(new Error(`Error deleting schedule '${id}': ${stringifyError(err)}`));
+    }
+}
+
+export async function search(db: knex.Knex, params: { name?: string; state?: ScheduleState; limit: number }): Promise<Result<Schedule[]>> {
+    try {
+        const query = db.from<DbSchedule>(SCHEDULES_TABLE).limit(params.limit);
+        if (params.name) {
+            query.where('name', params.name);
+        }
+        if (params.state) {
+            query.where('state', params.state);
+        }
+        const schedules = await query;
+        return Ok(schedules.map(DbSchedule.from));
+    } catch (err: unknown) {
+        return Err(new Error(`Error searching schedules: ${stringifyError(err)}`));
+    }
+}

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -27,7 +27,8 @@ describe('Task', () => {
                 startsAfter: new Date(),
                 createdToStartedTimeoutSecs: 10,
                 startedToCompletedTimeoutSecs: 20,
-                heartbeatTimeoutSecs: 5
+                heartbeatTimeoutSecs: 5,
+                scheduleId: null
             })
         ).unwrap();
         expect(task).toMatchObject({
@@ -45,7 +46,8 @@ describe('Task', () => {
             lastStateTransitionAt: expect.toBeIsoDateTimezone(),
             lastHeartbeatAt: expect.toBeIsoDateTimezone(),
             output: null,
-            terminated: false
+            terminated: false,
+            scheduleId: null
         });
     });
     it('should have their heartbeat updated', async () => {
@@ -192,7 +194,8 @@ async function createTask(db: knex.Knex, props?: Partial<tasks.TaskProps>): Prom
             startsAfter: props?.startsAfter || new Date(),
             createdToStartedTimeoutSecs: props?.createdToStartedTimeoutSecs || 10,
             startedToCompletedTimeoutSecs: props?.startedToCompletedTimeoutSecs || 20,
-            heartbeatTimeoutSecs: props?.heartbeatTimeoutSecs || 5
+            heartbeatTimeoutSecs: props?.heartbeatTimeoutSecs || 5,
+            scheduleId: props?.scheduleId || null
         })
         .then((t) => t.unwrap());
 }

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -57,6 +57,7 @@ interface DbTask {
     last_heartbeat_at: Date;
     output: JsonValue | null;
     terminated: boolean;
+    readonly schedule_id: string | null;
 }
 const DbTask = {
     to: (task: Task): DbTask => {
@@ -76,7 +77,8 @@ const DbTask = {
             last_state_transition_at: task.lastStateTransitionAt,
             last_heartbeat_at: task.lastHeartbeatAt,
             output: task.output,
-            terminated: task.terminated
+            terminated: task.terminated,
+            schedule_id: task.scheduleId
         };
     },
     from: (dbTask: DbTask): Task => {
@@ -96,7 +98,8 @@ const DbTask = {
             lastStateTransitionAt: dbTask.last_state_transition_at,
             lastHeartbeatAt: dbTask.last_heartbeat_at,
             output: dbTask.output,
-            terminated: dbTask.terminated
+            terminated: dbTask.terminated,
+            scheduleId: dbTask.schedule_id
         };
     }
 };
@@ -111,7 +114,8 @@ export async function create(db: knex.Knex, taskProps: TaskProps): Promise<Resul
         lastStateTransitionAt: now,
         lastHeartbeatAt: now,
         terminated: false,
-        output: null
+        output: null,
+        scheduleId: taskProps.scheduleId
     };
     try {
         const inserted = await db.from<DbTask>(TASKS_TABLE).insert(DbTask.to(newTask)).returning('*');
@@ -132,7 +136,10 @@ export async function get(db: knex.Knex, taskId: string): Promise<Result<Task>> 
     return Ok(DbTask.from(task));
 }
 
-export async function search(db: knex.Knex, params?: { ids?: string[]; groupKey?: string; state?: TaskState; limit?: number }): Promise<Result<Task[]>> {
+export async function search(
+    db: knex.Knex,
+    params?: { ids?: string[]; groupKey?: string; state?: TaskState; scheduleId?: string; limit?: number }
+): Promise<Result<Task[]>> {
     const query = db.from<DbTask>(TASKS_TABLE);
     if (params?.ids) {
         query.whereIn('id', params.ids);
@@ -142,6 +149,9 @@ export async function search(db: knex.Knex, params?: { ids?: string[]; groupKey?
     }
     if (params?.state) {
         query.where('state', params.state);
+    }
+    if (params?.scheduleId) {
+        query.where('schedule_id', params.scheduleId);
     }
     const limit = params?.limit || 100;
     const tasks = await query.limit(limit).orderBy('id');

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -83,7 +83,7 @@ export class Scheduler {
     }
 
     /**
-     * Schedule a task immediatly
+     * Schedule a task immediately
      * @param props - Scheduling properties
      * @param props.scheduling - 'immediate'
      * @params props.taskProps - Task properties

--- a/packages/scheduler/lib/types.ts
+++ b/packages/scheduler/lib/types.ts
@@ -1,5 +1,6 @@
-import type { TaskProps } from './models/tasks';
 import type { JsonValue } from 'type-fest';
+import type { TaskProps } from './models/tasks.js';
+import type { ScheduleProps } from './models/schedules.js';
 
 export const taskStates = ['CREATED', 'STARTED', 'SUCCEEDED', 'FAILED', 'EXPIRED', 'CANCELLED'] as const;
 export type TaskState = (typeof taskStates)[number];
@@ -23,9 +24,23 @@ export interface Task {
     readonly lastHeartbeatAt: Date;
     readonly output: JsonValue | null;
     readonly terminated: boolean;
+    readonly scheduleId: string | null;
 }
 
-export interface SchedulingProps {
-    taskProps: Omit<TaskProps, 'startsAfter'>;
-    scheduling: 'immediate';
+export type ImmediateProps = Omit<TaskProps, 'startsAfter' | 'scheduleId'>;
+export type { ScheduleProps };
+
+const scheduleStates = ['PAUSED', 'STARTED', 'DELETED'] as const;
+export type ScheduleState = (typeof scheduleStates)[number];
+
+export interface Schedule {
+    id: string;
+    name: string;
+    state: ScheduleState;
+    startsAt: Date;
+    frequencyMs: number;
+    payload: JsonValue;
+    createdAt: Date;
+    updatedAt: Date;
+    deletedAt: Date | null;
 }


### PR DESCRIPTION
Based on https://github.com/NangoHQ/nango/pull/2256. Review this one first 🙏 

This PR is adding model and logic to create schedules in the orchestrator. In a following PR I will add a scheduler worker_thread that will create tasks based on exisiting schedules when necessary

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
