### PR TITLE
fix(nango-yaml): object -> Record

### DIFF
--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -399,7 +399,7 @@ export interface Base {
   obj: {  nested: string;};
   optional?: string;
   arrayLiteral: any[];
-  objectLiteral: object;
+  objectLiteral: Record<string, any>;
   any: any;
   float: number;
   bigint: bigint;

--- a/packages/nango-yaml/lib/helpers.ts
+++ b/packages/nango-yaml/lib/helpers.ts
@@ -139,7 +139,7 @@ export const typesAliases: Record<string, string> = {
     boolean: 'boolean',
     bigint: 'bigint',
     date: 'Date',
-    object: 'object',
+    object: 'Record<string, any>',
     any: 'any',
     array: 'any[]',
     undefined: 'undefined'

--- a/packages/nango-yaml/lib/modelsParser.unit.test.ts
+++ b/packages/nango-yaml/lib/modelsParser.unit.test.ts
@@ -120,7 +120,7 @@ describe('parse', () => {
             expect(Object.fromEntries(parser.parsed)).toStrictEqual({
                 Test: {
                     name: 'Test',
-                    fields: [{ name: 'sub', optional: false, tsType: true, value: 'object', array: false }]
+                    fields: [{ name: 'sub', optional: false, tsType: true, value: 'Record<string, any>', array: false }]
                 }
             });
         });


### PR DESCRIPTION
## Describe your changes

For retro compat I supported this syntax as-is but `object` in javascript can also be null and other stuff while the intended behavior is to emulate a json object. Using `object` can cause some tools that are stricter to think something than what the user expected.

- Transform `object` to `Record`
