### PR TITLE
fix(telemetry): missing envId

### DIFF
--- a/packages/jobs/lib/crons/reconcileTemporalSchedules.ts
+++ b/packages/jobs/lib/crons/reconcileTemporalSchedules.ts
@@ -74,6 +74,7 @@ export async function exec(): Promise<void> {
                                 'CRON: Schedule is marked as paused in temporal but not in the database. The schedule has been unpaused in temporal',
                                 LogActionEnum.SYNC,
                                 {
+                                    environmentId: '',
                                     sync_id,
                                     schedule_id,
                                     level: 'warn',

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -229,7 +229,8 @@ export class Orchestrator {
                 {
                     workflowId,
                     input: JSON.stringify(input, null, 2),
-                    connection: JSON.stringify(connection),
+                    environmentId: String(connection.environment_id),
+                    connectionId: connection.connection_id,
                     actionName
                 },
                 `actionName:${actionName}`
@@ -263,7 +264,8 @@ export class Orchestrator {
                 {
                     workflowId,
                     input: JSON.stringify(input, null, 2),
-                    connection: JSON.stringify(connection),
+                    environmentId: String(connection.environment_id),
+                    connectionId: connection.connection_id,
                     actionName,
                     level: 'error'
                 },
@@ -569,8 +571,8 @@ export class Orchestrator {
                 LogActionEnum.POST_CONNECTION_SCRIPT,
                 {
                     workflowId,
-                    input: '',
-                    connection: JSON.stringify(connection),
+                    environmentId: String(connection.environment_id),
+                    connectionId: connection.connection_id,
                     name
                 },
                 `postConnectionScript:${name}`
@@ -602,8 +604,8 @@ export class Orchestrator {
                 LogActionEnum.POST_CONNECTION_SCRIPT,
                 {
                     workflowId,
-                    input: '',
-                    connection: JSON.stringify(connection),
+                    environmentId: String(connection.environment_id),
+                    connectionId: connection.connection_id,
                     name,
                     level: 'error'
                 },

--- a/packages/shared/lib/utils/telemetry.ts
+++ b/packages/shared/lib/utils/telemetry.ts
@@ -62,7 +62,7 @@ class Telemetry {
         eventId: string,
         message: string,
         operation: string,
-        context: Record<string, string> & { level?: 'info' | 'error' | 'warn' } = {},
+        context: Record<string, string> & { level?: 'info' | 'error' | 'warn'; environmentId: string },
         additionalTags = ''
     ) {
         const additionalProperties = {


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1279/track-new-metric-and-log-details-in-datadog

- Output expected value in the telemetry
- Enforce `environmentId`