### PR TITLE
fix(integration-templates): [nan-1328] remove auto start false

### DIFF
--- a/integration-templates/xero/nango.yaml
+++ b/integration-templates/xero/nango.yaml
@@ -8,7 +8,6 @@ integrations:
                 runs: every hour
                 output: Contact
                 sync_type: incremental
-                auto_start: false
                 endpoint: GET /xero/contacts
             accounts:
                 description: |
@@ -17,7 +16,6 @@ integrations:
                 scopes: accounting.settings
                 output: Account
                 sync_type: incremental
-                auto_start: false
                 endpoint: GET /xero/accounts
             items:
                 description: |
@@ -27,7 +25,6 @@ integrations:
                 scopes: accounting.settings
                 output: Item
                 sync_type: incremental
-                auto_start: false
                 endpoint: GET /xero/items
             invoices:
                 description: |
@@ -36,7 +33,6 @@ integrations:
                 scopes: accounting.transactions
                 output: Invoice
                 sync_type: incremental
-                auto_start: false
                 endpoint: GET /xero/invoices
             payments:
                 description: |
@@ -45,7 +41,6 @@ integrations:
                 scopes: accounting.transactions
                 output: Payment
                 sync_type: incremental
-                auto_start: false
                 endpoint: GET /xero/payments
         actions:
             create-contact:

--- a/packages/shared/flows.yaml
+++ b/packages/shared/flows.yaml
@@ -3428,7 +3428,6 @@ integrations:
                 runs: every hour
                 output: Contact
                 sync_type: incremental
-                auto_start: false
                 endpoint: GET /xero/contacts
             accounts:
                 description: >
@@ -3438,7 +3437,6 @@ integrations:
                 scopes: accounting.settings
                 output: Account
                 sync_type: incremental
-                auto_start: false
                 endpoint: GET /xero/accounts
             items:
                 description: >
@@ -3450,7 +3448,6 @@ integrations:
                 scopes: accounting.settings
                 output: Item
                 sync_type: incremental
-                auto_start: false
                 endpoint: GET /xero/items
             invoices:
                 description: |
@@ -3459,7 +3456,6 @@ integrations:
                 scopes: accounting.transactions
                 output: Invoice
                 sync_type: incremental
-                auto_start: false
                 endpoint: GET /xero/invoices
             payments:
                 description: |
@@ -3468,7 +3464,6 @@ integrations:
                 scopes: accounting.transactions
                 output: Payment
                 sync_type: incremental
-                auto_start: false
                 endpoint: GET /xero/payments
         actions:
             create-contact:


### PR DESCRIPTION
## Describe your changes
These syncs don't require metadata so no need for them to `auto_start: false`

## Issue ticket number and link
NAN-1328

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
