### PR TITLE
fix(slack): log operation to admin account only

### DIFF
--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -225,8 +225,9 @@ async function fillLocalsFromSession(req: Request, res: Response<any, RequestLoc
         res.locals['account'] = result.account;
         res.locals['environment'] = result.environment;
         next();
-    } catch {
-        res.status(401).send({ error: { code: 'unknown_key' } });
+    } catch (err) {
+        errorManager.report(err);
+        res.status(500).send({ error: { code: 'failed_to_fill_session' } });
         return;
     }
 }


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1507/investigate-notifer-logs-appearing-in-customer-dashboard

- Log slack notification to admin account only
We don't want to pollute customers account with something unexpected and not really actionable that also breaks connection/provider links (because they are on an other account)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for session management, changing response status from 401 to 500 for better error categorization.
  
- **New Features**
	- Enhanced Slack service by consolidating environment ID retrieval into a single operation, improving efficiency and error handling.

- **Improvements**
	- Updated logging to reflect accurate account and environment details, ensuring better observability of issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->