### PR TITLE
chore: add start endpoint to runner

### DIFF
--- a/packages/runner/lib/client.unit.test.ts
+++ b/packages/runner/lib/client.unit.test.ts
@@ -7,6 +7,28 @@ describe('Runner client', () => {
     const port = 3095;
     const serverUrl = `http://localhost:${port}`;
     let client: ReturnType<typeof getRunnerClient>;
+    const nangoProps: NangoProps = {
+        host: 'http://localhost:3003',
+        connectionId: 'connection-id',
+        environmentId: 1,
+        providerConfigKey: 'provider-config-key',
+        activityLogId: 1,
+        secretKey: 'secret-key',
+        nangoConnectionId: 1,
+        syncId: 'sync-id',
+        syncJobId: 1,
+        lastSyncDate: new Date(),
+        dryRun: true,
+        attributes: {},
+        track_deletes: false,
+        logMessages: {
+            counts: { updated: 0, added: 0, deleted: 0 },
+            messages: []
+        },
+        syncConfig: {} as SyncConfig,
+        runnerFlags: {} as any,
+        stubbedMetadata: {}
+    };
 
     beforeAll(() => {
         client = getRunnerClient(serverUrl);
@@ -18,42 +40,19 @@ describe('Runner client', () => {
         expect(result).toEqual({ status: 'ok' });
     });
 
-    it('should run code', async () => {
-        const nangoProps: NangoProps = {
-            host: 'http://localhost:3003',
-            connectionId: 'connection-id',
-            environmentId: 1,
-            providerConfigKey: 'provider-config-key',
-            activityLogId: 1,
-            secretKey: 'secret-key',
-            nangoConnectionId: 1,
-            syncId: 'sync-id',
-            syncJobId: 1,
-            lastSyncDate: new Date(),
-            dryRun: true,
-            attributes: {},
-            track_deletes: false,
-            logMessages: {
-                counts: { updated: 0, added: 0, deleted: 0 },
-                messages: []
-            },
-            syncConfig: {} as SyncConfig,
-            runnerFlags: {} as any,
-            stubbedMetadata: {}
-        };
-        const jsCode = `
-        f = async (nango) => {
-            const s = nango.lastSyncDate.toISOString();
-            const b = Buffer.from("hello world");
-            const t = await Promise.resolve(setTimeout(() => {}, 5));
-            return [1, 2, 3]
-        };
-        exports.default = f
-        `;
+    it('should run script', async () => {
+        const jsCode = `exports.default = async (nango) => [1, 2, 3]`;
         const isInvokedImmediately = false;
         const isWebhook = false;
 
         const run = client.run.mutate({ nangoProps, isInvokedImmediately, isWebhook, code: jsCode });
         await expect(run).resolves.toEqual([1, 2, 3]);
+    });
+
+    it('should start script', async () => {
+        const jsCode = `exports.default = async (nango) => [1, 2, 3]`;
+        const taskId = 'task-id';
+        const start = client.start.mutate({ taskId, nangoProps, scriptType: 'sync', code: jsCode });
+        await expect(start).resolves.toEqual(true);
     });
 });

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -13,20 +13,17 @@ import { logger } from './utils.js';
 
 export async function exec(
     nangoProps: NangoProps,
-    isInvokedImmediately: boolean,
-    isWebhook: boolean,
+    scriptType: 'sync' | 'action' | 'webhook' | 'post-connection-script',
     code: string,
     codeParams?: object
 ): Promise<RunnerOutput> {
-    const isAction = isInvokedImmediately && !isWebhook;
-
     const abortController = new AbortController();
 
-    if (!isInvokedImmediately && nangoProps.syncId) {
+    if (scriptType == 'sync' && nangoProps.syncId) {
         syncAbortControllers.set(nangoProps.syncId, abortController);
     }
 
-    const rawNango = isAction ? new NangoAction(nangoProps) : new NangoSync(nangoProps);
+    const rawNango = scriptType === 'action' ? new NangoAction(nangoProps) : new NangoSync(nangoProps);
 
     const nango = process.env['NANGO_TELEMETRY_SDK'] ? instrumentSDK(rawNango) : rawNango;
 
@@ -71,7 +68,7 @@ export async function exec(
             const context = vm.createContext(sandbox);
             const scriptExports = script.runInContext(context);
 
-            if (isWebhook) {
+            if (scriptType === 'webhook') {
                 if (!scriptExports.onWebhookPayloadReceived) {
                     const content = `There is no onWebhookPayloadReceived export for ${nangoProps.syncId}`;
 
@@ -84,7 +81,7 @@ export async function exec(
             if (!scriptExports.default || typeof scriptExports.default !== 'function') {
                 throw new Error(`Default exports is not a function but a ${typeof scriptExports.default}`);
             }
-            if (isAction) {
+            if (scriptType === 'action') {
                 let inputParams = codeParams;
                 if (typeof codeParams === 'object' && Object.keys(codeParams).length === 0) {
                     inputParams = undefined;

--- a/packages/runner/lib/exec.unit.test.ts
+++ b/packages/runner/lib/exec.unit.test.ts
@@ -1,0 +1,41 @@
+import { expect, describe, it } from 'vitest';
+import { exec } from './exec.js';
+import type { NangoProps, SyncConfig } from '@nangohq/shared';
+
+describe('Exec', () => {
+    it('execute code', async () => {
+        const nangoProps: NangoProps = {
+            host: 'http://localhost:3003',
+            connectionId: 'connection-id',
+            environmentId: 1,
+            providerConfigKey: 'provider-config-key',
+            activityLogId: 1,
+            secretKey: 'secret-key',
+            nangoConnectionId: 1,
+            syncId: 'sync-id',
+            syncJobId: 1,
+            lastSyncDate: new Date(),
+            dryRun: true,
+            attributes: {},
+            track_deletes: false,
+            logMessages: {
+                counts: { updated: 0, added: 0, deleted: 0 },
+                messages: []
+            },
+            syncConfig: {} as SyncConfig,
+            runnerFlags: {} as any,
+            stubbedMetadata: {}
+        };
+        const jsCode = `
+        f = async (nango) => {
+            const s = nango.lastSyncDate.toISOString();
+            const b = Buffer.from("hello world");
+            const t = await Promise.resolve(setTimeout(() => {}, 5));
+            return [1, 2, 3]
+        };
+        exports.default = f
+        `;
+        const res = exec(nangoProps, 'sync', jsCode);
+        await expect(res).resolves.toEqual([1, 2, 3]);
+    });
+});

--- a/packages/runner/lib/utils.ts
+++ b/packages/runner/lib/utils.ts
@@ -1,3 +1,21 @@
-import { getLogger } from '@nangohq/utils';
+import { getLogger, stringifyError } from '@nangohq/utils';
 
 export const logger = getLogger('Runner');
+
+export async function httpFetch({ method, url, data }: { method: string; url: string; data: string }): Promise<void> {
+    try {
+        const res = await fetch(url, {
+            method: method,
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json'
+            },
+            body: data
+        });
+        if (res.status > 299) {
+            logger.error(`Error (status=${res.status}) sending '${data}' to '${url}': ${JSON.stringify(await res.json())}`);
+        }
+    } catch (err) {
+        logger.error(`Error sending '${data}' to '${url}': ${stringifyError(err)}`);
+    }
+}


### PR DESCRIPTION
## Describe your changes

First setup of refactoring jobs/runner to remove the long request when executing scripts, replacing it by a 2-way communication between job and runners
In order to avoid breakage when deploying, I am first modifying the runner. Adding a new `start` endpoint and keeping the old `run` endpoint.
For now `start` is not being called.

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1421/refactor-runservice

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
