### PR TITLE
fix(cli): correct output when getConnection is 404

### DIFF
--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -228,7 +228,7 @@ export async function getConnection(providerConfigKey: string, connectionId: str
             return res.data;
         })
         .catch((err: unknown) => {
-            console.log(`❌ ${err instanceof AxiosError ? err.response?.data.error : JSON.stringify(err, ['message'])}`);
+            console.log(`❌ ${err instanceof AxiosError ? JSON.stringify(err.response?.data.error) : JSON.stringify(err, ['message'])}`);
         });
 }
 


### PR DESCRIPTION
## Describe your changes

- CLI was outputting [object object], this is a bit better but not perfectly readable
