### PR TITLE
feat: expose environment name in scripts

### DIFF
--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -250,6 +250,7 @@ export interface NangoProps {
     accountId?: number;
     connectionId: string;
     environmentId?: number;
+    environmentName?: string;
     activityLogId?: number | undefined;
     providerConfigKey: string;
     provider?: string;
@@ -292,6 +293,7 @@ export class NangoAction {
     syncId?: string;
     nangoConnectionId?: number;
     environmentId?: number;
+    environmentName?: string;
     syncJobId?: number;
     dryRun?: boolean;
     abortSignal?: AbortSignal;
@@ -346,6 +348,10 @@ export class NangoAction {
 
         if (config.environmentId) {
             this.environmentId = config.environmentId;
+        }
+
+        if (config.environmentName) {
+            this.environmentName = config.environmentName;
         }
 
         if (config.provider) {

--- a/packages/shared/lib/services/sync/run.service.ts
+++ b/packages/shared/lib/services/sync/run.service.ts
@@ -383,6 +383,7 @@ export default class SyncRun {
                 accountId: this.account?.id as number,
                 connectionId: String(this.nangoConnection.connection_id),
                 environmentId: this.nangoConnection.environment_id,
+                environmentName: this.environment?.name as string,
                 providerConfigKey: String(this.nangoConnection.provider_config_key),
                 provider: this.provider as string,
                 activityLogId: this.activityLogId,


### PR DESCRIPTION
Customer wants to have access to the environment name from within their custom scripts. See linear ticket for more info.

## Issue ticket number and link
https://linear.app/nango/issue/NAN-967/surface-env-name-in-scripts

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
