### PR TITLE
chore: prevent concurrent scheduling

### DIFF
--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -42,6 +42,11 @@ try {
     server.listen(port, () => {
         logger.info(`🚀 Orchestrator API ready at http://localhost:${port}`);
     });
+
+    // handle SIGTERM
+    process.on('SIGTERM', () => {
+        scheduler.stop();
+    });
 } catch (err) {
     logger.error(`Orchestrator API error: ${stringifyError(err)}`);
     process.exit(1);


### PR DESCRIPTION
Replaces https://github.com/NangoHQ/nango/pull/2352

Having more than one worker scheduling tasks at the same time might have unexpected consequences and race conditions.
This commit implements a lock around the scheduling transaction to ensure no concurrent scheduling

