### PR TITLE
fix(webhooks): [nan-1173] fix webhooks

### DIFF
--- a/packages/server/lib/controllers/appAuth.controller.ts
+++ b/packages/server/lib/controllers/appAuth.controller.ts
@@ -257,7 +257,7 @@ class AppAuthController {
                 content: 'App connection was successful and credentials were saved',
                 timestamp: Date.now()
             });
-            await logCtx.error('App connection was successful and credentials were saved');
+            await logCtx.info('App connection was successful and credentials were saved');
             await logCtx.success();
 
             await telemetry.log(LogTypes.AUTH_TOKEN_REQUEST_SUCCESS, 'App auth token request succeeded', LogActionEnum.AUTH, {

--- a/packages/server/lib/controllers/config.controller.ts
+++ b/packages/server/lib/controllers/config.controller.ts
@@ -113,7 +113,7 @@ class ConfigController {
                     const activeFlows = await getFlowConfigsByParams(environment.id, config.unique_key);
 
                     const integration: Integration = {
-                        authMode: template?.auth_mode || 'APP_STORE',
+                        authMode: template?.auth_mode || 'APP',
                         uniqueKey: config.unique_key,
                         provider: config.provider,
                         scripts: activeFlows.length,
@@ -121,7 +121,7 @@ class ConfigController {
                         creationDate: config.created_at
                     };
 
-                    if (template && template.auth_mode !== 'APP_STORE' && template.auth_mode !== 'CUSTOM') {
+                    if (template && template.auth_mode !== 'APP' && template.auth_mode !== 'CUSTOM') {
                         integration['connectionConfigParams'] = parseConnectionConfigParamsFromTemplate(template);
                     }
 

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -245,7 +245,7 @@ class OAuthController {
             }
 
             // certain providers need the credentials to be specified in the config
-            if (overrideCredentials) {
+            if (overrideCredentials && (overrideCredentials['oauth_client_id_override'] || overrideCredentials['oauth_client_secret_override'])) {
                 if (overrideCredentials['oauth_client_id_override']) {
                     config.oauth_client_id = overrideCredentials['oauth_client_id_override'];
 
@@ -1545,6 +1545,9 @@ class OAuthController {
                 );
             } else {
                 await updateSuccessActivityLog(activityLogId, template.auth_mode === 'CUSTOM' ? null : true);
+                if (template.auth_mode === 'CUSTOM') {
+                    await logCtx.success();
+                }
             }
 
             await telemetry.log(LogTypes.AUTH_TOKEN_REQUEST_SUCCESS, 'OAuth2 token request succeeded', LogActionEnum.AUTH, {
@@ -1555,7 +1558,6 @@ class OAuthController {
                 authMode: String(template.auth_mode)
             });
 
-            await logCtx.success();
             return publisher.notifySuccess(res, channel, providerConfigKey, connectionId, pending);
         } catch (err) {
             const prettyError = stringifyError(err, { pretty: true });

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -1545,9 +1545,6 @@ class OAuthController {
                 );
             } else {
                 await updateSuccessActivityLog(activityLogId, template.auth_mode === 'CUSTOM' ? null : true);
-                if (template.auth_mode === 'CUSTOM') {
-                    await logCtx.success();
-                }
             }
 
             await telemetry.log(LogTypes.AUTH_TOKEN_REQUEST_SUCCESS, 'OAuth2 token request succeeded', LogActionEnum.AUTH, {
@@ -1557,6 +1554,8 @@ class OAuthController {
                 connectionId: String(connectionId),
                 authMode: String(template.auth_mode)
             });
+
+            await logCtx.success();
 
             return publisher.notifySuccess(res, channel, providerConfigKey, connectionId, pending);
         } catch (err) {

--- a/packages/server/lib/hooks/connection/external-post-connection.ts
+++ b/packages/server/lib/hooks/connection/external-post-connection.ts
@@ -20,7 +20,7 @@ export async function externalPostConnection(
 
     const postConnectionScripts = await postConnectionScriptService.getByConfig(config_id);
 
-    if (!postConnectionScripts) {
+    if (!postConnectionScripts || postConnectionScripts.length === 0) {
         return;
     }
 

--- a/packages/server/lib/webhook/github-app-webhook-routing.ts
+++ b/packages/server/lib/webhook/github-app-webhook-routing.ts
@@ -1,4 +1,4 @@
-import type { InternalNango as Nango } from './internal-nango.js';
+import type { WebhookHandler } from './types.js';
 import type { Config as ProviderConfig } from '@nangohq/shared';
 import { getLogger } from '@nangohq/utils';
 
@@ -19,7 +19,7 @@ function validate(integration: ProviderConfig, headerSignature: string, body: an
     return crypto.timingSafeEqual(trusted, untrusted);
 }
 
-export default async function route(nango: Nango, integration: ProviderConfig, headers: Record<string, any>, body: any, logContextGetter: LogContextGetter) {
+const route: WebhookHandler = async (nango, integration, headers, body, _rawBody, logContextGetter: LogContextGetter) => {
     const signature = headers['x-hub-signature-256'];
 
     if (signature) {
@@ -33,4 +33,6 @@ export default async function route(nango: Nango, integration: ProviderConfig, h
     }
 
     return nango.executeScriptForWebhooks(integration, body, 'installation.id', 'installation_id', logContextGetter);
-}
+};
+
+export default route;

--- a/packages/server/lib/webhook/github-app-webhook-routing.ts
+++ b/packages/server/lib/webhook/github-app-webhook-routing.ts
@@ -32,7 +32,7 @@ const route: WebhookHandler = async (nango, integration, headers, body, _rawBody
         }
     }
 
-    return nango.executeScriptForWebhooks(integration, body, 'installation.id', 'installation_id', logContextGetter);
+    return nango.executeScriptForWebhooks(integration, body, 'action', 'installation.id', logContextGetter, 'installation_id');
 };
 
 export default route;

--- a/packages/server/lib/webhook/hubspot-webhook-routing.ts
+++ b/packages/server/lib/webhook/hubspot-webhook-routing.ts
@@ -1,7 +1,7 @@
-import type { InternalNango as Nango } from './internal-nango.js';
 import type { Config as ProviderConfig } from '@nangohq/shared';
 import { getLogger } from '@nangohq/utils';
 import crypto from 'crypto';
+import type { WebhookHandler } from './types.js';
 import type { LogContextGetter } from '@nangohq/logs';
 
 const logger = getLogger('Webhook.Hubspot');
@@ -19,7 +19,7 @@ export function validate(integration: ProviderConfig, headers: Record<string, an
     return crypto.timingSafeEqual(signatureBuffer, hashBuffer);
 }
 
-export default async function route(nango: Nango, integration: ProviderConfig, headers: Record<string, any>, body: any, logContextGetter: LogContextGetter) {
+const route: WebhookHandler = async (nango, integration, headers, body, _rawBody, logContextGetter: LogContextGetter) => {
     const valid = validate(integration, headers, body);
 
     if (!valid) {
@@ -27,6 +27,7 @@ export default async function route(nango: Nango, integration: ProviderConfig, h
         return;
     }
 
+    console.log(headers);
     if (Array.isArray(body)) {
         const groupedByObjectId = body.reduce((acc, event) => {
             (acc[event.objectId] = acc[event.objectId] || []).push(event);
@@ -54,4 +55,6 @@ export default async function route(nango: Nango, integration: ProviderConfig, h
     } else {
         return nango.executeScriptForWebhooks(integration, body, 'subscriptionType', 'portalId', logContextGetter);
     }
-}
+};
+
+export default route;

--- a/packages/server/lib/webhook/hubspot-webhook-routing.ts
+++ b/packages/server/lib/webhook/hubspot-webhook-routing.ts
@@ -27,7 +27,6 @@ const route: WebhookHandler = async (nango, integration, headers, body, _rawBody
         return;
     }
 
-    console.log(headers);
     if (Array.isArray(body)) {
         const groupedByObjectId = body.reduce((acc, event) => {
             (acc[event.objectId] = acc[event.objectId] || []).push(event);

--- a/packages/server/lib/webhook/hubspot-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/hubspot-webhook-routing.unit.test.ts
@@ -96,7 +96,7 @@ describe('Webhook route unit tests', () => {
         const createdHash = crypto.createHash('sha256').update(combinedSignature).digest('hex');
         const headers = { 'x-hubspot-signature': createdHash };
 
-        await HubspotWebhookRouting.default(nangoMock as unknown as Nango, integration as ProviderConfig, headers, body, logContextGetter);
+        await HubspotWebhookRouting.default(nangoMock as unknown as Nango, integration as ProviderConfig, headers, body, body.toString(), logContextGetter);
 
         expect(nangoMock.executeScriptForWebhooks).toHaveBeenCalledTimes(body.length);
 
@@ -149,7 +149,7 @@ describe('Webhook route unit tests', () => {
         const createdHash = crypto.createHash('sha256').update(combinedSignature).digest('hex');
         const headers = { 'x-hubspot-signature': createdHash };
 
-        await HubspotWebhookRouting.default(nangoMock as unknown as Nango, integration as ProviderConfig, headers, body, logContextGetter);
+        await HubspotWebhookRouting.default(nangoMock as unknown as Nango, integration as ProviderConfig, headers, body, body.toString(), logContextGetter);
 
         expect(nangoMock.executeScriptForWebhooks).toHaveBeenCalledTimes(body.length);
 

--- a/packages/server/lib/webhook/jira-webhook-routing.ts
+++ b/packages/server/lib/webhook/jira-webhook-routing.ts
@@ -1,8 +1,7 @@
-import type { InternalNango as Nango } from './internal-nango.js';
-import type { Config as ProviderConfig } from '@nangohq/shared';
+import type { WebhookHandler } from './types.js';
 import type { LogContextGetter } from '@nangohq/logs';
 
-export default async function route(nango: Nango, integration: ProviderConfig, _headers: Record<string, any>, body: any, logContextGetter: LogContextGetter) {
+const route: WebhookHandler = async (nango, integration, _headers, body, _rawBody, logContextGetter: LogContextGetter) => {
     if (Array.isArray(body)) {
         let connectionIds: string[] = [];
         for (const event of body) {
@@ -19,8 +18,10 @@ export default async function route(nango: Nango, integration: ProviderConfig, _
             }
         }
 
-        return connectionIds;
+        return { connectionIds };
     } else {
         return nango.executeScriptForWebhooks(integration, body, 'payload.webhookEvent', 'payload.user.accountId', logContextGetter, 'accountId');
     }
-}
+};
+
+export default route;

--- a/packages/server/lib/webhook/salesforce-webhook-routing.ts
+++ b/packages/server/lib/webhook/salesforce-webhook-routing.ts
@@ -1,7 +1,8 @@
-import type { InternalNango as Nango } from './internal-nango.js';
-import type { Config as ProviderConfig } from '@nangohq/shared';
+import type { WebhookHandler } from './types.js';
 import type { LogContextGetter } from '@nangohq/logs';
 
-export default async function route(nango: Nango, integration: ProviderConfig, _headers: Record<string, any>, body: any, logContextGetter: LogContextGetter) {
+const route: WebhookHandler = async (nango, integration, _headers, body, _rawBody, logContextGetter: LogContextGetter) => {
     return nango.executeScriptForWebhooks(integration, body, 'nango.eventType', 'nango.connectionId', logContextGetter, 'connectionId');
-}
+};
+
+export default route;

--- a/packages/server/lib/webhook/slack-webhook-routing.ts
+++ b/packages/server/lib/webhook/slack-webhook-routing.ts
@@ -1,15 +1,7 @@
-import type { InternalNango as Nango } from './internal-nango.js';
-import type { Config as ProviderConfig } from '@nangohq/shared';
-import type { WebhookResponse } from './types.js';
+import type { WebhookHandler } from './types.js';
 import type { LogContextGetter } from '@nangohq/logs';
 
-export default async function route(
-    nango: Nango,
-    integration: ProviderConfig,
-    headers: Record<string, any>,
-    body: Record<string, any>,
-    logContextGetter: LogContextGetter
-): Promise<WebhookResponse> {
+const route: WebhookHandler = async (nango, integration, headers, body, _rawBody, logContextGetter: LogContextGetter) => {
     // slack sometimes sends the payload as a form encoded string, so we need to parse it
     // it also sends json as a x-www-form-urlencoded string, so we need to handle that too
     let payload;
@@ -33,4 +25,6 @@ export default async function route(
 
         return { parsedBody: payload, connectionIds: response?.connectionIds || [] };
     }
-}
+};
+
+export default route;

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -985,6 +985,8 @@ class ConnectionService {
         });
         await logCtx.info('App connection was approved and credentials were saved');
 
+        await logCtx.success();
+
         await updateSuccessActivityLog(Number(activityLogId), true);
     }
 

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -985,8 +985,6 @@ class ConnectionService {
         });
         await logCtx.info('App connection was approved and credentials were saved');
 
-        await logCtx.success();
-
         await updateSuccessActivityLog(Number(activityLogId), true);
     }
 


### PR DESCRIPTION
## Describe your changes
Extra parameter `rawBody` pushed the arguments so that an error was being thrown on any webhook ```2024-06-10T17:48:43.711Z [ERROR] [Webhook.Manager] error processing incoming webhook for hubspot -  logContextGetter.create is not a function```

This happened when the `rawBody` argument was added with this [change](https://github.com/NangoHQ/nango/commit/5501f45294630ee614108737f3f093d52a63843b#diff-63266d085481df27d38eb6629f683f2885fec64be0139f5a403a76b0b3cbaf21R13) and then later an additional argument was added but wasn't updated for the other webhooks. When the last argument `logContextGetter` was added with this [change](https://github.com/NangoHQ/nango/commit/dfd74ff2e0d790b0bfbcab65cc42b0bf59b6dafe#diff-63266d085481df27d38eb6629f683f2885fec64be0139f5a403a76b0b3cbaf21R23) the arguments became misaligned.

## Issue ticket number and link
NAN-1173

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
