### PR TITLE
fix: axios error request method can be undefined

### DIFF
--- a/packages/server/lib/controllers/proxy.controller.ts
+++ b/packages/server/lib/controllers/proxy.controller.ts
@@ -420,7 +420,7 @@ class ProxyController {
         logCtx: LogContext
     ) {
         const safeHeaders = proxyService.stripSensitiveHeaders(config.headers, config);
-        await logCtx.http(`${error.request?.method.toUpperCase()} ${url} failed with status '${error.response?.status}'`, {
+        await logCtx.http(`${config.method.toUpperCase()} ${url} failed with status '${error.response?.status}'`, {
             meta: {
                 content: errorContent
             },


### PR DESCRIPTION
## Describe your changes

Proxy controller reportError function is crashing when axios error request method is undefined
https://dashboard.render.com/web/srv-cfifsvha6gdq1k7u46a0/logs?r=2024-09-12%4012%3A44%3A18%7E2024-09-12%4013%3A04%3A18&c=8a4f02be-5a19-46e4-8d80-fe88c1c2fabf&p=2024-09-12T12%3A54%3A18.068Z
With this change we don't rely on the axios error request but use the proxy config instead
