### PR TITLE
fix(jobs): putTask error payload is not always an Record<string, unknown>

### DIFF
--- a/packages/jobs/lib/routes/tasks/putTask.ts
+++ b/packages/jobs/lib/routes/tasks/putTask.ts
@@ -20,7 +20,7 @@ type PutTask = Endpoint<{
         error?:
             | {
                   type: string;
-                  payload: Record<string, unknown>; //TODO: can be an array?
+                  payload: Record<string, unknown>;
                   status: number;
               }
             | undefined;
@@ -91,7 +91,7 @@ const validate = validateRequest<PutTask>({
                 error: z
                     .object({
                         type: z.string(),
-                        payload: z.record(z.string(), z.any()),
+                        payload: z.record(z.string(), z.unknown()).or(z.unknown().transform((v) => ({ message: v }))),
                         status: z.number()
                     })
                     .optional(),


### PR DESCRIPTION
Some erroring tasks are not completing because the call to jobs PUT /tasks/... is failing with a zod valiation error:
```
Error: PUT http://jobs-production/tasks/0190feed-d5c6-72c9-bce0-4bc3e2708c43: status=400, response={"error":{"code":"invalid_request","errors":[{"code":"invalid_type","message":"Expected object, received array","path":["error","payload"]}]}}
```

Ideally we would make sure the payload sent is of correct type but it is easier to be more flexible on Jobs side since one of my next project is to improve the errors logs and I will probably modify the error handling in the runner.

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
