### PR TITLE
fix(cli): exit 1 when compilation fail

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -234,6 +234,7 @@ program
 
         const success = await compileAllFiles({ fullPath, debug });
         if (!success) {
+            console.log(chalk.red('Compilation was not fully successful. Please make sure all files compile before deploying'));
             process.exitCode = 1;
         }
     });

--- a/packages/cli/lib/services/compile.service.ts
+++ b/packages/cli/lib/services/compile.service.ts
@@ -67,7 +67,7 @@ export async function compileAllFiles({
             if (!completed) {
                 if (scriptName && file.inputPath.includes(scriptName)) {
                     success = false;
-                } else if (!scriptName) {
+                } else if (!scriptName && !file.inputPath.endsWith('models.ts')) {
                     success = false;
                 }
             }
@@ -196,7 +196,6 @@ async function compile({
     debug: boolean;
 }): Promise<boolean> {
     const providerConfiguration = getProviderConfigurationFromPath({ filePath: file.inputPath, parsed });
-
     if (!providerConfiguration) {
         return false;
     }

--- a/packages/cli/lib/services/compile.service.ts
+++ b/packages/cli/lib/services/compile.service.ts
@@ -67,6 +67,8 @@ export async function compileAllFiles({
             if (!completed) {
                 if (scriptName && file.inputPath.includes(scriptName)) {
                     success = false;
+                } else if (!scriptName) {
+                    success = false;
                 }
             }
         } catch (error) {
@@ -203,7 +205,6 @@ async function compile({
     const type = syncConfig?.type || 'sync';
 
     const success = compileImportedFile({ fullPath, filePath: file.inputPath, compiler, type, parsed });
-
     if (!success) {
         return false;
     }


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1622/github-actions-doesnt-fail-on-compilation-error

- Correctly exit 1 when compilation fail 
- Add missing error when calling `nango compile`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced console logging for the compilation process, providing clearer feedback on success or failure.

- **Bug Fixes**
	- Improved handling of undefined `scriptName` in the compilation logic to prevent unexpected failures.

- **Refactor**
	- Minor formatting adjustments for improved code readability without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->