### PR TITLE
fix(upload templates): using cut instead of dirname

### DIFF
--- a/.github/workflows/integration-template-upload.yaml
+++ b/.github/workflows/integration-template-upload.yaml
@@ -39,7 +39,7 @@ jobs:
                     dirs=$(find integration-templates -maxdepth 1 -type d | tail -n +2)
                   else
                     echo "Automatic trigger detected. Uploading changed templates."
-                    dirs=$(echo "${{ steps.changed-files-specific.outputs.all_changed_files }}" | xargs -n1 dirname | sort -u)
+                    dirs=$(echo "${{ steps.changed-files-specific.outputs.all_changed_files }}" | cut -d'/' -f1,2 | sort -u)
                   fi
                   for dir in $dirs; do
                     integration=$(basename $dir)


### PR DESCRIPTION
templates files can be in subfolders like actions/sync/etc... Using `cut -d'/' -f1,2` to get the templates root folder (ex: integration-templates/salesforce) instead of `dirname` that gives us all subfolders

if list of changed files is
```
integration-templates/exact-online/actions/attach-file-invoice.ts
integration-templates/exact-online/actions/create-customer.ts
integration-templates/exact-online/actions/create-invoice.ts
integration-templates/exact-online/actions/update-customer.ts
integration-templates/exact-online/actions/update-invoice.ts
integration-templates/exact-online/schema.zod.ts
integration-templates/salesforce/actions/fetch-fields.ts
```
we want 
```
integration-templates/exact-online
integration-templates/salesforce
```
and not 
```
integration-templates/exact-online
integration-templates/exact-online/actions
integration-templates/salesforce/actions
```
