### PR TITLE
fix(node-client): sync record types

### DIFF
--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -20,7 +20,6 @@ import type {
     ConnectionList,
     CreateConnectionOAuth1,
     CreateConnectionOAuth2,
-    GetRecordsRequestConfig,
     Integration,
     IntegrationWithCreds,
     ListRecordsRequestConfig,
@@ -409,50 +408,6 @@ export class Nango {
      *      GET ENVIRONMENT VARIABLES
      * =======
      */
-
-    /**
-     * @deprecated Use listRecords() instead.
-     */
-    public async getRecords<T = any>(config: GetRecordsRequestConfig): Promise<(T & { _nango_metadata: RecordMetadata })[]> {
-        const { connectionId, providerConfigKey, model, delta, offset, limit, includeNangoMetadata, filter } = config;
-        validateSyncRecordConfiguration(config);
-
-        const order = config?.order === 'asc' ? 'asc' : 'desc';
-
-        let sortBy = 'id';
-        switch (config.sortBy) {
-            case 'createdAt':
-                sortBy = 'created_at';
-                break;
-            case 'updatedAt':
-                sortBy = 'updated_at';
-                break;
-        }
-
-        if (includeNangoMetadata) {
-            console.warn(
-                `The includeNangoMetadata option will be deprecated soon and will be removed in a future release. Each record now has a _nango_metadata property which includes the same properties.`
-            );
-        }
-        const includeMetadata = includeNangoMetadata || false;
-
-        const url = `${this.serverUrl}/sync/records/?model=${model}&order=${order}&delta=${delta || ''}&offset=${offset || ''}&limit=${limit || ''}&sort_by=${
-            sortBy || ''
-        }&include_nango_metadata=${includeMetadata}${filter ? `&filter=${filter}` : ''}`;
-
-        const headers: Record<string, string | number | boolean> = {
-            'Connection-Id': connectionId,
-            'Provider-Config-Key': providerConfigKey
-        };
-
-        const options = {
-            headers: this.enrichHeaders(headers)
-        };
-
-        const response = await this.http.get(url, options);
-
-        return response.data;
-    }
 
     /**
      * Returns the synced data, ordered by modification date ascending

--- a/packages/node-client/lib/types.ts
+++ b/packages/node-client/lib/types.ts
@@ -23,7 +23,10 @@ import type {
     AppStoreCredentials,
     UnauthCredentials,
     CustomCredentials,
-    TbaCredentials
+    TbaCredentials,
+    RecordMetadata,
+    RecordLastAction,
+    NangoRecord
 } from '@nangohq/types';
 
 export type {
@@ -53,6 +56,7 @@ export type {
     TbaCredentials
 };
 export type { HTTP_VERB, NangoSyncEndpoint };
+export type { RecordMetadata, RecordLastAction, NangoRecord };
 
 export interface NangoProps {
     host?: string;
@@ -100,19 +104,6 @@ export interface ProxyConfiguration {
 
 export type FilterAction = 'added' | 'updated' | 'deleted' | 'ADDED' | 'UPDATED' | 'DELETED';
 export type CombinedFilterAction = `${FilterAction},${FilterAction}`;
-
-export interface GetRecordsRequestConfig {
-    providerConfigKey: string;
-    connectionId: string;
-    model: string;
-    delta?: string;
-    offset?: number;
-    limit?: number;
-    sortBy?: 'updatedAt' | 'createdAt' | 'id';
-    order?: 'asc' | 'desc';
-    includeNangoMetadata?: boolean;
-    filter?: FilterAction | CombinedFilterAction;
-}
 
 export interface ListRecordsRequestConfig {
     providerConfigKey: string;
@@ -269,16 +260,6 @@ export interface NangoSyncConfig {
     sync_type?: SyncType;
     nango_yaml_version?: string;
     webhookSubscriptions?: string[];
-}
-
-export type LastAction = 'ADDED' | 'UPDATED' | 'DELETED';
-
-export interface RecordMetadata {
-    first_seen_at: string;
-    last_seen_at: string;
-    last_action: LastAction;
-    deleted_at: string | null;
-    cursor: string;
 }
 
 export interface SyncResult {

--- a/packages/node-client/lib/utils.ts
+++ b/packages/node-client/lib/utils.ts
@@ -1,6 +1,6 @@
 import os from 'os';
 
-import type { ProxyConfiguration, GetRecordsRequestConfig } from './types.js';
+import type { ProxyConfiguration, ListRecordsRequestConfig } from './types.js';
 import { NANGO_VERSION } from './version.js';
 
 /**
@@ -23,8 +23,8 @@ export const validateProxyConfiguration = (config: ProxyConfiguration) => {
  * @param config - Configuration object for fetching sync records
  * @throws If required parameters are missing in the configuration
  */
-export const validateSyncRecordConfiguration = (config: GetRecordsRequestConfig) => {
-    const requiredParams: (keyof GetRecordsRequestConfig)[] = ['model', 'providerConfigKey', 'connectionId'];
+export const validateSyncRecordConfiguration = (config: ListRecordsRequestConfig) => {
+    const requiredParams: (keyof ListRecordsRequestConfig)[] = ['model', 'providerConfigKey', 'connectionId'];
 
     requiredParams.forEach((param) => {
         if (typeof config[param] === 'undefined') {


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1658/desync-between-node-client-and-backend-type

- Sync record types with backend
- Remove deprecated non-working method


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new types for enhanced record management, including `RecordMetadata`, `RecordLastAction`, and `NangoRecord`.
  
- **Changes**
	- Removed the `getRecords` method to streamline record retrieval, encouraging the use of the `listRecords` method instead.
	- Eliminated the `GetRecordsRequestConfig` interface, indicating a shift in how records are requested within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->