### PR TITLE
fix: runner request to jobs /idle endpoint

### DIFF
--- a/packages/runner/lib/monitor.ts
+++ b/packages/runner/lib/monitor.ts
@@ -1,7 +1,6 @@
 import os from 'os';
 import fs from 'fs';
 import type { NangoProps } from '@nangohq/shared';
-import * as superjson from 'superjson';
 import { httpFetch, logger } from './utils.js';
 
 const MEMORY_WARNING_PERCENTAGE_THRESHOLD = 75;
@@ -98,7 +97,7 @@ export class RunnerMonitor {
                     await httpFetch({
                         method: 'post',
                         url: `${this.jobsServiceUrl}/idle`,
-                        data: superjson.stringify({
+                        data: JSON.stringify({
                             runnerId: this.runnerId,
                             idleTimeMs
                         })


### PR DESCRIPTION
I broke the request made to jobs /idle endpoint when refactoring jobs/runner. It prevents idle runner to be suspended.

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
