### PR TITLE
fix: revert expireAt for podium

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -868,8 +868,6 @@ class ConnectionService {
                     expiresAt = parseTokenExpirationDate(rawCreds['expires_at']);
                 } else if (rawCreds['expires_in']) {
                     expiresAt = new Date(Date.now() + Number.parseInt(rawCreds['expires_in'], 10) * 1000);
-                } else if (template?.expires_in_ms) {
-                    expiresAt = new Date(Date.now() + template.expires_in_ms);
                 }
 
                 const oauth2Creds: OAuth2Credentials = {

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -2215,7 +2215,6 @@ podium:
         grant_type: authorization_code
     refresh_params:
         grant_type: refresh_token
-    expires_in_ms: 36000000
     proxy:
         headers:
             Podium-Version: ${connectionConfig.apiVersion}

--- a/packages/types/lib/integration/template.ts
+++ b/packages/types/lib/integration/template.ts
@@ -68,7 +68,6 @@ export interface TemplateOAuth2 extends Template {
 
     refresh_url?: string;
     expires_in_unit?: 'milliseconds';
-    expires_in_ms?: number; //in ms
 
     token_request_auth_method?: 'basic' | 'custom';
 }

--- a/scripts/validation/providers/schema.json
+++ b/scripts/validation/providers/schema.json
@@ -262,9 +262,6 @@
                     "type": "string",
                     "enum": ["milliseconds"]
                 },
-                "expires_in_ms": {
-                    "type": "number"
-                },
                 "token_response_metadata": {
                     "type": "array",
                     "items": {


### PR DESCRIPTION
## Describe your changes
Turns out that the provider actually includes an `expires_at` and `expires_in` values during token generation. This was undefined in their docs, probably made changes to the API without reviewing their [docs](https://docs.podium.com/docs/oauth#granted-access-response)
