### PR TITLE
fix(cors): allow public api to be reached from a frontend

### DIFF
--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -114,7 +114,8 @@ const publicAPI = express.Router();
 const publicAPICorsHandler = cors({
     maxAge: 600,
     exposedHeaders: 'Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset',
-    allowedHeaders: 'Nango-Activity-Log-Id, Nango-Is-Dry-Run, Nango-Is-Sync, Provider-Config-Key, Connection-Id',
+    allowedHeaders:
+        'Authorization, Content-Type, Accept, Origin, X-Requested-With, Nango-Activity-Log-Id, Nango-Is-Dry-Run, Nango-Is-Sync, Provider-Config-Key, Connection-Id',
     origin: '*'
 });
 publicAPI.use(publicAPICorsHandler);


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1491/fix-cors-issue-when-reaching-public-api-from-a-frontend

- Allow public api to be reached via frontend 
The regular auth was fine but not the custom ones

