### PR TITLE
chore(CLI): Protect against sync model renaming destructive consequences

### DIFF
--- a/docs-v2/reference/cli.mdx
+++ b/docs-v2/reference/cli.mdx
@@ -70,7 +70,7 @@ Global command flags:
 
 ```bash
 # Command flag to auto-confirm all prompts (useful for CI).
-# Note: Destructive changes (like removing a sync) requires confirmation, even when --auto-confirm is set. To bypass this restriction, the --allow-destructive flag can be passed to nango deploy.
+# Note: Destructive changes (like removing a sync or renaming a model) requires confirmation, even when --auto-confirm is set. To bypass this restriction, the --allow-destructive flag can be passed to nango deploy.
 --auto-confirm
 ```
 
@@ -89,7 +89,7 @@ NANGO_HOSTPORT=https://api.nango.dev # Default value
 NANGO_CLI_UPGRADE_MODE=prompt # Default value
 
 # Whether to prompt before deployments.
-# Note: Destructive changes (like removing a sync) requires confirmation, even when NANGO_DEPLOY_AUTO_CONFIRM is set to true. To bypass this restriction, the --allow-destructive flag can be passed to nango deploy.
+# Note: Destructive changes (like removing a sync or renaming a model) requires confirmation, even when NANGO_DEPLOY_AUTO_CONFIRM is set to true. To bypass this restriction, the --allow-destructive flag can be passed to nango deploy.
 NANGO_DEPLOY_AUTO_CONFIRM=false # Default value
 ```
 

--- a/docs-v2/reference/integration-configuration.mdx
+++ b/docs-v2/reference/integration-configuration.mdx
@@ -368,6 +368,9 @@ For [full refresh syncs](/understand/concepts/syncs#full-refresh-syncs), as the 
 
 For [incremental syncs](/understand/concepts/syncs#incremental-syncs), you can end up with model disparities, as older records will have outdated content. You will still be able to fetch them from the Nango cache. In some cases, it's better to trigger a full resync via the [API](/reference/api/sync/trigger) or the Nango UI, so that all historical records are fetched again using the new script & model.
 
+<Warning>
+Changing a model name in your configuration is the equivalent of deleting the model with the old name, and creating a new one.
+</Warning>
 
 # Importing models in scripts
 

--- a/packages/cli/lib/services/deploy.service.ts
+++ b/packages/cli/lib/services/deploy.service.ts
@@ -159,7 +159,7 @@ class DeployService {
                 console.log(JSON.stringify(response.data, null, 2));
             }
 
-            const { newSyncs, deletedSyncs } = response.data;
+            const { newSyncs, deletedSyncs, deletedModels } = response.data;
 
             for (const sync of newSyncs) {
                 const syncMessage =
@@ -179,13 +179,22 @@ class DeployService {
                 deletedSyncsConnectionsCount += sync.connections;
             }
 
+            if (deletedModels.length > 0) {
+                console.log(
+                    chalk.red(
+                        `The following models have been removed: ${deletedModels.join(', ')}. WARNING: Renaming a model is the equivalent of deleting the old model and creating a new one. Records from the old model won't be transferred to the new model. Consider running a full sync to transfer records.`
+                    )
+                );
+            }
+
             // force confirmation :
             // - if auto-confirm flag is not set
             // - OR if there are deleted syncs with connections (and allow-destructive flag is not set)
+            // - OR if there are deleted models (and allow-destructive flag is not set)
             // If CI, fail the deploy
-            const shouldConfirmDestructive = deletedSyncsConnectionsCount > 0 && !allowDestructive;
+            const shouldConfirmDestructive = (deletedSyncsConnectionsCount > 0 || deletedModels.length > 0) && !allowDestructive;
             if (shouldConfirm || shouldConfirmDestructive) {
-                let confirmationMsg = 'Are you sure you want to continue y/n?';
+                let confirmationMsg = `Are you sure you want to continue y/n?`;
                 if (!shouldConfirm && shouldConfirmDestructive) {
                     confirmationMsg += ' (set --allow-destructive flag to skip this confirmation)';
                 }

--- a/packages/server/lib/controllers/sync/deploy/postConfirmation.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postConfirmation.integration.test.ts
@@ -72,7 +72,8 @@ describe(`POST ${endpoint}`, () => {
             deletedActions: [],
             deletedSyncs: [],
             newActions: [],
-            newSyncs: []
+            newSyncs: [],
+            deletedModels: []
         });
         expect(res.res.status).toBe(200);
     });

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -533,6 +533,16 @@ export const getAndReconcileDifferences = async ({
     // the "custom" sync configs
     const existingSyncs = await getActiveCustomSyncConfigsByEnvironmentId(environmentId);
 
+    const deletedModels = flows
+        .filter((flow) => flow.type === 'sync')
+        .flatMap((flow) => {
+            const existing = existingSyncs.find((sync) => sync.sync_name === flow.syncName && sync.unique_key === flow.providerConfigKey);
+            if (existing) {
+                return existing?.models.filter((model) => !flow.models.includes(model));
+            }
+            return [];
+        });
+
     const deletedSyncs: SlimSync[] = [];
     const deletedActions: SlimAction[] = [];
 
@@ -591,7 +601,8 @@ export const getAndReconcileDifferences = async ({
         newSyncs,
         newActions,
         deletedSyncs,
-        deletedActions
+        deletedActions,
+        deletedModels
     };
 };
 

--- a/packages/types/lib/deploy/api.ts
+++ b/packages/types/lib/deploy/api.ts
@@ -53,4 +53,5 @@ export interface SyncAndActionDifferences {
     deletedSyncs: SlimSync[];
     newActions: SlimAction[];
     deletedActions: SlimAction[];
+    deletedModels: string[];
 }


### PR DESCRIPTION
Force confirmation when a model is being deleted or renamed.
The consequences of renaming a model are highlighted in our docs at https://docs.nango.dev/reference/integration-configuration#changing-a-model-or-script, with this PR we are making sure users confirm model renaming/deletion at deploy time

## Issue ticket number and link
https://linear.app/nango/issue/NAN-li/protect-against-sync-model-renaming-destructive-consequences

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
