### PR TITLE
fix: better payload for proxy logs and operations

### DIFF
--- a/packages/logs/lib/client.ts
+++ b/packages/logs/lib/client.ts
@@ -80,16 +80,23 @@ export class LogContextStateless {
         });
     }
 
+    async http(
+        message: string,
+        data: {
+            request: MessageRow['request'];
+            response: MessageRow['response'];
+            meta?: MessageRow['meta'];
+        }
+    ): Promise<boolean> {
+        const level: MessageRow['level'] = data.response && data.response.code >= 400 ? 'error' : 'info';
+        return await this.log({ type: 'http', level, message, ...data, source: 'internal' });
+    }
+
     /**
      * @deprecated Only there for retro compat
      */
     async trace(message: string, meta: MessageMeta | null = null): Promise<boolean> {
         return await this.log({ type: 'log', level: 'debug', message, meta, source: 'internal' });
-    }
-
-    async http(message: string, data: Pick<MessageRow, 'request' | 'response' | 'meta'>): Promise<boolean> {
-        const level: MessageRow['level'] = data.response && data.response.code >= 400 ? 'error' : 'info';
-        return await this.log({ type: 'http', level, message, ...data, source: 'internal' });
     }
 }
 

--- a/packages/logs/lib/models/messages.ts
+++ b/packages/logs/lib/models/messages.ts
@@ -204,6 +204,7 @@ export async function update(opts: { id: OperationRow['id']; data: SetRequired<P
     await client.update({
         index: getFullIndexName(indexMessages.index, opts.data.createdAt),
         id: opts.id,
+        retry_on_conflict: 3,
         refresh: isTest,
         body: {
             doc: {

--- a/packages/server/lib/controllers/proxy.controller.ts
+++ b/packages/server/lib/controllers/proxy.controller.ts
@@ -239,7 +239,6 @@ class ProxyController {
     }) {
         const safeHeaders = proxyService.stripSensitiveHeaders(config.headers, config);
         await logCtx.http(`${config.method.toUpperCase()} ${url} was successful`, {
-            meta: null,
             request: {
                 method: config.method,
                 url,

--- a/packages/webapp/src/pages/Logs/ShowMessage.tsx
+++ b/packages/webapp/src/pages/Logs/ShowMessage.tsx
@@ -12,13 +12,16 @@ export const ShowMessage: React.FC<{ message: MessageRow }> = ({ message }) => {
     }, [message.createdAt]);
 
     const payload = useMemo(() => {
-        if (!message.meta && !message.error) {
+        if (!message.meta && !message.error && !message.request && !message.response) {
             return null;
         }
 
-        const pl: Record<string, any> = {};
-        if (message.meta) {
-            pl.output = message.meta;
+        const pl: Record<string, any> = message.meta ? { ...message.meta } : {};
+        if (message.request) {
+            pl.request = message.request;
+        }
+        if (message.response) {
+            pl.response = message.response;
         }
         if (message.error) {
             pl.error = message.error.message;

--- a/packages/webapp/src/pages/Logs/ShowOperation.tsx
+++ b/packages/webapp/src/pages/Logs/ShowOperation.tsx
@@ -36,6 +36,21 @@ export const ShowOperation: React.FC<{ operationId: string }> = ({ operationId }
         return !operation || operation.state === 'waiting' || operation.state === 'running';
     }, [operation]);
 
+    const payload = useMemo(() => {
+        if (!operation?.meta && !operation?.request && !operation?.response) {
+            return null;
+        }
+
+        const pl: Record<string, any> = operation.meta ? { ...operation.meta } : {};
+        if (operation.request) {
+            pl.request = operation.request;
+        }
+        if (operation.response) {
+            pl.response = operation.response;
+        }
+        return pl;
+    }, [operation?.meta, operation?.request, operation?.response]);
+
     useInterval(
         () => {
             // Auto refresh
@@ -154,7 +169,7 @@ export const ShowOperation: React.FC<{ operationId: string }> = ({ operationId }
             </div>
             <div className="">
                 <h4 className="font-semibold text-sm mb-2">Payload</h4>
-                {operation.meta ? (
+                {payload ? (
                     <div className="text-gray-400 text-sm bg-pure-black py-2 max-h-36 overflow-y-scroll">
                         <Prism
                             language="json"
@@ -164,7 +179,7 @@ export const ShowOperation: React.FC<{ operationId: string }> = ({ operationId }
                                 return { code: { padding: '0', whiteSpace: 'pre-wrap' } };
                             }}
                         >
-                            {JSON.stringify(operation.meta, null, 2)}
+                            {JSON.stringify(payload, null, 2)}
                         </Prism>
                     </div>
                 ) : (


### PR DESCRIPTION
Showing request and response info in operations and logs payload for proxy call.

Operation payload shows info about the request to nango api
Log payload shows info about the request to the 3rd party api

Successful operation:
<img width="1314" alt="Screenshot 2024-08-22 at 13 07 53" src="https://github.com/user-attachments/assets/4aff8efc-f315-4ce4-b1ef-8468a498e071">
Successful log:
<img width="1078" alt="Screenshot 2024-08-22 at 13 08 01" src="https://github.com/user-attachments/assets/711ad88b-6718-4cc7-bc2d-17b9fa2e47a2">

Failed operation:
<img width="1496" alt="Screenshot 2024-08-22 at 13 07 34" src="https://github.com/user-attachments/assets/59eac376-24b3-4b0e-88ad-9bd14143baef">
Failed log:
<img width="1068" alt="Screenshot 2024-08-22 at 13 07 43" src="https://github.com/user-attachments/assets/bc48fd18-cce1-4355-b556-def6e0e21747">

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1526/improve-proxy-logs