### PR TITLE
fix: compute sync metrics once sync completes

### DIFF
--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -353,6 +353,9 @@ export async function handleSyncSuccess({ nangoProps }: { nangoProps: NangoProps
             createdAt: Date.now()
         });
 
+        metrics.duration(metrics.Types.SYNC_TRACK_RUNTIME, Date.now() - nangoProps.startedAt.getTime());
+        metrics.increment(metrics.Types.SYNC_SUCCESS);
+
         await logCtx.success();
     } catch (err) {
         await onFailure({
@@ -627,4 +630,6 @@ async function onFailure({
         log_id: logCtx.id,
         active: true
     });
+
+    metrics.increment(metrics.Types.SYNC_FAILURE);
 }

--- a/packages/jobs/lib/processor/handler.ts
+++ b/packages/jobs/lib/processor/handler.ts
@@ -1,6 +1,6 @@
 import tracer from 'dd-trace';
 import type { OrchestratorTask } from '@nangohq/nango-orchestrator';
-import { Err, Ok, metrics } from '@nangohq/utils';
+import { Err, Ok } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
 import { startSync, abortSync } from '../execution/sync.js';
 import { startAction } from '../execution/action.js';
@@ -11,14 +11,7 @@ export async function handler(task: OrchestratorTask): Promise<Result<void>> {
     if (task.isSync()) {
         const span = tracer.startSpan('jobs.handler.sync');
         return await tracer.scope().activate(span, async () => {
-            const start = Date.now();
             const res = await startSync(task);
-            if (res.isErr()) {
-                metrics.increment(metrics.Types.SYNC_FAILURE);
-            } else {
-                metrics.increment(metrics.Types.SYNC_SUCCESS);
-                metrics.duration(metrics.Types.SYNC_TRACK_RUNTIME, Date.now() - start);
-            }
             span.finish();
             return res.isErr() ? Err(res.error) : Ok(undefined);
         });


### PR DESCRIPTION
## Describe your changes
when refactoring jobs/runner I forgot to move the computation of the SYNC_TRACK_RUNTIME metric in the output handler. 

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
