### PR TITLE
chore: disable sync retry

### DIFF
--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -1008,7 +1008,7 @@ export class Orchestrator {
                 state: syncData.auto_start ? 'STARTED' : 'PAUSED',
                 frequencyMs: ms(interval.value as StringValue),
                 groupKey: 'sync',
-                retry: { max: 3 },
+                retry: { max: 0 },
                 timeoutSettingsInSecs: {
                     createdToStarted: 60 * 60, // 1 hour
                     startedToCompleted: 60 * 60 * 24, // 1 day


### PR DESCRIPTION
the goal is to avoid the noise of retrying tasks while migrating to orchestrator.

