### PR TITLE
fix(validation): cache ajv compilation

### DIFF
--- a/packages/cli/lib/services/local-integration.service.ts
+++ b/packages/cli/lib/services/local-integration.service.ts
@@ -64,6 +64,7 @@ class IntegrationService implements IntegrationServiceInterface {
                 if (isAction) {
                     // Validate action input against json schema
                     const valInput = validateData({
+                        version: nangoProps.syncConfig.version || '1',
                         input: input,
                         modelName: nangoProps.syncConfig.input,
                         jsonSchema: nangoProps.syncConfig.models_json_schema
@@ -84,6 +85,7 @@ class IntegrationService implements IntegrationServiceInterface {
                     // Validate action output against json schema
                     const modelNameOutput = nangoProps.syncConfig.models.length > 0 ? nangoProps.syncConfig.models[0] : undefined;
                     const valOutput = validateData({
+                        version: nangoProps.syncConfig.version || '1',
                         input: output,
                         modelName: modelNameOutput,
                         jsonSchema: nangoProps.syncConfig.models_json_schema

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -92,6 +92,7 @@ export async function exec(
 
                 // Validate action input against json schema
                 const valInput = validateData({
+                    version: nangoProps.syncConfig.version || '1',
                     input: inputParams,
                     modelName: nangoProps.syncConfig.input,
                     jsonSchema: nangoProps.syncConfig.models_json_schema
@@ -111,6 +112,7 @@ export async function exec(
 
                 // Validate action output against json schema
                 const valOutput = validateData({
+                    version: nangoProps.syncConfig.version || '1',
                     input: output,
                     modelName: nangoProps.syncConfig.models.length > 0 ? nangoProps.syncConfig.models[0] : undefined,
                     jsonSchema: nangoProps.syncConfig.models_json_schema

--- a/packages/shared/lib/sdk/dataValidation.unit.test.ts
+++ b/packages/shared/lib/sdk/dataValidation.unit.test.ts
@@ -1,14 +1,19 @@
-import { describe, expect, it } from 'vitest';
-import { validateData } from './dataValidation.js';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { clearValidationCache, validateData } from './dataValidation.js';
 
 describe('validateData', () => {
+    beforeEach(() => {
+        clearValidationCache();
+    });
+
     it('should skip if no json schema ', () => {
-        const val = validateData({ input: { foo: 'bar' }, modelName: 'Test', jsonSchema: undefined });
+        const val = validateData({ version: '1', input: { foo: 'bar' }, modelName: 'Test', jsonSchema: undefined });
         expect(val).toStrictEqual(true);
     });
 
     it('should return true if no error', () => {
         const val = validateData({
+            version: '1',
             input: { foo: 'bar' },
             modelName: 'Test',
             jsonSchema: { definitions: { Test: { type: 'object', properties: { foo: { type: 'string' } } } } }
@@ -18,6 +23,7 @@ describe('validateData', () => {
 
     it('should return an error', () => {
         const val = validateData({
+            version: '1',
             input: { foo: 'bar' },
             modelName: 'Test',
             jsonSchema: {
@@ -31,6 +37,7 @@ describe('validateData', () => {
 
     it('should support ref', () => {
         const val = validateData({
+            version: '1',
             input: { ref: { id: 'bar' } },
             modelName: 'Test1',
             jsonSchema: {
@@ -45,6 +52,7 @@ describe('validateData', () => {
 
     it('should support ref error', () => {
         const val = validateData({
+            version: '1',
             input: { ref: { id: 1 } },
             modelName: 'Test1',
             jsonSchema: {
@@ -67,6 +75,7 @@ describe('validateData', () => {
 
     it('should not throw if invalid json schema', () => {
         const val = validateData({
+            version: '1',
             input: { foo: 'bar' },
             modelName: 'Test',
             jsonSchema: {
@@ -79,6 +88,7 @@ describe('validateData', () => {
 
     it('should support exotic format', () => {
         const val = validateData({
+            version: '1',
             input: { foo: 'bar' },
             modelName: 'Test',
             jsonSchema: {
@@ -90,6 +100,7 @@ describe('validateData', () => {
 
     it('should handle empty input with model', () => {
         const val = validateData({
+            version: '1',
             input: undefined,
             modelName: 'Test',
             jsonSchema: {
@@ -111,6 +122,7 @@ describe('validateData', () => {
 
     it('should handle unexpected input', () => {
         const val = validateData({
+            version: '1',
             input: '1',
             modelName: undefined,
             jsonSchema: { definitions: {} }
@@ -128,6 +140,7 @@ describe('validateData', () => {
 
     it('should handle unknown modelName', () => {
         const val = validateData({
+            version: '1',
             input: '1',
             modelName: 'Test',
             jsonSchema: { definitions: {} }

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -838,7 +838,12 @@ export class NangoSync extends NangoAction {
 
         // Validate records
         for (const record of results) {
-            const validation = validateData({ input: JSON.parse(JSON.stringify(record)), jsonSchema: this.syncConfig!.models_json_schema, modelName: model });
+            const validation = validateData({
+                version: this.syncConfig?.version || '1',
+                input: JSON.parse(JSON.stringify(record)),
+                jsonSchema: this.syncConfig!.models_json_schema,
+                modelName: model
+            });
             if (validation === true) {
                 continue;
             }


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1418/cache-ajv-data-validation

- Cache AJV compiled schema 
We saw an increase in batchSave latency, initially we thought there was an issue with the request but it's the records validation that was to blame. We compiled the schema at every record which was not a good idea. 
In this PR we now cache schema per `model-version` which allows stable cache and automatic invalidation on deploy. There is no automated cache clear strategy as everything is happening in the runner/cli, but it's definitely something to keep in mind if we use it somewhere else.
This drastically improve performance (or get it back to what it was before):
for 10K large records `42s -> 4s`