### PR TITLE
fix(logs): correct timeout

### DIFF
--- a/packages/jobs/lib/crons/timeoutLogsOperations.ts
+++ b/packages/jobs/lib/crons/timeoutLogsOperations.ts
@@ -18,6 +18,7 @@ export function timeoutLogsOperations(): void {
             try {
                 logger.info(`Timeouting old operations...`);
                 await model.setTimeoutForAll();
+                logger.info(`✅ Timeouted`);
             } catch (err) {
                 errorManager.report(err, { source: ErrorSourceEnum.PLATFORM }, tracer);
             }

--- a/packages/logs/lib/models/messages.ts
+++ b/packages/logs/lib/models/messages.ts
@@ -372,9 +372,16 @@ export async function setTimeoutForAll(opts: { wait?: boolean } = {}): Promise<v
         refresh: opts.wait === true,
         query: {
             bool: {
-                must: [{ range: { expiresAt: { lt: 'now' } } }],
+                filter: [
+                    { range: { expiresAt: { lt: 'now' } } },
+                    {
+                        bool: {
+                            should: [{ term: { state: 'waiting' } }, { term: { state: 'running' } }]
+                        }
+                    }
+                ],
                 must_not: { exists: { field: 'parentId' } },
-                should: [{ term: { state: 'waiting' } }, { term: { state: 'running' } }]
+                should: []
             }
         },
         script: {

--- a/packages/server/lib/hooks/connection/external-post-connection.ts
+++ b/packages/server/lib/hooks/connection/external-post-connection.ts
@@ -50,15 +50,25 @@ export async function externalPostConnection(
         }
     );
 
+    let failed = false;
     for (const postConnectionScript of postConnectionScripts) {
         const { name, file_location: fileLocation } = postConnectionScript;
 
-        await getOrchestrator().triggerPostConnectionScript({
+        const res = await getOrchestrator().triggerPostConnectionScript({
             connection: createdConnection.connection,
             name,
             fileLocation,
             activityLogId: activityLogId as number,
             logCtx
         });
+        if (res.isErr()) {
+            failed = true;
+        }
+    }
+
+    if (failed) {
+        await logCtx.failed();
+    } else {
+        await logCtx.success();
     }
 }

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -617,7 +617,6 @@ export class Orchestrator {
             });
             await updateSuccessActivityLog(activityLogId, true);
             await logCtx.info(content);
-            await logCtx.success();
 
             await telemetry.log(
                 LogTypes.POST_CONNECTION_SCRIPT_SUCCESS,
@@ -647,7 +646,6 @@ export class Orchestrator {
                 content
             });
             await logCtx.error(content);
-            await logCtx.failed();
 
             errorManager.report(err, {
                 source: ErrorSourceEnum.PLATFORM,

--- a/packages/shared/lib/services/sync/run.service.ts
+++ b/packages/shared/lib/services/sync/run.service.ts
@@ -543,7 +543,6 @@ export default class SyncRun {
                         content
                     });
                     await this.logCtx?.info(content);
-                    await this.logCtx?.success();
 
                     await this.slackNotificationService?.removeFailingConnection(
                         this.nangoConnection,
@@ -783,7 +782,6 @@ export default class SyncRun {
                 content
             });
             await this.logCtx?.info(content);
-            await this.logCtx?.success();
         } else {
             await createActivityLogMessage({
                 level: 'info',

--- a/packages/webapp/src/hooks/useLogs.tsx
+++ b/packages/webapp/src/hooks/useLogs.tsx
@@ -53,7 +53,7 @@ export function useSearchOperations(env: string, body: SearchOperations['Body'],
         }
         if (man.error) {
             setData(undefined);
-            setError(man.error as any);
+            setError((typeof man.error === 'string' || man.error instanceof Error ? { error: { message: man.error } } : man.error) as any);
             return;
         }
 

--- a/packages/webapp/src/pages/Logs/components/SearchInOperation.tsx
+++ b/packages/webapp/src/pages/Logs/components/SearchInOperation.tsx
@@ -21,7 +21,7 @@ export const columns: ColumnDef<SearchOperationsData>[] = [
     {
         accessorKey: 'createdAt',
         header: 'Timestamp',
-        size: 170,
+        size: 180,
         cell: ({ row }) => {
             return <div className="font-code text-s">{formatDateToLogFormat(row.original.createdAt)}</div>;
         }


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1198/timeout-action-issue

- Operations were incorrectly set as timeout because of a wrong query
- Actions were reported twice as success
- external-post-connection were marked as failed or success too soon
- UI: column size for timestamp was too small
- UI: handle non-json error (server 500, hot reload error)

