### PR TITLE
feat(orchestrator): implement runSyncCommand

### DIFF
--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -147,7 +147,7 @@ describe('Scheduler', () => {
 async function recurring({ scheduler, state = 'PAUSED' }: { scheduler: Scheduler; state?: ScheduleState }): Promise<Schedule> {
     const recurringProps = {
         name: nanoid(),
-        state,
+        state: 'STARTED' as const,
         startsAt: new Date(),
         frequencyMs: 900_000,
         payload: { foo: 'bar' },

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -147,7 +147,7 @@ describe('Scheduler', () => {
 async function recurring({ scheduler, state = 'PAUSED' }: { scheduler: Scheduler; state?: ScheduleState }): Promise<Schedule> {
     const recurringProps = {
         name: nanoid(),
-        state: 'STARTED' as const,
+        state,
         startsAt: new Date(),
         frequencyMs: 900_000,
         payload: { foo: 'bar' },

--- a/packages/server/lib/controllers/onboarding.controller.ts
+++ b/packages/server/lib/controllers/onboarding.controller.ts
@@ -26,9 +26,7 @@ import {
     LogActionEnum,
     analytics,
     AnalyticsTypes,
-    getSyncConfigRaw,
-    getOrchestratorUrl,
-    Orchestrator
+    getSyncConfigRaw
 } from '@nangohq/shared';
 import type { IncomingPreBuiltFlowConfig } from '@nangohq/shared';
 import { getLogger } from '@nangohq/utils';
@@ -37,9 +35,10 @@ import { defaultOperationExpiration, logContextGetter } from '@nangohq/logs';
 import { records as recordsService } from '@nangohq/records';
 import type { GetOnboardingStatus } from '@nangohq/types';
 import type { RequestLocals } from '../utils/express.js';
-import { OrchestratorClient } from '@nangohq/nango-orchestrator';
+import { getOrchestrator } from '../utils/utils.js';
 
 const logger = getLogger('Server.Onboarding');
+const orchestrator = getOrchestrator();
 
 class OnboardingController {
     /**
@@ -262,6 +261,7 @@ class OnboardingController {
                 logger.info(`[demo] no sync were found ${environment.id}`);
                 await syncOrchestrator.runSyncCommand({
                     recordsService,
+                    orchestrator,
                     environment,
                     providerConfigKey: DEMO_GITHUB_CONFIG_KEY,
                     syncNames: [DEMO_SYNC_NAME],
@@ -272,6 +272,7 @@ class OnboardingController {
                 });
                 await syncOrchestrator.runSyncCommand({
                     recordsService,
+                    orchestrator,
                     environment,
                     providerConfigKey: DEMO_GITHUB_CONFIG_KEY,
                     syncNames: [DEMO_SYNC_NAME],
@@ -296,6 +297,7 @@ class OnboardingController {
                 logger.info(`[demo] no job were found ${environment.id}`);
                 await syncOrchestrator.runSyncCommand({
                     recordsService,
+                    orchestrator,
                     environment,
                     providerConfigKey: DEMO_GITHUB_CONFIG_KEY,
                     syncNames: [DEMO_SYNC_NAME],
@@ -447,7 +449,6 @@ class OnboardingController {
                     syncConfig: { id: syncConfig.id!, name: syncConfig?.sync_name }
                 }
             );
-            const orchestrator = new Orchestrator(new OrchestratorClient({ baseUrl: getOrchestratorUrl() }));
             const actionResponse = await orchestrator.triggerAction({
                 connection,
                 actionName: DEMO_ACTION_NAME,

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -52,6 +52,8 @@ import { records as recordsService } from '@nangohq/records';
 import type { RequestLocals } from '../utils/express.js';
 import { getOrchestrator } from '../utils/utils.js';
 
+const orchestrator = getOrchestrator();
+
 class SyncController {
     public async deploySync(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
         try {
@@ -300,6 +302,7 @@ class SyncController {
 
             const { success, error } = await syncOrchestrator.runSyncCommand({
                 recordsService,
+                orchestrator,
                 environment,
                 providerConfigKey: provider_config_key,
                 syncNames: syncNames as string[],
@@ -545,6 +548,7 @@ class SyncController {
 
             await syncOrchestrator.runSyncCommand({
                 recordsService,
+                orchestrator,
                 environment,
                 providerConfigKey: provider_config_key as string,
                 syncNames: syncNames as string[],
@@ -586,6 +590,7 @@ class SyncController {
 
             await syncOrchestrator.runSyncCommand({
                 recordsService,
+                orchestrator,
                 environment,
                 providerConfigKey: provider_config_key as string,
                 syncNames: syncNames as string[],
@@ -733,17 +738,7 @@ class SyncController {
                 return;
             }
 
-            const syncClient = await SyncClient.getInstance();
-
-            if (!syncClient) {
-                const error = new NangoError('failed_to_get_sync_client');
-                errorManager.errResFromNangoErr(res, error);
-                await logCtx.failed();
-
-                return;
-            }
-
-            const result = await syncClient.runSyncCommand({
+            const result = await orchestrator.runSyncCommandHelper({
                 scheduleId: schedule_id,
                 syncId: sync_id,
                 command,

--- a/packages/shared/lib/services/sync/orchestrator.service.ts
+++ b/packages/shared/lib/services/sync/orchestrator.service.ts
@@ -42,6 +42,7 @@ import { LogActionEnum } from '../../models/Activity.js';
 import { stringifyError } from '@nangohq/utils';
 import environmentService from '../environment.service.js';
 import type { Environment } from '../../models/Environment.js';
+import type { Orchestrator } from '../../clients/orchestrator.js';
 
 // Should be in "logs" package but impossible thanks to CLI
 export const syncCommandToOperation = {
@@ -192,6 +193,7 @@ export class OrchestratorService {
 
     public async runSyncCommand({
         recordsService,
+        orchestrator,
         environment,
         providerConfigKey,
         syncNames,
@@ -201,6 +203,7 @@ export class OrchestratorService {
         initiator
     }: {
         recordsService: RecordsServiceInterface;
+        orchestrator: Orchestrator;
         environment: Environment;
         providerConfigKey: string;
         syncNames: string[];
@@ -235,11 +238,6 @@ export class OrchestratorService {
             { account, environment, integration: { id: provider!.id!, name: provider!.unique_key, provider: provider!.provider } }
         );
 
-        const syncClient = await SyncClient.getInstance();
-        if (!syncClient) {
-            return { success: false, error: new NangoError('failed_to_get_sync_client'), response: false };
-        }
-
         if (connectionId) {
             const { success, error, response: connection } = await connectionService.getConnection(connectionId, providerConfigKey, environment.id);
 
@@ -263,7 +261,7 @@ export class OrchestratorService {
                     continue;
                 }
 
-                await syncClient.runSyncCommand({
+                await orchestrator.runSyncCommandHelper({
                     scheduleId: schedule.schedule_id,
                     syncId: sync?.id,
                     command,
@@ -305,7 +303,7 @@ export class OrchestratorService {
                     continue;
                 }
 
-                await syncClient.runSyncCommand({
+                await orchestrator.runSyncCommandHelper({
                     scheduleId: schedule.schedule_id,
                     syncId: sync.id,
                     command,

--- a/packages/shared/lib/services/sync/run.service.integration.test.ts
+++ b/packages/shared/lib/services/sync/run.service.integration.test.ts
@@ -50,6 +50,9 @@ const orchestratorClient = {
     },
     deleteSync: () => {
         return Promise.resolve({}) as any;
+    },
+    cancel: () => {
+        return Promise.resolve({}) as any;
     }
 };
 const slackService = new SlackService({ orchestratorClient, logContextGetter });


### PR DESCRIPTION
Built on top of https://github.com/NangoHQ/nango/pull/2289 (please review it first)

Implementing `runSyncCommand` in orchestrator.

I am not sure I understand the split of responsibility between `sync.client` and `orchestrator.service`. `sync.client runSyncCommand` is called by `orchestration.service runSyncCommand` but it is also called directly in a few places: for example [here](https://github.com/NangoHQ/nango/blob/dee08827d78616c013c4f3e27ddad53f46a7a298/packages/jobs/lib/crons/autoIdleDemo.ts#L81) and [here](https://github.com/NangoHQ/nango/blob/dee08827d78616c013c4f3e27ddad53f46a7a298/packages/server/lib/controllers/sync.controller.ts#L746). Same thing happens with the creation of sync schedules where there are 3 mains path to `startContinuous`, `deploys` goes through the `orchestrator.service` but `connectionCreatedHook` calls the `sync.client` directly 😢 
This make it very hard to have clean transition code. 
I have created a temporary function to take care of the feature flag branching. Code will be refactored once temporal is removed.

For now no schedule is being created in the orchestrator so all commands would fail if the flag is turned on. 
Next PR will add the creation of schedules.

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
