### PR TITLE
fix: support special characters in db urls

### DIFF
--- a/docs-v2/host/self-host/self-hosting-instructions.mdx
+++ b/docs-v2/host/self-host/self-hosting-instructions.mdx
@@ -51,6 +51,7 @@ Records saved by syncs can be persisted in a dedicated database. If you opt in f
 ```
 RECORDS_DATABASE_URL=postgresql://user:password@host:port/dbname
 ```
+Special characters in the RECORDS_DATABASE_URL should be URL encoded.
 If not specified, the records will be stored in the main database.
 
 <Tip>

--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -12,7 +12,7 @@ const databaseSchema = envs.ORCHESTRATOR_DATABASE_SCHEMA;
 const databaseUrl =
     envs.ORCHESTRATOR_DATABASE_URL ||
     envs.NANGO_DATABASE_URL ||
-    `postgres://${envs.NANGO_DB_USER}:${envs.NANGO_DB_PASSWORD}@${envs.NANGO_DB_HOST}:${envs.NANGO_DB_PORT}/${envs.NANGO_DB_NAME}`;
+    `postgres://${encodeURIComponent(envs.NANGO_DB_USER)}:${encodeURIComponent(envs.NANGO_DB_PASSWORD)}@${envs.NANGO_DB_HOST}:${envs.NANGO_DB_PORT}/${envs.NANGO_DB_NAME}`;
 
 try {
     const dbClient = new DatabaseClient({ url: databaseUrl, schema: databaseSchema });

--- a/packages/records/lib/db/config.ts
+++ b/packages/records/lib/db/config.ts
@@ -5,7 +5,7 @@ export const schema = envs.RECORDS_DATABASE_SCHEMA;
 const databaseUrl =
     envs.RECORDS_DATABASE_URL ||
     envs.NANGO_DATABASE_URL ||
-    `postgres://${envs.NANGO_DB_USER}:${envs.NANGO_DB_PASSWORD}@${envs.NANGO_DB_HOST}:${envs.NANGO_DB_PORT}/${envs.NANGO_DB_NAME}`;
+    `postgres://${encodeURIComponent(envs.NANGO_DB_USER)}:${encodeURIComponent(envs.NANGO_DB_PASSWORD)}@${envs.NANGO_DB_HOST}:${envs.NANGO_DB_PORT}/${envs.NANGO_DB_NAME}`;
 const runningMigrationOnly = process.argv.some((v) => v === 'migrate:latest');
 const isJS = !runningMigrationOnly;
 


### PR DESCRIPTION
This commit URL encodes db username and password when used inside postgres db url
If db urls are set as env vars, users must URL encode them if they contain any special char

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
