### PR TITLE
fix: remove orchestrator event emmitter max listeners limit

### DIFF
--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -32,6 +32,11 @@ try {
         on: eventsHandler.onCallbacks
     });
 
+    // default max listerner is 10
+    // but we need more listeners
+    // each processor fetching from a group_key adds a listerner for the long-polling dequeue
+    eventsHandler.setMaxListeners(Infinity);
+
     const server = getServer(scheduler, eventsHandler);
     const port = envs.NANGO_ORCHESTRATOR_PORT;
     server.listen(port, () => {


### PR DESCRIPTION
EventEmmitter max listeners default limit is 10.
In our case each processor dequeuing for a given group_key adds a listener so we need the limit to be higher.

I know each listener is adding performance and memory overheard but for now orchestrator runs on half a gig memory machine and using less than 30% of memory so we have some margin

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
