### PR TITLE
fix: sync/status type must be INCREMENTAL or INITIAL

### DIFF
--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -70,7 +70,7 @@ export async function startSync(task: TaskSync, startScriptFn = startScript): Pr
         team = accountAndEnv.account;
         environment = accountAndEnv.environment;
 
-        syncType = syncConfig.sync_type === SyncType.INCREMENTAL && lastSyncDate ? SyncType.INCREMENTAL : SyncType.FULL;
+        syncType = syncConfig.sync_type?.toLowerCase() === SyncType.INCREMENTAL.toLowerCase() && lastSyncDate ? SyncType.INCREMENTAL : SyncType.FULL;
 
         logCtx = await logContextGetter.create(
             { operation: { type: 'sync', action: 'run' }, message: 'Sync' },

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -13,11 +13,11 @@ import {
 import { errorNotificationService } from '../notification/error.service.js';
 import configService from '../config.service.js';
 import type { Connection, NangoConnection } from '../../models/Connection.js';
-import type { SyncDeploymentResult, Sync, SyncType, ReportedSyncJobStatus, SyncCommand } from '../../models/Sync.js';
+import type { SyncDeploymentResult, Sync, ReportedSyncJobStatus, SyncCommand } from '../../models/Sync.js';
+import { SyncType, SyncStatus } from '../../models/Sync.js';
 import { NangoError } from '../../utils/error.js';
 import type { Config as ProviderConfig } from '../../models/Provider.js';
 import type { ServiceResponse } from '../../models/Generic.js';
-import { SyncStatus } from '../../models/Sync.js';
 import type { LogContext, LogContextGetter } from '@nangohq/logs';
 import { getLogger, stringifyError } from '@nangohq/utils';
 import environmentService from '../environment.service.js';
@@ -431,7 +431,7 @@ export class SyncManagerService {
         }
         return {
             id: sync.id,
-            type: latestJob?.type as SyncType,
+            type: latestJob?.type === SyncType.INCREMENTAL ? latestJob.type : 'INITIAL',
             finishedAt: latestJob?.updated_at,
             nextScheduledSyncAt: schedule.nextDueDate,
             name: sync.name,


### PR DESCRIPTION
reverting a breaking change: /sync/status type must be INCREMENTAL or INITIAL instead of INCREMENTAL or FULL

The breaking change is due to 2 recent modifications:
1. when removing Temporal, `type` was changed to be INCREMENTAL or FULL
2. Sync Config sync_type is now lowercase

The 2nd change should probably be fixed as well but I am not sure of the consequences. For now just fixing the endpoint to  unblock customers and revert the breaking change

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
