### PR TITLE
fix: /sync/status should return sync frequency

### DIFF
--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -505,7 +505,7 @@ export class SyncManagerService {
             let frequency = sync.frequency;
             if (!frequency) {
                 const syncConfig = await getSyncConfigByParams(environmentId, sync.name, providerConfigKey);
-                frequency = syncConfig?.runs || '';
+                frequency = syncConfig?.runs || null;
             }
             if (schedules.isErr()) {
                 throw new Error(`Failed to get schedule for sync ${sync.id} in environment ${environmentId}: ${stringifyError(schedules.error)}`);


### PR DESCRIPTION
sync.frequency is null unless the value is overwritten for a given connection sync 
This fix ensures that we fetch the sync config value if no overwrite exists

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1269/frequency-not-returned-from-sync-status-endpoint

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
