### PR TITLE
fix(integration-templates): show the link only for the future upgrade not the current integration template

### DIFF
--- a/integration-templates/xero/actions/create-invoice.ts
+++ b/integration-templates/xero/actions/create-invoice.ts
@@ -6,6 +6,11 @@ export default async function runAction(nango: NangoAction, input: CreateInvoice
     const tenant_id = await getTenantId(nango);
 
     // Validate the invoices:
+    if (!input || !input.length) {
+        throw new nango.ActionError<ActionErrorResponse>({
+            message: `You must pass an array of invoices! Received: ${JSON.stringify(input)}`
+        });
+    }
 
     // 1) Contact is required
     const invalidInvoices = input.filter((x: any) => !x.external_contact_id || x.fees.length === 0);

--- a/integration-templates/xero/nango.yaml
+++ b/integration-templates/xero/nango.yaml
@@ -69,6 +69,7 @@ integrations:
                 scopes: accounting.transactions
                 output: InvoiceActionResponse
                 endpoint: POST /xero/invoices
+                version: 0.0.2
             update-invoice:
                 description: |
                     Updates one or more invoices in Xero. To delete an invoice

--- a/package-lock.json
+++ b/package-lock.json
@@ -33551,36 +33551,10 @@
                 "acorn": "^8"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/agent-base": {
-            "version": "7.1.1",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/async": {
             "version": "3.2.5",
             "inBundle": true,
             "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/asynckit": {
-            "version": "0.4.0",
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/axios": {
-            "version": "1.7.2",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/cjs-module-lexer": {
             "version": "1.3.1",
@@ -33625,17 +33599,6 @@
             "dependencies": {
                 "color": "^3.1.3",
                 "text-hex": "1.0.x"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/combined-stream": {
-            "version": "1.0.8",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
             }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/crypto-randomuuid": {
@@ -33693,27 +33656,6 @@
                 "node": ">=18"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/debug": {
-            "version": "4.3.5",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/debug/node_modules/ms": {
-            "version": "2.1.2",
-            "inBundle": true,
-            "license": "MIT"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/delay": {
             "version": "5.0.0",
             "inBundle": true,
@@ -33723,14 +33665,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/detect-newline": {
@@ -33751,11 +33685,6 @@
             "inBundle": true,
             "license": "MIT"
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/exponential-backoff": {
-            "version": "3.1.1",
-            "inBundle": true,
-            "license": "Apache-2.0"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/fecha": {
             "version": "4.2.3",
             "inBundle": true,
@@ -33765,62 +33694,6 @@
             "version": "1.1.0",
             "inBundle": true,
             "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/follow-redirects": {
-            "version": "1.15.6",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/form-data": {
-            "version": "4.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/https-proxy-agent": {
-            "version": "7.0.4",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.0.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/ieee754": {
             "version": "1.2.1",
@@ -33971,25 +33844,6 @@
                 "node": ">= 0.6"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/mime-db": {
-            "version": "1.52.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/mime-types": {
-            "version": "2.1.35",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/module-details-from-path": {
             "version": "1.0.3",
             "inBundle": true,
@@ -34108,11 +33962,6 @@
             "engines": {
                 "node": ">=12.0.0"
             }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "inBundle": true,
-            "license": "MIT"
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/readable-stream": {
             "version": "3.6.2",

--- a/packages/shared/flows.yaml
+++ b/packages/shared/flows.yaml
@@ -3549,6 +3549,7 @@ integrations:
                 scopes: accounting.transactions
                 output: InvoiceActionResponse
                 endpoint: POST /xero/invoices
+                version: 0.0.2
             update-invoice:
                 description: |
                     Updates one or more invoices in Xero. To delete an invoice

--- a/packages/webapp/src/pages/Integration/FlowPage.tsx
+++ b/packages/webapp/src/pages/Integration/FlowPage.tsx
@@ -430,19 +430,32 @@ export default function FlowPage(props: FlowPageProps) {
                                     <div className="flex items-center">
                                         <span className="ml-2 text-white">
                                             Template version:{' '}
-                                            <a
-                                                className="underline"
-                                                rel="noreferrer"
-                                                href={`${githubIntegrationTemplates}/${integration.provider}/${flow.type}s/${flow.name}.ts`}
-                                                target="_blank"
-                                            >
-                                                v{flow.version || '0.0.1'}
-                                            </a>
+                                            {flow.upgrade_version ? (
+                                                <span>v{flow.version || '0.0.1'}</span>
+                                            ) : (
+                                                <a
+                                                    className="underline"
+                                                    rel="noreferrer"
+                                                    href={`${githubIntegrationTemplates}/${integration.provider}/${flow.type}s/${flow.name}.ts`}
+                                                    target="_blank"
+                                                >
+                                                    v{flow.version || '0.0.1'}
+                                                </a>
+                                            )}
                                         </span>
                                         {flow.upgrade_version ? (
                                             <span className="flex items-center text-white mx-1">
                                                 {' '}
-                                                (latest: <span className="underline ml-1">v{flow.upgrade_version}</span>)
+                                                (latest:{' '}
+                                                <a
+                                                    target="_blank"
+                                                    href={`${githubIntegrationTemplates}/${integration.provider}/${flow.type}s/${flow.name}.ts`}
+                                                    rel="noreferrer"
+                                                    className="underline ml-1"
+                                                >
+                                                    v{flow.upgrade_version}
+                                                </a>
+                                                )
                                                 <Button
                                                     variant="black"
                                                     onClick={() => onScriptUprade(flow)}


### PR DESCRIPTION
## Describe your changes
- The link to the template should show for the upgrade template, not the current one
- Improve validation error for create-invoice

## Issue ticket number and link
NAN-1428

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
