### PR TITLE
fix(github-app-oauth): [nan-1733] GitHub app missing secret and update iss in case the app-id is missing

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1302,6 +1302,10 @@ class ConnectionService {
             iss: (config?.custom ? config.custom['app_id'] : config.oauth_client_id) as string
         };
 
+        if (!payload['iss'] && connectionConfig['app_id']) {
+            payload['iss'] = connectionConfig['app_id'];
+        }
+
         const { success, error, response: rawCredentials } = await this.getJWTCredentials(privateKey, tokenUrl, payload, headers, { algorithm: 'RS256' });
 
         if (!success || !rawCredentials) {

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/General.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/General.tsx
@@ -15,7 +15,7 @@ import SecretInput from '../../../../../components/ui/input/SecretInput';
 import type { EnvironmentAndAccount } from '@nangohq/server';
 
 export const SettingsGeneral: React.FC<{ data: GetIntegration['Success']['data']; environment: EnvironmentAndAccount['environment'] }> = ({
-    data: { integration, template },
+    data: { integration, meta, template },
     environment
 }) => {
     const { toast } = useToast();
@@ -102,8 +102,18 @@ export const SettingsGeneral: React.FC<{ data: GetIntegration['Success']['data']
                         <CopyButton text={`${environment.webhook_receive_url}/${integration.unique_key}`} />
                     </InfoBloc>
 
+                    {meta.webhookSecret && (
+                        <InfoBloc
+                            title="Webhook Secret"
+                            help={<p>Input this secret into the &quot;Webhook secret (optional)&quot; field in the Webhook section</p>}
+                        >
+                            <div>{meta.webhookSecret}</div>
+                            <CopyButton text={meta.webhookSecret} />
+                        </InfoBloc>
+                    )}
+
                     {template.webhook_user_defined_secret && (
-                        <InfoBloc title="Webhook Secret" help={<p>`Obtain the Webhook Secret from on the developer portal of the Integration Provider</p>}>
+                        <InfoBloc title="Webhook Secret" help={<p>Obtain the Webhook Secret from on the developer portal of the Integration Provider</p>}>
                             <SecretInput
                                 copy={true}
                                 id="incoming_webhook_secret"


### PR DESCRIPTION
## Describe your changes
The webhook secret was missing in the case of a Github App. Fallback to the connectionConfig value for app_id if missing in the config.

## Issue ticket number and link
NAN-1733

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
