### PR TITLE
fix: missing syncs in connections page

### DIFF
--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -186,7 +186,7 @@ export const getSyncs = async (
                             )
                         END as latest_sync `),
                     db.knex.raw(
-                        `ROW_NUMBER() OVER (PARTITION BY ${SYNC_JOB_TABLE}.sync_id ORDER BY ${SYNC_JOB_TABLE}.deleted ASC, ${SYNC_JOB_TABLE}.updated_at DESC) as job_row_number`
+                        `ROW_NUMBER() OVER (PARTITION BY ${TABLE}.id, ${SYNC_JOB_TABLE}.sync_id ORDER BY ${SYNC_JOB_TABLE}.updated_at DESC) as job_row_number`
                     )
                 )
                 .leftJoin(ACTIVE_LOG_TABLE, function () {


### PR DESCRIPTION
we partitioned syncs by jobs.sync_id but for syncs that have not run yet this value is null. All syncs that have not run will then be in the same bucket and we will only return the first one with `WHERE job_row_number = 1` Fixing the bug by also partitioning on sync.id to properly bucket all syncs independently even the ones that have not run yet

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
