### PR TITLE
fix(axios): disable axios proxy when passing agent

### DIFF
--- a/packages/utils/lib/axios.ts
+++ b/packages/utils/lib/axios.ts
@@ -1,5 +1,6 @@
 import { HttpProxyAgent } from 'http-proxy-agent';
 import { HttpsProxyAgent } from 'https-proxy-agent';
+import type { AxiosRequestConfig } from 'axios';
 import axios from 'axios';
 import http from 'node:http';
 import type { Agent as HttpAgent } from 'node:http';
@@ -19,8 +20,13 @@ if (hasHttpsProxy) {
     httpsAgent = new HttpsProxyAgent(hasHttpsProxy);
 }
 
-export const axiosInstance = axios.create({
-    proxy: false,
+const config: AxiosRequestConfig = {
     httpAgent: httpAgent,
     httpsAgent: httpsAgent
-});
+};
+
+if (hasHttpProxy || hasHttpsProxy) {
+    config.proxy = false;
+}
+
+export const axiosInstance = axios.create(config);

--- a/packages/utils/lib/axios.ts
+++ b/packages/utils/lib/axios.ts
@@ -6,8 +6,8 @@ import type { Agent as HttpAgent } from 'node:http';
 import type { Agent as HttpsAgent } from 'node:https';
 import https from 'node:https';
 
-export let httpAgent: HttpProxyAgent | HttpAgent = new http.Agent();
-export let httpsAgent: HttpsProxyAgent | HttpsAgent = new https.Agent();
+export let httpAgent: HttpProxyAgent<string> | HttpAgent = new http.Agent();
+export let httpsAgent: HttpsProxyAgent<string> | HttpsAgent = new https.Agent();
 
 const hasHttpProxy = process.env['http_proxy'] || process.env['HTTP_PROXY'];
 const hasHttpsProxy = process.env['https_proxy'] || process.env['HTTPS_PROXY'];

--- a/packages/utils/lib/axios.ts
+++ b/packages/utils/lib/axios.ts
@@ -6,8 +6,8 @@ import type { Agent as HttpAgent } from 'node:http';
 import type { Agent as HttpsAgent } from 'node:https';
 import https from 'node:https';
 
-export let httpAgent: HttpProxyAgent<string> | HttpAgent = new http.Agent();
-export let httpsAgent: HttpsProxyAgent<string> | HttpsAgent = new https.Agent();
+export let httpAgent: HttpProxyAgent | HttpAgent = new http.Agent();
+export let httpsAgent: HttpsProxyAgent | HttpsAgent = new https.Agent();
 
 const hasHttpProxy = process.env['http_proxy'] || process.env['HTTP_PROXY'];
 const hasHttpsProxy = process.env['https_proxy'] || process.env['HTTPS_PROXY'];
@@ -20,6 +20,7 @@ if (hasHttpsProxy) {
 }
 
 export const axiosInstance = axios.create({
+    proxy: false,
     httpAgent: httpAgent,
     httpsAgent: httpsAgent
 });


### PR DESCRIPTION
…h kicks in with https_proxy env set

## Describe your changes
As we are using httpProxyAgent we need to disable the axios default proxy so the httpProxyAgent is considered not the proxy with kicks in by default when we have https_proxy env set

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
