### PR TITLE
fix(nango-yaml): handle deep circular ref, correctly output recursive models

### DIFF
--- a/packages/cli/lib/services/__snapshots__/config.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/config.service.unit.test.ts.snap
@@ -185,6 +185,7 @@ exports[`load > should parse a nango.yaml file that is version 2 as expected 1`]
           "type": "action",
           "usedModels": [
             "GithubCreateOutput",
+            "GithubIssue",
             "GithubCreateIssueInput",
           ],
         },

--- a/packages/nango-yaml/lib/errors.ts
+++ b/packages/nango-yaml/lib/errors.ts
@@ -91,11 +91,14 @@ export class ParserErrorModelIsLiteral extends ParserError {
 }
 
 export class ParserErrorCycle extends ParserError {
-    constructor(options: { name: string }) {
+    constructor(options: { stack: Set<string> }) {
+        const arr = Array.from(options.stack);
+        const start = arr.shift();
+        const end = arr.pop();
         super({
             code: 'cyclic_model',
-            message: `Cyclic import ${options.name}->${options.name}`,
-            path: [options.name]
+            message: `Cyclic import ${start}->${end}`,
+            path: Array.from(options.stack)
         });
     }
 }

--- a/packages/nango-yaml/lib/modelsParser.unit.test.ts
+++ b/packages/nango-yaml/lib/modelsParser.unit.test.ts
@@ -373,7 +373,7 @@ describe('parse', () => {
             const parser = new ModelsParser({ raw: { Test: { user: 'Test' } } });
             parser.parseAll();
 
-            expect(parser.warnings).toStrictEqual([new ParserErrorCycle({ name: 'Test' })]);
+            expect(parser.warnings).toStrictEqual([new ParserErrorCycle({ stack: new Set(['Test']) })]);
             expect(Object.fromEntries(parser.parsed)).toStrictEqual({
                 Test: { name: 'Test', fields: [{ name: 'user', value: 'Test', model: true, optional: false, array: false }] }
             });
@@ -383,7 +383,7 @@ describe('parse', () => {
             const parser = new ModelsParser({ raw: { Test: { user: { author: 'Test' } } } });
             parser.parseAll();
 
-            expect(parser.warnings).toStrictEqual([new ParserErrorCycle({ name: 'Test' })]);
+            expect(parser.warnings).toStrictEqual([new ParserErrorCycle({ stack: new Set(['Test']) })]);
             expect(Object.fromEntries(parser.parsed)).toStrictEqual({
                 Test: {
                     name: 'Test',
@@ -392,11 +392,32 @@ describe('parse', () => {
             });
         });
 
+        it('should handle cyclic through model', () => {
+            const parser = new ModelsParser({ raw: { Start: { ref: 'Middle' }, Middle: { ref: 'End' }, End: { ref: 'Start' } } });
+            parser.parseAll();
+
+            expect(parser.warnings).toStrictEqual([new ParserErrorCycle({ stack: new Set(['Start', 'Middle', 'End']) })]);
+            expect(Object.fromEntries(parser.parsed)).toStrictEqual({
+                End: {
+                    name: 'End',
+                    fields: [{ array: false, model: true, name: 'ref', optional: false, value: 'Start' }]
+                },
+                Middle: {
+                    name: 'Middle',
+                    fields: [{ array: false, model: true, name: 'ref', optional: false, value: 'End' }]
+                },
+                Start: {
+                    name: 'Start',
+                    fields: [{ array: false, model: true, name: 'ref', optional: false, value: 'Middle' }]
+                }
+            });
+        });
+
         it('should handle cyclic through array', () => {
             const parser = new ModelsParser({ raw: { Test: { user: ['Test'] } } });
             parser.parseAll();
 
-            expect(parser.warnings).toStrictEqual([new ParserErrorCycle({ name: 'Test' })]);
+            expect(parser.warnings).toStrictEqual([new ParserErrorCycle({ stack: new Set(['Test']) })]);
             expect(Object.fromEntries(parser.parsed)).toStrictEqual({
                 Test: {
                     name: 'Test',

--- a/packages/nango-yaml/lib/parser.v2.ts
+++ b/packages/nango-yaml/lib/parser.v2.ts
@@ -210,7 +210,7 @@ export class NangoYamlParserV2 extends NangoYamlParser {
         }
 
         // Create anonymous model for validation
-        const parsed = this.modelsParser.parseFields({ fields: { input: rawInput }, parent: name });
+        const parsed = this.modelsParser.parseFields({ fields: { input: rawInput }, stack: new Set([name]) });
 
         const anon = `Anonymous_${integrationName.replace(/[^A-Za-z0-9_]/g, '')}_${type}_${name.replace(/[^A-Za-z0-9_]/g, '')}_input`;
         const anonModel: NangoModel = { name: anon, fields: parsed, isAnon: true };


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1331/handle-deep-recursive-model-and-output

- **Handle deeply nested circular ref**
While testing, I encountered an edge case I initially spotted but not tested hard enough. I added supported for circular ref, but only if it was a direct circular ref (`A -> A`); but well it's possible to go deeper, i.e: `A -> B -> C -> A`. It's now supported.

- **Output all used models per scripts** correctly
With deep circular ref and other large models, I wasn't fetching the model names recursively correctly. 
It wasn't the case before the refacto but the `model_schema` was only used for display; Now I'm using that field as a source of truth to find related json schema, so in some case we were missing a definition.
