### PR TITLE
fix(proxy): allow empty body for POST, PUT, PATCH

### DIFF
--- a/packages/server/lib/controllers/proxy.controller.ts
+++ b/packages/server/lib/controllers/proxy.controller.ts
@@ -334,8 +334,8 @@ class ProxyController {
                 headers,
                 decompress
             };
-            if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
-                requestConfig.data = data || {};
+            if (data && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
+                requestConfig.data = data;
             }
             const responseStream: AxiosResponse = await backOff(
                 () => {


### PR DESCRIPTION
Dropboxy API `POST /file/download` endpoint requires the body to be empty. (don't ask me why 🫨 )
It is currently not possible to /proxy to it at the moment because we are defaulting to {} which leads to an error being return by dropbox: `The request body is supposed to be empty, but it isn't; got "{}"`

With this commit we allow POST, PATCH, PUT with empty body

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1423/proxy-do-not-default-body-to-if-no-payload-is-provided-by-users

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
