### PR TITLE
chore(scheduler): cleanup tasks and schedules

### DIFF
--- a/packages/scheduler/lib/models/schedules.ts
+++ b/packages/scheduler/lib/models/schedules.ts
@@ -235,6 +235,7 @@ export async function search(
 
 export async function hardDeleteOlderThanNDays(db: knex.Knex, days: number): Promise<Result<DbSchedule[]>> {
     try {
+        // NOTE: only deleting one schedule at a time to avoid massive cascading deletes of tasks
         const deleted = await db
             .from<DbSchedule>(SCHEDULES_TABLE)
             .where(
@@ -245,7 +246,7 @@ export async function hardDeleteOlderThanNDays(db: knex.Knex, days: number): Pro
                     FROM ${SCHEDULES_TABLE}
                     WHERE "deleted_at" < NOW() - INTERVAL '${days} days'
                     ORDER BY "id" ASC
-                    LIMIT 1000
+                    LIMIT 1
                   ))`)
             )
             .del()

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -76,6 +76,7 @@ export class Scheduler {
     stop(): void {
         this.monitor?.stop();
         this.scheduling?.stop();
+        this.cleanup?.stop();
     }
 
     /**

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -10,10 +10,12 @@ import { SchedulingWorker } from './workers/scheduling/scheduling.worker.js';
 import type { DatabaseClient } from './db/client.js';
 import { logger } from './utils/logger.js';
 import { uuidv7 } from 'uuidv7';
+import { CleanupWorker } from './workers/cleanup/cleanup.worker.js';
 
 export class Scheduler {
     private monitor: MonitorWorker | null = null;
     private scheduling: SchedulingWorker | null = null;
+    private cleanup: CleanupWorker | null = null;
     private onCallbacks: Record<TaskState, (task: Task) => void>;
     private dbClient: DatabaseClient;
 
@@ -63,8 +65,9 @@ export class Scheduler {
                     this.onCallbacks[task.state](task);
                 }
             });
-            // TODO: ensure there is only one instance of the scheduler
             this.scheduling.start();
+            this.cleanup = new CleanupWorker({ databaseUrl: dbClient.url, databaseSchema: dbClient.schema });
+            this.cleanup.start();
         } else {
             throw new Error('Scheduler must be instantiated in the main thread');
         }

--- a/packages/scheduler/lib/workers/cleanup/cleanup.worker.boot.ts
+++ b/packages/scheduler/lib/workers/cleanup/cleanup.worker.boot.ts
@@ -1,0 +1,16 @@
+import '../../tracer.js';
+import { isMainThread, parentPort, workerData } from 'node:worker_threads';
+import { CleanupChild } from './cleanup.worker.js';
+import { DatabaseClient } from '../../db/client.js';
+import { logger } from '../../utils/logger.js';
+
+if (!isMainThread && parentPort) {
+    const { url, schema } = workerData;
+    if (!url || !schema) {
+        throw new Error('Missing required database url and schema for cleanup worker');
+    }
+    const dbClient = new DatabaseClient({ url, schema, poolMax: 10 });
+    new CleanupChild(parentPort, dbClient.db);
+} else {
+    logger.error('Failed to start cleanup in worker thread');
+}

--- a/packages/scheduler/lib/workers/cleanup/cleanup.worker.ts
+++ b/packages/scheduler/lib/workers/cleanup/cleanup.worker.ts
@@ -101,7 +101,7 @@ export class CleanupChild {
                 logger.info(`Hard deleted ${deletedSchedules.value.length} schedules`);
             }
             // hard delete terminated tasks older than 60 days unless it is the last task for an active schedule
-            const deletedTasks = await tasks.hardDeleteOlderThanNDays(trx, 0);
+            const deletedTasks = await tasks.hardDeleteOlderThanNDays(trx, 30);
             if (deletedTasks.isErr()) {
                 logger.error(deletedTasks.error);
             } else if (deletedTasks.value.length > 0) {

--- a/packages/scheduler/lib/workers/cleanup/cleanup.worker.ts
+++ b/packages/scheduler/lib/workers/cleanup/cleanup.worker.ts
@@ -1,0 +1,112 @@
+import * as fs from 'fs';
+import type { MessagePort } from 'node:worker_threads';
+import { Worker, isMainThread } from 'node:worker_threads';
+import { stringifyError } from '@nangohq/utils';
+import * as tasks from '../../models/tasks.js';
+import * as schedules from '../../models/schedules.js';
+import { setTimeout } from 'node:timers/promises';
+import type knex from 'knex';
+import { logger } from '../../utils/logger.js';
+
+interface ExpiredTasksMessage {
+    ids: string[];
+}
+
+export class CleanupWorker {
+    private worker: Worker | null;
+    constructor({ databaseUrl, databaseSchema }: { databaseUrl: string; databaseSchema: string }) {
+        if (isMainThread) {
+            const url = new URL('../../../dist/workers/cleanup/cleanup.worker.boot.js', import.meta.url);
+            if (!fs.existsSync(url)) {
+                throw new Error(`Cleanup script not found at ${url}`);
+            }
+
+            this.worker = new Worker(url, { workerData: { url: databaseUrl, schema: databaseSchema } });
+            // Throw error if cleanup exits with error
+            this.worker.on('error', (err) => {
+                throw new Error(`Cleanup exited with error: ${stringifyError(err)}`);
+            });
+            // Throw error if cleanup exits with non-zero exit code
+            this.worker.on('exit', (code) => {
+                if (code !== 0) {
+                    throw new Error(`Cleanup exited with exit code: ${code}`);
+                }
+            });
+        } else {
+            throw new Error('CleanupWorker should be instantiated in the main thread');
+        }
+    }
+
+    start(): void {
+        this.worker?.postMessage('start');
+    }
+
+    stop(): void {
+        if (this.worker) {
+            this.worker.postMessage('stop');
+            this.worker = null;
+        }
+    }
+
+    on(callback: (message: ExpiredTasksMessage) => void): void {
+        this.worker?.on('message', callback);
+    }
+}
+
+export class CleanupChild {
+    private db: knex.Knex;
+    private parent: MessagePort;
+    private cancelled: boolean = false;
+    private tickIntervalMs = 10_000;
+
+    constructor(parent: MessagePort, db: knex.Knex) {
+        if (isMainThread) {
+            throw new Error('Cleanup should not be instantiated in the main thread');
+        }
+        this.db = db;
+        this.parent = parent;
+        this.parent.on('message', async (msg: 'start' | 'stop') => {
+            switch (msg) {
+                case 'start':
+                    await this.start();
+                    break;
+                case 'stop':
+                    this.stop();
+                    break;
+            }
+        });
+    }
+
+    async start(): Promise<void> {
+        logger.info('Starting cleanup...');
+        // eslint-disable-next-line no-constant-condition
+        while (!this.cancelled) {
+            await this.clean();
+            await setTimeout(this.tickIntervalMs);
+        }
+    }
+
+    stop(): void {
+        logger.info('Stopping cleanup...');
+        this.cancelled = true;
+    }
+
+    async clean(): Promise<void> {
+        return await this.db.transaction(async (trx) => {
+            // hard delete schedules where deletedAt is older than 30 days
+            const deletedSchedules = await schedules.hardDeleteOlderThanNDays(trx, 30);
+            if (deletedSchedules.isErr()) {
+                logger.error(deletedSchedules.error);
+            } else if (deletedSchedules.value.length > 0) {
+                logger.info(`Hard deleted ${deletedSchedules.value.length} schedules`);
+            }
+            // hard delete terminated tasks older than 60 days unless it is the last task for an active schedule
+            const deletedTasks = await tasks.hardDeleteOlderThanNDays(trx, 0);
+            if (deletedTasks.isErr()) {
+                logger.error(deletedTasks.error);
+            } else if (deletedTasks.value.length > 0) {
+                logger.info(`Hard deleted ${deletedTasks.value.length} tasks`);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Hard deleting deleted schedules and terminated tasks older than 30 days in order to prevent those tables to grow indefinitely.
I picked 30 days arbitrarily but it gives us plenty of times for debugging if we need.

Cleaning up is following the same design as scheduling and monitoring. It is a worker_thread with an infinite loop deleting tasks and schedules

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1223/delete-tasks-after-30-days-and-deleted-schedules-after-90-days

tested locally
