### PR TITLE
fix: don't update schedule if frequency is alread set to the same value

### DIFF
--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -131,7 +131,7 @@ export class SyncManagerService {
                 }
 
                 const createdSync = await createSync(connection.id as number, syncName);
-                orchestrator.scheduleSyncHelper(
+                await orchestrator.scheduleSyncHelper(
                     connection,
                     createdSync as Sync,
                     syncConfig as ProviderConfig,


### PR DESCRIPTION
We were always updating the frequency even when we didn't need to.

This doesn't address the log saying frequency has been updated. I will do that later

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
