### PR TITLE
fix(webhooks): [nan-1178] disable automatic opt in for webhook settings

### DIFF
--- a/packages/webhooks/lib/auth.ts
+++ b/packages/webhooks/lib/auth.ts
@@ -29,6 +29,8 @@ export const sendAuth = async ({
         return;
     }
 
+    const success = typeof error === 'undefined';
+
     const body: NangoAuthWebhookBody = {
         from: 'nango',
         type: WebhookType.AUTH,
@@ -37,12 +39,17 @@ export const sendAuth = async ({
         authMode: auth_mode,
         provider,
         environment: environment.name,
-        success: Boolean(!error),
+        success,
         operation
     };
 
     if (error) {
         body.error = error;
+    }
+
+    // TODO when settings are available send this webhook
+    if (!success) {
+        return;
     }
 
     const webhooks = [

--- a/packages/webhooks/lib/sync.ts
+++ b/packages/webhooks/lib/sync.ts
@@ -64,6 +64,11 @@ export const sendSync = async ({
         }
     }
 
+    // TODO send when the failed sync update is opt in
+    if (!success) {
+        return;
+    }
+
     if (responseResults) {
         body.responseResults = {
             added: responseResults.added,


### PR DESCRIPTION
## Describe your changes
Until settings are ready don't automatically send sync failed webhook. This will be updated with https://linear.app/nango/issue/NAN-1142/update-options-on-environment-settings-to-allow-more-granular-webhook

## Issue ticket number and link
NAN-1178

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
