### PR TITLE
chore: send metric when tasks change state

### DIFF
--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -1,5 +1,5 @@
 import './tracer.js';
-import { getLogger, stringifyError } from '@nangohq/utils';
+import { getLogger, metrics, stringifyError } from '@nangohq/utils';
 import { getServer } from './server.js';
 import { envs } from './env.js';
 import type { Task } from '@nangohq/scheduler';
@@ -20,12 +20,30 @@ try {
 
     // TODO: add logic to update syncs and syncs jobs in the database
     const eventsHandler = new EventsHandler({
-        CREATED: (task: Task) => logger.info(`Task created: ${stringifyTask(task)}`),
-        STARTED: (task: Task) => logger.info(`Task started: ${stringifyTask(task)}`),
-        SUCCEEDED: (task: Task) => logger.info(`Task succeeded: ${stringifyTask(task)}`),
-        FAILED: (task: Task) => logger.error(`Task failed: ${stringifyTask(task)}`),
-        EXPIRED: (task: Task) => logger.error(`Task expired: ${stringifyTask(task)}`),
-        CANCELLED: (task: Task) => logger.info(`Task cancelled: ${stringifyTask(task)}`)
+        CREATED: (task: Task) => {
+            logger.info(`Task created: ${stringifyTask(task)}`);
+            metrics.increment(metrics.Types.ORCH_TASKS_CREATED);
+        },
+        STARTED: (task: Task) => {
+            logger.info(`Task started: ${stringifyTask(task)}`);
+            metrics.increment(metrics.Types.ORCH_TASKS_STARTED);
+        },
+        SUCCEEDED: (task: Task) => {
+            logger.info(`Task succeeded: ${stringifyTask(task)}`);
+            metrics.increment(metrics.Types.ORCH_TASKS_SUCCEEDED);
+        },
+        FAILED: (task: Task) => {
+            logger.error(`Task failed: ${stringifyTask(task)}`);
+            metrics.increment(metrics.Types.ORCH_TASKS_FAILED);
+        },
+        EXPIRED: (task: Task) => {
+            logger.error(`Task expired: ${stringifyTask(task)}`);
+            metrics.increment(metrics.Types.ORCH_TASKS_EXPIRED);
+        },
+        CANCELLED: (task: Task) => {
+            logger.info(`Task cancelled: ${stringifyTask(task)}`);
+            metrics.increment(metrics.Types.ORCH_TASKS_CANCELLED);
+        }
     });
     const scheduler = new Scheduler({
         dbClient,

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -43,7 +43,14 @@ export enum Types {
     WEBHOOK_EXECUTION = 'nango.jobs.webhookExecution',
     WEBHOOK_TRACK_RUNTIME = 'webhook_track_runtime',
     WEBHOOK_SUCCESS = 'nango.orch.webhook.success',
-    WEBHOOK_FAILURE = 'nango.orch.webhook.failure'
+    WEBHOOK_FAILURE = 'nango.orch.webhook.failure',
+
+    ORCH_TASKS_CREATED = 'nango.orch.tasks.created',
+    ORCH_TASKS_STARTED = 'nango.orch.tasks.started',
+    ORCH_TASKS_SUCCEEDED = 'nango.orch.tasks.succeeded',
+    ORCH_TASKS_FAILED = 'nango.orch.tasks.failed',
+    ORCH_TASKS_EXPIRED = 'nango.orch.tasks.expired',
+    ORCH_TASKS_CANCELLED = 'nango.orch.tasks.cancelled'
 }
 
 export function increment(metricName: Types, value = 1, dimensions?: Record<string, string | number>): void {


### PR DESCRIPTION
Increment metrics when tasks change state. I will use those metrics to add widgets in health dashboard and monitors to more easily detect issues like lofts of tasks expiration, etc...

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1224/improve-orchestrator-monitoring

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
