### PR TITLE
chore: prevents two scheduling workers to run at the same time

### DIFF
--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -18,7 +18,6 @@ try {
     const dbClient = new DatabaseClient({ url: databaseUrl, schema: databaseSchema });
     await dbClient.migrate();
 
-    // TODO: add logic to update syncs and syncs jobs in the database
     const eventsHandler = new EventsHandler({
         CREATED: (task: Task) => logger.info(`Task created: ${stringifyTask(task)}`),
         STARTED: (task: Task) => logger.info(`Task started: ${stringifyTask(task)}`),
@@ -41,6 +40,11 @@ try {
     const port = envs.NANGO_ORCHESTRATOR_PORT;
     server.listen(port, () => {
         logger.info(`🚀 Orchestrator API ready at http://localhost:${port}`);
+    });
+
+    // handle SIGTERM
+    process.on('SIGTERM', () => {
+        scheduler.stop();
     });
 } catch (err) {
     logger.error(`Orchestrator API error: ${stringifyError(err)}`);

--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -6,6 +6,7 @@ import { OrchestratorClient } from './client.js';
 import getPort from 'get-port';
 import { EventsHandler } from '../events.js';
 import { nanoid } from '@nangohq/utils';
+import { setTimeout } from 'timers/promises';
 
 const dbClient = getTestDbClient();
 const eventsHandler = new EventsHandler({
@@ -33,6 +34,7 @@ describe('OrchestratorClient', async () => {
 
     afterAll(async () => {
         scheduler.stop();
+        await setTimeout(1000); // waiting for the scheduler to stop
         await dbClient.clearDatabase();
     });
 

--- a/packages/orchestrator/lib/clients/processor.integration.test.ts
+++ b/packages/orchestrator/lib/clients/processor.integration.test.ts
@@ -37,6 +37,7 @@ describe('OrchestratorProcessor', async () => {
 
     afterAll(async () => {
         scheduler.stop();
+        await new Promise((resolve) => setTimeout(resolve, 1000));
         await dbClient.clearDatabase();
     });
 

--- a/packages/scheduler/lib/db/migrations/20240617171503_leader_lock_table.ts
+++ b/packages/scheduler/lib/db/migrations/20240617171503_leader_lock_table.ts
@@ -1,0 +1,18 @@
+import type { Knex } from 'knex';
+import { LEADER_LOCKS_TABLE } from '../../workers/leader.election.js';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`
+        CREATE TABLE IF NOT EXISTS ${LEADER_LOCKS_TABLE} (
+            key varchar(255) PRIMARY KEY,
+            node_id varchar(255) NOT NULL,
+            acquired_at timestamp with time zone NOT NULL
+        );
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`
+        DROP TABLE IF EXISTS ${LEADER_LOCKS_TABLE};
+    `);
+}

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -34,6 +34,7 @@ describe('Scheduler', () => {
 
     afterAll(async () => {
         scheduler.stop();
+        await new Promise((resolve) => setTimeout(resolve, 1000));
         await dbClient.clearDatabase();
     });
 

--- a/packages/scheduler/lib/workers/leader.election.integration.test.ts
+++ b/packages/scheduler/lib/workers/leader.election.integration.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getTestDbClient } from '../db/helpers.test';
+import { LeaderElection } from './leader.election.js';
+import { setTimeout } from 'node:timers/promises';
+
+describe('Election leader', () => {
+    const dbClient = getTestDbClient();
+    const db = dbClient.db;
+    const leaseTimeoutMs = 500;
+    const leaderElection = new LeaderElection({
+        db,
+        leaseTimeoutMs,
+        leaderKey: 'test'
+    });
+
+    beforeEach(async () => {
+        await dbClient.migrate();
+    });
+
+    afterEach(async () => {
+        await dbClient.clearDatabase();
+    });
+
+    it('should not acquire leadership if already a leader', async () => {
+        const res = await leaderElection.elect('node1');
+        expect(res.isOk()).toBe(true);
+
+        const res2 = await leaderElection.elect('node2');
+        expect(res2.isErr()).toBe(true);
+    });
+    it('should acquire leadership if previous leader releases the leadership', async () => {
+        const res = await leaderElection.elect('node1');
+        expect(res.isOk()).toBe(true);
+
+        // first attempt to acquire leadership should fail
+        const res2 = await leaderElection.elect('node2');
+        expect(res2.isErr()).toBe(true);
+
+        // release leadership
+        await leaderElection.release('node1');
+
+        const res3 = await leaderElection.elect('node2');
+        expect(res3.isOk()).toBe(true);
+    });
+    it('should acquire leadership if previous leader did not renew', async () => {
+        const res = await leaderElection.elect('node1');
+        expect(res.isOk()).toBe(true);
+
+        // first attempt to acquire leadership should fail
+        const res2 = await leaderElection.elect('node2');
+        expect(res2.isErr()).toBe(true);
+
+        // wait for lease to expire
+        await setTimeout(leaseTimeoutMs);
+
+        const res3 = await leaderElection.elect('node2');
+        expect(res3.isOk()).toBe(true);
+    });
+    it('should acquire leadership if already leader', async () => {
+        const res = await leaderElection.elect('node1');
+        expect(res.isOk()).toBe(true);
+
+        const res2 = await leaderElection.elect('node1');
+        expect(res2.isOk()).toBe(true);
+    });
+});

--- a/packages/scheduler/lib/workers/leader.election.ts
+++ b/packages/scheduler/lib/workers/leader.election.ts
@@ -1,0 +1,46 @@
+import type knex from 'knex';
+import { Err, Ok } from '@nangohq/utils';
+import type { Result } from '@nangohq/utils';
+
+export const LEADER_LOCKS_TABLE = 'leader_locks';
+
+export class LeaderElection {
+    private readonly db: knex.Knex;
+    private readonly leaderKey: string;
+    public readonly leaseTimeoutMs: number;
+
+    constructor({ db, leaderKey, leaseTimeoutMs }: { db: knex.Knex; leaderKey: string; leaseTimeoutMs: number }) {
+        this.db = db;
+        this.leaderKey = leaderKey;
+        this.leaseTimeoutMs = leaseTimeoutMs;
+    }
+
+    private async acquire(nodeId: string): Promise<boolean> {
+        // we use a single row table to store the leader lock
+        // if no row exists, we insert a new row with the current node as the leader
+        // if the current leader has not renewed its lease in time, we take over
+        // if the current leader is the same as the node trying to acquire leadership, we renew the lease
+        const res = await this.db
+            .insert({
+                key: this.leaderKey,
+                node_id: nodeId,
+                acquired_at: this.db.fn.now()
+            })
+            .into(LEADER_LOCKS_TABLE)
+            .onConflict('key')
+            .merge(['node_id', 'acquired_at'])
+            .where(`${LEADER_LOCKS_TABLE}.acquired_at`, '<', this.db.raw(`CURRENT_TIMESTAMP - INTERVAL '${this.leaseTimeoutMs} milliseconds'`))
+            .orWhere(`${LEADER_LOCKS_TABLE}.node_id`, '=', nodeId)
+            .returning('*');
+        return res.length > 0;
+    }
+
+    public async release(nodeId: string): Promise<void> {
+        await this.db.from(LEADER_LOCKS_TABLE).where('key', this.leaderKey).andWhere('node_id', nodeId).delete();
+    }
+
+    public async elect(nodeId: string): Promise<Result<void>> {
+        const acquired = await this.acquire(nodeId);
+        return acquired ? Ok(undefined) : Err(new Error(`Node ${nodeId} failed to acquire leadership.`));
+    }
+}


### PR DESCRIPTION
I thought I will be able to get away with implementing a mechanism to prevent two scheduling workers to run at the same time because we for now have a single instance of the orchestrator but in fact during deployment there is a short period where there are more than one instance running.

Having more than one scheduling workers at the same time might have unexpected consequences and race conditions.
This commit implements a simple distributed leader election backed by postgres to ensure there is never more than one scheduling worker running at once. 
A worker can acquire a lease by inserting a row in the db. Any other worker will see its lease acquisition fail. Then the mechanism relies on one assumption: the leader always renew its lease before it expires.
While the lease is valid only the current leader can renew it. Other workers can try to be elected leader, it will only be successful if the lease has expired.

## Issue ticket number and link

first part of https://linear.app/nango/issue/NAN-1230/orchestrator-support-multiple-instances

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
