### PR TITLE
fix: update sync frequency

### DIFF
--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -21,6 +21,7 @@ const TABLE = dbNamespace + 'syncs';
 const SYNC_JOB_TABLE = dbNamespace + 'sync_jobs';
 const SYNC_CONFIG_TABLE = dbNamespace + 'sync_configs';
 const ACTIVE_LOG_TABLE = dbNamespace + 'active_logs';
+const CONNECTIONS_TABLE = dbNamespace + 'connections';
 
 /**
  * Sync Service
@@ -373,9 +374,14 @@ export const getSyncsBySyncConfigId = async (environmentId: number, syncConfigId
     const results = await schema()
         .select('sync_name', `${TABLE}.id`)
         .from<Sync>(TABLE)
+        // Sync table doesn't have a unique foreign key to sync config
+        // so we need to join on the name
+        // and verify the sync connection environment
         .join(SYNC_CONFIG_TABLE, `${TABLE}.name`, `${SYNC_CONFIG_TABLE}.sync_name`)
+        .join(CONNECTIONS_TABLE, `${CONNECTIONS_TABLE}.id`, `${TABLE}.nango_connection_id`)
         .where({
-            environment_id: environmentId,
+            [`${CONNECTIONS_TABLE}.environment_id`]: environmentId,
+            [`${SYNC_CONFIG_TABLE}.environment_id`]: environmentId,
             [`${SYNC_CONFIG_TABLE}.id`]: syncConfigId,
             [`${TABLE}.deleted`]: false,
             [`${SYNC_CONFIG_TABLE}.deleted`]: false,


### PR DESCRIPTION
Updating frequency from the integration UI is failing. 
The endpoint retrieves all the syncs for the given integration and attempt to update the schedule frequency in the orchestrator. 
However the query to retrieve the syncs was wrongly returning sync that didn't belong to the current user because the join between syncs and sync_configs was done only on the name which is not unique. It could have had pretty bad consequence. Fortunately the orchestrator endpoint relies on a matching environment/sync and failed to retrieve the schedule so no data was corrupted. Just the frequency would not be updated. No other code was using the faulty query.

This commit fixes the query by also joining sync and connections to only select rows where connection's environment_id matches. 
Note: We should eventually add a foreign key to join syncs and sync_configs table

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1441/update-frequency-from-the-integration-ui-doesnt-work

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
