### PR TITLE
chore: use new sync_config_id column in sync table

### DIFF
--- a/packages/jobs/lib/crons/autoIdleDemo.integration.test.ts
+++ b/packages/jobs/lib/crons/autoIdleDemo.integration.test.ts
@@ -71,8 +71,26 @@ describe('Auto Idle Demo', async () => {
             accountId: 0
         });
         const connection = conn[0]!.connection;
-        const sync = (await createSync(connection.id!, DEMO_SYNC_NAME))!;
         const now = new Date();
+        const syncConfig: SyncConfig = {
+            id: 1,
+            environment_id: env.id,
+            sync_name: DEMO_SYNC_NAME,
+            type: 'sync',
+            file_location: 'file_location',
+            nango_config_id: 1,
+            models: ['model'],
+            model_schema: [{ name: 'model', fields: [{ name: 'field', type: 'type' }] }],
+            active: true,
+            runs: 'runs',
+            track_deletes: false,
+            auto_start: false,
+            webhook_subscriptions: [],
+            enabled: true,
+            created_at: now,
+            updated_at: now
+        };
+        const sync = (await createSync(connection.id!, syncConfig))!;
         const scheduleName = `environment:${env.id}:sync:${sync.id}`;
         await orchestratorService.getClient().recurring({
             name: scheduleName,

--- a/packages/jobs/lib/crons/autoIdleDemo.integration.test.ts
+++ b/packages/jobs/lib/crons/autoIdleDemo.integration.test.ts
@@ -27,7 +27,7 @@ describe('Auto Idle Demo', async () => {
 
     it('should pause schedule', async () => {
         const connName = nanoid();
-        const config = await configService.createProviderConfig({
+        const providerConfig = await configService.createProviderConfig({
             unique_key: DEMO_GITHUB_CONFIG_KEY,
             provider: 'github',
             environment_id: env.id,
@@ -36,12 +36,14 @@ describe('Auto Idle Demo', async () => {
             created_at: new Date(),
             updated_at: new Date()
         });
-        await db.knex
+        if (!providerConfig) throw new Error('Config not created');
+
+        const [syncConfig] = await db.knex
             .from<SyncConfig>('_nango_sync_configs')
             .insert({
                 created_at: new Date(),
                 sync_name: DEMO_SYNC_NAME,
-                nango_config_id: config!.id!,
+                nango_config_id: providerConfig.id!,
                 file_location: '_LOCAL_FILE_',
                 version: '1',
                 models: ['GithubIssueDemo'],
@@ -60,7 +62,9 @@ describe('Auto Idle Demo', async () => {
                 is_public: false,
                 enabled: true
             })
-            .returning('id');
+            .returning('*');
+        if (!syncConfig) throw new Error('Sync config not created');
+
         const conn = await connectionService.upsertConnection({
             connectionId: connName,
             providerConfigKey: DEMO_GITHUB_CONFIG_KEY,
@@ -72,25 +76,9 @@ describe('Auto Idle Demo', async () => {
         });
         const connection = conn[0]!.connection;
         const now = new Date();
-        const syncConfig: SyncConfig = {
-            id: 1,
-            environment_id: env.id,
-            sync_name: DEMO_SYNC_NAME,
-            type: 'sync',
-            file_location: 'file_location',
-            nango_config_id: 1,
-            models: ['model'],
-            model_schema: [{ name: 'model', fields: [{ name: 'field', type: 'type' }] }],
-            active: true,
-            runs: 'runs',
-            track_deletes: false,
-            auto_start: false,
-            webhook_subscriptions: [],
-            enabled: true,
-            created_at: now,
-            updated_at: now
-        };
-        const sync = (await createSync(connection.id!, syncConfig))!;
+        const sync = await createSync(connection.id!, syncConfig);
+        if (!sync) throw new Error('Sync not created');
+
         const scheduleName = `environment:${env.id}:sync:${sync.id}`;
         await orchestratorService.getClient().recurring({
             name: scheduleName,

--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -326,48 +326,13 @@ async function seeds(records: UnencryptedRecordData[], trackDeletes: boolean) {
         throw new Error('Failed to create connection');
     }
 
-    const sync = await seeders.createSyncSeeds(connection.id, env.id);
-    if (!sync.id) {
-        throw new Error('Failed to create sync');
-    }
-
-    const config = await seeders.createConfigSeed(env, providerConfigKey, 'google');
-    if (!config?.id) {
-        throw new Error('Failed to create config');
-    }
-
-    const syncConfig: SyncConfig = {
-        id: Math.floor(Math.random() * 1000),
-        sync_name: sync.name,
-        file_location: '',
-        models: [model],
-        track_deletes: trackDeletes,
-        type: 'sync',
-        attributes: {},
-        is_public: false,
-        version: '0',
-        active: true,
-        auto_start: false,
-        enabled: true,
-        environment_id: env.id,
-        model_schema: [],
-        nango_config_id: config.id,
-        runs: '',
-        webhook_subscriptions: [],
-        created_at: new Date(),
-        updated_at: new Date()
-    };
-    const syncConfigIds = await db.knex
-        .from<SyncConfig>('_nango_sync_configs')
-        .insert(
-            [syncConfig].map((syncConfig) => {
-                return { ...syncConfig, model_schema: JSON.stringify(syncConfig.model_schema) as any };
-            })
-        )
-        .returning('id');
-    if (!syncConfigIds[0]) {
-        throw new Error('Failed to create sync config');
-    }
+    const { syncConfig, sync } = await seeders.createSyncSeeds({
+        connectionId: connection.id,
+        envId: env.id,
+        providerConfigKey,
+        trackDeletes,
+        models: [model]
+    });
 
     const job = await seeders.createSyncJobSeeds(sync.id);
     if (!job.id) {

--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -326,7 +326,7 @@ async function seeds(records: UnencryptedRecordData[], trackDeletes: boolean) {
         throw new Error('Failed to create connection');
     }
 
-    const sync = await seeders.createSyncSeeds(connection.id);
+    const sync = await seeders.createSyncSeeds(connection.id, env.id);
     if (!sync.id) {
         throw new Error('Failed to create sync');
     }

--- a/packages/server/lib/controllers/v1/flows/id/patchFrequency.ts
+++ b/packages/server/lib/controllers/v1/flows/id/patchFrequency.ts
@@ -55,7 +55,7 @@ export const patchFlowFrequency = asyncWrapper<PatchFlowFrequency>(async (req, r
         return;
     }
 
-    const syncs = await getSyncsBySyncConfigId(valParams.data.id);
+    const syncs = await getSyncsBySyncConfigId(environment.id, valParams.data.id);
     for (const sync of syncs) {
         const updated = await orchestrator.updateSyncFrequency({
             syncId: sync.id,

--- a/packages/server/lib/controllers/v1/flows/id/patchFrequency.ts
+++ b/packages/server/lib/controllers/v1/flows/id/patchFrequency.ts
@@ -55,7 +55,7 @@ export const patchFlowFrequency = asyncWrapper<PatchFlowFrequency>(async (req, r
         return;
     }
 
-    const syncs = await getSyncsBySyncConfigId(environment.id, valParams.data.id);
+    const syncs = await getSyncsBySyncConfigId(valParams.data.id);
     for (const sync of syncs) {
         const updated = await orchestrator.updateSyncFrequency({
             syncId: sync.id,

--- a/packages/shared/lib/models/Sync.ts
+++ b/packages/shared/lib/models/Sync.ts
@@ -38,6 +38,7 @@ export interface Sync extends TimestampsAndDeleted {
     };
     frequency: string | null;
     last_fetched_at: Date | null;
+    sync_config_id: number;
 }
 
 export interface Action extends TimestampsAndDeleted {

--- a/packages/shared/lib/seeders/sync.seeder.ts
+++ b/packages/shared/lib/seeders/sync.seeder.ts
@@ -1,10 +1,48 @@
 import db from '@nangohq/database';
 import * as syncService from '../services/sync/sync.service.js';
-import type { Sync } from '../models/Sync.js';
+import configService from '../services/config.service.js';
+import type { Sync, SyncConfig } from '../models/Sync.js';
 
-export const createSyncSeeds = async (connectionId = 1): Promise<Sync> => {
-    const syncName = Math.random().toString(36).substring(7);
-    return (await syncService.createSync(connectionId, syncName)) as Sync;
+export const createSyncSeeds = async (connectionId: number, envId: number): Promise<Sync> => {
+    const now = new Date();
+    const providerConfig = await configService.createProviderConfig({
+        unique_key: Math.random().toString(36).substring(7),
+        provider: Math.random().toString(36).substring(7),
+        environment_id: envId,
+        oauth_client_id: '',
+        oauth_client_secret: '',
+        created_at: now,
+        updated_at: now
+    });
+    if (!providerConfig) throw new Error('Provider config not created');
+
+    const [syncConfig] = await db.knex
+        .from<SyncConfig>(`_nango_sync_configs`)
+        .insert({
+            environment_id: envId,
+            sync_name: Math.random().toString(36).substring(7),
+            type: 'sync',
+            file_location: 'file_location',
+            nango_config_id: providerConfig.id,
+            version: '1',
+            active: true,
+            runs: 'runs',
+            track_deletes: false,
+            auto_start: false,
+            webhook_subscriptions: [],
+            enabled: true,
+            created_at: now,
+            updated_at: now,
+            models: ['model'],
+            model_schema: []
+        } as SyncConfig)
+        .returning('*');
+    if (!syncConfig) throw new Error('Sync config not created');
+
+    const sync = await syncService.createSync(connectionId, syncConfig);
+    if (!sync) throw new Error('Sync not created');
+
+    return sync;
 };
 
 export const deleteAllSyncSeeds = async (): Promise<void> => {

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -370,12 +370,13 @@ export const findSyncByConnections = async (connectionIds: number[], sync_name: 
     return [];
 };
 
-export const getSyncsBySyncConfigId = async (syncConfigId: number): Promise<Sync[]> => {
+export const getSyncsBySyncConfigId = async (environmentId: number, syncConfigId: number): Promise<Sync[]> => {
     const results = await schema()
         .select('sync_name', `${TABLE}.id`)
         .from<Sync>(TABLE)
         .join(SYNC_CONFIG_TABLE, `${TABLE}.sync_config_id`, `${SYNC_CONFIG_TABLE}.id`)
         .where({
+            [`${SYNC_CONFIG_TABLE}.environment_id`]: environmentId,
             [`${SYNC_CONFIG_TABLE}.id`]: syncConfigId,
             [`${TABLE}.deleted`]: false,
             [`${SYNC_CONFIG_TABLE}.deleted`]: false,

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import db, { schema, dbNamespace } from '@nangohq/database';
-import type { Sync, Job as SyncJob } from '../../models/Sync.js';
+import type { Sync, SyncConfig, Job as SyncJob } from '../../models/Sync.js';
 import { SyncStatus } from '../../models/Sync.js';
 import type { Connection, NangoConnection } from '../../models/Connection.js';
 import type { ActiveLogIds, IncomingFlowConfig, SlimAction, SlimSync, SyncAndActionDifferences, SyncTypeLiteral } from '@nangohq/types';
@@ -21,7 +21,6 @@ const TABLE = dbNamespace + 'syncs';
 const SYNC_JOB_TABLE = dbNamespace + 'sync_jobs';
 const SYNC_CONFIG_TABLE = dbNamespace + 'sync_configs';
 const ACTIVE_LOG_TABLE = dbNamespace + 'active_logs';
-const CONNECTIONS_TABLE = dbNamespace + 'connections';
 
 /**
  * Sync Service
@@ -48,20 +47,21 @@ export const getById = async (id: string): Promise<Sync | null> => {
     return result[0];
 };
 
-export const createSync = async (nangoConnectionId: number, name: string): Promise<Sync | null> => {
-    const existingSync = await getSyncByIdAndName(nangoConnectionId, name);
+export const createSync = async (nangoConnectionId: number, syncConfig: SyncConfig): Promise<Sync | null> => {
+    const existingSync = await getSyncByIdAndName(nangoConnectionId, syncConfig.sync_name);
 
-    if (existingSync) {
+    if (existingSync || !syncConfig.id) {
         return null;
     }
 
     const sync: Omit<Sync, 'created_at' | 'updated_at'> = {
         id: uuidv4(),
         nango_connection_id: nangoConnectionId,
-        name,
+        name: syncConfig.sync_name,
         frequency: null,
         last_sync_date: null,
-        last_fetched_at: null
+        last_fetched_at: null,
+        sync_config_id: syncConfig.id
     };
 
     const result = await schema().from<Sync>(TABLE).insert(sync).returning('*');
@@ -370,18 +370,12 @@ export const findSyncByConnections = async (connectionIds: number[], sync_name: 
     return [];
 };
 
-export const getSyncsBySyncConfigId = async (environmentId: number, syncConfigId: number): Promise<Sync[]> => {
+export const getSyncsBySyncConfigId = async (syncConfigId: number): Promise<Sync[]> => {
     const results = await schema()
         .select('sync_name', `${TABLE}.id`)
         .from<Sync>(TABLE)
-        // Sync table doesn't have a unique foreign key to sync config
-        // so we need to join on the name
-        // and verify the sync connection environment
-        .join(SYNC_CONFIG_TABLE, `${TABLE}.name`, `${SYNC_CONFIG_TABLE}.sync_name`)
-        .join(CONNECTIONS_TABLE, `${CONNECTIONS_TABLE}.id`, `${TABLE}.nango_connection_id`)
+        .join(SYNC_CONFIG_TABLE, `${TABLE}.sync_config_id`, `${SYNC_CONFIG_TABLE}.id`)
         .where({
-            [`${CONNECTIONS_TABLE}.environment_id`]: environmentId,
-            [`${SYNC_CONFIG_TABLE}.environment_id`]: environmentId,
             [`${SYNC_CONFIG_TABLE}.id`]: syncConfigId,
             [`${TABLE}.deleted`]: false,
             [`${SYNC_CONFIG_TABLE}.deleted`]: false,
@@ -625,9 +619,7 @@ export async function findDemoSyncs(): Promise<PausableSyncs[]> {
             );
         })
         .join('_nango_sync_configs', function () {
-            this.on('_nango_sync_configs.environment_id', '_nango_environments.id')
-                .on('_nango_sync_configs.nango_config_id', '_nango_configs.id')
-                .on('_nango_sync_configs.sync_name', '_nango_syncs.name')
+            this.on('_nango_sync_configs.id', '_nango_syncs.sync_config_id')
                 .onVal('_nango_sync_configs.type', 'sync')
                 .onVal('_nango_sync_configs.deleted', false)
                 .onVal('_nango_sync_configs.active', true);


### PR DESCRIPTION
## Describe your changes

Follow up of https://github.com/NangoHQ/nango/pull/2711

## Issue ticket number and link

https://linear.app/nango/issue/NAN-1442/add-foreign-key-nango-syncs-nango-sync-configs

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
