### PR TITLE
fix(url): handle special characters in connection params

### DIFF
--- a/packages/shared/lib/clients/oauth2.client.ts
+++ b/packages/shared/lib/clients/oauth2.client.ts
@@ -18,8 +18,8 @@ export function getSimpleOAuth2ClientConfig(
     connectionConfig: Record<string, string>
 ): Merge<ModuleOptions, { http: WreckHttpOptions }> {
     const templateTokenUrl = typeof template.token_url === 'string' ? template.token_url : (template.token_url!['OAUTH2'] as string);
-    const tokenUrl = new URL(interpolateString(templateTokenUrl.replace(/connectionConfig\./g, ''), encodeParameters(connectionConfig)));
-    const authorizeUrl = new URL(interpolateString(template.authorization_url!.replace(/connectionConfig\./g, ''), encodeParameters(connectionConfig)));
+    const tokenUrl = makeUrl(templateTokenUrl, connectionConfig);
+    const authorizeUrl = makeUrl(template.authorization_url!, connectionConfig);
 
     const headers = { 'User-Agent': 'Nango' };
 
@@ -155,4 +155,11 @@ export async function getFreshOAuth2Credentials(
         });
         return { success: false, error, response: null };
     }
+}
+
+function makeUrl(template: string, config: Record<string, any>): URL {
+    const cleanTemplate = template.replace(/connectionConfig\./g, '');
+    const encodedParams = encodeParameters(config);
+    const interpolatedUrl = interpolateString(cleanTemplate, encodedParams);
+    return new URL(interpolatedUrl);
 }

--- a/packages/shared/lib/clients/oauth2.client.ts
+++ b/packages/shared/lib/clients/oauth2.client.ts
@@ -5,7 +5,7 @@ import { AuthorizationCode } from 'simple-oauth2';
 import connectionsManager from '../services/connection.service.js';
 import type { ServiceResponse } from '../models/Generic.js';
 import { LogActionEnum } from '../models/Telemetry.js';
-import { interpolateString } from '../utils/utils.js';
+import { interpolateString, encodeParameters } from '../utils/utils.js';
 import Boom from '@hapi/boom';
 import { NangoError } from '../utils/error.js';
 import errorManager, { ErrorSourceEnum } from '../utils/error.manager.js';
@@ -18,10 +18,9 @@ export function getSimpleOAuth2ClientConfig(
     connectionConfig: Record<string, string>
 ): Merge<ModuleOptions, { http: WreckHttpOptions }> {
     const templateTokenUrl = typeof template.token_url === 'string' ? template.token_url : (template.token_url!['OAUTH2'] as string);
-    const strippedTokenUrl = templateTokenUrl.replace(/connectionConfig\./g, '');
-    const tokenUrl = new URL(interpolateString(strippedTokenUrl, connectionConfig));
-    const strippedAuthorizeUrl = template.authorization_url!.replace(/connectionConfig\./g, '');
-    const authorizeUrl = new URL(interpolateString(strippedAuthorizeUrl, connectionConfig));
+    const tokenUrl = new URL(interpolateString(templateTokenUrl.replace(/connectionConfig\./g, ''), encodeParameters(connectionConfig)));
+    const authorizeUrl = new URL(interpolateString(template.authorization_url!.replace(/connectionConfig\./g, ''), encodeParameters(connectionConfig)));
+
     const headers = { 'User-Agent': 'Nango' };
 
     const authConfig = template as ProviderTemplateOAuth2;

--- a/packages/shared/lib/utils/utils.ts
+++ b/packages/shared/lib/utils/utils.ts
@@ -239,3 +239,7 @@ export function getConnectionConfig(queryParams: any): Record<string, string> {
     const arr = Object.entries(queryParams).filter(([, v]) => typeof v === 'string'); // Filter strings
     return Object.fromEntries(arr) as Record<string, string>;
 }
+
+export function encodeParameters(params: Record<string, any>): Record<string, string> {
+    return Object.fromEntries(Object.entries(params).map(([key, value]) => [key, encodeURIComponent(String(value))]));
+}

--- a/packages/shared/lib/utils/utils.unit.test.ts
+++ b/packages/shared/lib/utils/utils.unit.test.ts
@@ -12,3 +12,28 @@ describe('Proxy service Construct Header Tests', () => {
         expect(utils.isValidHttpUrl('/api/v2/tickets?per_page=100&include=requester,description&page=3')).toBe(false);
     });
 });
+describe('encodeParameters Function Tests', () => {
+    it('should encode parameters correctly', () => {
+        const params = {
+            redirectUri: 'https://redirectme.com'
+        };
+
+        const expected = {
+            redirectUri: 'https%3A%2F%2Fredirectme.com'
+        };
+
+        expect(utils.encodeParameters(params)).toEqual(expected);
+    });
+
+    it('should handle parameters with special characters', () => {
+        const params = {
+            redirectUri: 'https://redirectme.com?param=value&another=value'
+        };
+
+        const expected = {
+            redirectUri: 'https%3A%2F%2Fredirectme.com%3Fparam%3Dvalue%26another%3Dvalue'
+        };
+
+        expect(utils.encodeParameters(params)).toEqual(expected);
+    });
+});


### PR DESCRIPTION
## Describe your changes

- Updated implementation to handle various input scenarios including special characters.

## Issue ticket number and link
[EXT-121](https://linear.app/nango/issue/EXT-121/fix-stripe-app-sandbox-handling-special-chars-in-connection-params)
## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
