### PR TITLE
fix: action and webhook logs improvements

### DIFF
--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -105,11 +105,6 @@ export async function startAction(task: TaskAction): Promise<Result<void>> {
     }
 }
 export async function handleActionSuccess({ nangoProps }: { nangoProps: NangoProps }): Promise<void> {
-    const logCtx = await logContextGetter.get({ id: String(nangoProps.activityLogId) });
-    const content = `${nangoProps.syncConfig.sync_name} action was run successfully and results are being sent synchronously.`;
-
-    await logCtx.info(content);
-
     const connection: NangoConnection = {
         id: nangoProps.nangoConnectionId!,
         connection_id: nangoProps.connectionId,
@@ -219,5 +214,4 @@ async function onFailure({
             }
         });
     }
-    await logCtx.error(error.message, { error });
 }

--- a/packages/jobs/lib/execution/postConnection.ts
+++ b/packages/jobs/lib/execution/postConnection.ts
@@ -121,7 +121,6 @@ export async function handlePostConnectionSuccess({ nangoProps }: { nangoProps: 
         createdAt: Date.now()
     });
     const logCtx = await logContextGetter.get({ id: String(nangoProps.activityLogId) });
-    await logCtx.info(content);
     await logCtx.success();
 }
 

--- a/packages/server/lib/controllers/proxy.controller.ts
+++ b/packages/server/lib/controllers/proxy.controller.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
-import type { OutgoingHttpHeaders, IncomingHttpHeaders } from 'http';
+import type { OutgoingHttpHeaders } from 'http';
 import type { TransformCallback } from 'stream';
 import type stream from 'stream';
 import { Readable, Transform, PassThrough } from 'stream';
@@ -10,7 +10,7 @@ import type { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { backOff } from 'exponential-backoff';
 import type { HTTP_VERB, UserProvidedProxyConfiguration, InternalProxyConfiguration, ApplicationConstructedProxyConfiguration } from '@nangohq/shared';
 import { NangoError, LogActionEnum, errorManager, ErrorSourceEnum, proxyService, connectionService, configService, featureFlags } from '@nangohq/shared';
-import { metrics, getLogger, axiosInstance as axios } from '@nangohq/utils';
+import { metrics, getLogger, axiosInstance as axios, getHeaders } from '@nangohq/utils';
 import { logContextGetter } from '@nangohq/logs';
 import { connectionRefreshFailed as connectionRefreshFailedHook, connectionRefreshSuccess as connectionRefreshSuccessHook } from '../hooks/hooks.js';
 import type { LogContext } from '@nangohq/logs';
@@ -162,17 +162,6 @@ class ProxyController {
             metrics.increment(metrics.Types.PROXY_FAILURE);
             next(err);
         } finally {
-            const getHeaders = (hs: IncomingHttpHeaders | OutgoingHttpHeaders): Record<string, string> => {
-                const headers: Record<string, string> = {};
-                for (const [key, value] of Object.entries(hs)) {
-                    if (typeof value === 'string') {
-                        headers[key] = value;
-                    } else if (Array.isArray(value)) {
-                        headers[key] = value.join(', ');
-                    }
-                }
-                return headers;
-            };
             const reqHeaders = getHeaders(req.headers);
             reqHeaders['authorization'] = 'REDACTED';
             await logCtx?.enrichOperation({

--- a/packages/shared/lib/constants.ts
+++ b/packages/shared/lib/constants.ts
@@ -1,5 +1,3 @@
 import { isEnterprise } from '@nangohq/utils';
 
-export const SYNC_TASK_QUEUE = 'nango-syncs';
-export const WEBHOOK_TASK_QUEUE = 'nango-webhooks';
 export const CONNECTIONS_WITH_SCRIPTS_CAP_LIMIT = isEnterprise ? Infinity : 3;

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -533,7 +533,7 @@ export class NangoError extends Error {
 
             case 'action_script_runtime_error':
                 this.status = 500;
-                this.message = '';
+                this.message = 'The action script failed with a runtime error';
                 break;
 
             case 'script_cancelled':

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -140,6 +140,6 @@ export type OperationRow = Merge<Required<OperationRowInsert>, { accountId: numb
 export type MessageRowInsert = Pick<MessageRow, 'type' | 'message'> & Partial<Omit<MessageRow, 'type' | 'message'>> & { id?: never };
 
 // Buffer logs inside proxy calls
-export type LogsBuffer = Pick<MessageRow, 'level' | 'message' | 'createdAt'> & Partial<Pick<MessageRow, 'error' | 'meta'>>;
+export type LogsBuffer = Pick<MessageRow, 'level' | 'message' | 'createdAt'> & Partial<Pick<MessageRow, 'error' | 'meta' | 'type' | 'request' | 'response'>>;
 
 export type MessageOrOperationRow = MessageRow | OperationRow;

--- a/packages/utils/lib/express/headers.ts
+++ b/packages/utils/lib/express/headers.ts
@@ -1,0 +1,13 @@
+import type { IncomingHttpHeaders, OutgoingHttpHeaders } from 'http';
+
+export function getHeaders(hs: IncomingHttpHeaders | OutgoingHttpHeaders): Record<string, string> {
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(hs)) {
+        if (typeof value === 'string') {
+            headers[key] = value;
+        } else if (Array.isArray(value)) {
+            headers[key] = value.join(', ');
+        }
+    }
+    return headers;
+}

--- a/packages/utils/lib/index.ts
+++ b/packages/utils/lib/index.ts
@@ -12,6 +12,7 @@ export * from './string.js';
 export * from './express/requestLoggerMiddleware.js';
 export * from './express/route.js';
 export * from './express/validate.js';
+export * from './express/headers.js';
 export * from './workflows.js';
 export * from './axios.js';
 export * from './auth.js';


### PR DESCRIPTION
- Added request/response details to action operation payload
- Removed duplicates logs. We were indeed logging more or less the same thing at different levels (handler in jobs, trigger function and/or controller).
- Log messages for actions and webhooks are now shorter and mostly without data (ex: 'Started action A', 'The action failed')
Details like connection, provider, truncated response, error payload are now in the log payload

I want to add request/response details for proxied requests made within a script but it requires modifying the persist API which is ingesting the logs coming from the runner. I will do that in next PR. It would also be useful for the validation warning message

Note: You can ignore the `[Object Object], 100` log in the screenshot below. It is me manually logging something in the test script

Action operation:
<img width="1053" alt="Screenshot 2024-08-23 at 11 16 01" src="https://github.com/user-attachments/assets/03323bcb-d20c-4e11-a0f6-e4288d0a7eb8">

Action started log
<img width="1036" alt="Screenshot 2024-08-23 at 11 16 45" src="https://github.com/user-attachments/assets/a4a2438e-dc41-4f49-a526-29b2ce4f98ed">

Action successful log
<img width="861" alt="Screenshot 2024-08-23 at 11 17 15" src="https://github.com/user-attachments/assets/c2fbf7ad-962b-4e24-abdc-4f5435f2fb1d">

Failed action operation:
<img width="1065" alt="Screenshot 2024-08-23 at 11 17 49" src="https://github.com/user-attachments/assets/f6a27eed-2878-48cb-91e4-baf71dba91b2">

Action failed log
<img width="838" alt="Screenshot 2024-08-23 at 11 18 11" src="https://github.com/user-attachments/assets/1b37657b-de31-4824-8ff7-59007d974b09">

Same for webhook.
Note that operation is not enriched with request/response. @samuel I'll ping you to see if we can add it
<img width="1024" alt="Screenshot 2024-08-23 at 11 25 26" src="https://github.com/user-attachments/assets/30a4f223-931b-453d-9f41-a29a3f1a549d">


## Issue ticket number and link
https://linear.app/nango/issue/NAN-1525/improve-actions-error-logs

