### PR TITLE
chore: delete sync schedule

### DIFF
--- a/packages/server/lib/controllers/config.controller.ts
+++ b/packages/server/lib/controllers/config.controller.ts
@@ -24,7 +24,7 @@ import {
     getFlowConfigsByParams,
     getGlobalWebhookReceiveUrl
 } from '@nangohq/shared';
-import { parseConnectionConfigParamsFromTemplate } from '../utils/utils.js';
+import { getOrchestrator, parseConnectionConfigParamsFromTemplate } from '../utils/utils.js';
 import type { RequestLocals } from '../utils/express.js';
 
 export interface Integration {
@@ -45,6 +45,8 @@ interface FlowConfigs {
     enabledFlows: NangoSyncConfig[];
     disabledFlows: NangoSyncConfig[];
 }
+
+const orchestrator = getOrchestrator();
 
 const separateFlows = (flows: NangoSyncConfig[]): FlowConfigs => {
     return flows.reduce(
@@ -681,7 +683,7 @@ class ConfigController {
                 return;
             }
 
-            await configService.deleteProviderConfig(providerConfigKey, environmentId);
+            await configService.deleteProviderConfig(providerConfigKey, environmentId, orchestrator);
 
             res.status(204).send();
         } catch (err) {

--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -20,9 +20,11 @@ import {
     connectionRefreshSuccess as connectionRefreshSuccessHook,
     connectionRefreshFailed as connectionRefreshFailedHook
 } from '../hooks/hooks.js';
-import { getOrchestratorClient } from '../utils/utils.js';
+import { getOrchestrator, getOrchestratorClient } from '../utils/utils.js';
 
 export type { ConnectionList };
+
+const orchestrator = getOrchestrator();
 
 class ConnectionController {
     /**
@@ -154,7 +156,7 @@ class ConnectionController {
                 return;
             }
 
-            await connectionService.deleteConnection(connection, providerConfigKey, environment.id);
+            await connectionService.deleteConnection(connection, providerConfigKey, environment.id, orchestrator);
 
             res.status(204).send();
         } catch (err) {
@@ -196,7 +198,7 @@ class ConnectionController {
                 return;
             }
 
-            await connectionService.deleteConnection(connection, integration_key, info?.environmentId as number);
+            await connectionService.deleteConnection(connection, integration_key, info?.environmentId as number, orchestrator);
 
             const slackNotificationService = new SlackService({ orchestratorClient: getOrchestratorClient(), logContextGetter });
             await slackNotificationService.closeAllOpenNotifications(environment.id);

--- a/packages/server/lib/controllers/flow.controller.ts
+++ b/packages/server/lib/controllers/flow.controller.ts
@@ -246,7 +246,7 @@ class FlowController {
                 const syncs = await getSyncsByConnectionIdsAndEnvironmentIdAndSyncName(connections, environmentId, syncName);
 
                 for (const sync of syncs) {
-                    await syncOrchestrator.softDeleteSync(sync.id, environmentId);
+                    await syncOrchestrator.softDeleteSync(sync.id, environmentId, orchestrator);
                 }
             }
 

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -113,7 +113,8 @@ class SyncController {
                     debug,
                     singleDeployMode,
                     logCtx,
-                    logContextGetter
+                    logContextGetter,
+                    orchestrator
                 });
                 if (!success) {
                     reconcileSuccess = false;
@@ -160,7 +161,8 @@ class SyncController {
                 activityLogId: null,
                 debug,
                 singleDeployMode,
-                logContextGetter
+                logContextGetter,
+                orchestrator
             });
 
             res.send(result);
@@ -909,7 +911,7 @@ class SyncController {
                 return;
             }
 
-            await syncOrchestrator.softDeleteSync(syncId, environmentId);
+            await syncOrchestrator.softDeleteSync(syncId, environmentId, orchestrator);
 
             res.sendStatus(204);
         } catch (e) {

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -844,4 +844,17 @@ export class Orchestrator {
         });
         return res.isErr() ? Err(res.error) : Ok(undefined);
     }
+
+    async deleteSync({ syncId, environmentId }: { syncId: string; environmentId: number }): Promise<Result<void>> {
+        const res = await this.client.deleteSync({ scheduleName: `environment:${environmentId}:sync:${syncId}` });
+        if (res.isErr()) {
+            errorManager.report(res.error, {
+                source: ErrorSourceEnum.PLATFORM,
+                operation: LogActionEnum.SYNC,
+                environmentId,
+                metadata: { syncId, environmentId }
+            });
+        }
+        return res;
+    }
 }

--- a/packages/shared/lib/services/config.service.ts
+++ b/packages/shared/lib/services/config.service.ts
@@ -12,6 +12,7 @@ import encryptionManager from '../utils/encryption.manager.js';
 import syncOrchestrator from './sync/orchestrator.service.js';
 import { deleteSyncFilesForConfig, deleteByConfigId as deleteSyncConfigByConfigId } from '../services/sync/config/config.service.js';
 import environmentService from '../services/environment.service.js';
+import type { Orchestrator } from '../clients/orchestrator.js';
 
 class ConfigService {
     templates: Record<string, ProviderTemplate> | null;
@@ -167,7 +168,7 @@ class ConfigService {
         return { id: id[0]?.id, unique_key: config.unique_key } as Pick<ProviderConfig, 'id' | 'unique_key'>;
     }
 
-    async deleteProviderConfig(providerConfigKey: string, environment_id: number): Promise<number> {
+    async deleteProviderConfig(providerConfigKey: string, environment_id: number, orchestrator: Orchestrator): Promise<number> {
         const idResult = (
             await db.knex.select('id').from<ProviderConfig>(`_nango_configs`).where({ unique_key: providerConfigKey, environment_id, deleted: false })
         )[0];
@@ -178,7 +179,7 @@ class ConfigService {
 
         const { id } = idResult;
 
-        await syncOrchestrator.deleteSyncsByProviderConfig(environment_id, providerConfigKey);
+        await syncOrchestrator.deleteSyncsByProviderConfig(environment_id, providerConfigKey, orchestrator);
 
         if (isCloud) {
             const config = await this.getProviderConfig(providerConfigKey, environment_id);

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -41,6 +41,7 @@ import { RedisKVStore } from '../utils/kvstore/RedisStore.js';
 import type { KVStore } from '../utils/kvstore/KVStore.js';
 import type { LogContext, LogContextGetter } from '@nangohq/logs';
 import { CONNECTIONS_WITH_SCRIPTS_CAP_LIMIT } from '../constants.js';
+import type { Orchestrator } from '../clients/orchestrator.js';
 
 const logger = getLogger('Connection');
 const ACTIVE_LOG_TABLE = dbNamespace + 'active_logs';
@@ -561,7 +562,7 @@ class ConnectionService {
         return [...new Set(connections.map((config) => config.connection_id))];
     }
 
-    public async deleteConnection(connection: Connection, providerConfigKey: string, environment_id: number): Promise<number> {
+    public async deleteConnection(connection: Connection, providerConfigKey: string, environment_id: number, orchestrator: Orchestrator): Promise<number> {
         const del = await db.knex
             .from<Connection>(`_nango_connections`)
             .where({
@@ -572,7 +573,7 @@ class ConnectionService {
             })
             .update({ deleted: true, credentials: {}, credentials_iv: null, credentials_tag: null, deleted_at: new Date() });
 
-        await syncOrchestrator.softDeleteSyncsByConnection(connection);
+        await syncOrchestrator.softDeleteSyncsByConnection(connection, orchestrator);
 
         return del;
     }

--- a/packages/shared/lib/services/sync/orchestrator.service.ts
+++ b/packages/shared/lib/services/sync/orchestrator.service.ts
@@ -161,13 +161,15 @@ export class OrchestratorService {
         await deleteSyncConfig(syncConfigId);
     }
 
-    public async softDeleteSync(syncId: string, environmentId: number) {
-        await deleteScheduleForSync(syncId, environmentId);
+    public async softDeleteSync(syncId: string, environmentId: number, orchestrator: Orchestrator) {
+        await deleteScheduleForSync(syncId, environmentId); // TODO: legacy, to remove once temporal is removed
+
+        await orchestrator.deleteSync({ syncId, environmentId });
         await softDeleteSync(syncId);
         await errorNotificationService.sync.clearBySyncId({ sync_id: syncId });
     }
 
-    public async softDeleteSyncsByConnection(connection: Connection) {
+    public async softDeleteSyncsByConnection(connection: Connection, orchestrator: Orchestrator) {
         const syncs = await getSyncsByConnectionId(connection.id!);
 
         if (!syncs) {
@@ -175,11 +177,11 @@ export class OrchestratorService {
         }
 
         for (const sync of syncs) {
-            await this.softDeleteSync(sync.id, connection.environment_id);
+            await this.softDeleteSync(sync.id, connection.environment_id, orchestrator);
         }
     }
 
-    public async deleteSyncsByProviderConfig(environmentId: number, providerConfigKey: string) {
+    public async deleteSyncsByProviderConfig(environmentId: number, providerConfigKey: string, orchestrator: Orchestrator) {
         const syncs = await getSyncsByProviderConfigKey(environmentId, providerConfigKey);
 
         if (!syncs) {
@@ -187,7 +189,7 @@ export class OrchestratorService {
         }
 
         for (const sync of syncs) {
-            await this.softDeleteSync(sync.id, environmentId);
+            await this.softDeleteSync(sync.id, environmentId, orchestrator);
         }
     }
 

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -18,6 +18,7 @@ import connectionService from '../connection.service.js';
 import { DEMO_GITHUB_CONFIG_KEY, DEMO_SYNC_NAME } from '../onboarding.service.js';
 import type { LogContext, LogContextGetter } from '@nangohq/logs';
 import { LogActionEnum } from '../../models/Activity.js';
+import type { Orchestrator } from '../../clients/orchestrator.js';
 
 const TABLE = dbNamespace + 'syncs';
 const SYNC_JOB_TABLE = dbNamespace + 'sync_jobs';
@@ -536,7 +537,8 @@ export const getAndReconcileDifferences = async ({
     debug = false,
     singleDeployMode = false,
     logCtx,
-    logContextGetter
+    logContextGetter,
+    orchestrator
 }: {
     environmentId: number;
     flows: IncomingFlowConfig[];
@@ -546,6 +548,7 @@ export const getAndReconcileDifferences = async ({
     singleDeployMode?: boolean | undefined;
     logCtx?: LogContext;
     logContextGetter: LogContextGetter;
+    orchestrator: Orchestrator;
 }): Promise<SyncAndActionDifferences | null> => {
     const newSyncs: SlimSync[] = [];
     const newActions: SlimAction[] = [];
@@ -709,7 +712,7 @@ export const getAndReconcileDifferences = async ({
                         for (const connection of connections) {
                             const syncId = await getSyncByIdAndName(connection.id as number, existingSync.sync_name);
                             if (syncId) {
-                                await syncOrchestrator.softDeleteSync(syncId.id, environmentId);
+                                await syncOrchestrator.softDeleteSync(syncId.id, environmentId, orchestrator);
                             }
                         }
                     }


### PR DESCRIPTION
We delete sync schedule in both temporal and orchestrator. If schedule doesn't exist in orchestrator we just fails silently
