### PR TITLE
fix(jobs): initialize tracer in processing worker threads

### DIFF
--- a/packages/jobs/lib/processor/processor.worker.boot.ts
+++ b/packages/jobs/lib/processor/processor.worker.boot.ts
@@ -1,3 +1,4 @@
+import '../tracer.js';
 import { isMainThread, parentPort, workerData } from 'node:worker_threads';
 import { getLogger } from '@nangohq/utils';
 import { ProcessorChild } from './processor.worker.js';


### PR DESCRIPTION
Traces and metrics are missing since we started to switch from temporal to the orchestrator.

I forgot to initialize the tracer in jobs processing worker thread.
