### PR TITLE
fix(Netsuite): use expandSubResources to fetch all subentities

### DIFF
--- a/integration-templates/netsuite/actions/customer-create.ts
+++ b/integration-templates/netsuite/actions/customer-create.ts
@@ -45,7 +45,7 @@ export default async function runAction(nango: NangoAction, input: NetsuiteCusto
         body.defaultTaxReg = input.taxNumber;
     }
     if (Object.keys(address).length > 0) {
-        body.addressBook = { items: [address] };
+        body.addressBook = { items: [{ addressBookAddress: address }] };
     }
     const res = await nango.post({
         endpoint: '/customer',

--- a/integration-templates/netsuite/actions/customer-update.ts
+++ b/integration-templates/netsuite/actions/customer-update.ts
@@ -50,7 +50,7 @@ export default async function runAction(nango: NangoAction, input: NetsuiteCusto
         body.defaultTaxReg = input.taxNumber;
     }
     if (Object.keys(address).length > 0) {
-        body.addressBook = { items: [address] };
+        body.addressBook = { items: [{ addressBookAddress: address }] };
     }
 
     await nango.patch({

--- a/integration-templates/netsuite/actions/payment-create.ts
+++ b/integration-templates/netsuite/actions/payment-create.ts
@@ -17,7 +17,7 @@ export default async function runAction(nango: NangoAction, input: NetsuitePayme
         currency: { id: input.currency },
         tranId: input.paymentReference,
         status: { id: input.status },
-        apply: { items: input.applyTo.map((id) => ({ doc: id })) }
+        apply: { items: input.applyTo.map((id) => ({ doc: { id } })) }
     };
     if (input.description) {
         body.memo = input.description;

--- a/integration-templates/netsuite/actions/payment-update.ts
+++ b/integration-templates/netsuite/actions/payment-update.ts
@@ -30,7 +30,7 @@ export default async function runAction(nango: NangoAction, input: NetsuitePayme
         body.status = { id: input.status };
     }
     if (input.applyTo) {
-        body.apply = { items: input.applyTo.map((id) => ({ doc: id })) };
+        body.apply = { items: input.applyTo.map((id) => ({ doc: { id } })) };
     }
     if (input.description) {
         body.memo = input.description;

--- a/integration-templates/netsuite/syncs/credit-notes.ts
+++ b/integration-templates/netsuite/syncs/credit-notes.ts
@@ -15,7 +15,10 @@ export default async function fetchData(nango: NangoSync): Promise<void> {
         const mappedCreditNotes: NetsuiteCreditNote[] = [];
         for (const creditNoteLink of creditNotes) {
             const creditNote: NSAPI_GetResponse<NS_CreditNote> = await nango.get({
-                endpoint: `/creditmemo/${creditNoteLink.id}?expandSubResources=true`,
+                endpoint: `/creditmemo/${creditNoteLink.id}`,
+                params: {
+                    expandSubResources: 'true'
+                },
                 retries
             });
             if (!creditNote.data) {

--- a/integration-templates/netsuite/syncs/credit-notes.ts
+++ b/integration-templates/netsuite/syncs/credit-notes.ts
@@ -1,5 +1,5 @@
 import type { NangoSync, NetsuiteCreditNote, NetsuiteCreditNoteLine, ProxyConfiguration } from '../../models';
-import type { NS_CreditNote, NS_Item, NSAPI_GetResponse, NSAPI_GetResponses, NSAPI_Links } from '../types';
+import type { NS_CreditNote, NSAPI_GetResponse } from '../types';
 import { paginate } from '../helpers/pagination.js';
 
 const retries = 3;
@@ -15,7 +15,7 @@ export default async function fetchData(nango: NangoSync): Promise<void> {
         const mappedCreditNotes: NetsuiteCreditNote[] = [];
         for (const creditNoteLink of creditNotes) {
             const creditNote: NSAPI_GetResponse<NS_CreditNote> = await nango.get({
-                endpoint: `/creditmemo/${creditNoteLink.id}`,
+                endpoint: `/creditmemo/${creditNoteLink.id}?expandSubResources=true`,
                 retries
             });
             if (!creditNote.data) {
@@ -33,28 +33,17 @@ export default async function fetchData(nango: NangoSync): Promise<void> {
                 status: creditNote.data.status?.refName || ''
             };
 
-            const items: NSAPI_GetResponses<any> = await nango.get({
-                endpoint: `/creditmemo/${creditNoteLink.id}/item`,
-                retries
-            });
-            const itemIds = items.data.items.map((itemLink: NSAPI_Links) => {
-                return itemLink.links?.find((link) => link.rel === 'self')?.href?.match(/\/item\/(\d+)/)?.[1];
-            });
-            for (const itemId of itemIds) {
-                const item: NSAPI_GetResponse<NS_Item> = await nango.get({
-                    endpoint: `/creditmemo/${creditNoteLink.id}/item/${itemId}`,
-                    retries
-                });
+            for (const item of creditNote.data.item.items) {
                 const mappedCreditNoteLine: NetsuiteCreditNoteLine = {
-                    itemId: item.data.item?.id || '',
-                    quantity: item.data.quantity ? Number(item.data.quantity) : 0,
-                    amount: item.data.amount ? Number(item.data.amount) : 0
+                    itemId: item.item?.id || '',
+                    quantity: item.quantity ? Number(item.quantity) : 0,
+                    amount: item.amount ? Number(item.amount) : 0
                 };
-                if (item.data.taxDetailsReference) {
-                    mappedCreditNoteLine.vatCode = item.data.taxDetailsReference;
+                if (item.taxDetailsReference) {
+                    mappedCreditNoteLine.vatCode = item.taxDetailsReference;
                 }
-                if (item.data.item?.refName) {
-                    mappedCreditNoteLine.description = item.data.item?.refName;
+                if (item.item?.refName) {
+                    mappedCreditNoteLine.description = item.item?.refName;
                 }
                 mappedCreditNote.lines.push(mappedCreditNoteLine);
             }

--- a/integration-templates/netsuite/syncs/customers.ts
+++ b/integration-templates/netsuite/syncs/customers.ts
@@ -15,7 +15,10 @@ export default async function fetchData(nango: NangoSync): Promise<void> {
         const mappedCustomers: NetsuiteCustomer[] = [];
         for (const customerLink of customers) {
             const customer: NSAPI_GetResponse<NS_Customer> = await nango.get({
-                endpoint: `/customer/${customerLink.id}?expandSubResources=true`,
+                endpoint: `/customer/${customerLink.id}`,
+                params: {
+                    expandSubResources: 'true'
+                },
                 retries
             });
             if (!customer.data) {

--- a/integration-templates/netsuite/syncs/customers.ts
+++ b/integration-templates/netsuite/syncs/customers.ts
@@ -1,5 +1,5 @@
-import type { NangoSync, NetsuiteCustomer, NetsuiteAddress, ProxyConfiguration } from '../../models';
-import type { NS_Customer, NS_Address, NSAPI_GetResponse, NSAPI_GetResponses, NSAPI_Links } from '../types';
+import type { NangoSync, NetsuiteCustomer, ProxyConfiguration } from '../../models';
+import type { NS_Customer, NSAPI_GetResponse } from '../types';
 import { paginate } from '../helpers/pagination.js';
 
 const retries = 3;
@@ -15,73 +15,30 @@ export default async function fetchData(nango: NangoSync): Promise<void> {
         const mappedCustomers: NetsuiteCustomer[] = [];
         for (const customerLink of customers) {
             const customer: NSAPI_GetResponse<NS_Customer> = await nango.get({
-                endpoint: `/customer/${customerLink.id}`,
+                endpoint: `/customer/${customerLink.id}?expandSubResources=true`,
                 retries
             });
             if (!customer.data) {
                 await nango.log('Customer not found', { id: customerLink.id });
                 continue;
             }
-            const customerWithoutAddress = {
+            const address = customer.data.addressBook?.items[0]?.addressBookAddress;
+            mappedCustomers.push({
                 id: customer.data.id,
                 externalId: customer.data.externalId || null,
                 name: customer.data.companyName,
                 email: customer.data.email || null,
                 taxNumber: customer.data.defaultTaxReg || null,
-                phone: customer.data.phone || null
-            };
-            const address = await getAddress(customer.data.id, nango);
-
-            mappedCustomers.push({
-                ...customerWithoutAddress,
-                ...address
+                phone: customer.data.phone || null,
+                addressLine1: address?.addr1 || null,
+                addressLine2: address?.addr2 || null,
+                city: address?.city || null,
+                zip: address?.zip || null,
+                country: address?.country?.id || null,
+                state: address?.state?.id || null
             });
         }
 
         await nango.batchSave<NetsuiteCustomer>(mappedCustomers, 'NetsuiteCustomer');
-    }
-}
-
-async function getAddress(customerId: string, nango: NangoSync): Promise<NetsuiteAddress> {
-    const emptyAddress = {
-        addressLine1: null,
-        addressLine2: null,
-        city: null,
-        zip: null,
-        country: null,
-        state: null
-    };
-    try {
-        const addressBookRes: NSAPI_GetResponses<any> = await nango.get({
-            endpoint: `/customer/${customerId}/addressbook`,
-            retries
-        });
-
-        const addressBookIds = addressBookRes.data.items.map((addressLink: NSAPI_Links) => {
-            return addressLink.links?.find((link) => link.rel === 'self')?.href?.match(/\/addressBook\/(\d+)/)?.[1];
-        });
-
-        // NOTE: only first address is being used
-        if (addressBookIds.length > 0) {
-            const addressResponse: NSAPI_GetResponse<NS_Address> = await nango.get({
-                endpoint: `/customer/${customerId}/addressBook/${addressBookIds[0]}/addressBookAddress`,
-                retries
-            });
-
-            return {
-                addressLine1: addressResponse.data.addr1 || null,
-                addressLine2: addressResponse.data.addr2 || null,
-                city: addressResponse.data.city || null,
-                zip: addressResponse.data.zip || null,
-                country: addressResponse.data.country?.id || null,
-                state: addressResponse.data.state?.id || null
-            };
-        }
-        return emptyAddress;
-    } catch (error) {
-        // Note: not throwing error on address fetch failure
-        // as it is not critical for the customer data
-        await nango.log('Error fetching address', { customerId, error });
-        return emptyAddress;
     }
 }

--- a/integration-templates/netsuite/syncs/invoices.ts
+++ b/integration-templates/netsuite/syncs/invoices.ts
@@ -15,7 +15,10 @@ export default async function fetchData(nango: NangoSync): Promise<void> {
         const mappedInvoices: NetsuiteInvoice[] = [];
         for (const invoiceLink of invoices) {
             const invoice: NSAPI_GetResponse<NS_Invoice> = await nango.get({
-                endpoint: `/invoice/${invoiceLink.id}?expandSubResources=true`,
+                endpoint: `/invoice/${invoiceLink.id}`,
+                params: {
+                    expandSubResources: 'true'
+                },
                 retries
             });
             if (!invoice.data) {

--- a/integration-templates/netsuite/syncs/payments.ts
+++ b/integration-templates/netsuite/syncs/payments.ts
@@ -1,5 +1,5 @@
 import type { NangoSync, NetsuitePayment, ProxyConfiguration } from '../../models';
-import type { NS_Payment, NSAPI_GetResponse, NSAPI_GetResponses, NSAPI_Links } from '../types';
+import type { NS_Payment, NSAPI_GetResponse } from '../types';
 import { paginate } from '../helpers/pagination.js';
 
 const retries = 3;
@@ -15,21 +15,13 @@ export default async function fetchData(nango: NangoSync): Promise<void> {
         const mappedPayments: NetsuitePayment[] = [];
         for (const paymentLink of payments) {
             const payment: NSAPI_GetResponse<NS_Payment> = await nango.get({
-                endpoint: `/customerpayment/${paymentLink.id}`,
+                endpoint: `/customerpayment/${paymentLink.id}?expandSubResources=true`,
                 retries
             });
             if (!payment.data) {
                 await nango.log('Payment not found', { id: paymentLink.id });
                 continue;
             }
-            const apply: NSAPI_GetResponses<any> = await nango.get({
-                endpoint: `/customerpayment/${paymentLink.id}/apply`,
-                retries
-            });
-            const applyTo = apply.data.items.flatMap((applyLink: NSAPI_Links) => {
-                const doc = applyLink.links?.find((link) => link.rel === 'self')?.href?.match(/\/apply\/doc=(\d+)/)?.[1];
-                return doc ? [doc] : [];
-            });
             const mappedPayment: NetsuitePayment = {
                 id: payment.data.id,
                 createdAt: payment.data.tranDate || null,
@@ -38,7 +30,7 @@ export default async function fetchData(nango: NangoSync): Promise<void> {
                 currency: payment.data.currency?.refName || null,
                 paymentReference: payment.data.tranId || null,
                 status: payment.data.status?.id || null,
-                applyTo
+                applyTo: payment.data.apply?.items.map((item) => item.doc.id) || []
             };
             if (payment.data.memo) {
                 mappedPayment.description = payment.data.memo;

--- a/integration-templates/netsuite/syncs/payments.ts
+++ b/integration-templates/netsuite/syncs/payments.ts
@@ -15,7 +15,10 @@ export default async function fetchData(nango: NangoSync): Promise<void> {
         const mappedPayments: NetsuitePayment[] = [];
         for (const paymentLink of payments) {
             const payment: NSAPI_GetResponse<NS_Payment> = await nango.get({
-                endpoint: `/customerpayment/${paymentLink.id}?expandSubResources=true`,
+                endpoint: `/customerpayment/${paymentLink.id}`,
+                params: {
+                    expandSubResources: 'true'
+                },
                 retries
             });
             if (!payment.data) {

--- a/integration-templates/netsuite/types.ts
+++ b/integration-templates/netsuite/types.ts
@@ -2,18 +2,6 @@ export interface NSAPI_GetResponse<T> {
     data: T;
 }
 
-export interface NSAPI_GetResponses<T> {
-    data: {
-        items: T[];
-        hasMore: boolean;
-        links: NSAPI_Links;
-    };
-}
-
-export interface NSAPI_Links {
-    links: { rel?: string; href?: string }[];
-}
-
 export interface NS_Address {
     addr1?: string;
     addr2?: string;
@@ -22,6 +10,7 @@ export interface NS_Address {
     country?: { id: string };
     state?: { id: string };
 }
+
 export interface NS_Customer {
     id: string;
     externalId?: string;
@@ -30,7 +19,9 @@ export interface NS_Customer {
     defaultTaxReg?: string;
     phone?: string;
     addressBook: {
-        items: NS_Address[];
+        items: {
+            addressBookAddress: NS_Address;
+        }[];
     };
 }
 
@@ -105,6 +96,6 @@ export interface NS_Payment {
         refName?: string;
     };
     apply?: {
-        items: { doc: string }[];
+        items: { doc: { id: string } }[];
     };
 }


### PR DESCRIPTION
Using expandSubResources=true allows to save on a lot of extra requests and make the Netsuite syncs faster and more reliable

Note: like for the initial implementation I have tested the syncs but not the actions

https://linear.app/nango/issue/NAN-1657/netsuite-use-expandsubresources-query-parameter-to-avoid-multiple

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced data retrieval for credit notes, customers, invoices, and payments by including additional related resources in API requests.
	- Streamlined processing of customer addresses and payment applications, reducing the number of API calls and improving efficiency.

- **Bug Fixes**
	- Adjusted data structures for address and payment documents to ensure compatibility with external systems.

- **Documentation**
	- Updated TypeScript interfaces to reflect new data structures, improving clarity and robustness in data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->