### PR TITLE
fix(runner): pass a syncJobId to webhook handler

### DIFF
--- a/packages/jobs/lib/execution/webhook.ts
+++ b/packages/jobs/lib/execution/webhook.ts
@@ -61,6 +61,7 @@ export async function startWebhook(task: TaskWebhook): Promise<Result<void>> {
             attributes: syncConfig.attributes,
             syncConfig: syncConfig,
             syncId: sync.id,
+            syncJobId: -1,
             debug: false,
             runnerFlags: await getRunnerFlags(),
             startedAt: new Date()


### PR DESCRIPTION
## Describe your changes

- Missing syncJobId breaks the webhook handler for some customer
We need to think about its requirement
