### PR TITLE
chore: lower mininum frequency interval to 30s

### DIFF
--- a/packages/nango-yaml/lib/helpers.ts
+++ b/packages/nango-yaml/lib/helpers.ts
@@ -92,7 +92,7 @@ export function getInterval(runs: string, date: Date): IntervalResponse | Error 
         return new Error('sync_interval_invalid');
     }
 
-    if (ms(interval) < ms('5m')) {
+    if (ms(interval) < ms('30s')) {
         return new Error('sync_interval_too_short');
     }
 

--- a/packages/nango-yaml/lib/helpers.unit.test.ts
+++ b/packages/nango-yaml/lib/helpers.unit.test.ts
@@ -2,8 +2,8 @@ import { expect, describe, it } from 'vitest';
 import { getInterval, isJsOrTsType } from './helpers.js';
 
 describe('Nango Config Interval tests', () => {
-    it('throws error when interval is less than 5 minutes', () => {
-        const interval = getInterval('every 4m', new Date());
+    it('throws error when interval is less than 30 seconds', () => {
+        const interval = getInterval('every 20s', new Date());
         expect(interval).toStrictEqual(new Error('sync_interval_too_short'));
     });
 

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -764,7 +764,8 @@ class SyncController {
             if (frequency) {
                 const interval = getInterval(frequency, new Date());
                 if (interval instanceof Error) {
-                    res.status(400).send({ message: 'frequency must have a valid format (https://github.com/vercel/ms)' });
+                    const error = new NangoError(interval.message);
+                    res.status(400).send({ message: error.message });
                     return;
                 }
                 newFrequency = interval.interval;

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -753,7 +753,7 @@ export class Orchestrator {
             return Err(error);
         }
 
-        if (intervalMs < ms('5m')) {
+        if (intervalMs < ms('30s')) {
             const error = new NangoError('sync_interval_too_short');
             return Err(error);
         }

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -429,7 +429,7 @@ export class NangoError extends Error {
 
             case 'sync_interval_too_short':
                 this.status = 400;
-                this.message = 'Sync interval is too short. The minimum interval is 5 minutes.';
+                this.message = 'Sync interval is too short. The minimum interval is 30 seconds.';
                 break;
 
             case 'provider_not_on_account':

--- a/packages/webapp/src/pages/Integration/FlowPage.tsx
+++ b/packages/webapp/src/pages/Integration/FlowPage.tsx
@@ -200,6 +200,13 @@ export default function FlowPage(props: FlowPageProps) {
         let unit = '';
 
         switch (frequencyUnit) {
+            case 'seconds':
+            case 'second':
+            case 'secs':
+            case 'sec':
+            case 's':
+                unit = 'seconds';
+                break;
             case 'minutes':
             case 'minute':
             case 'min':
@@ -223,16 +230,16 @@ export default function FlowPage(props: FlowPageProps) {
 
         setModalConfirmationButton('primary');
 
-        if (unit === 'minutes' && parseInt(frequencyWithoutEvery) < 5) {
+        if (unit === 'seconds' && parseInt(frequencyWithoutEvery) < 30) {
             setModalTitle('Invalid frequency');
-            setModalContent('The minimum frequency is 5 minutes.');
+            setModalContent('The minimum frequency is 30 seconds.');
             setModalVisible(true);
             return;
         }
 
         if (unit === '') {
             setModalTitle('Invalid frequency unit');
-            setModalContent(`The unit "${frequencyUnit}" is not a valid time unit. Valid units are minutes, hours, and days.`);
+            setModalContent(`The unit "${frequencyUnit}" is not a valid time unit. Valid units are seconds, minutes, hours, and days.`);
             setModalVisible(true);
             return;
         }


### PR DESCRIPTION
## Describe your changes
We want to lower the minimum sync interval to 30s (instead of 5mins)

Note 1: when sync takes longer than frequency interval, a new execution is not started at the end of the interval but once the previous task is finished. Multiple intervals can be skipped

Note 2: people would need to upgrade their CLI because we validate the frequency from the nango.yaml client side

## Issue ticket number and link

https://linear.app/nango/issue/NAN-1668/lower-max-sync-frequency-to-30-seconds

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
