### PR TITLE
fix(nango-yaml): disallow empty array

### DIFF
--- a/docs-v2/reference/integration-configuration.mdx
+++ b/docs-v2/reference/integration-configuration.mdx
@@ -332,6 +332,19 @@ models:
     name?: string
 ```
 
+### Unsupported syntax
+
+A non-exhaustive list of unsupported syntax:
+```yaml nango.yaml
+models:
+  Task:
+    # Empty array
+    name: []
+    # Typescript utility types
+    user: Pick<User>
+```
+
+
 # Deploying your configuration
 
 Changes to your integration configuration become active once you deploy them to a Nango environment using the `nango deploy` CLI command.

--- a/docs-v2/reference/integration-configuration.mdx
+++ b/docs-v2/reference/integration-configuration.mdx
@@ -221,11 +221,12 @@ Types not listed here are not supported. If you think we are missing something, 
 
 ### Arrays
 
-Your can use array types if the `[]` notation:
+Your can use array types like this:
 ```yaml nango.yaml
 models:
   Folder:
     files: string[]
+    tickets: any[]
 ```
 
 ### Type & string unions

--- a/packages/nango-yaml/lib/modelsParser.ts
+++ b/packages/nango-yaml/lib/modelsParser.ts
@@ -169,6 +169,13 @@ export class ModelsParser {
             const isArray = value.endsWith('[]');
             const valueClean = isArray ? value.substring(0, value.length - 2) : value;
 
+            // empty array
+            if (valueClean === '') {
+                this.errors.push(new ParserErrorTypeSyntax({ value, path: [parent, name] }));
+                parsed.push({ name, value: valueClean, array: isArray, optional });
+                continue;
+            }
+
             const alias = getPotentialTypeAlias(valueClean);
             if (alias) {
                 parsed.push({ name, value: alias, tsType: true, array: isArray, optional });

--- a/packages/nango-yaml/lib/modelsParser.unit.test.ts
+++ b/packages/nango-yaml/lib/modelsParser.unit.test.ts
@@ -321,6 +321,13 @@ describe('parse', () => {
                 }
             });
         });
+
+        it('should throw on empty array type', () => {
+            const parser = new ModelsParser({ raw: { Test: { user: '[]' } } });
+            parser.parseAll();
+
+            expect(parser.errors).toStrictEqual([new ParserErrorTypeSyntax({ value: '[]', path: ['Test', 'user'] })]);
+        });
     });
 
     describe('typescript any', () => {


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1417/nangoyaml-should-throw-on-empty-array

- Do not allow this confusing syntax 


