### PR TITLE
fix(proxy): [nan-1049] if encoded at all then use pass through

### DIFF
--- a/packages/server/lib/controllers/proxy.controller.ts
+++ b/packages/server/lib/controllers/proxy.controller.ts
@@ -307,9 +307,9 @@ class ProxyController {
         const contentType = responseStream.headers['content-type'];
         const isJsonResponse = contentType && contentType.includes('application/json');
         const isChunked = responseStream.headers['transfer-encoding'] === 'chunked';
-        const isZip = responseStream.headers['content-encoding'] === 'gzip';
+        const isEncoded = Boolean(responseStream.headers['content-encoding']);
 
-        if (isChunked || isZip) {
+        if (isChunked || isEncoded) {
             const passThroughStream = new PassThrough();
             responseStream.data.pipe(passThroughStream);
             passThroughStream.pipe(res);


### PR DESCRIPTION
## Describe your changes
The default should be to use PassThrough so if the response is encoded at all then use it. I have only seen one case where we need to manually need to parse the response and that is from hubspot:

```curl --location 'http://localhost:3003/proxy/crm/v3/objects/companies'```

and the responding headers are

```
{
  date: 'Tue, 04 Jun 2024 19:43:20 GMT',
  'content-type': 'application/json;charset=utf-8',
  'content-length': '186',
  connection: 'close',
  'cf-ray': '88ea694b1e837da1-TLV',
  'cf-cache-status': 'DYNAMIC',
  'strict-transport-security': 'max-age=31536000; includeSubDomains; preload',
  vary: 'origin, Accept-Encoding',
  'access-control-allow-credentials': 'false',
  'x-content-type-options': 'nosniff',
  'x-envoy-upstream-service-time': '43',
  'x-evy-trace-listener': 'listener_https',
  'x-evy-trace-route-configuration': 'listener_https/all',
  'x-evy-trace-route-service-name': 'envoyset-translator',
  'x-evy-trace-served-by-pod': 'fra04/hubapi-td/envoy-proxy-68d6f869c4-6nd9x',
  'x-evy-trace-virtual-host': 'all',
  'x-hubspot-correlation-id': '10e9e438-db8f-45cf-be48-c7da9e6524ab',
  'x-hubspot-ratelimit-interval-milliseconds': '10000',
  'x-hubspot-ratelimit-max': '100',
  'x-hubspot-ratelimit-remaining': '99',
  'x-hubspot-ratelimit-secondly': '10',
  'x-hubspot-ratelimit-secondly-remaining': '9',
  'x-request-id': '10e9e438-db8f-45cf-be48-c7da9e6524ab',
  'report-to': '{"endpoints":[{"url":"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=u05BP5a7qjAw8nVHFWzSqbNjwNgirC0e3EHmSkcYd%2B%2FtefuMFCWWIt6411jKmcCoM6e3YuWXJFST5HYmbZgMLkIb82vMQZSHb7LxAYaRDMzUxW9Z70CRTxGIosucMtPH"}],"group":"cf-nel","max_age":604800}',
  nel: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}',
  server: 'cloudflare'
}
```

## Issue ticket number and link
NAN-1049

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
