### PR TITLE
fix(server): log request and add route to tracing

### DIFF
--- a/packages/server/lib/middleware/ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/ratelimit.middleware.ts
@@ -51,7 +51,8 @@ export const rateLimiterMiddleware = (req: Request, res: Response, next: NextFun
                 return;
             }
 
-            res.status(500).send({ error: { code: 'server_error' } });
+            logger.error('Failed to compute rate limit', { error: rateLimiterRes });
+            res.status(500).send({ error: { code: 'server_error', message: 'Failed to compute rate limit' } });
         });
 };
 
@@ -69,7 +70,7 @@ function getPointsToConsume(req: Request): number {
 
     if (paths.some((path) => req.path.startsWith(path))) {
         // limiting to 6 requests per period to avoid brute force attacks
-        return rateLimiter.points / 6;
+        return Math.floor(rateLimiter.points / 6);
     }
     return 1;
 }

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -7,7 +7,7 @@ import { WebSocketServer } from 'ws';
 import http from 'node:http';
 import db from '@nangohq/database';
 import { NANGO_VERSION, getGlobalOAuthCallbackUrl, getServerPort, getWebsocketsPath } from '@nangohq/shared';
-import { getLogger } from '@nangohq/utils';
+import { getLogger, requestLoggerMiddleware } from '@nangohq/utils';
 import oAuthSessionService from './services/oauth-session.service.js';
 import migrate from './utils/migrate.js';
 import { migrate as migrateRecords } from '@nangohq/records';
@@ -21,6 +21,13 @@ const { NANGO_MIGRATE_AT_START = 'true' } = process.env;
 const logger = getLogger('Server');
 
 const app = express();
+
+// Log all requests
+if (process.env['ENABLE_REQUEST_LOG'] !== 'false') {
+    app.use(requestLoggerMiddleware({ logger }));
+}
+
+// Load all routes
 app.use('/', router);
 
 const server = http.createServer(app);

--- a/packages/types/lib/utils.ts
+++ b/packages/types/lib/utils.ts
@@ -3,7 +3,8 @@ export type MaybePromise<T> = Promise<T> | T;
 export type LogMethod = (...args: any[]) => any;
 export interface Logger {
     error: LogMethod;
-    warn: LogMethod;
+    warn?: LogMethod;
+    warning?: LogMethod;
     info: LogMethod;
     debug: LogMethod;
     child: (...message: any[]) => Logger;

--- a/packages/utils/lib/express/requestLoggerMiddleware.ts
+++ b/packages/utils/lib/express/requestLoggerMiddleware.ts
@@ -1,0 +1,20 @@
+import type { Logger } from '@nangohq/types';
+import type { Handler } from 'express';
+import colors from '@colors/colors';
+
+export function requestLoggerMiddleware({ logger }: { logger: Logger }): Handler {
+    return (req, res, next) => {
+        res.on('finish', () => {
+            const route = req.route?.path || req.originalUrl;
+            const msg = `${req.method} ${route} -> ${res.statusCode}`;
+            if (res.statusCode >= 500) {
+                logger.error(colors.red(msg));
+            } else if (res.statusCode >= 400) {
+                logger.warning?.(colors.yellow(msg));
+            } else {
+                logger.info(msg);
+            }
+        });
+        next();
+    };
+}

--- a/packages/utils/lib/index.ts
+++ b/packages/utils/lib/index.ts
@@ -9,6 +9,7 @@ export * from './encryption.js';
 export * as metrics from './telemetry/metrics.js';
 export * from './retry.js';
 export * from './string.js';
+export * from './express/requestLoggerMiddleware.js';
 export * from './express/route.js';
 export * from './express/validate.js';
 export * from './workflows.js';


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1250/set-httproute-in-express-tag

- Log server requests
It's a bit annoying to not see if the request has reached the backend, especially in docker mode. Follow what Thomas has done for persist and orch + colors and log level

- Add correct to tracing
Datadog doesn't instrument correctly (probably laziness since OT is doing it right). The `route` prop is only available after match and the tracer is also only avalaible at this stage. So there is only one place to set this tag (`router.handle`), so I'm using asyncWrapper to not have to instrument anything. The drawbacks is that only new endpoints using this function are correctly sending the route. 

This finally allow seeing the route directly in traces and being able to graph/group routes by pattern

--- 
*Notice the holes are the old endpoints not using asyncWrapper*
![Screenshot 2024-06-19 at 16 19 57](https://github.com/NangoHQ/nango/assets/1637651/61244696-2fd9-4068-ab57-5b81de92e0a9)
