### PR TITLE
fix(ui): Make the connection creation date into a <time> element with a title

### DIFF
--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -225,7 +225,9 @@ export default function ConnectionList() {
                                             <p className="break-words break-all">{providerConfigKey}</p>
                                         </div>
                                         <div className="flex w-20">
-                                            <p className="">{formatDate(creationDate)}</p>
+                                            <time dateTime={creationDate} title={creationDate}>
+                                                {formatDate(creationDate)}
+                                            </time>
                                         </div>
                                     </div>
                                 )


### PR DESCRIPTION
## Describe your changes

This PR updates the "Created" column's value to be a proper `<time>` element with a `title` attribute, which allows the user to hover and see the exact datetime in a tooltip.

<img width="1101" alt="Screenshot 2024-06-12 at 11 16 38 AM" 
src="https://github.com/eabruzzese/nango/assets/293571/a79a5999-1deb-425b-af73-d9d2e259cc22">

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: very minor cosmetic change
- [ ] I added observability, otherwise the reason is: very minor cosmetic change
- [ ] I added analytics, otherwise the reason is: very minor cosmetic change
