### PR TITLE
fix(ui): correctly show v1 when there is no template

### DIFF
--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Endpoints/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Endpoints/Show.tsx
@@ -110,8 +110,6 @@ export const EndpointsShow: React.FC<{ integration: GetIntegration['Success']['d
         return null;
     }
 
-    console.log(v1Flow);
-
     return (
         <Routes>
             <Route path="/" element={<EndpointsList byGroup={byGroup} v1Flow={v1Flow} integration={integration} />} />

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Endpoints/components/List.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Endpoints/components/List.tsx
@@ -24,7 +24,7 @@ export const EndpointsList: React.FC<{ integration: GetIntegration['Success']['d
 }) => {
     const env = useStore((state) => state.env);
 
-    if (byGroup.length <= 0) {
+    if (byGroup.length <= 0 && v1Flow.length <= 0) {
         return (
             <EmptyState
                 title="No available endpoints"


### PR DESCRIPTION
## Describe your changes

- Correctly display v1 flows when there is no template at all 
I tested a mix of v1 and v2 , but it was displaying the empty state in case of only v1
