### PR TITLE
fix(cli): correctly compile file outside an integration

### DIFF
--- a/packages/cli/lib/services/compile.service.ts
+++ b/packages/cli/lib/services/compile.service.ts
@@ -64,10 +64,8 @@ export async function compileAllFiles({
     for (const file of integrationFiles) {
         try {
             const completed = await compile({ fullPath, file, parsed, compiler, debug });
-            if (!completed) {
+            if (completed === false) {
                 if (scriptName && file.inputPath.includes(scriptName)) {
-                    success = false;
-                } else if (!scriptName && !file.inputPath.endsWith('models.ts')) {
                     success = false;
                 }
             }
@@ -110,7 +108,7 @@ export async function compileSingleFile({
             debug
         });
 
-        return result;
+        return result === true;
     } catch (error) {
         console.error(`Error compiling ${file.inputPath}:`);
         console.error(error);
@@ -194,10 +192,10 @@ async function compile({
     parsed: NangoYamlParsed;
     compiler: tsNode.Service;
     debug: boolean;
-}): Promise<boolean> {
+}): Promise<boolean | null> {
     const providerConfiguration = getProviderConfigurationFromPath({ filePath: file.inputPath, parsed });
     if (!providerConfiguration) {
-        return false;
+        return null;
     }
 
     const syncConfig = [...providerConfiguration.syncs, ...providerConfiguration.actions].find((sync) => sync.name === file.baseName);


### PR DESCRIPTION
## Describe your changes

After last week fix, I missed the case where files could be located outside an integration folder (at root for example, e.g: schema.zod.ts)

- Correctly compile files outside an integration
To differentiate an error from not compiled, the function now returns null


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved clarity in compilation logic for better understanding of conditions.
	- Updated return semantics in the compilation functions, allowing for a `null` return value.
  
- **Bug Fixes**
	- Enhanced validation of compilation results to ensure stricter checks.

- **Refactor**
	- Simplified nested conditions for improved readability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->