### PR TITLE
fix: retry strategy

### DIFF
--- a/packages/utils/lib/retry.ts
+++ b/packages/utils/lib/retry.ts
@@ -36,12 +36,12 @@ export function httpRetryStrategy(error: unknown, _attemptNumber: number): boole
         return false;
     }
 
-    if (!error.response || !error.status) {
-        return false;
-    }
-
     if (error.code && handledCode.includes(error.code)) {
         return true;
+    }
+
+    if (!error.response || !error.status) {
+        return false;
     }
 
     if (error.status >= 499) {


### PR DESCRIPTION
ECONNRESET is not handled properly because the retry strategy logic returns early with false because error response and status are empty

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
