### PR TITLE
chore(orchestrator): add endpoint to api/client to run a schedule

### DIFF
--- a/packages/jobs/lib/processor/handler.ts
+++ b/packages/jobs/lib/processor/handler.ts
@@ -67,10 +67,10 @@ async function action(task: TaskAction): Promise<Result<JsonValue>> {
         return Err(error);
     }
     const res = jsonSchema.safeParse(response);
-    if (res.success) {
-        return Ok(res.data);
+    if (!res.success) {
+        return Err(`Invalid action response format: ${response}. Action: ${JSON.stringify(task)}`);
     }
-    return Err(`Invalid action response format: ${response}. Action: ${JSON.stringify(task)}`);
+    return Ok(res.data);
 }
 
 async function webhook(task: TaskWebhook): Promise<Result<JsonValue>> {
@@ -111,10 +111,10 @@ async function webhook(task: TaskWebhook): Promise<Result<JsonValue>> {
         return Err(error);
     }
     const res = jsonSchema.safeParse(response);
-    if (res.success) {
-        return Ok(res.data);
+    if (!res.success) {
+        return Err(`Invalid webhook response format: ${response}. Webhook: ${JSON.stringify(task)}`);
     }
-    return Err(`Invalid webhook response format: ${response}. Webhook: ${JSON.stringify(task)}`);
+    return Ok(res.data);
 }
 
 async function postConnection(task: TaskPostConnection): Promise<Result<JsonValue>> {

--- a/packages/jobs/lib/processor/handler.ts
+++ b/packages/jobs/lib/processor/handler.ts
@@ -68,7 +68,7 @@ async function action(task: TaskAction): Promise<Result<JsonValue>> {
     }
     const res = jsonSchema.safeParse(response);
     if (!res.success) {
-        return Err(`Invalid action response format: ${response}. Action: ${JSON.stringify(task)}`);
+        return Err(`Invalid action response format: ${response}. TaskId: ${task.id}`);
     }
     return Ok(res.data);
 }
@@ -112,7 +112,7 @@ async function webhook(task: TaskWebhook): Promise<Result<JsonValue>> {
     }
     const res = jsonSchema.safeParse(response);
     if (!res.success) {
-        return Err(`Invalid webhook response format: ${response}. Webhook: ${JSON.stringify(task)}`);
+        return Err(`Invalid webhook response format: ${response}. TaskId: ${task.id}`);
     }
     return Ok(res.data);
 }

--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -5,6 +5,7 @@ import { getServer } from '../server.js';
 import { OrchestratorClient } from './client.js';
 import getPort from 'get-port';
 import { EventsHandler } from '../events.js';
+import { nanoid } from '@nangohq/utils';
 
 const dbClient = getTestDbClient();
 const eventsHandler = new EventsHandler({
@@ -38,16 +39,16 @@ describe('OrchestratorClient', async () => {
     describe('recurring schedule', () => {
         it('should be created', async () => {
             const res = await client.recurring({
-                name: 'Task',
+                name: nanoid(),
                 startsAt: new Date(),
                 frequencyMs: 300_000,
-                groupKey: rndStr(),
+                groupKey: nanoid(),
                 retry: { count: 0, max: 0 },
                 timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
                 args: {
                     type: 'sync',
                     syncId: 'sync-a',
-                    syncName: rndStr(),
+                    syncName: nanoid(),
                     syncJobId: 5678,
                     connection: {
                         id: 123,
@@ -66,12 +67,12 @@ describe('OrchestratorClient', async () => {
         it('should be successful', async () => {
             const scheduledTask = await client.immediate({
                 name: 'Task',
-                groupKey: rndStr(),
+                groupKey: nanoid(),
                 retry: { count: 0, max: 0 },
                 timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
                 args: {
                     type: 'action',
-                    actionName: rndStr(),
+                    actionName: nanoid(),
                     connection: {
                         id: 123,
                         connection_id: 'C',
@@ -94,7 +95,7 @@ describe('OrchestratorClient', async () => {
 
     describe('executeAction', () => {
         it('should be successful when action task succeed', async () => {
-            const groupKey = rndStr();
+            const groupKey = nanoid();
             const output = { count: 9 };
 
             const processor = new MockProcessor({
@@ -105,7 +106,7 @@ describe('OrchestratorClient', async () => {
             });
             try {
                 const res = await client.executeAction({
-                    name: 'Task',
+                    name: nanoid(),
                     groupKey: groupKey,
                     args: {
                         actionName: 'Action',
@@ -125,7 +126,7 @@ describe('OrchestratorClient', async () => {
             }
         });
         it('should return an error if action task fails', async () => {
-            const groupKey = rndStr();
+            const groupKey = nanoid();
 
             const errorPayload = { message: 'something bad happened' };
             const processor = new MockProcessor({
@@ -161,7 +162,7 @@ describe('OrchestratorClient', async () => {
     });
     describe('executeWebhook', () => {
         it('should be successful when action task succeed', async () => {
-            const groupKey = rndStr();
+            const groupKey = nanoid();
             const output = { count: 9 };
 
             const processor = new MockProcessor({
@@ -172,7 +173,7 @@ describe('OrchestratorClient', async () => {
             });
             try {
                 const res = await client.executeWebhook({
-                    name: 'Task',
+                    name: nanoid(),
                     groupKey: groupKey,
                     args: {
                         webhookName: 'W',
@@ -193,7 +194,7 @@ describe('OrchestratorClient', async () => {
             }
         });
         it('should return an error if action task fails', async () => {
-            const groupKey = rndStr();
+            const groupKey = nanoid();
 
             const errorPayload = { message: 'something bad happened' };
             const processor = new MockProcessor({
@@ -204,11 +205,11 @@ describe('OrchestratorClient', async () => {
             });
             try {
                 const res = await client.executeWebhook({
-                    name: 'Task',
+                    name: nanoid(),
                     groupKey: groupKey,
                     args: {
                         webhookName: 'W',
-                        parentSyncName: rndStr(),
+                        parentSyncName: nanoid(),
                         connection: {
                             id: 1234,
                             connection_id: 'C',
@@ -230,9 +231,9 @@ describe('OrchestratorClient', async () => {
     });
     describe('succeed', () => {
         it('should support big output', async () => {
-            const groupKey = rndStr();
+            const groupKey = nanoid();
             const actionA = await client.immediate({
-                name: 'Task',
+                name: nanoid(),
                 groupKey,
                 retry: { count: 0, max: 0 },
                 timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
@@ -256,9 +257,9 @@ describe('OrchestratorClient', async () => {
     });
     describe('search', () => {
         it('should returns task by ids', async () => {
-            const groupKey = rndStr();
+            const groupKey = nanoid();
             const actionA = await client.immediate({
-                name: 'Task',
+                name: nanoid(),
                 groupKey,
                 retry: { count: 0, max: 0 },
                 timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
@@ -276,7 +277,7 @@ describe('OrchestratorClient', async () => {
                 }
             });
             const actionB = await client.immediate({
-                name: 'Task',
+                name: nanoid(),
                 groupKey,
                 retry: { count: 0, max: 0 },
                 timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
@@ -305,9 +306,9 @@ describe('OrchestratorClient', async () => {
             expect(res.unwrap()).toEqual([]);
         });
         it('should return scheduled tasks', async () => {
-            const groupKey = rndStr();
+            const groupKey = nanoid();
             const scheduledAction = await client.immediate({
-                name: 'Task',
+                name: nanoid(),
                 groupKey,
                 retry: { count: 0, max: 0 },
                 timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
@@ -325,7 +326,7 @@ describe('OrchestratorClient', async () => {
                 }
             });
             const scheduledWebhook = await client.immediate({
-                name: 'Task',
+                name: nanoid(),
                 groupKey,
                 retry: { count: 0, max: 0 },
                 timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
@@ -374,8 +375,4 @@ class MockProcessor {
     stop() {
         clearTimeout(this.interval);
     }
-}
-
-function rndStr() {
-    return Math.random().toString(36).substring(7);
 }

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -1,5 +1,6 @@
 import { route as postImmediateRoute } from '../routes/v1/postImmediate.js';
 import { route as postRecurringRoute } from '../routes/v1/postRecurring.js';
+import { route as postRecurringRunRoute } from '../routes/v1/recurring/postRecurringRun.js';
 import { route as postDequeueRoute } from '../routes/v1/postDequeue.js';
 import { route as postSearchRoute } from '../routes/v1/postSearch.js';
 import { route as getOutputRoute } from '../routes/v1/tasks/taskId/getOutput.js';
@@ -17,7 +18,12 @@ import type {
     ExecuteWebhookProps,
     ExecutePostConnectionProps,
     OrchestratorTask,
-    RecurringProps
+    RecurringProps,
+    ExecuteSyncProps,
+    UnpauseSyncProps,
+    PauseSyncProps,
+    CancelSyncProps,
+    VoidReturn
 } from './types.js';
 import { validateTask } from './validate.js';
 import type { JsonValue } from 'type-fest';
@@ -76,6 +82,50 @@ export class OrchestratorClient {
             });
         } else {
             return Ok(res);
+        }
+    }
+
+    // TODO
+    public async cancelSync(props: CancelSyncProps): Promise<VoidReturn> {
+        return Err({
+            name: 'not_implemented',
+            message: 'Not implemented',
+            payload: JSON.stringify({ scheduleName: props.scheduleName })
+        });
+    }
+
+    // TODO
+    public async pauseSync(props: PauseSyncProps): Promise<VoidReturn> {
+        return Err({
+            name: 'not_implemented',
+            message: 'Not implemented',
+            payload: JSON.stringify({ scheduleName: props.scheduleName })
+        });
+    }
+
+    // TODO
+    public async unpauseSync(props: UnpauseSyncProps): Promise<VoidReturn> {
+        return Err({
+            name: 'not_implemented',
+            message: 'Not implemented',
+            payload: JSON.stringify({ scheduleName: props.scheduleName })
+        });
+    }
+
+    public async executeSync(props: ExecuteSyncProps): Promise<VoidReturn> {
+        const res = await this.routeFetch(postRecurringRunRoute)({
+            body: {
+                scheduleName: props.scheduleName
+            }
+        });
+        if ('error' in res) {
+            return Err({
+                name: res.error.code,
+                message: res.error.message || `Error creating recurring schedule`,
+                payload: JSON.stringify(props)
+            });
+        } else {
+            return Ok(undefined);
         }
     }
 
@@ -175,7 +225,7 @@ export class OrchestratorClient {
         };
         return this.execute(schedulingProps);
     }
-
+    // TODO: rename to searchTask?
     public async search({ ids, groupKey, limit }: { ids?: string[]; groupKey?: string; limit?: number }): Promise<Result<OrchestratorTask[], ClientError>> {
         const body = {
             ...(ids ? { ids } : {}),
@@ -293,6 +343,7 @@ export class OrchestratorClient {
         }
     }
 
+    //TODO: rename to cancelTask?
     public async cancel({ taskId, reason }: { taskId: string; reason: string }): Promise<Result<OrchestratorTask, ClientError>> {
         const res = await this.routeFetch(putTaskRoute)({
             params: { taskId },

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -55,7 +55,7 @@ export class OrchestratorClient {
             return Err({
                 name: res.error.code,
                 message: res.error.message || `Error scheduling  immediate task`,
-                payload: JSON.stringify(props)
+                payload: props
             });
         } else {
             return Ok(res);
@@ -75,10 +75,11 @@ export class OrchestratorClient {
             }
         });
         if ('error' in res) {
+            const startsAt = props.startsAt.toISOString();
             return Err({
                 name: res.error.code,
                 message: res.error.message || `Error creating recurring schedule`,
-                payload: JSON.stringify(props)
+                payload: { ...props, startsAt }
             });
         } else {
             return Ok(res);
@@ -90,7 +91,7 @@ export class OrchestratorClient {
         return Err({
             name: 'not_implemented',
             message: 'Not implemented',
-            payload: JSON.stringify({ scheduleName: props.scheduleName })
+            payload: { scheduleName: props.scheduleName }
         });
     }
 
@@ -99,7 +100,7 @@ export class OrchestratorClient {
         return Err({
             name: 'not_implemented',
             message: 'Not implemented',
-            payload: JSON.stringify({ scheduleName: props.scheduleName })
+            payload: { scheduleName: props.scheduleName }
         });
     }
 
@@ -108,7 +109,7 @@ export class OrchestratorClient {
         return Err({
             name: 'not_implemented',
             message: 'Not implemented',
-            payload: JSON.stringify({ scheduleName: props.scheduleName })
+            payload: { scheduleName: props.scheduleName }
         });
     }
 
@@ -122,7 +123,7 @@ export class OrchestratorClient {
             return Err({
                 name: res.error.code,
                 message: res.error.message || `Error creating recurring schedule`,
-                payload: JSON.stringify(props)
+                payload: props
             });
         } else {
             return Ok(undefined);
@@ -243,7 +244,7 @@ export class OrchestratorClient {
             const tasks = res.flatMap((task) => {
                 const validated = validateTask(task);
                 if (validated.isErr()) {
-                    logger.error(`Search: error validating task: ${JSON.stringify(validated.error.message)}`);
+                    logger.error(`Search: error validating task: ${validated.error.message}`);
                     return [];
                 }
                 return [validated.value];
@@ -278,7 +279,7 @@ export class OrchestratorClient {
             const dequeuedTasks = res.flatMap((task) => {
                 const validated = validateTask(task);
                 if (validated.isErr()) {
-                    logger.error(`Dequeue: error validating task: ${JSON.stringify(validated.error.message)}`);
+                    logger.error(`Dequeue: error validating task: ${validated.error.message}`);
                     return [];
                 }
                 return [validated.value];

--- a/packages/orchestrator/lib/clients/processor.integration.test.ts
+++ b/packages/orchestrator/lib/clients/processor.integration.test.ts
@@ -5,7 +5,7 @@ import { OrchestratorClient } from './client.js';
 import { OrchestratorProcessor } from './processor.js';
 import getPort from 'get-port';
 import { EventsHandler } from '../events.js';
-import { Ok, Err } from '@nangohq/utils';
+import { Ok, Err, nanoid } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
 import type { JsonValue } from 'type-fest';
 import type { OrchestratorTask } from './types.js';
@@ -41,7 +41,7 @@ describe('OrchestratorProcessor', async () => {
     });
 
     it('should process tasks and mark them as successful if processing succeed', async () => {
-        const groupKey = rndStr();
+        const groupKey = nanoid();
         const mockProcess = vi.fn(async (): Promise<Result<JsonValue>> => Ok({ foo: 'bar' }));
         const n = 10;
         await processN(mockProcess, groupKey, n);
@@ -53,7 +53,7 @@ describe('OrchestratorProcessor', async () => {
         }
     });
     it('should process tasks and mark them as failed if processing failed', async () => {
-        const groupKey = rndStr();
+        const groupKey = nanoid();
         const mockProcess = vi.fn(async (): Promise<Result<JsonValue>> => Err('Failed'));
         const n = 10;
         await processN(mockProcess, groupKey, n);
@@ -65,7 +65,7 @@ describe('OrchestratorProcessor', async () => {
         }
     });
     it('should cancel terminated tasks', async () => {
-        const groupKey = rndStr();
+        const groupKey = nanoid();
         const mockAbort = vi.fn((_taskId: string) => {});
         const mockProcess = vi.fn(async (task: OrchestratorTask): Promise<Result<JsonValue>> => {
             let aborted = false;
@@ -116,7 +116,7 @@ async function processN(handler: (task: OrchestratorTask) => Promise<Result<Json
 async function immediateTask({ groupKey }: { groupKey: string }) {
     return scheduler.immediate({
         groupKey,
-        name: 'Task',
+        name: nanoid(),
         retryMax: 0,
         retryCount: 0,
         createdToStartedTimeoutSecs: 30,
@@ -135,8 +135,4 @@ async function immediateTask({ groupKey }: { groupKey: string }) {
             input: { foo: 'bar' }
         }
     });
-}
-
-function rndStr() {
-    return Math.random().toString(36).substring(7);
 }

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -52,7 +52,8 @@ const commonSchemaFields = {
     id: z.string().uuid(),
     name: z.string().min(1),
     groupKey: z.string().min(1),
-    state: z.enum(taskStates)
+    state: z.enum(taskStates),
+    retryCount: z.number().int()
 };
 const syncSchema = z.object({
     ...commonSchemaFields,
@@ -79,6 +80,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 id: sync.data.id,
                 state: sync.data.state,
                 name: sync.data.name,
+                attempt: sync.data.retryCount + 1,
                 syncId: sync.data.payload.syncId,
                 syncName: sync.data.payload.syncName,
                 connection: sync.data.payload.connection,
@@ -94,6 +96,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 state: action.data.state,
                 id: action.data.id,
                 name: action.data.name,
+                attempt: action.data.retryCount + 1,
                 actionName: action.data.payload.actionName,
                 connection: action.data.payload.connection,
                 activityLogId: action.data.payload.activityLogId,
@@ -108,6 +111,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 id: webhook.data.id,
                 state: webhook.data.state,
                 name: webhook.data.name,
+                attempt: webhook.data.retryCount + 1,
                 webhookName: webhook.data.payload.webhookName,
                 parentSyncName: webhook.data.payload.parentSyncName,
                 connection: webhook.data.payload.connection,
@@ -123,6 +127,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 id: postConnection.data.id,
                 state: postConnection.data.state,
                 name: postConnection.data.name,
+                attempt: postConnection.data.retryCount + 1,
                 postConnectionName: postConnection.data.payload.postConnectionName,
                 connection: postConnection.data.payload.connection,
                 fileLocation: postConnection.data.payload.fileLocation,

--- a/packages/orchestrator/lib/routes/v1/postDequeue.ts
+++ b/packages/orchestrator/lib/routes/v1/postDequeue.ts
@@ -28,6 +28,7 @@ const validate = validateRequest<PostDequeue>({
                 limit: z.coerce.number().positive(),
                 longPolling: z.coerce.boolean()
             })
+            .strict()
             .parse(data)
 });
 

--- a/packages/orchestrator/lib/routes/v1/postImmediate.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediate.ts
@@ -65,6 +65,7 @@ const validate = validateRequest<PostImmediate>({
                 }),
                 args: argsSchema(data)
             })
+            .strict()
             .parse(data);
     }
 });

--- a/packages/orchestrator/lib/routes/v1/postRecurring.ts
+++ b/packages/orchestrator/lib/routes/v1/postRecurring.ts
@@ -51,6 +51,7 @@ const validate = validateRequest<PostRecurring>({
                 }),
                 args: syncArgsSchema
             })
+            .strict()
             .parse(data);
     }
 });

--- a/packages/orchestrator/lib/routes/v1/postSearch.ts
+++ b/packages/orchestrator/lib/routes/v1/postSearch.ts
@@ -27,6 +27,7 @@ const validate = validateRequest<PostSearch>({
                 limit: z.coerce.number().positive().optional(),
                 ids: z.array(z.string().uuid()).optional()
             })
+            .strict()
             .parse(data)
 });
 

--- a/packages/orchestrator/lib/routes/v1/recurring/postRecurringRun.ts
+++ b/packages/orchestrator/lib/routes/v1/recurring/postRecurringRun.ts
@@ -19,7 +19,10 @@ export type PostRecurringRun = Endpoint<{
 
 const validate = validateRequest<PostRecurringRun>({
     parseBody: (data: any) => {
-        return z.object({ scheduleName: z.string().min(1) }).parse(data);
+        return z
+            .object({ scheduleName: z.string().min(1) })
+            .strict()
+            .parse(data);
     }
 });
 

--- a/packages/orchestrator/lib/routes/v1/recurring/postRecurringRun.ts
+++ b/packages/orchestrator/lib/routes/v1/recurring/postRecurringRun.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import type { Scheduler } from '@nangohq/scheduler';
+import type { ApiError, Endpoint } from '@nangohq/types';
+import type { EndpointRequest, EndpointResponse, RouteHandler, Route } from '@nangohq/utils';
+import { validateRequest } from '@nangohq/utils';
+
+const path = '/v1/recurring/run';
+const method = 'POST';
+
+export type PostRecurringRun = Endpoint<{
+    Method: typeof method;
+    Path: typeof path;
+    Body: {
+        scheduleName: string;
+    };
+    Error: ApiError<'recurring_run_failed'>;
+    Success: { scheduleId: string };
+}>;
+
+const validate = validateRequest<PostRecurringRun>({
+    parseBody: (data: any) => {
+        return z.object({ scheduleName: z.string().min(1) }).parse(data);
+    }
+});
+
+const handler = (scheduler: Scheduler) => {
+    return async (req: EndpointRequest<PostRecurringRun>, res: EndpointResponse<PostRecurringRun>) => {
+        const schedule = await scheduler.immediate({
+            scheduleName: req.body.scheduleName
+        });
+        if (schedule.isErr()) {
+            return res.status(500).json({ error: { code: 'recurring_run_failed', message: schedule.error.message } });
+        }
+        return res.status(201).json({ scheduleId: schedule.value.id });
+    };
+};
+
+export const route: Route<PostRecurringRun> = { path, method };
+
+export const routeHandler = (scheduler: Scheduler): RouteHandler<PostRecurringRun> => {
+    return {
+        ...route,
+        validate,
+        handler: handler(scheduler)
+    };
+};

--- a/packages/orchestrator/lib/routes/v1/tasks/putTaskId.ts
+++ b/packages/orchestrator/lib/routes/v1/tasks/putTaskId.ts
@@ -24,8 +24,12 @@ const path = '/v1/tasks/:taskId';
 const method = 'PUT';
 
 const validate = validateRequest<PutTask>({
-    parseBody: (data) => z.object({ output: jsonSchema, state: z.enum(['SUCCEEDED', 'FAILED']) }).parse(data),
-    parseParams: (data) => z.object({ taskId: z.string().uuid() }).parse(data)
+    parseBody: (data) =>
+        z
+            .object({ output: jsonSchema, state: z.enum(['SUCCEEDED', 'FAILED']) })
+            .strict()
+            .parse(data),
+    parseParams: (data) => z.object({ taskId: z.string().uuid() }).strict().parse(data)
 });
 
 const handler = (scheduler: Scheduler) => {

--- a/packages/orchestrator/lib/routes/v1/tasks/taskId/getOutput.ts
+++ b/packages/orchestrator/lib/routes/v1/tasks/taskId/getOutput.ts
@@ -33,7 +33,7 @@ const validate = validateRequest<GetOutput>({
                     .transform((val) => val === 'true')
             })
             .parse(data),
-    parseParams: (data) => z.object({ taskId: z.string().uuid() }).parse(data)
+    parseParams: (data) => z.object({ taskId: z.string().uuid() }).strict().parse(data)
 });
 
 const handler = (scheduler: Scheduler, eventEmitter: EventEmitter) => {

--- a/packages/orchestrator/lib/routes/v1/tasks/taskId/postHeartbeat.ts
+++ b/packages/orchestrator/lib/routes/v1/tasks/taskId/postHeartbeat.ts
@@ -18,7 +18,7 @@ type PostHeartbeat = Endpoint<{
 }>;
 
 const validate = validateRequest<PostHeartbeat>({
-    parseParams: (data) => z.object({ taskId: z.string().uuid() }).parse(data)
+    parseParams: (data) => z.object({ taskId: z.string().uuid() }).strict().parse(data)
 });
 
 const handler = (scheduler: Scheduler) => {

--- a/packages/orchestrator/lib/server.ts
+++ b/packages/orchestrator/lib/server.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import type { Express, Request, Response, NextFunction } from 'express';
 import { routeHandler as postImmediateHandler } from './routes/v1/postImmediate.js';
 import { routeHandler as postRecurringHandler } from './routes/v1/postRecurring.js';
+import { routeHandler as postRecurringRunHandler } from './routes/v1/recurring/postRecurringRun.js';
 import { routeHandler as postSearchHandler } from './routes/v1/postSearch.js';
 import { routeHandler as postDequeueHandler } from './routes/v1/postDequeue.js';
 import { routeHandler as putTaskHandler } from './routes/v1/tasks/putTaskId.js';
@@ -41,6 +42,7 @@ export const getServer = (scheduler: Scheduler, eventEmmiter: EventEmitter): Exp
     createRoute(server, getHealthHandler);
     createRoute(server, postImmediateHandler(scheduler));
     createRoute(server, postRecurringHandler(scheduler));
+    createRoute(server, postRecurringRunHandler(scheduler));
     createRoute(server, postSearchHandler(scheduler));
     createRoute(server, putTaskHandler(scheduler));
     createRoute(server, getOutputHandler(scheduler, eventEmmiter));

--- a/packages/scheduler/lib/db/helpers.test.ts
+++ b/packages/scheduler/lib/db/helpers.test.ts
@@ -5,3 +5,12 @@ export const getTestDbClient = () =>
         url: `postgres://${process.env['NANGO_DB_USER']}:${process.env['NANGO_DB_PASSWORD']}@${process.env['NANGO_DB_HOST']}:${process.env['NANGO_DB_PORT']}/${process.env['NANGO_DB_NAME']}`,
         schema: 'scheduler'
     });
+
+export const rndStr = (length: number = 5) => {
+    const chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    let result = '';
+    for (let i = 0; i < length; i++) {
+        result += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return result;
+};

--- a/packages/scheduler/lib/db/helpers.test.ts
+++ b/packages/scheduler/lib/db/helpers.test.ts
@@ -5,12 +5,3 @@ export const getTestDbClient = () =>
         url: `postgres://${process.env['NANGO_DB_USER']}:${process.env['NANGO_DB_PASSWORD']}@${process.env['NANGO_DB_HOST']}:${process.env['NANGO_DB_PORT']}/${process.env['NANGO_DB_NAME']}`,
         schema: 'scheduler'
     });
-
-export const rndStr = (length: number = 5) => {
-    const chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-    let result = '';
-    for (let i = 0; i < length; i++) {
-        result += chars.charAt(Math.floor(Math.random() * chars.length));
-    }
-    return result;
-};

--- a/packages/scheduler/lib/db/migrations/20240606211412_unique_name.ts
+++ b/packages/scheduler/lib/db/migrations/20240606211412_unique_name.ts
@@ -16,10 +16,10 @@ export async function up(knex: Knex): Promise<void> {
 export async function down(knex: Knex): Promise<void> {
     await knex.raw(`
             ALTER TABLE ${SCHEDULES_TABLE}
-            DROP CONSTRAINT tasks_unique_name;
+            DROP CONSTRAINT schedules_unique_name;
         `);
     await knex.raw(`
             ALTER TABLE ${TASKS_TABLE}
-            DROP CONSTRAINT schedules_unique_name;
+            DROP CONSTRAINT tasks_unique_name;
         `);
 }

--- a/packages/scheduler/lib/db/migrations/20240606211412_unique_name.ts
+++ b/packages/scheduler/lib/db/migrations/20240606211412_unique_name.ts
@@ -1,0 +1,25 @@
+import type { Knex } from 'knex';
+import { SCHEDULES_TABLE } from '../../models/schedules.js';
+import { TASKS_TABLE } from '../../models/tasks.js';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`
+            ALTER TABLE ${SCHEDULES_TABLE}
+            ADD CONSTRAINT tasks_unique_name UNIQUE (name);
+        `);
+    await knex.raw(`
+            ALTER TABLE ${TASKS_TABLE}
+            ADD CONSTRAINT schedules_unique_name UNIQUE (name);
+        `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`
+            ALTER TABLE ${SCHEDULES_TABLE}
+            DROP CONSTRAINT tasks_unique_name;
+        `);
+    await knex.raw(`
+            ALTER TABLE ${TASKS_TABLE}
+            DROP CONSTRAINT schedules_unique_name;
+        `);
+}

--- a/packages/scheduler/lib/db/migrations/20240606211412_unique_name.ts
+++ b/packages/scheduler/lib/db/migrations/20240606211412_unique_name.ts
@@ -5,11 +5,11 @@ import { TASKS_TABLE } from '../../models/tasks.js';
 export async function up(knex: Knex): Promise<void> {
     await knex.raw(`
             ALTER TABLE ${SCHEDULES_TABLE}
-            ADD CONSTRAINT tasks_unique_name UNIQUE (name);
+            ADD CONSTRAINT schedules_unique_name UNIQUE (name);
         `);
     await knex.raw(`
             ALTER TABLE ${TASKS_TABLE}
-            ADD CONSTRAINT schedules_unique_name UNIQUE (name);
+            ADD CONSTRAINT tasks_unique_name UNIQUE (name);
         `);
 }
 

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -2,7 +2,7 @@ import { expect, describe, it, beforeEach, afterEach } from 'vitest';
 import * as tasks from './tasks.js';
 import { taskStates } from '../types.js';
 import type { TaskState, Task } from '../types.js';
-import { getTestDbClient } from '../db/helpers.test.js';
+import { getTestDbClient, rndStr } from '../db/helpers.test.js';
 import type { knex } from 'knex';
 
 describe('Task', () => {
@@ -142,11 +142,11 @@ describe('Task', () => {
         expect(l2.length).toBe(1);
         expect(l2.map((t) => t.id)).toStrictEqual([t1.id]);
 
-        const l3 = (await tasks.search(db, { state: 'CREATED' })).unwrap();
+        const l3 = (await tasks.search(db, { states: ['CREATED'] })).unwrap();
         expect(l3.length).toBe(2);
         expect(l3.map((t) => t.id)).toStrictEqual([t2.id, t3.id]);
 
-        const l4 = (await tasks.search(db, { state: 'CREATED', groupKey: 'unkown' })).unwrap();
+        const l4 = (await tasks.search(db, { states: ['CREATED'], groupKey: 'unkown' })).unwrap();
         expect(l4.length).toBe(0);
 
         const l5 = (await tasks.search(db, { ids: [t1.id, t2.id] })).unwrap();
@@ -186,9 +186,9 @@ async function createTaskWithState(db: knex.Knex, state: TaskState): Promise<Tas
 async function createTask(db: knex.Knex, props?: Partial<tasks.TaskProps>): Promise<Task> {
     return tasks
         .create(db, {
-            name: props?.name || rndString(),
+            name: props?.name || rndStr(),
             payload: props?.payload || {},
-            groupKey: props?.groupKey || rndString(),
+            groupKey: props?.groupKey || rndStr(),
             retryMax: props?.retryMax || 3,
             retryCount: props?.retryCount || 1,
             startsAfter: props?.startsAfter || new Date(),
@@ -202,8 +202,4 @@ async function createTask(db: knex.Knex, props?: Partial<tasks.TaskProps>): Prom
 
 async function startTask(db: knex.Knex, props?: Partial<tasks.TaskProps>): Promise<Task> {
     return createTask(db, props).then(async (t) => (await tasks.transitionState(db, { taskId: t.id, newState: 'STARTED' })).unwrap());
-}
-
-function rndString(): string {
-    return (Math.random() + 1).toString(36).substring(2, 5);
 }

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -2,8 +2,9 @@ import { expect, describe, it, beforeEach, afterEach } from 'vitest';
 import * as tasks from './tasks.js';
 import { taskStates } from '../types.js';
 import type { TaskState, Task } from '../types.js';
-import { getTestDbClient, rndStr } from '../db/helpers.test.js';
+import { getTestDbClient } from '../db/helpers.test.js';
 import type { knex } from 'knex';
+import { nanoid } from '@nangohq/utils';
 
 describe('Task', () => {
     const dbClient = getTestDbClient();
@@ -186,9 +187,9 @@ async function createTaskWithState(db: knex.Knex, state: TaskState): Promise<Tas
 async function createTask(db: knex.Knex, props?: Partial<tasks.TaskProps>): Promise<Task> {
     return tasks
         .create(db, {
-            name: props?.name || rndStr(),
+            name: props?.name || nanoid(),
             payload: props?.payload || {},
-            groupKey: props?.groupKey || rndStr(),
+            groupKey: props?.groupKey || nanoid(),
             retryMax: props?.retryMax || 3,
             retryCount: props?.retryCount || 1,
             startsAfter: props?.startsAfter || new Date(),

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -33,7 +33,7 @@ describe('Task', () => {
             })
         ).unwrap();
         expect(task).toMatchObject({
-            id: expect.any(String) as string,
+            id: expect.any(String),
             name: 'Test Task',
             payload: { foo: 'bar' },
             groupKey: 'groupA',

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -108,7 +108,6 @@ export async function create(db: knex.Knex, taskProps: TaskProps): Promise<Resul
     const now = new Date();
     const newTask: Task = {
         ...taskProps,
-        name: `${taskProps.name}:attempt:${taskProps.retryCount + 1}`,
         id: uuidv7(),
         createdAt: now,
         state: 'CREATED',

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -138,7 +138,7 @@ export async function get(db: knex.Knex, taskId: string): Promise<Result<Task>> 
 
 export async function search(
     db: knex.Knex,
-    params?: { ids?: string[]; groupKey?: string; state?: TaskState; scheduleId?: string; limit?: number }
+    params?: { ids?: string[]; groupKey?: string; states?: TaskState[]; scheduleId?: string; limit?: number }
 ): Promise<Result<Task[]>> {
     const query = db.from<DbTask>(TASKS_TABLE);
     if (params?.ids) {
@@ -147,8 +147,8 @@ export async function search(
     if (params?.groupKey) {
         query.where('group_key', params.groupKey);
     }
-    if (params?.state) {
-        query.where('state', params.state);
+    if (params?.states) {
+        query.whereIn('state', params.states);
     }
     if (params?.scheduleId) {
         query.where('schedule_id', params.scheduleId);

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -108,6 +108,7 @@ export async function create(db: knex.Knex, taskProps: TaskProps): Promise<Resul
     const now = new Date();
     const newTask: Task = {
         ...taskProps,
+        name: `${taskProps.name}:attempt:${taskProps.retryCount + 1}`,
         id: uuidv7(),
         createdAt: now,
         state: 'CREATED',

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -1,9 +1,9 @@
 import { expect, describe, it, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import { Scheduler } from './scheduler.js';
-import type { Task } from './types.js';
+import type { ImmediateProps, Schedule, Task } from './types.js';
 import type { TaskProps } from './models/tasks.js';
 import * as tasks from './models/tasks.js';
-import { getTestDbClient } from './db/helpers.test.js';
+import { getTestDbClient, rndStr } from './db/helpers.test.js';
 
 describe('Scheduler', () => {
     const dbClient = getTestDbClient();
@@ -37,73 +37,73 @@ describe('Scheduler', () => {
     });
 
     it('mark task as SUCCEEDED', async () => {
-        const task = await immediateTask(scheduler);
+        const task = await immediate(scheduler);
         (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
         const succeeded = (await scheduler.succeed({ taskId: task.id, output: { foo: 'bar' } })).unwrap();
         expect(succeeded.state).toBe('SUCCEEDED');
     });
     it('should retry failed task if max retries is not reached', async () => {
-        const task = await immediateTask(scheduler, { taskProps: { retryMax: 2, retryCount: 1 } });
+        const task = await immediate(scheduler, { taskProps: { retryMax: 2, retryCount: 1 } });
         await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 });
         (await scheduler.fail({ taskId: task.id, error: { message: 'failure happened' } })).unwrap();
         const retried = (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
         expect(retried.length).toBe(1);
     });
     it('should not retry failed task if reached max retries', async () => {
-        const task = await immediateTask(scheduler, { taskProps: { retryMax: 2, retryCount: 2 } });
+        const task = await immediate(scheduler, { taskProps: { retryMax: 2, retryCount: 2 } });
         (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
         (await scheduler.fail({ taskId: task.id, error: { message: 'failure happened' } })).unwrap();
         const retried = (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
         expect(retried.length).toBe(0);
     });
     it('should dequeue task', async () => {
-        const task = await immediateTask(scheduler);
+        const task = await immediate(scheduler);
         const dequeued = (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
         expect(dequeued.length).toBe(1);
     });
     it('should call callback when task is created', async () => {
-        await immediateTask(scheduler);
+        await immediate(scheduler);
         expect(callbacks.CREATED).toHaveBeenCalledOnce();
     });
     it('should call callback when task is started', async () => {
-        const task = await immediateTask(scheduler);
+        const task = await immediate(scheduler);
         (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
         expect(callbacks.STARTED).toHaveBeenCalledOnce();
     });
     it('should call callback when task is failed', async () => {
-        const task = await immediateTask(scheduler);
+        const task = await immediate(scheduler);
         (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
         (await scheduler.fail({ taskId: task.id, error: { message: 'failure happend' } })).unwrap();
         expect(callbacks.FAILED).toHaveBeenCalledOnce();
     });
     it('should call callback when task is succeeded', async () => {
-        const task = await immediateTask(scheduler);
+        const task = await immediate(scheduler);
         (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
         (await scheduler.succeed({ taskId: task.id, output: { foo: 'bar' } })).unwrap();
         expect(callbacks.SUCCEEDED).toHaveBeenCalledOnce();
     });
     it('should call callback when task is cancelled', async () => {
-        const task = await immediateTask(scheduler);
+        const task = await immediate(scheduler);
         (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
         (await scheduler.cancel({ taskId: task.id, reason: 'cancelled by user' })).unwrap();
         expect(callbacks.CANCELLED).toHaveBeenCalledOnce();
     });
     it('should call callback when task is expired', async () => {
         const timeout = 1;
-        await immediateTask(scheduler, { taskProps: { createdToStartedTimeoutSecs: timeout } });
+        await immediate(scheduler, { taskProps: { createdToStartedTimeoutSecs: timeout } });
         await new Promise((resolve) => setTimeout(resolve, timeout * 1500));
         expect(callbacks.EXPIRED).toHaveBeenCalledOnce();
     });
     it('should monitor and expires created tasks if timeout is reached', async () => {
         const timeout = 1;
-        const task = await immediateTask(scheduler, { taskProps: { createdToStartedTimeoutSecs: timeout } });
+        const task = await immediate(scheduler, { taskProps: { createdToStartedTimeoutSecs: timeout } });
         await new Promise((resolve) => setTimeout(resolve, timeout * 1500));
         const expired = (await tasks.get(db, task.id)).unwrap();
         expect(expired.state).toBe('EXPIRED');
     });
     it('should monitor and expires started tasks if timeout is reached', async () => {
         const timeout = 1;
-        const task = await immediateTask(scheduler, { taskProps: { startedToCompletedTimeoutSecs: timeout } });
+        const task = await immediate(scheduler, { taskProps: { startedToCompletedTimeoutSecs: timeout } });
         (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
         await new Promise((resolve) => setTimeout(resolve, timeout * 1500));
         const taskAfter = (await tasks.get(db, task.id)).unwrap();
@@ -111,31 +111,67 @@ describe('Scheduler', () => {
     });
     it('should monitor and expires started tasks if heartbeat timeout is reached', async () => {
         const timeout = 1;
-        const task = await immediateTask(scheduler, { taskProps: { heartbeatTimeoutSecs: timeout } });
+        const task = await immediate(scheduler, { taskProps: { heartbeatTimeoutSecs: timeout } });
         (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
         await new Promise((resolve) => setTimeout(resolve, timeout * 1500));
         const taskAfter = (await tasks.get(db, task.id)).unwrap();
         expect(taskAfter.state).toBe('EXPIRED');
     });
-    // TODO: add tests for recurring tasks
+    it('should not run an immediate task for a schedule if another task is already running', async () => {
+        const schedule = await recurring(scheduler);
+        await immediate(scheduler, { schedule }); // first task: OK
+        expect(await immediate(scheduler, { schedule })).toThrow();
+    });
 });
 
-async function immediateTask(
-    scheduler: Scheduler,
-    props?: {
-        taskProps?: Partial<Omit<TaskProps, 'startsAfter'>>;
-        scheduling?: 'immediate';
-    }
-): Promise<Task> {
-    const taskProps = {
-        name: props?.taskProps?.name || 'test',
-        payload: props?.taskProps?.payload || {},
-        groupKey: props?.taskProps?.groupKey || (Math.random() + 1).toString(36).substring(2, 5),
-        retryMax: props?.taskProps?.retryMax || 1,
-        retryCount: props?.taskProps?.retryCount || 0,
-        createdToStartedTimeoutSecs: props?.taskProps?.createdToStartedTimeoutSecs || 3600,
-        startedToCompletedTimeoutSecs: props?.taskProps?.startedToCompletedTimeoutSecs || 3600,
-        heartbeatTimeoutSecs: props?.taskProps?.heartbeatTimeoutSecs || 600
+async function recurring(scheduler: Scheduler): Promise<Schedule> {
+    const recurringProps = {
+        name: 'recurring',
+        startsAt: new Date(),
+        frequencyMs: 900_000,
+        payload: { foo: 'bar' },
+        groupKey: rndStr(),
+        retryMax: 0,
+        retryCount: 0,
+        createdToStartedTimeoutSecs: 3600,
+        startedToCompletedTimeoutSecs: 3600,
+        heartbeatTimeoutSecs: 600
     };
+    return (await scheduler.recurring(recurringProps)).unwrap();
+}
+
+async function immediate(
+    scheduler: Scheduler,
+    props?:
+        | {
+              taskProps?: Partial<Omit<TaskProps, 'startsAfter'>>;
+              scheduling?: 'immediate';
+          }
+        | { schedule: Schedule }
+): Promise<Task> {
+    let taskProps: ImmediateProps;
+    if (props && 'schedule' in props) {
+        taskProps = {
+            name: `${props.schedule.name}-${rndStr()}`,
+            payload: props.schedule.payload,
+            groupKey: props.schedule.groupKey,
+            retryMax: props.schedule.retryMax,
+            retryCount: props.schedule.retryCount,
+            createdToStartedTimeoutSecs: props.schedule.createdToStartedTimeoutSecs,
+            startedToCompletedTimeoutSecs: props.schedule.startedToCompletedTimeoutSecs,
+            heartbeatTimeoutSecs: props.schedule.heartbeatTimeoutSecs
+        };
+    } else {
+        taskProps = {
+            name: props?.taskProps?.name || 'test',
+            payload: props?.taskProps?.payload || {},
+            groupKey: props?.taskProps?.groupKey || rndStr(),
+            retryMax: props?.taskProps?.retryMax || 1,
+            retryCount: props?.taskProps?.retryCount || 0,
+            createdToStartedTimeoutSecs: props?.taskProps?.createdToStartedTimeoutSecs || 3600,
+            startedToCompletedTimeoutSecs: props?.taskProps?.startedToCompletedTimeoutSecs || 3600,
+            heartbeatTimeoutSecs: props?.taskProps?.heartbeatTimeoutSecs || 600
+        };
+    }
     return (await scheduler.immediate(taskProps)).unwrap();
 }

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, it, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import { Scheduler } from './scheduler.js';
-import type { ImmediateProps, Schedule, Task } from './types.js';
+import type { Schedule, Task } from './types.js';
 import type { TaskProps } from './models/tasks.js';
 import * as tasks from './models/tasks.js';
 import { getTestDbClient } from './db/helpers.test.js';
@@ -150,21 +150,14 @@ async function immediate(
           }
         | { schedule: Schedule }
 ): Promise<Task> {
-    let taskProps: ImmediateProps;
+    let taskProps;
     if (props && 'schedule' in props) {
         taskProps = {
-            name: `${props.schedule.name}-${nanoid()}`,
-            payload: props.schedule.payload,
-            groupKey: props.schedule.groupKey,
-            retryMax: props.schedule.retryMax,
-            retryCount: props.schedule.retryCount,
-            createdToStartedTimeoutSecs: props.schedule.createdToStartedTimeoutSecs,
-            startedToCompletedTimeoutSecs: props.schedule.startedToCompletedTimeoutSecs,
-            heartbeatTimeoutSecs: props.schedule.heartbeatTimeoutSecs
+            scheduleName: props.schedule.name
         };
     } else {
         taskProps = {
-            name: props?.taskProps?.name || 'test',
+            name: props?.taskProps?.name || nanoid(),
             payload: props?.taskProps?.payload || {},
             groupKey: props?.taskProps?.groupKey || nanoid(),
             retryMax: props?.taskProps?.retryMax || 1,

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -121,7 +121,7 @@ describe('Scheduler', () => {
     it('should not run an immediate task for a schedule if another task is already running', async () => {
         const schedule = await recurring(scheduler);
         await immediate(scheduler, { schedule }); // first task: OK
-        expect(await immediate(scheduler, { schedule })).toThrow();
+        await expect(immediate(scheduler, { schedule })).rejects.toThrow();
     });
 });
 

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -3,7 +3,8 @@ import { Scheduler } from './scheduler.js';
 import type { ImmediateProps, Schedule, Task } from './types.js';
 import type { TaskProps } from './models/tasks.js';
 import * as tasks from './models/tasks.js';
-import { getTestDbClient, rndStr } from './db/helpers.test.js';
+import { getTestDbClient } from './db/helpers.test.js';
+import { nanoid } from '@nangohq/utils';
 
 describe('Scheduler', () => {
     const dbClient = getTestDbClient();
@@ -130,7 +131,7 @@ async function recurring(scheduler: Scheduler): Promise<Schedule> {
         startsAt: new Date(),
         frequencyMs: 900_000,
         payload: { foo: 'bar' },
-        groupKey: rndStr(),
+        groupKey: nanoid(),
         retryMax: 0,
         retryCount: 0,
         createdToStartedTimeoutSecs: 3600,
@@ -152,7 +153,7 @@ async function immediate(
     let taskProps: ImmediateProps;
     if (props && 'schedule' in props) {
         taskProps = {
-            name: `${props.schedule.name}-${rndStr()}`,
+            name: `${props.schedule.name}-${nanoid()}`,
             payload: props.schedule.payload,
             groupKey: props.schedule.groupKey,
             retryMax: props.schedule.retryMax,
@@ -165,7 +166,7 @@ async function immediate(
         taskProps = {
             name: props?.taskProps?.name || 'test',
             payload: props?.taskProps?.payload || {},
-            groupKey: props?.taskProps?.groupKey || rndStr(),
+            groupKey: props?.taskProps?.groupKey || nanoid(),
             retryMax: props?.taskProps?.retryMax || 1,
             retryCount: props?.taskProps?.retryCount || 0,
             createdToStartedTimeoutSecs: props?.taskProps?.createdToStartedTimeoutSecs || 3600,

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -236,7 +236,7 @@ export class Scheduler {
             // Create a new task if the task is retryable
             if (task.retryMax > task.retryCount) {
                 const taskProps: ImmediateProps = {
-                    name: task.name,
+                    name: `${task.name}:${task.retryCount + 1}`, // Append retry count to make it unique
                     payload: task.payload,
                     groupKey: task.groupKey,
                     retryMax: task.retryMax,

--- a/packages/shared/lib/services/sync/run.service.integration.test.ts
+++ b/packages/shared/lib/services/sync/run.service.integration.test.ts
@@ -38,6 +38,18 @@ const orchestratorClient = {
     },
     executePostConnection: () => {
         return Promise.resolve({}) as any;
+    },
+    executeSync: () => {
+        return Promise.resolve({}) as any;
+    },
+    cancelSync: () => {
+        return Promise.resolve({}) as any;
+    },
+    pauseSync: () => {
+        return Promise.resolve({}) as any;
+    },
+    unpauseSync: () => {
+        return Promise.resolve({}) as any;
     }
 };
 const slackService = new SlackService({ orchestratorClient, logContextGetter });


### PR DESCRIPTION
Adding the endpoint in orchestrator api/client to create a schedule run, that will be used when manually triggering a sync

This commit also contains some preliminary work to add sync support to the orchestrator (attempt attribute, unique name...) + some TODOs. 
Sorry for squeezing several changes in a single PR/commit. I started to add support for sync in the orchestrator but it is quite a big change so I paused and submitting this partial PR

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
