### PR TITLE
fix: actions/webhooks should always report failure when failing

### DIFF
--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -173,23 +173,7 @@ export class Orchestrator {
             }
 
             if (res.isErr()) {
-                await createActivityLogMessageAndEnd({
-                    level: 'error',
-                    environment_id,
-                    activity_log_id: activityLogId,
-                    timestamp: Date.now(),
-                    content: `Failed with error ${res.error.type} ${JSON.stringify(res.error.payload)}`
-                });
-                await logCtx.error(`Failed with error ${res.error.type}`, { payload: res.error.payload });
-                await createActivityLogMessageAndEnd({
-                    level: 'error',
-                    environment_id,
-                    activity_log_id: activityLogId,
-                    timestamp: Date.now(),
-                    content: `The action workflow ${workflowId} did not complete successfully`
-                });
-                await logCtx.error(`The action workflow ${workflowId} did not complete successfully`);
-                return res;
+                throw res.error;
             }
 
             const content = `The action workflow ${workflowId} was successfully run. A truncated response is: ${JSON.stringify(res.value, null, 2)?.slice(0, 100)}`;
@@ -424,17 +408,7 @@ export class Orchestrator {
             }
 
             if (res.isErr()) {
-                await createActivityLogMessageAndEnd({
-                    level: 'error',
-                    environment_id: integration.environment_id,
-                    activity_log_id: activityLogId as number,
-                    timestamp: Date.now(),
-                    content: `The webhook workflow ${workflowId} did not complete successfully`
-                });
-                await logCtx.error('The webhook workflow did not complete successfully');
-                await logCtx.failed();
-
-                return res;
+                throw res.error;
             }
 
             await createActivityLogMessageAndEnd({


### PR DESCRIPTION
There were 2 error handling path in actions/webhooks execution logic. One of this path was not setting logs and telemetry correctly. This commit removes the early return and throws the error so it can be handled by the try catch

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
