### PR TITLE
feat: schedule syncs via the orchestrator

### DIFF
--- a/packages/jobs/lib/processor/handler.ts
+++ b/packages/jobs/lib/processor/handler.ts
@@ -35,7 +35,7 @@ async function abort(_task: OrchestratorTask): Promise<Result<void>> {
 }
 
 async function sync(task: TaskSync): Promise<Result<JsonValue>> {
-    return Err(`Not implemented: ${JSON.stringify({ taskId: task.id })}`);
+    return Ok({ id: task.id });
 }
 
 async function action(task: TaskAction): Promise<Result<JsonValue>> {

--- a/packages/jobs/lib/processor/processor.ts
+++ b/packages/jobs/lib/processor/processor.ts
@@ -21,10 +21,17 @@ export class Processor {
     start() {
         logger.info('Starting task processors');
         try {
+            const syncWorker = new ProcessorWorker({
+                orchestratorUrl: this.orchestratorServiceUrl,
+                groupKey: 'sync',
+                maxConcurrency: 200
+            });
+            syncWorker.start();
+
             const actionWorker = new ProcessorWorker({
                 orchestratorUrl: this.orchestratorServiceUrl,
                 groupKey: 'action',
-                maxConcurrency: 500
+                maxConcurrency: 200
             });
             actionWorker.start();
 
@@ -34,7 +41,7 @@ export class Processor {
                 maxConcurrency: 50
             });
             webhookWorker.start();
-            this.workers = [actionWorker, webhookWorker];
+            this.workers = [syncWorker, actionWorker, webhookWorker];
             this.stopped = false;
         } catch (e) {
             logger.error(e);

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -18,7 +18,6 @@ interface SyncArgs {
         environment_id: number;
         connection_id: string;
     };
-    syncJobId: number;
 }
 interface ActionArgs {
     actionName: string;
@@ -89,7 +88,6 @@ export function TaskSync(props: TaskCommonFields & SyncArgs): TaskSync {
         attempt: props.attempt,
         syncId: props.syncId,
         syncName: props.syncName,
-        syncJobId: props.syncJobId,
         debug: props.debug,
         connection: props.connection,
         abortController: new AbortController(),

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -20,7 +20,6 @@ export const syncArgsSchema = z.object({
     type: z.literal('sync'),
     syncId: z.string().min(1),
     syncName: z.string().min(1),
-    syncJobId: z.number().int().positive(),
     debug: z.boolean(),
     ...commonSchemaArgsFields
 });
@@ -84,7 +83,6 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 syncId: sync.data.payload.syncId,
                 syncName: sync.data.payload.syncName,
                 connection: sync.data.payload.connection,
-                syncJobId: sync.data.payload.syncJobId,
                 debug: sync.data.payload.debug
             })
         );

--- a/packages/orchestrator/lib/routes/v1/postRecurring.ts
+++ b/packages/orchestrator/lib/routes/v1/postRecurring.ts
@@ -5,6 +5,7 @@ import type { ApiError, Endpoint } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, RouteHandler, Route } from '@nangohq/utils';
 import { validateRequest } from '@nangohq/utils';
 import { syncArgsSchema } from '../../clients/validate.js';
+import type { TaskType } from '../../types.js';
 
 const path = '/v1/recurring';
 const method = 'POST';
@@ -27,7 +28,7 @@ export type PostRecurring = Endpoint<{
             startedToCompleted: number;
             heartbeat: number;
         };
-        args: JsonValue;
+        args: JsonValue & { type: TaskType };
     };
     Error: ApiError<'recurring_failed'>;
     Success: { scheduleId: string };

--- a/packages/server/lib/controllers/flow.controller.ts
+++ b/packages/server/lib/controllers/flow.controller.ts
@@ -58,7 +58,7 @@ class FlowController {
                 return;
             }
 
-            await syncOrchestrator.triggerIfConnectionsExist(preBuiltResponse.result, environment.id, logContextGetter);
+            await syncOrchestrator.triggerIfConnectionsExist(preBuiltResponse.result, environment.id, logContextGetter, orchestrator);
 
             res.sendStatus(200);
         } catch (e) {
@@ -125,7 +125,7 @@ class FlowController {
                 return;
             }
 
-            await syncOrchestrator.triggerIfConnectionsExist(preBuiltResponse.result, environmentId, logContextGetter);
+            await syncOrchestrator.triggerIfConnectionsExist(preBuiltResponse.result, environmentId, logContextGetter, orchestrator);
 
             res.status(201).send(preBuiltResponse.result);
         } catch (e) {
@@ -213,7 +213,7 @@ class FlowController {
 
             await enableConfig(Number(id));
 
-            await syncOrchestrator.triggerIfConnectionsExist([flow], environment.id, logContextGetter);
+            await syncOrchestrator.triggerIfConnectionsExist([flow], environment.id, logContextGetter, orchestrator);
 
             res.status(200).send([{ ...flow, enabled: true }]);
         } catch (e) {

--- a/packages/server/lib/controllers/onboarding.controller.ts
+++ b/packages/server/lib/controllers/onboarding.controller.ts
@@ -218,7 +218,7 @@ class OnboardingController {
                 return;
             }
 
-            await syncOrchestrator.triggerIfConnectionsExist(deploy.response.result, environment.id, logContextGetter);
+            await syncOrchestrator.triggerIfConnectionsExist(deploy.response.result, environment.id, logContextGetter, orchestrator);
 
             void analytics.track(AnalyticsTypes.DEMO_2_SUCCESS, account.id, { user_id: user.id });
             res.status(200).json({ success: true });

--- a/packages/shared/lib/clients/sync.client.ts
+++ b/packages/shared/lib/clients/sync.client.ts
@@ -5,7 +5,7 @@ import type { StringValue } from 'ms';
 import ms from 'ms';
 import fs from 'fs-extra';
 import type { Config as ProviderConfig } from '../models/Provider.js';
-import type { NangoIntegrationData, NangoConfig, NangoIntegration } from '../models/NangoConfig.js';
+import type { NangoIntegrationData } from '../models/NangoConfig.js';
 import type { Sync, SyncWithSchedule } from '../models/Sync.js';
 import { SyncStatus, SyncType, ScheduleStatus, SyncCommand } from '../models/Sync.js';
 import type { LogLevel } from '../models/Activity.js';
@@ -19,20 +19,16 @@ import {
 } from '../services/activity/activity.service.js';
 import { isSyncJobRunning, createSyncJob, updateRunId } from '../services/sync/job.service.js';
 import { getInterval } from '../services/nango-config.service.js';
-import { getSyncConfig, getSyncConfigRaw } from '../services/sync/config/config.service.js';
+import { getSyncConfigRaw } from '../services/sync/config/config.service.js';
 import { updateOffset, createSchedule as createSyncSchedule, getScheduleById } from '../services/sync/schedule.service.js';
-import connectionService from '../services/connection.service.js';
-import configService from '../services/config.service.js';
-import { createSync, clearLastSyncDate } from '../services/sync/sync.service.js';
+import { clearLastSyncDate } from '../services/sync/sync.service.js';
 import errorManager, { ErrorSourceEnum } from '../utils/error.manager.js';
 import { NangoError } from '../utils/error.js';
 import type { LogContext, LogContextGetter } from '@nangohq/logs';
-import { isTest, isProd, getLogger, Ok, Err, stringifyError } from '@nangohq/utils';
+import { isTest, isProd, Ok, Err, stringifyError } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
 import type { InitialSyncArgs } from '../models/worker.js';
 import environmentService from '../services/environment.service.js';
-
-const logger = getLogger('Sync.Client');
 
 const generateWorkflowId = (sync: Pick<Sync, 'id'>, syncName: string, connectionId: string) => `${SYNC_TASK_QUEUE}.${syncName}.${connectionId}-${sync.id}`;
 const generateScheduleId = (sync: Pick<Sync, 'id'>, syncName: string, connectionId: string) =>
@@ -104,49 +100,6 @@ class SyncClient {
 
     getClient = (): Client | null => this.client;
 
-    async initiate(nangoConnectionId: number, logContextGetter: LogContextGetter): Promise<void> {
-        const nangoConnection = (await connectionService.getConnectionById(nangoConnectionId)) as NangoConnection;
-        const nangoConfig = await getSyncConfig(nangoConnection);
-        if (!nangoConfig) {
-            logger.error(
-                'Failed to load the Nango config - will not start any syncs! If you expect to see a sync make sure you used the nango cli deploy command'
-            );
-            return;
-        }
-        const { integrations }: NangoConfig = nangoConfig;
-        const providerConfigKey = nangoConnection?.provider_config_key;
-
-        if (!integrations[providerConfigKey]) {
-            logger.info(`No syncs registered for provider ${providerConfigKey} - will not start any syncs!`);
-            return;
-        }
-
-        if (!this.client) {
-            logger.info('Failed to get a Temporal client - will not start any syncs!');
-            return;
-        }
-
-        const providerConfig: ProviderConfig = (await configService.getProviderConfig(
-            nangoConnection?.provider_config_key,
-            nangoConnection?.environment_id
-        )) as ProviderConfig;
-
-        const syncObject = integrations[providerConfigKey] as unknown as Record<string, NangoIntegration>;
-        const syncNames = Object.keys(syncObject);
-        for (const syncName of syncNames) {
-            const syncData = syncObject[syncName] as unknown as NangoIntegrationData;
-
-            if (!syncData.enabled) {
-                continue;
-            }
-            const sync = await createSync(nangoConnectionId, syncName);
-
-            if (sync) {
-                await this.startContinuous(nangoConnection, sync, providerConfig, syncName, syncData, logContextGetter);
-            }
-        }
-    }
-
     /**
      * Start Continuous
      * @desc get the connection information and the provider information
@@ -160,6 +113,7 @@ class SyncClient {
         syncName: string,
         syncData: NangoIntegrationData,
         logContextGetter: LogContextGetter,
+        shouldLog: boolean,
         debug = false
     ): Promise<void> {
         let logCtx: LogContext | undefined;
@@ -200,7 +154,8 @@ class SyncClient {
                     integration: { id: providerConfig.id!, name: providerConfig.unique_key, provider: providerConfig.provider },
                     connection: { id: nangoConnection.id!, name: nangoConnection.connection_id },
                     syncConfig: { id: syncConfig!.id!, name: syncConfig!.sync_name }
-                }
+                },
+                { dryRun: shouldLog }
             );
 
             const { success, error, response } = getInterval(syncData.runs, new Date());

--- a/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
@@ -12,20 +12,20 @@ import { mockErrorManagerReport } from '../../../utils/error.manager.mocks.js';
 import { logContextGetter } from '@nangohq/logs';
 import type { Environment } from '../../../models/Environment.js';
 import type { Account } from '../../../models/Admin.js';
-import { Ok } from '@nangohq/utils';
 import { Orchestrator } from '../../../clients/orchestrator.js';
 import type { OrchestratorClientInterface } from '../../../clients/orchestrator.js';
 
 const orchestratorClientNoop: OrchestratorClientInterface = {
-    executeAction: () => Promise.resolve(Ok({})),
-    executeWebhook: () => Promise.resolve(Ok({})),
-    executePostConnection: () => Promise.resolve(Ok({})),
-    executeSync: () => Promise.resolve(Ok(undefined)),
-    cancel: () => Promise.resolve(Ok({} as any)),
-    pauseSync: () => Promise.resolve(Ok(undefined)),
-    unpauseSync: () => Promise.resolve(Ok(undefined)),
-    deleteSync: () => Promise.resolve(Ok(undefined)),
-    updateSyncFrequency: () => Promise.resolve(Ok(undefined))
+    recurring: () => Promise.resolve({}) as any,
+    executeAction: () => Promise.resolve({}) as any,
+    executeWebhook: () => Promise.resolve({}) as any,
+    executePostConnection: () => Promise.resolve({}) as any,
+    executeSync: () => Promise.resolve({}) as any,
+    cancel: () => Promise.resolve({}) as any,
+    pauseSync: () => Promise.resolve({}) as any,
+    unpauseSync: () => Promise.resolve({}) as any,
+    deleteSync: () => Promise.resolve({}) as any,
+    updateSyncFrequency: () => Promise.resolve({}) as any
 };
 const mockOrchestrator = new Orchestrator(orchestratorClientNoop);
 

--- a/packages/shared/lib/services/sync/orchestrator.service.ts
+++ b/packages/shared/lib/services/sync/orchestrator.service.ts
@@ -1,4 +1,4 @@
-import { deleteSyncConfig, deleteSyncFilesForConfig } from './config/config.service.js';
+import { deleteSyncConfig, deleteSyncFilesForConfig, getSyncConfig } from './config/config.service.js';
 import connectionService from '../connection.service.js';
 import { deleteScheduleForSync, getSchedule, updateScheduleStatus } from './schedule.service.js';
 import { getLatestSyncJob } from './job.service.js';
@@ -22,7 +22,7 @@ import { errorNotificationService } from '../notification/error.service.js';
 import SyncClient from '../../clients/sync.client.js';
 import configService from '../config.service.js';
 import type { LogLevel } from '../../models/Activity.js';
-import type { Connection } from '../../models/Connection.js';
+import type { Connection, NangoConnection } from '../../models/Connection.js';
 import type {
     Job as SyncJob,
     Schedule as SyncSchedule,
@@ -39,10 +39,11 @@ import { SyncStatus, ScheduleStatus, SyncConfigType, SyncCommand, CommandToActiv
 import type { LogContext, LogContextGetter } from '@nangohq/logs';
 import type { RecordsServiceInterface } from '../../clients/sync.client.js';
 import { LogActionEnum } from '../../models/Activity.js';
-import { stringifyError } from '@nangohq/utils';
+import { getLogger, stringifyError } from '@nangohq/utils';
 import environmentService from '../environment.service.js';
 import type { Environment } from '../../models/Environment.js';
 import type { Orchestrator } from '../../clients/orchestrator.js';
+import type { NangoConfig, NangoIntegration, NangoIntegrationData } from '../../models/NangoConfig.js';
 
 // Should be in "logs" package but impossible thanks to CLI
 export const syncCommandToOperation = {
@@ -61,14 +62,58 @@ interface CreateSyncArgs {
     syncName: string;
 }
 
+const logger = getLogger('orchestrator.service');
+
 export class OrchestratorService {
-    public async create(
+    public async createSyncForConnection(nangoConnectionId: number, logContextGetter: LogContextGetter, orchestrator: Orchestrator): Promise<void> {
+        const nangoConnection = (await connectionService.getConnectionById(nangoConnectionId)) as NangoConnection;
+        const nangoConfig = await getSyncConfig(nangoConnection);
+        if (!nangoConfig) {
+            logger.error(
+                'Failed to load the Nango config - will not start any syncs! If you expect to see a sync make sure you used the nango cli deploy command'
+            );
+            return;
+        }
+        const { integrations }: NangoConfig = nangoConfig;
+        const providerConfigKey = nangoConnection?.provider_config_key;
+
+        if (!integrations[providerConfigKey]) {
+            return;
+        }
+
+        const syncClient = await SyncClient.getInstance();
+        if (!syncClient) {
+            return;
+        }
+
+        const providerConfig: ProviderConfig = (await configService.getProviderConfig(
+            nangoConnection?.provider_config_key,
+            nangoConnection?.environment_id
+        )) as ProviderConfig;
+
+        const syncObject = integrations[providerConfigKey] as unknown as Record<string, NangoIntegration>;
+        const syncNames = Object.keys(syncObject);
+        for (const syncName of syncNames) {
+            const syncData = syncObject[syncName] as unknown as NangoIntegrationData;
+
+            if (!syncData.enabled) {
+                continue;
+            }
+            const sync = await createSync(nangoConnectionId, syncName);
+            if (sync) {
+                await orchestrator.scheduleSyncHelper(nangoConnection, sync, providerConfig, syncName, syncData, logContextGetter);
+            }
+        }
+    }
+
+    public async createSyncForConnections(
         connections: Connection[],
         syncName: string,
         providerConfigKey: string,
         environmentId: number,
         sync: IncomingFlowConfig,
         logContextGetter: LogContextGetter,
+        orchestrator: Orchestrator,
         debug = false,
         activityLogId?: number,
         logCtx?: LogContext
@@ -93,8 +138,7 @@ export class OrchestratorService {
                 }
 
                 const createdSync = await createSync(connection.id as number, syncName);
-                const syncClient = await SyncClient.getInstance();
-                await syncClient?.startContinuous(
+                orchestrator.scheduleSyncHelper(
                     connection,
                     createdSync as Sync,
                     syncConfig as ProviderConfig,
@@ -134,6 +178,7 @@ export class OrchestratorService {
     public async createSyncs(
         syncArgs: CreateSyncArgs[],
         logContextGetter: LogContextGetter,
+        orchestrator: Orchestrator,
         debug = false,
         activityLogId?: number,
         logCtx?: LogContext
@@ -141,7 +186,18 @@ export class OrchestratorService {
         let success = true;
         for (const syncToCreate of syncArgs) {
             const { connections, providerConfigKey, environmentId, sync, syncName } = syncToCreate;
-            const result = await this.create(connections, syncName, providerConfigKey, environmentId, sync, logContextGetter, debug, activityLogId, logCtx);
+            const result = await this.createSyncForConnections(
+                connections,
+                syncName,
+                providerConfigKey,
+                environmentId,
+                sync,
+                logContextGetter,
+                orchestrator,
+                debug,
+                activityLogId,
+                logCtx
+            );
             if (!result) {
                 success = false;
             }
@@ -423,7 +479,12 @@ export class OrchestratorService {
      * Trigger If Connections Exist
      * @desc for the recently deploy flows, create the sync and trigger it if there are connections
      */
-    public async triggerIfConnectionsExist(flows: SyncDeploymentResult[], environmentId: number, logContextGetter: LogContextGetter) {
+    public async triggerIfConnectionsExist(
+        flows: SyncDeploymentResult[],
+        environmentId: number,
+        logContextGetter: LogContextGetter,
+        orchestrator: Orchestrator
+    ) {
         for (const flow of flows) {
             if (flow.type === SyncConfigType.ACTION) {
                 continue;
@@ -438,17 +499,19 @@ export class OrchestratorService {
             const { providerConfigKey } = flow;
             const name = flow.name || flow.syncName;
 
-            await this.create(
+            await this.createSyncForConnections(
                 existingConnections as Connection[],
                 name as string,
                 providerConfigKey,
                 environmentId,
                 flow as unknown as IncomingFlowConfig,
                 logContextGetter,
+                orchestrator,
                 false
             );
         }
     }
+    // TODO:
     private async fetchSyncData(syncId: string, environmentId: number) {
         const syncClient = await SyncClient.getInstance();
         const schedule = await getSchedule(syncId);

--- a/packages/shared/lib/services/sync/run.service.integration.test.ts
+++ b/packages/shared/lib/services/sync/run.service.integration.test.ts
@@ -30,33 +30,16 @@ class integrationServiceMock implements IntegrationServiceInterface {
 }
 
 const orchestratorClient = {
-    executeAction: () => {
-        return Promise.resolve({}) as any;
-    },
-    executeWebhook: () => {
-        return Promise.resolve({}) as any;
-    },
-    executePostConnection: () => {
-        return Promise.resolve({}) as any;
-    },
-    executeSync: () => {
-        return Promise.resolve({}) as any;
-    },
-    pauseSync: () => {
-        return Promise.resolve({}) as any;
-    },
-    unpauseSync: () => {
-        return Promise.resolve({}) as any;
-    },
-    deleteSync: () => {
-        return Promise.resolve({}) as any;
-    },
-    updateSyncFrequency: () => {
-        return Promise.resolve({}) as any;
-    },
-    cancel: () => {
-        return Promise.resolve({}) as any;
-    }
+    recurring: () => Promise.resolve({}) as any,
+    executeAction: () => Promise.resolve({}) as any,
+    executeWebhook: () => Promise.resolve({}) as any,
+    executePostConnection: () => Promise.resolve({}) as any,
+    executeSync: () => Promise.resolve({}) as any,
+    cancel: () => Promise.resolve({}) as any,
+    pauseSync: () => Promise.resolve({}) as any,
+    unpauseSync: () => Promise.resolve({}) as any,
+    deleteSync: () => Promise.resolve({}) as any,
+    updateSyncFrequency: () => Promise.resolve({}) as any
 };
 const slackService = new SlackService({ orchestratorClient, logContextGetter });
 

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -658,7 +658,7 @@ export const getAndReconcileDifferences = async ({
             await logCtx?.debug(`Creating ${syncsToCreate.length} sync${syncsToCreate.length === 1 ? '' : 's'} ${JSON.stringify(syncNames)}`);
         }
         // this is taken out of the loop to ensure it awaits all the calls properly
-        const result = await syncOrchestrator.createSyncs(syncsToCreate, logContextGetter, debug, activityLogId!, logCtx);
+        const result = await syncOrchestrator.createSyncs(syncsToCreate, logContextGetter, orchestrator, debug, activityLogId!, logCtx);
 
         if (!result) {
             if (activityLogId) {


### PR DESCRIPTION
New syncs are going to be created in both the orchestrator and temporal but they are not yet processed via the orchestrator.
This will allow us to check schedule are created correctly and tasks are scheduled properly

Next PR will modify `handler.ts` to actually process the sync task.


