### PR TITLE
fix: POST /connection: add support for OAUTH2_CC auth mode

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -395,7 +395,7 @@ class ConnectionService {
         account: DBTeam;
         metadata?: Metadata | null;
         connectionConfig?: ConnectionConfig;
-        parsedRawCredentials: OAuth2Credentials | OAuth1Credentials;
+        parsedRawCredentials: OAuth2Credentials | OAuth1Credentials | OAuth2ClientCredentials;
         connectionCreatedHook: (res: ConnectionUpsertResponse) => MaybePromise<void>;
     }) {
         const [importedConnection] = await this.upsertConnection({


### PR DESCRIPTION
Connection for OAUTH2_CC provider cannot be imported at the moment. Probably an oversight when OAUTH2_CC auth mode was added

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1561/cannot-import-a-oauth2-cc-connection

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
