### PR TITLE
fix(nango-yaml): support __string advanced syntax

### DIFF
--- a/packages/cli/fixtures/nango-yaml/v2/advanced-syntax/nango.yaml
+++ b/packages/cli/fixtures/nango-yaml/v2/advanced-syntax/nango.yaml
@@ -39,3 +39,13 @@ models:
 
     Record:
         __string: any
+
+    RecordUnion:
+        __string: any | string | boolean
+    RecordArrayUnion:
+        __string:
+            - any
+            - string
+    RecordObject:
+        __string:
+            str: string

--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -393,10 +393,23 @@ export interface Record {
   [key: string]: any;
 };
 
+export interface RecordUnion {
+  [key: string]: any | string | boolean;
+};
+
+export interface RecordArrayUnion {
+  [key: string]: (any | string)[];
+};
+
+export interface RecordObject {
+  [key: string]: {  str: string;};
+};
+
 /** @deprecated It is recommended to use a Model */
 export type Anonymous_unauthenticated_action_inputoutputunion_output = string | null[]
 
 /** @deprecated It is recommended to use a Model */
 export type Anonymous_unauthenticated_action_inputoutputunion_input = true | 'hello' | Ref
-// ------ /Models"
+// ------ /Models
+"
 `;

--- a/packages/cli/lib/services/model.service.ts
+++ b/packages/cli/lib/services/model.service.ts
@@ -102,11 +102,7 @@ export function fieldsToTypescript({ fields }: { fields: NangoModelField[] }) {
 
     // Insert dynamic key at the beginning
     if (dynamic) {
-        if (!Array.isArray(dynamic.value)) {
-            output.push(`  [key: string]: ${fieldToTypescript({ field: dynamic })};`);
-        } else {
-            output.push(`  [key: string]: {${fieldsToTypescript({ fields: dynamic.value }).join('\n')}};`);
-        }
+        output.push(`  [key: string]: ${fieldToTypescript({ field: dynamic })};`);
     }
 
     // Regular fields

--- a/packages/cli/lib/services/model.service.unit.test.ts
+++ b/packages/cli/lib/services/model.service.unit.test.ts
@@ -71,7 +71,14 @@ describe('buildModelTs', () => {
     it('should support all advanced syntax', () => {
         const { response: parsed } = load(path.resolve(__dirname, `../../fixtures/nango-yaml/v2/advanced-syntax`));
         const res = buildModelsTS({ parsed: parsed! });
-        expect(removeVersion(res.split('\n').slice(0, 48).join('\n'))).toMatchSnapshot();
+        const acc = [];
+        for (const line of res.split('\n')) {
+            if (line === '// ------ SDK') {
+                break;
+            }
+            acc.push(line);
+        }
+        expect(removeVersion(acc.join('\n'))).toMatchSnapshot();
     });
 });
 

--- a/packages/nango-yaml/lib/modelsParser.ts
+++ b/packages/nango-yaml/lib/modelsParser.ts
@@ -103,6 +103,13 @@ export class ModelsParser {
                 continue;
             }
 
+            // Special key for dynamic interface `[key: string]: *`
+            if (name === '__string') {
+                const acc = this.parseFields({ fields: { tmp: value }, parent })[0]!;
+                dynamicField = { ...acc, name, dynamic: true, optional };
+                continue;
+            }
+
             // Array of unknown
             if (Array.isArray(value)) {
                 const acc = this.parseFields({ fields: value as unknown as NangoYamlModelFields, parent });
@@ -132,13 +139,6 @@ export class ModelsParser {
                 }
 
                 parsed.push({ name, value: acc, optional });
-                continue;
-            }
-
-            // Special key for dynamic interface `[key: string]: *`
-            if (name === '__string') {
-                const acc = this.parseFields({ fields: { tmp: value }, parent })[0]!;
-                dynamicField = { ...acc, name, dynamic: true, optional };
                 continue;
             }
 


### PR DESCRIPTION
## Describe your changes

- Fix advanced syntax for `__string`
The parsing was correct for union but not the output due to a leftover, added multiple e2e test.
The parsing was coming too late for object and array.
