### PR TITLE
feat: add keystore package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5414,6 +5414,10 @@
             "resolved": "packages/frontend",
             "link": true
         },
+        "node_modules/@nangohq/keystore": {
+            "resolved": "packages/keystore",
+            "link": true
+        },
         "node_modules/@nangohq/kvstore": {
             "resolved": "packages/kvstore",
             "link": true
@@ -33242,6 +33246,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "packages/keystore": {
+            "name": "@nangohq/keystore",
+            "version": "1.0.0",
+            "dependencies": {
+                "@nangohq/utils": "file:../utils",
+                "dd-trace": "5.21.0",
+                "knex": "3.1.0"
+            },
+            "devDependencies": {
+                "vitest": "1.6.0"
+            }
+        },
         "packages/kvstore": {
             "name": "@nangohq/kvstore",
             "version": "1.0.0",
@@ -33485,6 +33501,7 @@
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@nangohq/database": "file:../database",
+                "@nangohq/keystore": "file:../keystore",
                 "@nangohq/logs": "file:../logs",
                 "@nangohq/nango-orchestrator": "file:../orchestrator",
                 "@nangohq/nango-yaml": "file:../nango-yaml",
@@ -35360,36 +35377,10 @@
                 "acorn": "^8"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/agent-base": {
-            "version": "7.1.1",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/async": {
             "version": "3.2.6",
             "inBundle": true,
             "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/asynckit": {
-            "version": "0.4.0",
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/axios": {
-            "version": "1.7.7",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/cjs-module-lexer": {
             "version": "1.4.1",
@@ -35434,17 +35425,6 @@
             "dependencies": {
                 "color": "^3.1.3",
                 "text-hex": "1.0.x"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/combined-stream": {
-            "version": "1.0.8",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
             }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/crypto-randomuuid": {
@@ -35500,27 +35480,6 @@
                 "node": ">=18"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/debug": {
-            "version": "4.3.7",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/debug/node_modules/ms": {
-            "version": "2.1.3",
-            "inBundle": true,
-            "license": "MIT"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/delay": {
             "version": "5.0.0",
             "inBundle": true,
@@ -35530,14 +35489,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/detect-newline": {
@@ -35558,16 +35509,6 @@
             "inBundle": true,
             "license": "MIT"
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/exponential-backoff": {
-            "version": "3.1.1",
-            "inBundle": true,
-            "license": "Apache-2.0"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/fast-safe-stringify": {
-            "version": "2.1.1",
-            "inBundle": true,
-            "license": "MIT"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/fecha": {
             "version": "4.2.3",
             "inBundle": true,
@@ -35577,70 +35518,6 @@
             "version": "1.1.0",
             "inBundle": true,
             "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/follow-redirects": {
-            "version": "1.15.9",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/form-data": {
-            "version": "4.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/guess-json-indent": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/https-proxy-agent": {
-            "version": "7.0.4",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.0.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/ieee754": {
             "version": "1.2.1",
@@ -35775,25 +35652,6 @@
                 "node": ">=12"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/mime-db": {
-            "version": "1.52.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/mime-types": {
-            "version": "2.1.35",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/module-details-from-path": {
             "version": "1.0.3",
             "inBundle": true,
@@ -35908,11 +35766,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "inBundle": true,
-            "license": "MIT"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/readable-stream": {
             "version": "3.6.2",
             "inBundle": true,
@@ -36026,22 +35879,6 @@
                 "safe-buffer": "~5.2.0"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/string-byte-length": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/string-byte-slice": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/text-hex": {
             "version": "1.0.0",
             "inBundle": true,
@@ -36058,19 +35895,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 14.0.0"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/truncate-json": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "guess-json-indent": "^3.0.0",
-                "string-byte-length": "^3.0.0",
-                "string-byte-slice": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=18.18.0"
             }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/type-fest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5470,6 +5470,10 @@
             "resolved": "packages/shared",
             "link": true
         },
+        "node_modules/@nangohq/type": {
+            "resolved": "packages/type",
+            "link": true
+        },
         "node_modules/@nangohq/types": {
             "resolved": "packages/types",
             "link": true
@@ -33255,6 +33259,7 @@
                 "knex": "3.1.0"
             },
             "devDependencies": {
+                "@nangohq/type": "file:../type",
                 "vitest": "1.6.0"
             }
         },
@@ -36169,6 +36174,9 @@
             "engines": {
                 "node": ">= 12.0.0"
             }
+        },
+        "packages/type": {
+            "dev": true
         },
         "packages/types": {
             "name": "@nangohq/types",

--- a/packages/keystore/lib/db/helpers.test.ts
+++ b/packages/keystore/lib/db/helpers.test.ts
@@ -1,0 +1,27 @@
+import { migrate } from './migrate.js';
+import { knex } from 'knex';
+import { isTest } from '@nangohq/utils';
+
+export const testDb = {
+    schema: 'keystore_test',
+    init: async (): Promise<knex.Knex> => {
+        const url = `postgres://${process.env['NANGO_DB_USER']}:${process.env['NANGO_DB_PASSWORD']}@${process.env['NANGO_DB_HOST']}:${process.env['NANGO_DB_PORT']}/${process.env['NANGO_DB_NAME']}`;
+        const knexConfig = {
+            client: 'postgres',
+            connection: {
+                connectionString: url,
+                statement_timeout: 60000
+            },
+            searchPath: testDb.schema,
+            pool: { min: 2, max: 10 }
+        };
+        const db = knex(knexConfig);
+        await migrate(db, testDb.schema);
+        return db;
+    },
+    clear: async (db: knex.Knex) => {
+        if (isTest) {
+            await db.raw(`DROP SCHEMA IF EXISTS ${testDb.schema} CASCADE`);
+        }
+    }
+};

--- a/packages/keystore/lib/db/migrate.ts
+++ b/packages/keystore/lib/db/migrate.ts
@@ -1,0 +1,32 @@
+import path from 'node:path';
+import type knex from 'knex';
+import { fileURLToPath } from 'node:url';
+import { logger } from '../utils/logger.js';
+
+export async function migrate(db: knex.Knex, schema: string): Promise<void> {
+    logger.info('[keystore] migration');
+
+    const runningMigrationOnly = process.argv.some((v) => v === 'migrate:latest');
+    const isJS = !runningMigrationOnly;
+    const migrationsConfig = {
+        extension: isJS ? 'js' : 'ts',
+        directory: 'migrations',
+        tableName: 'migrations_keystore',
+        loadExtensions: [isJS ? '.js' : '.ts'],
+        schemaName: schema
+    };
+
+    const filename = fileURLToPath(import.meta.url);
+    const dirname = path.dirname(path.join(filename, '../../'));
+    const dir = path.join(dirname, 'dist/db/migrations');
+
+    await db.raw(`CREATE SCHEMA IF NOT EXISTS ${schema}`);
+    const [, pendingMigrations] = (await db.migrate.list({ ...migrationsConfig, directory: dir })) as [unknown, string[]];
+    if (pendingMigrations.length === 0) {
+        logger.info('[keystore] nothing to do');
+        return;
+    }
+
+    await db.migrate.latest({ ...migrationsConfig, directory: dir });
+    logger.info('[keystore] migrations completed.');
+}

--- a/packages/keystore/lib/db/migrate.ts
+++ b/packages/keystore/lib/db/migrate.ts
@@ -3,7 +3,7 @@ import type knex from 'knex';
 import { fileURLToPath } from 'node:url';
 import { logger } from '../utils/logger.js';
 
-export async function migrate(db: knex.Knex, schema: string): Promise<void> {
+export async function migrate(db: knex.Knex, migrationSchema: string = 'migrations'): Promise<void> {
     logger.info('[keystore] migration');
 
     const runningMigrationOnly = process.argv.some((v) => v === 'migrate:latest');
@@ -11,16 +11,16 @@ export async function migrate(db: knex.Knex, schema: string): Promise<void> {
     const migrationsConfig = {
         extension: isJS ? 'js' : 'ts',
         directory: 'migrations',
+        schemaName: migrationSchema,
         tableName: 'migrations_keystore',
-        loadExtensions: [isJS ? '.js' : '.ts'],
-        schemaName: schema
+        loadExtensions: [isJS ? '.js' : '.ts']
     };
 
     const filename = fileURLToPath(import.meta.url);
     const dirname = path.dirname(path.join(filename, '../../'));
     const dir = path.join(dirname, 'dist/db/migrations');
 
-    await db.raw(`CREATE SCHEMA IF NOT EXISTS ${schema}`);
+    await db.raw(`CREATE SCHEMA IF NOT EXISTS ${migrationSchema}`);
     const [, pendingMigrations] = (await db.migrate.list({ ...migrationsConfig, directory: dir })) as [unknown, string[]];
     if (pendingMigrations.length === 0) {
         logger.info('[keystore] nothing to do');

--- a/packages/keystore/lib/db/migrations/20240920184658_initial_keystore_model.ts
+++ b/packages/keystore/lib/db/migrations/20240920184658_initial_keystore_model.ts
@@ -1,0 +1,37 @@
+import type { Knex } from 'knex';
+import { PRIVATE_KEYS_TABLE } from '../../models/privatekeys.js';
+
+export const config = {
+    transaction: false
+};
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.transaction(async (trx) => {
+        await trx.raw(`
+            CREATE TYPE entity_types AS ENUM (
+                'session',
+                'connection',
+                'environment'
+            );
+        `);
+        await trx.raw(`
+            CREATE TABLE IF NOT EXISTS ${PRIVATE_KEYS_TABLE} (
+                id SERIAL PRIMARY KEY,
+                display_name VARCHAR(255) NOT NULL,
+                encrypted BYTEA NOT NULL,
+                hash TEXT NOT NULL UNIQUE,
+                created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+                deleted_at TIMESTAMP WITH TIME ZONE,
+                expires_at TIMESTAMP WITH TIME ZONE,
+                last_access_at TIMESTAMP WITH TIME ZONE,
+                entity_type entity_types NOT NULL,
+                entity_id INTEGER NOT NULL
+            );
+        `);
+    });
+    await knex.raw(`CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_${PRIVATE_KEYS_TABLE}_type_hash" ON ${PRIVATE_KEYS_TABLE} (entity_type, hash);`);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`DROP TABLE IF EXISTS ${PRIVATE_KEYS_TABLE}`);
+}

--- a/packages/keystore/lib/db/migrations/20240920184658_initial_keystore_model.ts
+++ b/packages/keystore/lib/db/migrations/20240920184658_initial_keystore_model.ts
@@ -8,7 +8,7 @@ export const config = {
 export async function up(knex: Knex): Promise<void> {
     await knex.transaction(async (trx) => {
         await trx.raw(`
-            CREATE TYPE entity_types AS ENUM (
+            CREATE TYPE private_key_entity_types AS ENUM (
                 'session',
                 'connection',
                 'environment'
@@ -18,18 +18,18 @@ export async function up(knex: Knex): Promise<void> {
             CREATE TABLE IF NOT EXISTS ${PRIVATE_KEYS_TABLE} (
                 id SERIAL PRIMARY KEY,
                 display_name VARCHAR(255) NOT NULL,
-                encrypted BYTEA NOT NULL,
+                account_id INTEGER NOT NULL,
+                environment_id INTEGER NOT NULL,
+                encrypted BYTEA,
                 hash TEXT NOT NULL UNIQUE,
                 created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-                deleted_at TIMESTAMP WITH TIME ZONE,
                 expires_at TIMESTAMP WITH TIME ZONE,
                 last_access_at TIMESTAMP WITH TIME ZONE,
-                entity_type entity_types NOT NULL,
+                entity_type private_key_entity_types NOT NULL,
                 entity_id INTEGER NOT NULL
             );
         `);
     });
-    await knex.raw(`CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_${PRIVATE_KEYS_TABLE}_type_hash" ON ${PRIVATE_KEYS_TABLE} (entity_type, hash);`);
 }
 
 export async function down(knex: Knex): Promise<void> {

--- a/packages/keystore/lib/index.ts
+++ b/packages/keystore/lib/index.ts
@@ -1,0 +1,3 @@
+export * from './types.js';
+export * from './db/migrate.js';
+export * from './models/privatekeys.js';

--- a/packages/keystore/lib/index.ts
+++ b/packages/keystore/lib/index.ts
@@ -1,3 +1,2 @@
-export * from './types.js';
 export * from './db/migrate.js';
 export * from './models/privatekeys.js';

--- a/packages/keystore/lib/models/privatekeys.integration.test.ts
+++ b/packages/keystore/lib/models/privatekeys.integration.test.ts
@@ -1,0 +1,169 @@
+import { expect, describe, it, afterAll } from 'vitest';
+import { createPrivateKey, getPrivateKey, deletePrivateKey, decryptPrivateKey } from './privatekeys.js';
+import { testDb } from '../db/helpers.test.js';
+
+describe('PrivateKey', async () => {
+    const db = await testDb.init();
+
+    afterAll(async () => {
+        await testDb.clear(db);
+    });
+
+    it('should be created and retrieved', async () => {
+        const entityType = 'session';
+        const displayName = 'this is my key';
+        const createKey = await createPrivateKey(db, {
+            displayName,
+            entityType,
+            entityId: 1
+        });
+        if (createKey.isErr()) {
+            throw createKey.error;
+        }
+        const keyValue = createKey.value;
+        const getKey = await getPrivateKey(db, {
+            keyValue,
+            entityType
+        });
+        if (getKey.isErr()) {
+            throw getKey.error;
+        }
+        expect(getKey.value.displayName).toBe(displayName);
+        expect(getKey.value.entityType).toBe(entityType);
+
+        const decrypted = decryptPrivateKey(getKey.value);
+        if (decrypted.isErr()) {
+            throw decrypted.error;
+        }
+        expect(decrypted.value.substring(0, 11)).toBe('nango_sess_');
+    });
+
+    it('should return an error if the key is not found', async () => {
+        const res = await getPrivateKey(db, {
+            keyValue: 'abc',
+            entityType: 'session'
+        });
+        expect(res.isErr()).toBe(true);
+    });
+
+    it('should return an error if the key exists but entity is incorrect', async () => {
+        const createKey = await createPrivateKey(db, {
+            displayName: 'this is my key',
+            entityType: 'session',
+            entityId: 1
+        });
+        if (createKey.isErr()) {
+            throw createKey.error;
+        }
+        const getKey = await getPrivateKey(db, {
+            keyValue: createKey.value,
+            entityType: 'connection'
+        });
+        expect(getKey.isErr()).toBe(true);
+    });
+
+    it('should be deleted', async () => {
+        const entityType = 'session';
+        const createKey = await createPrivateKey(db, {
+            displayName: 'this is my key',
+            entityType,
+            entityId: 1
+        });
+        if (createKey.isErr()) {
+            throw createKey.error;
+        }
+
+        const getKey = await getPrivateKey(db, {
+            keyValue: createKey.value,
+            entityType
+        });
+        if (getKey.isErr()) {
+            throw getKey.error;
+        }
+
+        const deleteKey = await deletePrivateKey(db, {
+            keyValue: createKey.value,
+            entityType
+        });
+        expect(deleteKey.isOk()).toBe(true);
+
+        const getKeyAgain = await getPrivateKey(db, {
+            keyValue: createKey.value,
+            entityType
+        });
+        expect(getKeyAgain.isErr()).toBe(true);
+    });
+
+    it('should have their last_access_at updated when retrieved', async () => {
+        const entityType = 'session';
+        const createKey = await createPrivateKey(db, {
+            displayName: 'this is my key',
+            entityType,
+            entityId: 1
+        });
+        if (createKey.isErr()) {
+            throw createKey.error;
+        }
+        const getKey = await getPrivateKey(db, {
+            keyValue: createKey.value,
+            entityType
+        });
+        if (getKey.isErr()) {
+            throw getKey.error;
+        }
+        const lastAccessAt1 = getKey.value.lastAccessAt;
+        expect(lastAccessAt1).not.toBe(null);
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        const getKeyAgain = await getPrivateKey(db, {
+            keyValue: createKey.value,
+            entityType
+        });
+        if (getKeyAgain.isErr()) {
+            throw getKeyAgain.error;
+        }
+        const lastAccessAt2 = getKeyAgain.value.lastAccessAt;
+        expect(lastAccessAt2).not.toBe(null);
+        expect(lastAccessAt2?.getTime() || 0).toBeGreaterThan(lastAccessAt1?.getTime() || 0);
+    });
+
+    it('should be retrieved before it expires', async () => {
+        const entityType = 'session';
+        const ttlInMs = 30;
+        const createKey = await createPrivateKey(db, {
+            displayName: 'this is my key',
+            entityType,
+            entityId: 1,
+            ttlInMs
+        });
+        if (createKey.isErr()) {
+            throw createKey.error;
+        }
+        await new Promise((resolve) => setTimeout(resolve, ttlInMs / 2));
+        const getKey = await getPrivateKey(db, {
+            keyValue: createKey.value,
+            entityType
+        });
+        expect(getKey.isOk()).toBe(true);
+    });
+
+    it('should expires', async () => {
+        const entityType = 'session';
+        const ttlInMs = 5;
+        const createKey = await createPrivateKey(db, {
+            displayName: 'this is my key',
+            entityType,
+            entityId: 1,
+            ttlInMs
+        });
+        if (createKey.isErr()) {
+            throw createKey.error;
+        }
+        await new Promise((resolve) => setTimeout(resolve, ttlInMs * 2));
+        const getKey = await getPrivateKey(db, {
+            keyValue: createKey.value,
+            entityType
+        });
+        expect(getKey.isErr()).toBe(true);
+    });
+});

--- a/packages/keystore/lib/models/privatekeys.ts
+++ b/packages/keystore/lib/models/privatekeys.ts
@@ -1,0 +1,152 @@
+import * as crypto from 'crypto';
+import type knex from 'knex';
+import type { Result } from '@nangohq/utils';
+import { Ok, Err } from '@nangohq/utils';
+import type { EntityType, PrivateKey } from '../types.js';
+import { getEncryption } from '../utils/encryption.js';
+
+export const PRIVATE_KEYS_TABLE = 'private_keys';
+
+type PrivateKeyErrorCodes = 'not_found' | 'invalid' | 'creation_failed';
+export class PrivateKeyError extends Error {
+    public code: PrivateKeyErrorCodes;
+    public payload?: Record<string, unknown>;
+    constructor({ code, message, payload }: { code: PrivateKeyErrorCodes; message: string; payload?: Record<string, unknown> }) {
+        super(message);
+        this.code = code;
+        this.payload = payload || {};
+    }
+}
+
+export interface DbPrivateKey {
+    readonly id: number;
+    readonly display_name: string;
+    readonly encrypted: Buffer;
+    readonly hash: string;
+    readonly created_at: Date;
+    readonly deleted_at: Date | null;
+    readonly expires_at: Date | null;
+    readonly last_access_at: Date | null;
+    readonly entity_type: EntityType;
+    readonly entity_id: number;
+}
+type DbInsertPrivateKey = Omit<DbPrivateKey, 'id' | 'created_at' | 'deleted_at' | 'last_access_at'>;
+
+export const DbPrivateKey = {
+    to: (key: PrivateKey): DbPrivateKey => {
+        return {
+            id: key.id,
+            display_name: key.displayName,
+            encrypted: key.encrypted,
+            hash: key.hash,
+            created_at: key.createdAt,
+            deleted_at: key.deletedAt,
+            expires_at: key.expiresAt,
+            last_access_at: key.lastAccessAt,
+            entity_type: key.entityType,
+            entity_id: key.entityId
+        };
+    },
+    from: (dbKey: DbPrivateKey): PrivateKey => {
+        return {
+            id: dbKey.id,
+            displayName: dbKey.display_name,
+            encrypted: dbKey.encrypted,
+            hash: dbKey.hash,
+            createdAt: dbKey.created_at,
+            deletedAt: dbKey.deleted_at,
+            expiresAt: dbKey.expires_at,
+            lastAccessAt: dbKey.last_access_at,
+            entityType: dbKey.entity_type,
+            entityId: dbKey.entity_id
+        };
+    }
+};
+
+export async function createPrivateKey(
+    db: knex.Knex,
+    { displayName, entityType, entityId, ttlInMs }: Pick<PrivateKey, 'displayName' | 'entityType' | 'entityId'> & { ttlInMs?: number }
+): Promise<Result<string, PrivateKeyError>> {
+    const now = new Date();
+    const prefix = entityType.slice(0, 4);
+    const random = crypto.randomBytes(32).toString('hex');
+    const keyValue = `nango_${prefix}_${random}`;
+    const key: DbInsertPrivateKey = {
+        display_name: displayName,
+        encrypted: encryptValue(keyValue),
+        hash: hashValue(keyValue),
+        expires_at: ttlInMs ? new Date(now.getTime() + ttlInMs) : null,
+        entity_type: entityType,
+        entity_id: entityId
+    };
+    const [dbKey] = await db.into(PRIVATE_KEYS_TABLE).insert(key).returning('*');
+    if (!dbKey) {
+        return Err(new PrivateKeyError({ code: 'creation_failed', message: 'Failed to create private key' }));
+    }
+    return Ok(keyValue);
+}
+
+export async function getPrivateKey(
+    db: knex.Knex,
+    { keyValue, entityType }: { keyValue: string; entityType: EntityType }
+): Promise<Result<PrivateKey, PrivateKeyError>> {
+    const now = new Date();
+    const [key] = await db
+        .update({ last_access_at: now })
+        .from<DbPrivateKey>(PRIVATE_KEYS_TABLE)
+        .where({ hash: hashValue(keyValue), entity_type: entityType, deleted_at: null })
+        .andWhere((builder) => builder.whereNull('expires_at').orWhere('expires_at', '>', now))
+        .returning('*');
+    if (!key) {
+        return Err(
+            new PrivateKeyError({
+                code: 'not_found',
+                message: `Private key not found`,
+                payload: {
+                    keyValue: keyValue.substring(0, 8),
+                    entityType
+                }
+            })
+        );
+    }
+    return Ok(DbPrivateKey.from(key));
+}
+
+export async function deletePrivateKey(
+    db: knex.Knex,
+    { keyValue, entityType }: { keyValue: string; entityType: EntityType }
+): Promise<Result<void, PrivateKeyError>> {
+    const now = new Date();
+    const [key] = await db
+        .update({ last_access_at: now, deleted_at: now })
+        .from<DbPrivateKey>(PRIVATE_KEYS_TABLE)
+        .where({ hash: hashValue(keyValue), entity_type: entityType, deleted_at: null })
+        .returning('*');
+    if (!key) {
+        return Err(new PrivateKeyError({ code: 'not_found', message: `Private key not found` }));
+    }
+    return Ok(undefined);
+}
+
+export function decryptPrivateKey(key: PrivateKey): Result<string, PrivateKeyError> {
+    return decryptValue(key.encrypted);
+}
+
+function encryptValue(keyValue: string): Buffer {
+    const encryption = getEncryption();
+    const [encrypted, iv, tag] = encryption.encrypt(keyValue);
+    return Buffer.from(`${encrypted}:${iv}:${tag}`);
+}
+
+function decryptValue(encryptedValue: Buffer): Result<string, PrivateKeyError> {
+    const encryption = getEncryption();
+    const [encrypted, iv, tag] = encryptedValue.toString().split(':');
+    if (!encrypted || !iv || !tag) {
+        return Err(new PrivateKeyError({ code: 'invalid', message: 'Invalid encrypted value' }));
+    }
+    return Ok(encryption.decrypt(encrypted, iv, tag));
+}
+
+function hashValue(keyValue: string): string {
+    return keyValue;
+}

--- a/packages/keystore/lib/types.ts
+++ b/packages/keystore/lib/types.ts
@@ -1,0 +1,15 @@
+export const entityTypes = ['session', 'connection', 'environment'] as const;
+export type EntityType = (typeof entityTypes)[number];
+
+export interface PrivateKey {
+    readonly id: number;
+    readonly displayName: string;
+    readonly encrypted: Buffer;
+    readonly hash: string;
+    readonly createdAt: Date;
+    readonly deletedAt: Date | null;
+    readonly expiresAt: Date | null;
+    readonly lastAccessAt: Date | null;
+    readonly entityType: EntityType;
+    readonly entityId: number;
+}

--- a/packages/keystore/lib/utils/encryption.ts
+++ b/packages/keystore/lib/utils/encryption.ts
@@ -1,0 +1,15 @@
+import { Encryption } from '@nangohq/utils';
+import { envs } from './env.js';
+
+let encryption: Encryption | null = null;
+
+export function getEncryption(): Encryption {
+    if (!encryption) {
+        const encryptionKey = envs.NANGO_ENCRYPTION_KEY;
+        if (!encryptionKey) {
+            throw new Error('NANGO_ENCRYPTION_KEY is not set');
+        }
+        encryption = new Encryption(encryptionKey);
+    }
+    return encryption;
+}

--- a/packages/keystore/lib/utils/env.ts
+++ b/packages/keystore/lib/utils/env.ts
@@ -1,0 +1,3 @@
+import { ENVS, parseEnvs } from '@nangohq/utils';
+
+export const envs = parseEnvs(ENVS);

--- a/packages/keystore/lib/utils/logger.ts
+++ b/packages/keystore/lib/utils/logger.ts
@@ -1,0 +1,3 @@
+import { getLogger } from '@nangohq/utils';
+
+export const logger = getLogger('keystore');

--- a/packages/keystore/lib/utils/tracer.ts
+++ b/packages/keystore/lib/utils/tracer.ts
@@ -1,0 +1,11 @@
+import tracer from 'dd-trace';
+
+tracer.init({
+    service: 'nango-keystore'
+});
+tracer.use('pg', {
+    service: (params: { database: string }) => `postgres-${params.database}`
+});
+tracer.use('dns', {
+    enabled: false
+});

--- a/packages/keystore/package.json
+++ b/packages/keystore/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "@nangohq/keystore",
+    "version": "1.0.0",
+    "type": "module",
+    "main": "dist/index.js",
+    "private": true,
+    "scripts": {
+        "dev:migration:create": "npm run knex -- migrate:make",
+        "dev:migration:run": "npm run knex -- migrate:latest",
+        "knex": "tsx ../../node_modules/knex/bin/cli.js --knexfile lib/db/knexfile.ts",
+        "prod:migration:run": "knex --knexfile dist/db/knexfile.js migrate:latest"
+    },
+    "keywords": [],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/NangoHQ/nango.git",
+        "directory": "packages/keystore"
+    },
+    "dependencies": {
+        "@nangohq/utils": "file:../utils",
+        "dd-trace": "5.21.0",
+        "knex": "3.1.0"
+    },
+    "devDependencies": {
+        "vitest": "1.6.0"
+    }
+}

--- a/packages/keystore/package.json
+++ b/packages/keystore/package.json
@@ -22,6 +22,7 @@
         "knex": "3.1.0"
     },
     "devDependencies": {
+        "@nangohq/type": "file:../type",
         "vitest": "1.6.0"
     }
 }

--- a/packages/keystore/tsconfig.json
+++ b/packages/keystore/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "lib",
+        "outDir": "dist"
+    },
+    "references": [{ "path": "../utils" }],
+    "include": ["lib/**/*", "../utils/lib/vitest.d.ts"]
+}

--- a/packages/keystore/tsconfig.json
+++ b/packages/keystore/tsconfig.json
@@ -4,6 +4,6 @@
         "rootDir": "lib",
         "outDir": "dist"
     },
-    "references": [{ "path": "../utils" }],
+    "references": [{ "path": "../utils" }, { "path": "../types" }],
     "include": ["lib/**/*", "../utils/lib/vitest.d.ts"]
 }

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -23,6 +23,7 @@ COPY packages/nango-yaml/ packages/nango-yaml/
 COPY packages/records/ packages/records/
 COPY packages/scheduler/ packages/scheduler/
 COPY packages/orchestrator/ packages/orchestrator/
+COPY packages/keystore/ packages/keystore/
 
 RUN npm pkg delete scripts.prepare
 RUN npm ci --omit=dev

--- a/packages/server/lib/migrate.ts
+++ b/packages/server/lib/migrate.ts
@@ -6,7 +6,7 @@ import { migrate as migrateKeystore } from '@nangohq/keystore';
 
 const db = new KnexDatabase({ timeoutMs: 0 }); // Disable timeout for migrations
 await migrate(db);
-await migrateKeystore(db.knex, db.schema());
+await migrateKeystore(db.knex);
 await migrateLogs();
 await migrateRecords();
 

--- a/packages/server/lib/migrate.ts
+++ b/packages/server/lib/migrate.ts
@@ -1,8 +1,12 @@
+import { KnexDatabase } from '@nangohq/database';
 import migrate from './utils/migrate.js';
 import { start as migrateLogs } from '@nangohq/logs';
 import { migrate as migrateRecords } from '@nangohq/records';
+import { migrate as migrateKeystore } from '@nangohq/keystore';
 
-await migrate();
+const db = new KnexDatabase({ timeoutMs: 0 }); // Disable timeout for migrations
+await migrate(db);
+await migrateKeystore(db.knex, db.schema());
 await migrateLogs();
 await migrateRecords();
 

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -50,7 +50,7 @@ wss.on('connection', async (ws: WebSocket) => {
 if (NANGO_MIGRATE_AT_START === 'true') {
     const db = new KnexDatabase({ timeoutMs: 0 }); // Disable timeout for migrations
     await migrate(db);
-    await migrateKeystore(db.knex, db.schema());
+    await migrateKeystore(db.knex);
     await migrateLogs();
     await migrateRecords();
 } else {

--- a/packages/server/lib/utils/migrate.ts
+++ b/packages/server/lib/utils/migrate.ts
@@ -3,10 +3,9 @@ import { getLogger } from '@nangohq/utils';
 const logger = getLogger('Server');
 
 import { encryptionManager } from '@nangohq/shared';
-import { KnexDatabase } from '@nangohq/database';
+import type { KnexDatabase } from '@nangohq/database';
 
-export default async function migrate() {
-    const db = new KnexDatabase({ timeoutMs: 0 }); // Disable timeout for migrations
+export default async function migrate(db: KnexDatabase): Promise<void> {
     logger.info('Migrating database ...');
     await db.knex.raw(`CREATE SCHEMA IF NOT EXISTS ${db.schema()}`);
     await db.migrate(process.env['NANGO_DB_MIGRATION_FOLDER'] || '../database/lib/migrations');

--- a/packages/server/nodemon.json
+++ b/packages/server/nodemon.json
@@ -1,5 +1,15 @@
 {
-    "watch": ["dist", "../shared/dist", "../logs/dist", "../records/dist", "../utils/dist", "../webhooks/dist", "../../.env", "../shared/providers.yaml"],
+    "watch": [
+        "dist",
+        "../shared/dist",
+        "../logs/dist",
+        "../records/dist",
+        "../utils/dist",
+        "../webhooks/dist",
+        "../keystore/dist",
+        "../../.env",
+        "../shared/providers.yaml"
+    ],
     "ext": "js,ts,json",
     "ignore": ["src/**/*.test.ts"],
     "exec": "tsx -r dotenv/config lib/server.ts Dotenv_config_path=./../../.env"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,6 +32,7 @@
         "@nangohq/types": "file:../types",
         "@nangohq/utils": "file:../utils",
         "@nangohq/webhooks": "file:../webhooks",
+        "@nangohq/keystore": "file:../keystore",
         "@workos-inc/node": "6.2.0",
         "axios": "^1.7.4",
         "body-parser": "1.20.3",

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -12,6 +12,9 @@
             "path": "../logs"
         },
         {
+            "path": "../keystore"
+        },
+        {
             "path": "../webhooks"
         },
         {
@@ -36,9 +39,5 @@
             "path": "../orchestrator"
         }
     ],
-    "include": [
-        "lib/**/*",
-        "../shared/lib/express.d.ts",
-        "../utils/lib/vitest.d.ts"
-    ]
+    "include": ["lib/**/*", "../shared/lib/express.d.ts", "../utils/lib/vitest.d.ts"]
 }

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -7,6 +7,7 @@ export type * from './onboarding/api.js';
 export type * from './record/api.js';
 export type * from './logs/api.js';
 export type * from './logs/messages.js';
+export type * from './keystore/index.js';
 
 export type * from './account/api.js';
 export type * from './user/api.js';

--- a/packages/types/lib/keystore/index.ts
+++ b/packages/types/lib/keystore/index.ts
@@ -4,10 +4,11 @@ export type EntityType = (typeof entityTypes)[number];
 export interface PrivateKey {
     readonly id: number;
     readonly displayName: string;
-    readonly encrypted: Buffer;
+    readonly environmentId: number;
+    readonly accountId: number;
+    readonly encrypted: Buffer | null;
     readonly hash: string;
     readonly createdAt: Date;
-    readonly deletedAt: Date | null;
     readonly expiresAt: Date | null;
     readonly lastAccessAt: Date | null;
     readonly entityType: EntityType;

--- a/packages/types/lib/keystore/index.ts
+++ b/packages/types/lib/keystore/index.ts
@@ -1,5 +1,4 @@
-export const entityTypes = ['session', 'connection', 'environment'] as const;
-export type EntityType = (typeof entityTypes)[number];
+export type EntityType = 'session' | 'connection' | 'environment';
 
 export interface PrivateKey {
     readonly id: number;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -60,6 +60,9 @@
         },
         {
             "path": "packages/data-ingestion"
+        },
+        {
+            "path": "packages/keystore"
         }
     ]
 }


### PR DESCRIPTION
## Describe your changes

A new keystore package containing logic to create, store, retrieve and delete private keys.
I decided to make it an independant package instead of adding it to `server` so it can be self-contained and reusable. It means the table migrations are different (which creates new migrations table) but also means the package can be used independently. 
The db client must be provided though so it can use the same as the one used by the service importing `keystore`. 
In this PR I added keystore to `server`. In next PR I will add the endpoint used in the new auth flow to create and check session token

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1758/implement-keystore-package

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests, otherwise the reason is: 
- [x] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
