### PR TITLE
chore: display job and stage in github action name

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,5 @@
 name: '[Release] Deploy service'
+run-name: '[Release] [${{ inputs.stage }}] Deploy ${{ inputs.service }}'
 
 on:
     workflow_dispatch:


### PR DESCRIPTION
Right now you need 3 clicks to find out which stage a service is being deployed to.
Adding service and stage in the name to make it easier to access this info

<img width="1158" alt="Screenshot 2024-08-14 at 10 01 49" src="https://github.com/user-attachments/assets/7499c069-dcd0-4753-803a-b2ba182eaac5">


## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
