### PR TITLE
fix(orchestrator): race condition in dequeue

### DIFF
--- a/packages/orchestrator/lib/routes/v1/postDequeue.ts
+++ b/packages/orchestrator/lib/routes/v1/postDequeue.ts
@@ -58,12 +58,14 @@ const handler = (scheduler: Scheduler, eventEmitter: EventEmitter) => {
             }
         };
         const onTaskStarted = async (_t: Task) => {
-            const getTasks = await scheduler.dequeue({ groupKey, limit });
-            if (getTasks.isErr()) {
-                cleanupAndRespond((res) => res.status(500).json({ error: { code: 'dequeue_failed', message: getTasks.error.message } }));
-            } else {
-                cleanupAndRespond((res) => res.status(200).json(getTasks.value));
-            }
+            cleanupAndRespond(async (res) => {
+                const getTasks = await scheduler.dequeue({ groupKey, limit });
+                if (getTasks.isErr()) {
+                    res.status(500).json({ error: { code: 'dequeue_failed', message: getTasks.error.message } });
+                } else {
+                    res.status(200).json(getTasks.value);
+                }
+            });
         };
         const timeout = setTimeout(() => {
             cleanupAndRespond((res) => res.status(200).send([]));


### PR DESCRIPTION
another race condition in orchestrator dequeue where the new task event can be received at the same time of the timeout triggering. The dequeued tasks will then not be sent back to the processor. Here again the fix is simple: only try to dequeue after having cleanup the timeout and check that no response was already sent

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: I managed to write a test to trigger the race condition but it was only occuring 50% of the time :(
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
