### PR TITLE
fix(proxy): send no data if empty body

### DIFF
--- a/packages/server/lib/controllers/proxy.controller.ts
+++ b/packages/server/lib/controllers/proxy.controller.ts
@@ -334,7 +334,8 @@ class ProxyController {
                 headers,
                 decompress
             };
-            if (data && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
+            const nonEmpty = (v: unknown) => v != null && v !== '' && (typeof v !== 'object' || Object.keys(v).length > 0);
+            if (nonEmpty(data) && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
                 requestConfig.data = data;
             }
             const responseStream: AxiosResponse = await backOff(

--- a/packages/server/lib/controllers/proxy.controller.ts
+++ b/packages/server/lib/controllers/proxy.controller.ts
@@ -67,7 +67,7 @@ class ProxyController {
                 providerConfigKey,
                 connectionId,
                 retries: retries ? Number(retries) : 0,
-                data: req.body,
+                data: req.rawBody,
                 headers,
                 baseUrlOverride,
                 decompress: decompress === 'true' ? true : false,
@@ -334,8 +334,7 @@ class ProxyController {
                 headers,
                 decompress
             };
-            const nonEmpty = (v: unknown) => v != null && v !== '' && (typeof v !== 'object' || Object.keys(v).length > 0);
-            if (nonEmpty(data) && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
+            if (data && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
                 requestConfig.data = data;
             }
             const responseStream: AxiosResponse = await backOff(

--- a/packages/server/lib/controllers/proxy.controller.ts
+++ b/packages/server/lib/controllers/proxy.controller.ts
@@ -9,7 +9,7 @@ import querystring from 'querystring';
 import type { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { backOff } from 'exponential-backoff';
 import type { HTTP_VERB, UserProvidedProxyConfiguration, InternalProxyConfiguration, ApplicationConstructedProxyConfiguration } from '@nangohq/shared';
-import { NangoError, LogActionEnum, errorManager, ErrorSourceEnum, proxyService, connectionService, configService } from '@nangohq/shared';
+import { NangoError, LogActionEnum, errorManager, ErrorSourceEnum, proxyService, connectionService, configService, featureFlags } from '@nangohq/shared';
 import { metrics, getLogger, axiosInstance as axios } from '@nangohq/utils';
 import { logContextGetter } from '@nangohq/logs';
 import { connectionRefreshFailed as connectionRefreshFailedHook, connectionRefreshSuccess as connectionRefreshSuccessHook } from '../hooks/hooks.js';
@@ -62,12 +62,15 @@ class ProxyController {
 
             const headers = parseHeaders(req);
 
+            const rawBodyFlag = await featureFlags.isEnabled('proxy:rawbody', 'global', false);
+            const data = rawBodyFlag ? req.rawBody : req.body;
+
             const externalConfig: UserProvidedProxyConfiguration = {
                 endpoint,
                 providerConfigKey,
                 connectionId,
                 retries: retries ? Number(retries) : 0,
-                data: req.rawBody,
+                data,
                 headers,
                 baseUrlOverride,
                 decompress: decompress === 'true' ? true : false,


### PR DESCRIPTION
Dropbox API is very strict about receiving empty body and will fail if passing an empty object {}. I am gonna blame express body parser for returning a empty object when request has no body. 
This commit ensures that the empty body at all is send if data is empty. The drawback is that it won't be possible to actually send an empty object when this PR is merged. 

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1423/proxy-do-not-default-body-to-if-no-payload-is-provided-by-user

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
