### PR TITLE
fix(integrations): add flag auto_start

### DIFF
--- a/integration-templates/google-drive/nango.yaml
+++ b/integration-templates/google-drive/nango.yaml
@@ -17,6 +17,8 @@ integrations:
                     and using the ID field provided by the response
                     (https://developers.google.com/drive/picker/reference/results)
                 input: DocumentMetadata
+                auto_start: false
+                version: 1.0.1
                 output: Document
                 sync_type: full
                 endpoint: GET /google-drive/documents

--- a/packages/shared/flows.yaml
+++ b/packages/shared/flows.yaml
@@ -1657,6 +1657,8 @@ integrations:
                     and using the ID field provided by the response
                     (https://developers.google.com/drive/picker/reference/results)
                 input: DocumentMetadata
+                auto_start: false
+                version: 1.0.1
                 output: Document
                 sync_type: full
                 endpoint: GET /google-drive/documents


### PR DESCRIPTION
## Describe your changes

- Add flag `auto_start: false` 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new configuration parameters for the Google Drive integration, allowing users to manually start the integration process.
	- Added versioning for the Google Drive integration, improving tracking of changes and updates.
  
- **Bug Fixes**
	- Resolved issues related to automatic initiation of integrations, enhancing user control over integration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->