### PR TITLE
fix(webapp): [nan-1295] stable ordering of syncs and actions

### DIFF
--- a/packages/webapp/src/pages/Integration/Scripts.tsx
+++ b/packages/webapp/src/pages/Integration/Scripts.tsx
@@ -20,8 +20,8 @@ interface ScriptProps {
 
 export default function Scripts(props: ScriptProps) {
     const { integration, endpoints, reload, setFlow, setSubTab, setFlowConfig } = props;
-    const syncs = [...(endpoints?.allFlows?.syncs || []), ...(endpoints?.disabledFlows?.syncs || [])];
-    const actions = [...(endpoints?.allFlows?.actions || []), ...(endpoints?.disabledFlows?.actions || [])];
+    const syncs = [...(endpoints?.allFlows?.syncs || []), ...(endpoints?.disabledFlows?.syncs || [])].sort((a, b) => a.name.localeCompare(b.name));
+    const actions = [...(endpoints?.allFlows?.actions || []), ...(endpoints?.disabledFlows?.actions || [])].sort((a, b) => a.name.localeCompare(b.name));
     const hasScripts = syncs.length || actions.length;
 
     const routeToScript = (flow: Flow) => {


### PR DESCRIPTION
## Describe your changes
Sort the sync and actions by name to prevent reordering when enabling

## Issue ticket number and link
NAN-1295

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
