### PR TITLE
fix(sdk): simplify message on validation error

### DIFF
--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -797,7 +797,14 @@ export class NangoSync extends NangoAction {
                     `Request to persist API (batchSave) failed: errorCode=${response.status} response='${JSON.stringify(response.data)}'`,
                     this.stringify()
                 );
-                throw new Error(`cannot save records for sync '${this.syncId}': ${JSON.stringify(response.data)}`);
+
+                if (response.status === 400) {
+                    throw new Error(
+                        `Records invalid format. Please make sure you are sending an array of objects that each contain an 'id' property with type string`
+                    );
+                } else {
+                    throw new Error(`Failed to save records: ${JSON.stringify(response.data)}`);
+                }
             }
         }
         return true;


### PR DESCRIPTION
## Describe your changes

fixes https://linear.app/nango/issue/NAN-1021/improve-error-message-when-missing-record-id-in-batchsave

- Simplify the message we throw when persist is returning a validation error (zod output is not readable and even less as a stringified json)