### PR TITLE
chore: log error in handlePayloadTooBigError

### DIFF
--- a/packages/jobs/lib/execution/operations/output.ts
+++ b/packages/jobs/lib/execution/operations/output.ts
@@ -75,16 +75,20 @@ export async function handleError({
 }
 
 async function handlePayloadTooBigError({ taskId, error, nangoProps }: { taskId: string; error: ClientError; nangoProps: NangoProps }): Promise<void> {
-    if (
-        error.payload &&
-        typeof error.payload === 'object' &&
-        'response' in error.payload &&
-        error.payload['response'] &&
-        typeof error.payload['response'] === 'object'
-    ) {
-        const res = error.payload['response'] as unknown as ApiError<string>;
-        if (res.error.code === 'payload_too_big') {
-            await orchestratorClient.failed({ taskId, error: new NangoError('script_output_too_big', { syncId: nangoProps.syncId }) });
+    try {
+        if (
+            error.payload &&
+            typeof error.payload === 'object' &&
+            'response' in error.payload &&
+            error.payload['response'] &&
+            typeof error.payload['response'] === 'object'
+        ) {
+            const res = error.payload['response'] as unknown as ApiError<string>;
+            if (res.error.code === 'payload_too_big') {
+                await orchestratorClient.failed({ taskId, error: new NangoError('script_output_too_big', { syncId: nangoProps.syncId }) });
+            }
         }
+    } catch (err: unknown) {
+        logger.error(`failed to handle payload too big error for task ${taskId}`, err);
     }
 }


### PR DESCRIPTION
I noticed the following error this morning when a runner send the output of a task back to jobs:
Error: PUT /tasks/:taskId: status=500, response={"error":{"code":"server_error","message":"Cannot read properties of undefined (reading 'code')"}} It looks like setting the task as failed/succeed fails but the error doesn't have the shape we expect.
Adding a try/catch to log the error and let the execution continue and log the setSucceed/setFailed error

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
