### PR TITLE
docs: typo in self-hosting instructions

### DIFF
--- a/docs-v2/host/self-host/self-hosting-instructions.mdx
+++ b/docs-v2/host/self-host/self-hosting-instructions.mdx
@@ -129,7 +129,7 @@ You can disable telemetry by setting the env var `TELEMETRY=false` (in the
 ## Logs[](#logs 'Direct link to Logs')
 
 We use Elasticsearch to store Nango's execution logs and power the logs UI.
-To limit the requirements to self-host, this stack is optional and up to the developper to setup.
+To limit the requirements to self-host, this stack is optional and up to the developer to setup.
 
 If you want to enable logs, you will need to:
 - Host an Elasticsearch cluster


### PR DESCRIPTION
## Describe your changes
Documentation typo fix
