### PR TITLE
fix(anrok): handle errors correctly, fix types

### DIFF
--- a/integration-templates/anrok/actions/create-or-update-transaction.ts
+++ b/integration-templates/anrok/actions/create-or-update-transaction.ts
@@ -2,6 +2,7 @@ import type { NangoAction, TransactionActionResponse, Transaction, SuccessTransa
 
 import type { AnrokResponse } from '../types';
 import { mapFees } from '../mappers/fees.js';
+import { errorToObject } from '../utils.js';
 
 export default async function runAction(nango: NangoAction, rawInput: Transaction[]): Promise<TransactionActionResponse> {
     const response: TransactionActionResponse = {
@@ -40,28 +41,26 @@ export default async function runAction(nango: NangoAction, rawInput: Transactio
             ];
         }
 
-        await nango
-            .post<AnrokResponse>({
+        try {
+            const res = await nango.post<AnrokResponse>({
                 endpoint: 'v1/seller/transactions/createOrUpdate',
                 data: anrokTransaction
-            })
-            .then((res) => {
-                const { preTaxAmount, taxAmountToCollect, lineItems } = res.data;
-                const transactionResponse: SuccessTransaction = {
-                    ...transaction,
-                    sub_total_excluding_taxes: Number(preTaxAmount),
-                    taxes_amount_cents: taxAmountToCollect,
-                    fees: mapFees(transaction.fees, lineItems)
-                };
-
-                response.succeeded.push(transactionResponse);
-            })
-            .catch((error) => {
-                response.failed.push({
-                    ...transaction,
-                    validation_errors: error.response.data
-                });
             });
+            const { preTaxAmount, taxAmountToCollect, lineItems } = res.data;
+            const transactionResponse: SuccessTransaction = {
+                ...transaction,
+                sub_total_excluding_taxes: Number(preTaxAmount),
+                taxes_amount_cents: taxAmountToCollect,
+                fees: mapFees(transaction.fees, lineItems)
+            };
+
+            response.succeeded.push(transactionResponse);
+        } catch (err) {
+            response.failed.push({
+                ...transaction,
+                validation_errors: errorToObject(err)
+            });
+        }
     }
     return response;
 }

--- a/integration-templates/anrok/actions/void-transaction.ts
+++ b/integration-templates/anrok/actions/void-transaction.ts
@@ -1,4 +1,5 @@
 import type { NangoAction, TransactionToDelete, TransactionDeletionActionResponse } from '../../models';
+import { errorToObject } from '../utils.js';
 
 export default async function runAction(nango: NangoAction, rawInput: TransactionToDelete[]): Promise<TransactionDeletionActionResponse> {
     const response: TransactionDeletionActionResponse = {
@@ -7,23 +8,21 @@ export default async function runAction(nango: NangoAction, rawInput: Transactio
     };
     const input = Array.isArray(rawInput) ? rawInput : [rawInput];
     for (const transaction of input) {
-        await nango
-            .post({
+        try {
+            await nango.post({
                 endpoint: `v1/seller/transactions/id:${transaction.id}/void`,
                 headers: {
                     'Content-Type': 'application/json'
                 },
                 data: {}
-            })
-            .then(() => {
-                response.succeeded.push(transaction);
-            })
-            .catch((error) => {
-                response.failed.push({
-                    ...transaction,
-                    validation_errors: error.response.data
-                });
             });
+            response.succeeded.push(transaction);
+        } catch (err) {
+            response.failed.push({
+                ...transaction,
+                validation_errors: errorToObject(err)
+            });
+        }
     }
     return response;
 }

--- a/integration-templates/anrok/mappers/fees.ts
+++ b/integration-templates/anrok/mappers/fees.ts
@@ -17,7 +17,7 @@ export function mapFees(fees: TransactionFee[], lineItems: AnrokLineItem[]): Tra
                 }
             } else if (juris.notTaxedReason) {
                 taxBreakdown.push({
-                    reason: juris.notTaxedReason.reason.type,
+                    reason: juris.notTaxedReason.reason?.type || '',
                     type: juris.notTaxedReason.type
                 });
             }

--- a/integration-templates/anrok/nango.yaml
+++ b/integration-templates/anrok/nango.yaml
@@ -77,7 +77,7 @@ models:
         reason?: string
     FailedTransaction:
         __extends: Transaction
-        validation_errors: any[]
+        validation_errors: any
     SuccessTransaction:
         __extends: Transaction
         sub_total_excluding_taxes?: number
@@ -98,10 +98,10 @@ models:
         failed: FailedTransactionToDelete[]
     FailedTransactionToDelete:
         __extends: TransactionToDelete
-        validation_errors: any[]
+        validation_errors: any
     FailedTransactionToNegate:
         __extends: TransactionToNegate
-        validation_errors: any[]
+        validation_errors: any
     TransactionFeeWithTaxBreakdown:
         __extends: TransactionFee
         tax_amount_cents: number

--- a/integration-templates/anrok/types.ts
+++ b/integration-templates/anrok/types.ts
@@ -10,7 +10,7 @@ export interface AnrokJuris {
     taxes: AnrokTax[];
     notTaxedReason: {
         type: string | null;
-        reason: {
+        reason?: {
             type: string;
         };
     };

--- a/integration-templates/anrok/utils.ts
+++ b/integration-templates/anrok/utils.ts
@@ -1,0 +1,9 @@
+export function errorToObject(err: unknown) {
+    if ('response' in (err as any)) {
+        return (err as any).response.data;
+    }
+    if (err instanceof Error) {
+        return JSON.parse(JSON.stringify(err, ['name', 'message']));
+    }
+    return err;
+}

--- a/packages/shared/flows.yaml
+++ b/packages/shared/flows.yaml
@@ -100,7 +100,7 @@ integrations:
                 currency: string
                 contact: AnrokContact
                 fees: TransactionFee[]
-                validation_errors: any[]
+                validation_errors: any
             SuccessTransaction:
                 id?: string | undefined
                 issuing_date: string
@@ -125,11 +125,11 @@ integrations:
                 failed: FailedTransactionToDelete[]
             FailedTransactionToDelete:
                 id: string
-                validation_errors: any[]
+                validation_errors: any
             FailedTransactionToNegate:
                 id: string
                 voided_id: string
-                validation_errors: any[]
+                validation_errors: any
             TransactionFeeWithTaxBreakdown:
                 item_id: string
                 item_code: string | null


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1557/anrok-actions-returns-a-500-when-calling-actions

- Handle errors correctly 
Catch err was assumed to be AxiosError but it was a Javascript error

- Fix types for `notTaxedReason` can be missing from anrok response 
That was the original error

- Fix types for `validation_errors` it has never been an array

- Changed to async/await for clarity, there was no reason to mix both. 

