### PR TITLE
chore(migration): add sync_config_id column to sync_config table

### DIFF
--- a/packages/database/lib/migrations/20240910183251_sync_config_id.cjs
+++ b/packages/database/lib/migrations/20240910183251_sync_config_id.cjs
@@ -1,0 +1,31 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = function (knex) {
+    return knex.schema
+        .alterTable('_nango_syncs', function (table) {
+            table.integer('sync_config_id').unsigned().references('id').inTable('_nango_sync_configs').onDelete('CASCADE');
+        })
+        .then(() => {
+            return knex.raw(`
+            UPDATE _nango_syncs AS syncs
+            SET sync_config_id = sync_configs.id
+            FROM _nango_sync_configs AS sync_configs
+            JOIN _nango_connections AS connections ON sync_configs.nango_config_id = connections.config_id
+            WHERE syncs.name = sync_configs.sync_name
+              AND syncs.nango_connection_id = connections.id
+              AND sync_configs.environment_id = connections.environment_id
+              AND sync_configs.type = 'sync'
+              AND syncs.sync_config_id IS NULL;
+        `);
+        });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = function (knex) {
+    return knex.schema.alterTable('_nango_syncs', function (table) {
+        table.dropColumn('sync_config_id');
+    });
+};


### PR DESCRIPTION
linking sync_config from sync currently requires to check the connection table and match on connectionId, environmentId and syncName. Adding a sync_config_id foreign key to the sync table for more performant queries and easier debugging

Following PR is using this new column: https://github.com/NangoHQ/nango/pull/2712

There were actually a bug a couple of month ago that was caused by a missing join where fetching syncs: https://github.com/NangoHQ/nango/pull/2518/files. This change should make such bug less likely to happen.

## Issue ticket number and link

https://linear.app/nango/issue/NAN-1442/add-foreign-key-nango-syncs-nango-sync-configs

