### PR TITLE
fix(webapp): [nan-1147] remove refresh option on refresh token

### DIFF
--- a/packages/webapp/src/pages/Connection/Authorization.tsx
+++ b/packages/webapp/src/pages/Connection/Authorization.tsx
@@ -156,12 +156,7 @@ export default function Authorization(props: AuthorizationProps) {
             {connection.credentials.type === AuthModes.OAuth2 && connection.credentials.refresh_token && (
                 <div className="flex flex-col">
                     <span className="text-gray-400 text-xs uppercase mb-1">Refresh Token</span>
-                    <SecretInput
-                        disabled
-                        value={refreshing ? 'Refreshing...' : connection.credentials.refresh_token}
-                        copy={true}
-                        refresh={handleForceRefresh}
-                    />
+                    <SecretInput disabled value={refreshing ? 'Refreshing...' : connection.credentials.refresh_token} copy={true} />
                 </div>
             )}
             <div className="flex flex-col">


### PR DESCRIPTION
## Describe your changes
Remove refresh button on the refresh token field because you can't get a new refresh token by clicking the button so it is misleading. Only the refresh should be on the access token because you can retrieve a new access token.

## Issue ticket number and link
NAN-1147

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
