### PR TITLE
fix(sdk): handle circular json in log()

### DIFF
--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -14,7 +14,7 @@ import type { SyncConfig } from '../models/Sync.js';
 import type { RunnerFlags } from '../services/sync/run.utils.js';
 import { validateData } from './dataValidation.js';
 import { NangoError } from '../utils/error.js';
-import { stringifyAndTruncateLog } from './utils.js';
+import { stringifyAndTruncateLog, stringifyObject } from './utils.js';
 import type { DBTeam, MessageRowInsert } from '@nangohq/types';
 
 const logger = getLogger('SDK');
@@ -824,10 +824,10 @@ export class NangoAction {
                             Authorization: `Bearer ${this.nango.secretKey}`,
                             'Content-Type': 'application/json'
                         },
-                        data: {
+                        data: stringifyObject({
                             activityLogId: this.activityLogId,
                             log
-                        }
+                        })
                     });
                 },
                 { retry: httpRetryStrategy }

--- a/packages/shared/lib/sdk/sync.unit.test.ts
+++ b/packages/shared/lib/sdk/sync.unit.test.ts
@@ -457,24 +457,25 @@ describe('Log', () => {
         await nangoAction.log('hello', { level: 'error' });
 
         expect(mock).toHaveBeenCalledWith({
-            data: {
-                activityLogId: '1',
-                log: {
-                    type: 'log',
-                    level: 'error',
-                    message: 'hello',
-                    createdAt: expect.any(String),
-                    environmentId: 1,
-                    meta: null,
-                    source: 'user'
-                }
-            },
+            data: expect.any(String),
             headers: {
                 Authorization: 'Bearer ***',
                 'Content-Type': 'application/json'
             },
             method: 'POST',
             url: '/environment/1/log'
+        });
+        expect(JSON.parse((mock.mock.calls as any)[0][0].data)).toStrictEqual({
+            activityLogId: '1',
+            log: {
+                type: 'log',
+                level: 'error',
+                message: 'hello',
+                createdAt: expect.any(String),
+                environmentId: 1,
+                meta: null,
+                source: 'user'
+            }
         });
     });
 

--- a/packages/shared/lib/sdk/utils.ts
+++ b/packages/shared/lib/sdk/utils.ts
@@ -1,5 +1,22 @@
 import safeStringify from 'fast-safe-stringify';
 
+export function stringifyObject(value: any): string {
+    return safeStringify.stableStringify(
+        value,
+        (key, value) => {
+            if (value instanceof Buffer || key === '_sessionCache') {
+                return '[Buffer]';
+            }
+            if (key === 'Authorization') {
+                return '[Redacted]';
+            }
+            return value;
+        },
+        undefined,
+        { depthLimit: 10, edgesLimit: 20 }
+    );
+}
+
 export function stringifyAndTruncateLog(value: any, maxSize: number = 99_000): string {
     if (value === null) {
         return 'null';
@@ -8,7 +25,7 @@ export function stringifyAndTruncateLog(value: any, maxSize: number = 99_000): s
         return 'undefined';
     }
 
-    let msg = typeof value === 'string' ? value : safeStringify.stableStringify(value, undefined, undefined, { depthLimit: 10, edgesLimit: 20 });
+    let msg = typeof value === 'string' ? value : stringifyObject(value);
 
     if (msg && msg.length > maxSize) {
         msg = `${msg.substring(0, maxSize)}... (truncated)`;

--- a/packages/shared/lib/sdk/utils.unit.test.ts
+++ b/packages/shared/lib/sdk/utils.unit.test.ts
@@ -31,8 +31,22 @@ describe('stringifyAndTruncateLog', () => {
         const str = stringifyAndTruncateLog({ foo: 1 });
         expect(str).toStrictEqual('{"foo":1}');
     });
+
     it('should handle array', () => {
         const str = stringifyAndTruncateLog([{ foo: 1 }, 2]);
         expect(str).toStrictEqual('[{"foo":1},2]');
+    });
+
+    it('should handle circular', () => {
+        const obj: Record<string, any> = { foo: 'bar' };
+        obj['circular'] = obj;
+        const str = stringifyAndTruncateLog(obj);
+        expect(str).toStrictEqual('{"circular":"[Circular]","foo":"bar"}');
+    });
+
+    it('should redac know keys', () => {
+        const obj: Record<string, any> = { Authorization: 'super secret key' };
+        const str = stringifyAndTruncateLog(obj);
+        expect(str).toStrictEqual('{"Authorization":"[Redacted]"}');
     });
 });

--- a/packages/shared/lib/sdk/utils.unit.test.ts
+++ b/packages/shared/lib/sdk/utils.unit.test.ts
@@ -44,7 +44,7 @@ describe('stringifyAndTruncateLog', () => {
         expect(str).toStrictEqual('{"circular":"[Circular]","foo":"bar"}');
     });
 
-    it('should redac know keys', () => {
+    it('should redac known keys', () => {
         const obj: Record<string, any> = { Authorization: 'super secret key' };
         const str = stringifyAndTruncateLog(obj);
         expect(str).toStrictEqual('{"Authorization":"[Redacted]"}');


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1735/log-do-not-work-with-circular-ref

- Correctly handle circular ref in json when calling `log()`
It was previously not an issue because we were stringify everything in the message which already handled the circular ref. But now we have split both usage and let axios handle stringification, which apparently doesn't work. 

- Also took the opportunity to redac Authorization header 