### PR TITLE
fix: show version in NPM publish github action title

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,5 @@
 name: '[Release] NPM publish'
+run-name: '[Release] NPM publish ${{ inputs.version }}'
 
 on:
     workflow_dispatch:


### PR DESCRIPTION
## Describe your changes
Showing the version in the github action title to make it easier to see which version was last published without having to click
