### PR TITLE
fix(scheduler): retrying when task fails can interfere with scheduling

### DIFF
--- a/packages/scheduler/lib/models/schedules.ts
+++ b/packages/scheduler/lib/models/schedules.ts
@@ -203,9 +203,15 @@ export async function remove(db: knex.Knex, id: string): Promise<Result<Schedule
     }
 }
 
-export async function search(db: knex.Knex, params: { name?: string; state?: ScheduleState; limit: number; forUpdate?: boolean }): Promise<Result<Schedule[]>> {
+export async function search(
+    db: knex.Knex,
+    params: { id?: string; name?: string; state?: ScheduleState; limit: number; forUpdate?: boolean }
+): Promise<Result<Schedule[]>> {
     try {
         const query = db.from<DbSchedule>(SCHEDULES_TABLE).limit(params.limit);
+        if (params.id) {
+            query.where('id', params.id);
+        }
         if (params.name) {
             query.where('name', params.name);
         }

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -232,29 +232,42 @@ export class Scheduler {
      * const failed = await scheduler.fail({ taskId: '00000000-0000-0000-0000-000000000000', error: {message: 'error'});
      */
     public async fail({ taskId, error }: { taskId: string; error: JsonValue }): Promise<Result<Task>> {
-        const failed = await tasks.transitionState(this.dbClient.db, { taskId, newState: 'FAILED', output: error });
-        if (failed.isOk()) {
-            const task = failed.value;
-            this.onCallbacks[task.state](task);
-            // Create a new task if the task is retryable
-            if (task.retryMax > task.retryCount) {
-                const taskProps: ImmediateProps = {
-                    name: `${task.name}:${task.retryCount + 1}`, // Append retry count to make it unique
-                    payload: task.payload,
-                    groupKey: task.groupKey,
-                    retryMax: task.retryMax,
-                    retryCount: task.retryCount + 1,
-                    createdToStartedTimeoutSecs: task.createdToStartedTimeoutSecs,
-                    startedToCompletedTimeoutSecs: task.startedToCompletedTimeoutSecs,
-                    heartbeatTimeoutSecs: task.heartbeatTimeoutSecs
-                };
-                const res = await this.immediate(taskProps);
-                if (res.isErr()) {
-                    logger.error(`Error retrying task '${taskId}': ${stringifyError(res.error)}`);
+        return await this.dbClient.db.transaction(async (trx) => {
+            const task = await tasks.get(trx, taskId);
+            if (task.isErr()) {
+                return Err(`fail: Error fetching task '${taskId}': ${stringifyError(task.error)}`);
+            }
+            // if task is from a schedule,
+            // lock the schedule to prevent concurrent update or scheduling of tasks
+            // while we are potentially creating a new retry task
+            if (task.value.scheduleId) {
+                await schedules.search(trx, { id: task.value.scheduleId, limit: 1, forUpdate: true });
+            }
+
+            const failed = await tasks.transitionState(trx, { taskId, newState: 'FAILED', output: error });
+            if (failed.isOk()) {
+                const task = failed.value;
+                this.onCallbacks[task.state](task);
+                // Create a new task if the task is retryable
+                if (task.retryMax > task.retryCount) {
+                    const taskProps: ImmediateProps = {
+                        name: `${task.name}:${task.retryCount + 1}`, // Append retry count to make it unique
+                        payload: task.payload,
+                        groupKey: task.groupKey,
+                        retryMax: task.retryMax,
+                        retryCount: task.retryCount + 1,
+                        createdToStartedTimeoutSecs: task.createdToStartedTimeoutSecs,
+                        startedToCompletedTimeoutSecs: task.startedToCompletedTimeoutSecs,
+                        heartbeatTimeoutSecs: task.heartbeatTimeoutSecs
+                    };
+                    const res = await this.immediate(taskProps);
+                    if (res.isErr()) {
+                        logger.error(`Error retrying task '${taskId}': ${stringifyError(res.error)}`);
+                    }
                 }
             }
-        }
-        return failed;
+            return failed;
+        });
     }
 
     /**


### PR DESCRIPTION
when a task fails a retry one is potentially created. We are now locking the schedule to ensure failing a task and retrying doesn't interfere with the scheduling worker or any other update of the schedule.

Forgot this scenario when I implemented schedule locking in https://github.com/NangoHQ/nango/pull/2296

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
