### PR TITLE
chore: retry in orchestrator client

### DIFF
--- a/packages/jobs/lib/execution/operations/output.ts
+++ b/packages/jobs/lib/execution/operations/output.ts
@@ -84,7 +84,7 @@ async function handlePayloadTooBigError({ taskId, error, nangoProps }: { taskId:
             typeof error.payload['response'] === 'object'
         ) {
             const res = error.payload['response'] as unknown as ApiError<string>;
-            if (res.error.code === 'payload_too_big') {
+            if (res.error && res.error.code === 'payload_too_big') {
                 await orchestratorClient.failed({ taskId, error: new NangoError('script_output_too_big', { syncId: nangoProps.syncId }) });
             }
         }


### PR DESCRIPTION
I have noticed some ECONNRESET errros from jobs to orchestrator. (14 occurances yesterday)
Making orchestrator client more resilient to connection errors by retrying.

Also small fix in `handlePayloadTooBigError`, checking if `res.err` is defined

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
