### PR TITLE
chore: reduce dequeue long polling timeout to 10s

### DIFF
--- a/packages/orchestrator/lib/routes/v1/postDequeue.ts
+++ b/packages/orchestrator/lib/routes/v1/postDequeue.ts
@@ -45,7 +45,7 @@ export const routeHandler = (scheduler: Scheduler, eventEmitter: EventEmitter): 
 const handler = (scheduler: Scheduler, eventEmitter: EventEmitter) => {
     return async (req: EndpointRequest<PostDequeue>, res: EndpointResponse<PostDequeue>) => {
         const { groupKey, limit, longPolling: longPolling } = req.body;
-        const longPollingTimeoutMs = 60_000;
+        const longPollingTimeoutMs = 10_000;
         const eventId = `task:created:${groupKey}`;
         const cleanupAndRespond = (respond: (res: EndpointResponse<PostDequeue>) => void) => {
             if (timeout) {


### PR DESCRIPTION
I was extremely conservative when setting the dequeue polling timeout to 60s 
Lowering the timeout to 10s. Having one dequeuing per processor every 10seconds is still very conservative I think

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
