### PR TITLE
fix: slow connection page

### DIFF
--- a/packages/database/lib/migrations/20240708161616_index_sync_configs.cjs
+++ b/packages/database/lib/migrations/20240708161616_index_sync_configs.cjs
@@ -1,0 +1,11 @@
+exports.config = { transaction: false };
+
+exports.up = async function (knex, _) {
+    await knex.schema.raw(
+        `CREATE INDEX CONCURRENTLY idx_nango_sync_configs_sync_name_active ON _nango_sync_configs USING BTREE (sync_name) WHERE active = true`
+    );
+};
+
+exports.down = async function (knex, _) {
+    await knex.schema.raw('DROP INDEX CONCURRENTLY idx_nango_sync_configs_sync_name_active');
+};

--- a/packages/database/lib/migrations/20240708161616_index_sync_configs.cjs
+++ b/packages/database/lib/migrations/20240708161616_index_sync_configs.cjs
@@ -2,10 +2,12 @@ exports.config = { transaction: false };
 
 exports.up = async function (knex, _) {
     await knex.schema.raw(
-        `CREATE INDEX CONCURRENTLY idx_nango_sync_configs_sync_name_active ON _nango_sync_configs USING BTREE (sync_name) WHERE active = true`
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_nango_sync_configs_active
+            ON _nango_sync_configs USING BTREE (type, sync_name, nango_config_id)
+            WHERE active = true`
     );
 };
 
 exports.down = async function (knex, _) {
-    await knex.schema.raw('DROP INDEX CONCURRENTLY idx_nango_sync_configs_sync_name_active');
+    await knex.schema.raw('DROP INDEX CONCURRENTLY IF EXISTS idx_nango_sync_configs_active');
 };


### PR DESCRIPTION
## Describe your changes
The query to fetch syncs info had 2 quite expensive components. For each sync it must:
1. get the active sync config details
2. determine what's the latest sync job

This PR contains 2 commits making the query much faster:
1. Add an index on sync_configs on `sync_name where active = true`
2. Bring [the subquery to fetch the latest job ](https://github.com/NangoHQ/nango/commit/42a21c207d3558ab604fa5901d125169818ac9be#diff-7be9b1d2fee1ed263243cfe652dbb029abdc165631a55b0677119bf8fb3a743cL177-L196)but sort on `created_at` so it can use an index without having to sort

query plan before 
```
Subquery Scan on syncs  (cost=11876.63..11890.70 rows=5 width=242)
  Filter: (syncs.job_row_number = 1)
  ->  Sort  (cost=11876.63..11878.97 rows=938 width=266)
        Sort Key: _nango_syncs.name
        ->  WindowAgg  (cost=11804.53..11830.32 rows=938 width=266)
              Run Condition: (row_number() OVER (?) <= 1)
              ->  Sort  (cost=11804.53..11806.87 rows=938 width=294)
                    Sort Key: _nango_syncs.id, _nango_sync_jobs.sync_id, _nango_sync_jobs.updated_at DESC
                    ->  Nested Loop Left Join  (cost=1.13..11758.22 rows=938 width=294)
                          ->  Nested Loop  (cost=0.56..6546.82 rows=1 width=163)
                                Join Filter: ((_nango_syncs.name)::text = (_nango_sync_configs.sync_name)::text)
                                ->  Nested Loop Left Join  (cost=0.56..5.01 rows=1 width=107)
                                      ->  Index Scan using idx_connectionid_name_where_deleted on _nango_syncs  (cost=0.28..2.50 rows=1 width=87)
                                            Index Cond: (nango_connection_id = 20202)
                                      ->  Index Scan using idx_sync_id_active_true on _nango_active_logs  (cost=0.28..2.50 rows=1 width=36)
                                            Index Cond: (sync_id = _nango_syncs.id)
                                            Filter: ((type)::text = 'sync'::text)
                                ->  Seq Scan on _nango_sync_configs  (cost=0.00..6541.74 rows=5 width=76)
                                      Filter: ((NOT deleted) AND active AND (nango_config_id = 2975) AND ((type)::text = 'sync'::text))
                          ->  Index Scan using idx_jobs_id_status_type_where_delete on _nango_sync_jobs  (cost=0.56..5165.26 rows=4614 width=131)
                                Index Cond: (sync_id = _nango_syncs.id)
                                Filter: (sync_config_id IS NOT NULL)
```

query plan after the index
```
Subquery Scan on syncs  (cost=5345.12..5359.19 rows=5 width=242)
  Filter: (syncs.job_row_number = 1)
  ->  Sort  (cost=5345.12..5347.46 rows=938 width=266)
        Sort Key: _nango_syncs.name
        ->  WindowAgg  (cost=5273.01..5298.81 rows=938 width=266)
              Run Condition: (row_number() OVER (?) <= 1)
              ->  Sort  (cost=5273.01..5275.36 rows=938 width=294)
                    Sort Key: _nango_syncs.id, _nango_sync_jobs.sync_id, _nango_sync_jobs.updated_at DESC
                    ->  Nested Loop Left Join  (cost=1.41..5226.71 rows=938 width=294)
                          ->  Nested Loop  (cost=0.84..10.81 rows=1 width=163)
                                ->  Nested Loop Left Join  (cost=0.56..5.01 rows=1 width=107)
                                      ->  Index Scan using idx_connectionid_name_where_deleted on _nango_syncs  (cost=0.28..2.50 rows=1 width=87)
                                            Index Cond: (nango_connection_id = 20202)
                                      ->  Index Scan using idx_sync_id_active_true on _nango_active_logs  (cost=0.28..2.50 rows=1 width=36)
                                            Index Cond: (sync_id = _nango_syncs.id)
                                            Filter: ((type)::text = 'sync'::text)
                                ->  Index Scan using idx_nango_sync_configs_composite on _nango_sync_configs  (cost=0.28..5.79 rows=1 width=76)
                                      Index Cond: ((sync_name)::text = (_nango_syncs.name)::text)
                                      Filter: ((NOT deleted) AND (nango_config_id = 2975) AND ((type)::text = 'sync'::text))
                          ->  Index Scan using idx_jobs_id_status_type_where_delete on _nango_sync_jobs  (cost=0.56..5169.73 rows=4617 width=131)
                                Index Cond: (sync_id = _nango_syncs.id)
                                Filter: (sync_config_id IS NOT NULL)
```


query plan final 
```
Nested Loop  (cost=0.84..13.70 rows=1 width=234)
  ->  Nested Loop Left Join  (cost=0.56..5.01 rows=1 width=107)
        ->  Index Scan using idx_connectionid_name_where_deleted on _nango_syncs  (cost=0.28..2.50 rows=1 width=87)
              Index Cond: (nango_connection_id = 20202)
        ->  Index Scan using idx_sync_id_active_true on _nango_active_logs  (cost=0.28..2.50 rows=1 width=36)
              Index Cond: (sync_id = _nango_syncs.id)
              Filter: ((type)::text = 'sync'::text)
  ->  Index Scan using idx_nango_sync_configs_composite on _nango_sync_configs  (cost=0.28..5.79 rows=1 width=73)
        Index Cond: ((sync_name)::text = (_nango_syncs.name)::text)
        Filter: ((NOT deleted) AND ((type)::text = 'sync'::text) AND (nango_config_id = 2975))
  SubPlan 1
    ->  Limit  (cost=0.86..2.89 rows=1 width=40)
          ->  Nested Loop  (cost=0.86..8506.14 rows=4195 width=40)
                ->  Index Scan using idx_jobs_syncid_createdat_where_deleted on _nango_sync_jobs  (cost=0.56..5208.23 rows=4626 width=115)
                      Index Cond: (sync_id = _nango_syncs.id)
                ->  Memoize  (cost=0.30..1.58 rows=1 width=54)
                      Cache Key: _nango_sync_jobs.sync_config_id
                      Cache Mode: logical
                      ->  Index Scan using _nango_sync_configs_pkey on _nango_sync_configs _nango_sync_configs_1  (cost=0.29..1.57 rows=1 width=54)
                            Index Cond: (id = _nango_sync_jobs.sync_config_id)
                            Filter: (NOT deleted)
```

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1307/connection-long-loading-time

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
