### PR TITLE
chore: RECORDS_DATABASE_URL defaults to main db

### DIFF
--- a/docs-v2/host/self-host/self-hosting-instructions.mdx
+++ b/docs-v2/host/self-host/self-hosting-instructions.mdx
@@ -47,6 +47,12 @@ NANGO_DB_NAME=<REPLACE>
 NANGO_DB_SSL=true
 ```
 
+Records saved by syncs can be persisted in a dedicated database. If you opt in for this setup, set the `RECORDS_DATABASE_URL` env var. Ex:
+```
+RECORDS_DATABASE_URL=postgresql://user:password@host:port/dbname
+```
+If not specified, the records will be stored in the main database.
+
 <Tip>
 Deploying with Render or Heroku automatically generates a persistent database
 connected to your Nango instance.

--- a/packages/records/lib/db/config.ts
+++ b/packages/records/lib/db/config.ts
@@ -2,13 +2,17 @@ import { envs } from '../env.js';
 import type { Knex } from 'knex';
 
 export const schema = envs.RECORDS_DATABASE_SCHEMA;
+const databaseUrl =
+    envs.RECORDS_DATABASE_URL ||
+    envs.NANGO_DATABASE_URL ||
+    `postgres://${envs.NANGO_DB_USER}:${envs.NANGO_DB_PASSWORD}@${envs.NANGO_DB_HOST}:${envs.NANGO_DB_PORT}/${envs.NANGO_DB_NAME}`;
 const runningMigrationOnly = process.argv.some((v) => v === 'migrate:latest');
 const isJS = !runningMigrationOnly;
 
 const config: Knex.Config = {
     client: 'postgres',
     connection: {
-        connectionString: envs.RECORDS_DATABASE_URL,
+        connectionString: databaseUrl,
         statement_timeout: 60000
     },
     searchPath: schema,

--- a/packages/records/lib/env.ts
+++ b/packages/records/lib/env.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ENVS, parseEnvs } from '@nangohq/utils';
 
-export const envs = parseEnvs(ENVS.required({ RECORDS_DATABASE_URL: true }));
+export const envs = parseEnvs(ENVS);
 
 export const filename = fileURLToPath(import.meta.url);
 export const dirname = path.dirname(path.join(filename, '../../'));

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -94,7 +94,7 @@ export const ENVS = z.object({
     NANGO_DB_ADDITIONAL_SCHEMAS: z.string().optional(),
 
     // Records
-    RECORDS_DATABASE_URL: z.string().url().optional().default('postgres://nango:nango@localhost:5432/nango'), //TODO remove default and deal with default value in the records package (ie: envVar || mainDB || localhost )
+    RECORDS_DATABASE_URL: z.string().url().optional(),
     RECORDS_DATABASE_SCHEMA: z.string().optional().default('nango_records'),
 
     // Redis


### PR DESCRIPTION
Defaulting the records database to the main db instead of localhost. self-hosting nango now doesn't require to set the RECORDS_DATABASE_URL but only if one wants/needs to persist records in a dedicated db.

Also adding mention of RECORDS_DATABASE_URL in self-hosting docs

## Issue ticket number and link
https://linear.app/nango/issue/NAN-897/update-self-hosting-docs-to-mention-records-database-url

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
