### PR TITLE
fix(validation): do no throw if invalid json schema

### DIFF
--- a/packages/shared/lib/sdk/dataValidation.unit.test.ts
+++ b/packages/shared/lib/sdk/dataValidation.unit.test.ts
@@ -64,4 +64,16 @@ describe('validateInput', () => {
             }
         ]);
     });
+
+    it('should not throw if invalid json schema', () => {
+        const val = validateInput({
+            input: { foo: 'bar' },
+            modelName: 'Test',
+            jsonSchema: {
+                definitions: { Test: { type: 'object', properties: { ref: { $ref: '#/definitions/NotFound' } } } }
+            }
+        });
+        // Stringify because it's an exotic error object
+        expect(JSON.parse(JSON.stringify(val))).toStrictEqual([{ missingRef: '#/definitions/NotFound', missingSchema: '' }]);
+    });
 });


### PR DESCRIPTION
## Describe your changes

We want to have a controlled output in case of the feature being disabled like rn

- Do not throw if the json schema is invalid (missing ref, etc.)
