### PR TITLE
fix(slack-notifications): [nan-1164] multiple notifications on refresh error

### DIFF
--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -187,7 +187,8 @@ export const connectionRefreshFailed = async ({
 
     const slackNotificationService = new SlackService({ orchestratorClient: getOrchestratorClient(), logContextGetter });
 
-    await delay(500);
+    const randomDelay = Math.random() * 1000;
+    await delay(randomDelay);
     await slackNotificationService.reportFailure(connection, connection.connection_id, 'auth', logCtx.id, environment.id, config.provider);
 };
 

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -37,8 +37,6 @@ import { sendAuth as sendAuthWebhook } from '@nangohq/webhooks';
 const logger = getLogger('hooks');
 const orchestrator = getOrchestrator();
 
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
 export const connectionCreationStartCapCheck = async ({
     providerConfigKey,
     environmentId,
@@ -187,8 +185,6 @@ export const connectionRefreshFailed = async ({
 
     const slackNotificationService = new SlackService({ orchestratorClient: getOrchestratorClient(), logContextGetter });
 
-    const randomDelay = Math.random() * 1000;
-    await delay(randomDelay);
     await slackNotificationService.reportFailure(connection, connection.connection_id, 'auth', logCtx.id, environment.id, config.provider);
 };
 

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -37,6 +37,8 @@ import { sendAuth as sendAuthWebhook } from '@nangohq/webhooks';
 const logger = getLogger('hooks');
 const orchestrator = getOrchestrator();
 
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 export const connectionCreationStartCapCheck = async ({
     providerConfigKey,
     environmentId,
@@ -142,7 +144,7 @@ export const connectionRefreshSuccess = async ({
 
     const slackNotificationService = new SlackService({ orchestratorClient: getOrchestratorClient(), logContextGetter });
 
-    void slackNotificationService.removeFailingConnection(connection, connection.connection_id, 'auth', null, environment.id, config.provider);
+    await slackNotificationService.removeFailingConnection(connection, connection.connection_id, 'auth', null, environment.id, config.provider);
 };
 
 export const connectionRefreshFailed = async ({
@@ -185,7 +187,8 @@ export const connectionRefreshFailed = async ({
 
     const slackNotificationService = new SlackService({ orchestratorClient: getOrchestratorClient(), logContextGetter });
 
-    void slackNotificationService.reportFailure(connection, connection.connection_id, 'auth', logCtx.id, environment.id, config.provider);
+    await delay(500);
+    await slackNotificationService.reportFailure(connection, connection.connection_id, 'auth', logCtx.id, environment.id, config.provider);
 };
 
 export const connectionTest = async (


### PR DESCRIPTION
## Describe your changes
This annoying issue is hard to reproduce without removing the locking delay on local for the `tryAcquire` method

```
const ttlInMs = 1;
const acquisitionTimeoutMs = 1;
const { tries } = await this.locking.tryAcquire(lockKey, ttlInMs, acquisitionTimeoutMs);
```
With that multiple slack notifications can be seen which in my testing was mitigated by:
- Adding in transactions and `forUpdate` to the database lookups and inserts
- Adding a slight randomized delay for webhook firing to prevent concurrent firing
- `await` the slack notification call

## Testing
- It seemed the customers issue was stemming from proxy calls and only with salesforce which is likely caused by the introspection call. So I tested with a script that made many concurrent proxy calls:

```
Promise.allSettled([
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
  nango.get({
    providerConfigKey: "salesforce",
    connectionId: "sf-2",
    endpoint: `/services/data/v51.0/sobjects/Contacts/describe`,
  }),
```

With this I was seeing multiple slack notifications but with the update logic now only one is received consistently. 

## Issue ticket number and link
NAN-1163

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
