### PR TITLE
feat(integrations): [nan-1187] add asana templates

### DIFF
--- a/integration-templates/asana/actions/create-task.ts
+++ b/integration-templates/asana/actions/create-task.ts
@@ -1,0 +1,24 @@
+import type { NangoAction, AsanaTask, Task, CreateAsanaTask, NangoActionError } from '../../models';
+// eslint-disable-next-line import/extensions
+import { toTask } from '../mappers/to-task';
+
+export default async function runAction(nango: NangoAction, input: CreateAsanaTask): Promise<Task> {
+    if (!input.parent && !input.projects) {
+        throw new nango.ActionError<NangoActionError>({
+            type: 'validation_error',
+            message:
+                'You must specify one of workspace, parent or projects. For more information on API status codes and how to handle them, read the docs on errors: https://developers.asana.com/docs/errors'
+        });
+    }
+
+    const response = await nango.post<{ data: AsanaTask }>({
+        endpoint: '/api/1.0/tasks',
+        data: {
+            data: input
+        }
+    });
+
+    const { data } = response;
+
+    return toTask(data.data);
+}

--- a/integration-templates/asana/actions/create-task.ts
+++ b/integration-templates/asana/actions/create-task.ts
@@ -1,6 +1,5 @@
 import type { NangoAction, AsanaTask, Task, CreateAsanaTask, NangoActionError } from '../../models';
-// eslint-disable-next-line import/extensions
-import { toTask } from '../mappers/to-task';
+import { toTask } from '../mappers/to-task.js';
 
 export default async function runAction(nango: NangoAction, input: CreateAsanaTask): Promise<Task> {
     if (!input.parent && !input.projects) {

--- a/integration-templates/asana/actions/delete-task.ts
+++ b/integration-templates/asana/actions/delete-task.ts
@@ -1,0 +1,15 @@
+import type { NangoAction, Id, NangoActionError } from '../../models';
+
+export default async function runAction(nango: NangoAction, input: Id): Promise<boolean> {
+    if (!input.id) {
+        throw new nango.ActionError<NangoActionError>({
+            type: 'validation_error',
+            message: 'You must specify a task id (gid) to delete.'
+        });
+    }
+    const response = await nango.delete({
+        endpoint: `/api/1.0/tasks/${input.id}`
+    });
+
+    return response.status === 200;
+}

--- a/integration-templates/asana/actions/fetch-projects.ts
+++ b/integration-templates/asana/actions/fetch-projects.ts
@@ -1,0 +1,15 @@
+import type { NangoAction, BaseAsanaModel, AsanaProjectInput } from '../../models';
+
+export default async function runAction(nango: NangoAction, input: AsanaProjectInput): Promise<BaseAsanaModel[]> {
+    const limit = input.limit || 10;
+    const workspace = input.workspace;
+    const response = await nango.get({
+        endpoint: '/api/1.0/projects',
+        params: {
+            limit,
+            workspace
+        }
+    });
+
+    return response.data.data;
+}

--- a/integration-templates/asana/actions/fetch-workspaces.ts
+++ b/integration-templates/asana/actions/fetch-workspaces.ts
@@ -1,0 +1,15 @@
+import type { NangoAction, BaseAsanaModel, Limit } from '../../models';
+
+export default async function runAction(nango: NangoAction, input: Limit): Promise<BaseAsanaModel[]> {
+    const limit = input?.limit || 10;
+
+    const response = await nango.get({
+        endpoint: '/api/1.0/workspaces',
+        params: {
+            opt_fields: 'is_organization',
+            limit
+        }
+    });
+
+    return response.data.data;
+}

--- a/integration-templates/asana/actions/update-task.ts
+++ b/integration-templates/asana/actions/update-task.ts
@@ -1,0 +1,33 @@
+import type { NangoAction, Task, AsanaUpdateTask, AsanaTask, NangoActionError } from '../../models';
+// eslint-disable-next-line import/extensions
+import { toTask } from '../mappers/to-task';
+
+export default async function runAction(nango: NangoAction, input: AsanaUpdateTask): Promise<Task> {
+    if (!input.id) {
+        throw new nango.ActionError<NangoActionError>({
+            type: 'validation_error',
+            message: 'You must specify a task id (gid) to update.'
+        });
+    }
+
+    const normalizedInput = normalizeDates(input);
+
+    const response = await nango.put<{ data: AsanaTask }>({
+        endpoint: `/api/1.0/tasks/${input.id}`,
+        data: {
+            data: normalizedInput
+        }
+    });
+
+    const { data } = response;
+
+    return toTask(data.data);
+}
+
+function normalizeDates(input: AsanaUpdateTask): AsanaUpdateTask {
+    return {
+        ...input,
+        due_on: input.due_on ? new Date(input.due_on).toISOString() : undefined,
+        due_at: input.due_at ? new Date(input.due_at).toISOString() : undefined
+    };
+}

--- a/integration-templates/asana/actions/update-task.ts
+++ b/integration-templates/asana/actions/update-task.ts
@@ -1,6 +1,5 @@
 import type { NangoAction, Task, AsanaUpdateTask, AsanaTask, NangoActionError } from '../../models';
-// eslint-disable-next-line import/extensions
-import { toTask } from '../mappers/to-task';
+import { toTask } from '../mappers/to-task.js';
 
 export default async function runAction(nango: NangoAction, input: AsanaUpdateTask): Promise<Task> {
     if (!input.id) {

--- a/integration-templates/asana/mappers/to-task.ts
+++ b/integration-templates/asana/mappers/to-task.ts
@@ -1,0 +1,24 @@
+import type { AsanaTask, Task } from '../../models';
+
+export function toTask(task: AsanaTask): Task {
+    return {
+        id: task.gid,
+        url: task.permalink_url,
+        status: task.completed ? 'completed' : 'open',
+        title: task.name,
+        description: task.notes || null,
+        due_date: task.due_on ? new Date(task.due_on).toISOString() : null,
+        assignee: task.assignee
+            ? {
+                  id: task.assignee.id,
+                  email: task.assignee.email || null,
+                  name: task.assignee.name,
+                  avatar_url: '',
+                  created_at: null,
+                  modified_at: null
+              }
+            : null,
+        created_at: task.created_at,
+        modified_at: task.modified_at
+    };
+}

--- a/integration-templates/asana/mappers/to-user.ts
+++ b/integration-templates/asana/mappers/to-user.ts
@@ -1,0 +1,12 @@
+import type { AsanaUser, User } from '../../models';
+
+export function toUser(user: AsanaUser): User {
+    return {
+        id: user.gid,
+        name: user.name,
+        email: user.email || null,
+        avatar_url: user.photo ? user.photo.image_128x128 : null,
+        created_at: null,
+        modified_at: null
+    };
+}

--- a/integration-templates/asana/nango.yaml
+++ b/integration-templates/asana/nango.yaml
@@ -2,19 +2,149 @@ integrations:
     asana:
         syncs:
             tasks:
-                runs: every 30min
+                runs: every hour
+                description: Retrieve all tasks that exist in the workspace
+                output: Task
+                endpoint: GET /ticketing/tasks
+                sync_type: incremental
+            users:
+                runs: every hour
+                description: Retrieve all users that exist in the workspace
+                output: User
+                endpoint: GET ticketing/users
+                sync_type: incremental
+            workspaces:
+                runs: every hour
+                description: Retrieve all workspaces for a user
+                output: AsanaWorkspace
+                endpoint: GET ticketing/workspaces
+            projects:
+                runs: every hour
+                description: Retrieves all projects for a user
+                output: AsanaProject
+                endpoint: GET ticketing/projects
+        actions:
+            fetch-workspaces:
+                description: Fetch the workspaces with a limit (default 10) of a user to allow them to
+                    selection of projects to sync
+                endpoint: GET ticketing/workspaces/limit
+                output: BaseAsanaModel[]
+                input: Limit
+            fetch-projects:
+                description: Fetch the projects with a limit (default 10) given a workspace of a user to allow
+                    selection when choosing the tasks to sync.
+                endpoint: GET ticketing/projects/limit
+                output: BaseAsanaModel[]
+                input: AsanaProjectInput
+            create-task:
+                input: CreateAsanaTask
+                endpoint: POST ticketing/task
+                output: Task
                 description: |
-                    Fetches a list of tasks from Asana, retrieving tasks from only the first project of the first workspace
-                scopes:
-                    - default
+                    Create a task using Asana specific fields and return a unified model task. See https://developers.asana.com/reference/createtask for Asana specific fields
+            update-task:
+                description: Update a task and be able to assign the task to a specific user
+                input: AsanaUpdateTask
+                endpoint: PATCH ticketing/task
                 output: AsanaTask
-                sync_type: full
-                endpoint: /asana/tasks
+            delete-task:
+                input: Id
+                endpoint: DELETE ticketing/task
+                output: boolean
 models:
-    AsanaTask:
+    Id:
         id: string
-        project_id: string
+    Timestamps:
+        created_at: string | null
+        modified_at: string | null
+    NangoActionError:
+        type: validation_error | generic_error
+        message: string
+    BaseAsanaModel:
+        gid: string
+        resource_type: string
+        name: string
+    Limit:
+        limit: number | undefined
+    User:
+        __extends: Timestamps
+        id: string
+        name: string
+        email: string | null
+        avatar_url: string | null
+    Task:
+        __extends: Timestamps
+        id: string
+        title: string
+        url: string
+        status: string
+        description: string | null
+        assignee: User | null
+        due_date: string | null
+    AsanaProjectInput:
+        __extends: Limit
+        workspace: string
+    CreateAsanaTask:
+        name: string
+        workspace: string | undefined
+        parent: string | undefined
+        projects: string[] | undefined
+    AsanaTask:
+        __extends: BaseAsanaModel,Timestamps
+        gid: string
         name: string
         completed: boolean
-        created_at: date
-        modified_at: date
+        due_date: string | null
+        tags: string[]
+        start_on: string | null
+        due_at: string | null
+        due_on: string | null
+        completed_at: string | null
+        actual_time_minutes: number
+        assignee: AsanaUser | null
+        start_at: string | null
+        num_hearts: number
+        num_likes: number
+        workspace: BaseAsanaModel
+        hearted: boolean
+        hearts: string[]
+        liked: boolean
+        likes: string[]
+        notes: string
+        assignee_status: string
+        followers: BaseAsanaModel[]
+        parent:
+            gid: string
+            resource_type: string
+            name: string
+            resource_subtype: string
+        permalink_url: string
+    AsanaPhoto:
+        image_1024x1024: string
+        image_128x128: string
+        image_21x21: string
+        image_27x27: string
+        image_36x36: string
+        image_60x60: string
+    AsanaUser:
+        __extends: BaseAsanaModel
+        id: string
+        email: string
+        photo: AsanaPhoto | null
+        workspace: string | undefined
+    AsanaUpdateTask:
+        id: string
+        due_at: string | undefined
+        due_on: string | undefined
+        completed: boolean | undefined
+        notes: string | undefined
+        projects: string[] | undefined
+        assignee: string | undefined
+        parent: string | undefined
+        tags: string[] | undefined
+        workspace: string | undefined
+    AsanaWorkspace:
+        __extends: BaseAsanaModel
+        is_organization: boolean
+    AsanaProject:
+        __extends: BaseAsanaModel

--- a/integration-templates/asana/syncs/projects.ts
+++ b/integration-templates/asana/syncs/projects.ts
@@ -1,0 +1,24 @@
+import type { NangoSync, BaseAsanaModel, AsanaProject } from '../../models';
+
+export default async function fetchData(nango: NangoSync): Promise<void> {
+    for await (const workspaces of nango.paginate<BaseAsanaModel>({ endpoint: '/api/1.0/workspaces', params: { limit: 100 }, retries: 10 })) {
+        for (const workspace of workspaces) {
+            for await (const projects of nango.paginate<BaseAsanaModel>({
+                endpoint: '/api/1.0/projects',
+                params: {
+                    workspace: workspace.gid,
+                    limit: 100
+                },
+                retries: 10
+            })) {
+                const projectsWithId = projects.map((project) => {
+                    return {
+                        ...project,
+                        id: project.gid
+                    };
+                });
+                await nango.batchSave<AsanaProject>(projectsWithId, 'AsanaProject');
+            }
+        }
+    }
+}

--- a/integration-templates/asana/syncs/tasks.ts
+++ b/integration-templates/asana/syncs/tasks.ts
@@ -1,65 +1,53 @@
-import type { AsanaTask, NangoSync } from '../../models';
+import type { NangoSync, BaseAsanaModel, AsanaTask, Task } from '../../models';
+// eslint-disable-next-line import/extensions
+import { toUser } from '../mappers/to-user';
+// eslint-disable-next-line import/extensions
+import { toTask } from '../mappers/to-task';
 
-export default async function fetchData(nango: NangoSync) {
-    // Get the user's workspaces & projects
-    // For testing we just get the first project of the first workspace
-    const workspaces = await paginate(nango, '/api/1.0/workspaces');
-    const workspace = workspaces[0];
+export default async function fetchData(nango: NangoSync): Promise<void> {
+    const lastSyncDate = nango.lastSyncDate;
 
-    const projects = await paginate(nango, '/api/1.0/projects', { workspace: workspace.gid });
-    const project = projects[0];
+    for await (const workspaces of nango.paginate<BaseAsanaModel>({ endpoint: '/api/1.0/workspaces', params: { limit: 100 }, retries: 10 })) {
+        for (const workspace of workspaces) {
+            for await (const projects of nango.paginate<BaseAsanaModel>({
+                endpoint: '/api/1.0/projects',
+                params: { workspace: workspace.gid, limit: 100 },
+                retries: 10
+            })) {
+                for (const project of projects) {
+                    const params: Record<string, string> = {
+                        project: project.gid,
+                        limit: '100',
+                        opt_fields: [
+                            'name',
+                            'resource_type',
+                            'completed',
+                            'due_on',
+                            'permalink_url',
+                            'name',
+                            'notes',
+                            'created_at',
+                            'modified_at',
+                            'assignee.name',
+                            'assignee.email',
+                            'assignee.photo'
+                        ].join(',')
+                    };
 
-    // Get all tasks for the project
-    const filters = {
-        project: project.gid,
-        opt_fields: 'name,completed,created_at,modified_at'
-    };
-    const tasks = await paginate(nango, '/api/1.0/tasks', filters);
-    let mappedTasks: AsanaTask[] = [];
-    for (const task of tasks) {
-        mappedTasks.push({
-            id: task.gid,
-            project_id: project.gid,
-            name: task.name,
-            completed: task.completed,
-            created_at: task.created_at,
-            modified_at: task.modified_at
-        });
-
-        if (mappedTasks.length > 49) {
-            await nango.batchSave(mappedTasks, 'AsanaTask');
-            mappedTasks = [];
-        }
-    }
-    await nango.batchSave(mappedTasks, 'AsanaTask');
-}
-
-async function paginate(nango: NangoSync, endpoint: string, queryParams?: Record<string, string | string[]>) {
-    const MAX_PAGE = 100;
-    let results: any[] = [];
-    let page = null;
-    const callParams = queryParams || {};
-    while (true) {
-        if (page) {
-            callParams['offset'] = `${page}`;
-        }
-
-        const resp = await nango.get({
-            endpoint: endpoint,
-            params: {
-                limit: `${MAX_PAGE}`,
-                ...callParams
+                    if (lastSyncDate) {
+                        params['modified_since'] = lastSyncDate.toISOString();
+                    }
+                    for await (const tasks of nango.paginate<AsanaTask>({ endpoint: '/api/1.0/tasks', params, retries: 10 })) {
+                        const normalizedTasks = tasks.map((task) => {
+                            return {
+                                ...toTask(task),
+                                assignee: task.assignee ? toUser(task.assignee) : null
+                            };
+                        });
+                        await nango.batchSave<Task>(normalizedTasks, 'Task');
+                    }
+                }
             }
-        });
-
-        results = results.concat(resp.data.data);
-
-        if (resp.data.next_page) {
-            page = resp.data.next_page.offset;
-        } else {
-            break;
         }
     }
-
-    return results;
 }

--- a/integration-templates/asana/syncs/tasks.ts
+++ b/integration-templates/asana/syncs/tasks.ts
@@ -1,8 +1,6 @@
 import type { NangoSync, BaseAsanaModel, AsanaTask, Task } from '../../models';
-// eslint-disable-next-line import/extensions
-import { toUser } from '../mappers/to-user';
-// eslint-disable-next-line import/extensions
-import { toTask } from '../mappers/to-task';
+import { toUser } from '../mappers/to-user.js';
+import { toTask } from '../mappers/to-task.js';
 
 export default async function fetchData(nango: NangoSync): Promise<void> {
     const lastSyncDate = nango.lastSyncDate;

--- a/integration-templates/asana/syncs/users.ts
+++ b/integration-templates/asana/syncs/users.ts
@@ -1,0 +1,32 @@
+import type { NangoSync, AsanaWorkspace, AsanaUser, User } from '../../models';
+// eslint-disable-next-line import/extensions
+import { toUser } from '../mappers/to-user';
+
+export default async function fetchData(nango: NangoSync): Promise<void> {
+    for await (const workspaces of nango.paginate<AsanaWorkspace>({
+        endpoint: '/api/1.0/workspaces',
+        params: {
+            limit: 100,
+            // NOTE: if we sync organizations and workspaces it is possible we get
+            // duplicate users
+            opt_fields: ['is_organization', 'name'].join(',')
+        },
+        retries: 10
+    })) {
+        for (const workspace of workspaces) {
+            // can't do a lookup of the protected "Personal Projects" workspace
+            if (workspace.name !== 'Personal Projects') {
+                const params: Record<string, string> = {
+                    workspace: workspace.gid,
+                    limit: '100',
+                    opt_fields: ['gid', 'name', 'email', 'photo', 'resource_type'].join(',')
+                };
+                for await (const users of nango.paginate<AsanaUser>({ endpoint: '/api/1.0/users', params, retries: 10 })) {
+                    const normalizedUsers = users.map((user) => toUser(user));
+
+                    await nango.batchSave<User>(normalizedUsers, 'User');
+                }
+            }
+        }
+    }
+}

--- a/integration-templates/asana/syncs/users.ts
+++ b/integration-templates/asana/syncs/users.ts
@@ -1,6 +1,5 @@
 import type { NangoSync, AsanaWorkspace, AsanaUser, User } from '../../models';
-// eslint-disable-next-line import/extensions
-import { toUser } from '../mappers/to-user';
+import { toUser } from '../mappers/to-user.js';
 
 export default async function fetchData(nango: NangoSync): Promise<void> {
     for await (const workspaces of nango.paginate<AsanaWorkspace>({

--- a/integration-templates/asana/syncs/workspaces.ts
+++ b/integration-templates/asana/syncs/workspaces.ts
@@ -1,0 +1,18 @@
+import type { NangoSync, AsanaWorkspace } from '../../models';
+
+export default async function fetchData(nango: NangoSync): Promise<void> {
+    const params: Record<string, string> = {
+        limit: '100',
+        opt_fields: ['gid', 'name', 'resource_type', 'is_organization'].join(',')
+    };
+
+    for await (const workspaces of nango.paginate<AsanaWorkspace>({ endpoint: '/api/1.0/workspaces', params, retries: 10 })) {
+        const workspacesWithId = workspaces.map((workspace) => {
+            return {
+                ...workspace,
+                id: workspace.gid
+            };
+        });
+        await nango.batchSave<AsanaWorkspace>(workspacesWithId, 'AsanaWorkspace');
+    }
+}

--- a/packages/cli/lib/services/compile.service.ts
+++ b/packages/cli/lib/services/compile.service.ts
@@ -151,7 +151,8 @@ function compileImportedFile({
 
     for (const importedFile of importedFiles) {
         const importedFilePath = path.resolve(path.dirname(filePath), importedFile);
-        const importedFilePathWithExtension = importedFilePath + '.ts';
+        const importedFilePathWithoutExtension = path.join(path.dirname(importedFilePath), path.basename(importedFilePath, path.extname(importedFilePath)));
+        const importedFilePathWithExtension = importedFilePathWithoutExtension + '.ts';
 
         /// if it is a library import then we can skip it
         if (!fs.existsSync(importedFilePathWithExtension)) {
@@ -186,7 +187,7 @@ function compileImportedFile({
         compiler.compile(fs.readFileSync(importedFilePathWithExtension, 'utf8'), importedFilePathWithExtension);
         console.log(chalk.green(`Compiled "${importedFilePathWithExtension}" successfully`));
 
-        finalResult = compileImportedFile({ fullPath, filePath: importedFilePath + '.ts', compiler, type, modelNames });
+        finalResult = compileImportedFile({ fullPath, filePath: importedFilePathWithExtension, compiler, type, modelNames });
     }
 
     return finalResult;

--- a/packages/shared/flows.yaml
+++ b/packages/shared/flows.yaml
@@ -19,23 +19,118 @@ integrations:
     asana:
         syncs:
             tasks:
-                runs: every 30min
+                runs: every hour
+                description: Retrieve all tasks that exist in the workspace
+                output: Task
+                endpoint: GET /ticketing/tasks
+                sync_type: incremental
+            users:
+                runs: every hour
+                description: Retrieve all users that exist in the workspace
+                output: User
+                endpoint: GET ticketing/users
+                sync_type: incremental
+            workspaces:
+                runs: every hour
+                description: Retrieve all workspaces for a user
+                output: AsanaWorkspace
+                endpoint: GET ticketing/workspaces
+            projects:
+                runs: every hour
+                description: Retrieves all projects for a user
+                output: AsanaProject
+                endpoint: GET ticketing/projects
+        actions:
+            fetch-workspaces:
+                description: >-
+                    Fetch the workspaces with a limit (default 10) of a user to allow them
+                    to selection of projects to sync
+                endpoint: GET ticketing/workspaces/limit
+                output: BaseAsanaModel[]
+                input: Limit
+            fetch-projects:
+                description: >-
+                    Fetch the projects with a limit (default 10) given a workspace of a
+                    user to allow selection when choosing the tasks to sync.
+                endpoint: GET ticketing/projects/limit
+                output: BaseAsanaModel[]
+                input: AsanaProjectInput
+            create-task:
+                input: CreateAsanaTask
+                endpoint: POST ticketing/task
+                output: Task
                 description: >
-                    Fetches a list of tasks from Asana, retrieving tasks from only the
-                    first project of the first workspace
-                scopes:
-                    - default
+                    Create a task using Asana specific fields and return a unified model
+                    task. See https://developers.asana.com/reference/createtask for Asana
+                    specific fields
+            update-task:
+                description: Update a task and be able to assign the task to a specific user
+                input: AsanaUpdateTask
+                endpoint: PATCH ticketing/task
                 output: AsanaTask
-                sync_type: full
-                endpoint: /asana/tasks
+            delete-task:
+                input: Id
+                endpoint: DELETE ticketing/task
+                output: boolean
         models:
-            AsanaTask:
+            Id:
                 id: string
-                project_id: string
+            Timestamps:
+                created_at: string | null
+                modified_at: string | null
+            NangoActionError:
+                type: validation_error | generic_error
+                message: string
+            BaseAsanaModel:
+                gid: string
+                resource_type: string
                 name: string
-                completed: boolean
-                created_at: date
-                modified_at: date
+            Limit:
+                limit: number | undefined
+            User:
+                created_at: string | null
+                modified_at: string | null
+            Task:
+                created_at: string | null
+                modified_at: string | null
+            AsanaProjectInput:
+                limit: number | undefined
+            CreateAsanaTask:
+                name: string
+                workspace: string | undefined
+                parent: string | undefined
+                projects: string[] | undefined
+            AsanaTask: {}
+            AsanaPhoto:
+                image_1024x1024: string
+                image_128x128: string
+                image_21x21: string
+                image_27x27: string
+                image_36x36: string
+                image_60x60: string
+            AsanaUser:
+                gid: string
+                resource_type: string
+                name: string
+            AsanaUpdateTask:
+                id: string
+                due_at: string | undefined
+                due_on: string | undefined
+                completed: boolean | undefined
+                notes: string | undefined
+                projects: string[] | undefined
+                assignee: string | undefined
+                parent: string | undefined
+                tags: string[] | undefined
+                workspace: string | undefined
+            AsanaWorkspace:
+                gid: string
+                resource_type: string
+                name: string
+            AsanaProject:
+                gid: string
+                resource_type: string
+                name: string
     ashby:
         syncs:
             candidates:

--- a/packages/shared/lib/services/flow.service.unit.test.ts
+++ b/packages/shared/lib/services/flow.service.unit.test.ts
@@ -157,28 +157,6 @@ describe('Flow service tests', () => {
         expect(flows).not.toStrictEqual({});
         expect(flows).toHaveProperty('integrations');
         expect(Object.keys(flows.integrations).length).toBeGreaterThan(20);
-        expect(flows.integrations['asana']).toStrictEqual({
-            models: {
-                AsanaTask: {
-                    completed: 'boolean',
-                    created_at: 'date',
-                    id: 'string',
-                    modified_at: 'date',
-                    name: 'string',
-                    project_id: 'string'
-                }
-            },
-            syncs: {
-                tasks: {
-                    description: `Fetches a list of tasks from Asana, retrieving tasks from only the first project of the first workspace
-`,
-                    endpoint: '/asana/tasks',
-                    output: 'AsanaTask',
-                    runs: 'every 30min',
-                    scopes: ['default'],
-                    sync_type: 'full'
-                }
-            }
-        });
+        expect(flows.integrations).toHaveProperty('github');
     });
 });

--- a/packages/shared/lib/services/flow.service.unit.test.ts
+++ b/packages/shared/lib/services/flow.service.unit.test.ts
@@ -158,5 +158,28 @@ describe('Flow service tests', () => {
         expect(flows).toHaveProperty('integrations');
         expect(Object.keys(flows.integrations).length).toBeGreaterThan(20);
         expect(flows.integrations).toHaveProperty('github');
+        expect(flows.integrations['algolia']).toStrictEqual({
+            models: {
+                AlgoliaContact: {
+                    createdAt: 'date',
+                    taskID: 'number',
+                    objectID: 'string'
+                },
+                AlgoliaCreateContactInput: {
+                    name: 'string',
+                    company: 'string',
+                    email: 'string'
+                }
+            },
+            actions: {
+                'create-contacts': {
+                    description: `Action to add a single record contact to an index
+`,
+                    output: 'AlgoliaContact',
+                    input: 'AlgoliaCreateContactInput',
+                    endpoint: 'POST /algolia/create-contacts'
+                }
+            }
+        });
     });
 });


### PR DESCRIPTION
## Describe your changes
Add asana templates with a unified `Task` and `User` model

Since the compile file is what gets copied over to a specific users integrations, even if it uses relative imports it still should _just work_. Needs confirmation.

## Issue ticket number and link
NAN-1187

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
