### PR TITLE
fix(xero-auth): [nan-1684] handle multiple tenants

### DIFF
--- a/integration-templates/xero/helpers/get-tenant-id.ts
+++ b/integration-templates/xero/helpers/get-tenant-id.ts
@@ -7,8 +7,13 @@ export async function getTenantId(nango: NangoAction | NangoSync) {
         return connection.connection_config['tenant_id'];
     }
 
-    const tenants = await nango.get({
+    const connections = await nango.get({
         endpoint: 'connections'
     });
-    return tenants.data[0]['tenantId'];
+
+    if (connections.data.length === 1) {
+        return connections.data[0]['tenantId'];
+    } else {
+        throw new Error('Multiple tenants found. Please reauthenticate to set the tenant id.');
+    }
 }

--- a/packages/server/lib/hooks/connection/salesforce-post-connection.ts
+++ b/packages/server/lib/hooks/connection/salesforce-post-connection.ts
@@ -1,6 +1,8 @@
 import type { InternalNango as Nango } from './post-connection.js';
+import { getLogger } from '@nangohq/utils';
 
-export default function execute(nango: Nango) {
-    // TODO implementation later
-    console.log(nango);
+const logger = getLogger('post-connection:salesforce');
+
+export default function execute(_nango: Nango) {
+    logger.info('No post-connection logic needed for Salesforce');
 }

--- a/packages/server/lib/hooks/connection/xero-post-connection.ts
+++ b/packages/server/lib/hooks/connection/xero-post-connection.ts
@@ -2,6 +2,10 @@ import type { InternalNango as Nango } from './post-connection.js';
 import type { OAuth2Credentials } from '@nangohq/types';
 import jwt from 'jsonwebtoken';
 import { isAxiosError } from 'axios';
+import { getLogger } from '@nangohq/utils';
+import { z } from 'zod';
+
+const logger = getLogger('post-connection:xero');
 
 interface XeroConnection {
     id: string;
@@ -12,22 +16,24 @@ interface XeroConnection {
     updatedDateUtc: string;
 }
 
-interface XeroJWTPayload {
-    nbf: number;
-    exp: number;
-    iss: string;
-    aud: string;
-    client_id: string;
-    sub: string;
-    auth_time: number;
-    xero_userid: string;
-    global_session_id: string;
-    sid: string;
-    jti: string;
-    authentication_event_id: string;
-    scope: string[];
-    amr: string[];
-}
+const XeroJWTPayloadSchema = z.object({
+    payload: z.object({
+        nbf: z.number().optional(),
+        exp: z.number().optional(),
+        iss: z.string().optional(),
+        aud: z.string().optional(),
+        client_id: z.string().optional(),
+        sub: z.string().optional(),
+        auth_time: z.number().optional(),
+        xero_userid: z.string().optional(),
+        global_session_id: z.string().optional(),
+        sid: z.string().optional(),
+        jti: z.string().optional(),
+        authentication_event_id: z.string(),
+        scope: z.array(z.string()).optional(),
+        amr: z.array(z.string()).optional()
+    })
+});
 
 export default async function execute(nango: Nango) {
     const connection = await nango.getConnection();
@@ -51,19 +57,26 @@ export default async function execute(nango: Nango) {
         const credentials = connection.credentials as OAuth2Credentials;
         const token = credentials.access_token;
         const decoded = jwt.decode(token, { complete: true });
-        if (!decoded) {
+        if (!decoded || typeof decoded.payload === 'string') {
+            logger.info('Failed to decode JWT token or payload is a string. Skipping tenant_id update.');
             return;
         }
-        const payload = decoded.payload as XeroJWTPayload;
-        const authentication_event_id = payload.authentication_event_id;
-        const foundConnection = response.data.find((connection: XeroConnection) => connection.authEventId === authentication_event_id);
+        const decodedToken = XeroJWTPayloadSchema.safeParse(decoded);
+        if (decodedToken.success) {
+            const authentication_event_id = decodedToken.data.payload.authentication_event_id;
+            const foundConnection = response.data.find((connection: XeroConnection) => connection.authEventId === authentication_event_id);
 
-        if (foundConnection) {
-            await nango.updateConnectionConfig({ tenant_id: foundConnection['tenantId'] });
+            if (foundConnection) {
+                tenant_id = foundConnection['tenantId'];
+            }
+        } else {
+            logger.info('Failed to parse decoded JWT payload. Skipping tenant_id update.');
         }
     }
 
     if (tenant_id) {
         await nango.updateConnectionConfig({ tenant_id });
+    } else {
+        logger.info('No tenant_id found in response. Skipping tenant_id update.');
     }
 }

--- a/packages/server/lib/hooks/connection/xero-post-connection.ts
+++ b/packages/server/lib/hooks/connection/xero-post-connection.ts
@@ -1,19 +1,69 @@
 import type { InternalNango as Nango } from './post-connection.js';
+import type { OAuth2Credentials } from '@nangohq/types';
+import jwt from 'jsonwebtoken';
 import { isAxiosError } from 'axios';
+
+interface XeroConnection {
+    id: string;
+    authEventId: string;
+    tenantType: string;
+    tenantName: string;
+    createdDateUtc: string;
+    updatedDateUtc: string;
+}
+
+interface XeroJWTPayload {
+    nbf: number;
+    exp: number;
+    iss: string;
+    aud: string;
+    client_id: string;
+    sub: string;
+    auth_time: number;
+    xero_userid: string;
+    global_session_id: string;
+    sid: string;
+    jti: string;
+    authentication_event_id: string;
+    scope: string[];
+    amr: string[];
+}
 
 export default async function execute(nango: Nango) {
     const connection = await nango.getConnection();
+
     const response = await nango.proxy({
         endpoint: 'connections',
         connectionId: connection.connection_id,
         providerConfigKey: connection.provider_config_key
     });
 
-    if (isAxiosError(response) || !response || !response.data || response.data.length === 0 || !response.data[0].id) {
+    if (isAxiosError(response) || !response || !response.data || response.data.length === 0) {
         return;
     }
 
-    const tenant_id = response.data[0]['tenantId'];
+    let tenant_id = '';
 
-    await nango.updateConnectionConfig({ tenant_id });
+    if (response.data.length === 1) {
+        tenant_id = response.data[0]['tenantId'];
+    } else {
+        // decode the jwt to find the corresponding tenant if there are multiple
+        const credentials = connection.credentials as OAuth2Credentials;
+        const token = credentials.access_token;
+        const decoded = jwt.decode(token, { complete: true });
+        if (!decoded) {
+            return;
+        }
+        const payload = decoded.payload as XeroJWTPayload;
+        const authentication_event_id = payload.authentication_event_id;
+        const foundConnection = response.data.find((connection: XeroConnection) => connection.authEventId === authentication_event_id);
+
+        if (foundConnection) {
+            await nango.updateConnectionConfig({ tenant_id: foundConnection['tenantId'] });
+        }
+    }
+
+    if (tenant_id) {
+        await nango.updateConnectionConfig({ tenant_id });
+    }
 }


### PR DESCRIPTION
## Describe your changes
Xero allows for multiple organizations but in our post connection script we just grabbed the first one. Decode the JWT as described in https://developer.xero.com/documentation/guides/oauth2/pkce-flow/#5-check-the-tenants-youre-authorized-to-access to find the `authEventId` to use the appropriate tenant to set to the `connectionConfig`

## Issue ticket number and link
NAN-1684

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
