### PR TITLE
chore(requestLoggerMiddleware): log body when error

### DIFF
--- a/packages/utils/lib/express/requestLoggerMiddleware.ts
+++ b/packages/utils/lib/express/requestLoggerMiddleware.ts
@@ -4,13 +4,20 @@ import colors from '@colors/colors';
 
 export function requestLoggerMiddleware({ logger }: { logger: Logger }): Handler {
     return (req, res, next) => {
+        let resBody: any;
+        const originalSend = res.send;
+        res.send = function (body: any) {
+            resBody = body;
+            originalSend.call(this, body);
+            return this;
+        };
         res.on('finish', () => {
             const route = req.route?.path || req.originalUrl;
             const msg = `${req.method} ${route} -> ${res.statusCode}`;
             if (res.statusCode >= 500) {
-                logger.error(colors.red(msg));
+                logger.error(colors.red(msg), resBody);
             } else if (res.statusCode >= 400) {
-                logger.warning?.(colors.yellow(msg));
+                logger.warning?.(colors.yellow(msg), resBody);
             } else {
                 logger.info(msg);
             }


### PR DESCRIPTION
## Describe your changes

It is currently hard to debug errors from orchestrator or persist services because we only log the status code. This commit adds the body to the log when status < 400
