### PR TITLE
feat(orchestrator): pause/unpause/delete sync

### DIFF
--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -40,6 +40,7 @@ describe('OrchestratorClient', async () => {
         it('should be created', async () => {
             const res = await client.recurring({
                 name: nanoid(),
+                state: 'STARTED',
                 startsAt: new Date(),
                 frequencyMs: 300_000,
                 groupKey: nanoid(),

--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -62,12 +62,43 @@ describe('OrchestratorClient', async () => {
             });
             expect(res.isOk()).toBe(true);
         });
+        it('should be paused/unpaused/deleted', async () => {
+            const scheduleName = nanoid();
+            await client.recurring({
+                name: scheduleName,
+                state: 'STARTED',
+                startsAt: new Date(),
+                frequencyMs: 300_000,
+                groupKey: nanoid(),
+                retry: { count: 0, max: 0 },
+                timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
+                args: {
+                    type: 'sync',
+                    syncId: 'sync-a',
+                    syncName: nanoid(),
+                    syncJobId: 5678,
+                    connection: {
+                        id: 123,
+                        connection_id: 'C',
+                        provider_config_key: 'P',
+                        environment_id: 456
+                    },
+                    debug: false
+                }
+            });
+            const paused = await client.pauseSync({ scheduleName });
+            expect(paused.isOk(), `pausing failed ${JSON.stringify(paused)}`).toBe(true);
+            const unpaused = await client.unpauseSync({ scheduleName });
+            expect(unpaused.isOk(), `pausing failed ${JSON.stringify(unpaused)}`).toBe(true);
+            const deleted = await client.deleteSync({ scheduleName });
+            expect(deleted.isOk(), `pausing failed ${JSON.stringify(deleted)}`).toBe(true);
+        });
     });
 
     describe('heartbeat', () => {
         it('should be successful', async () => {
             const scheduledTask = await client.immediate({
-                name: 'Task',
+                name: nanoid(),
                 groupKey: nanoid(),
                 retry: { count: 0, max: 0 },
                 timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
@@ -138,7 +169,7 @@ describe('OrchestratorClient', async () => {
             });
             try {
                 const res = await client.executeAction({
-                    name: 'Task',
+                    name: nanoid(),
                     groupKey: groupKey,
                     args: {
                         actionName: 'Action',

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -1,5 +1,6 @@
 import { route as postImmediateRoute } from '../routes/v1/postImmediate.js';
 import { route as postRecurringRoute } from '../routes/v1/postRecurring.js';
+import { route as putRecurringRoute } from '../routes/v1/putRecurring.js';
 import { route as postRecurringRunRoute } from '../routes/v1/recurring/postRecurringRun.js';
 import { route as postDequeueRoute } from '../routes/v1/postDequeue.js';
 import { route as postSearchRoute } from '../routes/v1/postSearch.js';
@@ -84,36 +85,58 @@ export class OrchestratorClient {
         }
     }
 
-    public async cancelSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn> {
-        return Err({
-            name: 'not_implemented',
-            message: 'Not implemented',
-            payload: { scheduleName }
-        });
-    }
-
     public async pauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn> {
-        return Err({
-            name: 'not_implemented',
-            message: 'Not implemented',
-            payload: { scheduleName }
+        const res = await this.routeFetch(putRecurringRoute)({
+            body: {
+                state: 'PAUSED',
+                scheduleName: scheduleName
+            }
         });
+        if ('error' in res) {
+            return Err({
+                name: res.error.code,
+                message: res.error.message || `Error pausing recurring schedule`,
+                payload: { scheduleName }
+            });
+        } else {
+            return Ok(undefined);
+        }
     }
 
     public async unpauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn> {
-        return Err({
-            name: 'not_implemented',
-            message: 'Not implemented',
-            payload: { scheduleName }
+        const res = await this.routeFetch(putRecurringRoute)({
+            body: {
+                state: 'STARTED',
+                scheduleName: scheduleName
+            }
         });
+        if ('error' in res) {
+            return Err({
+                name: res.error.code,
+                message: res.error.message || `Error pausing recurring schedule`,
+                payload: { scheduleName }
+            });
+        } else {
+            return Ok(undefined);
+        }
     }
 
     public async deleteSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn> {
-        return Err({
-            name: 'not_implemented',
-            message: 'Not implemented',
-            payload: { scheduleName }
+        const res = await this.routeFetch(putRecurringRoute)({
+            body: {
+                state: 'DELETED',
+                scheduleName: scheduleName
+            }
         });
+        if ('error' in res) {
+            return Err({
+                name: res.error.code,
+                message: res.error.message || `Error pausing recurring schedule`,
+                payload: { scheduleName }
+            });
+        } else {
+            return Ok(undefined);
+        }
     }
 
     public async executeSync(props: ExecuteSyncProps): Promise<VoidReturn> {
@@ -347,7 +370,6 @@ export class OrchestratorClient {
         }
     }
 
-    //TODO: rename to cancelTask?
     public async cancel({ taskId, reason }: { taskId: string; reason: string }): Promise<Result<OrchestratorTask, ClientError>> {
         const res = await this.routeFetch(putTaskRoute)({
             params: { taskId },

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -86,53 +86,26 @@ export class OrchestratorClient {
     }
 
     public async pauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn> {
-        const res = await this.routeFetch(putRecurringRoute)({
-            body: {
-                state: 'PAUSED',
-                scheduleName: scheduleName
-            }
-        });
-        if ('error' in res) {
-            return Err({
-                name: res.error.code,
-                message: res.error.message || `Error pausing recurring schedule`,
-                payload: { scheduleName }
-            });
-        } else {
-            return Ok(undefined);
-        }
+        return this.setSyncState({ scheduleName, state: 'PAUSED' });
     }
 
     public async unpauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn> {
-        const res = await this.routeFetch(putRecurringRoute)({
-            body: {
-                state: 'STARTED',
-                scheduleName: scheduleName
-            }
-        });
-        if ('error' in res) {
-            return Err({
-                name: res.error.code,
-                message: res.error.message || `Error pausing recurring schedule`,
-                payload: { scheduleName }
-            });
-        } else {
-            return Ok(undefined);
-        }
+        return this.setSyncState({ scheduleName, state: 'STARTED' });
     }
 
     public async deleteSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn> {
+        return this.setSyncState({ scheduleName, state: 'DELETED' });
+    }
+
+    private async setSyncState({ scheduleName, state }: { scheduleName: string; state: 'STARTED' | 'PAUSED' | 'DELETED' }): Promise<VoidReturn> {
         const res = await this.routeFetch(putRecurringRoute)({
-            body: {
-                state: 'DELETED',
-                scheduleName: scheduleName
-            }
+            body: { state, scheduleName }
         });
         if ('error' in res) {
             return Err({
                 name: res.error.code,
-                message: res.error.message || `Error pausing recurring schedule`,
-                payload: { scheduleName }
+                message: res.error.message || `Error setting schedule state`,
+                payload: { scheduleName, state }
             });
         } else {
             return Ok(undefined);

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -20,9 +20,6 @@ import type {
     OrchestratorTask,
     RecurringProps,
     ExecuteSyncProps,
-    UnpauseSyncProps,
-    PauseSyncProps,
-    CancelSyncProps,
     VoidReturn
 } from './types.js';
 import { validateTask } from './validate.js';
@@ -66,6 +63,7 @@ export class OrchestratorClient {
         const res = await this.routeFetch(postRecurringRoute)({
             body: {
                 name: props.name,
+                state: props.state,
                 startsAt: props.startsAt,
                 frequencyMs: props.frequencyMs,
                 groupKey: props.groupKey,
@@ -86,30 +84,35 @@ export class OrchestratorClient {
         }
     }
 
-    // TODO
-    public async cancelSync(props: CancelSyncProps): Promise<VoidReturn> {
+    public async cancelSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn> {
         return Err({
             name: 'not_implemented',
             message: 'Not implemented',
-            payload: { scheduleName: props.scheduleName }
+            payload: { scheduleName }
         });
     }
 
-    // TODO
-    public async pauseSync(props: PauseSyncProps): Promise<VoidReturn> {
+    public async pauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn> {
         return Err({
             name: 'not_implemented',
             message: 'Not implemented',
-            payload: { scheduleName: props.scheduleName }
+            payload: { scheduleName }
         });
     }
 
-    // TODO
-    public async unpauseSync(props: UnpauseSyncProps): Promise<VoidReturn> {
+    public async unpauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn> {
         return Err({
             name: 'not_implemented',
             message: 'Not implemented',
-            payload: { scheduleName: props.scheduleName }
+            payload: { scheduleName }
+        });
+    }
+
+    public async deleteSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn> {
+        return Err({
+            name: 'not_implemented',
+            message: 'Not implemented',
+            payload: { scheduleName }
         });
     }
 

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -63,16 +63,6 @@ export type ExecuteActionProps = Omit<ExecuteProps, 'args'> & { args: ActionArgs
 export type ExecuteWebhookProps = Omit<ExecuteProps, 'args'> & { args: WebhookArgs };
 export type ExecutePostConnectionProps = Omit<ExecuteProps, 'args'> & { args: PostConnectionArgs };
 export type ExecuteSyncProps = PostRecurringRun['Body'];
-// TODO:
-export interface CancelSyncProps {
-    scheduleName: string;
-}
-export interface PauseSyncProps {
-    scheduleName: string;
-}
-export interface UnpauseSyncProps {
-    scheduleName: string;
-}
 
 export type OrchestratorTask = TaskSync | TaskAction | TaskWebhook | TaskPostConnection;
 

--- a/packages/orchestrator/lib/routes/v1/postRecurring.ts
+++ b/packages/orchestrator/lib/routes/v1/postRecurring.ts
@@ -14,6 +14,7 @@ export type PostRecurring = Endpoint<{
     Path: typeof path;
     Body: {
         name: string;
+        state: 'STARTED' | 'PAUSED';
         startsAt: Date;
         frequencyMs: number;
         groupKey: string;
@@ -37,6 +38,7 @@ const validate = validateRequest<PostRecurring>({
         return z
             .object({
                 name: z.string().min(1),
+                state: z.enum(['STARTED', 'PAUSED']),
                 startsAt: z.coerce.date(),
                 frequencyMs: z.number().int().positive(),
                 groupKey: z.string().min(1),
@@ -60,6 +62,7 @@ const handler = (scheduler: Scheduler) => {
     return async (req: EndpointRequest<PostRecurring>, res: EndpointResponse<PostRecurring>) => {
         const schedule = await scheduler.recurring({
             name: req.body.name,
+            state: req.body.state,
             payload: req.body.args,
             startsAt: req.body.startsAt,
             frequencyMs: req.body.frequencyMs,

--- a/packages/orchestrator/lib/routes/v1/putRecurring.ts
+++ b/packages/orchestrator/lib/routes/v1/putRecurring.ts
@@ -37,7 +37,7 @@ const handler = (scheduler: Scheduler) => {
         if (schedule.isErr()) {
             return res.status(500).json({ error: { code: 'recurring_failed', message: schedule.error.message } });
         }
-        return res.status(201).json({ scheduleId: schedule.value.id });
+        return res.status(200).json({ scheduleId: schedule.value.id });
     };
 };
 

--- a/packages/orchestrator/lib/routes/v1/putRecurring.ts
+++ b/packages/orchestrator/lib/routes/v1/putRecurring.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import type { Scheduler } from '@nangohq/scheduler';
+import type { ApiError, Endpoint } from '@nangohq/types';
+import type { EndpointRequest, EndpointResponse, RouteHandler, Route } from '@nangohq/utils';
+import { validateRequest } from '@nangohq/utils';
+
+const path = '/v1/recurring';
+const method = 'PUT';
+
+export type PostRecurring = Endpoint<{
+    Method: typeof method;
+    Path: typeof path;
+    Body: {
+        scheduleName: string;
+        state: 'STARTED' | 'PAUSED' | 'DELETED';
+    };
+    Error: ApiError<'recurring_failed'>;
+    Success: { scheduleId: string };
+}>;
+
+const validate = validateRequest<PostRecurring>({
+    parseBody: (data: any) => {
+        return z
+            .object({
+                scheduleName: z.string().min(1),
+                state: z.enum(['STARTED', 'PAUSED', 'DELETED'])
+            })
+            .strict()
+            .parse(data);
+    }
+});
+
+const handler = (scheduler: Scheduler) => {
+    return async (req: EndpointRequest<PostRecurring>, res: EndpointResponse<PostRecurring>) => {
+        const { scheduleName, state } = req.body;
+        const schedule = await scheduler.setScheduleState({ scheduleName, state });
+        if (schedule.isErr()) {
+            return res.status(500).json({ error: { code: 'recurring_failed', message: schedule.error.message } });
+        }
+        return res.status(201).json({ scheduleId: schedule.value.id });
+    };
+};
+
+export const route: Route<PostRecurring> = { path, method };
+
+export const routeHandler = (scheduler: Scheduler): RouteHandler<PostRecurring> => {
+    return {
+        ...route,
+        validate,
+        handler: handler(scheduler)
+    };
+};

--- a/packages/orchestrator/lib/server.ts
+++ b/packages/orchestrator/lib/server.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import type { Express, Request, Response, NextFunction } from 'express';
 import { routeHandler as postImmediateHandler } from './routes/v1/postImmediate.js';
 import { routeHandler as postRecurringHandler } from './routes/v1/postRecurring.js';
+import { routeHandler as putRecurringHandler } from './routes/v1/putRecurring.js';
 import { routeHandler as postRecurringRunHandler } from './routes/v1/recurring/postRecurringRun.js';
 import { routeHandler as postSearchHandler } from './routes/v1/postSearch.js';
 import { routeHandler as postDequeueHandler } from './routes/v1/postDequeue.js';
@@ -43,6 +44,7 @@ export const getServer = (scheduler: Scheduler, eventEmmiter: EventEmitter): Exp
     createRoute(server, postImmediateHandler(scheduler));
     createRoute(server, postRecurringHandler(scheduler));
     createRoute(server, postRecurringRunHandler(scheduler));
+    createRoute(server, putRecurringHandler(scheduler));
     createRoute(server, postSearchHandler(scheduler));
     createRoute(server, putTaskHandler(scheduler));
     createRoute(server, getOutputHandler(scheduler, eventEmmiter));

--- a/packages/scheduler/lib/models/schedules.integration.test.ts
+++ b/packages/scheduler/lib/models/schedules.integration.test.ts
@@ -82,6 +82,7 @@ async function createSchedule(db: knex.Knex): Promise<Schedule> {
     return (
         await schedules.create(db, {
             name: 'Test Schedule',
+            state: 'STARTED',
             payload: { foo: 'bar' },
             startsAt: new Date(),
             frequencyMs: 300_000,

--- a/packages/scheduler/lib/models/schedules.ts
+++ b/packages/scheduler/lib/models/schedules.ts
@@ -15,7 +15,8 @@ interface ScheduleStateTransition {
 export const validScheduleStateTransitions = [
     { from: 'STARTED', to: 'PAUSED' },
     { from: 'STARTED', to: 'DELETED' },
-    { from: 'PAUSED', to: 'STARTED' }
+    { from: 'PAUSED', to: 'STARTED' },
+    { from: 'PAUSED', to: 'DELETED' }
 ] as const;
 export type ValidScheduleStateTransitions = (typeof validScheduleStateTransitions)[number];
 
@@ -112,7 +113,6 @@ export async function create(db: knex.Knex, props: ScheduleProps): Promise<Resul
     const newSchedule: Schedule = {
         ...props,
         id: uuidv7(),
-        state: 'STARTED',
         payload: props.payload,
         startsAt: now,
         frequencyMs: props.frequencyMs,
@@ -153,7 +153,13 @@ export async function transitionState(db: knex.Knex, scheduleId: string, to: Sch
         if (transition.isErr()) {
             return Err(transition.error);
         }
-        const updated = await db.from<DbSchedule>(SCHEDULES_TABLE).where('id', scheduleId).update({ state: to, updated_at: new Date() }).returning('*');
+        const now = new Date();
+        const values = {
+            state: to,
+            updated_at: now,
+            ...(to === 'DELETED' ? { deleted_at: now } : {})
+        };
+        const updated = await db.from<DbSchedule>(SCHEDULES_TABLE).where('id', scheduleId).update(values).returning('*');
         if (!updated?.[0]) {
             return Err(new Error(`Error: no schedule '${scheduleId}' updated`));
         }

--- a/packages/scheduler/lib/models/schedules.ts
+++ b/packages/scheduler/lib/models/schedules.ts
@@ -106,7 +106,7 @@ export const DbSchedule = {
     })
 };
 
-export type ScheduleProps = Omit<Schedule, 'id' | 'state' | 'createdAt' | 'updatedAt' | 'deletedAt'>;
+export type ScheduleProps = Omit<Schedule, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'>;
 export async function create(db: knex.Knex, props: ScheduleProps): Promise<Result<Schedule>> {
     const now = new Date();
     const newSchedule: Schedule = {

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -74,7 +74,7 @@ describe('Scheduler', () => {
     it('should call callback when task is failed', async () => {
         const task = await immediate(scheduler);
         (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
-        (await scheduler.fail({ taskId: task.id, error: { message: 'failure happend' } })).unwrap();
+        (await scheduler.fail({ taskId: task.id, error: { message: 'failure happened' } })).unwrap();
         expect(callbacks.FAILED).toHaveBeenCalledOnce();
     });
     it('should call callback when task is succeeded', async () => {

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -128,6 +128,7 @@ describe('Scheduler', () => {
 async function recurring(scheduler: Scheduler): Promise<Schedule> {
     const recurringProps = {
         name: 'recurring',
+        state: 'STARTED' as const,
         startsAt: new Date(),
         frequencyMs: 900_000,
         payload: { foo: 'bar' },

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -256,16 +256,13 @@ export class Scheduler {
 
     /**
      * Cancel a task
-     * @param cancelBy - Cancel by task id or schedule name
+     * @param cancelBy - Cancel by task id
      * @param reason - Reason for cancellation
      * @returns Task
      * @example
      * const cancelled = await scheduler.cancel({ taskId: '00000000-0000-0000-0000-000000000000' });
      */
-    public async cancel(cancelBy: { taskId: string; reason: JsonValue } | { scheduleName: string; reason: JsonValue }): Promise<Result<Task>> {
-        if ('scheduleName' in cancelBy) {
-            throw new Error(`Cancelling tasks for schedule '${cancelBy.scheduleName}' not implemented`);
-        }
+    public async cancel(cancelBy: { taskId: string; reason: JsonValue }): Promise<Result<Task>> {
         const cancelled = await tasks.transitionState(this.dbClient.db, {
             taskId: cancelBy.taskId,
             newState: 'CANCELLED',

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -46,7 +46,6 @@ export interface OrchestratorClientInterface {
     executeWebhook(props: ExecuteWebhookProps): Promise<ExecuteReturn>;
     executePostConnection(props: ExecutePostConnectionProps): Promise<ExecuteReturn>;
     executeSync(props: ExecuteSyncProps): Promise<VoidReturn>;
-    cancelSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn>;
     pauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn>;
     unpauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn>;
     deleteSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn>;

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -26,9 +26,6 @@ import type {
     ExecuteWebhookProps,
     ExecutePostConnectionProps,
     ExecuteSyncProps,
-    CancelSyncProps,
-    PauseSyncProps,
-    UnpauseSyncProps,
     VoidReturn
 } from '@nangohq/nango-orchestrator';
 import type { Account } from '../models/Admin.js';
@@ -49,9 +46,10 @@ export interface OrchestratorClientInterface {
     executeWebhook(props: ExecuteWebhookProps): Promise<ExecuteReturn>;
     executePostConnection(props: ExecutePostConnectionProps): Promise<ExecuteReturn>;
     executeSync(props: ExecuteSyncProps): Promise<VoidReturn>;
-    cancelSync(props: CancelSyncProps): Promise<VoidReturn>;
-    pauseSync(props: PauseSyncProps): Promise<VoidReturn>;
-    unpauseSync(props: UnpauseSyncProps): Promise<VoidReturn>;
+    cancelSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn>;
+    pauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn>;
+    unpauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn>;
+    deleteSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn>;
 }
 
 export class Orchestrator {

--- a/packages/shared/lib/services/sync/run.service.integration.test.ts
+++ b/packages/shared/lib/services/sync/run.service.integration.test.ts
@@ -42,9 +42,6 @@ const orchestratorClient = {
     executeSync: () => {
         return Promise.resolve({}) as any;
     },
-    cancelSync: () => {
-        return Promise.resolve({}) as any;
-    },
     pauseSync: () => {
         return Promise.resolve({}) as any;
     },

--- a/packages/shared/lib/services/sync/run.service.integration.test.ts
+++ b/packages/shared/lib/services/sync/run.service.integration.test.ts
@@ -50,6 +50,9 @@ const orchestratorClient = {
     },
     unpauseSync: () => {
         return Promise.resolve({}) as any;
+    },
+    deleteSync: () => {
+        return Promise.resolve({}) as any;
     }
 };
 const slackService = new SlackService({ orchestratorClient, logContextGetter });


### PR DESCRIPTION
Adding way to pause/unpause/delete a schedule in the orchestrator
Also allowing to create a schedule in paused state. This is going to be required to support sync auto_start

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
