### PR TITLE
chore: cleaning up legacy records tables

### DIFF
--- a/packages/database/lib/migrations/20240628193211_legacy_records_drop.cjs
+++ b/packages/database/lib/migrations/20240628193211_legacy_records_drop.cjs
@@ -1,0 +1,16 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.schema.dropTableIfExists('_nango_sync_data_records_deletes');
+    await knex.schema.dropTableIfExists('_nango_sync_data_records');
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = function () {
+    // there is no coming back from this
+};


### PR DESCRIPTION
Those tables have not been in used for months now.

I am currently slowly deleting records so the migration will just drop the empty tables

## Issue ticket number and link
https://linear.app/nango/issue/NAN-852/cleanup-nango-sync-data-records-and-nango-sync-data-records-deletes

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
