### PR TITLE
fix(github-app-oauth): [nan-1628] add escape hatch for avoiding encoding params

### DIFF
--- a/packages/shared/lib/clients/oauth2.client.ts
+++ b/packages/shared/lib/clients/oauth2.client.ts
@@ -19,7 +19,7 @@ export function getSimpleOAuth2ClientConfig(
 ): Merge<ModuleOptions, { http: WreckHttpOptions }> {
     const templateTokenUrl = typeof template.token_url === 'string' ? template.token_url : (template.token_url!['OAUTH2'] as string);
     const tokenUrl = makeUrl(templateTokenUrl, connectionConfig);
-    const authorizeUrl = makeUrl(template.authorization_url!, connectionConfig);
+    const authorizeUrl = makeUrl(template.authorization_url!, connectionConfig, template.authorization_url_encode);
 
     const headers = { 'User-Agent': 'Nango' };
 
@@ -157,9 +157,9 @@ export async function getFreshOAuth2Credentials(
     }
 }
 
-function makeUrl(template: string, config: Record<string, any>): URL {
+function makeUrl(template: string, config: Record<string, any>, encodeAllParams = true): URL {
     const cleanTemplate = template.replace(/connectionConfig\./g, '');
-    const encodedParams = encodeParameters(config);
+    const encodedParams = encodeAllParams ? encodeParameters(config) : config;
     const interpolatedUrl = interpolateString(cleanTemplate, encodedParams);
     return new URL(interpolatedUrl);
 }

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -1180,6 +1180,7 @@ github-app-oauth:
     alias: github
     auth_mode: CUSTOM
     authorization_url: ${connectionConfig.appPublicLink}/installations/new
+    authorization_url_encode: false
     token_url:
         OAUTH2: https://github.com/login/oauth/access_token
         APP: https://api.github.com/app/installations/${connectionConfig.installation_id}/access_tokens

--- a/packages/types/lib/integration/template.ts
+++ b/packages/types/lib/integration/template.ts
@@ -33,6 +33,7 @@ export interface Template {
         };
     };
     authorization_url?: string;
+    authorization_url_encode?: boolean;
     access_token_url?: string;
     authorization_params?: Record<string, string>;
     scope_separator?: string;

--- a/scripts/validation/providers/schema.json
+++ b/scripts/validation/providers/schema.json
@@ -68,6 +68,9 @@
                 "authorization_url": {
                     "type": "string"
                 },
+                "authorization_url_encode": {
+                    "type": "boolean"
+                },
                 "authorization_url_replacements": {
                     "type": "object",
                     "additionalProperties": true


### PR DESCRIPTION
## Describe your changes
The Github app oauth provider authorization should not be encoded as it produces an invalid URL. It was expected from https://github.com/NangoHQ/nango/pull/2608 that `connectionConfig` is used in query params but it is used for the full URL as well in some cases. This adds in a boolean configuration to avoid encoding.

## Issue ticket number and link
NAN-1628

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for controlling URL encoding in the authorization process.
	- Added flexibility to the URL construction by allowing optional encoding of parameters.

- **Bug Fixes**
	- Resolved issues related to the construction of authorization URLs, enhancing compatibility with GitHub's OAuth.

- **Documentation**
	- Updated interface and schema documentation to reflect the new `authorization_url_encode` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->