### PR TITLE
fix(logs): cosmetic fix

### DIFF
--- a/packages/server/lib/controllers/config.controller.integration.test.ts
+++ b/packages/server/lib/controllers/config.controller.integration.test.ts
@@ -53,7 +53,7 @@ describe('Should verify the config controller HTTP API calls', async () => {
 
         expect(statusSpy).toHaveBeenCalledWith(400);
         let err = new NangoError('missing_body');
-        expect(sendMock).toHaveBeenCalledWith({ error: err.message, type: err.type, payload: err.payload });
+        expect(sendMock).toHaveBeenCalledWith({ error: { message: err.message, code: err.type, payload: err.payload } });
 
         sendMock.mockReset();
 
@@ -66,7 +66,7 @@ describe('Should verify the config controller HTTP API calls', async () => {
         await configController.createProviderConfig(req as unknown as Request, res, next as NextFunction);
         expect(statusSpy).toHaveBeenCalledWith(400);
         err = new NangoError('missing_provider_config');
-        expect(sendMock).toHaveBeenCalledWith({ error: err.message, type: err.type, payload: err.payload });
+        expect(sendMock).toHaveBeenCalledWith({ error: { message: err.message, code: err.type, payload: err.payload } });
     });
 
     it('CREATE a provider config successfully and then LIST', async () => {

--- a/packages/server/lib/utils/tests.ts
+++ b/packages/server/lib/utils/tests.ts
@@ -83,7 +83,9 @@ export function isSuccess<TType extends Record<string, any>>(json: TType): asser
  */
 export function shouldBeProtected({ res, json }: { res: Response; json: any }) {
     isError(json);
-    expect(json).toStrictEqual({ error: 'Authentication failed. The request is missing the Authorization header.', payload: {}, type: 'missing_auth_header' });
+    expect(json).toStrictEqual({
+        error: { message: 'Authentication failed. The request is missing the Authorization header.', payload: {}, code: 'missing_auth_header' }
+    });
     expect(res.status).toBe(401);
 }
 

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -59,7 +59,7 @@ class ConnectionService {
         providerConfigKey: string,
         provider: string,
         parsedRawCredentials: AuthCredentials,
-        connectionConfig: Record<string, string | boolean>,
+        connectionConfig: ConnectionConfig,
         environment_id: number,
         accountId: number,
         metadata?: Metadata

--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -200,7 +200,7 @@ export async function deploy({
             timestamp: Date.now(),
             content: `Successfully deployed the ${nameOfType}${flowsWithVersions.length > 1 ? 's' : ''} ${JSON.stringify(flowsWithVersions, null, 2)}`
         });
-        await logCtx.info(`Successfully deployed ${flowsWithVersions.length} items${flowsWithVersions.length > 1 ? 's' : ''}`, {
+        await logCtx.info(`Successfully deployed ${flowsWithVersions.length} script${flowsWithVersions.length > 1 ? 's' : ''}`, {
             nameOfType,
             count: flowsWithVersions.length,
             syncNames: flowsWithVersions.map((flow) => flow['syncName']),

--- a/packages/shared/lib/utils/error.manager.ts
+++ b/packages/shared/lib/utils/error.manager.ts
@@ -127,9 +127,9 @@ class ErrorManager {
         if (err) {
             logger.error(`Response error: ${JSON.stringify({ statusCode: err.status, type: err.type, payload: err.payload, message: err.message })}`);
             if (!err.message) {
-                res.status(err.status || 500).send({ type: err.type || 'unknown_error', payload: err.payload });
+                res.status(err.status || 500).send({ error: { code: err.type || 'unknown_error', payload: err.payload } });
             } else {
-                res.status(err.status || 500).send({ error: err.message, type: err.type, payload: err.payload });
+                res.status(err.status || 500).send({ error: { message: err.message, code: err.type, payload: err.payload } });
             }
         } else {
             res.status(500).json({ error: { code: 'unknown_empty_error' } });

--- a/packages/types/lib/api.ts
+++ b/packages/types/lib/api.ts
@@ -17,7 +17,8 @@ export type ResDefaultErrors =
     | ApiError<'invalid_query_params', ValidationError[]>
     | ApiError<'invalid_body', ValidationError[]>
     | ApiError<'invalid_uri_params', ValidationError[]>
-    | ApiError<'feature_disabled'>;
+    | ApiError<'feature_disabled'>
+    | ApiError<'generic_error_support', undefined, string>;
 
 export type EndpointMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 /**

--- a/packages/types/lib/api.ts
+++ b/packages/types/lib/api.ts
@@ -18,6 +18,7 @@ export type ResDefaultErrors =
     | ApiError<'invalid_body', ValidationError[]>
     | ApiError<'invalid_uri_params', ValidationError[]>
     | ApiError<'feature_disabled'>
+    | ApiError<'missing_auth_header'>
     | ApiError<'generic_error_support', undefined, string>;
 
 export type EndpointMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';

--- a/packages/webapp/src/pages/Logs/Search.tsx
+++ b/packages/webapp/src/pages/Logs/Search.tsx
@@ -327,7 +327,12 @@ export const LogsSearch: React.FC = () => {
                     </div>
                 ) : (
                     <Info color={'red'} classNames="text-xs" size={20}>
-                        An error occurred, refresh your page or reach out to the support.
+                        An error occurred, refresh your page or reach out to the support.{' '}
+                        {error.error.code === 'generic_error_support' && (
+                            <>
+                                (id: <span className="select-all">{error.error.payload}</span>)
+                            </>
+                        )}
                     </Info>
                 )}
             </DashboardLayout>

--- a/packages/webapp/src/pages/Logs/components/OperationTag.tsx
+++ b/packages/webapp/src/pages/Logs/components/OperationTag.tsx
@@ -52,7 +52,8 @@ export const OperationTag: React.FC<{ message: string; operation: Exclude<Search
                 <p>
                     {message}{' '}
                     <code className="text-xs">
-                        ({operation.type}:{'action' in operation && operation.action})
+                        ({operation.type}
+                        {'action' in operation && <>:{operation.action}</>})
                     </code>
                 </p>
             </Tooltip.TooltipContent>

--- a/packages/webapp/src/utils/utils.tsx
+++ b/packages/webapp/src/utils/utils.tsx
@@ -110,22 +110,6 @@ export function formatDateToUSFormat(dateString: string): string {
 
 export function formatDateToLogFormat(dateString: string): string {
     const date = new Date(dateString);
-    const options: Intl.DateTimeFormatOptions = {
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
-        month: 'short',
-        day: '2-digit',
-        fractionalSecondDigits: 2,
-        hour12: false
-    };
-
-    const formattedDate = date.toLocaleString('en-US', options);
-
-    if (formattedDate === 'Invalid Date') {
-        return '-';
-    }
-
     return format(date, 'MMM dd, HH:mm:ss:SS');
 }
 

--- a/packages/webapp/src/utils/utils.tsx
+++ b/packages/webapp/src/utils/utils.tsx
@@ -1,5 +1,6 @@
 import { clsx } from 'clsx';
 import type { ClassValue } from 'clsx';
+import { format } from 'date-fns';
 import { twMerge } from 'tailwind-merge';
 import type { Flow, SyncResult, NangoSyncModel } from '../types';
 
@@ -125,8 +126,7 @@ export function formatDateToLogFormat(dateString: string): string {
         return '-';
     }
 
-    const parts = formattedDate.split(', ');
-    return `${parts[0]} ${parts[1]}`;
+    return format(date, 'MMM dd, HH:mm:ss:SS');
 }
 
 function formatFutureRun(nextRun: number): Date | undefined {


### PR DESCRIPTION
## Describe your changes

- Consistent date format across browser
Turns out `Intl.DateTimeFormat` is up to the browser, so each one have a different way to present what is supposed to be standard :| 
- Add `:action` only if the operation has one
- Fix HTTP 500 error handling in Logs
- Change HTTP 500 error signature to follow new pattern


