### PR TITLE
fix(klaviyo-integration): [nan-1511] allow oauth to dynamically inject headers

### DIFF
--- a/packages/shared/lib/services/proxy.service.ts
+++ b/packages/shared/lib/services/proxy.service.ts
@@ -450,7 +450,12 @@ class ProxyService {
                     let tokenPair;
                     switch (config.template.auth_mode) {
                         case 'OAUTH2':
-                            tokenPair = { accessToken: config.token };
+                            if (value.includes('connectionConfig')) {
+                                value = value.replace(/connectionConfig\./g, '');
+                                tokenPair = config.connection.connection_config;
+                            } else {
+                                tokenPair = { accessToken: config.token };
+                            }
                             break;
                         case 'BASIC':
                         case 'API_KEY':

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -1516,7 +1516,7 @@ klaviyo:
         base_url: https://a.klaviyo.com
         headers:
             Authorization: Klaviyo-API-Key ${apiKey}
-            revision: ${connectionConfig.revisionHeader}
+            revision: '2024-07-15'
         verification:
             method: GET
             endpoint: /api/accounts
@@ -1540,7 +1540,7 @@ klaviyo-oauth:
     proxy:
         base_url: https://a.klaviyo.com
         headers:
-            revision: ${connectionConfig.revisionHeader}
+            revision: '2024-07-15'
         retry:
             after: 'Retry-After'
     docs: https://docs.nango.dev/integrations/all/klaviyo


### PR DESCRIPTION
## Describe your changes
OAUTH2 wasn't able to dynamically inject values from the connectionConfig. For Klaviyo automcally set the revision and if a user wants to override they could manually set the header

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
