### PR TITLE
fix(webhook): allow handler to save records

### DIFF
--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -1,7 +1,7 @@
 import { expect, describe, it, beforeAll, afterAll, vi } from 'vitest';
 import { server } from './server.js';
 import fetch from 'node-fetch';
-import type { AuthCredentials, Connection, Sync, Job as SyncJob } from '@nangohq/shared';
+import type { AuthCredentials, Sync, Job as SyncJob } from '@nangohq/shared';
 import db, { multipleMigrations } from '@nangohq/database';
 import { environmentService, connectionService, createSync, createSyncJob, SyncType, SyncStatus, accountService } from '@nangohq/shared';
 import { logContextGetter, migrateLogsMapping } from '@nangohq/logs';
@@ -17,7 +17,7 @@ describe('Persist API', () => {
         account: DBTeam;
         env: DBEnvironment;
         activityLogId: string;
-        connection: Connection;
+        connection: Exclude<Awaited<ReturnType<typeof connectionService.getConnectionById>>, null>;
         sync: Sync;
         syncJob: SyncJob;
     };
@@ -291,14 +291,22 @@ const initDb = async () => {
     const connectionId = connectionRes[0]?.connection.id;
     if (!connectionId) throw new Error('Connection not created');
 
-    const connection = (await connectionService.getConnectionById(connectionId)) as Connection;
+    const connection = await connectionService.getConnectionById(connectionId);
     if (!connection) throw new Error('Connection not found');
 
     const sync = await createSync(connectionId, 'sync-test');
     if (!sync?.id) throw new Error('Sync not created');
 
-    const syncJob = (await createSyncJob(sync.id, SyncType.FULL, SyncStatus.RUNNING, `job-test`, connection)) as SyncJob;
-    if (!syncJob) throw new Error('Sync job not created');
+    const syncJob = await createSyncJob({
+        sync_id: sync.id,
+        type: SyncType.FULL,
+        status: SyncStatus.RUNNING,
+        job_id: `job-test`,
+        nangoConnection: connection
+    });
+    if (!syncJob) {
+        throw new Error('Sync job not created');
+    }
 
     return {
         account: (await accountService.getAccountById(0))!,

--- a/packages/server/lib/webhook/index.ts
+++ b/packages/server/lib/webhook/index.ts
@@ -7,4 +7,5 @@ export { default as salesforceWebhookRouting } from './salesforce-webhook-routin
 export { default as slackWebhookRouting } from './slack-webhook-routing.js';
 export { default as checkrWebhookRouting } from './checkr-webhook-routing.js';
 export { default as microsoftTeamsWebhookRouting } from './microsoft-teams-webhook-routing.js';
+export { default as unauthenticatedWebhookRouting } from './unauthenticated-webhook-routing.js';
 export * from './types.js';

--- a/packages/server/lib/webhook/internal-nango.ts
+++ b/packages/server/lib/webhook/internal-nango.ts
@@ -101,6 +101,8 @@ export const internalNango: InternalNango = {
 
         const type = get(body, webhookType);
 
+        const orchestrator = getOrchestrator();
+
         for (const syncConfig of syncConfigsWithWebhooks) {
             const { webhook_subscriptions } = syncConfig;
 
@@ -111,7 +113,7 @@ export const internalNango: InternalNango = {
             for (const webhook of webhook_subscriptions) {
                 if (type === webhook) {
                     for (const connection of connections) {
-                        await getOrchestrator().triggerWebhook({
+                        await orchestrator.triggerWebhook({
                             account,
                             environment,
                             integration,

--- a/packages/server/lib/webhook/unauthenticated-webhook-routing.ts
+++ b/packages/server/lib/webhook/unauthenticated-webhook-routing.ts
@@ -1,0 +1,12 @@
+import type { WebhookHandler } from './types.js';
+import type { LogContextGetter } from '@nangohq/logs';
+
+const route: WebhookHandler = async (nango, integration, _headers, body, _, logContextGetter: LogContextGetter) => {
+    /**
+     * Only accepted format
+     * { type: '__STRING__', connectionId: '__STRING__', ... }
+     */
+    return await nango.executeScriptForWebhooks(integration, body, 'type', 'connectionId', logContextGetter, 'connectionId');
+};
+
+export default route;

--- a/packages/shared/lib/seeders/sync-job.seeder.ts
+++ b/packages/shared/lib/seeders/sync-job.seeder.ts
@@ -4,7 +4,7 @@ import type { Job } from '../models/Sync.js';
 import { SyncType, SyncStatus } from '../models/Sync.js';
 
 export const createSyncJobSeeds = async (syncId: string): Promise<Job> => {
-    return (await jobService.createSyncJob(syncId, SyncType.FULL, SyncStatus.RUNNING, '', null)) as Job;
+    return (await jobService.createSyncJob({ sync_id: syncId, type: SyncType.FULL, status: SyncStatus.RUNNING, job_id: '', nangoConnection: null })) as Job;
 };
 
 export const deleteAllSyncJobSeeds = async (): Promise<void> => {

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -3071,6 +3071,7 @@ unanet:
 unauthenticated:
     auth_mode: NONE
     docs: https://docs.nango.dev/integrations/overview
+    webhook_routing_script: unauthenticatedWebhookRouting
 vimeo:
     categories:
         - video


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1545/using-nangosync-in-webhook-handler-is-not-possible

- Allow webhook handlers to call batchSave
To do that we create a temporary job to have a syncJobId. Ultimately this is not that useful but because batchSave needs that to compute the results it was the easiest solution. 
Calling batch save in a webhook handler has many side effects and could be problematic with track_deletes, I would not recommend using it in combination of a regular sync.

- Allow `unauthenticated` to receive webhook
It's handy for debugging purposes, and very unlikely that any custom integration could fit the required model shape. However, if they can, we have no reason to block it.

## 🧪 Test

```yaml
      webhooks:
        description: proxy
        sync_type: full
        track_deletes: false
        runs: every 30 days
        auto_start: false
        output: Webhook
        endpoint: GET /unauth/webhook
        webhook-subscriptions: '*'
```

```ts
import type { NangoSync, Webhook } from "../../models";

export default async function fetchData(nango: NangoSync): Promise<void> {
  await nango.log("do nothing");
}

export async function onWebhookPayloadReceived(
  nango: NangoSync,
  payload: any,
): Promise<void> {
  await nango.batchSave<Webhook>([payload.data], "Webhook");
}
```

```sh
curl -i -XPOST http://localhost:3003/webhook/__ENV_UUID__/unauthenticated -H "content-type: application/json" -d '{"connectionId":"test-connection-id", "type": "*", "data": {"id": "str"}}'
```

<img width="1073" alt="Screenshot 2024-08-12 at 17 40 12" src="https://github.com/user-attachments/assets/58e4301a-21cc-4635-aa4e-df5dad54e87a">
