### PR TITLE
chore: add support for full log message in persist API

### DIFF
--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteRecords.ts
@@ -48,7 +48,7 @@ const handler = async (req: EndpointRequest<DeleteRecords>, res: EndpointRespons
     if (result.isOk()) {
         res.status(204).send();
     } else {
-        res.status(500).json({ error: { code: 'delete_records_failed', message: `Failed to save records: ${result.error.message}` } });
+        res.status(500).json({ error: { code: 'delete_records_failed', message: `Failed to delete records: ${result.error.message}` } });
     }
     return;
 };

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/putRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/putRecords.ts
@@ -48,7 +48,7 @@ const handler = async (req: EndpointRequest<PutRecords>, res: EndpointResponse<P
     if (result.isOk()) {
         res.status(204).send();
     } else {
-        res.status(500).json({ error: { code: 'put_records_failed', message: `Failed to delete records: ${result.error.message}` } });
+        res.status(500).json({ error: { code: 'put_records_failed', message: `Failed to update records: ${result.error.message}` } });
     }
     return;
 };

--- a/packages/persist/lib/routes/environment/environmentId/postLog.ts
+++ b/packages/persist/lib/routes/environment/environmentId/postLog.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { ApiError, Endpoint } from '@nangohq/types';
+import type { ApiError, Endpoint, MessageRowInsert } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, RouteHandler, Route } from '@nangohq/utils';
 import { validateRequest } from '@nangohq/utils';
 import { logContextGetter, oldLevelToNewLevel } from '@nangohq/logs';
@@ -8,18 +8,86 @@ type LegacyLogLevel = 'info' | 'debug' | 'error' | 'warn' | 'http' | 'verbose' |
 
 const MAX_LOG_CHAR = 10000;
 
+interface LegacyLogBody {
+    activityLogId: string;
+    level: LegacyLogLevel;
+    msg: string;
+    timestamp?: number | undefined;
+}
+const legacyLogBodySchema = z.object({
+    activityLogId: z.string(),
+    level: z.enum(['info', 'debug', 'error', 'warn', 'http', 'verbose', 'silly']),
+    msg: z.string(),
+    timestamp: z.number().optional()
+});
+
+interface LogBody {
+    activityLogId: string;
+    log: MessageRowInsert;
+}
+
+export const logBodySchema = z.object({
+    activityLogId: z.string(),
+    log: z.object({
+        type: z.enum(['log', 'http']),
+        message: z.string(),
+        source: z.enum(['internal', 'user']).optional().default('internal'),
+        level: z.enum(['debug', 'info', 'warn', 'error']),
+        title: z.string().nullable().optional().default(null),
+        state: z.enum(['waiting', 'running', 'success', 'failed', 'timeout', 'cancelled']).optional().default('waiting'),
+        code: z.enum(['success']).nullable().optional().default(null),
+        accountId: z.number().nullable().optional().default(null),
+        accountName: z.string().nullable().optional().default(null),
+        environmentId: z.number().nullable().optional().default(null),
+        environmentName: z.string().nullable().optional().default(null),
+        providerName: z.string().nullable().optional().default(null),
+        integrationId: z.number().nullable().optional().default(null),
+        integrationName: z.string().nullable().optional().default(null),
+        connectionId: z.number().nullable().optional().default(null),
+        connectionName: z.string().nullable().optional().default(null),
+        syncConfigId: z.number().nullable().optional().default(null),
+        syncConfigName: z.string().nullable().optional().default(null),
+        jobId: z.string().nullable().optional().default(null),
+        userId: z.number().nullable().optional().default(null),
+        error: z
+            .object({
+                name: z.string(),
+                message: z.string(),
+                type: z.string().nullable().optional().default(null),
+                payload: z.any().optional()
+            })
+            .nullable()
+            .optional()
+            .default(null),
+        request: z
+            .object({
+                url: z.string(),
+                method: z.string(),
+                headers: z.record(z.string())
+            })
+            .nullable()
+            .optional()
+            .default(null),
+        response: z
+            .object({
+                code: z.number(),
+                headers: z.record(z.string())
+            })
+            .nullable()
+            .optional()
+            .default(null),
+        meta: z.record(z.any()).nullable().optional().default(null),
+        createdAt: z.string()
+    })
+});
+
 type PostLog = Endpoint<{
     Method: typeof method;
     Path: typeof path;
     Params: {
         environmentId: number;
     };
-    Body: {
-        activityLogId: string;
-        level: LegacyLogLevel;
-        msg: string;
-        timestamp?: number | undefined;
-    };
+    Body: LegacyLogBody | LogBody;
     Error: ApiError<'post_log_failed'>;
     Success: never;
 }>;
@@ -28,16 +96,13 @@ export const path = '/environment/:environmentId/log';
 const method = 'POST';
 
 const validate = validateRequest<PostLog>({
-    parseBody: (data) =>
-        z
-            .object({
-                activityLogId: z.string(),
-                level: z.enum(['info', 'debug', 'error', 'warn', 'http', 'verbose', 'silly']),
-                msg: z.string(),
-                timestamp: z.number().optional()
-            })
-            .strict()
-            .parse(data),
+    parseBody: (data) => {
+        const legacyParse = legacyLogBodySchema.strict().safeParse(data);
+        if (legacyParse.success) {
+            return legacyParse.data;
+        }
+        return logBodySchema.strict().parse(data);
+    },
     parseParams: (data) =>
         z
             .object({
@@ -50,23 +115,34 @@ const validate = validateRequest<PostLog>({
 const handler = async (req: EndpointRequest<PostLog>, res: EndpointResponse<PostLog>) => {
     const {
         params: { environmentId },
-        body: { activityLogId, level, msg, timestamp }
+        body
     } = req;
-    const truncatedMsg = msg.length > MAX_LOG_CHAR ? `${msg.substring(0, MAX_LOG_CHAR)}... (truncated)` : msg;
-    const logCtx = logContextGetter.getStateLess({ id: String(activityLogId) }, { logToConsole: false });
-    const result = await logCtx.log({
-        type: 'log',
-        message: truncatedMsg,
-        environmentId: environmentId,
-        level: oldLevelToNewLevel[level],
-        source: 'user',
-        createdAt: (timestamp ? new Date(timestamp) : new Date()).toISOString()
-    });
 
+    const truncate = (str: string) => (str.length > MAX_LOG_CHAR ? `${str.substring(0, MAX_LOG_CHAR)}... (truncated)` : str);
+
+    let log: MessageRowInsert;
+    if ('log' in body) {
+        log = {
+            ...body.log,
+            message: truncate(body.log.message)
+        };
+    } else {
+        const { level, msg, timestamp } = body;
+        log = {
+            type: 'log',
+            message: truncate(msg),
+            environmentId: environmentId,
+            level: oldLevelToNewLevel[level],
+            source: 'user',
+            createdAt: (timestamp ? new Date(timestamp) : new Date()).toISOString()
+        };
+    }
+    const logCtx = logContextGetter.getStateLess({ id: String(body.activityLogId) }, { logToConsole: false });
+    const result = await logCtx.log(log);
     if (result) {
         res.status(204).send();
     } else {
-        res.status(500).json({ error: { code: 'post_log_failed', message: `Failed to save log ${activityLogId}` } });
+        res.status(500).json({ error: { code: 'post_log_failed', message: `Failed to save log ${body.activityLogId}` } });
     }
     return;
 };


### PR DESCRIPTION
## Describe your changes

Following up on https://github.com/NangoHQ/nango/pull/2658 Please review this one first

Adding support for passing full log message to persistAPI. We are still sending legacy simplified logs for now.

## Issue ticket number and link

https://linear.app/nango/issue/NAN-1525/improve-actions-error-logs

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced logging functionality with support for a new log structure, allowing for more detailed log entries.
	- Introduced a new interface for improved request body handling in the logging system.

- **Bug Fixes**
	- Updated error messages for deletion and update operations to provide clearer feedback to users.

- **Documentation**
	- Improved clarity in error handling responses to better reflect the nature of failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->