### PR TITLE
fix(tiktok-accounts): [nan-1233] check for nested data

### DIFF
--- a/packages/shared/lib/clients/provider.client.ts
+++ b/packages/shared/lib/clients/provider.client.ts
@@ -320,7 +320,7 @@ class ProviderClient {
 
             const response = await axios.post(refreshTokenUrl, body);
 
-            if (response.status === 200 && response.data !== null) {
+            if (response.status === 200 && response.data && response.data.data) {
                 return {
                     access_token: response.data.data['access_token'],
                     token_type: response.data.data['token_type'],


### PR DESCRIPTION
## Describe your changes
Check for data object to avoid error 
```
ERROR] [logs] log: Failed to refresh credentials [{"meta":{"status":400,"type":"refresh_token_external_error","payload":{"message":"An unhandled error of type 'tiktok_token_refresh_request_error' with payload '\"Cannot read properties of undefined (reading 'access_token')\"' has occurred"},"message":"The external API returned an error when trying to refresh the access token. Please try again later."}}]
```

## Issue ticket number and link
NAN-1233

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
