### PR TITLE
fix: token refresh locking logic

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -705,7 +705,8 @@ class ConnectionService {
 
         if (connection?.credentials?.type === 'OAUTH2' || connection?.credentials?.type === 'APP' || connection?.credentials?.type === 'OAUTH2_CC') {
             const { success, error, response } = await this.refreshCredentialsIfNeeded({
-                oldConnection: connection,
+                connectionId: connection.connection_id,
+                environmentId: environment.id,
                 providerConfig: config,
                 template: template as ProviderTemplateOAuth2,
                 environment_id: environment.id,
@@ -846,134 +847,115 @@ class ConnectionService {
     }
 
     private async refreshCredentialsIfNeeded({
-        oldConnection,
+        connectionId,
+        environmentId,
         providerConfig,
         template,
         environment_id,
         instantRefresh = false
     }: {
-        oldConnection: Connection;
+        connectionId: string;
+        environmentId: number;
         providerConfig: ProviderConfig;
         template: ProviderTemplateOAuth2;
         environment_id: number;
         instantRefresh?: boolean;
     }): Promise<ServiceResponse<{ refreshed: boolean; credentials: OAuth2Credentials | AppCredentials | AppStoreCredentials | OAuth2ClientCredentials }>> {
-        const connectionId = oldConnection.connection_id;
-        const credentials = oldConnection.credentials as OAuth2Credentials;
-        const providerConfigKey = oldConnection.provider_config_key;
-        const environmentId = oldConnection.environment_id;
+        const providerConfigKey = providerConfig.unique_key;
 
-        const shouldRefresh = await this.shouldRefreshCredentials(oldConnection, credentials, providerConfig, template, instantRefresh);
+        const getConnection = async (): Promise<{ connection: Connection; shouldRefresh: boolean }> => {
+            const { success, error, response: connection } = await this.getConnection(connectionId, providerConfigKey, environmentId);
 
-        if (shouldRefresh) {
-            await telemetry.log(LogTypes.AUTH_TOKEN_REFRESH_START, 'Token refresh is being started', LogActionEnum.AUTH, {
-                environmentId: String(environment_id),
-                connectionId,
-                providerConfigKey,
-                provider: providerConfig.provider
-            });
-            // We must ensure that only one refresh is running at a time across all instances.
-            // Using a simple redis entry as a lock with a TTL to ensure it is always released.
-            // NOTES:
-            // - This is not a distributed lock and will not work in a multi-redis environment.
-            // - It could also be unsafe in case of a Redis crash.
-            // We are using this for now as it is a simple solution that should work for most cases.
-            const lockKey = `lock:refresh:${environment_id}:${providerConfigKey}:${connectionId}`;
+            if (!success || !connection) {
+                throw error;
+            }
+
+            const shouldRefresh = await this.shouldRefreshCredentials(
+                connection,
+                connection.credentials as OAuth2Credentials,
+                providerConfig,
+                template,
+                instantRefresh
+            );
+
+            return { connection, shouldRefresh };
+        };
+
+        // Check if the credentials need to be refreshed
+        // If not, return the current credentials as they are still valid
+        const { connection, shouldRefresh } = await getConnection();
+        if (!shouldRefresh) {
+            return {
+                success: true,
+                error: null,
+                response: {
+                    refreshed: false,
+                    credentials: connection.credentials as OAuth2Credentials | AppCredentials | AppStoreCredentials | OAuth2ClientCredentials
+                }
+            };
+        }
+
+        await telemetry.log(LogTypes.AUTH_TOKEN_REFRESH_START, 'Token refresh is being started', LogActionEnum.AUTH, {
+            environmentId: String(environment_id),
+            connectionId,
+            providerConfigKey,
+            provider: providerConfig.provider
+        });
+        // We must ensure that only one refresh is running at a time
+        // Using a simple redis entry as a lock with a TTL to ensure it is always released.
+        // NOTES:
+        // - This is not a distributed lock and will not work in a multi-redis environment.
+        // - It could also be unsafe in case of a Redis crash.
+        // We are using this for now as it is a simple solution that should work for most cases.
+        const lockKey = `lock:refresh:${environment_id}:${providerConfigKey}:${connectionId}`;
+        try {
+            const ttlInMs = 10000;
+            const acquisitionTimeoutMs = ttlInMs * 1.2; // giving some extra time for the lock to be released
+
+            let connectionToRefresh = connection;
             try {
-                const ttlInMs = 10000;
-                const acquisitionTimeoutMs = ttlInMs * 1.2; // giving some extra time for the lock to be released
-
-                let freshConnection = oldConnection;
-                try {
-                    const { tries } = await this.locking.tryAcquire(lockKey, ttlInMs, acquisitionTimeoutMs);
-                    if (tries > 0) {
-                        // Another refresh was running so we check if the credentials were refreshed
-                        // If yes, we return the new credentials
-                        // If not, we proceed with the refresh
-                        const { success, error, response: connection } = await this.getConnection(connectionId, providerConfig.unique_key, environmentId);
-                        if (success && connection) {
-                            const shouldRefresh = await this.shouldRefreshCredentials(
-                                connection,
-                                connection.credentials as OAuth2Credentials,
-                                providerConfig,
-                                template,
-                                false
-                            );
-                            if (!shouldRefresh) {
-                                return {
-                                    success: true,
-                                    error: null,
-                                    response: {
-                                        refreshed: true,
-                                        credentials: connection.credentials as
-                                            | OAuth2Credentials
-                                            | AppCredentials
-                                            | AppStoreCredentials
-                                            | OAuth2ClientCredentials
-                                    }
-                                };
+                const { tries } = await this.locking.tryAcquire(lockKey, ttlInMs, acquisitionTimeoutMs);
+                if (tries > 0) {
+                    // Another refresh was running so we check if the credentials were refreshed
+                    // If yes, we return the new credentials
+                    // If not, we proceed with the refresh
+                    const { connection, shouldRefresh } = await getConnection();
+                    if (!shouldRefresh) {
+                        return {
+                            success: true,
+                            error: null,
+                            response: {
+                                refreshed: false,
+                                credentials: connection.credentials as OAuth2Credentials | AppCredentials | AppStoreCredentials | OAuth2ClientCredentials
                             }
-                            freshConnection = connection;
-                        } else {
-                            throw error;
-                        }
+                        };
                     }
-                } catch (err) {
-                    // lock acquisition might have timed out
-                    // but refresh might have been successfully performed by another execution
-                    // while we were waiting for the lock
-                    // so we check if the credentials were refreshed
-                    // if yes, we return the new credentials
-                    // if not, we actually fail the refresh
-                    const { success, response: connection } = await this.getConnection(connectionId, providerConfig.unique_key, environmentId);
-                    if (success && connection) {
-                        const shouldRefresh = await this.shouldRefreshCredentials(
-                            connection,
-                            connection.credentials as OAuth2Credentials,
-                            providerConfig,
-                            template,
-                            false
-                        );
-                        if (!shouldRefresh) {
-                            return {
-                                success: true,
-                                error: null,
-                                response: {
-                                    refreshed: true,
-                                    credentials: connection.credentials as OAuth2Credentials | AppCredentials | AppStoreCredentials | OAuth2ClientCredentials
-                                }
-                            };
-                        }
-                    }
-                    throw err;
+                    connectionToRefresh = connection;
                 }
-
-                const { success, error, response: newCredentials } = await this.getNewCredentials(freshConnection, providerConfig, template);
-                if (!success || !newCredentials) {
-                    await telemetry.log(LogTypes.AUTH_TOKEN_REFRESH_FAILURE, `Token refresh failed, ${error?.message}`, LogActionEnum.AUTH, {
-                        environmentId: String(environment_id),
-                        connectionId,
-                        providerConfigKey,
-                        provider: providerConfig.provider,
-                        level: 'error'
-                    });
-
-                    return { success, error, response: null };
-                }
-
-                freshConnection.credentials = newCredentials;
-                await this.updateConnection(freshConnection);
-
-                await telemetry.log(LogTypes.AUTH_TOKEN_REFRESH_SUCCESS, 'Token refresh was successful', LogActionEnum.AUTH, {
-                    environmentId: String(environment_id),
-                    connectionId,
-                    providerConfigKey,
-                    provider: providerConfig.provider
-                });
-
-                return { success: true, error: null, response: { refreshed: shouldRefresh, credentials: newCredentials } };
             } catch (err) {
-                await telemetry.log(LogTypes.AUTH_TOKEN_REFRESH_FAILURE, `Token refresh failed, ${stringifyError(err)}`, LogActionEnum.AUTH, {
+                // lock acquisition might have timed out
+                // but refresh might have been successfully performed by another execution
+                // while we were waiting for the lock
+                // so we check if the credentials were refreshed
+                // if yes, we return the new credentials
+                // if not, we actually fail the refresh
+                const { connection, shouldRefresh } = await getConnection();
+                if (!shouldRefresh) {
+                    return {
+                        success: true,
+                        error: null,
+                        response: {
+                            refreshed: false,
+                            credentials: connection.credentials as OAuth2Credentials | AppCredentials | AppStoreCredentials | OAuth2ClientCredentials
+                        }
+                    };
+                }
+                throw err;
+            }
+
+            const { success, error, response: newCredentials } = await this.getNewCredentials(connectionToRefresh, providerConfig, template);
+            if (!success || !newCredentials) {
+                await telemetry.log(LogTypes.AUTH_TOKEN_REFRESH_FAILURE, `Token refresh failed, ${error?.message}`, LogActionEnum.AUTH, {
                     environmentId: String(environment_id),
                     connectionId,
                     providerConfigKey,
@@ -981,15 +963,35 @@ class ConnectionService {
                     level: 'error'
                 });
 
-                const error = new NangoError('refresh_token_external_error', { message: err instanceof Error ? err.message : 'unknown error' });
-
-                return { success: false, error, response: null };
-            } finally {
-                await this.locking.release(lockKey);
+                return { success, error, response: null };
             }
-        }
 
-        return { success: true, error: null, response: { refreshed: shouldRefresh, credentials } };
+            connectionToRefresh.credentials = newCredentials;
+            await this.updateConnection(connectionToRefresh);
+
+            await telemetry.log(LogTypes.AUTH_TOKEN_REFRESH_SUCCESS, 'Token refresh was successful', LogActionEnum.AUTH, {
+                environmentId: String(environment_id),
+                connectionId,
+                providerConfigKey,
+                provider: providerConfig.provider
+            });
+
+            return { success: true, error: null, response: { refreshed: true, credentials: newCredentials } };
+        } catch (err) {
+            await telemetry.log(LogTypes.AUTH_TOKEN_REFRESH_FAILURE, `Token refresh failed, ${stringifyError(err)}`, LogActionEnum.AUTH, {
+                environmentId: String(environment_id),
+                connectionId,
+                providerConfigKey,
+                provider: providerConfig.provider,
+                level: 'error'
+            });
+
+            const error = new NangoError('refresh_token_external_error', { message: err instanceof Error ? err.message : 'unknown error' });
+
+            return { success: false, error, response: null };
+        } finally {
+            await this.locking.release(lockKey);
+        }
     }
 
     public async getAppStoreCredentials(


### PR DESCRIPTION
One customer is experiencing connection refresh failures with the following error:
Acquiring lock for key: lock:refresh:XXX timed out after 12000ms They are making concurrent calls to `/proxy` while the token is expired. Each request trying to acquire the lock is waiting and then attempts again to refresh the token. When a lot of concurrent requests, waiting for all the other requests in the queue to refetch the connection token can exceed the lock acquisition timeout.
This commit is introducing 2 fixes:
- after waiting for acquiring the lock, first check if the connection has been refreshed, if yes returns the credentials directly.
- if lock acquisition times out, also check if the connection has been refreshed and only fails if it is not the case.

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1164/salesforcebox-connections-failing-to-refresh-intermittently

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
