### PR TITLE
fix: every 1 hour" in nango.yaml -> "every1h" in UI

### DIFF
--- a/packages/webapp/src/utils/utils.tsx
+++ b/packages/webapp/src/utils/utils.tsx
@@ -213,12 +213,15 @@ export function formatFrequency(frequency: string): string {
     const unitMap: Record<string, string> = {
         minutes: 'm',
         minute: 'm',
+        mins: 'm',
+        min: 'm',
         hours: 'h',
         hour: 'h',
         days: 'd',
         day: 'd'
     };
 
+    frequency = frequency.replace('every', '');
     for (const [unit, abbreviation] of Object.entries(unitMap)) {
         if (frequency.includes(unit)) {
             return frequency.replace(unit, abbreviation).replace(/\s/g, '');


### PR DESCRIPTION
The replace `\s` would replace all spaces including the one after every.
Removing the `every` in displayed frequency since it doesn't add any value

before
<img width="1039" alt="Screenshot 2024-06-28 at 11 14 00" src="https://github.com/NangoHQ/nango/assets/233326/e3e1fd4e-029e-40b5-b95a-6914ef68b2f6">

after
<img width="1034" alt="Screenshot 2024-06-28 at 11 13 05" src="https://github.com/NangoHQ/nango/assets/233326/b6655429-c4af-4116-a282-1392033c8b20">

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
