### PR TITLE
fix: remove schedule_id column in schedules

### DIFF
--- a/packages/scheduler/lib/db/migrations/20240614161301_remove_schedules_schedule_id.ts
+++ b/packages/scheduler/lib/db/migrations/20240614161301_remove_schedules_schedule_id.ts
@@ -1,0 +1,16 @@
+import type { Knex } from 'knex';
+import { SCHEDULES_TABLE } from '../../models/schedules.js';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`
+        ALTER TABLE ${SCHEDULES_TABLE}
+        DROP COLUMN IF EXISTS schedule_id;
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`
+        ALTER TABLE ${SCHEDULES_TABLE}
+        ADD COLUMN IF NOT EXISTS schedule_id integer uuid;
+    `);
+}


### PR DESCRIPTION
No idea why I added a `schedule_id` column in https://github.com/NangoHQ/nango/blob/master/packages/scheduler/lib/db/migrations/20240605205506_schedules_index.ts#L12
Maybe bad copy-pasting :(
