### PR TITLE
fix(orchestrator): update schedule last task when running sync manually and add runSyncCommand error loggging

### DIFF
--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -178,6 +178,9 @@ export class Scheduler {
             const created = await tasks.create(trx, taskProps);
             if (created.isOk()) {
                 const task = created.value;
+                if (task.scheduleId) {
+                    await schedules.update(trx, { id: task.scheduleId, lastScheduledTaskId: task.id });
+                }
                 this.onCallbacks[task.state](task);
             }
             return created;


### PR DESCRIPTION
2 commits, 2 changes:
- update the schedule last task when sync is run manually, otherwise we can run into a scenario where a sync is run manually right before the schedule due date. Then the scheduling worker would create a new task, not knowing about the manually run one and 2 syncs would be running at the same time.
- we were not logging errors in `runSyncCommand`

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
