### PR TITLE
feat: make connectionId optional when creating a new connection

### DIFF
--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -253,12 +253,9 @@ class ConnectionController {
     async createConnection(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
         try {
             const { environment, account } = res.locals;
-            const { connection_id, provider_config_key, metadata, connection_config } = req.body;
+            const { provider_config_key, metadata, connection_config } = req.body;
 
-            if (!connection_id) {
-                errorManager.errRes(res, 'missing_connection');
-                return;
-            }
+            const connectionId = (req.body['connection_id'] as string) || connectionService.generateConnectionId();
 
             if (!provider_config_key) {
                 errorManager.errRes(res, 'missing_provider_config');
@@ -359,7 +356,7 @@ class ConnectionController {
                 };
 
                 const [imported] = await connectionService.importOAuthConnection({
-                    connectionId: connection_id,
+                    connectionId,
                     providerConfigKey: provider_config_key,
                     provider: providerName,
                     metadata,
@@ -422,7 +419,7 @@ class ConnectionController {
                 };
 
                 const [imported] = await connectionService.importOAuthConnection({
-                    connectionId: connection_id,
+                    connectionId,
                     providerConfigKey: provider_config_key,
                     provider: providerName,
                     metadata,
@@ -471,7 +468,7 @@ class ConnectionController {
                 };
 
                 const [imported] = await connectionService.importOAuthConnection({
-                    connectionId: connection_id,
+                    connectionId,
                     providerConfigKey: provider_config_key,
                     provider: providerName,
                     metadata,
@@ -513,7 +510,7 @@ class ConnectionController {
                     );
                 };
                 const [imported] = await connectionService.importApiAuthConnection({
-                    connectionId: connection_id,
+                    connectionId,
                     providerConfigKey: provider_config_key,
                     provider: providerName,
                     metadata,
@@ -555,7 +552,7 @@ class ConnectionController {
                 };
 
                 const [imported] = await connectionService.importApiAuthConnection({
-                    connectionId: connection_id,
+                    connectionId,
                     providerConfigKey: provider_config_key,
                     provider: providerName,
                     metadata,
@@ -602,7 +599,7 @@ class ConnectionController {
                 }
 
                 const [imported] = await connectionService.upsertConnection({
-                    connectionId: connection_id,
+                    connectionId,
                     providerConfigKey: provider_config_key,
                     provider: providerName,
                     parsedRawCredentials: credentials as unknown as AuthCredentials,
@@ -650,7 +647,7 @@ class ConnectionController {
                 }
 
                 const [imported] = await connectionService.upsertTbaConnection({
-                    connectionId: connection_id,
+                    connectionId,
                     providerConfigKey: provider_config_key,
                     credentials: tbaCredentials,
                     connectionConfig: {
@@ -670,7 +667,7 @@ class ConnectionController {
                 }
             } else if (provider.auth_mode === 'NONE') {
                 const [imported] = await connectionService.upsertUnauthConnection({
-                    connectionId: connection_id,
+                    connectionId,
                     providerConfigKey: provider_config_key,
                     provider: providerName,
                     environment,
@@ -702,7 +699,10 @@ class ConnectionController {
                 );
             }
 
-            res.status(201).send(req.body);
+            res.status(201).send({
+                ...req.body,
+                connection_id: connectionId
+            });
         } catch (err) {
             next(err);
         }

--- a/packages/server/lib/utils/hmac.ts
+++ b/packages/server/lib/utils/hmac.ts
@@ -14,7 +14,7 @@ export async function hmacCheck({
     environment: DBEnvironment;
     logCtx: LogContext;
     providerConfigKey: string;
-    connectionId: string;
+    connectionId: string | undefined;
     hmac: string | undefined;
     res: Response;
 }) {
@@ -28,7 +28,7 @@ export async function hmacCheck({
 
             return;
         }
-        const verified = await hmacService.verify(hmac, environment.id, providerConfigKey, connectionId);
+        const verified = await hmacService.verify(hmac, environment.id, providerConfigKey, ...(connectionId ? [connectionId] : []));
         if (!verified) {
             await logCtx.error('Invalid HMAC');
             await logCtx.failed();

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -55,6 +55,7 @@ import { CONNECTIONS_WITH_SCRIPTS_CAP_LIMIT } from '../constants.js';
 import type { Orchestrator } from '../clients/orchestrator.js';
 import { SlackService } from './notification/slack.service.js';
 import { getProvider } from './providers.js';
+import { v4 as uuidv4 } from 'uuid';
 
 const logger = getLogger('Connection');
 const ACTIVE_LOG_TABLE = dbNamespace + 'active_logs';
@@ -67,6 +68,10 @@ class ConnectionService {
 
     constructor(locking: Locking) {
         this.locking = locking;
+    }
+
+    public generateConnectionId(): string {
+        return uuidv4();
     }
 
     public async upsertConnection({

--- a/packages/shared/lib/services/hmac.service.ts
+++ b/packages/shared/lib/services/hmac.service.ts
@@ -21,8 +21,9 @@ class HmacService {
         return key;
     }
 
-    async verify(expectedDigest: string, id: number, ...values: string[]): Promise<boolean> {
-        const actualDigest = await this.digest(id, ...values);
+    async verify(expectedDigest: string, id: number, ...values: (string | undefined)[]): Promise<boolean> {
+        const definedValues: string[] = values.flatMap((v) => (v === undefined ? [] : [v]));
+        const actualDigest = await this.digest(id, ...definedValues);
         return expectedDigest === actualDigest;
     }
 

--- a/packages/types/lib/auth/http.api.ts
+++ b/packages/types/lib/auth/http.api.ts
@@ -9,7 +9,7 @@ export type PostPublicTbaAuthorization = Endpoint<{
         oauth_client_secret_override?: string | undefined;
     };
     Querystring: {
-        connection_id: string;
+        connection_id?: string | undefined;
         public_key: string;
         params?: Record<string, any> | undefined;
         hmac?: string | undefined;
@@ -39,7 +39,7 @@ export type PostPublicTableauAuthorization = Endpoint<{
         content_url?: string | undefined;
     };
     Querystring: {
-        connection_id: string;
+        connection_id?: string | undefined;
         public_key: string;
         params?: Record<string, any> | undefined;
         hmac?: string | undefined;
@@ -64,7 +64,7 @@ export type PostPublicTableauAuthorization = Endpoint<{
 export type PostPublicUnauthenticatedAuthorization = Endpoint<{
     Method: 'POST';
     Querystring: {
-        connection_id: string;
+        connection_id?: string | undefined;
         hmac?: string | undefined;
     };
     Params: {

--- a/packages/webapp/src/pages/Connection/Create.tsx
+++ b/packages/webapp/src/pages/Connection/Create.tsx
@@ -205,14 +205,19 @@ export default function IntegrationCreate() {
                 content_url: contentUrl
             };
         }
-
-        nango[authMode === 'NONE' ? 'create' : 'auth'](target.integration_unique_key.value, target.connection_id.value, {
+        const connectionConfig = {
             user_scope: authMode === 'NONE' ? undefined : selectedScopes || [],
             params,
             authorization_params: authorizationParams || {},
             hmac: hmacDigest || '',
             credentials
-        })
+        };
+        const getConnection =
+            authMode === 'NONE'
+                ? nango.create(target.integration_unique_key.value, target.connection_id.value, connectionConfig)
+                : nango.auth(target.integration_unique_key.value, target.connection_id.value, connectionConfig);
+
+        getConnection
             .then(() => {
                 toast.success('Connection created!', { position: toast.POSITION.BOTTOM_CENTER });
                 analyticsTrack('web:connection_created', { provider: integration?.provider || 'unknown' });


### PR DESCRIPTION
## Describe your changes

Making connectionId optional when creating a connection. If connectionId is not provided a uuid is generated.
I haven't updated the documentation which is still relevant. I will do it once we decide not passing the connectionId is the default way. With this PR we are making it possible without promoting it yet.

## Issue ticket number and link

https://linear.app/nango/issue/NAN-1747/make-connectionid-optional-when-creating-a-new-connection

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
