### PR TITLE
fix(slack): only notify success when refreshing

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -708,18 +708,18 @@ class ConnectionService {
                 const errorWithPayload = new NangoError(error.type, connection);
 
                 return Err(errorWithPayload);
+            } else {
+                await onRefreshSuccess({
+                    connection,
+                    environment,
+                    config
+                });
             }
 
             connection.credentials = credentials as OAuth2Credentials;
         }
 
         await this.updateLastFetched(connection.id);
-
-        await onRefreshSuccess({
-            connection,
-            environment,
-            config
-        });
 
         return Ok(connection);
     }


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1200/slack-message-are-always-resolved-even-if-incorrect

- `onRefreshSuccess` was called at every getConnectionCredentials, even when no refresh were happening
That means a proxy call would set success but then a refresh would set failed, back and forth until the end of time :D
Let me know if that makes sense @khaliqgant 

- Added more logs just so we can debug this quicker in prod
