### PR TITLE
fix(orchestrator): accept bigger task output

### DIFF
--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -3,7 +3,7 @@ import { getLogger, stringifyError } from '@nangohq/utils';
 import { getServer } from './server.js';
 import { envs } from './env.js';
 import type { Task } from '@nangohq/scheduler';
-import { Scheduler, DatabaseClient } from '@nangohq/scheduler';
+import { Scheduler, DatabaseClient, stringifyTask } from '@nangohq/scheduler';
 import { EventsHandler } from './events.js';
 
 const logger = getLogger('Orchestrator');
@@ -20,12 +20,12 @@ try {
 
     // TODO: add logic to update syncs and syncs jobs in the database
     const eventsHandler = new EventsHandler({
-        CREATED: (task: Task) => console.log(`Task created: ${JSON.stringify(task)}`),
-        STARTED: (task: Task) => console.log(`Task started: ${JSON.stringify(task)}`),
-        SUCCEEDED: (task: Task) => console.log(`Task succeeded: ${JSON.stringify(task)}`),
-        FAILED: (task: Task) => console.log(`Task failed: ${JSON.stringify(task)}`),
-        EXPIRED: (task: Task) => console.log(`Task expired: ${JSON.stringify(task)}`),
-        CANCELLED: (task: Task) => console.log(`Task cancelled: ${JSON.stringify(task)}`)
+        CREATED: (task: Task) => logger.info(`Task created: ${stringifyTask(task)}`),
+        STARTED: (task: Task) => logger.info(`Task started: ${stringifyTask(task)}`),
+        SUCCEEDED: (task: Task) => logger.info(`Task succeeded: ${stringifyTask(task)}`),
+        FAILED: (task: Task) => logger.error(`Task failed: ${stringifyTask(task)}`),
+        EXPIRED: (task: Task) => logger.error(`Task expired: ${stringifyTask(task)}`),
+        CANCELLED: (task: Task) => logger.info(`Task cancelled: ${stringifyTask(task)}`)
     });
     const scheduler = new Scheduler({
         dbClient,

--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -200,6 +200,32 @@ describe('OrchestratorClient', async () => {
             }
         });
     });
+    describe('succeed', () => {
+        it('should support big output', async () => {
+            const groupKey = rndStr();
+            const actionA = await client.schedule({
+                name: 'Task',
+                groupKey,
+                retry: { count: 0, max: 0 },
+                timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
+                args: {
+                    type: 'action',
+                    actionName: `A`,
+                    connection: {
+                        id: 123,
+                        connection_id: 'C',
+                        provider_config_key: 'P',
+                        environment_id: 456
+                    },
+                    activityLogId: 789,
+                    input: { foo: 'bar' }
+                }
+            });
+            await client.dequeue({ groupKey, limit: 1, longPolling: false });
+            const res = await client.succeed({ taskId: actionA.unwrap().taskId, output: { a: 'a'.repeat(10_000_000) } });
+            expect(res.isOk()).toBe(true);
+        });
+    });
     describe('search', () => {
         it('should returns task by ids', async () => {
             const groupKey = rndStr();

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -110,14 +110,14 @@ export class OrchestratorClient {
         const { args, ...rest } = props;
         const schedulingProps = {
             ...rest,
+            timeoutSettingsInSecs: {
+                createdToStarted: 30,
+                startedToCompleted: 15 * 60,
+                heartbeat: 999999 // actions don't need to heartbeat
+            },
             args: {
                 ...args,
-                type: 'action' as const,
-                timeoutSettingsInSecs: {
-                    createdToStarted: 30,
-                    startedToCompleted: 30,
-                    heartbeat: 999 // actions don't need to heartbeat
-                }
+                type: 'action' as const
             }
         };
         return this.execute(schedulingProps);
@@ -127,14 +127,14 @@ export class OrchestratorClient {
         const { args, ...rest } = props;
         const schedulingProps = {
             ...rest,
+            timeoutSettingsInSecs: {
+                createdToStarted: 30,
+                startedToCompleted: 15 * 60,
+                heartbeat: 999999 // webhooks don't need to heartbeat
+            },
             args: {
                 ...args,
-                type: 'webhook' as const,
-                timeoutSettingsInSecs: {
-                    createdToStarted: 30,
-                    startedToCompleted: 30,
-                    heartbeat: 999 // webhooks don't need to heartbeat
-                }
+                type: 'webhook' as const
             }
         };
         return this.execute(schedulingProps);

--- a/packages/orchestrator/lib/server.ts
+++ b/packages/orchestrator/lib/server.ts
@@ -17,7 +17,7 @@ const logger = getLogger('Orchestrator.server');
 export const getServer = (scheduler: Scheduler, eventEmmiter: EventEmitter): Express => {
     const server = express();
 
-    server.use(express.json({ limit: '100kb' }));
+    server.use(express.json({ limit: '10mb' }));
 
     // Logging middleware
     server.use((req: Request, res: Response, next: NextFunction) => {

--- a/packages/scheduler/lib/format.ts
+++ b/packages/scheduler/lib/format.ts
@@ -1,0 +1,7 @@
+import type { Task } from './types';
+
+export function stringifyTask(task: Task): string {
+    // remove payload and output from the stringified task
+    // to avoid logging sensitive data and/or large data
+    return JSON.stringify({ ...task, payload: 'REDACTED', output: 'REDACTED' });
+}

--- a/packages/scheduler/lib/index.ts
+++ b/packages/scheduler/lib/index.ts
@@ -2,3 +2,4 @@ export * from './scheduler.js';
 export * from './types.js';
 export * from './db/helpers.test.js';
 export * from './db/client.js';
+export * from './format.js';


### PR DESCRIPTION
I was a bit conservative with my 100k payload limit for the orchestrator server. Upping to 10mb because some customers are hitting the limit. This commit also fixes setting the default timeout and we don't log the task payload and ouptput anymore

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
