### PR TITLE
fix(ui): clear cache on integration save

### DIFF
--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/App.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/App.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react';
 import { useStore } from '../../../../../store';
 import { apiPatchIntegration } from '../../../../../hooks/useIntegration';
 import { useToast } from '../../../../../hooks/useToast';
+import { mutate } from 'swr';
 
 export const SettingsApp: React.FC<{ data: GetIntegration['Success']['data']; environment: EnvironmentAndAccount['environment'] }> = ({
     data: { integration },
@@ -32,6 +33,7 @@ export const SettingsApp: React.FC<{ data: GetIntegration['Success']['data']; en
             toast({ title: updated.json.error.message || 'Failed to update, an error occurred', variant: 'error' });
         } else {
             toast({ title: 'Successfully updated integration', variant: 'success' });
+            void mutate((key) => typeof key === 'string' && key.startsWith(`/api/v1/integrations`));
         }
 
         setLoading(false);

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/Custom.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/Custom.tsx
@@ -12,6 +12,7 @@ import { useStore } from '../../../../../store';
 import SecretTextarea from '../../../../../components/ui/input/SecretTextArea';
 import { apiPatchIntegration } from '../../../../../hooks/useIntegration';
 import { useToast } from '../../../../../hooks/useToast';
+import { mutate } from 'swr';
 
 export const SettingsCustom: React.FC<{ data: GetIntegration['Success']['data']; environment: EnvironmentAndAccount['environment'] }> = ({
     data: { integration },
@@ -36,6 +37,7 @@ export const SettingsCustom: React.FC<{ data: GetIntegration['Success']['data'];
             toast({ title: updated.json.error.message || 'Failed to update, an error occurred', variant: 'error' });
         } else {
             toast({ title: 'Successfully updated integration', variant: 'success' });
+            void mutate((key) => typeof key === 'string' && key.startsWith(`/api/v1/integrations`));
         }
 
         setLoading(false);

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuth.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuth.tsx
@@ -12,6 +12,7 @@ import { useStore } from '../../../../../store';
 import TagsInput from '../../../../../components/ui/input/TagsInput';
 import { apiPatchIntegration } from '../../../../../hooks/useIntegration';
 import { useToast } from '../../../../../hooks/useToast';
+import { mutate } from 'swr';
 
 export const SettingsOAuth: React.FC<{ data: GetIntegration['Success']['data']; environment: EnvironmentAndAccount['environment'] }> = ({
     data: { integration, template },
@@ -33,6 +34,7 @@ export const SettingsOAuth: React.FC<{ data: GetIntegration['Success']['data']; 
         if ('error' in updated.json) {
             toast({ title: updated.json.error.message || 'Failed to update, an error occurred', variant: 'error' });
         } else {
+            void mutate((key) => typeof key === 'string' && key.startsWith(`/api/v1/integrations`));
             toast({ title: 'Successfully updated integration', variant: 'success' });
         }
 


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1784/refresh-cache-on-integration-save

- Refresh cache when we save integration credentials
