### PR TITLE
fix(demo): reup fetch data

### DIFF
--- a/packages/server/lib/controllers/onboarding.controller.ts
+++ b/packages/server/lib/controllers/onboarding.controller.ts
@@ -252,31 +252,22 @@ class OnboardingController {
                 return;
             }
 
+            const syncCommandOption: Parameters<typeof syncManager.runSyncCommand>[0] = {
+                recordsService,
+                orchestrator,
+                environment,
+                providerConfigKey: DEMO_GITHUB_CONFIG_KEY,
+                syncNames: [DEMO_SYNC_NAME],
+                command: SyncCommand.UNPAUSE,
+                logContextGetter,
+                connectionId: req.body.connectionId,
+                initiator: 'demo'
+            };
             if (status.length <= 0) {
                 // If for any reason we don't have a sync, because of a partial state
                 logger.info(`[demo] no sync were found ${environment.id}`);
-                await syncManager.runSyncCommand({
-                    recordsService,
-                    orchestrator,
-                    environment,
-                    providerConfigKey: DEMO_GITHUB_CONFIG_KEY,
-                    syncNames: [DEMO_SYNC_NAME],
-                    command: SyncCommand.RUN_FULL,
-                    logContextGetter,
-                    connectionId: req.body.connectionId,
-                    initiator: 'demo'
-                });
-                await syncManager.runSyncCommand({
-                    recordsService,
-                    orchestrator,
-                    environment,
-                    providerConfigKey: DEMO_GITHUB_CONFIG_KEY,
-                    syncNames: [DEMO_SYNC_NAME],
-                    command: SyncCommand.UNPAUSE,
-                    logContextGetter,
-                    connectionId: req.body.connectionId,
-                    initiator: 'demo'
-                });
+                await syncManager.runSyncCommand({ ...syncCommandOption, command: SyncCommand.UNPAUSE });
+                await syncManager.runSyncCommand({ ...syncCommandOption, command: SyncCommand.RUN_FULL });
 
                 res.status(200).json({ retry: true });
                 return;
@@ -288,20 +279,11 @@ class OnboardingController {
                 return;
             }
 
-            if (!job.nextScheduledSyncAt && job.jobStatus === SyncStatus.PAUSED) {
+            if (!job.nextScheduledSyncAt && job.status === SyncStatus.PAUSED) {
                 // If the sync has never run
                 logger.info(`[demo] no job were found ${environment.id}`);
-                await syncManager.runSyncCommand({
-                    recordsService,
-                    orchestrator,
-                    environment,
-                    providerConfigKey: DEMO_GITHUB_CONFIG_KEY,
-                    syncNames: [DEMO_SYNC_NAME],
-                    command: SyncCommand.RUN_FULL,
-                    logContextGetter,
-                    connectionId: req.body.connectionId,
-                    initiator: 'demo'
-                });
+                await syncManager.runSyncCommand({ ...syncCommandOption, command: SyncCommand.UNPAUSE });
+                await syncManager.runSyncCommand({ ...syncCommandOption, command: SyncCommand.RUN_FULL });
             }
 
             if (job.jobStatus === SyncStatus.SUCCESS) {

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -253,7 +253,7 @@ export class SyncManagerService {
                 }
 
                 await orchestrator.runSyncCommand({
-                    syncId: sync?.id,
+                    syncId: sync.id,
                     command,
                     environmentId: environment.id,
                     logCtx,


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1645/fix-interactive-demo


- Fix demo was not fetching data anymore
`status` instead of `jobStatus` + unpause schedule before triggering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the construction and execution of synchronization commands, reducing redundancy and enhancing maintainability.
	- Updated job status check to streamline the conditional logic.

- **Bug Fixes**
	- Adjusted the handling of the `syncId` property to ensure it is accessed directly, improving control flow (note: this change may require validation of the `sync` object state).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->