### PR TITLE
fix: actions failing with cannot convert undefined or null to object

### DIFF
--- a/packages/jobs/lib/execution/operations/start.ts
+++ b/packages/jobs/lib/execution/operations/start.ts
@@ -53,7 +53,7 @@ export async function startScript({
             taskId: taskId,
             nangoProps,
             code: script,
-            codeParams: input as object
+            codeParams: (input as object) || {}
         });
 
         if (!res) {


### PR DESCRIPTION
calling action/trigger without any input results in the following error "Cannot convert undefined or null to object" error on line https://github.com/NangoHQ/nango/blob/master/packages/runner/lib/exec.ts#L81

checking for `typeof === 'object'` only protects against `undefined` because `typeof null === 'object'` is true. :facepalm: I'll let you google why. :D 
This issue was introduced by the run.service refactor. Before we were protected by this line https://github.com/NangoHQ/nango/pull/2547/files#diff-9aa7145930aaa906c0e2c114964bd750b856aba74326de7e46ce217429abe6cfL180-L182 which prevented input to ever be null but only undefined if no input 

It might be pretty rare in prod because it only happens when using the action/trigger endpoint (with an action that takes not input) but not when using the
/v1/USER_DEFINED_ENDPOINT. In this case no input becomes an empty object instead of null 
https://github.com/NangoHQ/nango/blob/master/packages/server/lib/controllers/sync.controller.ts#L228-L247

With this commit we ensure that `codeParams = null`is never sent to the runner. 
When refactoring runner not to use trpc anymore I'll make sure to remove the casting to object and pass a json object that would be validated on the runner side. In the meantime, I am just making sure null is never send to runner

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
