### PR TITLE
fix(activeLogs): drop v1 activity_log_id

### DIFF
--- a/packages/database/lib/migrations/20240621155627_active_logs_activitylogid.cjs
+++ b/packages/database/lib/migrations/20240621155627_active_logs_activitylogid.cjs
@@ -1,0 +1,18 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = function (knex) {
+    return knex.schema.alterTable('_nango_active_logs', function (trx) {
+        trx.dropColumn('activity_log_id');
+    });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = function (knex) {
+    return knex.schema.alterTable('_nango_active_logs', function (trx) {
+        trx.integer('activity_log_id').unsigned();
+        trx.foreign('activity_log_id').references('id').inTable('_nango_activity_logs').onDelete('CASCADE');
+    });
+};

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -164,7 +164,6 @@ export const connectionRefreshFailed = async ({
         type: 'auth',
         action: 'token_refresh',
         connection_id: connection.id!,
-        activity_log_id: -1,
         log_id: logCtx.id,
         active: true
     });

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -533,7 +533,6 @@ class ConnectionService {
                 '_nango_connections.metadata',
                 db.knex.raw(`
                   (SELECT json_build_object(
-                      'activity_log_id', activity_log_id,
                       'log_id', log_id
                     )
                     FROM ${ACTIVE_LOG_TABLE}

--- a/packages/shared/lib/services/notification/error.service.ts
+++ b/packages/shared/lib/services/notification/error.service.ts
@@ -7,12 +7,12 @@ import db from '@nangohq/database';
 
 const DB_TABLE = '_nango_active_logs';
 
-type ErrorNotification = Required<Pick<ActiveLog, 'type' | 'action' | 'connection_id' | 'activity_log_id' | 'log_id' | 'active'>>;
+type ErrorNotification = Required<Pick<ActiveLog, 'type' | 'action' | 'connection_id' | 'log_id' | 'active'>>;
 type SyncErrorNotification = ErrorNotification & Required<Pick<ActiveLog, 'sync_id'>>;
 
 export const errorNotificationService = {
     auth: {
-        create: async ({ type, action, connection_id, activity_log_id, log_id, active }: ErrorNotification): Promise<Result<ActiveLog>> => {
+        create: async ({ type, action, connection_id, log_id, active }: ErrorNotification): Promise<Result<ActiveLog>> => {
             return await db.knex.transaction(async (trx) => {
                 await errorNotificationService.auth.clear({ connection_id, trx });
                 const created = await trx
@@ -21,7 +21,6 @@ export const errorNotificationService = {
                         type,
                         action,
                         connection_id,
-                        activity_log_id,
                         log_id,
                         active
                     })
@@ -42,7 +41,7 @@ export const errorNotificationService = {
         }
     },
     sync: {
-        create: async ({ type, action, sync_id, connection_id, activity_log_id, log_id, active }: SyncErrorNotification): Promise<Result<ActiveLog>> => {
+        create: async ({ type, action, sync_id, connection_id, log_id, active }: SyncErrorNotification): Promise<Result<ActiveLog>> => {
             return await db.knex.transaction(async (trx) => {
                 await errorNotificationService.sync.clear({ sync_id, connection_id, trx });
                 const created = await trx
@@ -52,7 +51,6 @@ export const errorNotificationService = {
                         action,
                         sync_id,
                         connection_id,
-                        activity_log_id,
                         log_id,
                         active
                     })

--- a/packages/shared/lib/services/sync/run.service.ts
+++ b/packages/shared/lib/services/sync/run.service.ts
@@ -976,7 +976,6 @@ export default class SyncRun {
                 type: 'sync',
                 sync_id: this.syncId,
                 connection_id: this.nangoConnection.id,
-                activity_log_id: this.activityLogId as unknown as number,
                 log_id: this.logCtx?.id,
                 active: true
             });

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -222,16 +222,11 @@ export const getSyncs = async (
             `${SYNC_SCHEDULE_TABLE}.offset`,
             `${SYNC_SCHEDULE_TABLE}.status as schedule_status`,
             `${SYNC_CONFIG_TABLE}.models`,
-            `${ACTIVE_LOG_TABLE}.activity_log_id as error_activity_log_id`,
             `${ACTIVE_LOG_TABLE}.log_id as error_log_id`,
             db.knex.raw(`
-                CASE
-                    WHEN COUNT(${ACTIVE_LOG_TABLE}.activity_log_id) = 0 THEN NULL
-                    ELSE json_build_object(
-                        'activity_log_id', ${ACTIVE_LOG_TABLE}.activity_log_id,
-                        'log_id', ${ACTIVE_LOG_TABLE}.log_id
-                    )
-                END as active_logs
+                json_build_object(
+                    'log_id', ${ACTIVE_LOG_TABLE}.log_id
+                ) as active_logs
             `),
             db.knex.raw(
                 `(
@@ -281,7 +276,6 @@ export const getSyncs = async (
         .groupBy(
             `${TABLE}.id`,
             `${SYNC_SCHEDULE_TABLE}.frequency`,
-            `${ACTIVE_LOG_TABLE}.activity_log_id`,
             `${ACTIVE_LOG_TABLE}.log_id`,
             `${SYNC_SCHEDULE_TABLE}.offset`,
             `${SYNC_SCHEDULE_TABLE}.status`,

--- a/packages/types/lib/notification/active-logs/db.ts
+++ b/packages/types/lib/notification/active-logs/db.ts
@@ -5,10 +5,9 @@ export interface ActiveLog extends Timestamps {
     type: string;
     action: string;
     connection_id: number;
-    activity_log_id: number;
     log_id: string;
     active: boolean;
     sync_id: string | null;
 }
 
-export type ActiveLogIds = Pick<ActiveLog, 'activity_log_id' | 'log_id'>;
+export type ActiveLogIds = Pick<ActiveLog, 'log_id'>;

--- a/packages/webapp/src/pages/Connection/Show.tsx
+++ b/packages/webapp/src/pages/Connection/Show.tsx
@@ -234,7 +234,7 @@ We could not retrieve and/or refresh your access token due to the following erro
                         onClick={() => setActiveTab(Tabs.Syncs)}
                     >
                         Syncs
-                        {syncs && syncs.find((sync) => typeof sync.active_logs?.activity_log_id === 'number') && (
+                        {syncs && syncs.some((sync) => sync.active_logs?.log_id) && (
                             <span className="ml-2 bg-red-base h-1.5 w-1.5 rounded-full inline-block"></span>
                         )}
                     </li>
@@ -268,7 +268,7 @@ We could not retrieve and/or refresh your access token due to the following erro
                             <Link
                                 to={getLogsUrl({
                                     env,
-                                    operationId: connectionResponse.errorLog.activity_log_id,
+                                    operationId: connectionResponse.errorLog.log_id,
                                     connections: connectionResponse.connection.connection_id,
                                     day: connectionResponse.errorLog?.created_at
                                 })}
@@ -281,26 +281,23 @@ We could not retrieve and/or refresh your access token due to the following erro
                 </div>
             )}
 
-            {activeTab === Tabs.Syncs && syncs && syncs.find((sync) => typeof sync.active_logs?.activity_log_id === 'number') && (
+            {activeTab === Tabs.Syncs && syncs && syncs.some((sync) => sync.active_logs?.log_id) && (
                 <div className="flex my-4">
                     <Info showIcon={false} size={14} padding="py-1 px-1" color="red">
                         <div className="flex items-center text-sm">
                             <ErrorCircle />
                             <span className="ml-2">
                                 Last sync execution failed for the following sync
-                                {syncs.filter((sync) => typeof sync.active_logs?.activity_log_id === 'number').length > 1 ? 's' : ''}:{' '}
+                                {syncs.filter((sync) => sync.active_logs?.log_id).length > 1 ? 's' : ''}:{' '}
                                 {syncs
-                                    .filter((sync) => typeof sync.active_logs?.activity_log_id === 'number')
+                                    .filter((sync) => sync.active_logs?.log_id)
                                     .map((sync, index) => (
                                         <Fragment key={sync.name}>
                                             {sync.name} (
-                                            <Link
-                                                className="underline"
-                                                to={getLogsUrl({ env, operationId: sync.active_logs?.activity_log_id, syncs: sync.name })}
-                                            >
+                                            <Link className="underline" to={getLogsUrl({ env, operationId: sync.active_logs?.log_id, syncs: sync.name })}>
                                                 logs
                                             </Link>
-                                            ){index < syncs.filter((sync) => typeof sync.active_logs?.activity_log_id === 'number').length - 1 && ', '}
+                                            ){index < syncs.filter((sync) => sync.active_logs?.log_id).length - 1 && ', '}
                                         </Fragment>
                                     ))}
                                 .

--- a/packages/webapp/src/pages/Connection/Syncs.tsx
+++ b/packages/webapp/src/pages/Connection/Syncs.tsx
@@ -419,7 +419,7 @@ export default function Syncs({ syncs, connection, provider, reload, loaded, syn
                                                             <Link
                                                                 to={getLogsUrl({
                                                                     env,
-                                                                    operationId: sync.latest_sync?.activity_log_id || sync.active_logs?.activity_log_id,
+                                                                    operationId: sync.latest_sync?.activity_log_id,
                                                                     connections: connection?.connection_id,
                                                                     syncs: sync.name,
                                                                     day: new Date(sync.latest_sync?.updated_at)


### PR DESCRIPTION
## Describe your changes

Contributes to https://linear.app/nango/issue/NAN-585/stop-writing-from-v1

When I removed v1 from hooks I didn't realized active_logs had a foreign key attached to the table, so the value `-1` wasn't really cutting it.

- Drop column `activity_log_id` from table `_nango_active_logs`
