### PR TITLE
fix(api): wrong handling for createProvider return type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34760,36 +34760,10 @@
                 "acorn": "^8"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/agent-base": {
-            "version": "7.1.1",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/async": {
             "version": "3.2.6",
             "inBundle": true,
             "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/asynckit": {
-            "version": "0.4.0",
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/axios": {
-            "version": "1.7.7",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/cjs-module-lexer": {
             "version": "1.4.0",
@@ -34834,17 +34808,6 @@
             "dependencies": {
                 "color": "^3.1.3",
                 "text-hex": "1.0.x"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/combined-stream": {
-            "version": "1.0.8",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
             }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/crypto-randomuuid": {
@@ -34900,27 +34863,6 @@
                 "node": ">=18"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/debug": {
-            "version": "4.3.7",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/debug/node_modules/ms": {
-            "version": "2.1.3",
-            "inBundle": true,
-            "license": "MIT"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/delay": {
             "version": "5.0.0",
             "inBundle": true,
@@ -34930,14 +34872,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/detect-newline": {
@@ -34958,11 +34892,6 @@
             "inBundle": true,
             "license": "MIT"
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/exponential-backoff": {
-            "version": "3.1.1",
-            "inBundle": true,
-            "license": "Apache-2.0"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/fecha": {
             "version": "4.2.3",
             "inBundle": true,
@@ -34972,62 +34901,6 @@
             "version": "1.1.0",
             "inBundle": true,
             "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/follow-redirects": {
-            "version": "1.15.9",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/form-data": {
-            "version": "4.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/https-proxy-agent": {
-            "version": "7.0.4",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.0.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/ieee754": {
             "version": "1.2.1",
@@ -35162,25 +35035,6 @@
                 "node": ">=12"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/mime-db": {
-            "version": "1.52.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/mime-types": {
-            "version": "2.1.35",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/module-details-from-path": {
             "version": "1.0.3",
             "inBundle": true,
@@ -35294,11 +35148,6 @@
             "engines": {
                 "node": ">=12.0.0"
             }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "inBundle": true,
-            "license": "MIT"
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/readable-stream": {
             "version": "3.6.2",

--- a/packages/server/lib/controllers/config.controller.ts
+++ b/packages/server/lib/controllers/config.controller.ts
@@ -413,12 +413,12 @@ class ConfigController {
 
             const result = await configService.createProviderConfig(config);
 
-            if (Array.isArray(result) && result.length === 1 && result[0] != null && 'id' in result[0]) {
-                void analytics.track(AnalyticsTypes.CONFIG_CREATED, accountId, { provider: config.provider });
+            if (result) {
+                void analytics.track(AnalyticsTypes.CONFIG_CREATED, accountId, { provider: result.provider });
                 res.status(200).send({
                     config: {
-                        unique_key: config.unique_key,
-                        provider: config.provider
+                        unique_key: result.unique_key,
+                        provider: result.provider
                     }
                 });
             } else {


### PR DESCRIPTION
## Describe your changes

fixes https://linear.app/nango/issue/NAN-1682/create-provider-from-api-is-working-with-an-error

- The return type from  `configService.createProviderConfig` has changed but this place was still expecting the old return
I'm surprised Typescript does not complain more about typecasting something that is not possible, but I guess it's handy when you actually want it.
