### PR TITLE
feat(connections): Allow editing of connection display name, customer email, and customer domain via detail view on web app

### DIFF
--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -413,11 +413,23 @@ export default class Nango {
             }
 
             if (connectionConfig.hmac) {
-                query.push(`hmac=${connectionConfig.hmac}`);
+                query.push(`hmac=${encodeURIComponent(connectionConfig.hmac)}`);
             }
 
             if (connectionConfig.user_scope) {
-                query.push(`user_scope=${connectionConfig.user_scope.join(',')}`);
+                query.push(`user_scope=${encodeURIComponent(connectionConfig.user_scope.join(','))}`);
+            }
+
+            if (connectionConfig.display_name) {
+                query.push(`params[display_name]=${encodeURIComponent(connectionConfig.display_name)}`);
+            }
+
+            if (connectionConfig.customer_email) {
+                query.push(`params[customer_email]=${encodeURIComponent(connectionConfig.customer_email)}`);
+            }
+
+            if (connectionConfig.customer_domain) {
+                query.push(`params[customer_domain]=${encodeURIComponent(connectionConfig.customer_domain)}`);
             }
 
             if (connectionConfig.credentials) {
@@ -458,6 +470,9 @@ interface ConnectionConfig {
     user_scope?: string[];
     authorization_params?: Record<string, string | undefined>;
     credentials?: OAuthCredentialsOverride | BasicApiCredentials | ApiKeyCredentials | AppStoreCredentials | TBACredentials;
+    display_name?: string;
+    customer_email?: string;
+    customer_domain?: string;
 }
 
 interface OAuthCredentialsOverride {

--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -120,6 +120,7 @@ class ConnectionController {
 
                 if (isWeb) {
                     list.active_logs = connection.active_logs;
+                    list.connection_config = connection.connection_config;
                 }
 
                 return list;
@@ -647,7 +648,16 @@ class ConnectionController {
                     updatedConnection = imported;
                 }
             } else if (template.auth_mode === 'NONE') {
-                const [imported] = await connectionService.upsertUnauthConnection(connection_id, provider_config_key, provider, environment.id, account.id);
+                const { connection_config } = req.body;
+
+                const [imported] = await connectionService.upsertUnauthConnection(
+                    connection_id,
+                    provider_config_key,
+                    provider,
+                    connection_config,
+                    environment.id,
+                    account.id
+                );
 
                 if (imported) {
                     updatedConnection = imported;

--- a/packages/server/lib/controllers/connection/setMetadata.ts
+++ b/packages/server/lib/controllers/connection/setMetadata.ts
@@ -30,7 +30,7 @@ export const setMetadata = asyncWrapper<SetMetadata>(async (req, res) => {
 
     const { environment } = res.locals;
 
-    const body: Required<MetadataBody> = val.data;
+    const body: MetadataBody = val.data;
 
     const { connection_id: connectionIdArg, provider_config_key: providerConfigKey, metadata } = body;
 

--- a/packages/server/lib/controllers/unauth.controller.ts
+++ b/packages/server/lib/controllers/unauth.controller.ts
@@ -1,5 +1,15 @@
 import type { Request, Response, NextFunction } from 'express';
-import { errorManager, analytics, AnalyticsTypes, configService, connectionService, hmacService, ErrorSourceEnum, LogActionEnum } from '@nangohq/shared';
+import {
+    errorManager,
+    analytics,
+    AnalyticsTypes,
+    configService,
+    connectionService,
+    hmacService,
+    ErrorSourceEnum,
+    LogActionEnum,
+    getConnectionConfig
+} from '@nangohq/shared';
 import type { LogContext } from '@nangohq/logs';
 import { logContextGetter } from '@nangohq/logs';
 import { stringifyError } from '@nangohq/utils';
@@ -11,6 +21,11 @@ class UnAuthController {
         const { environment, account } = res.locals;
         const { providerConfigKey } = req.params;
         const connectionId = req.query['connection_id'] as string | undefined;
+        const connectionConfig = req.query['params'] != null ? getConnectionConfig(req.query['params']) : {};
+
+        console.log('THIS JUST RAN OH YEAH');
+        console.log(req.query['params']);
+        console.log(connectionConfig);
 
         let logCtx: LogContext | undefined;
 
@@ -86,6 +101,7 @@ class UnAuthController {
                 connectionId,
                 providerConfigKey,
                 config.provider,
+                connectionConfig,
                 environment.id,
                 account.id
             );

--- a/packages/server/lib/controllers/unauth.controller.ts
+++ b/packages/server/lib/controllers/unauth.controller.ts
@@ -23,10 +23,6 @@ class UnAuthController {
         const connectionId = req.query['connection_id'] as string | undefined;
         const connectionConfig = req.query['params'] != null ? getConnectionConfig(req.query['params']) : {};
 
-        console.log('THIS JUST RAN OH YEAH');
-        console.log(req.query['params']);
-        console.log(connectionConfig);
-
         let logCtx: LogContext | undefined;
 
         try {

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -199,6 +199,7 @@ web.route('/api/v1/integration/:providerConfigKey/connections').get(webAuth, con
 web.route('/api/v1/provider').get(configController.listProvidersFromYaml.bind(configController));
 
 web.route('/api/v1/connection').get(webAuth, connectionController.listConnections.bind(connectionController));
+web.route('/api/v1/connection/metadata').patch(webAuth, updateMetadata);
 web.route('/api/v1/connection/:connectionId').get(webAuth, getConnectionWeb);
 web.route('/api/v1/connection/:connectionId').delete(webAuth, connectionController.deleteConnection.bind(connectionController));
 web.route('/api/v1/connection/admin/:connectionId').delete(webAuth, connectionController.deleteAdminConnection.bind(connectionController));

--- a/packages/shared/lib/models/Connection.ts
+++ b/packages/shared/lib/models/Connection.ts
@@ -84,4 +84,5 @@ export interface ConnectionList {
     created: string;
     metadata?: Metadata | null;
     active_logs?: ActiveLogIds | null;
+    connection_config?: ConnectionConfig;
 }

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -231,6 +231,7 @@ class ConnectionService {
         connectionId: string,
         providerConfigKey: string,
         provider: string,
+        connectionConfig: ConnectionConfig,
         environment_id: number,
         accountId: number
     ): Promise<ConnectionUpsertResponse[]> {
@@ -245,7 +246,8 @@ class ConnectionService {
                     connection_id: connectionId,
                     provider_config_key: providerConfigKey,
                     config_id: config_id as number,
-                    updated_at: new Date()
+                    updated_at: new Date(),
+                    connection_config: connectionConfig
                 })
                 .returning('*');
 
@@ -259,7 +261,7 @@ class ConnectionService {
                 connection_id: connectionId,
                 provider_config_key: providerConfigKey,
                 credentials: {},
-                connection_config: {},
+                connection_config: connectionConfig,
                 environment_id,
                 config_id: config_id!
             })
@@ -579,7 +581,17 @@ class ConnectionService {
     public async listConnections(
         environment_id: number,
         connectionId?: string
-    ): Promise<{ id: number; connection_id: string; provider: string; created: string; metadata: Metadata; active_logs: ActiveLogIds }[]> {
+    ): Promise<
+        {
+            id: number;
+            connection_id: string;
+            provider: string;
+            created: string;
+            metadata: Metadata;
+            active_logs: ActiveLogIds;
+            connection_config: ConnectionConfig;
+        }[]
+    > {
         const queryBuilder = db.knex
             .from<Connection>(`_nango_connections`)
             .select(
@@ -588,6 +600,7 @@ class ConnectionService {
                 { provider: '_nango_connections.provider_config_key' },
                 { created: '_nango_connections.created_at' },
                 '_nango_connections.metadata',
+                '_nango_connections.connection_config',
                 db.knex.raw(`
                   (SELECT json_build_object(
                       'log_id', log_id

--- a/packages/types/lib/connection/api/metadata.ts
+++ b/packages/types/lib/connection/api/metadata.ts
@@ -5,6 +5,9 @@ export interface MetadataBody {
     connection_id: string | string[];
     provider_config_key: string;
     metadata: Metadata;
+    display_name?: string;
+    customer_domain?: string;
+    customer_email?: string;
 }
 
 type MetadataError = ApiError<'invalid_body'> | ApiError<'unknown_connection'>;

--- a/packages/webapp/src/components/MultiSelect.tsx
+++ b/packages/webapp/src/components/MultiSelect.tsx
@@ -12,9 +12,10 @@ export interface MultiSelectArgs<T> {
     defaultSelect: T[];
     all?: boolean;
     onChange: (selected: T[]) => void;
+    emptyLabel?: string;
 }
 
-export const MultiSelect: React.FC<MultiSelectArgs<any>> = ({ label, options, selected, defaultSelect, all, onChange }) => {
+export const MultiSelect: React.FC<MultiSelectArgs<any>> = ({ label, options, selected, defaultSelect, all, onChange, emptyLabel = 'No framework found.' }) => {
     const [open, setOpen] = useState(false);
 
     const select = (val: string, checked: boolean) => {
@@ -71,7 +72,7 @@ export const MultiSelect: React.FC<MultiSelectArgs<any>> = ({ label, options, se
             <PopoverContent className="w-56 p-0 text-white bg-active-gray" align="end">
                 <Command>
                     <CommandList>
-                        <CommandEmpty>No framework found.</CommandEmpty>
+                        <CommandEmpty>{emptyLabel}</CommandEmpty>
                         <CommandGroup>
                             {options.map((option) => {
                                 const checked = selected.some((sel) => option.value === sel);

--- a/packages/webapp/src/components/ui/input/EditableField.tsx
+++ b/packages/webapp/src/components/ui/input/EditableField.tsx
@@ -1,0 +1,56 @@
+import type React from 'react';
+import { useState } from 'react';
+import { Pencil1Icon } from '@radix-ui/react-icons';
+import { Tooltip } from '@geist-ui/core';
+import { cn } from '../../../utils/utils';
+
+interface EditableFieldProps {
+    value: string;
+    onSave: (newValue: string) => void;
+    onChange?: (newValue: string) => void;
+    className?: string;
+    dark?: boolean;
+}
+
+const EditableField: React.FC<EditableFieldProps> = ({ value, onSave, onChange, className, dark = false }) => {
+    const [isEditing, setIsEditing] = useState(false);
+    const [editValue, setEditValue] = useState(value);
+
+    const handleBlur = () => {
+        setIsEditing(false);
+        onSave(editValue);
+    };
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const newValue = e.target.value;
+        setEditValue(newValue);
+        if (onChange) {
+            onChange(newValue);
+        }
+    };
+
+    return (
+        <div className={`flex items-center gap-2 ${className}`}>
+            {isEditing ? (
+                <input
+                    type="text"
+                    value={editValue}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    onKeyDown={(e) => e.key === 'Enter' && handleBlur()}
+                    autoFocus
+                    className="border-border-gray bg-active-gray text-text-light-gray focus:border-white focus:ring-white block w-full appearance-none rounded-md border px-3 py-1 text-sm placeholder-gray-400 shadow-sm focus:outline-none"
+                />
+            ) : (
+                <>
+                    <span className="text-white break-all">{value || '-'}</span>
+                    <Tooltip text="Edit" type={dark ? 'dark' : 'default'}>
+                        <Pencil1Icon onClick={() => setIsEditing(true)} color="gray" className={cn(`h-4 w-4 cursor-pointer`, className)} />
+                    </Tooltip>
+                </>
+            )}
+        </div>
+    );
+};
+
+export default EditableField;

--- a/packages/webapp/src/pages/Connection/Authorization.tsx
+++ b/packages/webapp/src/pages/Connection/Authorization.tsx
@@ -28,9 +28,9 @@ export default function Authorization(props: AuthorizationProps) {
 
     if (!loaded) return <Loading spaceRatio={2.5} className="top-24" />;
 
-    const displayName = connection.metadata ? connection.metadata['nango.meta.display_name'] : undefined;
-    const customerEmail = connection.metadata ? connection.metadata['nango.meta.customer_email'] : undefined;
-    const customerDomain = connection.metadata ? connection.metadata['nango.meta.customer_domain'] : undefined;
+    const displayName = connection.connection_config?.display_name;
+    const customerDomain = connection.connection_config?.customer_domain;
+    const customerEmail = connection.connection_config?.customer_email;
 
     return (
         <div className="mx-auto space-y-12 text-sm w-[976px]">

--- a/packages/webapp/src/pages/Connection/Authorization.tsx
+++ b/packages/webapp/src/pages/Connection/Authorization.tsx
@@ -28,14 +28,17 @@ export default function Authorization(props: AuthorizationProps) {
 
     if (!loaded) return <Loading spaceRatio={2.5} className="top-24" />;
 
+    const displayName = connection.metadata ? connection.metadata['nango.meta.display_name'] : undefined;
+    const customerEmail = connection.metadata ? connection.metadata['nango.meta.customer_email'] : undefined;
+    const customerDomain = connection.metadata ? connection.metadata['nango.meta.customer_domain'] : undefined;
+
     return (
         <div className="mx-auto space-y-12 text-sm w-[976px]">
             <div className="flex">
                 <div className="flex flex-col w-1/2">
-                    <span className="text-gray-400 text-xs uppercase mb-1">Connection ID</span>
+                    <span className="text-gray-400 text-xs uppercase mb-1">Connection Display Name</span>
                     <div className="flex items-center gap-2">
-                        <span className="text-white break-all">{connection.connection_id}</span>
-                        <CopyButton text={connection.connection_id} dark />
+                        <span className="text-white break-all">{typeof displayName === 'string' ? displayName : '-'}</span>
                     </div>
                 </div>
                 {connection.created_at && (
@@ -46,6 +49,25 @@ export default function Authorization(props: AuthorizationProps) {
                 )}
             </div>
             <div className="flex">
+                <div className="flex flex-col w-1/2">
+                    <span className="text-gray-400 text-xs uppercase mb-1">Domain</span>
+                    <div className="flex items-center gap-2">
+                        <span className="text-white break-all">{typeof customerDomain === 'string' ? customerDomain : '-'}</span>
+                    </div>
+                </div>
+                <div className="flex flex-col w-1/2">
+                    <span className="text-gray-400 text-xs uppercase mb-1">Connection ID</span>
+                    <div className="flex items-center gap-2">
+                        <span className="text-white break-all">{connection.connection_id}</span>
+                        <CopyButton text={connection.connection_id} dark />
+                    </div>
+                </div>
+            </div>
+            <div className="flex">
+                <div className="flex flex-col w-1/2">
+                    <span className="text-gray-400 text-xs uppercase mb-2">Customer Email</span>
+                    <span className="text-white break-all">{typeof customerEmail === 'string' ? customerEmail : '-'}</span>
+                </div>
                 <div className="flex flex-col w-1/2">
                     <span className="text-gray-400 text-xs uppercase mb-2">Auth Type</span>
                     <span className="text-white">{connection.credentials.type || 'None'}</span>

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -27,10 +27,10 @@ export default function ConnectionList() {
 
     const [connections, setConnections] = useState<Connection[] | null>(null);
     const [filteredConnections, setFilteredConnections] = useState<Connection[]>([]);
-    const [setNumberofErroredConnections, setNumberOfErroredConnections] = useState<number>(0);
-    const [selectedIntegration, setSelectedIntegration] = useState<string[]>(defaultFilter);
+    const [numberOfErroredConnections, setNumberOfErroredConnections] = useState<number>(0);
+    const [selectedIntegrations, setSelectedIntegrations] = useState<string[]>(defaultFilter);
     const [connectionSearch, setConnectionSearch] = useState<string>('');
-    const [states, setStates] = useState<string[]>(defaultFilter);
+    const [selectedStatuses, setSelectedStatuses] = useState<string[]>(defaultFilter);
 
     useEffect(() => {
         if (data) {
@@ -47,15 +47,19 @@ export default function ConnectionList() {
                 filtered = filtered?.filter((connection) => connection.connection_id.toLowerCase().includes(connectionSearch.toLowerCase()));
             }
 
-            if (selectedIntegration.length > 0 && !selectedIntegration.includes('all')) {
-                filtered = filtered?.filter((connection) => selectedIntegration.includes(connection.provider_config_key));
+            if (selectedIntegrations.length > 0 && !selectedIntegrations.includes('all')) {
+                filtered = filtered?.filter((connection) => selectedIntegrations.includes(connection.provider_config_key));
             }
 
-            if (states.length !== 0 && !states.includes('all') && !(states.includes('ok') && states.includes('error'))) {
-                if (states.includes('error')) {
+            if (
+                selectedStatuses.length !== 0 &&
+                !selectedStatuses.includes('all') &&
+                !(selectedStatuses.includes('ok') && selectedStatuses.includes('error'))
+            ) {
+                if (selectedStatuses.includes('error')) {
                     filtered = filtered?.filter((connection) => connection.active_logs);
                 }
-                if (states.includes('ok')) {
+                if (selectedStatuses.includes('ok')) {
                     filtered = filtered?.filter((connection) => !connection.active_logs);
                 }
             }
@@ -63,7 +67,7 @@ export default function ConnectionList() {
             setFilteredConnections(filtered || []);
             setNumberOfErroredConnections((filtered || []).filter((connection) => connection.active_logs).length);
         }
-    }, [connectionSearch, selectedIntegration, states, data]);
+    }, [connectionSearch, selectedIntegrations, selectedStatuses, data]);
 
     const debouncedSearch = useCallback(
         debounce((value: string) => {
@@ -83,10 +87,10 @@ export default function ConnectionList() {
 
     const handleIntegrationChange = (values: string[]) => {
         if (values.includes('all')) {
-            setSelectedIntegration(defaultFilter);
+            setSelectedIntegrations(defaultFilter);
             return;
         }
-        setSelectedIntegration(values);
+        setSelectedIntegrations(values);
     };
 
     useEffect(() => {
@@ -160,7 +164,7 @@ export default function ConnectionList() {
                         {filteredConnections.length} connection{filteredConnections.length !== 1 ? 's' : ''}
                         {errorNotifications > 0 && (
                             <span className="flex items-center ml-1">
-                                ({setNumberofErroredConnections} errored)<span className="ml-1 bg-red-base h-1.5 w-1.5 rounded-full"></span>
+                                ({numberOfErroredConnections} errored)<span className="ml-1 bg-red-base h-1.5 w-1.5 rounded-full"></span>
                             </span>
                         )}
                     </div>
@@ -180,7 +184,7 @@ export default function ConnectionList() {
                                 options={providers.map((integration: string) => {
                                     return { name: integration, value: integration };
                                 })}
-                                selected={selectedIntegration}
+                                selected={selectedIntegrations}
                                 defaultSelect={defaultFilter}
                                 onChange={handleIntegrationChange}
                                 all
@@ -191,9 +195,9 @@ export default function ConnectionList() {
                                     { name: 'OK', value: 'ok' },
                                     { name: 'Error', value: 'error' }
                                 ]}
-                                selected={states}
+                                selected={selectedStatuses}
                                 defaultSelect={defaultFilter}
-                                onChange={setStates}
+                                onChange={setSelectedStatuses}
                                 all
                             />
                         </div>

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -195,7 +195,7 @@ export default function ConnectionList() {
                                 <MultiSelect
                                     label="Customer Domains"
                                     options={connections.reduce((acc: { name: string; value: string }[], connection: Connection) => {
-                                        const sitename = connection.metadata?.['nango.meta.customer_domain'];
+                                        const sitename = connection?.connection_config ? connection.connection_config['customer_domain'] : undefined;
                                         if (typeof sitename === 'string') {
                                             acc.push({
                                                 name: sitename,
@@ -244,7 +244,7 @@ export default function ConnectionList() {
                                         provider_config_key: providerConfigKey,
                                         created: creationDate,
                                         active_logs,
-                                        metadata
+                                        connection_config
                                     }) => (
                                         <div
                                             key={`tr-${id}`}
@@ -257,13 +257,13 @@ export default function ConnectionList() {
                                         >
                                             <div className="flex items-center w-1/4 gap-2 py-2 truncate">
                                                 <span className="break-words break-all truncate">
-                                                    {metadata ? (metadata['nango.meta.display_name'] as string | undefined) : '-'}
+                                                    {connection_config?.display_name ? (connection_config.display_name as string | undefined) : '-'}
                                                 </span>
                                                 {active_logs && <ErrorCircle />}
                                             </div>
                                             <div className="flex w-1/4">
                                                 <span className="break-words break-all truncate">
-                                                    {metadata ? (metadata['nango.meta.customer_domain'] as string | undefined) : '-'}
+                                                    {connection_config?.customer_domain ? (connection_config.customer_domain as string | undefined) : '-'}
                                                 </span>
                                             </div>
                                             <div className="flex items-center w-1/4 gap-3">

--- a/packages/webapp/src/utils/api.tsx
+++ b/packages/webapp/src/utils/api.tsx
@@ -585,6 +585,61 @@ export function useGetConnectionDetailsAPI(env: string) {
     };
 }
 
+export function useEditConnectionMetadataAPI(env: string) {
+    const signout = useSignout();
+
+    return async (
+        connectionId: string,
+        providerConfigKey: string,
+        metadata: Record<string, string> | undefined = undefined,
+        displayName: string | undefined = undefined,
+        customerEmail: string | undefined = undefined,
+        customerDomain: string | undefined = undefined
+    ) => {
+        try {
+            const body: Record<string, any> = {
+                connection_id: connectionId,
+                provider_config_key: providerConfigKey
+            };
+
+            if (metadata) {
+                body.metadata = metadata;
+            }
+
+            if (displayName) {
+                body.display_name = displayName;
+            }
+
+            if (customerEmail) {
+                body.customer_email = customerEmail;
+            }
+
+            if (customerDomain) {
+                body.customer_domain = customerDomain;
+            }
+
+            const options = {
+                method: 'PATCH',
+                body: JSON.stringify(body)
+            };
+
+            const res = await apiFetch(`/api/v1/connection/metadata?env=${env}`, options);
+
+            if (res.status === 401) {
+                return signout();
+            }
+
+            if (res.status !== 200) {
+                return serverErrorToast();
+            }
+
+            return res;
+        } catch {
+            requestErrorToast();
+        }
+    };
+}
+
 export function useDeleteConnectionAPI(env: string) {
     const signout = useSignout();
 


### PR DESCRIPTION
## Describe your changes
Adds functionality to edit connections to the web app. Extends off of [this PR](https://github.com/NangoHQ/nango/pull/2477).

<img width="1190" alt="image" src="https://github.com/NangoHQ/nango/assets/24847059/d8c31e02-3570-494e-9de1-227cb064678d">


This is a tentative draft PR so we can discuss the approach in more depth. We don't have a dedicated endpoint to update a connectionConfig, so I've jammed the parameters into the update metadata endpoint which equally doesn't feel right. The obvious approach would be to add a dedicated updateConnectionConfig endpoint, but doing that without causing footguns means we'd need to keep a separate list of potential connectionConfig parameters and whether or not they can be edited.

All this is making me lean towards the idea that perhaps these fields are neither metadata nor connection configuration, and should instead be considered _frontmatter_ - human intelligible metadata to be used in interfaces. 

## Issue ticket number and link
N/A

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
