### PR TITLE
fix: allow special characters in provider config key

### DIFF
--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -6,7 +6,7 @@ export const providerSchema = z
     .max(255);
 export const providerConfigKeySchema = z
     .string()
-    .regex(/^[a-zA-Z0-9_-]+$/)
+    .regex(/^[a-zA-Z0-9~:.@ _-]+$/) // For legacy reason (some people are using special characters)
     .max(255);
 export const scriptNameSchema = z
     .string()


### PR DESCRIPTION
for legacy reason some customers use special chars in their provider config key

Characters have been identified running the following sql query against the prod replica db
```
SELECT DISTINCT unnest(string_to_array(provider_config_key, NULL)) AS unique_character
FROM nango._nango_connections
WHERE provider_config_key IS NOT NULL
ORDER BY unique_character;
```