### PR TITLE
fix(connection): refresh credentials should re-fetch connection before proceeding

### DIFF
--- a/packages/shared/lib/utils/lock/locking.ts
+++ b/packages/shared/lib/utils/lock/locking.ts
@@ -8,19 +8,22 @@ export class Locking {
         this.store = store;
     }
 
-    public async tryAcquire(key: string, ttlInMs: number, acquisitionTimeoutMs: number): Promise<void> {
+    public async tryAcquire(key: string, ttlInMs: number, acquisitionTimeoutMs: number): Promise<{ tries: number }> {
         if (ttlInMs <= 0) {
             throw new Error(`lock's TTL must be greater than 0`);
         }
         if (acquisitionTimeoutMs <= 0) {
             throw new Error(`acquisitionTimeoutMs must be greater than 0`);
         }
+
         const start = Date.now();
+        let tries = 0;
         while (Date.now() - start < acquisitionTimeoutMs) {
             try {
                 await this.acquire(key, ttlInMs);
-                return;
+                return { tries };
             } catch {
+                tries += 1;
                 await new Promise((resolve) => setTimeout(resolve, 50));
             }
         }


### PR DESCRIPTION
## Describe your changes

Should fix https://linear.app/nango/issue/NAN-1164/credal-box-connection-failing-to-refresh-intermittently

- When refreshing credentials if another one was running the `connection` reference was obsolete but we would reuse it to try to refresh again. The short term fix is to re-refetch and continue, but we could return the new credentials directly
