### PR TITLE
fix(logs): insert message without an ID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34656,7 +34656,20 @@
             "version": "0.40.2",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "devDependencies": {
-                "axios": "^1.3.4"
+                "axios": "^1.3.4",
+                "type-fest": "4.14.0"
+            }
+        },
+        "packages/types/node_modules/type-fest": {
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.14.0.tgz",
+            "integrity": "sha512-on5/Cw89wwqGZQu+yWO0gGMGu8VNxsaW9SB2HE8yJjllEk7IDTwnSN1dUVldYILhYPN5HzD7WAaw2cc/jBfn0Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "packages/utils": {

--- a/packages/logs/lib/client.integration.test.ts
+++ b/packages/logs/lib/client.integration.test.ts
@@ -38,7 +38,7 @@ describe('client', () => {
     });
 
     it('should insert an operation', async () => {
-        const spy = vi.spyOn(model, 'createMessage');
+        const spy = vi.spyOn(model, 'createOperation');
         const ctx = await logContextGetter.create(operationPayload, { start: false, account, environment }, { logToConsole: false });
         expect(ctx).toMatchObject({ id: expect.any(String) });
         expect(spy).toHaveBeenCalled();

--- a/packages/logs/lib/client.ts
+++ b/packages/logs/lib/client.ts
@@ -14,11 +14,11 @@ interface Options {
  * Context without operation (stateless)
  */
 export class LogContextStateless {
-    id: string;
+    id: OperationRow['id'];
     dryRun: boolean;
     logToConsole: boolean;
 
-    constructor(data: { parentId: string }, options: Options = { dryRun: false, logToConsole: true }) {
+    constructor(data: { parentId: OperationRow['id'] }, options: Options = { dryRun: false, logToConsole: true }) {
         this.id = data.parentId;
         this.dryRun = isCli || !envs.NANGO_LOGS_ENABLED ? true : options.dryRun || false;
         this.logToConsole = options.logToConsole ?? true;

--- a/packages/logs/lib/es/index.integration.test.ts
+++ b/packages/logs/lib/es/index.integration.test.ts
@@ -3,8 +3,8 @@ import { deleteIndex, migrateMapping } from './helpers.js';
 import { client } from './client.js';
 import { indexMessages } from './schema.js';
 import { nanoid } from '@nangohq/utils';
-import { createMessage, getOperation, update } from '../models/messages.js';
-import { getFormattedMessage } from '../models/helpers.js';
+import { createOperation, getOperation, update } from '../models/messages.js';
+import { getFormattedOperation } from '../models/helpers.js';
 
 // This file is sequential
 describe('mapping', () => {
@@ -36,7 +36,7 @@ describe('mapping', () => {
         const today = new Date();
         // Log to automatically create an index
         const id = nanoid();
-        await createMessage(getFormattedMessage({ id, message: 'hello', operation: { type: 'action' }, createdAt: today.toISOString() }));
+        await createOperation(getFormattedOperation({ id, message: 'hello', operation: { type: 'action' }, createdAt: today.toISOString() }));
         await update({ id, data: { state: 'failed', createdAt: today.toISOString() } });
 
         // Should have created a today index
@@ -56,7 +56,7 @@ describe('mapping', () => {
 
         // Log to automatically create an index
         const id = nanoid();
-        await createMessage(getFormattedMessage({ id, message: 'hello', operation: { type: 'action' }, createdAt: yesterday.toISOString() }));
+        await createOperation(getFormattedOperation({ id, message: 'hello', operation: { type: 'action' }, createdAt: yesterday.toISOString() }));
         await update({ id, data: { state: 'failed', createdAt: yesterday.toISOString() } });
 
         // Should have created a yesterday index

--- a/packages/logs/lib/models/helpers.ts
+++ b/packages/logs/lib/models/helpers.ts
@@ -1,5 +1,5 @@
 import { nanoid } from '@nangohq/utils';
-import type { MessageRow } from '@nangohq/types';
+import type { MessageRow, OperationRow, OperationRowInsert } from '@nangohq/types';
 import { z } from 'zod';
 import type { estypes } from '@elastic/elasticsearch';
 import { defaultOperationExpiration } from '../env.js';
@@ -16,25 +16,17 @@ export interface FormatMessageData {
     meta?: MessageRow['meta'];
 }
 
-export function getFormattedMessage(
-    data: Partial<MessageRow>,
+export function getFormattedOperation(
+    data: OperationRowInsert,
     { account, user, environment, integration, connection, syncConfig, meta }: FormatMessageData = {}
-): MessageRow {
-    const now = new Date();
+): OperationRow {
     return {
+        ...getFormattedMessage(data as unknown as MessageRow),
         id: data.id || nanoid(),
+        operation: data.operation,
 
-        source: data.source || 'internal',
-        level: data.level || 'info',
-        operation: data.operation || null,
-        type: data.type || 'log',
-        message: data.message || '',
-        title: data.title || null,
-        code: data.code || null,
-        state: data.state || 'waiting',
-
-        accountId: account?.id ?? data.accountId ?? null,
-        accountName: account?.name || data.accountName || null,
+        accountId: account?.id ?? data.accountId ?? -1,
+        accountName: account?.name || data.accountName || '',
 
         environmentId: environment?.id ?? data.environmentId ?? null,
         environmentName: environment?.name || data.environmentName || null,
@@ -50,8 +42,45 @@ export function getFormattedMessage(
         syncConfigName: syncConfig?.name || data.syncConfigName || null,
 
         jobId: data.jobId || null,
+        meta: meta || data.meta || null,
 
         userId: user?.id || data.userId || null,
+        parentId: null
+    };
+}
+export function getFormattedMessage(data: Partial<MessageRow>, { meta }: FormatMessageData = {}): MessageRow {
+    const now = new Date();
+    return {
+        id: data.id || data.operation ? nanoid() : null,
+
+        source: data.source || 'internal',
+        level: data.level || 'info',
+        operation: data.operation || null,
+        type: data.type || 'log',
+        message: data.message || '',
+        title: data.title || null,
+        code: data.code || null,
+        state: data.state || 'waiting',
+
+        accountId: null,
+        accountName: null,
+
+        environmentId: null,
+        environmentName: null,
+
+        integrationId: null,
+        integrationName: null,
+        providerName: null,
+
+        connectionId: null,
+        connectionName: null,
+
+        syncConfigId: null,
+        syncConfigName: null,
+
+        jobId: data.jobId || null,
+
+        userId: null,
         parentId: data.parentId || null,
 
         error: data.error || null,

--- a/packages/logs/lib/models/helpers.ts
+++ b/packages/logs/lib/models/helpers.ts
@@ -51,7 +51,7 @@ export function getFormattedOperation(
 export function getFormattedMessage(data: Partial<MessageRow>, { meta }: FormatMessageData = {}): MessageRow {
     const now = new Date();
     return {
-        id: data.id || data.operation ? nanoid() : null,
+        id: data.id || nanoid(), // This ID is for debugging purpose, not for insertion
 
         source: data.source || 'internal',
         level: data.level || 'info',

--- a/packages/logs/lib/models/logContextGetter.ts
+++ b/packages/logs/lib/models/logContextGetter.ts
@@ -53,7 +53,7 @@ export const logContextGetter = {
     /**
      * Return a Context without creating an operation
      */
-    async get({ id }: { id: string }, options?: Options): Promise<LogContext> {
+    async get({ id }: { id: OperationRow['id'] }, options?: Options): Promise<LogContext> {
         try {
             if (envs.NANGO_LOGS_ENABLED) {
                 const store = await getKVStore();
@@ -71,7 +71,7 @@ export const logContextGetter = {
         return new LogContext({ parentId: id, operation: { id: nanoid(), createdAt: new Date().toISOString() } as OperationRow }, { ...options, dryRun: true });
     },
 
-    getStateLess({ id }: { id: string }, options?: Options): LogContextStateless {
+    getStateLess({ id }: { id: OperationRow['id'] }, options?: Options): LogContextStateless {
         return new LogContextStateless({ parentId: id }, options);
     }
 };

--- a/packages/logs/lib/models/logContextGetter.ts
+++ b/packages/logs/lib/models/logContextGetter.ts
@@ -1,12 +1,12 @@
 import { nanoid, stringifyError } from '@nangohq/utils';
 import type { SetRequired } from 'type-fest';
-import { createMessage, getOperation } from './messages.js';
+import { createOperation, getOperation } from './messages.js';
 import { envs } from '../env.js';
 import type { FormatMessageData } from './helpers.js';
-import { getFormattedMessage } from './helpers.js';
+import { getFormattedOperation } from './helpers.js';
 import { LogContext, LogContextStateless } from '../client.js';
 import { getKVStore, logger } from '../utils.js';
-import type { MessageRow, OperationRow, OperationRowInsert } from '@nangohq/types';
+import type { OperationRow, OperationRowInsert } from '@nangohq/types';
 
 interface Options {
     dryRun?: boolean;
@@ -28,7 +28,7 @@ export const logContextGetter = {
         { start, ...rest }: SetRequired<OperationContextData, 'account' | 'environment'>,
         options?: Options
     ): Promise<LogContext> {
-        const msg = getFormattedMessage(data, rest);
+        const msg = getFormattedOperation(data, rest);
         if (typeof start === 'undefined' || start) {
             msg.startedAt = msg.startedAt ?? new Date().toISOString();
             msg.state = msg.state === 'waiting' ? 'running' : msg.state;
@@ -36,7 +36,7 @@ export const logContextGetter = {
 
         try {
             if (envs.NANGO_LOGS_ENABLED && !options?.dryRun) {
-                const res = await createMessage(msg);
+                const res = await createOperation(msg);
                 const store = await getKVStore();
                 await store.set(`es:operation:${msg.id}:indexName`, res.index, { ttlInMs: 60 * 1000 });
             } else if (options?.logToConsole !== false) {
@@ -53,7 +53,7 @@ export const logContextGetter = {
     /**
      * Return a Context without creating an operation
      */
-    async get({ id }: { id: MessageRow['id'] }, options?: Options): Promise<LogContext> {
+    async get({ id }: { id: string }, options?: Options): Promise<LogContext> {
         try {
             if (envs.NANGO_LOGS_ENABLED) {
                 const store = await getKVStore();
@@ -71,7 +71,7 @@ export const logContextGetter = {
         return new LogContext({ parentId: id, operation: { id: nanoid(), createdAt: new Date().toISOString() } as OperationRow }, { ...options, dryRun: true });
     },
 
-    getStateLess({ id }: { id: MessageRow['id'] }, options?: Options): LogContextStateless {
+    getStateLess({ id }: { id: string }, options?: Options): LogContextStateless {
         return new LogContextStateless({ parentId: id }, options);
     }
 };

--- a/packages/logs/lib/models/messages.integration.test.ts
+++ b/packages/logs/lib/models/messages.integration.test.ts
@@ -5,7 +5,7 @@ import { getOperation, listOperations, listMessages, setTimeoutForAll } from './
 import { afterEach } from 'node:test';
 import { logContextGetter } from './logContextGetter.js';
 import type { OperationRowInsert } from '@nangohq/types';
-import { getFormattedMessage } from './helpers.js';
+import { getFormattedOperation } from './helpers.js';
 import { indexMessages } from '../es/schema.js';
 
 const account = { id: 1234, name: 'test' };
@@ -58,12 +58,12 @@ describe('model', () => {
 
         it('should timeout old operations', async () => {
             const ctx1 = await logContextGetter.create(
-                getFormattedMessage({ ...operationPayload, expiresAt: new Date(Date.now() - 86400 * 1000).toISOString() }),
+                getFormattedOperation({ ...operationPayload, expiresAt: new Date(Date.now() - 86400 * 1000).toISOString() }),
                 { account, environment },
                 { logToConsole: false }
             );
             const ctx2 = await logContextGetter.create(
-                getFormattedMessage({ ...operationPayload, expiresAt: new Date(Date.now() + 86400 * 1000).toISOString() }),
+                getFormattedOperation({ ...operationPayload, expiresAt: new Date(Date.now() + 86400 * 1000).toISOString() }),
                 { account, environment },
                 { logToConsole: false }
             );

--- a/packages/logs/lib/models/messages.ts
+++ b/packages/logs/lib/models/messages.ts
@@ -34,14 +34,29 @@ export interface ListFilters {
 export const ResponseError = errors.ResponseError;
 
 /**
- * Create one message
+ * Create one operation
  */
-export async function createMessage(row: MessageRow): Promise<{ index: string }> {
-    const res = await client.create<MessageRow>({
+export async function createOperation(row: OperationRow): Promise<{ index: string }> {
+    const res = await client.create<OperationRow>({
         index: indexMessages.index,
         id: row.id,
         document: row,
-        refresh: row.operation ? true : isTest,
+        refresh: true,
+        pipeline: `daily.${indexMessages.index}`
+    });
+    return { index: res._index };
+}
+
+/**
+ * Create one message
+ * /!\ it's inserted without an ID to improve indexing time
+ * https://www.elastic.co/guide/en/elasticsearch/reference/current/tune-for-indexing-speed.html#_use_auto_generated_ids
+ */
+export async function createMessage(row: MessageRow): Promise<{ index: string }> {
+    const res = await client.index<MessageRow>({
+        index: indexMessages.index,
+        document: row,
+        refresh: isTest,
         pipeline: `daily.${indexMessages.index}`
     });
     return { index: res._index };
@@ -162,7 +177,7 @@ export async function listOperations(opts: {
 /**
  * Get a single operation
  */
-export async function getOperation(opts: { id: MessageRow['id']; indexName?: string | null }): Promise<MessageRow> {
+export async function getOperation(opts: { id: string; indexName?: string | null }): Promise<OperationRow> {
     if (opts.indexName) {
         const res = await client.get<OperationRow>({ index: opts.indexName, id: opts.id });
         return res._source!;
@@ -185,7 +200,7 @@ export async function getOperation(opts: { id: MessageRow['id']; indexName?: str
 /**
  * Update a row (can be a partial update)
  */
-export async function update(opts: { id: MessageRow['id']; data: SetRequired<Partial<Omit<MessageRow, 'id'>>, 'createdAt'> }): Promise<void> {
+export async function update(opts: { id: string; data: SetRequired<Partial<Omit<MessageRow, 'id'>>, 'createdAt'> }): Promise<void> {
     await client.update({
         index: getFullIndexName(indexMessages.index, opts.data.createdAt),
         id: opts.id,
@@ -199,38 +214,39 @@ export async function update(opts: { id: MessageRow['id']; data: SetRequired<Par
     });
 }
 
+type UpdateProps = { id: string } & Pick<MessageRow, 'createdAt'>;
 /**
  * Set an operation as currently running
  */
-export async function setRunning(opts: Pick<MessageRow, 'id' | 'createdAt'>): Promise<void> {
+export async function setRunning(opts: UpdateProps): Promise<void> {
     await update({ id: opts.id, data: { createdAt: opts.createdAt, state: 'running', startedAt: new Date().toISOString() } });
 }
 
 /**
  * Set an operation as success
  */
-export async function setSuccess(opts: Pick<MessageRow, 'id' | 'createdAt'>): Promise<void> {
+export async function setSuccess(opts: UpdateProps): Promise<void> {
     await update({ id: opts.id, data: { createdAt: opts.createdAt, state: 'success', endedAt: new Date().toISOString() } });
 }
 
 /**
  * Set an operation as failed
  */
-export async function setFailed(opts: Pick<MessageRow, 'id' | 'createdAt'>): Promise<void> {
+export async function setFailed(opts: UpdateProps): Promise<void> {
     await update({ id: opts.id, data: { createdAt: opts.createdAt, state: 'failed', endedAt: new Date().toISOString() } });
 }
 
 /**
  * Set an operation as failed
  */
-export async function setCancelled(opts: Pick<MessageRow, 'id' | 'createdAt'>): Promise<void> {
+export async function setCancelled(opts: UpdateProps): Promise<void> {
     await update({ id: opts.id, data: { createdAt: opts.createdAt, state: 'cancelled', endedAt: new Date().toISOString() } });
 }
 
 /**
  * Set an operation as timeout
  */
-export async function setTimeouted(opts: Pick<MessageRow, 'id' | 'createdAt'>): Promise<void> {
+export async function setTimeouted(opts: UpdateProps): Promise<void> {
     await update({ id: opts.id, data: { createdAt: opts.createdAt, state: 'timeout', endedAt: new Date().toISOString() } });
 }
 

--- a/packages/logs/lib/models/messages.ts
+++ b/packages/logs/lib/models/messages.ts
@@ -49,7 +49,7 @@ export async function createOperation(row: OperationRow): Promise<{ index: strin
 
 /**
  * Create one message
- * /!\ it's inserted without an ID to improve indexing time
+ * /!\ They are inserted without an ID to improve indexing time
  * https://www.elastic.co/guide/en/elasticsearch/reference/current/tune-for-indexing-speed.html#_use_auto_generated_ids
  */
 export async function createMessage(row: MessageRow): Promise<{ index: string }> {
@@ -177,7 +177,7 @@ export async function listOperations(opts: {
 /**
  * Get a single operation
  */
-export async function getOperation(opts: { id: string; indexName?: string | null }): Promise<OperationRow> {
+export async function getOperation(opts: { id: OperationRow['id']; indexName?: string | null }): Promise<OperationRow> {
     if (opts.indexName) {
         const res = await client.get<OperationRow>({ index: opts.indexName, id: opts.id });
         return res._source!;
@@ -200,7 +200,7 @@ export async function getOperation(opts: { id: string; indexName?: string | null
 /**
  * Update a row (can be a partial update)
  */
-export async function update(opts: { id: string; data: SetRequired<Partial<Omit<MessageRow, 'id'>>, 'createdAt'> }): Promise<void> {
+export async function update(opts: { id: OperationRow['id']; data: SetRequired<Partial<Omit<MessageRow, 'id'>>, 'createdAt'> }): Promise<void> {
     await client.update({
         index: getFullIndexName(indexMessages.index, opts.data.createdAt),
         id: opts.id,
@@ -214,39 +214,38 @@ export async function update(opts: { id: string; data: SetRequired<Partial<Omit<
     });
 }
 
-type UpdateProps = { id: string } & Pick<MessageRow, 'createdAt'>;
 /**
  * Set an operation as currently running
  */
-export async function setRunning(opts: UpdateProps): Promise<void> {
+export async function setRunning(opts: Pick<OperationRow, 'id' | 'createdAt'>): Promise<void> {
     await update({ id: opts.id, data: { createdAt: opts.createdAt, state: 'running', startedAt: new Date().toISOString() } });
 }
 
 /**
  * Set an operation as success
  */
-export async function setSuccess(opts: UpdateProps): Promise<void> {
+export async function setSuccess(opts: Pick<OperationRow, 'id' | 'createdAt'>): Promise<void> {
     await update({ id: opts.id, data: { createdAt: opts.createdAt, state: 'success', endedAt: new Date().toISOString() } });
 }
 
 /**
  * Set an operation as failed
  */
-export async function setFailed(opts: UpdateProps): Promise<void> {
+export async function setFailed(opts: Pick<OperationRow, 'id' | 'createdAt'>): Promise<void> {
     await update({ id: opts.id, data: { createdAt: opts.createdAt, state: 'failed', endedAt: new Date().toISOString() } });
 }
 
 /**
  * Set an operation as failed
  */
-export async function setCancelled(opts: UpdateProps): Promise<void> {
+export async function setCancelled(opts: Pick<OperationRow, 'id' | 'createdAt'>): Promise<void> {
     await update({ id: opts.id, data: { createdAt: opts.createdAt, state: 'cancelled', endedAt: new Date().toISOString() } });
 }
 
 /**
  * Set an operation as timeout
  */
-export async function setTimeouted(opts: UpdateProps): Promise<void> {
+export async function setTimeouted(opts: Pick<OperationRow, 'id' | 'createdAt'>): Promise<void> {
     await update({ id: opts.id, data: { createdAt: opts.createdAt, state: 'timeout', endedAt: new Date().toISOString() } });
 }
 

--- a/packages/logs/lib/utils.ts
+++ b/packages/logs/lib/utils.ts
@@ -2,7 +2,7 @@ import { getLogger } from '@nangohq/utils';
 import { createKVStore } from '@nangohq/kvstore';
 import type { KVStore } from '@nangohq/kvstore';
 
-export const logger = getLogger('elasticsearch');
+export const logger = getLogger('logs');
 
 export const isCli = process.argv.find((value) => value.includes('/bin/nango') || value.includes('cli/dist/index'));
 

--- a/packages/types/lib/logs/api.ts
+++ b/packages/types/lib/logs/api.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-redundant-type-constituents */
 import type { Endpoint } from '../api';
-import type { MessageOperation, MessageRow, MessageState, OperationRow } from './messages';
+import type { MessageRow, MessageState, OperationList, OperationRow } from './messages';
 
-type Concat<T extends MessageOperation> = T[keyof T] | (T extends { action: string } ? `${T['type']}:${T['action']}` : never);
+type Concat<T extends OperationList> = T[keyof T] | (T extends { action: string } ? `${T['type']}:${T['action']}` : never);
 
 export type SearchOperations = Endpoint<{
     Method: 'POST';
@@ -24,7 +24,7 @@ export type SearchOperations = Endpoint<{
     };
 }>;
 export type SearchOperationsState = 'all' | MessageState;
-export type SearchOperationsType = 'all' | Concat<MessageOperation>;
+export type SearchOperationsType = 'all' | Concat<OperationList>;
 export type SearchOperationsIntegration = 'all' | string;
 export type SearchOperationsConnection = 'all' | string;
 export type SearchOperationsSync = 'all' | string;

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -1,3 +1,5 @@
+import type { Merge } from 'type-fest';
+
 /**
  * Level of the log and operation
  */
@@ -29,39 +31,39 @@ export type MessageState = 'waiting' | 'running' | 'success' | 'failed' | 'timeo
 /**
  * Operations
  */
-export interface MessageOpSync {
+export interface OperationSync {
     type: 'sync';
     action: 'pause' | 'unpause' | 'run' | 'request_run' | 'request_run_full' | 'cancel' | 'init';
 }
-export interface MessageOpProxy {
+export interface OperationProxy {
     type: 'proxy';
 }
-export interface MessageOpAction {
+export interface OperationAction {
     type: 'action';
 }
-export interface MessageOpAuth {
+export interface OperationAuth {
     type: 'auth';
     action: 'create_connection' | 'refresh_token' | 'post_connection';
 }
-export interface MessageOpAdmin {
+export interface OperationAdmin {
     type: 'admin';
     action: 'impersonation';
 }
-export interface MessageOpWebhook {
+export interface OperationWebhook {
     type: 'webhook';
     action: 'incoming' | 'outgoing';
 }
-export interface MessageOpDeploy {
+export interface OperationDeploy {
     type: 'deploy';
     action: 'prebuilt' | 'custom';
 }
-export type MessageOperation = MessageOpSync | MessageOpProxy | MessageOpAction | MessageOpWebhook | MessageOpDeploy | MessageOpAuth | MessageOpAdmin;
+export type OperationList = OperationSync | OperationProxy | OperationAction | OperationWebhook | OperationDeploy | OperationAuth | OperationAdmin;
 
 /**
  * Full schema
  */
-export type MessageRow = {
-    id: string;
+export interface MessageRow {
+    id: string | null;
 
     // State
     source: 'internal' | 'user';
@@ -71,6 +73,7 @@ export type MessageRow = {
     title: string | null;
     state: MessageState;
     code: MessageCode | null;
+    operation: null;
 
     // Ids
     accountId: number | null;
@@ -123,18 +126,20 @@ export type MessageRow = {
     startedAt: string | null;
     endedAt: string | null;
     expiresAt: string | null;
-} & { operation: MessageOperation | null };
+}
 
 /**
  * What is required to insert a Message
  */
-export type OperationRequired = 'operation' | 'message';
-export type OperationRowInsert = Pick<MessageRow, OperationRequired> & Partial<Omit<MessageRow, OperationRequired>>;
-export type OperationRow = Pick<MessageRow, OperationRequired> & Omit<MessageRow, OperationRequired>;
+export type OperationRowInsert = Merge<Partial<MessageRow>, { message: string; operation: OperationList }>;
+export type OperationRow = Merge<Required<OperationRowInsert>, { id: string; accountId: number; accountName: string }>;
 
 /**
  * What is required to insert a Message
  */
-export type MessageRowInsert = Pick<MessageRow, 'type' | 'message'> & Partial<Omit<MessageRow, 'type' | 'message'>> & { id?: string | undefined };
+export type MessageRowInsert = Pick<MessageRow, 'type' | 'message'> & Partial<Omit<MessageRow, 'type' | 'message'>> & { id?: never };
 
+// Buffer logs inside proxy calls
 export type LogsBuffer = Pick<MessageRow, 'level' | 'message' | 'createdAt'> & Partial<Pick<MessageRow, 'error' | 'meta'>>;
+
+export type MessageOrOperationRow = MessageRow | OperationRow;

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -63,7 +63,7 @@ export type OperationList = OperationSync | OperationProxy | OperationAction | O
  * Full schema
  */
 export interface MessageRow {
-    id: string | null;
+    id: string;
 
     // State
     source: 'internal' | 'user';
@@ -132,7 +132,7 @@ export interface MessageRow {
  * What is required to insert a Message
  */
 export type OperationRowInsert = Merge<Partial<MessageRow>, { message: string; operation: OperationList }>;
-export type OperationRow = Merge<Required<OperationRowInsert>, { id: string; accountId: number; accountName: string }>;
+export type OperationRow = Merge<Required<OperationRowInsert>, { accountId: number; accountName: string }>;
 
 /**
  * What is required to insert a Message

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -12,7 +12,8 @@
         "directory": "packages/utils"
     },
     "devDependencies": {
-        "axios": "^1.3.4"
+        "axios": "^1.3.4",
+        "type-fest": "4.14.0"
     },
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "files": [

--- a/packages/webapp/src/pages/Logs/ShowOperation.tsx
+++ b/packages/webapp/src/pages/Logs/ShowOperation.tsx
@@ -102,7 +102,7 @@ export const ShowOperation: React.FC<{ operationId: string }> = ({ operationId }
                 <div className="flex gap-2 items-center w-[30%]">
                     <div className="font-semibold text-sm">Type</div>
                     <div className="text-gray-400 text-xs pt-[1px]">
-                        <OperationTag message={operation.message} operation={operation.operation!} highlight />
+                        <OperationTag message={operation.message} operation={operation.operation} highlight />
                     </div>
                 </div>
             </div>

--- a/packages/webapp/src/pages/Logs/components/MessageRow.tsx
+++ b/packages/webapp/src/pages/Logs/components/MessageRow.tsx
@@ -1,6 +1,6 @@
 import type { Row } from '@tanstack/react-table';
 import { flexRender } from '@tanstack/react-table';
-import type { SearchOperationsData } from '@nangohq/types';
+import type { SearchMessagesData } from '@nangohq/types';
 
 import { Drawer, DrawerContent, DrawerTrigger, DrawerClose } from '../../../components/ui/Drawer';
 import * as Table from '../../../components/ui/Table';
@@ -9,7 +9,7 @@ import { ArrowLeftIcon } from '@radix-ui/react-icons';
 import { cn } from '../../../utils/utils';
 
 const drawerWidth = '834px';
-export const MessageRow: React.FC<{ row: Row<SearchOperationsData> }> = ({ row }) => {
+export const MessageRow: React.FC<{ row: Row<SearchMessagesData> }> = ({ row }) => {
     return (
         <Drawer direction="right" snapPoints={[drawerWidth]} handleOnly={true} noBodyStyles={true} nested>
             <DrawerTrigger asChild type={null as unknown as 'button'}>

--- a/packages/webapp/src/pages/Logs/components/ProviderTag.tsx
+++ b/packages/webapp/src/pages/Logs/components/ProviderTag.tsx
@@ -1,7 +1,7 @@
 import type { SearchMessagesData } from '@nangohq/types';
 import IntegrationLogo from '../../../components/ui/IntegrationLogo';
 
-export const ProviderTag: React.FC<{ msg: SearchMessagesData }> = ({ msg }) => {
+export const ProviderTag: React.FC<{ msg: Pick<SearchMessagesData, 'providerName' | 'integrationId' | 'integrationName'> }> = ({ msg }) => {
     if (!msg.integrationId || !msg.providerName) {
         return <>-</>;
     }

--- a/packages/webapp/src/pages/Logs/components/SearchInOperation.tsx
+++ b/packages/webapp/src/pages/Logs/components/SearchInOperation.tsx
@@ -2,7 +2,7 @@ import type { ColumnDef } from '@tanstack/react-table';
 import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import { Input } from '../../../components/ui/input/Input';
 import { useSearchMessages } from '../../../hooks/useLogs';
-import type { SearchMessages, SearchOperationsData } from '@nangohq/types';
+import type { SearchMessages, SearchMessagesData } from '@nangohq/types';
 import { formatDateToLogFormat, formatQuantity } from '../../../utils/utils';
 import { useStore } from '../../../store';
 import * as Table from '../../../components/ui/Table';
@@ -17,7 +17,7 @@ import { Tag } from '../../../components/ui/label/Tag';
 import { Skeleton } from '../../../components/ui/Skeleton';
 import Button from '../../../components/ui/button/Button';
 
-export const columns: ColumnDef<SearchOperationsData>[] = [
+export const columns: ColumnDef<SearchMessagesData>[] = [
     {
         accessorKey: 'createdAt',
         header: 'Timestamp',
@@ -76,7 +76,7 @@ export const SearchInOperation: React.FC<{ operationId: string; isLive: boolean 
     const [hasLoadedMore, setHasLoadedMore] = useState<boolean>(false);
     const [readyToDisplay, setReadyToDisplay] = useState<boolean>(false);
     const { data, error, loading, trigger, manualFetch } = useSearchMessages(env, { limit, operationId, search });
-    const [messages, setMessages] = useState<SearchOperationsData[]>([]);
+    const [messages, setMessages] = useState<SearchMessagesData[]>([]);
 
     useDebounce(
         () => {

--- a/packages/webapp/src/pages/Logs/constants.tsx
+++ b/packages/webapp/src/pages/Logs/constants.tsx
@@ -36,7 +36,7 @@ export const columns: ColumnDef<SearchOperationsData>[] = [
         header: 'Type',
         size: 100,
         cell: ({ row }) => {
-            return <OperationTag message={row.original.message} operation={row.original.operation!} />;
+            return <OperationTag message={row.original.message} operation={row.original.operation} />;
         }
     },
     {


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1244/insert-messages-without-an-id

Now that we have Elasticsearch in prod I can focus a bit more time on performance quick wins.

- Insert messages (not operation) without an ID
I knew this from the beginning but I just wanted to simplify the code. They recommend not using an ID because if you pass one, all the instances need to search in their whole catalog to see if this ID already exists. Whereas if you don't send it, they will autogenerate an ordered id without checking. This should help but no clue how much.

- Clarify types between OperationRow and MessageRow which were different already but a bit mixed up
It's not perfect yet since most fields are optional 
- Fix some type errors