### PR TITLE
feat(sdk): add new endpoints

### DIFF
--- a/docs-v2/reference/api/integration/get.mdx
+++ b/docs-v2/reference/api/integration/get.mdx
@@ -4,7 +4,7 @@ openapi: 'GET /integrations/{uniqueKey}'
 ---
 
 <ResponseExample>
-  ```json Example Response
+```json Example Response
 {
   "data": {
     "unique_key": "slack-nango-community",
@@ -14,5 +14,5 @@ openapi: 'GET /integrations/{uniqueKey}'
     "updated_at": "2023-10-16T08:45:26.241Z",
   }
 }
-  ```
+```
 </ResponseExample>

--- a/docs-v2/reference/api/integration/list.mdx
+++ b/docs-v2/reference/api/integration/list.mdx
@@ -3,8 +3,18 @@ title: 'List all integrations'
 openapi: 'GET /integrations'
 ---
 
+<RequestExample>
+
+```ts Node Client
+const nango = new Nango({ secretKey });
+
+const response = await nango.listIntegrations();
+```
+
+</RequestExample>
+
 <ResponseExample>
-  ```json Example Response
+```json Example Response
 {
   "data": [
     {
@@ -23,5 +33,5 @@ openapi: 'GET /integrations'
     },
   ]
 }
-  ```
+```
 </ResponseExample>

--- a/docs-v2/reference/sdks/node.mdx
+++ b/docs-v2/reference/sdks/node.mdx
@@ -125,7 +125,7 @@ await nango.getProvider(<NAME>)
 Returns a list of integrations.
 
 ```js
-await nango.listIntegrationsV2()
+await nango.listIntegrations()
 ```
 
 **Example Response**
@@ -133,7 +133,7 @@ await nango.listIntegrationsV2()
 <Expandable>
 ```json
 {
-    "data": [
+    "configs": [
         {
             "unique_key": "slack-nango-community",
             "provider": "slack",

--- a/docs-v2/reference/sdks/node.mdx
+++ b/docs-v2/reference/sdks/node.mdx
@@ -153,39 +153,6 @@ await nango.listIntegrationsV2()
 ```
 </Expandable>
 
-### List all integrations (Deprecated)
-
-Returns a list of integrations.
-
-```js
-await nango.listIntegrations()
-```
-
-**Example Response**
-
-<Expandable>
-```json
-{
-    "configs": [
-        {
-            "unique_key": "slack-nango-community",
-            "provider": "slack",
-            "logo": "http://localhost:3003/images/template-logos/slack.svg",
-            "created_at": "2023-10-16T08:45:26.241Z",
-            "updated_at": "2023-10-16T08:45:26.241Z",
-        },
-        {
-            "unique_key": "github-prod",
-            "provider": "github",
-            "logo": "http://localhost:3003/images/template-logos/github.svg",
-            "created_at": "2023-10-16T08:45:26.241Z",
-            "updated_at": "2023-10-16T08:45:26.241Z",
-        },
-    ]
-}
-```
-</Expandable>
-
 ### Get an integration
 
 Returns a specific integration.
@@ -202,7 +169,7 @@ await nango.getIntegrationV2(<UNIQUE_KEY>, { include?: ['webhook'] });
     </ResponseField>
 
     <ResponseField name="include" type="array" required>
-        Include more data. Allowed values: `webhook`
+        Include sensitive data. Allowed values: `webhook`
     </ResponseField>
 </Expandable>
 

--- a/docs-v2/reference/sdks/node.mdx
+++ b/docs-v2/reference/sdks/node.mdx
@@ -97,7 +97,7 @@ await nango.listProviders()
 Returns a specific provider.
 
 ```js
-await nango.getProvider(<NAME>)
+await nango.getProvider({ provider: <NAME> })
 ```
 
 **Example Response**
@@ -158,18 +158,28 @@ await nango.listIntegrations()
 Returns a specific integration.
 
 ```js
-await nango.getIntegrationV2(<UNIQUE_KEY>, { include?: ['webhook'] });
+await nango.getIntegration({ unique_key: <UNIQUE_KEY> });
+
+// Deprecated
+await nango.getIntegration(<INTEGRATION-ID>);
 ```
 
 **Parameters**
 
 <Expandable>
-    <ResponseField name="uniqueKey" type="string" required>
-        The integration ID (`unique_key`)
+    <ResponseField name="unique_key" type="string" required>
+         The integration ID (`unique_key`)
+    </ResponseField>
+    <ResponseField name="include" type="array">
+        Include sensitive data. Allowed values: `webhook`
     </ResponseField>
 
-    <ResponseField name="include" type="array" required>
-        Include sensitive data. Allowed values: `webhook`
+    <ResponseField name="providerConfigKey" type="string" required deprecated>
+        The integration ID.
+    </ResponseField>
+
+    <ResponseField name="includeIntegrationCredentials" type="boolean" deprecated>
+        Defaults to `false`.
     </ResponseField>
 </Expandable>
 
@@ -184,54 +194,6 @@ await nango.getIntegrationV2(<UNIQUE_KEY>, { include?: ['webhook'] });
         "logo": "http://localhost:3003/images/template-logos/slack.svg",
         "created_at": "2023-10-16T08:45:26.241Z",
         "updated_at": "2023-10-16T08:45:26.241Z",
-    }
-}
-```
-</Expandable>
-
-### Get an integration (Deprecated)
-
-Returns a specific integration.
-
-```js
-await nango.getIntegration(<INTEGRATION-ID>);
-```
-
-**Parameters**
-
-<Expandable>
-    <ResponseField name="providerConfigKey" type="string" required>
-        The integration ID.
-    </ResponseField>
-
-    <ResponseField name="includeIntegrationCredentials" type="boolean">
-        Defaults to `false`.
-    </ResponseField>
-</Expandable>
-
-**Example Response**
-
-<Expandable>
-```json
-{
-    "config": {
-        "unique_key": "slack-nango-community",
-        "provider": "slack",
-        "syncs": [
-            {
-                "name": "slack-messages",
-                "created_at": "2023-10-16T08:45:26.241Z",
-                "updated_at": "2023-10-16T08:45:26.241Z",
-                "description": "Continuously fetch the latest Slack messages. Details: full refresh. Required scopes(s): channels:read, groups:read, mpim:read, im:read"
-            }
-        ],
-        "actions": [
-            {
-                "name": "github-list-repos-action",
-                "created_at": "2023-10-17T17:28:03.839Z",
-                "updated_at": "2023-10-17T17:28:03.839Z"
-            }
-        ]
     }
 }
 ```

--- a/docs-v2/reference/sdks/node.mdx
+++ b/docs-v2/reference/sdks/node.mdx
@@ -32,7 +32,7 @@ const nango = new Nango({ secretKey: '<SECRET-KEY>' });
       </ResponseField>
 
       <ResponseField name="host" type="string">
-        Omitting the host points to Nango Cloud. For local development, use `http://localhost:3003`. Use your instance URL if self-hosting. 
+        Omitting the host points to Nango Cloud. For local development, use `http://localhost:3003`. Use your instance URL if self-hosting.
       </ResponseField>
     </Expandable>
   </ResponseField>
@@ -61,9 +61,99 @@ try {
 }
 ```
 
+# Providers
+
+### List all providers
+
+Returns a list of providers.
+
+```js
+await nango.listProviders()
+```
+
+**Example Response**
+
+<Expandable>
+```json
+{
+    "data": [
+        {
+            "name": "posthog",
+            "categories": ["dev-tools"],
+            "auth_mode": "API_KEY",
+            "proxy": {
+                "base_url": "https://api.posthog.com",
+            },
+            "docs": "https://docs.nango.dev/integrations/all/posthog"
+        }
+    ]
+}
+```
+</Expandable>
+
+
+### Get a provider
+
+Returns a specific provider.
+
+```js
+await nango.getProvider(<NAME>)
+```
+
+**Example Response**
+
+<Expandable>
+```json
+{
+    "data": {
+        "name": "posthog",
+        "categories": ["dev-tools"],
+        "auth_mode": "API_KEY",
+        "proxy": {
+            "base_url": "https://api.posthog.com",
+        },
+        "docs": "https://docs.nango.dev/integrations/all/posthog"
+    }
+}
+```
+</Expandable>
+
 # Integrations
 
 ### List all integrations
+
+Returns a list of integrations.
+
+```js
+await nango.listIntegrationsV2()
+```
+
+**Example Response**
+
+<Expandable>
+```json
+{
+    "data": [
+        {
+            "unique_key": "slack-nango-community",
+            "provider": "slack",
+            "logo": "http://localhost:3003/images/template-logos/slack.svg",
+            "created_at": "2023-10-16T08:45:26.241Z",
+            "updated_at": "2023-10-16T08:45:26.241Z",
+        },
+        {
+            "unique_key": "github-prod",
+            "provider": "github",
+            "logo": "http://localhost:3003/images/template-logos/github.svg",
+            "created_at": "2023-10-16T08:45:26.241Z",
+            "updated_at": "2023-10-16T08:45:26.241Z",
+        },
+    ]
+}
+```
+</Expandable>
+
+### List all integrations (Deprecated)
 
 Returns a list of integrations.
 
@@ -79,11 +169,17 @@ await nango.listIntegrations()
     "configs": [
         {
             "unique_key": "slack-nango-community",
-            "provider": "slack"
+            "provider": "slack",
+            "logo": "http://localhost:3003/images/template-logos/slack.svg",
+            "created_at": "2023-10-16T08:45:26.241Z",
+            "updated_at": "2023-10-16T08:45:26.241Z",
         },
         {
             "unique_key": "github-prod",
-            "provider": "github"
+            "provider": "github",
+            "logo": "http://localhost:3003/images/template-logos/github.svg",
+            "created_at": "2023-10-16T08:45:26.241Z",
+            "updated_at": "2023-10-16T08:45:26.241Z",
         },
     ]
 }
@@ -91,6 +187,42 @@ await nango.listIntegrations()
 </Expandable>
 
 ### Get an integration
+
+Returns a specific integration.
+
+```js
+await nango.getIntegrationV2(<UNIQUE_KEY>, { include?: ['webhook'] });
+```
+
+**Parameters**
+
+<Expandable>
+    <ResponseField name="uniqueKey" type="string" required>
+        The integration ID (`unique_key`)
+    </ResponseField>
+
+    <ResponseField name="include" type="array" required>
+        Include more data. Allowed values: `webhook`
+    </ResponseField>
+</Expandable>
+
+**Example Response**
+
+<Expandable>
+```json
+{
+    "data": {
+        "unique_key": "slack-nango-community",
+        "provider": "slack",
+        "logo": "http://localhost:3003/images/template-logos/slack.svg",
+        "created_at": "2023-10-16T08:45:26.241Z",
+        "updated_at": "2023-10-16T08:45:26.241Z",
+    }
+}
+```
+</Expandable>
+
+### Get an integration (Deprecated)
 
 Returns a specific integration.
 
@@ -106,8 +238,8 @@ await nango.getIntegration(<INTEGRATION-ID>);
     </ResponseField>
 
     <ResponseField name="includeIntegrationCredentials" type="boolean">
-        Defaults to `false`. 
-    </ResponseField>   
+        Defaults to `false`.
+    </ResponseField>
 </Expandable>
 
 **Example Response**
@@ -159,7 +291,7 @@ await nango.createIntegration(<PROVIDER-ID>, <INTEGRATION-ID>);
 
     <ResponseField name="credentials" type="Record<string, string>">
         The credentials to include depend on the specific integration that you want to create.
-    </ResponseField>   
+    </ResponseField>
 
     <ResponseField name="credentials" type="Record<string, string>">
     <Expandable title="credentials" defaultOpen>
@@ -212,7 +344,7 @@ await nango.updateIntegration(<PROVIDER-ID>, <INTEGRATION-ID>);
 
     <ResponseField name="credentials" type="Record<string, string>">
         The credentials to include depend on the specific integration that you want to create.
-    </ResponseField>   
+    </ResponseField>
 
     <ResponseField name="credentials" type="Record<string, string>">
     <Expandable title="credentials" defaultOpen>
@@ -244,7 +376,7 @@ await nango.updateIntegration(<PROVIDER-ID>, <INTEGRATION-ID>);
 ```
 </Expandable>
 
-### Delete an integration 
+### Delete an integration
 
 Deletes a specific integration.
 
@@ -329,7 +461,7 @@ await nango.getConnection(<INTEGRATION-ID>, <CONNECTION-ID>);
 ```
 
 <Info>
-The response content depends on the API authentication type (OAuth 2, OAuth 1, API key, Basic auth, etc.). 
+The response content depends on the API authentication type (OAuth 2, OAuth 1, API key, Basic auth, etc.).
 
 If you do not want to deal with collecting & injecting credentials in requests for multiple authentication types, use the Proxy ([step-by-step guide](/integrate/guides/proxy-requests-to-an-api)).
 </Info>
@@ -362,16 +494,16 @@ We recommend not caching tokens for longer than 5 minutes to ensure they are fre
 <Expandable>
 ```json
 {
-    "id": 18393,                                 
-    "created_at": "2023-03-08T09:43:03.725Z",     
-    "updated_at": "2023-03-08T09:43:03.725Z",     
-    "provider_config_key": "github",              
-    "connection_id": "1",                         
+    "id": 18393,
+    "created_at": "2023-03-08T09:43:03.725Z",
+    "updated_at": "2023-03-08T09:43:03.725Z",
+    "provider_config_key": "github",
+    "connection_id": "1",
     "credentials": {
-        "type": "OAUTH2",                         
-        "access_token": "gho_tsXLG73f....",       
-        "refresh_token": "gho_fjofu84u9....",     
-        "expires_at": "2024-03-08T09:43:03.725Z", 
+        "type": "OAUTH2",
+        "access_token": "gho_tsXLG73f....",
+        "refresh_token": "gho_fjofu84u9....",
+        "expires_at": "2024-03-08T09:43:03.725Z",
         "raw": { // Raw token response from the OAuth provider: Contents vary!
             "access_token": "gho_tsXLG73f....",
             "refresh_token": "gho_fjofu84u9....",
@@ -379,17 +511,17 @@ We recommend not caching tokens for longer than 5 minutes to ensure they are fre
             "scope": "public_repo,user"
         }
     },
-    "connection_config": {                       
+    "connection_config": {
         "subdomain": "myshop",
         "realmId": "XXXXX",
         "instance_id": "YYYYYYY"
-    },                      
-    "account_id": 0,                              
-    "metadata": {                                 
+    },
+    "account_id": 0,
+    "metadata": {
         "myProperty": "yes",
         "filter": "closed=true"
     }
-}                              
+}
 ```
 </Expandable>
 
@@ -729,8 +861,8 @@ Returns the synced data.
 import type { ModelName } from '<path-to-nango-integrations>/models'
 
 const records = await nango.listRecords<ModelName>({
-    providerConfigKey: '<INTEGRATION-ID>',    
-    connectionId: '<CONNECTION-ID>',                
+    providerConfigKey: '<INTEGRATION-ID>',
+    connectionId: '<CONNECTION-ID>',
     model: '<MODEL-NAME>'
 });
 ```
@@ -767,13 +899,13 @@ const records = await nango.listRecords<ModelName>({
       </ResponseField>
 
       <ResponseField name="limit" type="number">
-        The maximum number of records to return. Defaults to 100. 
+        The maximum number of records to return. Defaults to 100.
       </ResponseField>
 
       <ResponseField name="filter" type="string">
-        Filter to only show results that have been added or updated or deleted. 
+        Filter to only show results that have been added or updated or deleted.
 
-        Available options: added, updated, deleted 
+        Available options: added, updated, deleted
       </ResponseField>
 
       <ResponseField name="modifiedAfter" type="string">
@@ -831,7 +963,7 @@ const records = await nango.triggerSync('<INTEGRATION-ID>', ['SYNC_NAME1', 'SYNC
         The integration ID.
     </ResponseField>
     <ResponseField name="syncs" type="string[]" required>
-        The name of the syncs to trigger. If the array is empty, all syncs are triggered. 
+        The name of the syncs to trigger. If the array is empty, all syncs are triggered.
     </ResponseField>
     <ResponseField name="connectionId" type="string">
         The connection ID. If omitted, the sync will trigger for all relevant connections.
@@ -857,7 +989,7 @@ await nango.startSync('<INTEGRATION-ID>', ['SYNC_NAME1', 'SYNC_NAME2'], '<CONNEC
         The integration ID.
     </ResponseField>
     <ResponseField name="syncs" type="string[]" required>
-        The name of the syncs that should be triggered. 
+        The name of the syncs that should be triggered.
     </ResponseField>
     <ResponseField name="connectionId" type="string">
         The connection ID. If ommitted, the sync will trigger for all relevant connections.
@@ -883,7 +1015,7 @@ await nango.startSync('<INTEGRATION-ID>', ['SYNC_NAME1', 'SYNC_NAME2'], '<CONNEC
         The integration ID.
     </ResponseField>
     <ResponseField name="syncs" type="string[]" required>
-        The name of the syncs that should be paused. 
+        The name of the syncs that should be paused.
     </ResponseField>
     <ResponseField name="connectionId" type="string">
         The connection ID. If ommitted, the sync will pause for all relevant connections.
@@ -955,7 +1087,7 @@ await nango.updateSyncConnectionFrequency('<INTEGRATION-ID>', 'SYNC_NAME', '<CON
         The name of the sync.
     </ResponseField>
     <ResponseField name="connectionId" type="string" required>
-        The connection ID. 
+        The connection ID.
     </ResponseField>
     <ResponseField name="frequency" type="string" required>
         The frequency you want to set (ex: 'every hour'). Set to `null` to revert to the default frequency.  Uses the https://github.com/vercel/ms notations. Min frequency: 5 minutes.
@@ -1014,7 +1146,7 @@ await nango.triggerAction('<INTEGRATION-ID>', '<CONNECTION_ID>', '<ACTION-NAME>'
         The integration ID.
     </ResponseField>
     <ResponseField name="connectionId" type="string" required>
-        The connection ID. 
+        The connection ID.
     </ResponseField>
     <ResponseField name="actionName" type="string" required>
         The name of the action to trigger.
@@ -1039,7 +1171,7 @@ await nango.triggerAction('<INTEGRATION-ID>', '<CONNECTION_ID>', '<ACTION-NAME>'
 Makes an HTTP request using the [proxy](/understand/concepts/proxy):
 
 ```js
-const config = { 
+const config = {
     endpoint: '/some-endpoint',
     providerConfigKey: '<INTEGRATION-ID>',
     connectionId: '<CONNECTION-ID>'
@@ -1064,7 +1196,7 @@ await nango.delete(config); // DELETE request
                 The integration ID (for credential injection).
             </ResponseField>
             <ResponseField name="connectionId" type="string" required>
-                The connection ID (for credential injection). 
+                The connection ID (for credential injection).
             </ResponseField>
             <ResponseField name="headers" type="Record<string, string>">
                 The headers of the request.
@@ -1088,7 +1220,7 @@ await nango.delete(config); // DELETE request
                 Override the decompress option when making requests. Optional, defaults to false
             </ResponseField>
             <ResponseField name="responseType" type="'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream'">
-                The type of the response. 
+                The type of the response.
             </ResponseField>
         </Expandable>
     </ResponseField>

--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -362,6 +362,14 @@ paths:
                   schema:
                       type: string
                   description: The integration ID (unique_key) that you created in Nango.
+                - name: include
+                  in: query
+                  schema:
+                      type: array
+                      items:
+                        type: string
+                        enum: [webhook]
+                  description: The integration ID (unique_key) that you created in Nango.
             responses:
                 '200':
                     description: Successfully returned an integration

--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -331,7 +331,7 @@ export declare class NangoAction {
      */
     setFieldMapping(fieldMapping: Record<string, string>): Promise<AxiosResponse<object>>;
     getMetadata<T = Metadata>(): Promise<T>;
-    getWebhookURL(): Promise<string | undefined>;
+    getWebhookURL(): Promise<string | null | undefined>;
     /**
      * @deprecated please use getMetadata instead.
      */

--- a/packages/node-client/bin/get-integration.js
+++ b/packages/node-client/bin/get-integration.js
@@ -4,7 +4,7 @@ const args = process.argv.slice(2);
 const nango = new Nango({ host: 'http://localhost:3003', secretKey: args[0] });
 
 nango
-    .getIntegrationV2(args[1])
+    .getIntegration({ uniqueKey: args[1] })
     .then((response) => {
         console.log(response);
     })

--- a/packages/node-client/bin/get-integration.js
+++ b/packages/node-client/bin/get-integration.js
@@ -4,7 +4,7 @@ const args = process.argv.slice(2);
 const nango = new Nango({ host: 'http://localhost:3003', secretKey: args[0] });
 
 nango
-    .getIntegration(args[1], args[2])
+    .getIntegrationV2(args[1])
     .then((response) => {
         console.log(response);
     })

--- a/packages/node-client/bin/get-provider.js
+++ b/packages/node-client/bin/get-provider.js
@@ -1,0 +1,11 @@
+import { Nango } from '../dist/index.js';
+const args = process.argv.slice(2);
+
+const nango = new Nango({ host: 'http://localhost:3003', secretKey: args[0] });
+
+try {
+  const res = await nango.getProvider({ provider: args[1] })
+  console.log(res);
+} catch (err) {
+  console.log(err?.response?.data || err.message);
+}

--- a/packages/node-client/bin/get-providers.js
+++ b/packages/node-client/bin/get-providers.js
@@ -1,0 +1,11 @@
+import { Nango } from '../dist/index.js';
+const args = process.argv.slice(2);
+
+const nango = new Nango({ host: 'http://localhost:3003', secretKey: args[0] });
+
+try {
+  const res = await nango.listProviders()
+  console.log(res);
+} catch (err) {
+  console.log(err?.response?.data || err.message);
+}

--- a/packages/node-client/bin/list-integrations.js
+++ b/packages/node-client/bin/list-integrations.js
@@ -4,7 +4,7 @@ const args = process.argv.slice(2);
 const nango = new Nango({ host: 'http://localhost:3003', secretKey: args[0] });
 
 nango
-    .listIntegrationsV2()
+    .listIntegrations()
     .then((response) => {
         console.log(response);
     })

--- a/packages/node-client/bin/list-integrations.js
+++ b/packages/node-client/bin/list-integrations.js
@@ -4,7 +4,7 @@ const args = process.argv.slice(2);
 const nango = new Nango({ host: 'http://localhost:3003', secretKey: args[0] });
 
 nango
-    .listIntegrations()
+    .listIntegrationsV2()
     .then((response) => {
         console.log(response);
     })

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -159,34 +159,38 @@ export class Nango {
 
     /**
      * Returns a specific integration
-     * @param providerConfigKey - The key identifying the provider configuration on Nango
-     * @param includeIntegrationCredentials - An optional flag indicating whether to include integration credentials in the response. Default is false
-     * @returns A promise that resolves with an object containing an integration configuration
-     * @deprecated Use `getIntegrationV2()`
-     */
-    public async getIntegration(
-        providerConfigKey: string,
-        includeIntegrationCredentials: boolean = false
-    ): Promise<{ config: Integration | IntegrationWithCreds }> {
-        const url = `${this.serverUrl}/config/${providerConfigKey}`;
-        const response = await this.http.get(url, { headers: this.enrichHeaders({}), params: { include_creds: includeIntegrationCredentials } });
-        return response.data;
-    }
-
-    /**
-     * Returns a specific integration
      * @param uniqueKey - The key identifying the provider configuration on Nango
      * @returns A promise that resolves with an object containing an integration
      */
-    public async getIntegrationV2(
-        uniqueKey: GetPublicIntegration['Params']['uniqueKey'],
+    public async getIntegration(
+        params: GetPublicIntegration['Params'],
         queries?: GetPublicIntegration['Querystring']
-    ): Promise<GetPublicIntegration['Success']> {
-        const url = new URL(`${this.serverUrl}/integrations/${uniqueKey}`);
-        addQueryParams(url, queries);
+    ): Promise<GetPublicIntegration['Success']>;
 
-        const response = await this.http.get(url.href, { headers: this.enrichHeaders({}) });
-        return response.data;
+    /**
+     * Returns a specific integration
+     * @param providerConfigKey - The key identifying the provider configuration on Nango
+     * @param includeIntegrationCredentials - An optional flag indicating whether to include integration credentials in the response. Default is false
+     * @returns A promise that resolves with an object containing an integration configuration
+     * @deprecated Use `getIntegration({ unique_key })`
+     */
+    public async getIntegration(providerConfigKey: string, includeIntegrationCredentials?: boolean): Promise<{ config: Integration | IntegrationWithCreds }>;
+
+    public async getIntegration(
+        params: string | GetPublicIntegration['Params'],
+        queries?: boolean | GetPublicIntegration['Querystring']
+    ): Promise<{ config: Integration | IntegrationWithCreds } | GetPublicIntegration['Success']> {
+        if (typeof params === 'string') {
+            const url = `${this.serverUrl}/config/${params}`;
+            const response = await this.http.get(url, { headers: this.enrichHeaders({}), params: { include_creds: queries } });
+            return response.data;
+        } else {
+            const url = new URL(`${this.serverUrl}/integrations/${params.uniqueKey}`);
+            addQueryParams(url, queries as GetPublicIntegration['Querystring']);
+
+            const response = await this.http.get(url.href, { headers: this.enrichHeaders({}) });
+            return response.data;
+        }
     }
 
     /**

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -146,25 +146,15 @@ export class Nango {
 
     /**
      * Returns a list of integrations
-     * @returns A promise that resolves with an object containing an array of integration configurations
-     * @deprecated Use `listIntegrationsV2()`
-     */
-    public async listIntegrations(): Promise<GetPublicListIntegrationsLegacy['Success']> {
-        const url = `${this.serverUrl}/config`;
-        const response = await this.http.get(url, { headers: this.enrichHeaders({}) });
-
-        return response.data;
-    }
-
-    /**
-     * Returns a list of integrations
      * @returns A promise that resolves with an object containing an array of integrations
      */
-    public async listIntegrationsV2(): Promise<GetPublicListIntegrations['Success']> {
+    public async listIntegrations(): Promise<GetPublicListIntegrationsLegacy['Success']> {
         const url = `${this.serverUrl}/integrations`;
         const response = await this.http.get(url, { headers: this.enrichHeaders({}) });
 
-        return response.data;
+        const tmp: GetPublicListIntegrations['Success'] = response.data;
+        // To avoid deprecating this method we emulate legacy format
+        return { configs: tmp.data };
     }
 
     /**

--- a/packages/node-client/lib/utils.ts
+++ b/packages/node-client/lib/utils.ts
@@ -40,3 +40,19 @@ export function getUserAgent(userAgent?: string): string {
     const osVersion = os.release().replace(' ', '_');
     return `nango-node-client/${NANGO_VERSION} (${osName}/${osVersion}; node.js/${nodeVersion})${userAgent ? `; ${userAgent}` : ''}`;
 }
+
+export function addQueryParams(url: URL, queries?: Record<string, any> | undefined) {
+    if (!queries) {
+        return;
+    }
+
+    Object.entries(queries).forEach(([name, value]) => {
+        if (Array.isArray(value)) {
+            for (const el of value) {
+                url.searchParams.set(name, el);
+            }
+        } else {
+            url.searchParams.set(name, value || '');
+        }
+    });
+}

--- a/packages/node-client/lib/utils.ts
+++ b/packages/node-client/lib/utils.ts
@@ -51,8 +51,8 @@ export function addQueryParams(url: URL, queries?: Record<string, any> | undefin
             for (const el of value) {
                 url.searchParams.set(name, el);
             }
-        } else {
-            url.searchParams.set(name, value || '');
+        } else if (value !== null && value !== undefined) {
+            url.searchParams.set(name, value);
         }
     });
 }

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.integration.test.ts
@@ -81,7 +81,7 @@ describe(`GET ${endpoint}`, () => {
 
         isSuccess(res.json);
         expect(res.res.status).toBe(200);
-        expect(res.json.data.webhook_url).toStrictEqual('efe');
+        expect(res.json.data.webhook_url).toStrictEqual(null);
     });
 
     it('should not list other env', async () => {

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.integration.test.ts
@@ -18,7 +18,7 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should be protected', async () => {
-        const res = await api.fetch(endpoint, { method: 'GET', params: { uniqueKey: 'github' } });
+        const res = await api.fetch(endpoint, { method: 'GET', params: { uniqueKey: 'github' }, query: {} });
 
         shouldBeProtected(res);
     });
@@ -45,7 +45,7 @@ describe(`GET ${endpoint}`, () => {
     it('should list empty', async () => {
         const env = await seeders.createEnvironmentSeed();
 
-        const res = await api.fetch(endpoint, { method: 'GET', token: env.secret_key, params: { uniqueKey: 'github' } });
+        const res = await api.fetch(endpoint, { method: 'GET', token: env.secret_key, params: { uniqueKey: 'github' }, query: {} });
 
         isError(res.json);
         expect(res.res.status).toBe(404);
@@ -58,7 +58,7 @@ describe(`GET ${endpoint}`, () => {
         const env = await seeders.createEnvironmentSeed();
         await seeders.createConfigSeed(env, 'github', 'github');
 
-        const res = await api.fetch(endpoint, { method: 'GET', token: env.secret_key, params: { uniqueKey: 'github' } });
+        const res = await api.fetch(endpoint, { method: 'GET', token: env.secret_key, params: { uniqueKey: 'github' }, query: {} });
 
         isSuccess(res.json);
         expect(res.res.status).toBe(200);
@@ -73,12 +73,23 @@ describe(`GET ${endpoint}`, () => {
         });
     });
 
+    it('should get webhook', async () => {
+        const env = await seeders.createEnvironmentSeed();
+        await seeders.createConfigSeed(env, 'github', 'github');
+
+        const res = await api.fetch(endpoint, { method: 'GET', token: env.secret_key, params: { uniqueKey: 'github' }, query: { include: ['webhook'] } });
+
+        isSuccess(res.json);
+        expect(res.res.status).toBe(200);
+        expect(res.json.data.webhook_url).toStrictEqual('efe');
+    });
+
     it('should not list other env', async () => {
         const env = await seeders.createEnvironmentSeed();
         const env2 = await seeders.createEnvironmentSeed();
         await seeders.createConfigSeed(env2, 'github', 'github');
 
-        const res = await api.fetch(endpoint, { method: 'GET', token: env.secret_key, params: { uniqueKey: 'github' } });
+        const res = await api.fetch(endpoint, { method: 'GET', token: env.secret_key, params: { uniqueKey: 'github' }, query: {} });
 
         isError(res.json);
         expect(res.res.status).toBe(404);

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
@@ -16,13 +16,8 @@ const valInclude = z.enum(['webhook']);
 const validationQuery = z
     .object({
         include: z
-            .union([
-                z
-                    .string()
-                    .transform((v) => [v])
-                    .pipe(z.array(valInclude)),
-                z.array(valInclude)
-            ])
+            .union([valInclude, z.array(valInclude)])
+            .transform((val) => (Array.isArray(val) ? val : val ? [val] : []))
             .optional()
     })
     .strict();

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
@@ -12,9 +12,18 @@ export const validationParams = z
     })
     .strict();
 
+const valInclude = z.enum(['webhook']);
 const validationQuery = z
     .object({
-        include: z.array(z.enum(['credentials', 'webhook'])).optional()
+        include: z
+            .union([
+                z
+                    .string()
+                    .transform((v) => [v])
+                    .pipe(z.array(valInclude)),
+                z.array(valInclude)
+            ])
+            .optional()
     })
     .strict();
 
@@ -35,7 +44,6 @@ export const getPublicIntegration = asyncWrapper<GetPublicIntegration>(async (re
     const params: GetPublicIntegration['Params'] = valParams.data;
     const query: GetPublicIntegration['Querystring'] = valQuery.data;
 
-    console.log(query, req.query);
     const queryInclude = new Set(query.include || []);
 
     const integration = await configService.getProviderConfig(params.uniqueKey, environment.id);

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
@@ -1,7 +1,7 @@
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
-import type { GetPublicIntegration } from '@nangohq/types';
-import { configService } from '@nangohq/shared';
+import { zodErrorToHTTP } from '@nangohq/utils';
+import type { ApiPublicIntegrationInclude, GetPublicIntegration } from '@nangohq/types';
+import { configService, getGlobalWebhookReceiveUrl, getProvider } from '@nangohq/shared';
 import { z } from 'zod';
 import { providerConfigKeySchema } from '../../../helpers/validation.js';
 import { integrationToPublicApi } from '../../../formatters/integration.js';
@@ -12,10 +12,16 @@ export const validationParams = z
     })
     .strict();
 
+const validationQuery = z
+    .object({
+        include: z.array(z.enum(['credentials', 'webhook'])).optional()
+    })
+    .strict();
+
 export const getPublicIntegration = asyncWrapper<GetPublicIntegration>(async (req, res) => {
-    const emptyQuery = requireEmptyQuery(req);
-    if (emptyQuery) {
-        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+    const valQuery = validationQuery.safeParse(req.query);
+    if (!valQuery.success) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valQuery.error) } });
         return;
     }
 
@@ -27,6 +33,10 @@ export const getPublicIntegration = asyncWrapper<GetPublicIntegration>(async (re
 
     const { environment } = res.locals;
     const params: GetPublicIntegration['Params'] = valParams.data;
+    const query: GetPublicIntegration['Querystring'] = valQuery.data;
+
+    console.log(query, req.query);
+    const queryInclude = new Set(query.include || []);
 
     const integration = await configService.getProviderConfig(params.uniqueKey, environment.id);
     if (!integration) {
@@ -34,7 +44,18 @@ export const getPublicIntegration = asyncWrapper<GetPublicIntegration>(async (re
         return;
     }
 
+    const provider = getProvider(integration.provider);
+    if (!provider) {
+        res.status(404).send({ error: { code: 'not_found', message: `Unknown provider ${integration.provider}` } });
+        return;
+    }
+
+    const include: ApiPublicIntegrationInclude = {};
+    if (queryInclude.has('webhook')) {
+        include.webhook_url = provider.webhook_routing_script ? `${getGlobalWebhookReceiveUrl()}/${environment.uuid}/${integration.provider}` : null;
+    }
+
     res.status(200).send({
-        data: integrationToPublicApi(integration)
+        data: integrationToPublicApi(integration, include)
     });
 });

--- a/packages/server/lib/formatters/integration.ts
+++ b/packages/server/lib/formatters/integration.ts
@@ -1,4 +1,4 @@
-import type { ApiIntegration, ApiPublicIntegration, IntegrationConfig } from '@nangohq/types';
+import type { ApiIntegration, ApiPublicIntegration, ApiPublicIntegrationInclude, IntegrationConfig } from '@nangohq/types';
 import { basePublicUrl } from '@nangohq/utils';
 
 export function integrationToApi(data: IntegrationConfig): ApiIntegration {
@@ -9,11 +9,12 @@ export function integrationToApi(data: IntegrationConfig): ApiIntegration {
     };
 }
 
-export function integrationToPublicApi(data: IntegrationConfig): ApiPublicIntegration {
+export function integrationToPublicApi(data: IntegrationConfig, include?: ApiPublicIntegrationInclude): ApiPublicIntegration {
     return {
         unique_key: data.unique_key,
         provider: data.provider,
         logo: `${basePublicUrl}/images/template-logos/${data.provider}.svg`,
+        ...include,
         created_at: data.created_at.toISOString(),
         updated_at: data.updated_at.toISOString()
     };

--- a/packages/server/lib/utils/tests.ts
+++ b/packages/server/lib/utils/tests.ts
@@ -37,8 +37,18 @@ export function apiFetch(baseUrl: string) {
             (TEndpoint['Body'] extends never ? { body?: never } : { body: TEndpoint['Body'] }) &
             (TEndpoint['Params'] extends never ? { params?: never } : { params: TEndpoint['Params'] })
     ): Promise<{ res: Response; json: APIEndpointsPicker<TMethod, TPath>['Reply'] }> {
-        const search = new URLSearchParams(query as Record<string, any>);
-        const url = new URL(`${baseUrl}${path}?${search.toString()}`);
+        const url = new URL(`${baseUrl}${path}`);
+        if (query) {
+            Object.entries(query).forEach(([name, value]) => {
+                if (Array.isArray(value)) {
+                    for (const el of value) {
+                        url.searchParams.set(name, el);
+                    }
+                } else {
+                    url.searchParams.set(name, (value as any) || '');
+                }
+            });
+        }
         const headers = new Headers();
 
         if (token) {

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -6,7 +6,6 @@ import proxyService from '../services/proxy.service.js';
 import type { AxiosInstance } from 'axios';
 import axios, { AxiosError } from 'axios';
 import { getPersistAPIUrl } from '../utils/utils.js';
-import type { IntegrationWithCreds } from '@nangohq/node';
 import type { UserProvidedProxyConfiguration } from '../models/Proxy.js';
 import {
     getLogger,
@@ -22,7 +21,7 @@ import type { SyncConfig } from '../models/Sync.js';
 import type { RunnerFlags } from '../services/sync/run.utils.js';
 import { validateData } from './dataValidation.js';
 import { NangoError } from '../utils/error.js';
-import type { DBTeam, MessageRowInsert } from '@nangohq/types';
+import type { DBTeam, GetPublicIntegration, MessageRowInsert } from '@nangohq/types';
 import { getProvider } from '../services/providers.js';
 
 const logger = getLogger('SDK');
@@ -395,7 +394,7 @@ export class NangoAction {
         string,
         { connection: Connection; timestamp: number }
     >();
-    private memoizedIntegration: IntegrationWithCreds | undefined;
+    private memoizedIntegration: GetPublicIntegration['Success']['data'] | undefined;
 
     constructor(config: NangoProps, { persistApi }: { persistApi: AxiosInstance } = { persistApi: defaultPersistApi }) {
         this.connectionId = config.connectionId;
@@ -660,17 +659,17 @@ export class NangoAction {
         return (await this.getConnection(this.providerConfigKey, this.connectionId)).metadata as T;
     }
 
-    public async getWebhookURL(): Promise<string | undefined> {
+    public async getWebhookURL(): Promise<string | null | undefined> {
         this.exitSyncIfAborted();
         if (this.memoizedIntegration) {
             return this.memoizedIntegration.webhook_url;
         }
 
-        const { config: integration } = await this.nango.getIntegration(this.providerConfigKey, true);
+        const { data: integration } = await this.nango.getIntegrationV2(this.providerConfigKey, { include: ['webhook'] });
         if (!integration || !integration.provider) {
             throw Error(`There was no provider found for the provider config key: ${this.providerConfigKey}`);
         }
-        this.memoizedIntegration = integration as IntegrationWithCreds;
+        this.memoizedIntegration = integration;
         return this.memoizedIntegration.webhook_url;
     }
 

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -665,7 +665,7 @@ export class NangoAction {
             return this.memoizedIntegration.webhook_url;
         }
 
-        const { data: integration } = await this.nango.getIntegrationV2(this.providerConfigKey, { include: ['webhook'] });
+        const { data: integration } = await this.nango.getIntegration({ uniqueKey: this.providerConfigKey }, { include: ['webhook'] });
         if (!integration || !integration.provider) {
             throw Error(`There was no provider found for the provider config key: ${this.providerConfigKey}`);
         }

--- a/packages/shared/lib/sdk/sync.unit.test.ts
+++ b/packages/shared/lib/sdk/sync.unit.test.ts
@@ -49,7 +49,7 @@ describe('cache', () => {
         const nodeClient = (await import('@nangohq/node')).Nango;
         nodeClient.prototype.getConnection = vi.fn().mockReturnValue({ credentials: {} });
         nodeClient.prototype.setMetadata = vi.fn().mockReturnValue({});
-        nodeClient.prototype.getIntegrationV2 = vi.fn().mockReturnValue({ data: { provider: 'github' } });
+        nodeClient.prototype.getIntegration = vi.fn().mockReturnValue({ data: { provider: 'github' } });
         vi.spyOn(proxyService, 'route').mockImplementation(() => Promise.resolve({ response: {} as AxiosResponse, logs: [] }));
     });
     afterEach(() => {
@@ -92,7 +92,7 @@ describe('cache', () => {
         it('getWebhookURL should reuse integration', async () => {
             await nangoAction.getWebhookURL();
             await nangoAction.getWebhookURL();
-            expect(nango.getIntegrationV2).toHaveBeenCalledTimes(1);
+            expect(nango.getIntegration).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/shared/lib/sdk/sync.unit.test.ts
+++ b/packages/shared/lib/sdk/sync.unit.test.ts
@@ -49,7 +49,7 @@ describe('cache', () => {
         const nodeClient = (await import('@nangohq/node')).Nango;
         nodeClient.prototype.getConnection = vi.fn().mockReturnValue({ credentials: {} });
         nodeClient.prototype.setMetadata = vi.fn().mockReturnValue({});
-        nodeClient.prototype.getIntegration = vi.fn().mockReturnValue({ config: { provider: 'github' } });
+        nodeClient.prototype.getIntegrationV2 = vi.fn().mockReturnValue({ data: { provider: 'github' } });
         vi.spyOn(proxyService, 'route').mockImplementation(() => Promise.resolve({ response: {} as AxiosResponse, logs: [] }));
     });
     afterEach(() => {
@@ -92,7 +92,7 @@ describe('cache', () => {
         it('getWebhookURL should reuse integration', async () => {
             await nangoAction.getWebhookURL();
             await nangoAction.getWebhookURL();
-            expect(nango.getIntegration).toHaveBeenCalledTimes(1);
+            expect(nango.getIntegrationV2).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -8,7 +8,12 @@ import type { LegacySyncModelSchema, NangoConfigMetadata } from '../deploy/incom
 import type { JSONSchema7 } from 'json-schema';
 import type { SyncType } from '../scripts/syncs/api';
 
-export type ApiPublicIntegration = Merge<Pick<IntegrationConfig, 'created_at' | 'updated_at' | 'unique_key' | 'provider'>, ApiTimestamps> & { logo: string };
+export type ApiPublicIntegration = Merge<Pick<IntegrationConfig, 'created_at' | 'updated_at' | 'unique_key' | 'provider'>, ApiTimestamps> & {
+    logo: string;
+} & ApiPublicIntegrationInclude;
+export interface ApiPublicIntegrationInclude {
+    webhook_url?: string | null;
+}
 
 export type GetPublicListIntegrationsLegacy = Endpoint<{
     Method: 'GET';
@@ -17,6 +22,7 @@ export type GetPublicListIntegrationsLegacy = Endpoint<{
         configs: ApiPublicIntegration[];
     };
 }>;
+
 export type GetPublicListIntegrations = Endpoint<{
     Method: 'GET';
     Path: '/integrations';
@@ -29,6 +35,7 @@ export type GetPublicIntegration = Endpoint<{
     Method: 'GET';
     Path: '/integrations/:uniqueKey';
     Params: { uniqueKey: string };
+    Querystring: { include?: ('credentials' | 'webhook')[] | undefined };
     Success: { data: ApiPublicIntegration };
 }>;
 

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -35,7 +35,7 @@ export type GetPublicIntegration = Endpoint<{
     Method: 'GET';
     Path: '/integrations/:uniqueKey';
     Params: { uniqueKey: string };
-    Querystring: { include?: ('credentials' | 'webhook')[] | undefined };
+    Querystring: { include?: 'webhook'[] | undefined };
     Success: { data: ApiPublicIntegration };
 }>;
 


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1753/document-new-endpoints-integrations-and-providers

- Add new endpoints to the SDK
There is only one method that was different enough, queries and output that even with signature overload it wasn't possible to make it non-breaking. Honestly, I didn't find anything compelling to deprecate without either being ugly or breaking customers' scripts, so very open to suggestions. 

- Document new SDK method
- Add support for `include=webhook` in `GET /integrations/:key`
The SDK needs it, and some customers use it. It's a secret but not credentials, so I didn't put a too vague name. If we need credentials at some point, we can differentiate.