### PR TITLE
fix: missing FLAG_AUTH_ENABLED in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,6 +33,7 @@ services:
             - SERVER_PORT=${SERVER_PORT}
             - CSP_REPORT_ONLY=true
             - NANGO_SERVER_URL=${NANGO_SERVER_URL:-http://localhost:3003}
+            - FLAG_AUTH_ENABLED=${FLAG_AUTH_ENABLED}
             - NANGO_DASHBOARD_USERNAME=${NANGO_DASHBOARD_USERNAME}
             - NANGO_DASHBOARD_PASSWORD=${NANGO_DASHBOARD_PASSWORD}
             - LOG_LEVEL=${LOG_LEVEL:-info}


### PR DESCRIPTION
While trying to run locally as per documentation, it defaulted to Sign In form even if FLAG_AUTH_ENABLED was set in ENV.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
