### PR TITLE
feat(orchestrator): scheduling tasks based on schedules

### DIFF
--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -41,6 +41,9 @@ describe('OrchestratorClient', async () => {
                 name: 'Task',
                 startsAt: new Date(),
                 frequencyMs: 300_000,
+                groupKey: rndStr(),
+                retry: { count: 0, max: 0 },
+                timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
                 args: {
                     type: 'sync',
                     syncId: 'sync-a',

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -62,6 +62,9 @@ export class OrchestratorClient {
                 name: props.name,
                 startsAt: props.startsAt,
                 frequencyMs: props.frequencyMs,
+                groupKey: props.groupKey,
+                retry: props.retry,
+                timeoutSettingsInSecs: props.timeoutSettingsInSecs,
                 args: props.args
             }
         });

--- a/packages/scheduler/lib/db/migrations/20240605205506_schedules_index.ts
+++ b/packages/scheduler/lib/db/migrations/20240605205506_schedules_index.ts
@@ -1,0 +1,44 @@
+import type { Knex } from 'knex';
+import { SCHEDULES_TABLE } from '../../models/schedules.js';
+import { TASKS_TABLE } from '../../models/tasks.js';
+
+export const config = {
+    transaction: false
+};
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`
+            ALTER TABLE ${SCHEDULES_TABLE}
+            ADD COLUMN IF NOT EXISTS schedule_id uuid,
+            ADD COLUMN IF NOT EXISTS group_key varchar(255) NOT NULL,
+            ADD COLUMN IF NOT EXISTS retry_max integer NOT NULL default(0),
+            ADD COLUMN IF NOT EXISTS retry_count integer NOT NULL default(0),
+            ADD COLUMN IF NOT EXISTS created_to_started_timeout_secs integer NOT NULL,
+            ADD COLUMN IF NOT EXISTS started_to_completed_timeout_secs integer NOT NULL,
+            ADD COLUMN IF NOT EXISTS heartbeat_timeout_secs integer NOT NULL;
+        `);
+    // Tasks indexes
+    await knex.raw(`CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_tasks_schedule_id" ON ${TASKS_TABLE} USING BTREE (schedule_id);`);
+    await knex.raw(`CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_tasks_starts_after" ON ${TASKS_TABLE} USING BTREE (starts_after);`);
+    await knex.raw(`CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_tasks_state" ON ${TASKS_TABLE} USING BTREE (state);`);
+
+    // Schedules indexes
+    await knex.raw(`CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_schedules_state_started" ON ${SCHEDULES_TABLE} USING BTREE (state) WHERE state = 'STARTED';`);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`DROP INDEX IF EXISTS "idx_tasks_schedule_id";`);
+    await knex.raw(`DROP INDEX IF EXISTS "idx_tasks_starts_after";`);
+    await knex.raw(`DROP INDEX IF EXISTS "idx_tasks_state";`);
+    await knex.raw(`DROP INDEX IF EXISTS "idx_schedules_state_started";`);
+    await knex.raw(`
+            ALTER TABLE ${SCHEDULES_TABLE}
+            DROP COLUMN IF EXISTS schedule_id,
+            DROP COLUMN IF EXISTS group_key,
+            DROP COLUMN IF EXISTS retry_max,
+            DROP COLUMN IF EXISTS retry_count,
+            DROP COLUMN IF EXISTS created_to_started_timeout_secs,
+            DROP COLUMN IF EXISTS started_to_completed_timeout_secs,
+            DROP COLUMN IF EXISTS heartbeat_timeout_secs;
+        `);
+}

--- a/packages/scheduler/lib/index.ts
+++ b/packages/scheduler/lib/index.ts
@@ -2,4 +2,4 @@ export * from './scheduler.js';
 export * from './types.js';
 export * from './db/helpers.test.js';
 export * from './db/client.js';
-export * from './format.js';
+export * from './utils/format.js';

--- a/packages/scheduler/lib/models/schedules.ts
+++ b/packages/scheduler/lib/models/schedules.ts
@@ -30,13 +30,19 @@ const ScheduleStateTransition = {
     }
 };
 
-interface DbSchedule {
+export interface DbSchedule {
     readonly id: string;
     readonly name: string;
     state: ScheduleState;
     readonly starts_at: Date;
     frequency: string;
     payload: JsonValue;
+    readonly group_key: string;
+    readonly retry_count: number;
+    readonly retry_max: number;
+    readonly created_to_started_timeout_secs: number;
+    readonly started_to_completed_timeout_secs: number;
+    readonly heartbeat_timeout_secs: number;
     readonly created_at: Date;
     updated_at: Date;
     deleted_at: Date | null;
@@ -63,7 +69,7 @@ function postgresIntervalInMs(i: {
     );
 }
 
-const DbSchedule = {
+export const DbSchedule = {
     to: (schedule: Schedule): DbSchedule => ({
         id: schedule.id.toString(),
         name: schedule.name,
@@ -71,6 +77,12 @@ const DbSchedule = {
         starts_at: schedule.startsAt,
         frequency: `${schedule.frequencyMs} milliseconds`,
         payload: schedule.payload,
+        group_key: schedule.groupKey,
+        retry_count: schedule.retryCount,
+        retry_max: schedule.retryMax,
+        created_to_started_timeout_secs: schedule.createdToStartedTimeoutSecs,
+        started_to_completed_timeout_secs: schedule.startedToCompletedTimeoutSecs,
+        heartbeat_timeout_secs: schedule.heartbeatTimeoutSecs,
         created_at: schedule.createdAt,
         updated_at: schedule.updatedAt,
         deleted_at: schedule.deletedAt
@@ -82,6 +94,12 @@ const DbSchedule = {
         startsAt: dbSchedule.starts_at,
         frequencyMs: postgresIntervalInMs(dbSchedule.frequency as any),
         payload: dbSchedule.payload,
+        groupKey: dbSchedule.group_key,
+        retryCount: dbSchedule.retry_count,
+        retryMax: dbSchedule.retry_max,
+        createdToStartedTimeoutSecs: dbSchedule.created_to_started_timeout_secs,
+        startedToCompletedTimeoutSecs: dbSchedule.started_to_completed_timeout_secs,
+        heartbeatTimeoutSecs: dbSchedule.heartbeat_timeout_secs,
         createdAt: dbSchedule.created_at,
         updatedAt: dbSchedule.updated_at,
         deletedAt: dbSchedule.deleted_at

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -40,7 +40,7 @@ const TaskStateTransition = {
     }
 };
 
-interface DbTask {
+export interface DbTask {
     readonly id: string;
     readonly name: string;
     readonly payload: JsonValue;
@@ -59,7 +59,7 @@ interface DbTask {
     terminated: boolean;
     readonly schedule_id: string | null;
 }
-const DbTask = {
+export const DbTask = {
     to: (task: Task): DbTask => {
         return {
             id: task.id,

--- a/packages/scheduler/lib/types.ts
+++ b/packages/scheduler/lib/types.ts
@@ -34,13 +34,19 @@ const scheduleStates = ['PAUSED', 'STARTED', 'DELETED'] as const;
 export type ScheduleState = (typeof scheduleStates)[number];
 
 export interface Schedule {
-    id: string;
-    name: string;
-    state: ScheduleState;
-    startsAt: Date;
-    frequencyMs: number;
-    payload: JsonValue;
-    createdAt: Date;
-    updatedAt: Date;
-    deletedAt: Date | null;
+    readonly id: string;
+    readonly name: string;
+    readonly state: ScheduleState;
+    readonly startsAt: Date;
+    readonly frequencyMs: number;
+    readonly payload: JsonValue;
+    readonly groupKey: string;
+    readonly retryMax: number;
+    readonly retryCount: number;
+    readonly createdToStartedTimeoutSecs: number;
+    readonly startedToCompletedTimeoutSecs: number;
+    readonly heartbeatTimeoutSecs: number;
+    readonly createdAt: Date;
+    readonly updatedAt: Date;
+    readonly deletedAt: Date | null;
 }

--- a/packages/scheduler/lib/utils/format.ts
+++ b/packages/scheduler/lib/utils/format.ts
@@ -1,4 +1,4 @@
-import type { Task } from './types';
+import type { Task } from '../types';
 
 export function stringifyTask(task: Task): string {
     // remove payload and output from the stringified task

--- a/packages/scheduler/lib/workers/monitor/monitor.worker.boot.ts
+++ b/packages/scheduler/lib/workers/monitor/monitor.worker.boot.ts
@@ -1,9 +1,7 @@
 import { isMainThread, parentPort, workerData } from 'node:worker_threads';
-import { getLogger } from '@nangohq/utils';
 import { MonitorChild } from './monitor.worker.js';
-import { DatabaseClient } from './db/client.js';
-
-const logger = getLogger('Scheduler.monitor');
+import { DatabaseClient } from '../../db/client.js';
+import { logger } from '../../utils/logger.js';
 
 if (!isMainThread && parentPort) {
     const { url, schema } = workerData;

--- a/packages/scheduler/lib/workers/monitor/monitor.worker.ts
+++ b/packages/scheduler/lib/workers/monitor/monitor.worker.ts
@@ -1,12 +1,11 @@
 import * as fs from 'fs';
 import type { MessagePort } from 'node:worker_threads';
 import { Worker, isMainThread } from 'node:worker_threads';
-import { getLogger, stringifyError } from '@nangohq/utils';
-import * as tasks from './models/tasks.js';
+import { stringifyError } from '@nangohq/utils';
+import * as tasks from '../../models/tasks.js';
 import { setTimeout } from 'node:timers/promises';
 import type knex from 'knex';
-
-const logger = getLogger('Scheduler.monitor.worker');
+import { logger } from '../../utils/logger.js';
 
 interface MessageOut {
     ids: string[];
@@ -16,7 +15,7 @@ export class MonitorWorker {
     private worker: Worker | null;
     constructor({ databaseUrl, databaseSchema }: { databaseUrl: string; databaseSchema: string }) {
         if (isMainThread) {
-            const url = new URL('../dist/monitor.js', import.meta.url);
+            const url = new URL('../../../dist/workers/monitor/monitor.worker.boot.js', import.meta.url);
             if (!fs.existsSync(url)) {
                 throw new Error(`Monitor script not found at ${url}`);
             }

--- a/packages/scheduler/lib/workers/scheduling/scheduling.integration.test.ts
+++ b/packages/scheduler/lib/workers/scheduling/scheduling.integration.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { dueSchedules } from './scheduling.js';
+import { getTestDbClient } from '../../db/helpers.test.js';
+import { DbSchedule, SCHEDULES_TABLE } from '../../models/schedules.js';
+import { uuidv7 } from 'uuidv7';
+import type knex from 'knex';
+import type { Schedule, ScheduleState, Task, TaskState } from '../../types.js';
+import { TASKS_TABLE, DbTask } from '../../models/tasks.js';
+
+describe('dueSchedules', () => {
+    const dbClient = getTestDbClient();
+    const db = dbClient.db;
+
+    beforeEach(async () => {
+        await dbClient.migrate();
+    });
+
+    afterEach(async () => {
+        await dbClient.clearDatabase();
+    });
+
+    it('should not return schedule that is deleted', async () => {
+        await addSchedule(db, { state: 'DELETED', frequency: '3 minutes' });
+        const due = await dueSchedules(db);
+        expect(due.isOk()).toBe(true);
+        console.log(due.unwrap());
+        expect(due.unwrap().length).toBe(0);
+    });
+    it('should not return schedule that is paused', async () => {
+        await addSchedule(db, { state: 'PAUSED', frequency: '3 minutes' });
+        const due = await dueSchedules(db);
+        expect(due.isOk()).toBe(true);
+        console.log(due.unwrap());
+        expect(due.unwrap().length).toBe(0);
+    });
+    it('should not return schedule that is set to start in the future', async () => {
+        await addSchedule(db, { state: 'STARTED', frequency: '3 minutes', startsAt: Seconds.after(1 * 60) });
+        const due = await dueSchedules(db);
+        expect(due.isOk()).toBe(true);
+        console.log(due.unwrap());
+        expect(due.unwrap().length).toBe(0);
+    });
+    it('should not return schedule that have a recent task completed', async () => {
+        const startsAt = Seconds.ago(-5 * 60); // 5 minutes ago
+        const schedule = await addSchedule(db, { startsAt, frequency: '10 minutes' });
+        await addTask(db, {
+            scheduleId: schedule.id,
+            state: 'SUCCEEDED',
+            startsAfter: startsAt,
+            lastStateTransitionAt: Seconds.after(20, startsAt)
+        });
+        const due = await dueSchedules(db);
+        expect(due.isOk()).toBe(true);
+        expect(due.unwrap().length).toBe(0);
+    });
+    it('should not return schedule that have a task running', async () => {
+        const startsAt = Seconds.ago(-5 * 60); // 5 minutes ago
+        const schedule = await addSchedule(db, { startsAt, frequency: '10 minutes' });
+        await addTask(db, {
+            scheduleId: schedule.id,
+            state: 'STARTED',
+            startsAfter: startsAt,
+            lastStateTransitionAt: startsAt
+        });
+        const due = await dueSchedules(db);
+        expect(due.isOk()).toBe(true);
+        expect(due.unwrap().length).toBe(0);
+    });
+    it('should return schedule that has never run', async () => {
+        await addSchedule(db);
+        const due = await dueSchedules(db);
+        expect(due.isOk()).toBe(true);
+        expect(due.unwrap().length).toBe(1);
+    });
+    it('should return schedule that has not run recently', async () => {
+        const startsAt = Seconds.ago(6 * 60); // 10 minutes ago
+        const schedule = await addSchedule(db, { startsAt, frequency: '5 minutes' });
+        const task = await addTask(db, {
+            scheduleId: schedule.id,
+            state: 'SUCCEEDED',
+            startsAfter: startsAt,
+            lastStateTransitionAt: Seconds.after(20, startsAt)
+        });
+        console.log(schedule, task);
+        const due = await dueSchedules(db);
+        expect(due.isOk()).toBe(true);
+        expect(due.unwrap().length).toBe(1);
+    });
+});
+
+const Seconds = {
+    after: (seconds: number, date: Date = new Date()): Date => {
+        return new Date(date.getTime() + seconds * 1000);
+    },
+    ago: (seconds: number, date: Date = new Date()): Date => {
+        return new Date(date.getTime() - seconds * 1000);
+    }
+};
+
+async function addSchedule(db: knex.Knex, params?: { state?: ScheduleState; startsAt?: Date; frequency?: string }): Promise<Schedule> {
+    const schedule: DbSchedule = {
+        id: uuidv7(),
+        name: Math.random().toString(36).substring(7),
+        state: params?.state || 'STARTED',
+        starts_at: params?.startsAt || new Date(),
+        frequency: params?.frequency || '5 minutes',
+        payload: {},
+        group_key: Math.random().toString(36).substring(7),
+        retry_count: 0,
+        retry_max: 0,
+        created_to_started_timeout_secs: 1,
+        started_to_completed_timeout_secs: 1,
+        heartbeat_timeout_secs: 1,
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: params?.state === 'DELETED' ? new Date() : null
+    };
+    const res = await db.from<DbSchedule>(SCHEDULES_TABLE).insert(schedule).returning('*');
+    const inserted = res[0];
+    if (!inserted) {
+        throw new Error('Failed to insert schedule');
+    }
+    return DbSchedule.from(inserted);
+}
+
+async function addTask(
+    db: knex.Knex,
+    params?: {
+        scheduleId?: string;
+        state?: TaskState;
+        lastStateTransitionAt?: Date;
+        startsAfter?: Date;
+    }
+): Promise<Task> {
+    const task: DbTask = {
+        id: uuidv7(),
+        schedule_id: params?.scheduleId || uuidv7(),
+        group_key: Math.random().toString(36).substring(7),
+        name: Math.random().toString(36).substring(7),
+        state: params?.state || 'CREATED',
+        payload: {},
+        retry_max: 0,
+        retry_count: 0,
+        created_at: params?.startsAfter || new Date(),
+        last_state_transition_at: params?.lastStateTransitionAt || new Date(),
+        starts_after: params?.startsAfter || new Date(),
+        created_to_started_timeout_secs: 1,
+        started_to_completed_timeout_secs: 1,
+        heartbeat_timeout_secs: 1,
+        last_heartbeat_at: new Date(),
+        output: {},
+        terminated: params?.state !== 'CREATED' && params?.state !== 'STARTED'
+    };
+    const res = await db.from<DbTask>(TASKS_TABLE).insert(task).returning('*');
+    const inserted = res[0];
+    if (!inserted) {
+        throw new Error('Failed to insert task');
+    }
+    return DbTask.from(inserted);
+}

--- a/packages/scheduler/lib/workers/scheduling/scheduling.integration.test.ts
+++ b/packages/scheduler/lib/workers/scheduling/scheduling.integration.test.ts
@@ -23,21 +23,18 @@ describe('dueSchedules', () => {
         await addSchedule(db, { state: 'DELETED', frequency: '3 minutes' });
         const due = await dueSchedules(db);
         expect(due.isOk()).toBe(true);
-        console.log(due.unwrap());
         expect(due.unwrap().length).toBe(0);
     });
     it('should not return schedule that is paused', async () => {
         await addSchedule(db, { state: 'PAUSED', frequency: '3 minutes' });
         const due = await dueSchedules(db);
         expect(due.isOk()).toBe(true);
-        console.log(due.unwrap());
         expect(due.unwrap().length).toBe(0);
     });
     it('should not return schedule that is set to start in the future', async () => {
         await addSchedule(db, { state: 'STARTED', frequency: '3 minutes', startsAt: Seconds.after(1 * 60) });
         const due = await dueSchedules(db);
         expect(due.isOk()).toBe(true);
-        console.log(due.unwrap());
         expect(due.unwrap().length).toBe(0);
     });
     it('should not return schedule that have a recent task completed', async () => {
@@ -75,13 +72,12 @@ describe('dueSchedules', () => {
     it('should return schedule that has not run recently', async () => {
         const startsAt = Seconds.ago(6 * 60); // 10 minutes ago
         const schedule = await addSchedule(db, { startsAt, frequency: '5 minutes' });
-        const task = await addTask(db, {
+        await addTask(db, {
             scheduleId: schedule.id,
             state: 'SUCCEEDED',
             startsAfter: startsAt,
             lastStateTransitionAt: Seconds.after(20, startsAt)
         });
-        console.log(schedule, task);
         const due = await dueSchedules(db);
         expect(due.isOk()).toBe(true);
         expect(due.unwrap().length).toBe(1);

--- a/packages/scheduler/lib/workers/scheduling/scheduling.ts
+++ b/packages/scheduler/lib/workers/scheduling/scheduling.ts
@@ -1,0 +1,48 @@
+import type knex from 'knex';
+import type { Schedule } from '../../types.js';
+import { DbSchedule, SCHEDULES_TABLE } from '../../models/schedules.js';
+import type { Result } from '@nangohq/utils';
+import { Err, Ok, stringifyError } from '@nangohq/utils';
+import { TASKS_TABLE } from '../../models/tasks.js';
+
+export async function dueSchedules(db: knex.Knex): Promise<Result<Schedule[]>> {
+    try {
+        const query = db
+            .with(
+                'last_run_times',
+                // calculate the last run time for each schedule that is started/not deleted
+                db
+                    .select(
+                        's.id',
+                        db.raw(`
+                            s.starts_at + (FLOOR(EXTRACT(EPOCH FROM (NOW() - s.starts_at)) / EXTRACT(EPOCH FROM s.frequency)) * s.frequency) AS last_run_time
+                        `)
+                    )
+                    .from({ s: SCHEDULES_TABLE })
+                    .where({ state: 'STARTED' })
+                    .whereRaw('s.starts_at <= NOW()')
+            )
+            .select('*')
+            .from<DbSchedule>({ s: SCHEDULES_TABLE })
+            .joinRaw('JOIN last_run_times lrt ON s.id = lrt.id')
+            // filter out schedules that have a running task
+            .whereNotExists(
+                db
+                    .select('id')
+                    .from({ t: TASKS_TABLE })
+                    .whereRaw('t.schedule_id = s.id')
+                    .where(function () {
+                        this.where({ state: 'CREATED' }).orWhere({ state: 'STARTED' });
+                    })
+            )
+            // filter out schedules that have tasks started after the last run time
+            .whereNotExists(
+                db.select('id').from({ t: TASKS_TABLE }).whereRaw('t.schedule_id = s.id').andWhere('t.starts_after', '>=', db.raw('lrt.last_run_time'))
+            );
+        const schedules = await query;
+        return Ok(schedules.map(DbSchedule.from));
+    } catch (err: unknown) {
+        console.log(err);
+        return Err(new Error(`Error getting due schedules: ${stringifyError(err)}`));
+    }
+}

--- a/packages/scheduler/lib/workers/scheduling/scheduling.worker.boot.ts
+++ b/packages/scheduler/lib/workers/scheduling/scheduling.worker.boot.ts
@@ -1,0 +1,15 @@
+import { isMainThread, parentPort, workerData } from 'node:worker_threads';
+import { SchedulingChild } from './scheduling.worker.js';
+import { DatabaseClient } from '../../db/client.js';
+import { logger } from '../../utils/logger.js';
+
+if (!isMainThread && parentPort) {
+    const { url, schema } = workerData;
+    if (!url || !schema) {
+        throw new Error('Missing required database url and schema for scheduling worker');
+    }
+    const dbClient = new DatabaseClient({ url, schema, poolMax: 10 });
+    new SchedulingChild(parentPort, dbClient.db);
+} else {
+    logger.error('Failed to start scheduling in worker thread');
+}

--- a/packages/scheduler/lib/workers/scheduling/scheduling.worker.ts
+++ b/packages/scheduler/lib/workers/scheduling/scheduling.worker.ts
@@ -1,0 +1,113 @@
+import * as fs from 'fs';
+import type { MessagePort } from 'node:worker_threads';
+import { Worker, isMainThread } from 'node:worker_threads';
+import { stringifyError } from '@nangohq/utils';
+import { setTimeout } from 'node:timers/promises';
+import type knex from 'knex';
+import { logger } from '../../utils/logger.js';
+import { dueSchedules } from './scheduling.js';
+import * as tasks from '../../models/tasks.js';
+
+export class SchedulingWorker {
+    private worker: Worker | null;
+    constructor({ databaseUrl, databaseSchema }: { databaseUrl: string; databaseSchema: string }) {
+        if (isMainThread) {
+            const url = new URL('../../../dist/workers/scheduling/scheduling.worker.boot.js', import.meta.url);
+            if (!fs.existsSync(url)) {
+                throw new Error(`Scheduling script not found at ${url}`);
+            }
+
+            this.worker = new Worker(url, { workerData: { url: databaseUrl, schema: databaseSchema } });
+            // Throw error if worker exits with error
+            this.worker.on('error', (err) => {
+                throw new Error(`Scheduling exited with error: ${stringifyError(err)}`);
+            });
+            // Throw error if worker exits with non-zero exit code
+            this.worker.on('exit', (code) => {
+                if (code !== 0) {
+                    throw new Error(`Scheduling exited with exit code: ${code}`);
+                }
+            });
+        } else {
+            throw new Error('SchedulingWorker should be instantiated in the main thread');
+        }
+    }
+
+    start(): void {
+        this.worker?.postMessage('start');
+    }
+
+    stop(): void {
+        if (this.worker) {
+            this.worker.postMessage('stop');
+            this.worker = null;
+        }
+    }
+}
+
+export class SchedulingChild {
+    private db: knex.Knex;
+    private parent: MessagePort;
+    private cancelled: boolean = false;
+    private tickIntervalMs = 100;
+
+    constructor(parent: MessagePort, db: knex.Knex) {
+        if (isMainThread) {
+            throw new Error('Scheduling should not be instantiated in the main thread');
+        }
+        this.db = db;
+        this.parent = parent;
+        this.parent.on('message', async (msg: 'start' | 'stop') => {
+            switch (msg) {
+                case 'start':
+                    await this.start();
+                    break;
+                case 'stop':
+                    this.stop();
+                    break;
+            }
+        });
+    }
+
+    async start(): Promise<void> {
+        logger.info('Starting scheduling...');
+        // eslint-disable-next-line no-constant-condition
+        while (!this.cancelled) {
+            await this.schedule();
+            await setTimeout(this.tickIntervalMs);
+        }
+    }
+
+    stop(): void {
+        logger.info('Stopping scheduling...');
+        this.cancelled = true;
+    }
+
+    async schedule(): Promise<void> {
+        await this.db.transaction(async (trx) => {
+            const schedules = await dueSchedules(trx);
+            if (schedules.isErr()) {
+                logger.error(`Failed to get due schedules: ${schedules.error}`);
+                return;
+            }
+            for (const schedule of schedules.value) {
+                const task = await tasks.create(trx, {
+                    scheduleId: schedule.id,
+                    startsAfter: new Date(),
+                    name: `${schedule.name}:${new Date().toISOString()}`,
+                    payload: schedule.payload,
+                    groupKey: schedule.groupKey,
+                    retryCount: schedule.retryCount,
+                    retryMax: schedule.retryMax,
+                    createdToStartedTimeoutSecs: schedule.createdToStartedTimeoutSecs,
+                    startedToCompletedTimeoutSecs: schedule.startedToCompletedTimeoutSecs,
+                    heartbeatTimeoutSecs: schedule.heartbeatTimeoutSecs
+                });
+                if (task.isErr()) {
+                    logger.error(`Failed to create task for schedule: ${schedule.id}`);
+                    return;
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
This PR:
- adds retry and timeout fields to schedule so they can be passed to the tasks
- adds a scheduling worker that is repeatedly scan the database to find schedules due to run
- adds indexes to tasks and schedules table to speed up the scheduling query

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
