### PR TITLE
fix(xero-integration-template): [nan-1438] xero updates to match the API better

### DIFF
--- a/integration-templates/xero/fixtures/invoice-2.json
+++ b/integration-templates/xero/fixtures/invoice-2.json
@@ -1,0 +1,22 @@
+[
+    {
+        "number": "inv_w7i7HRdRFT0wnB",
+        "fees": [
+            {
+                "description": "desc",
+                "units": 2,
+                "precise_unit_amount": 7500,
+                "taxes_amount_cents": 3000,
+                "amount_cents": 1275000,
+                "discount_amount_cents": 10,
+                "discount_rate": 15
+            }
+        ],
+        "external_contact_id": "69559f1c-5b66-4320-826d-892cc34c4934",
+        "issuing_date": "2024-07-15T22:00:00.000Z",
+        "payment_due_date": "2024-08-15T06:16:47.759Z",
+        "type": "ACCREC",
+        "url": "https://local.app.hyperline.dev/invoices/inv_w7i7HRdRFT0wnB",
+        "status": "DRAFT"
+    }
+]

--- a/integration-templates/xero/mappers/to-invoice.ts
+++ b/integration-templates/xero/mappers/to-invoice.ts
@@ -32,8 +32,8 @@ function toInvoiceItem(xeroInvoiceItem: XeroLineItem): InvoiceFee {
         precise_unit_amount: Number(xeroInvoiceItem.UnitAmount),
         account_code: xeroInvoiceItem.AccountCode,
         account_external_id: xeroInvoiceItem.AccountId,
-        amount_cents: parseFloat(xeroInvoiceItem.LineAmount) * 100, // Amounts in xero are not in cents
-        taxes_amount_cents: parseFloat(xeroInvoiceItem.TaxAmount) * 100 // Amounts in xero are not in cents
+        amount_cents: Math.round(parseFloat(xeroInvoiceItem.LineAmount) * 100),
+        taxes_amount_cents: Math.round(parseFloat(xeroInvoiceItem.TaxAmount) * 100)
     };
 
     if (xeroInvoiceItem.DiscountRate) {
@@ -41,7 +41,7 @@ function toInvoiceItem(xeroInvoiceItem: XeroLineItem): InvoiceFee {
     }
 
     if (xeroInvoiceItem.DiscountAmount) {
-        item.discount_amount_cents = xeroInvoiceItem.DiscountAmount * 100; // Amounts in xero are not in cents
+        item.discount_amount_cents = Math.round(xeroInvoiceItem.DiscountAmount * 100);
     }
 
     return item;
@@ -109,15 +109,15 @@ export function toXeroInvoice(invoice: CreateInvoice | Invoice) {
         }
 
         if (item.amount_cents) {
-            xeroItem['LineAmount'] = item.amount_cents / 100;
+            xeroItem['LineAmount'] = (item.amount_cents / 100).toFixed(2);
         }
 
         if (item.taxes_amount_cents) {
-            xeroItem['TaxAmount'] = item.taxes_amount_cents / 100;
+            xeroItem['TaxAmount'] = (item.taxes_amount_cents / 100).toFixed(2);
         }
 
         if (item.discount_amount_cents) {
-            xeroItem['DiscountAmount'] = item.discount_amount_cents / 100;
+            xeroItem['DiscountAmount'] = (item.discount_amount_cents / 100).toFixed(2);
         }
 
         if (item.discount_rate) {

--- a/integration-templates/xero/mappers/to-invoice.ts
+++ b/integration-templates/xero/mappers/to-invoice.ts
@@ -16,6 +16,10 @@ export function toInvoice(xeroInvoice: XeroInvoice): Invoice {
         fees: xeroInvoice.LineItems.map(toInvoiceItem)
     };
 
+    if (xeroInvoice.Url) {
+        invoice.url = xeroInvoice.Url;
+    }
+
     return invoice;
 }
 
@@ -31,6 +35,14 @@ function toInvoiceItem(xeroInvoiceItem: XeroLineItem): InvoiceFee {
         amount_cents: parseFloat(xeroInvoiceItem.LineAmount) * 100, // Amounts in xero are not in cents
         taxes_amount_cents: parseFloat(xeroInvoiceItem.TaxAmount) * 100 // Amounts in xero are not in cents
     };
+
+    if (xeroInvoiceItem.DiscountRate) {
+        item.discount_rate = xeroInvoiceItem.DiscountRate;
+    }
+
+    if (xeroInvoiceItem.DiscountAmount) {
+        item.discount_amount_cents = xeroInvoiceItem.DiscountAmount * 100; // Amounts in xero are not in cents
+    }
 
     return item;
 }
@@ -70,6 +82,10 @@ export function toXeroInvoice(invoice: CreateInvoice | Invoice) {
         xeroInvoice['DueDate'] = dueDate.toISOString().split('T')[0];
     }
 
+    if (invoice.url) {
+        xeroInvoice['Url'] = invoice.url;
+    }
+
     for (const item of invoice.fees) {
         const xeroItem: Record<string, any> = {
             Description: item.description,
@@ -98,6 +114,14 @@ export function toXeroInvoice(invoice: CreateInvoice | Invoice) {
 
         if (item.taxes_amount_cents) {
             xeroItem['TaxAmount'] = item.taxes_amount_cents / 100;
+        }
+
+        if (item.discount_amount_cents) {
+            xeroItem['DiscountAmount'] = item.discount_amount_cents / 100;
+        }
+
+        if (item.discount_rate) {
+            xeroItem['DiscountRate'] = item.discount_rate;
         }
 
         xeroInvoice['LineItems'].push(xeroItem);

--- a/integration-templates/xero/nango.yaml
+++ b/integration-templates/xero/nango.yaml
@@ -69,7 +69,7 @@ integrations:
                 scopes: accounting.transactions
                 output: InvoiceActionResponse
                 endpoint: POST /xero/invoices
-                version: 0.0.2
+                version: 1.0.0
             update-invoice:
                 description: |
                     Updates one or more invoices in Xero. To delete an invoice
@@ -209,6 +209,7 @@ models:
     BaseInvoice:
         type: ACCPAY | ACCREC
         external_contact_id: string
+        url?: string
     CreateInvoice:
         __extends: BaseInvoice
         fees: CreateInvoiceFee[]
@@ -216,21 +217,22 @@ models:
         payment_due_date?: date | null
         status?: string
         number?: string
-        tax_rate?: number
         currency?: string
         purchase_order?: string | null
-    CreateInvoiceFee:
-        description: string
-        item_id?: string
+    BaseInvoiceFee:
+        account_code?: string
         item_code?: string | null
+        account_external_id?: string | null
+        discount_amount_cents?: number | null
+        discount_rate?: number | null
+    CreateInvoiceFee:
+        __extends: BaseInvoiceFee
+        item_id?: string
+        description: string
         units?: number
         precise_unit_amount?: number | null
-        account_code?: string
-        account_external_id?: string | null
         amount_cents?: number | null
         taxes_amount_cents?: number | null
-        rate?: number | null
-        price?: number | null
     Invoice:
         __extends: BaseInvoice
         id: string
@@ -242,17 +244,13 @@ models:
         purchase_order: string | null
         fees: InvoiceFee[]
     InvoiceFee:
+        __extends: BaseInvoiceFee
         item_id: string
-        item_code?: string | null
         description: string | null
         units: number | null
         precise_unit_amount: number | null
-        account_code?: string
-        account_external_id?: string | null
         amount_cents: number | null
         taxes_amount_cents: number | null
-        rate?: number | null
-        price?: number | null
     FailedInvoice:
         __extends: Invoice
         validation_errors: any[]

--- a/integration-templates/xero/types.ts
+++ b/integration-templates/xero/types.ts
@@ -49,17 +49,20 @@ interface Tracking {
 }
 
 export interface LineItem {
-    ItemCode: string;
     Description: string;
-    Quantity: string;
     UnitAmount: string;
-    TaxType: string;
     TaxAmount: string;
     LineAmount: string;
+    Tracking: Tracking[];
+    Quantity: number;
+    DiscountRate?: number;
+    DiscountEnteredAsPercent?: boolean;
+    DiscountAmount?: number;
+    ItemCode: string;
+    TaxType: string;
     AccountCode: string;
     AccountId: string;
     Item: Item;
-    Tracking: Tracking[];
     LineItemID: string;
 }
 
@@ -76,6 +79,8 @@ export interface Invoice {
     DateString: string;
     DueDateString: string;
     Status: 'AUTHORISED' | 'DRAFT' | 'PAID';
+    Reference: string;
+    Url?: string;
     LineAmountTypes: 'Exclusive' | 'Inclusive' | 'NoTax';
     LineItems: LineItem[];
     SubTotal: string;

--- a/packages/shared/flows.yaml
+++ b/packages/shared/flows.yaml
@@ -3549,7 +3549,7 @@ integrations:
                 scopes: accounting.transactions
                 output: InvoiceActionResponse
                 endpoint: POST /xero/invoices
-                version: 0.0.2
+                version: 1.0.0
             update-invoice:
                 description: |
                     Updates one or more invoices in Xero. To delete an invoice
@@ -3720,32 +3720,40 @@ integrations:
             BaseInvoice:
                 type: ACCPAY | ACCREC
                 external_contact_id: string
+                url?: string
             CreateInvoice:
                 type: ACCPAY | ACCREC
                 external_contact_id: string
+                url?: string
                 fees: CreateInvoiceFee[]
                 issuing_date?: date
                 payment_due_date?: date | null
                 status?: string
                 number?: string
-                tax_rate?: number
                 currency?: string
                 purchase_order?: string | null
-            CreateInvoiceFee:
-                description: string
-                item_id?: string
+            BaseInvoiceFee:
+                account_code?: string
                 item_code?: string | null
+                account_external_id?: string | null
+                discount_amount_cents?: number | null
+                discount_rate?: number | null
+            CreateInvoiceFee:
+                account_code?: string
+                item_code?: string | null
+                account_external_id?: string | null
+                discount_amount_cents?: number | null
+                discount_rate?: number | null
+                item_id?: string
+                description: string
                 units?: number
                 precise_unit_amount?: number | null
-                account_code?: string
-                account_external_id?: string | null
                 amount_cents?: number | null
                 taxes_amount_cents?: number | null
-                rate?: number | null
-                price?: number | null
             Invoice:
                 type: ACCPAY | ACCREC
                 external_contact_id: string
+                url?: string
                 id: string
                 issuing_date: string | null
                 payment_due_date: string | null
@@ -3755,20 +3763,21 @@ integrations:
                 purchase_order: string | null
                 fees: InvoiceFee[]
             InvoiceFee:
-                item_id: string
+                account_code?: string
                 item_code?: string | null
+                account_external_id?: string | null
+                discount_amount_cents?: number | null
+                discount_rate?: number | null
+                item_id: string
                 description: string | null
                 units: number | null
                 precise_unit_amount: number | null
-                account_code?: string
-                account_external_id?: string | null
                 amount_cents: number | null
                 taxes_amount_cents: number | null
-                rate?: number | null
-                price?: number | null
             FailedInvoice:
                 type: ACCPAY | ACCREC
                 external_contact_id: string
+                url?: string
                 id: string
                 issuing_date: string | null
                 payment_due_date: string | null

--- a/scripts/run-integration-template.bash
+++ b/scripts/run-integration-template.bash
@@ -20,7 +20,7 @@ mkdir -p $TEMP_DIRECTORY/nango-integrations
 cp -r integration-templates/$INTEGRATION $TEMP_DIRECTORY/nango-integrations
 
 mv $TEMP_DIRECTORY/nango-integrations/$INTEGRATION/nango.yaml $TEMP_DIRECTORY/nango-integrations/nango.yaml
-mv $TEMP_DIRECTORY/nango-integrations/$INTEGRATION/fixtures $TEMP_DIRECTORY/nango-integrations/fixtures
+[ -d $TEMP_DIRECTORY/nango-integrations/$INTEGRATION/fixtures ] && mv $TEMP_DIRECTORY/nango-integrations/$INTEGRATION/fixtures $TEMP_DIRECTORY/nango-integrations/fixtures
 
 pushd $TEMP_DIRECTORY/nango-integrations
 

--- a/scripts/run-integration-template.bash
+++ b/scripts/run-integration-template.bash
@@ -13,13 +13,14 @@ TEMP_DIRECTORY=tmp-run-integration-template
 INTEGRATION=$1
 shift
 
-NANGO_SECRET_KEY_DEV=$(grep NANGO_SECRET_KEY_DEV .env | cut -d '=' -f2)
+NANGO_SECRET_KEY_DEV=$(grep -v '^#' .env | grep NANGO_SECRET_KEY_DEV | cut -d '=' -f2)
 
 rm -rf $TEMP_DIRECTORY
 mkdir -p $TEMP_DIRECTORY/nango-integrations
 cp -r integration-templates/$INTEGRATION $TEMP_DIRECTORY/nango-integrations
 
 mv $TEMP_DIRECTORY/nango-integrations/$INTEGRATION/nango.yaml $TEMP_DIRECTORY/nango-integrations/nango.yaml
+mv $TEMP_DIRECTORY/nango-integrations/$INTEGRATION/fixtures $TEMP_DIRECTORY/nango-integrations/fixtures
 
 pushd $TEMP_DIRECTORY/nango-integrations
 


### PR DESCRIPTION
## Describe your changes
Update the xero create-invoice to better match the API. Mappings are as follows:
```
# fees
# Xero => Nango
Quantity => units
UnitAmount => precise_unit_amount
LineAmount => amount_cents
TaxAmount => taxes_amount_cents
DiscountAmount => discount_amount_cents
DiscountRate => discount_rate
```

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
