### PR TITLE
fix(proxy): error response with no data should report failure

### DIFF
--- a/packages/server/lib/controllers/proxy.controller.ts
+++ b/packages/server/lib/controllers/proxy.controller.ts
@@ -297,8 +297,13 @@ class ProxyController {
             res.writeHead(error.response.status, error.response.headers as OutgoingHttpHeaders);
         }
         if (errorData) {
+            const chunks: Buffer[] = [];
             errorData.pipe(stringify).pipe(res);
             stringify.on('data', (data) => {
+                chunks.push(data);
+            });
+            stringify.on('end', () => {
+                const data = chunks.length > 0 ? Buffer.concat(chunks).toString() : 'no data';
                 void this.reportError(error, url, config, data, logCtx);
             });
         } else {


### PR DESCRIPTION
When the proxy response is an error without any data, the log operation was not marked as failed

before:
<img width="1028" alt="Screenshot 2024-08-02 at 14 21 24" src="https://github.com/user-attachments/assets/1608979c-645e-4595-923a-27867d5b666f">

after:
<img width="1024" alt="Screenshot 2024-08-02 at 14 21 17" src="https://github.com/user-attachments/assets/4cd773e5-8747-40e0-9fd3-5bab627ff235">


## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
