### PR TITLE
fix: frequency when no quantity

### DIFF
--- a/packages/webapp/src/utils/utils.tsx
+++ b/packages/webapp/src/utils/utils.tsx
@@ -219,8 +219,8 @@ export function formatFrequency(frequency: string): string {
         hour: 'h',
         days: 'd',
         day: 'd',
-        months: 'mon',
-        month: 'mon',
+        months: 'mos',
+        month: 'mo',
         years: 'y',
         year: 'y'
     };

--- a/packages/webapp/src/utils/utils.tsx
+++ b/packages/webapp/src/utils/utils.tsx
@@ -218,10 +218,20 @@ export function formatFrequency(frequency: string): string {
         hours: 'h',
         hour: 'h',
         days: 'd',
-        day: 'd'
+        day: 'd',
+        months: 'mon',
+        month: 'mon',
+        years: 'y',
+        year: 'y'
     };
 
-    frequency = frequency.replace('every', '');
+    // 1. replace every: every 5 minutes -> 5 minutes
+    frequency = frequency.replace('every', '').trim();
+    // 2. prefix with `1` if no quantity. Ex: every day -> day -> 1day
+    if (!/^\d/.test(frequency)) {
+        frequency = '1' + frequency;
+    }
+    // 3. replace unit by shortname if possible: Ex: 5 minutes -> 5m
     for (const [unit, abbreviation] of Object.entries(unitMap)) {
         if (frequency.includes(unit)) {
             return frequency.replace(unit, abbreviation).replace(/\s/g, '');


### PR DESCRIPTION
if frequency is set to `every hour` the connection page shows `h`.
This commit ensures such frequencies shows as `1h` (or `1d`, ...) 

Also adding abbreviation for month and year even though we don't have a lot of such syncs, it is just to be consistent

<img width="1033" alt="Screenshot 2024-07-02 at 10 38 11" src="https://github.com/NangoHQ/nango/assets/233326/5a4f0e78-ef93-42b6-a194-5652ddc0104c">


## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
