### PR TITLE
chore: add index for sync_config_id column in sync table

### DIFF
--- a/packages/database/lib/migrations/20240912210952_index_sync_config_id_sync.cjs
+++ b/packages/database/lib/migrations/20240912210952_index_sync_config_id_sync.cjs
@@ -1,0 +1,18 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex, _) {
+    await knex.schema.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_sync_config_id_where_deleted"
+            ON "_nango_syncs" USING BTREE ("sync_config_id")
+            WHERE deleted = false`
+    );
+};
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex, _) {
+    await knex.schema.raw('DROP INDEX CONCURRENTLY IF EXISTS idx_sync_config_id_where_deleted');
+};


### PR DESCRIPTION
## Describe your changes
I have added the `sync_config_id` column to the `sync` table earlier this week but I forgot to add an index to make the join with `sync_config_table` faster
