### PR TITLE
feat: process syncs via the orchestrator

### DIFF
--- a/packages/jobs/lib/activities.ts
+++ b/packages/jobs/lib/activities.ts
@@ -53,7 +53,7 @@ export async function routeSync(args: InitialSyncArgs): Promise<boolean | object
     const isEnvEnabled = await featureFlags.isEnabled('orchestrator:schedule', `${environmentId}`, false);
     const isOrchestrator = isGloballyEnabled || isEnvEnabled;
     if (isOrchestrator) {
-        return false;
+        return true;
     }
 
     // https://typescript.temporal.io/api/classes/activity.Context
@@ -66,7 +66,7 @@ export async function routeSync(args: InitialSyncArgs): Promise<boolean | object
         environmentId: providerConfig.environment_id,
         config_id: providerConfig.id!,
         name: syncName,
-        isAction: false
+        isAction: true
     }))!;
 
     return syncProvider({

--- a/packages/jobs/lib/processor/handler.ts
+++ b/packages/jobs/lib/processor/handler.ts
@@ -1,10 +1,30 @@
 import type { OrchestratorTask, TaskWebhook, TaskAction, TaskPostConnection, TaskSync } from '@nangohq/nango-orchestrator';
 import { jsonSchema } from '@nangohq/nango-orchestrator';
 import type { JsonValue } from 'type-fest';
-import { Err, Ok } from '@nangohq/utils';
+import { Err, Ok, stringifyError } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
-import { configService, createSyncJob, getSyncByIdAndName, syncRunService, SyncStatus, SyncType } from '@nangohq/shared';
+import type { LogLevel } from '@nangohq/shared';
+import {
+    configService,
+    createActivityLog,
+    createActivityLogAndLogMessage,
+    createActivityLogMessage,
+    createSyncJob,
+    environmentService,
+    errorManager,
+    ErrorSourceEnum,
+    featureFlags,
+    getLastSyncDate,
+    getSyncByIdAndName,
+    getSyncConfigRaw,
+    LogActionEnum,
+    syncRunService,
+    SyncStatus,
+    SyncType,
+    updateSyncJobStatus
+} from '@nangohq/shared';
 import { sendSync } from '@nangohq/webhooks';
+import type { LogContext } from '@nangohq/logs';
 import { logContextGetter } from '@nangohq/logs';
 import { records as recordsService } from '@nangohq/records';
 import integrationService from '../integration.service.js';
@@ -29,13 +49,174 @@ export async function handler(task: OrchestratorTask): Promise<Result<JsonValue>
     return Err(`Unreachable`);
 }
 
-async function abort(_task: OrchestratorTask): Promise<Result<void>> {
-    // TODO: Implement abort processing
-    return Ok(undefined);
+async function abort(task: OrchestratorTask): Promise<Result<void>> {
+    try {
+        if (task.isSync()) {
+            await integrationService.cancelScript(task.syncId, task.connection.environment_id);
+            return Ok(undefined);
+        }
+        return Err(`Failed to cancel. Task type not supported`);
+    } catch (err) {
+        return Err(`Failed to cancel: ${stringifyError(err)}`);
+    }
 }
 
 async function sync(task: TaskSync): Promise<Result<JsonValue>> {
-    return Ok({ id: task.id });
+    const isGloballyEnabled = await featureFlags.isEnabled('orchestrator:schedule', 'global', false);
+    const isEnvEnabled = await featureFlags.isEnabled('orchestrator:schedule', `${task.connection.environment_id}`, false);
+    const isOrchestrator = isGloballyEnabled || isEnvEnabled;
+    if (!isOrchestrator) {
+        return Ok({ dryrun: true });
+    }
+    let logCtx: LogContext | undefined;
+    const lastSyncDate = await getLastSyncDate(task.syncId);
+    const providerConfig = await configService.getProviderConfig(task.connection.provider_config_key, task.connection.environment_id);
+    if (providerConfig === null) {
+        return Err(`Provider config not found for connection: ${task.connection}. TaskId: ${task.id}`);
+    }
+    const syncType = lastSyncDate ? SyncType.INCREMENTAL : SyncType.FULL;
+    const syncJob = await createSyncJob(task.syncId, syncType, SyncStatus.RUNNING, task.name, task.connection, task.id);
+    if (!syncJob) {
+        return Err(`Failed to create sync job for sync: ${task.syncId}. TaskId: ${task.id}`);
+    }
+    try {
+        const log = {
+            level: 'info' as LogLevel,
+            success: null,
+            action: lastSyncDate ? LogActionEnum.FULL_SYNC : LogActionEnum.SYNC,
+            start: Date.now(),
+            end: Date.now(),
+            timestamp: Date.now(),
+            connection_id: task.connection.connection_id,
+            provider_config_key: task.connection.provider_config_key,
+            provider: providerConfig.provider,
+            session_id: syncJob.id.toString(),
+            environment_id: task.connection.environment_id,
+            operation_name: task.syncName
+        };
+        const activityLogId = await createActivityLog(log);
+        if (activityLogId === null) {
+            return Err(`Failed to create activity log: ${JSON.stringify(task)}`);
+        }
+
+        const syncConfig = await getSyncConfigRaw({
+            environmentId: providerConfig.environment_id,
+            config_id: providerConfig.id!,
+            name: task.syncName,
+            isAction: false
+        });
+
+        if (!syncConfig) {
+            return Err(`Sync config not found: ${JSON.stringify(task)}`);
+        }
+
+        const accountAndEnv = await environmentService.getAccountAndEnvironment({ environmentId: task.connection.environment_id });
+        if (!accountAndEnv) {
+            return Err(`Account and environment not found: ${JSON.stringify(task)}}`);
+        }
+        const { account, environment } = accountAndEnv;
+
+        logCtx = await logContextGetter.create(
+            { id: String(activityLogId), operation: { type: 'sync', action: 'run' }, message: 'Sync' },
+            {
+                account,
+                environment,
+                integration: { id: providerConfig.id!, name: providerConfig.unique_key, provider: providerConfig.provider },
+                connection: { id: task.connection.id, name: task.connection.connection_id },
+                syncConfig: { id: syncConfig.id!, name: syncConfig.sync_name }
+            }
+        );
+
+        if (task.debug) {
+            await createActivityLogMessage({
+                level: 'info',
+                environment_id: task.connection.environment_id,
+                activity_log_id: activityLogId,
+                timestamp: Date.now(),
+                content: `Starting sync ${syncType} for ${task.syncName} with syncId ${task.syncId} and syncJobId ${syncJob.id} with execution id ${task.id} and attempt ${task.attempt}`
+            });
+            await logCtx.info('Starting sync', {
+                syncType: syncType,
+                syncName: task.syncName,
+                syncId: task.syncId,
+                syncJobId: syncJob.id,
+                attempt: task.attempt,
+                executionId: task.id
+            });
+        }
+
+        const syncRun = new syncRunService({
+            bigQueryClient,
+            integrationService,
+            recordsService,
+            slackService,
+            sendSyncWebhook: sendSync,
+            writeToDb: true,
+            syncId: task.syncId,
+            syncJobId: syncJob.id,
+            nangoConnection: task.connection,
+            syncName: task.syncName,
+            syncType: syncType,
+            activityLogId,
+            provider: providerConfig.provider,
+            debug: task.debug,
+            logCtx
+        });
+
+        const { success, error, response } = await syncRun.run();
+        if (!success) {
+            return Err(`Sync failed with error ${error}: ${JSON.stringify(task)}`);
+        }
+        const res = jsonSchema.safeParse(response);
+        if (!res.success) {
+            return Err(`Invalid sync response format: ${response}: ${JSON.stringify(task)}`);
+        }
+        await updateSyncJobStatus(syncJob.id, SyncStatus.SUCCESS);
+        return Ok(res.data);
+    } catch (err) {
+        const prettyError = stringifyError(err, { pretty: true });
+        const log = {
+            level: 'info' as LogLevel,
+            success: false,
+            action: lastSyncDate ? LogActionEnum.FULL_SYNC : LogActionEnum.SYNC,
+            start: Date.now(),
+            end: Date.now(),
+            timestamp: Date.now(),
+            connection_id: task.connection.connection_id,
+            provider_config_key: task.connection.provider_config_key,
+            provider: providerConfig.provider,
+            session_id: syncJob.id.toString(),
+            environment_id: task.connection.environment_id,
+            operation_name: task.syncName
+        };
+        const content = `The ${syncType} sync failed to run: ${prettyError}`;
+
+        await createActivityLogAndLogMessage(log, {
+            level: 'error',
+            environment_id: task.connection.environment_id,
+            timestamp: Date.now(),
+            content
+        });
+        if (logCtx) {
+            await logCtx.error(content, { error: err });
+            await logCtx.failed();
+        }
+
+        errorManager.report(content, {
+            environmentId: task.connection.environment_id,
+            source: ErrorSourceEnum.PLATFORM,
+            operation: syncType,
+            metadata: {
+                connectionId: task.connection.connection_id,
+                providerConfigKey: task.connection.provider_config_key,
+                syncType,
+                syncName: task.syncName
+            }
+        });
+
+        await updateSyncJobStatus(syncJob.id, SyncStatus.ERROR);
+        return Err(`Failed sync run: ${prettyError}. TaskId: ${task.id}`);
+    }
 }
 
 async function action(task: TaskAction): Promise<Result<JsonValue>> {


### PR DESCRIPTION
This PR:
- adds processing of sync in the orchestrator processor (behind a flag)
- adds support for sync cancellation in the orchestrator processor
- add support for sync heartbeat in the orchestrator processor

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
