### PR TITLE
fix(proxy): file upload via multipart/form-data or application/octet-stream

### DIFF
--- a/packages/node-client/bin/proxy-octet-stream.js
+++ b/packages/node-client/bin/proxy-octet-stream.js
@@ -7,8 +7,6 @@ const nango = new Nango({ host: 'http://localhost:3003', secretKey: args[0] });
 const filePath = './test.pdf';
 const fileName = filePath.split('/').pop();
 const buffer = fs.readFileSync(filePath);
-const formData = new FormData();
-formData.append('file', new Blob([buffer]), fileName);
 
 nango
     .proxy({
@@ -16,10 +14,11 @@ nango
         connectionId: 'u',
         baseUrlOverride: 'http://localhost:3009',
         method: 'POST',
-        endpoint: '/upload/multipart',
-        data: formData,
+        endpoint: '/upload/octet-stream',
+        data: buffer,
         headers: {
-            'Content-Type': 'multipart/form-data'
+            'Content-Type': 'application/octet-stream',
+            'X-File-Name': fileName
         }
     })
     .then((response) => {

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -705,6 +705,10 @@ export class Nango {
             ...customPrefixedHeaders
         };
 
+        if (customHeaders?.['Content-Type']) {
+            headers['Content-Type'] = customHeaders['Content-Type'];
+        }
+
         if (retries) {
             headers['Retries'] = retries;
         }

--- a/packages/server/lib/controllers/proxy.controller.ts
+++ b/packages/server/lib/controllers/proxy.controller.ts
@@ -8,7 +8,7 @@ import url from 'url';
 import querystring from 'querystring';
 import type { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { backOff } from 'exponential-backoff';
-import type { HTTP_VERB, UserProvidedProxyConfiguration, InternalProxyConfiguration, ApplicationConstructedProxyConfiguration } from '@nangohq/shared';
+import type { HTTP_VERB, UserProvidedProxyConfiguration, InternalProxyConfiguration, ApplicationConstructedProxyConfiguration, File } from '@nangohq/shared';
 import { NangoError, LogActionEnum, errorManager, ErrorSourceEnum, proxyService, connectionService, configService, featureFlags } from '@nangohq/shared';
 import { metrics, getLogger, axiosInstance as axios, getHeaders } from '@nangohq/utils';
 import { logContextGetter } from '@nangohq/logs';
@@ -65,6 +65,10 @@ class ProxyController {
 
             const rawBodyFlag = await featureFlags.isEnabled('proxy:rawbody', 'global', false);
             const data = rawBodyFlag ? req.rawBody : req.body;
+            let files: File[] = [];
+            if (Array.isArray(req.files)) {
+                files = req.files as File[];
+            }
 
             const externalConfig: UserProvidedProxyConfiguration = {
                 endpoint,
@@ -72,6 +76,7 @@ class ProxyController {
                 connectionId,
                 retries: retries ? Number(retries) : 0,
                 data,
+                files,
                 headers,
                 baseUrlOverride,
                 decompress: decompress === 'true' ? true : false,

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -110,16 +110,18 @@ if (isTest) {
     webAuth = apiAuth;
 }
 
+const bodyLimit = '75mb';
 router.use(
     express.json({
-        limit: '75mb',
+        limit: bodyLimit,
         verify: (req: Request, _, buf) => {
             req.rawBody = buf.toString();
         }
     })
 );
-router.use(bodyParser.raw({ type: 'text/xml' }));
-router.use(express.urlencoded({ extended: true }));
+router.use(bodyParser.raw({ type: 'application/octet-stream', limit: bodyLimit }));
+router.use(bodyParser.raw({ type: 'text/xml', limit: bodyLimit }));
+router.use(express.urlencoded({ extended: true, limit: bodyLimit }));
 
 const upload = multer({ storage: multer.memoryStorage() });
 

--- a/packages/shared/lib/models/Proxy.ts
+++ b/packages/shared/lib/models/Proxy.ts
@@ -4,12 +4,25 @@ import type { BasicApiCredentials, ApiKeyCredentials, AppCredentials, TbaCredent
 import type { Connection } from './Connection.js';
 import type { Template as ProviderTemplate } from '@nangohq/types';
 
+export interface File {
+    fieldname: string;
+    originalname: string;
+    encoding: string;
+    mimetype: string;
+    size: number;
+    destination: string;
+    filename: string;
+    path: string;
+    buffer: Buffer;
+}
+
 interface BaseProxyConfiguration {
     providerConfigKey: string;
     connectionId: string;
     endpoint: string;
     retries?: number;
     data?: unknown;
+    files?: File[];
     headers?: Record<string, string>;
     params?: string | Record<string, string | number>;
     paramsSerializer?: ParamsSerializerOptions;

--- a/packages/shared/lib/services/proxy.service.ts
+++ b/packages/shared/lib/services/proxy.service.ts
@@ -170,6 +170,12 @@ class ProxyService {
             Object.keys(data as any).forEach((key) => {
                 formData.append(key, (data as any)[key]);
             });
+            for (const file of externalConfig.files || []) {
+                formData.append(file.fieldname, file.buffer, {
+                    filename: file.originalname,
+                    contentType: file.mimetype
+                });
+            }
 
             data = formData;
         }


### PR DESCRIPTION
- fixing /proxy to allow file upload with `Content-Type: multipart/form-data`
- adding support for uploading file in proxy with `Content-Type: application/octet-stream`
- fixing node client to upload file via `nango.proxy()`

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1473/enable-file-upload-with-nango-proxy

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
