### PR TITLE
chore: update aws s3 lib to fix fast-xml-parse vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,148 +92,288 @@
             }
         },
         "node_modules/@aws-crypto/crc32": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
-            "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+            "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
             "dependencies": {
-                "@aws-crypto/util": "^3.0.0",
+                "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
-                "tslib": "^1.11.1"
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
+        },
+        "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-crypto/crc32c": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
-            "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+            "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
             "dependencies": {
-                "@aws-crypto/util": "^3.0.0",
+                "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
-                "tslib": "^1.11.1"
+                "tslib": "^2.6.2"
             }
         },
-        "node_modules/@aws-crypto/ie11-detection": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^1.11.1"
-            }
+        "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-crypto/sha1-browser": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+            "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
             "dependencies": {
-                "@aws-crypto/ie11-detection": "^3.0.0",
-                "@aws-crypto/supports-web-crypto": "^3.0.0",
-                "@aws-crypto/util": "^3.0.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
                 "@aws-sdk/util-locate-window": "^3.0.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
             }
+        },
+        "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-crypto/sha256-browser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-            "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
             "dependencies": {
-                "@aws-crypto/ie11-detection": "^3.0.0",
-                "@aws-crypto/sha256-js": "^3.0.0",
-                "@aws-crypto/supports-web-crypto": "^3.0.0",
-                "@aws-crypto/util": "^3.0.0",
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
                 "@aws-sdk/util-locate-window": "^3.0.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
             }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-crypto/sha256-js": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-            "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
             "dependencies": {
-                "@aws-crypto/util": "^3.0.0",
+                "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
-                "tslib": "^1.11.1"
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
+        },
+        "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-crypto/supports-web-crypto": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
             "dependencies": {
-                "tslib": "^1.11.1"
+                "tslib": "^2.6.2"
             }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-crypto/util": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
             "dependencies": {
                 "@aws-sdk/types": "^3.222.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
             }
         },
-        "node_modules/@aws-sdk/client-s3": {
-            "version": "3.590.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.590.0.tgz",
-            "integrity": "sha512-so+pNua0ihsHaSdskw8HCwruoYTAfYSEs3ix4GD1++83C96KaJp3udAutYiCA+84JXg9zitFa7eK7ORJAVZmTw==",
+        "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
             "dependencies": {
-                "@aws-crypto/sha1-browser": "3.0.0",
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sso-oidc": "3.590.0",
-                "@aws-sdk/client-sts": "3.590.0",
-                "@aws-sdk/core": "3.588.0",
-                "@aws-sdk/credential-provider-node": "3.590.0",
-                "@aws-sdk/middleware-bucket-endpoint": "3.587.0",
-                "@aws-sdk/middleware-expect-continue": "3.577.0",
-                "@aws-sdk/middleware-flexible-checksums": "3.587.0",
-                "@aws-sdk/middleware-host-header": "3.577.0",
-                "@aws-sdk/middleware-location-constraint": "3.577.0",
-                "@aws-sdk/middleware-logger": "3.577.0",
-                "@aws-sdk/middleware-recursion-detection": "3.577.0",
-                "@aws-sdk/middleware-sdk-s3": "3.587.0",
-                "@aws-sdk/middleware-signing": "3.587.0",
-                "@aws-sdk/middleware-ssec": "3.577.0",
-                "@aws-sdk/middleware-user-agent": "3.587.0",
-                "@aws-sdk/region-config-resolver": "3.587.0",
-                "@aws-sdk/signature-v4-multi-region": "3.587.0",
-                "@aws-sdk/types": "3.577.0",
-                "@aws-sdk/util-endpoints": "3.587.0",
-                "@aws-sdk/util-user-agent-browser": "3.577.0",
-                "@aws-sdk/util-user-agent-node": "3.587.0",
-                "@aws-sdk/xml-builder": "3.575.0",
-                "@smithy/config-resolver": "^3.0.1",
-                "@smithy/core": "^2.1.1",
-                "@smithy/eventstream-serde-browser": "^3.0.0",
-                "@smithy/eventstream-serde-config-resolver": "^3.0.0",
-                "@smithy/eventstream-serde-node": "^3.0.0",
-                "@smithy/fetch-http-handler": "^3.0.1",
-                "@smithy/hash-blob-browser": "^3.0.0",
-                "@smithy/hash-node": "^3.0.0",
-                "@smithy/hash-stream-node": "^3.0.0",
-                "@smithy/invalid-dependency": "^3.0.0",
-                "@smithy/md5-js": "^3.0.0",
-                "@smithy/middleware-content-length": "^3.0.0",
-                "@smithy/middleware-endpoint": "^3.0.1",
-                "@smithy/middleware-retry": "^3.0.3",
-                "@smithy/middleware-serde": "^3.0.0",
-                "@smithy/middleware-stack": "^3.0.0",
-                "@smithy/node-config-provider": "^3.1.0",
-                "@smithy/node-http-handler": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/smithy-client": "^3.1.1",
-                "@smithy/types": "^3.0.0",
-                "@smithy/url-parser": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/tslib": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+        },
+        "node_modules/@aws-sdk/client-s3": {
+            "version": "3.635.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.635.0.tgz",
+            "integrity": "sha512-4RP+DJZWqUka1MW2aSEzTzntY3GrDzS26D8dHZvbt2I0x+dSmlnmXiJkCxLjmti2SDVYAGL9gX6e7mLS7W55jA==",
+            "dependencies": {
+                "@aws-crypto/sha1-browser": "5.2.0",
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.635.0",
+                "@aws-sdk/client-sts": "3.635.0",
+                "@aws-sdk/core": "3.635.0",
+                "@aws-sdk/credential-provider-node": "3.635.0",
+                "@aws-sdk/middleware-bucket-endpoint": "3.620.0",
+                "@aws-sdk/middleware-expect-continue": "3.620.0",
+                "@aws-sdk/middleware-flexible-checksums": "3.620.0",
+                "@aws-sdk/middleware-host-header": "3.620.0",
+                "@aws-sdk/middleware-location-constraint": "3.609.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.620.0",
+                "@aws-sdk/middleware-sdk-s3": "3.635.0",
+                "@aws-sdk/middleware-ssec": "3.609.0",
+                "@aws-sdk/middleware-user-agent": "3.632.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/signature-v4-multi-region": "3.635.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.632.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@aws-sdk/xml-builder": "3.609.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.4.0",
+                "@smithy/eventstream-serde-browser": "^3.0.6",
+                "@smithy/eventstream-serde-config-resolver": "^3.0.3",
+                "@smithy/eventstream-serde-node": "^3.0.5",
+                "@smithy/fetch-http-handler": "^3.2.4",
+                "@smithy/hash-blob-browser": "^3.1.2",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/hash-stream-node": "^3.1.2",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/md5-js": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.5",
+                "@smithy/middleware-endpoint": "^3.1.0",
+                "@smithy/middleware-retry": "^3.0.15",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
                 "@smithy/util-base64": "^3.0.0",
                 "@smithy/util-body-length-browser": "^3.0.0",
                 "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.3",
-                "@smithy/util-defaults-mode-node": "^3.0.3",
-                "@smithy/util-endpoints": "^2.0.1",
-                "@smithy/util-retry": "^3.0.0",
-                "@smithy/util-stream": "^3.0.1",
+                "@smithy/util-defaults-mode-browser": "^3.0.15",
+                "@smithy/util-defaults-mode-node": "^3.0.15",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "@smithy/util-stream": "^3.1.3",
                 "@smithy/util-utf8": "^3.0.0",
-                "@smithy/util-waiter": "^3.0.0",
+                "@smithy/util-waiter": "^3.1.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -246,46 +386,46 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.590.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.590.0.tgz",
-            "integrity": "sha512-6xbC6oQVJKBRTyXyR3C15ksUsPOyW4p+uCj7dlKYWGJvh4vGTV8KhZKS53oPG8t4f1+OMJWjr5wKuXRoaFsmhQ==",
+            "version": "3.635.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.635.0.tgz",
+            "integrity": "sha512-/Hl69+JpFUo9JNVmh2gSvMgYkE4xjd+1okiRoPBbQqjI7YBP2JWCUDP8IoEkNq3wj0vNTq0OWfn6RpZycIkAXQ==",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/core": "3.588.0",
-                "@aws-sdk/middleware-host-header": "3.577.0",
-                "@aws-sdk/middleware-logger": "3.577.0",
-                "@aws-sdk/middleware-recursion-detection": "3.577.0",
-                "@aws-sdk/middleware-user-agent": "3.587.0",
-                "@aws-sdk/region-config-resolver": "3.587.0",
-                "@aws-sdk/types": "3.577.0",
-                "@aws-sdk/util-endpoints": "3.587.0",
-                "@aws-sdk/util-user-agent-browser": "3.577.0",
-                "@aws-sdk/util-user-agent-node": "3.587.0",
-                "@smithy/config-resolver": "^3.0.1",
-                "@smithy/core": "^2.1.1",
-                "@smithy/fetch-http-handler": "^3.0.1",
-                "@smithy/hash-node": "^3.0.0",
-                "@smithy/invalid-dependency": "^3.0.0",
-                "@smithy/middleware-content-length": "^3.0.0",
-                "@smithy/middleware-endpoint": "^3.0.1",
-                "@smithy/middleware-retry": "^3.0.3",
-                "@smithy/middleware-serde": "^3.0.0",
-                "@smithy/middleware-stack": "^3.0.0",
-                "@smithy/node-config-provider": "^3.1.0",
-                "@smithy/node-http-handler": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/smithy-client": "^3.1.1",
-                "@smithy/types": "^3.0.0",
-                "@smithy/url-parser": "^3.0.0",
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.635.0",
+                "@aws-sdk/middleware-host-header": "3.620.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.620.0",
+                "@aws-sdk/middleware-user-agent": "3.632.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.632.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.4.0",
+                "@smithy/fetch-http-handler": "^3.2.4",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.5",
+                "@smithy/middleware-endpoint": "^3.1.0",
+                "@smithy/middleware-retry": "^3.0.15",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
                 "@smithy/util-base64": "^3.0.0",
                 "@smithy/util-body-length-browser": "^3.0.0",
                 "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.3",
-                "@smithy/util-defaults-mode-node": "^3.0.3",
-                "@smithy/util-endpoints": "^2.0.1",
-                "@smithy/util-middleware": "^3.0.0",
-                "@smithy/util-retry": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.15",
+                "@smithy/util-defaults-mode-node": "^3.0.15",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
@@ -294,53 +434,55 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.590.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.590.0.tgz",
-            "integrity": "sha512-3yCLPjq6WFfDpdUJKk/gSz4eAPDTjVknXaveMPi2QoVBCshneOnJsV16uNKlpVF1frTHrrDRfKYmbaVh6nFBvQ==",
+            "version": "3.635.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.635.0.tgz",
+            "integrity": "sha512-RIwDlhzAFttB1vbpznewnPqz7h1H/2UhQLwB38yfZBwYQOxyxVfLV5j5VoUUX3jY4i4qH9wiHc7b02qeAOZY6g==",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.590.0",
-                "@aws-sdk/core": "3.588.0",
-                "@aws-sdk/credential-provider-node": "3.590.0",
-                "@aws-sdk/middleware-host-header": "3.577.0",
-                "@aws-sdk/middleware-logger": "3.577.0",
-                "@aws-sdk/middleware-recursion-detection": "3.577.0",
-                "@aws-sdk/middleware-user-agent": "3.587.0",
-                "@aws-sdk/region-config-resolver": "3.587.0",
-                "@aws-sdk/types": "3.577.0",
-                "@aws-sdk/util-endpoints": "3.587.0",
-                "@aws-sdk/util-user-agent-browser": "3.577.0",
-                "@aws-sdk/util-user-agent-node": "3.587.0",
-                "@smithy/config-resolver": "^3.0.1",
-                "@smithy/core": "^2.1.1",
-                "@smithy/fetch-http-handler": "^3.0.1",
-                "@smithy/hash-node": "^3.0.0",
-                "@smithy/invalid-dependency": "^3.0.0",
-                "@smithy/middleware-content-length": "^3.0.0",
-                "@smithy/middleware-endpoint": "^3.0.1",
-                "@smithy/middleware-retry": "^3.0.3",
-                "@smithy/middleware-serde": "^3.0.0",
-                "@smithy/middleware-stack": "^3.0.0",
-                "@smithy/node-config-provider": "^3.1.0",
-                "@smithy/node-http-handler": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/smithy-client": "^3.1.1",
-                "@smithy/types": "^3.0.0",
-                "@smithy/url-parser": "^3.0.0",
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.635.0",
+                "@aws-sdk/credential-provider-node": "3.635.0",
+                "@aws-sdk/middleware-host-header": "3.620.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.620.0",
+                "@aws-sdk/middleware-user-agent": "3.632.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.632.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.4.0",
+                "@smithy/fetch-http-handler": "^3.2.4",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.5",
+                "@smithy/middleware-endpoint": "^3.1.0",
+                "@smithy/middleware-retry": "^3.0.15",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
                 "@smithy/util-base64": "^3.0.0",
                 "@smithy/util-body-length-browser": "^3.0.0",
                 "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.3",
-                "@smithy/util-defaults-mode-node": "^3.0.3",
-                "@smithy/util-endpoints": "^2.0.1",
-                "@smithy/util-middleware": "^3.0.0",
-                "@smithy/util-retry": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.15",
+                "@smithy/util-defaults-mode-node": "^3.0.15",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.635.0"
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc/node_modules/tslib": {
@@ -354,48 +496,48 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.590.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.590.0.tgz",
-            "integrity": "sha512-f4R1v1LSn4uLYZ5qj4DyL6gp7PXXzJeJsm2seheiJX+53LSF5L7XSDnQVtX1p9Tevv0hp2YUWUTg6QYwIVSuGg==",
+            "version": "3.635.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.635.0.tgz",
+            "integrity": "sha512-Al2ytE69+cbA44qHlelqhzWwbURikfF13Zkal9utIG5Q6T2c7r8p6sePN92n8l/x1v0FhJ5VTxKak+cPTE0CZQ==",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sso-oidc": "3.590.0",
-                "@aws-sdk/core": "3.588.0",
-                "@aws-sdk/credential-provider-node": "3.590.0",
-                "@aws-sdk/middleware-host-header": "3.577.0",
-                "@aws-sdk/middleware-logger": "3.577.0",
-                "@aws-sdk/middleware-recursion-detection": "3.577.0",
-                "@aws-sdk/middleware-user-agent": "3.587.0",
-                "@aws-sdk/region-config-resolver": "3.587.0",
-                "@aws-sdk/types": "3.577.0",
-                "@aws-sdk/util-endpoints": "3.587.0",
-                "@aws-sdk/util-user-agent-browser": "3.577.0",
-                "@aws-sdk/util-user-agent-node": "3.587.0",
-                "@smithy/config-resolver": "^3.0.1",
-                "@smithy/core": "^2.1.1",
-                "@smithy/fetch-http-handler": "^3.0.1",
-                "@smithy/hash-node": "^3.0.0",
-                "@smithy/invalid-dependency": "^3.0.0",
-                "@smithy/middleware-content-length": "^3.0.0",
-                "@smithy/middleware-endpoint": "^3.0.1",
-                "@smithy/middleware-retry": "^3.0.3",
-                "@smithy/middleware-serde": "^3.0.0",
-                "@smithy/middleware-stack": "^3.0.0",
-                "@smithy/node-config-provider": "^3.1.0",
-                "@smithy/node-http-handler": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/smithy-client": "^3.1.1",
-                "@smithy/types": "^3.0.0",
-                "@smithy/url-parser": "^3.0.0",
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.635.0",
+                "@aws-sdk/core": "3.635.0",
+                "@aws-sdk/credential-provider-node": "3.635.0",
+                "@aws-sdk/middleware-host-header": "3.620.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.620.0",
+                "@aws-sdk/middleware-user-agent": "3.632.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.632.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.4.0",
+                "@smithy/fetch-http-handler": "^3.2.4",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.5",
+                "@smithy/middleware-endpoint": "^3.1.0",
+                "@smithy/middleware-retry": "^3.0.15",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
                 "@smithy/util-base64": "^3.0.0",
                 "@smithy/util-body-length-browser": "^3.0.0",
                 "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.3",
-                "@smithy/util-defaults-mode-node": "^3.0.3",
-                "@smithy/util-endpoints": "^2.0.1",
-                "@smithy/util-middleware": "^3.0.0",
-                "@smithy/util-retry": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.15",
+                "@smithy/util-defaults-mode-node": "^3.0.15",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
@@ -409,16 +551,19 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.588.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.588.0.tgz",
-            "integrity": "sha512-O1c2+9ce46Z+iiid+W3iC1IvPbfIo5ev9CBi54GdNB9SaI8/3+f8MJcux0D6c9toCF0ArMersN/gp8ek57e9uQ==",
+            "version": "3.635.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.635.0.tgz",
+            "integrity": "sha512-i1x/E/sgA+liUE1XJ7rj1dhyXpAKO1UKFUcTTHXok2ARjWTvszHnSXMOsB77aPbmn0fUp1JTx2kHUAZ1LVt5Bg==",
             "dependencies": {
-                "@smithy/core": "^2.1.1",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/signature-v4": "^3.0.0",
-                "@smithy/smithy-client": "^3.1.1",
-                "@smithy/types": "^3.0.0",
-                "fast-xml-parser": "4.2.5",
+                "@smithy/core": "^2.4.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/signature-v4": "^4.1.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "fast-xml-parser": "4.4.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -431,13 +576,13 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.587.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.587.0.tgz",
-            "integrity": "sha512-Hyg/5KFECIk2k5o8wnVEiniV86yVkhn5kzITUydmNGCkXdBFHMHRx6hleQ1bqwJHbBskyu8nbYamzcwymmGwmw==",
+            "version": "3.620.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+            "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/property-provider": "^3.1.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -450,18 +595,18 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.587.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.587.0.tgz",
-            "integrity": "sha512-Su1SRWVRCuR1e32oxX3C1V4c5hpPN20WYcRfdcr2wXwHqSvys5DrnmuCC+JoEnS/zt3adUJhPliTqpfKgSdMrA==",
+            "version": "3.635.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.635.0.tgz",
+            "integrity": "sha512-iJyRgEjOCQlBMXqtwPLIKYc7Bsc6nqjrZybdMDenPDa+kmLg7xh8LxHsu9088e+2/wtLicE34FsJJIfzu3L82g==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/fetch-http-handler": "^3.0.1",
-                "@smithy/node-http-handler": "^3.0.0",
-                "@smithy/property-provider": "^3.1.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/smithy-client": "^3.1.1",
-                "@smithy/types": "^3.0.0",
-                "@smithy/util-stream": "^3.0.1",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/fetch-http-handler": "^3.2.4",
+                "@smithy/node-http-handler": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-stream": "^3.1.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -474,27 +619,27 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.590.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.590.0.tgz",
-            "integrity": "sha512-Y5cFciAK38VIvRgZeND7HvFNR32thGtQb8Xop6cMn33FC78uwcRIu9Hc9699XTclCZqz4+Xl1WU+dZ+rnFn2AA==",
+            "version": "3.635.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.635.0.tgz",
+            "integrity": "sha512-+OqcNhhOFFY08YHLjO9/Y1n37RKAO7LADnsJ7VTXca7IfvYh27BVBn+FdlqnyEb1MQ5ArHTY4pq3pKRIg6RW4Q==",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.587.0",
-                "@aws-sdk/credential-provider-http": "3.587.0",
-                "@aws-sdk/credential-provider-process": "3.587.0",
-                "@aws-sdk/credential-provider-sso": "3.590.0",
-                "@aws-sdk/credential-provider-web-identity": "3.587.0",
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/credential-provider-imds": "^3.1.0",
-                "@smithy/property-provider": "^3.1.0",
-                "@smithy/shared-ini-file-loader": "^3.1.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/credential-provider-env": "3.620.1",
+                "@aws-sdk/credential-provider-http": "3.635.0",
+                "@aws-sdk/credential-provider-process": "3.620.1",
+                "@aws-sdk/credential-provider-sso": "3.635.0",
+                "@aws-sdk/credential-provider-web-identity": "3.621.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/credential-provider-imds": "^3.2.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.590.0"
+                "@aws-sdk/client-sts": "^3.635.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
@@ -503,21 +648,21 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.590.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.590.0.tgz",
-            "integrity": "sha512-Ky38mNFoXobGrDQ11P3dU1e+q1nRJ7eZl8l15KUpvZCe/hOudbxQi/epQrCazD/gRYV2fTyczdLlZzB5ZZ8DhQ==",
+            "version": "3.635.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.635.0.tgz",
+            "integrity": "sha512-bmd23mnb94S6AxmWPgqJTnvT9ONKlTx7EPafE1RNO+vUl6mHih4iyqX6ZPaRcSfaPx4U1R7H1RM8cSnafXgaBg==",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.587.0",
-                "@aws-sdk/credential-provider-http": "3.587.0",
-                "@aws-sdk/credential-provider-ini": "3.590.0",
-                "@aws-sdk/credential-provider-process": "3.587.0",
-                "@aws-sdk/credential-provider-sso": "3.590.0",
-                "@aws-sdk/credential-provider-web-identity": "3.587.0",
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/credential-provider-imds": "^3.1.0",
-                "@smithy/property-provider": "^3.1.0",
-                "@smithy/shared-ini-file-loader": "^3.1.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/credential-provider-env": "3.620.1",
+                "@aws-sdk/credential-provider-http": "3.635.0",
+                "@aws-sdk/credential-provider-ini": "3.635.0",
+                "@aws-sdk/credential-provider-process": "3.620.1",
+                "@aws-sdk/credential-provider-sso": "3.635.0",
+                "@aws-sdk/credential-provider-web-identity": "3.621.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/credential-provider-imds": "^3.2.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -530,14 +675,14 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.587.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.587.0.tgz",
-            "integrity": "sha512-V4xT3iCqkF8uL6QC4gqBJg/2asd/damswP1h9HCfqTllmPWzImS+8WD3VjgTLw5b0KbTy+ZdUhKc0wDnyzkzxg==",
+            "version": "3.620.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+            "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/property-provider": "^3.1.0",
-                "@smithy/shared-ini-file-loader": "^3.1.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -550,16 +695,16 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.590.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.590.0.tgz",
-            "integrity": "sha512-v+0j/I+je9okfwXsgmLppmwIE+TuMp5WqLz7r7PHz9KjzLyKaKTDvfllFD+8oPpBqnmOWiJ9qTGPkrfhB7a/fQ==",
+            "version": "3.635.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.635.0.tgz",
+            "integrity": "sha512-hO/fKyvUaGpK9zyvCnmJz70EputvGWDr2UTOn/RzvcR6UB4yXoFf0QcCMubEsE3v67EsAv6PadgOeJ0vz6IazA==",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.590.0",
-                "@aws-sdk/token-providers": "3.587.0",
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/property-provider": "^3.1.0",
-                "@smithy/shared-ini-file-loader": "^3.1.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/client-sso": "3.635.0",
+                "@aws-sdk/token-providers": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -572,20 +717,20 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.587.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.587.0.tgz",
-            "integrity": "sha512-XqIx/I2PG7kyuw3WjAP9wKlxy8IvFJwB8asOFT1xPFoVfZYKIogjG9oLP5YiRtfvDkWIztHmg5MlVv3HdJDGRw==",
+            "version": "3.621.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+            "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/property-provider": "^3.1.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.587.0"
+                "@aws-sdk/client-sts": "^3.621.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
@@ -594,15 +739,15 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-            "version": "3.587.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.587.0.tgz",
-            "integrity": "sha512-HkFXLPl8pr6BH/Q0JpOESqEKL0ZK3sk7aSZ1S6GE4RXET7H5R94THULXqQFZzD48gZcyFooO/yNKZTqrZFaWKg==",
+            "version": "3.620.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.620.0.tgz",
+            "integrity": "sha512-eGLL0W6L3HDb3OACyetZYOWpHJ+gLo0TehQKeQyy2G8vTYXqNTeqYhuI6up9HVjBzU9eQiULVQETmgQs7TFaRg==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
+                "@aws-sdk/types": "3.609.0",
                 "@aws-sdk/util-arn-parser": "3.568.0",
-                "@smithy/node-config-provider": "^3.1.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-config-provider": "^3.0.0",
                 "tslib": "^2.6.2"
             },
@@ -616,13 +761,13 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/middleware-expect-continue": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.577.0.tgz",
-            "integrity": "sha512-6dPp8Tv4F0of4un5IAyG6q++GrRrNQQ4P2NAMB1W0VO4JoEu1C8GievbbDLi88TFIFmtKpnHB0ODCzwnoe8JsA==",
+            "version": "3.620.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.620.0.tgz",
+            "integrity": "sha512-QXeRFMLfyQ31nAHLbiTLtk0oHzG9QLMaof5jIfqcUwnOkO8YnQdeqzakrg1Alpy/VQ7aqzIi8qypkBe2KXZz0A==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -635,16 +780,16 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/middleware-flexible-checksums": {
-            "version": "3.587.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.587.0.tgz",
-            "integrity": "sha512-URMwp/budDvKhIvZ4a6zIBfFTun/iDlPWXqsGKYjEtHt8jz27OSjCZtDtIeqW4WTBdKL8KZgQcl+DdaE5M1qiQ==",
+            "version": "3.620.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.620.0.tgz",
+            "integrity": "sha512-ftz+NW7qka2sVuwnnO1IzBku5ccP+s5qZGeRTPgrKB7OzRW85gthvIo1vQR2w+OwHFk7WJbbhhWwbCbktnP4UA==",
             "dependencies": {
-                "@aws-crypto/crc32": "3.0.0",
-                "@aws-crypto/crc32c": "3.0.0",
-                "@aws-sdk/types": "3.577.0",
+                "@aws-crypto/crc32": "5.2.0",
+                "@aws-crypto/crc32c": "5.2.0",
+                "@aws-sdk/types": "3.609.0",
                 "@smithy/is-array-buffer": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
@@ -658,13 +803,13 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.577.0.tgz",
-            "integrity": "sha512-9ca5MJz455CODIVXs0/sWmJm7t3QO4EUa1zf8pE8grLpzf0J94bz/skDWm37Pli13T3WaAQBHCTiH2gUVfCsWg==",
+            "version": "3.620.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+            "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -677,12 +822,12 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/middleware-location-constraint": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.577.0.tgz",
-            "integrity": "sha512-DKPTD2D2s+t2QUo/IXYtVa/6Un8GZ+phSTBkyBNx2kfZz4Kwavhl/JJzSqTV3GfCXkVdFu7CrjoX7BZ6qWeTUA==",
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.609.0.tgz",
+            "integrity": "sha512-xzsdoTkszGVqGVPjUmgoP7TORiByLueMHieI1fhQL888WPdqctwAx3ES6d/bA9Q/i8jnc6hs+Fjhy8UvBTkE9A==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -695,12 +840,12 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.577.0.tgz",
-            "integrity": "sha512-aPFGpGjTZcJYk+24bg7jT4XdIp42mFXSuPt49lw5KygefLyJM/sB0bKKqPYYivW0rcuZ9brQ58eZUNthrzYAvg==",
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+            "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -713,13 +858,13 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.577.0.tgz",
-            "integrity": "sha512-pn3ZVEd2iobKJlR3H+bDilHjgRnNrQ6HMmK9ZzZw89Ckn3Dcbv48xOv4RJvu0aU8SDLl/SNCxppKjeLDTPGBNA==",
+            "version": "3.620.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+            "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -732,18 +877,23 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.587.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.587.0.tgz",
-            "integrity": "sha512-vtXTGEiw1E9Fax4LmcU2Z208gbrC8ShrdsSLmGcRPpu5NPOGBFBSDG5sy5EDNClrFxIl/Le8coQnD0EDBtx+uQ==",
+            "version": "3.635.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.635.0.tgz",
+            "integrity": "sha512-RLdYJPEV4JL/7NBoFUs7VlP90X++5FlJdxHz0DzCjmiD3qCviKy+Cym3qg1gBgHwucs5XisuClxDrGokhAdTQw==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
+                "@aws-sdk/core": "3.635.0",
+                "@aws-sdk/types": "3.609.0",
                 "@aws-sdk/util-arn-parser": "3.568.0",
-                "@smithy/node-config-provider": "^3.1.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/signature-v4": "^3.0.0",
-                "@smithy/smithy-client": "^3.1.1",
-                "@smithy/types": "^3.0.0",
+                "@smithy/core": "^2.4.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/signature-v4": "^4.1.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-stream": "^3.1.3",
+                "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -755,35 +905,13 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
-        "node_modules/@aws-sdk/middleware-signing": {
-            "version": "3.587.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.587.0.tgz",
-            "integrity": "sha512-tiZaTDj4RvhXGRAlncFn7CSEfL3iNPO67WSaxAq+Ls5j1VgczPhu5262cWONNoMgth3nXR1hhLC4ITSl/a6AzA==",
-            "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/property-provider": "^3.1.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/signature-v4": "^3.0.0",
-                "@smithy/types": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-signing/node_modules/tslib": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
-        },
         "node_modules/@aws-sdk/middleware-ssec": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.577.0.tgz",
-            "integrity": "sha512-i2BPJR+rp8xmRVIGc0h1kDRFcM2J9GnClqqpc+NLSjmYadlcg4mPklisz9HzwFVcRPJ5XcGf3U4BYs5G8+iTyg==",
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.609.0.tgz",
+            "integrity": "sha512-GZSD1s7+JswWOTamVap79QiDaIV7byJFssBW68GYjyRS5EBjNfwA/8s+6uE6g39R3ojyTbYOmvcANoZEhSULXg==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -796,14 +924,14 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.587.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.587.0.tgz",
-            "integrity": "sha512-SyDomN+IOrygLucziG7/nOHkjUXES5oH5T7p8AboO8oakMQJdnudNXiYWTicQWO52R51U6CR27rcMPTGeMedYA==",
+            "version": "3.632.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.632.0.tgz",
+            "integrity": "sha512-yY/sFsHKwG9yzSf/DTclqWJaGPI2gPBJDCGBujSqTG1zlS7Ot4fqi91DZ6088BFWzbOorDzJFcAhAEFzc6LuQg==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@aws-sdk/util-endpoints": "3.587.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.632.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -816,15 +944,15 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.587.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.587.0.tgz",
-            "integrity": "sha512-93I7IPZtulZQoRK+O20IJ4a1syWwYPzoO2gc3v+/GNZflZPV3QJXuVbIm0pxBsu0n/mzKGUKqSOLPIaN098HcQ==",
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+            "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/node-config-provider": "^3.1.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-config-provider": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -837,15 +965,15 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
-            "version": "3.587.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.587.0.tgz",
-            "integrity": "sha512-TR9+ZSjdXvXUz54ayHcCihhcvxI9W7102J1OK6MrLgBlPE7uRhAx42BR9L5lLJ86Xj3LuqPWf//o9d/zR9WVIg==",
+            "version": "3.635.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.635.0.tgz",
+            "integrity": "sha512-J6QY4/invOkpogCHjSaDON1hF03viPpOnsrzVuCvJMmclS/iG62R4EY0wq1alYll0YmSdmKlpJwHMWwGtqK63Q==",
             "dependencies": {
-                "@aws-sdk/middleware-sdk-s3": "3.587.0",
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/signature-v4": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/middleware-sdk-s3": "3.635.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/signature-v4": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -858,21 +986,21 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.587.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.587.0.tgz",
-            "integrity": "sha512-ULqhbnLy1hmJNRcukANBWJmum3BbjXnurLPSFXoGdV0llXYlG55SzIla2VYqdveQEEjmsBuTZdFvXAtNpmS5Zg==",
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+            "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/property-provider": "^3.1.0",
-                "@smithy/shared-ini-file-loader": "^3.1.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-sso-oidc": "^3.587.0"
+                "@aws-sdk/client-sso-oidc": "^3.614.0"
             }
         },
         "node_modules/@aws-sdk/token-providers/node_modules/tslib": {
@@ -881,11 +1009,11 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.577.0.tgz",
-            "integrity": "sha512-FT2JZES3wBKN/alfmhlo+3ZOq/XJ0C7QOZcDNrpKjB0kqYoKjhVKZ/Hx6ArR0czkKfHzBBEs6y40ebIHx2nSmA==",
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+            "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -914,13 +1042,13 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.587.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.587.0.tgz",
-            "integrity": "sha512-8I1HG6Em8wQWqKcRW6m358mqebRVNpL8XrrEoT4In7xqkKkmYtHRNVYP6lcmiQh5pZ/c/FXu8dSchuFIWyEtqQ==",
+            "version": "3.632.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.632.0.tgz",
+            "integrity": "sha512-LlYMU8pAbcEQphOpE6xaNLJ8kPGhklZZTVzZVpVW477NaaGgoGTMYNXTABYHcxeF5E2lLrxql9OmVpvr8GWN8Q==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/types": "^3.0.0",
-                "@smithy/util-endpoints": "^2.0.1",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-endpoints": "^2.0.5",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -933,26 +1061,28 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/util-locate-window": {
-            "version": "3.310.0",
-            "license": "Apache-2.0",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
+            "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
-            "version": "2.5.3",
-            "license": "0BSD"
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.577.0.tgz",
-            "integrity": "sha512-zEAzHgR6HWpZOH7xFgeJLc6/CzMcx4nxeQolZxVZoB5pPaJd3CjyRhZN0xXeZB0XIRCWmb4yJBgyiugXLNMkLA==",
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+            "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             }
@@ -963,13 +1093,13 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.587.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.587.0.tgz",
-            "integrity": "sha512-Pnl+DUe/bvnbEEDHP3iVJrOtE3HbFJBPgsD6vJ+ml/+IYk1Eq49jEG+EHZdNTPz3SDG0kbp2+7u41MKYJHR/iQ==",
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+            "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
             "dependencies": {
-                "@aws-sdk/types": "3.577.0",
-                "@smithy/node-config-provider": "^3.1.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -989,23 +1119,12 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
-        "node_modules/@aws-sdk/util-utf8-browser": {
-            "version": "3.259.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
-            "version": "2.5.3",
-            "license": "0BSD"
-        },
         "node_modules/@aws-sdk/xml-builder": {
-            "version": "3.575.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.575.0.tgz",
-            "integrity": "sha512-cWgAwmbFYNCFzPwxL705+lWps0F3ZvOckufd2KKoEZUmtpVw9/txUXNrPySUXSmRTSRhoatIMABNfStWR043bQ==",
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.609.0.tgz",
+            "integrity": "sha512-l9XxNcA4HX98rwCC2/KoiWcmEiRfZe4G+mYwDbCFT87JIMj6GBhLDkAzr/W8KAaA2IDr8Vc6J8fZPgVulxxfMA==",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9260,11 +9379,11 @@
             }
         },
         "node_modules/@smithy/abort-controller": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.0.0.tgz",
-            "integrity": "sha512-p6GlFGBt9K4MYLu72YuJ523NVR4A8oHlC5M2JO6OmQqN8kAc/uh1JqLE+FizTokrSJGg0CSvC+BrsmGzKtsZKA==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+            "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9304,14 +9423,14 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/config-resolver": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.1.tgz",
-            "integrity": "sha512-hbkYJc20SBDz2qqLzttjI/EqXemtmWk0ooRznLsiXp3066KQRTvuKHa7U4jCZCJq6Dozqvy0R1/vNESC9inPJg==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+            "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
             "dependencies": {
-                "@smithy/node-config-provider": "^3.1.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-config-provider": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9324,17 +9443,19 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/core": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.0.tgz",
-            "integrity": "sha512-ygLZSSKgt9bR8HAxR9mK+U5obvAJBr6zlQuhN5soYWx/amjDoQN4dTkydTypgKe6rIbUjTILyLU+W5XFwXr4kg==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.0.tgz",
+            "integrity": "sha512-cHXq+FneIF/KJbt4q4pjN186+Jf4ZB0ZOqEaZMBhT79srEyGDDBV31NqBRBjazz8ppQ1bJbDJMY9ba5wKFV36w==",
             "dependencies": {
-                "@smithy/middleware-endpoint": "^3.0.1",
-                "@smithy/middleware-retry": "^3.0.3",
-                "@smithy/middleware-serde": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/smithy-client": "^3.1.1",
-                "@smithy/types": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.0",
+                "@smithy/middleware-endpoint": "^3.1.0",
+                "@smithy/middleware-retry": "^3.0.15",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9347,14 +9468,14 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.0.tgz",
-            "integrity": "sha512-q4A4d38v8pYYmseu/jTS3Z5I3zXlEOe5Obi+EJreVKgSVyWUHOd7/yaVCinC60QG4MRyCs98tcxBH1IMC0bu7Q==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+            "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
             "dependencies": {
-                "@smithy/node-config-provider": "^3.1.0",
-                "@smithy/property-provider": "^3.1.0",
-                "@smithy/types": "^3.0.0",
-                "@smithy/url-parser": "^3.0.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9367,12 +9488,12 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/eventstream-codec": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.0.0.tgz",
-            "integrity": "sha512-PUtyEA0Oik50SaEFCZ0WPVtF9tz/teze2fDptW6WRXl+RrEenH8UbEjudOz8iakiMl3lE3lCVqYf2Y+znL8QFQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.2.tgz",
+            "integrity": "sha512-0mBcu49JWt4MXhrhRAlxASNy0IjDRFU+aWNDRal9OtUJvJNiwDuyKMUONSOjLjSCeGwZaE0wOErdqULer8r7yw==",
             "dependencies": {
-                "@aws-crypto/crc32": "3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@aws-crypto/crc32": "5.2.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-hex-encoding": "^3.0.0",
                 "tslib": "^2.6.2"
             }
@@ -9383,12 +9504,12 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/eventstream-serde-browser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.0.tgz",
-            "integrity": "sha512-NB7AFiPN4NxP/YCAnrvYR18z2/ZsiHiF7VtG30gshO9GbFrIb1rC8ep4NGpJSWrz6P64uhPXeo4M0UsCLnZKqw==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.6.tgz",
+            "integrity": "sha512-2hM54UWQUOrki4BtsUI1WzmD13/SeaqT/AB3EUJKbcver/WgKNaiJ5y5F5XXuVe6UekffVzuUDrBZVAA3AWRpQ==",
             "dependencies": {
-                "@smithy/eventstream-serde-universal": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/eventstream-serde-universal": "^3.0.5",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9401,11 +9522,11 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/eventstream-serde-config-resolver": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.0.tgz",
-            "integrity": "sha512-RUQG3vQ3LX7peqqHAbmayhgrF5aTilPnazinaSGF1P0+tgM3vvIRWPHmlLIz2qFqB9LqFIxditxc8O2Z6psrRw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.3.tgz",
+            "integrity": "sha512-NVTYjOuYpGfrN/VbRQgn31x73KDLfCXCsFdad8DiIc3IcdxL+dYA9zEQPyOP7Fy2QL8CPy2WE4WCUD+ZsLNfaQ==",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9418,12 +9539,12 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/eventstream-serde-node": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.0.tgz",
-            "integrity": "sha512-baRPdMBDMBExZXIUAoPGm/hntixjt/VFpU6+VmCyiYJYzRHRxoaI1MN+5XE+hIS8AJ2GCHLMFEIOLzq9xx1EgQ==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.5.tgz",
+            "integrity": "sha512-+upXvnHNyZP095s11jF5dhGw/Ihzqwl5G+/KtMnoQOpdfC3B5HYCcDVG9EmgkhJMXJlM64PyN5gjJl0uXFQehQ==",
             "dependencies": {
-                "@smithy/eventstream-serde-universal": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/eventstream-serde-universal": "^3.0.5",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9436,12 +9557,12 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/eventstream-serde-universal": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.0.tgz",
-            "integrity": "sha512-HNFfShmotWGeAoW4ujP8meV9BZavcpmerDbPIjkJbxKbN8RsUcpRQ/2OyIxWNxXNH2GWCAxuSB7ynmIGJlQ3Dw==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.5.tgz",
+            "integrity": "sha512-5u/nXbyoh1s4QxrvNre9V6vfyoLWuiVvvd5TlZjGThIikc3G+uNiG9uOTCWweSRjv1asdDIWK7nOmN7le4RYHQ==",
             "dependencies": {
-                "@smithy/eventstream-codec": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/eventstream-codec": "^3.1.2",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9454,13 +9575,13 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.0.1.tgz",
-            "integrity": "sha512-uaH74i5BDj+rBwoQaXioKpI0SHBJFtOVwzrCpxZxphOW0ki5jhj7dXvDMYM2IJem8TpdFvS2iC08sjOblfFGFg==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+            "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
             "dependencies": {
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/querystring-builder": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/querystring-builder": "^3.0.3",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-base64": "^3.0.0",
                 "tslib": "^2.6.2"
             }
@@ -9471,13 +9592,13 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/hash-blob-browser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.0.0.tgz",
-            "integrity": "sha512-/Wbpdg+bwJvW7lxR/zpWAc1/x/YkcqguuF2bAzkJrvXriZu1vm8r+PUdE4syiVwQg7PPR2dXpi3CLBb9qRDaVQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.2.tgz",
+            "integrity": "sha512-hAbfqN2UbISltakCC2TP0kx4LqXBttEv2MqSPE98gVuDFMf05lU+TpC41QtqGP3Ff5A3GwZMPfKnEy0VmEUpmg==",
             "dependencies": {
                 "@smithy/chunked-blob-reader": "^3.0.0",
                 "@smithy/chunked-blob-reader-native": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             }
         },
@@ -9487,11 +9608,11 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/hash-node": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.0.tgz",
-            "integrity": "sha512-84qXstNemP3XS5jcof0el6+bDfjzuvhJPQTEfro3lgtbCtKgzPm3MgiS6ehXVPjeQ5+JS0HqmTz8f/RYfzHVxw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+            "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-buffer-from": "^3.0.0",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
@@ -9506,11 +9627,11 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/hash-stream-node": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.0.0.tgz",
-            "integrity": "sha512-J0i7de+EgXDEGITD4fxzmMX8CyCNETTIRXlxjMiNUvvu76Xn3GJ31wQR85ynlPk2wI1lqoknAFJaD1fiNDlbIA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.2.tgz",
+            "integrity": "sha512-PBgDMeEdDzi6JxKwbfBtwQG9eT9cVwsf0dZzLXoJF4sHKHs5HEo/3lJWpn6jibfJwT34I1EBXpBnZE8AxAft6g==",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
@@ -9524,11 +9645,11 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/invalid-dependency": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.0.tgz",
-            "integrity": "sha512-F6wBBaEFgJzj0s4KUlliIGPmqXemwP6EavgvDqYwCH40O5Xr2iMHvS8todmGVZtuJCorBkXsYLyTu4PuizVq5g==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+            "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             }
         },
@@ -9554,11 +9675,11 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/md5-js": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.0.tgz",
-            "integrity": "sha512-Tm0vrrVzjlD+6RCQTx7D3Ls58S3FUH1ZCtU1MIh/qQmaOo1H9lMN2as6CikcEwgattnA9SURSdoJJ27xMcEfMA==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.3.tgz",
+            "integrity": "sha512-O/SAkGVwpWmelpj/8yDtsaVe6sINHLB1q8YE/+ZQbDxIw3SRLbTZuRaI10K12sVoENdnHqzPp5i3/H+BcZ3m3Q==",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             }
@@ -9569,12 +9690,12 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/middleware-content-length": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.0.tgz",
-            "integrity": "sha512-3C4s4d/iGobgCtk2tnWW6+zSTOBg1PRAm2vtWZLdriwTroFbbWNSr3lcyzHdrQHnEXYCC5K52EbpfodaIUY8sg==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+            "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
             "dependencies": {
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9587,16 +9708,16 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/middleware-endpoint": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.1.tgz",
-            "integrity": "sha512-lQ/UOdGD4KM5kLZiAl0q8Qy3dPbynvAXKAdXnYlrA1OpaUwr+neSsVokDZpY6ZVb5Yx8jnus29uv6XWpM9P4SQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+            "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
             "dependencies": {
-                "@smithy/middleware-serde": "^3.0.0",
-                "@smithy/node-config-provider": "^3.1.0",
-                "@smithy/shared-ini-file-loader": "^3.1.0",
-                "@smithy/types": "^3.0.0",
-                "@smithy/url-parser": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.0",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-middleware": "^3.0.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9609,17 +9730,17 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/middleware-retry": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.3.tgz",
-            "integrity": "sha512-Wve1qzJb83VEU/6q+/I0cQdAkDnuzELC6IvIBwDzUEiGpKqXgX1v10FUuZGbRS6Ov/P+HHthcAoHOJZQvZNAkA==",
+            "version": "3.0.15",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+            "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
             "dependencies": {
-                "@smithy/node-config-provider": "^3.1.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/service-error-classification": "^3.0.0",
-                "@smithy/smithy-client": "^3.1.1",
-                "@smithy/types": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.0",
-                "@smithy/util-retry": "^3.0.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/service-error-classification": "^3.0.3",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
                 "tslib": "^2.6.2",
                 "uuid": "^9.0.1"
             },
@@ -9633,11 +9754,11 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/middleware-serde": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.0.tgz",
-            "integrity": "sha512-I1vKG1foI+oPgG9r7IMY1S+xBnmAn1ISqployvqkwHoSb8VPsngHDTOgYGYBonuOKndaWRUGJZrKYYLB+Ane6w==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+            "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9650,11 +9771,11 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/middleware-stack": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.0.tgz",
-            "integrity": "sha512-+H0jmyfAyHRFXm6wunskuNAqtj7yfmwFB6Fp37enytp2q047/Od9xetEaUbluyImOlGnGpaVGaVfjwawSr+i6Q==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+            "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9667,13 +9788,13 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/node-config-provider": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.0.tgz",
-            "integrity": "sha512-ngfB8QItUfTFTfHMvKuc2g1W60V1urIgZHqD1JNFZC2tTWXahqf2XvKXqcBS7yZqR7GqkQQZy11y/lNOUWzq7Q==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+            "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
             "dependencies": {
-                "@smithy/property-provider": "^3.1.0",
-                "@smithy/shared-ini-file-loader": "^3.1.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9686,14 +9807,14 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.0.0.tgz",
-            "integrity": "sha512-3trD4r7NOMygwLbUJo4eodyQuypAWr7uvPnebNJ9a70dQhVn+US8j/lCnvoJS6BXfZeF7PkkkI0DemVJw+n+eQ==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+            "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
             "dependencies": {
-                "@smithy/abort-controller": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/querystring-builder": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/abort-controller": "^3.1.1",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/querystring-builder": "^3.0.3",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9706,11 +9827,11 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/property-provider": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.0.tgz",
-            "integrity": "sha512-Tj3+oVhqdZgemjCiWjFlADfhvLF4C/uKDuKo7/tlEsRQ9+3emCreR2xndj970QSRSsiCEU8hZW3/8JQu+n5w4Q==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+            "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9723,11 +9844,11 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/protocol-http": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.0.tgz",
-            "integrity": "sha512-qOQZOEI2XLWRWBO9AgIYuHuqjZ2csyr8/IlgFDHDNuIgLAMRx2Bl8ck5U5D6Vh9DPdoaVpuzwWMa0xcdL4O/AQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+            "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9740,11 +9861,11 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/querystring-builder": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.0.tgz",
-            "integrity": "sha512-bW8Fi0NzyfkE0TmQphDXr1AmBDbK01cA4C1Z7ggwMAU5RDz5AAv/KmoRwzQAS0kxXNf/D2ALTEgwK0U2c4LtRg==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+            "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-uri-escape": "^3.0.0",
                 "tslib": "^2.6.2"
             },
@@ -9758,11 +9879,11 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/querystring-parser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.0.tgz",
-            "integrity": "sha512-UzHwthk0UEccV4dHzPySnBy34AWw3V9lIqUTxmozQ+wPDAO9csCWMfOLe7V9A2agNYy7xE+Pb0S6K/J23JSzfQ==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+            "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9775,22 +9896,22 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/service-error-classification": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.0.tgz",
-            "integrity": "sha512-3BsBtOUt2Gsnc3X23ew+r2M71WwtpHfEDGhHYHSDg6q1t8FrWh15jT25DLajFV1H+PpxAJ6gqe9yYeRUsmSdFA==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+            "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
             "dependencies": {
-                "@smithy/types": "^3.0.0"
+                "@smithy/types": "^3.3.0"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/shared-ini-file-loader": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.0.tgz",
-            "integrity": "sha512-dAM7wSX0NR3qTNyGVN/nwwpEDzfV9T/3AN2eABExWmda5VqZKSsjlINqomO5hjQWGv+IIkoXfs3u2vGSNz8+Rg==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+            "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9803,14 +9924,15 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.0.0.tgz",
-            "integrity": "sha512-kXFOkNX+BQHe2qnLxpMEaCRGap9J6tUGLzc3A9jdn+nD4JdMwCKTJ+zFwQ20GkY+mAXGatyTw3HcoUlR39HwmA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+            "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
             "dependencies": {
                 "@smithy/is-array-buffer": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-hex-encoding": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
                 "@smithy/util-uri-escape": "^3.0.0",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
@@ -9825,15 +9947,15 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/smithy-client": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.1.tgz",
-            "integrity": "sha512-tj4Ku7MpzZR8cmVuPcSbrLFVxmptWktmJMwST/uIEq4sarabEdF8CbmQdYB7uJ/X51Qq2EYwnRsoS7hdR4B7rA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+            "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
             "dependencies": {
-                "@smithy/middleware-endpoint": "^3.0.1",
-                "@smithy/middleware-stack": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.0",
-                "@smithy/types": "^3.0.0",
-                "@smithy/util-stream": "^3.0.1",
+                "@smithy/middleware-endpoint": "^3.1.0",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/protocol-http": "^4.1.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-stream": "^3.1.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9846,9 +9968,9 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/types": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
-            "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -9862,12 +9984,12 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/url-parser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.0.tgz",
-            "integrity": "sha512-2XLazFgUu+YOGHtWihB3FSLAfCUajVfNBXGGYjOaVKjLAuAxx3pSBY3hBgLzIgB17haf59gOG3imKqTy8mcrjw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+            "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
             "dependencies": {
-                "@smithy/querystring-parser": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/querystring-parser": "^3.0.3",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             }
         },
@@ -9957,13 +10079,13 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.3.tgz",
-            "integrity": "sha512-3DFON2bvXJAukJe+qFgPV/rorG7ZD3m4gjCXHD1V5z/tgKQp5MCTCLntrd686tX6tj8Uli3lefWXJudNg5WmCA==",
+            "version": "3.0.15",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+            "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
             "dependencies": {
-                "@smithy/property-provider": "^3.1.0",
-                "@smithy/smithy-client": "^3.1.1",
-                "@smithy/types": "^3.0.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             },
@@ -9977,16 +10099,16 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.3.tgz",
-            "integrity": "sha512-D0b8GJXecT00baoSQ3Iieu3k3mZ7GY8w1zmg8pdogYrGvWJeLcIclqk2gbkG4K0DaBGWrO6v6r20iwIFfDYrmA==",
+            "version": "3.0.15",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+            "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
             "dependencies": {
-                "@smithy/config-resolver": "^3.0.1",
-                "@smithy/credential-provider-imds": "^3.1.0",
-                "@smithy/node-config-provider": "^3.1.0",
-                "@smithy/property-provider": "^3.1.0",
-                "@smithy/smithy-client": "^3.1.1",
-                "@smithy/types": "^3.0.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/credential-provider-imds": "^3.2.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/smithy-client": "^3.2.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9999,12 +10121,12 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/util-endpoints": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.1.tgz",
-            "integrity": "sha512-ZRT0VCOnKlVohfoABMc8lWeQo/JEFuPWctfNRXgTHbyOVssMOLYFUNWukxxiHRGVAhV+n3c0kPW+zUqckjVPEA==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
+            "integrity": "sha512-ReQP0BWihIE68OAblC/WQmDD40Gx+QY1Ez8mTdFMXpmjfxSyz2fVQu3A4zXRfQU9sZXtewk3GmhfOHswvX+eNg==",
             "dependencies": {
-                "@smithy/node-config-provider": "^3.1.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -10033,11 +10155,11 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/util-middleware": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.0.tgz",
-            "integrity": "sha512-q5ITdOnV2pXHSVDnKWrwgSNTDBAMHLptFE07ua/5Ty5WJ11bvr0vk2a7agu7qRhrCFRQlno5u3CneU5EELK+DQ==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+            "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -10050,12 +10172,12 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/util-retry": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.0.tgz",
-            "integrity": "sha512-nK99bvJiziGv/UOKJlDvFF45F00WgPLKVIGUfAK+mDhzVN2hb/S33uW2Tlhg5PVBoqY7tDVqL0zmu4OxAHgo9g==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+            "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
             "dependencies": {
-                "@smithy/service-error-classification": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/service-error-classification": "^3.0.3",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -10068,13 +10190,13 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/util-stream": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.1.tgz",
-            "integrity": "sha512-7F7VNNhAsfMRA8I986YdOY5fE0/T1/ZjFF6OLsqkvQVNP3vZ/szYDfGCyphb7ioA09r32K/0qbSFfNFU68aSzA==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+            "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
             "dependencies": {
-                "@smithy/fetch-http-handler": "^3.0.1",
-                "@smithy/node-http-handler": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/fetch-http-handler": "^3.2.4",
+                "@smithy/node-http-handler": "^3.1.4",
+                "@smithy/types": "^3.3.0",
                 "@smithy/util-base64": "^3.0.0",
                 "@smithy/util-buffer-from": "^3.0.0",
                 "@smithy/util-hex-encoding": "^3.0.0",
@@ -10124,12 +10246,12 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/@smithy/util-waiter": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.0.0.tgz",
-            "integrity": "sha512-+fEXJxGDLCoqRKVSmo0auGxaqbiCo+8oph+4auefYjaNxjOLKSY2MxVQfRzo65PaZv4fr+5lWg+au7vSuJJ/zw==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.2.tgz",
+            "integrity": "sha512-4pP0EV3iTsexDx+8PPGAKCQpd/6hsQBaQhqWzU4hqKPHN5epPsxKbvUTIiYIHTxaKt6/kEaqPBpu/ufvfbrRzw==",
             "dependencies": {
-                "@smithy/abort-controller": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/abort-controller": "^3.1.1",
+                "@smithy/types": "^3.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -17887,17 +18009,17 @@
             "dev": true
         },
         "node_modules/fast-xml-parser": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-            "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+            "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
             "funding": [
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/naturalintelligence"
-                },
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/NaturalIntelligence"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
                 }
             ],
             "dependencies": {
@@ -29527,6 +29649,7 @@
         },
         "node_modules/tslib": {
             "version": "1.14.1",
+            "dev": true,
             "license": "0BSD"
         },
         "node_modules/tsup": {
@@ -32808,7 +32931,7 @@
             ],
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@aws-sdk/client-s3": "3.590.0",
+                "@aws-sdk/client-s3": "3.635.0",
                 "@datadog/datadog-api-client": "1.26.0",
                 "@hapi/boom": "^10.0.1",
                 "@nangohq/database": "file:../database",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,7 +18,7 @@
     },
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
-        "@aws-sdk/client-s3": "3.590.0",
+        "@aws-sdk/client-s3": "3.635.0",
         "@datadog/datadog-api-client": "1.26.0",
         "@hapi/boom": "^10.0.1",
         "@nangohq/database": "file:../database",


### PR DESCRIPTION
> fast-xml-parser  <4.4.1
> Severity: high
> fast-xml-parser vulnerable to ReDOS at currency parsing - https://github.com/advisories/GHSA-mpg4-rc92-vx8v

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
