### PR TITLE
fix: prevent concurrent scheduling of tasks

### DIFF
--- a/packages/scheduler/lib/models/schedules.ts
+++ b/packages/scheduler/lib/models/schedules.ts
@@ -203,7 +203,7 @@ export async function remove(db: knex.Knex, id: string): Promise<Result<Schedule
     }
 }
 
-export async function search(db: knex.Knex, params: { name?: string; state?: ScheduleState; limit: number }): Promise<Result<Schedule[]>> {
+export async function search(db: knex.Knex, params: { name?: string; state?: ScheduleState; limit: number; forUpdate?: boolean }): Promise<Result<Schedule[]>> {
     try {
         const query = db.from<DbSchedule>(SCHEDULES_TABLE).limit(params.limit);
         if (params.name) {
@@ -211,6 +211,9 @@ export async function search(db: knex.Knex, params: { name?: string; state?: Sch
         }
         if (params.state) {
             query.where('state', params.state);
+        }
+        if (params.forUpdate) {
+            query.forUpdate();
         }
         const schedules = await query;
         return Ok(schedules.map(DbSchedule.from));

--- a/packages/scheduler/lib/workers/scheduling/scheduling.ts
+++ b/packages/scheduler/lib/workers/scheduling/scheduling.ts
@@ -21,6 +21,9 @@ export async function dueSchedules(db: knex.Knex): Promise<Result<Schedule[]>> {
                     .from({ s: SCHEDULES_TABLE })
                     .where({ state: 'STARTED' })
                     .whereRaw('s.starts_at <= NOW()')
+                    // Locking schedules to prevent any concurrent update or concurrent scheduling of tasks
+                    .forUpdate()
+                    .skipLocked()
             )
             .select('*')
             .from<DbSchedule>({ s: SCHEDULES_TABLE })


### PR DESCRIPTION
Addressing you comment from last week @bodinsamuel about concurrent scheduling of tasks

Tasks based on schedules can be scheduled in 3 different ways:
- the scheduling worker
- manual triggering of a sync
- pausing/deleting a sync 
- 
- We are now locking the schedule rows if necessary to ensure no concurrent scheduling logic happens that could lead to race conditions and tasks being scheduled concurrently by 2 different code paths



## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
