### PR TITLE
fix(cli): [nan-1105] don't overwrite post connection file if it exists already

### DIFF
--- a/packages/cli/lib/cli.ts
+++ b/packages/cli/lib/cli.ts
@@ -83,7 +83,7 @@ export const generate = async (debug = false, inParentDirectory = false) => {
                 });
                 const stripped = rendered.replace(/^\s+/, '');
 
-                if (!fs.existsSync(`${dirPrefix}/${name}.ts`)) {
+                if (!fs.existsSync(`${dirPrefix}/${providerConfigKey}/${type}s/${name}.ts`)) {
                     fs.mkdirSync(`${dirPrefix}/${providerConfigKey}/${type}s`, { recursive: true });
                     fs.writeFileSync(`${dirPrefix}/${providerConfigKey}/${type}s/${name}.ts`, stripped);
                     if (debug) {


### PR DESCRIPTION
## Describe your changes
Running generate overwrites the file which is annoying if there is content

## Issue ticket number and link
NAN-1105

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
