### PR TITLE
fix: webhook syncType must be INITIAL instead of FULL

### DIFF
--- a/packages/types/lib/webhooks/api.ts
+++ b/packages/types/lib/webhooks/api.ts
@@ -1,5 +1,5 @@
 import type { AuthOperationType, AuthModeType } from '../auth/api.js';
-import type { SyncResult, SyncType } from '../scripts/syncs/api.js';
+import type { SyncResult } from '../scripts/syncs/api.js';
 import type { ErrorPayload } from '../api.js';
 
 export type WebhookTypes = 'sync' | 'auth' | 'forward';
@@ -19,7 +19,7 @@ export interface NangoSyncWebhookBodyBase extends NangoWebhookBase {
     providerConfigKey: string;
     syncName: string;
     model: string;
-    syncType: SyncType;
+    syncType: 'INCREMENTAL' | 'INITIAL';
 }
 
 export interface NangoSyncWebhookBodySuccess extends NangoSyncWebhookBodyBase {

--- a/packages/webhooks/lib/sync.ts
+++ b/packages/webhooks/lib/sync.ts
@@ -55,7 +55,8 @@ export const sendSync = async ({
         providerConfigKey: connection.provider_config_key,
         syncName,
         model,
-        syncType: operation
+        // For backward compatibility reason we are sending the syncType as INITIAL instead of FULL
+        syncType: operation === 'INCREMENTAL' ? 'INCREMENTAL' : 'INITIAL'
     };
     let finalBody: NangoSyncWebhookBody;
 


### PR DESCRIPTION
following up on https://github.com/NangoHQ/nango/pull/2560 which was reverting a breaking change of /sync/status endpoint.
 This commit is fixing the same issue in webhook body

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
