### PR TITLE
fix(logs): truncate only non required properties

### DIFF
--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -836,8 +836,13 @@ export class NangoAction {
                     if (data.length > MAX_LOG_PAYLOAD) {
                         log.message += ` ... (truncated, payload was too large)`;
                         // Truncating can remove mandatory field so we only try to truncate meta
-                        const meta = JSON.parse(truncateJsonString(stringifyObject(log.meta), MAX_LOG_PAYLOAD - 1000)) as MessageRowInsert['meta'];
-                        data = stringifyObject({ activityLogId: this.activityLogId, log: { ...log, meta } });
+                        data = stringifyObject({
+                            activityLogId: this.activityLogId,
+                            log: {
+                                ...log,
+                                meta: JSON.parse(truncateJsonString(stringifyObject(log.meta), MAX_LOG_PAYLOAD - 1000)) as MessageRowInsert['meta']
+                            }
+                        });
                     }
 
                     return await this.persistApi({

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -16,7 +16,7 @@ import {
     MAX_LOG_PAYLOAD,
     stringifyAndTruncateValue,
     stringifyObject,
-    truncateJsonString
+    truncateJson
 } from '@nangohq/utils';
 import type { SyncConfig } from '../models/Sync.js';
 import type { RunnerFlags } from '../services/sync/run.utils.js';
@@ -836,13 +836,12 @@ export class NangoAction {
                     if (data.length > MAX_LOG_PAYLOAD) {
                         log.message += ` ... (truncated, payload was too large)`;
                         // Truncating can remove mandatory field so we only try to truncate meta
-                        data = stringifyObject({
-                            activityLogId: this.activityLogId,
-                            log: {
-                                ...log,
-                                meta: JSON.parse(truncateJsonString(stringifyObject(log.meta), MAX_LOG_PAYLOAD - 1000)) as MessageRowInsert['meta']
-                            }
-                        });
+                        if (log.meta) {
+                            data = stringifyObject({
+                                activityLogId: this.activityLogId,
+                                log: { ...log, meta: truncateJson(log.meta) as MessageRowInsert['meta'] }
+                            });
+                        }
                     }
 
                     return await this.persistApi({

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -835,7 +835,9 @@ export class NangoAction {
                     // The idea is to always log something instead of silently crashing without overloading persist
                     if (data.length > MAX_LOG_PAYLOAD) {
                         log.message += ` ... (truncated, payload was too large)`;
-                        data = truncateJsonString(stringifyObject({ activityLogId: this.activityLogId, log }), MAX_LOG_PAYLOAD);
+                        // Truncating can remove mandatory field so we only try to truncate meta
+                        const meta = JSON.parse(truncateJsonString(stringifyObject(log.meta), MAX_LOG_PAYLOAD - 1000)) as MessageRowInsert['meta'];
+                        data = stringifyObject({ activityLogId: this.activityLogId, log: { ...log, meta } });
                     }
 
                     return await this.persistApi({

--- a/packages/utils/lib/json.ts
+++ b/packages/utils/lib/json.ts
@@ -48,7 +48,7 @@ export function stringifyAndTruncateValue(value: any, maxSize: number = MAX_LOG_
  * Will entirely remove properties that are too big
  */
 export function truncateJson(value: Record<string, any>, maxSize: number = MAX_LOG_PAYLOAD) {
-    return JSON.parse(truncateJsonPkg(JSON.stringify(value), maxSize).jsonString);
+    return JSON.parse(truncateJsonPkg(stringifyObject(value), maxSize).jsonString);
 }
 
 /**


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1769/logs-truncation-removes-mandatory-fields

- Only truncate `meta` object
When truncating a log's JSON it would randomly remove mandatory properties if it was too big. Now we truncate only selected property, it's not yet bulletproof because people could send a large message and large `meta` object too. We should limit the message size