### PR TITLE
fix(auth): stop leaking stack and credentials when erroring

### DIFF
--- a/packages/shared/lib/clients/provider.client.ts
+++ b/packages/shared/lib/clients/provider.client.ts
@@ -453,8 +453,8 @@ class ProviderClient {
             };
             // Sample failure response: { "result": "1001", "message": "Service exceptions" }
             throw new NangoError('refresh_token_external_error', payload);
-        } catch (e: any) {
-            throw new NangoError('refresh_token_external_error', e.message);
+        } catch (err) {
+            throw new NangoError('refresh_token_external_error', { message: err instanceof Error ? err.message : 'unknown error' });
         }
     }
 

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -917,17 +917,8 @@ class ConnectionService {
                 });
 
                 return { success: true, error: null, response: { refreshed: shouldRefresh, credentials: newCredentials } };
-            } catch (err: any) {
-                const errorMessage = err.message || 'Unknown error';
-                const errorDetails = {
-                    message: errorMessage,
-                    name: err.name || 'Error',
-                    stack: err.stack || 'No stack trace'
-                };
-
-                const errorString = JSON.stringify(errorDetails);
-
-                await telemetry.log(LogTypes.AUTH_TOKEN_REFRESH_FAILURE, `Token refresh failed, ${errorString}`, LogActionEnum.AUTH, {
+            } catch (err) {
+                await telemetry.log(LogTypes.AUTH_TOKEN_REFRESH_FAILURE, `Token refresh failed, ${stringifyError(err)}`, LogActionEnum.AUTH, {
                     environmentId: String(environment_id),
                     connectionId,
                     providerConfigKey,
@@ -935,7 +926,7 @@ class ConnectionService {
                     level: 'error'
                 });
 
-                const error = new NangoError('refresh_token_external_error', errorDetails);
+                const error = new NangoError('refresh_token_external_error', { message: err instanceof Error ? err.message : 'unknown error' });
 
                 return { success: false, error, response: null };
             } finally {
@@ -1205,12 +1196,8 @@ class ConnectionService {
             );
 
             return { success: true, error: null, response: tokenResponse.data };
-        } catch (e: any) {
-            const errorPayload = {
-                message: e.message || 'Unknown error',
-                name: e.name || 'Error'
-            };
-            const error = new NangoError('refresh_token_external_error', errorPayload);
+        } catch (err) {
+            const error = new NangoError('refresh_token_external_error', { message: err instanceof Error ? err.message : 'unknown error' });
             return { success: false, error, response: null };
         }
     }

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -336,9 +336,6 @@ export class NangoError extends Error {
             case 'refresh_token_external_error':
                 this.status = 400;
                 this.message = `The external API returned an error when trying to refresh the access token. Please try again later.`;
-                if (this.payload) {
-                    this.message += ` ${JSON.stringify(this.payload, null, 2)}`;
-                }
                 break;
 
             case 'request_token_external_error':


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1271/non-descriptive-refresh-token-logserror

- Do not leak stack trace to logs and api response
- Do not leak credentials to logs and datadog