### PR TITLE
fix(datadog): enable tcp tracing

### DIFF
--- a/packages/jobs/lib/tracer.ts
+++ b/packages/jobs/lib/tracer.ts
@@ -9,3 +9,10 @@ tracer.use('pg', {
 tracer.use('elasticsearch', {
     service: 'nango-elasticsearch'
 });
+tracer.use('net', {
+    enabled: true,
+    service: 'jobs-net'
+});
+tracer.use('dns', {
+    enabled: false
+});

--- a/packages/orchestrator/lib/tracer.ts
+++ b/packages/orchestrator/lib/tracer.ts
@@ -7,3 +7,6 @@ tracer.use('pg', {
     service: (params: { database: string }) => `postgres-${params.database}`
 });
 tracer.use('express');
+tracer.use('dns', {
+    enabled: false
+});

--- a/packages/persist/lib/tracer.ts
+++ b/packages/persist/lib/tracer.ts
@@ -10,3 +10,6 @@ tracer.use('elasticsearch', {
     service: 'nango-elasticsearch'
 });
 tracer.use('express');
+tracer.use('dns', {
+    enabled: false
+});

--- a/packages/runner/lib/tracer.ts
+++ b/packages/runner/lib/tracer.ts
@@ -17,5 +17,6 @@ tracer
         enabled: false
     })
     .use('net', {
-        enabled: false
+        enabled: true,
+        service: 'runner-net'
     });

--- a/packages/scheduler/lib/tracer.ts
+++ b/packages/scheduler/lib/tracer.ts
@@ -6,3 +6,6 @@ tracer.init({
 tracer.use('pg', {
     service: (params: { database: string }) => `postgres-${params.database}`
 });
+tracer.use('dns', {
+    enabled: false
+});

--- a/packages/server/lib/tracer.ts
+++ b/packages/server/lib/tracer.ts
@@ -13,3 +13,10 @@ tracer.use('express');
 tracer.use('http', {
     blocklist: ['/health', '/favicon.ico', '/logo-dark.svg', '/logo-text.svg', /^\/static\//, /^\/images\//, '/manifest.json']
 });
+tracer.use('net', {
+    enabled: true,
+    service: 'server-net'
+});
+tracer.use('dns', {
+    enabled: false
+});


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1426/dd-enable-tcp-tracing

- Enable TCP tracing
This will help us find slow connections and potential improvements. I disabled DNS because there not much we could do here, it can be a nice to have but not game change in most cases