### PR TITLE
chore(CLI): force confirmation when deletedSyncs

### DIFF
--- a/docs-v2/reference/cli.mdx
+++ b/docs-v2/reference/cli.mdx
@@ -70,6 +70,7 @@ Global command flags:
 
 ```bash
 # Command flag to auto-confirm all prompts (useful for CI).
+# Note: Destructive changes (like removing a sync) requires confirmation, even when --auto-confirm is set. To bypass this restriction, the --allow-destructive flag can be passed to nango deploy.
 --auto-confirm
 ```
 
@@ -88,6 +89,7 @@ NANGO_HOSTPORT=https://api.nango.dev # Default value
 NANGO_CLI_UPGRADE_MODE=prompt # Default value
 
 # Whether to prompt before deployments.
+# Note: Destructive changes (like removing a sync) requires confirmation, even when NANGO_DEPLOY_AUTO_CONFIRM is set to true. To bypass this restriction, the --allow-destructive flag can be passed to nango deploy.
 NANGO_DEPLOY_AUTO_CONFIRM=false # Default value
 ```
 

--- a/github-actions/nango-deploy.example.yaml
+++ b/github-actions/nango-deploy.example.yaml
@@ -1,0 +1,52 @@
+name: Deploy Nango Integrations
+'on':
+    # To deploy nango integrations automatically on code changes:
+    # - uncomment the push option below
+    # - set the appropriate branch
+    # - uncomment the elif at the bottom of this file to deploy to the appropriate stage
+    # push:
+    #     branches:
+    #         - main
+    workflow_dispatch:
+        inputs:
+            stage:
+                type: choice
+                description: 'stage to deploy to, defaults to dev'
+                required: true
+                default: 'dev'
+                options:
+                    - dev
+                    - prod
+            allowDestructive:
+                type: choice
+                description: 'deploy destructive changes without confirmation'
+                required: true
+                default: false
+                options:
+                    - true
+                    - false
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check if NANGO_DEV_SECRET_KEY is set
+              run: |
+                  if [ -z "${{ secrets.NANGO_DEV_SECRET_KEY }}" ]; then
+                    echo "Error: NANGO_DEV_SECRET_KEY secret is not set"
+                    exit 1
+                  fi
+            - name: Checkout code
+              uses: actions/checkout@v4
+            - name: Install Nango CLI
+              run: npm install nango -g
+            - name: run Nango deploy
+              run: |
+                  cd nango-integrations
+                  if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+                      stage="${{ inputs.stage }}"
+                  # elif [ "${{ github.ref }}" == "refs/heads/main" ]; then
+                  #     stage="prod"
+                  else
+                      stage="dev"
+                  fi
+                  nango deploy "$stage" --auto-confirm ${{ inputs.allowDestructive == 'true' && '--allow-destructive' || '' }}

--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -158,6 +158,7 @@ program
     .option('-s, --sync [syncName]', 'Optional deploy only this sync name.')
     .option('-a, --action [actionName]', 'Optional deploy only this action name.')
     .option('--no-compile-interfaces', `Don't compile the ${nangoConfigFile}`, true)
+    .option('--allow-destructive', 'Allow destructive changes to be deployed without confirmation', false)
     .action(async function (this: Command, environment: string) {
         const options: DeployOptions = this.opts();
         const { debug } = options;
@@ -189,6 +190,7 @@ program
     .arguments('environment')
     .option('-v, --version [version]', 'Optional: Set a version of this deployment to tag this integration with. Can be used for rollbacks.')
     .option('--no-compile-interfaces', `Don't compile the ${nangoConfigFile}`, true)
+    .option('--allow-destructive', 'Allow destructive changes to be deployed without confirmation', false)
     .action(async function (this: Command, environment: string) {
         const options: DeployOptions = this.opts();
         const fullPath = process.cwd();
@@ -205,10 +207,11 @@ program
 program
     .command('deploy:staging', { hidden: true })
     .alias('ds')
-    .description('Deploy a Nango integration to local')
+    .description('Deploy a Nango integration to staging')
     .arguments('environment')
     .option('-v, --version [version]', 'Optional: Set a version of this deployment to tag this integration with. Can be used for rollbacks.')
     .option('--no-compile-interfaces', `Don't compile the ${nangoConfigFile}`, true)
+    .option('--allow-destructive', 'Allow destructive changes to be deployed without confirmation', false)
     .action(async function (this: Command, environment: string) {
         const options: DeployOptions = this.opts();
         const fullPath = process.cwd();

--- a/packages/cli/lib/services/deploy.service.ts
+++ b/packages/cli/lib/services/deploy.service.ts
@@ -182,11 +182,20 @@ class DeployService {
             // force confirmation :
             // - if auto-confirm flag is not set
             // - OR if there are deleted syncs with connections (and allow-destructive flag is not set)
+            // If CI, fail the deploy
             const shouldConfirmDestructive = deletedSyncsConnectionsCount > 0 && !allowDestructive;
             if (shouldConfirm || shouldConfirmDestructive) {
                 let confirmationMsg = 'Are you sure you want to continue y/n?';
                 if (!shouldConfirm && shouldConfirmDestructive) {
                     confirmationMsg += ' (set --allow-destructive flag to skip this confirmation)';
+                }
+                if (process.env['CI']) {
+                    console.log(
+                        chalk.red(
+                            `Syncs/Actions were not deployed. Confirm the deploy by passing the --auto-confirm flag${shouldConfirmDestructive ? ' and --allow-destructive flag' : ''}. Exiting`
+                        )
+                    );
+                    process.exit(1);
                 }
                 const confirmation = await promptly.confirm(confirmationMsg);
                 if (!confirmation) {

--- a/packages/cli/lib/types.ts
+++ b/packages/cli/lib/types.ts
@@ -12,4 +12,5 @@ export interface DeployOptions extends GlobalOptions {
     version?: string;
     sync?: string;
     action?: string;
+    allowDestructive?: boolean;
 }


### PR DESCRIPTION
This is the first step to address https://linear.app/nango/project/data-loss-prevention-255ab3eaad30/overview
More specifically addressing sync deletion/renaming.

Forcing confirmation when deploying via the CLI and sync(s) with connection(s) is(are) being deleted
Ignoring `--allow-confirm` flag since it is used for more than one scenario.
Behavior can be by-passed with explicit --allow-destrictive flag at the risk of deploying a change that could cause records to be deleted

To deploy syncs deletion users must pass the very explicit `--allow-destructive` flag to their CI or deploy manually with this flag.

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
