### PR TITLE
fix(slack): only notify success if it has refreshed (again)

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -639,11 +639,7 @@ class ConnectionService {
         const template: ProviderTemplate = configService.getTemplate(config?.provider);
 
         if (connection?.credentials?.type === 'OAUTH2' || connection?.credentials?.type === 'APP' || connection?.credentials?.type === 'OAUTH2_CC') {
-            const {
-                success,
-                error,
-                response: credentials
-            } = await this.refreshCredentialsIfNeeded({
+            const { success, error, response } = await this.refreshCredentialsIfNeeded({
                 connection,
                 providerConfig: config,
                 template: template as ProviderTemplateOAuth2,
@@ -651,7 +647,7 @@ class ConnectionService {
                 instantRefresh
             });
 
-            if (!success && error) {
+            if ((!success && error) || !response) {
                 const log: ActivityLog = {
                     level: 'error' as LogLevel,
                     success: false,
@@ -695,8 +691,8 @@ class ConnectionService {
                         activityLogId,
                         logCtx,
                         authError: {
-                            type: error.type,
-                            description: error.message
+                            type: error!.type,
+                            description: error!.message
                         },
                         environment,
                         template,
@@ -705,10 +701,10 @@ class ConnectionService {
                 }
 
                 // TODO: this leak credentials to the logs
-                const errorWithPayload = new NangoError(error.type, connection);
+                const errorWithPayload = new NangoError(error!.type, connection);
 
                 return Err(errorWithPayload);
-            } else {
+            } else if (response.refreshed) {
                 await onRefreshSuccess({
                     connection,
                     environment,
@@ -716,7 +712,7 @@ class ConnectionService {
                 });
             }
 
-            connection.credentials = credentials as OAuth2Credentials;
+            connection.credentials = response.credentials as OAuth2Credentials;
         }
 
         await this.updateLastFetched(connection.id);
@@ -815,7 +811,7 @@ class ConnectionService {
         template: ProviderTemplateOAuth2;
         environment_id: number;
         instantRefresh?: boolean;
-    }): Promise<ServiceResponse<OAuth2Credentials | AppCredentials | AppStoreCredentials | OAuth2ClientCredentials>> {
+    }): Promise<ServiceResponse<{ refreshed: boolean; credentials: OAuth2Credentials | AppCredentials | AppStoreCredentials | OAuth2ClientCredentials }>> {
         const connectionId = connection.connection_id;
         const credentials = connection.credentials as OAuth2Credentials;
         const providerConfigKey = connection.provider_config_key;
@@ -863,7 +859,7 @@ class ConnectionService {
                     provider: providerConfig.provider
                 });
 
-                return { success: true, error: null, response: newCredentials };
+                return { success: true, error: null, response: { refreshed: shouldRefresh, credentials: newCredentials } };
             } catch (e: any) {
                 const errorMessage = e.message || 'Unknown error';
                 const errorDetails = {
@@ -890,7 +886,7 @@ class ConnectionService {
             }
         }
 
-        return { success: true, error: null, response: credentials };
+        return { success: true, error: null, response: { refreshed: shouldRefresh, credentials } };
     }
 
     public async getAppStoreCredentials(

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -799,7 +799,7 @@ class ConnectionService {
         }
     }
 
-    public async refreshCredentialsIfNeeded({
+    private async refreshCredentialsIfNeeded({
         connection,
         providerConfig,
         template,


### PR DESCRIPTION
## Describe your changes

Fix of the previous fix.  A little omission when I read the code,`refreshCredentialsIfNeeded` always return credentials wether it was refreshed or not.

- Correctly notify success if it has been refreshed (hopefully good this time)
