### PR TITLE
fix(syncs table): sync_config_id must be updated when new deploy

### DIFF
--- a/packages/database/lib/migrations/20240916181552_fix_sync_sync_config_id.cjs
+++ b/packages/database/lib/migrations/20240916181552_fix_sync_sync_config_id.cjs
@@ -1,0 +1,25 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = function (knex) {
+    // when the sync_config_id column was introduced,
+    // it was populated with the correct values
+    // however the sync_config_id must be updated every time a new version of a sync config is created
+    // this migration will fix the sync_config_id column for all existing syncs
+    return knex.raw(`
+            UPDATE _nango_syncs AS syncs
+            SET sync_config_id = sync_configs.id
+            FROM _nango_sync_configs AS sync_configs
+            JOIN _nango_connections AS connections ON sync_configs.nango_config_id = connections.config_id
+            WHERE syncs.name = sync_configs.sync_name
+              AND syncs.nango_connection_id = connections.id
+              AND sync_configs.environment_id = connections.environment_id
+              AND sync_configs.type = 'sync'
+              AND sync_configs.active = true;
+        `);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = function () {};


### PR DESCRIPTION
I introduced a bug last week when adding the `sync_config_id` column to the `syncs` table. The value is set when a sync is created and never changes. However each time a sync definition is deployed (or prebuild templates are upgraded) a new version of the `sync_config` is added but the `sync.sync_config_id` is currently not updated and keep pointing to the same `sync_config` that is now inactive.

Impact: This new `sync_config_id` is only used by the patch frequency endpoint and demo auto idle feature for now but the bug should be fixed asap

This commit is ensuring that sync_config_id in syncs table is updated on deploy/upgrade as well as fixing the drift of `sync_config_id` values in the db
