### PR TITLE
fix: schedule nextDueDate should be null when schedule is not running

### DIFF
--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -69,7 +69,7 @@ export interface OrchestratorSchedule {
     name: string;
     frequencyMs: number;
     state: ScheduleState;
-    nextDueDate: Date;
+    nextDueDate: Date | null;
 }
 
 export type OrchestratorTask = TaskSync | TaskAction | TaskWebhook | TaskPostConnection;

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -176,7 +176,7 @@ export function validateSchedule(schedule: Schedule): Result<OrchestratorSchedul
             name: validation.data.name,
             state: validation.data.state,
             frequencyMs: validation.data.frequencyMs,
-            nextDueDate: getNextDueDate(validation.data.startsAt, validation.data.frequencyMs)
+            nextDueDate: validation.data.state == 'STARTED' ? getNextDueDate(validation.data.startsAt, validation.data.frequencyMs) : null
         };
         return Ok(schedule);
     }

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -298,7 +298,7 @@ export const getSyncs = async (
                 return {
                     ...sync,
                     status: syncManager.classifySyncStatus(sync?.latest_sync?.status, schedule.state),
-                    futureActionTimes: schedule.state === 'PAUSED' ? [] : [schedule.nextDueDate.getTime() / 1000]
+                    futureActionTimes: schedule.nextDueDate ? [schedule.nextDueDate.getTime() / 1000] : []
                 };
             }
             return sync;


### PR DESCRIPTION
this would cause the github demo to fail at the fetching data step because it relies on checking for nextDueDate to trigger a sync or not.

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1293/interactive-demo-fetch-new-data-step-doesnt-work-anymore

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
