### PR TITLE
chore(integration-template-reference): [nan-1760] update references to integration templates to point to the new repo

### DIFF
--- a/docs-v2/customize/guides/extend-an-integration-template.mdx
+++ b/docs-v2/customize/guides/extend-an-integration-template.mdx
@@ -16,7 +16,7 @@ Pre-requisite: set up an integrations folder ([step-by-step guide](/customize/gu
 
 # Download the template code
 
-Download the template code locally. The code is available on [GitHub](https://github.com/NangoHQ/nango/tree/master/integration-templates) or directly in the Nango UI in the _Endpoints_ tab of an integration.
+Download the template code locally. The code is available on [GitHub](https://github.com/NangoHQ/integration-templates/tree/main/integrations) or directly in the Nango UI in the _Endpoints_ tab of an integration.
 
 # Copy/paste the integration configuration & scripts
 

--- a/docs-v2/integrations/integration-templates/algolia.mdx
+++ b/docs-v2/integrations/integration-templates/algolia.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Algolia'
 </Card>
 
 <Card title="Get the Algolia template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/algolia"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/algolia"
       icon="github">
     Get the latest version of the Algolia integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/anrok.mdx
+++ b/docs-v2/integrations/integration-templates/anrok.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Anrok'
 </Card>
 
 <Card title="Get the Anrok template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/anrok"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/anrok"
       icon="github">
     Get the latest version of the Anrok integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/asana.mdx
+++ b/docs-v2/integrations/integration-templates/asana.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Asana'
 </Card>
 
 <Card title="Get the Asana template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/asana"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/asana"
       icon="github">
     Get the latest version of the Asana integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/ashby.mdx
+++ b/docs-v2/integrations/integration-templates/ashby.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Ashby'
 </Card>
 
 <Card title="Get the Ashby template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/ashby"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/ashby"
       icon="github">
     Get the latest version of the Ashby integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/bamboohr-basic.mdx
+++ b/docs-v2/integrations/integration-templates/bamboohr-basic.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Bamboohr Basic'
 </Card>
 
 <Card title="Get the Bamboohr Basic template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/bamboohr-basic"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/bamboohr-basic"
       icon="github">
     Get the latest version of the Bamboohr Basic integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/calendly.mdx
+++ b/docs-v2/integrations/integration-templates/calendly.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Calendly'
 </Card>
 
 <Card title="Get the Calendly template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/calendly"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/calendly"
       icon="github">
     Get the latest version of the Calendly integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/checkr-partner-staging.mdx
+++ b/docs-v2/integrations/integration-templates/checkr-partner-staging.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Checkr Partner Staging'
 </Card>
 
 <Card title="Get the Checkr Partner Staging template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/checkr-partner-staging"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/checkr-partner-staging"
       icon="github">
     Get the latest version of the Checkr Partner Staging integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/checkr-partner.mdx
+++ b/docs-v2/integrations/integration-templates/checkr-partner.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Checkr Partner'
 </Card>
 
 <Card title="Get the Checkr Partner template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/checkr-partner"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/checkr-partner"
       icon="github">
     Get the latest version of the Checkr Partner integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/clari-copilot.mdx
+++ b/docs-v2/integrations/integration-templates/clari-copilot.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Clari Copilot'
 </Card>
 
 <Card title="Get the Clari Copilot template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/clari-copilot"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/clari-copilot"
       icon="github">
     Get the latest version of the Clari Copilot integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/confluence.mdx
+++ b/docs-v2/integrations/integration-templates/confluence.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Confluence'
 </Card>
 
 <Card title="Get the Confluence template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/confluence"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/confluence"
       icon="github">
     Get the latest version of the Confluence integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/discourse.mdx
+++ b/docs-v2/integrations/integration-templates/discourse.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Discourse'
 </Card>
 
 <Card title="Get the Discourse template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/discourse"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/discourse"
       icon="github">
     Get the latest version of the Discourse integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/evaluagent.mdx
+++ b/docs-v2/integrations/integration-templates/evaluagent.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Evaluagent'
 </Card>
 
 <Card title="Get the Evaluagent  template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/evaluagent"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/evaluagent"
       icon="github">
     Get the latest version of the Evaluagent  integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/exact-online.mdx
+++ b/docs-v2/integrations/integration-templates/exact-online.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Exact Online'
 </Card>
 
 <Card title="Get the Exact Online template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/exact-online"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/exact-online"
       icon="github">
     Get the latest version of the Exact Online integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/expensify.mdx
+++ b/docs-v2/integrations/integration-templates/expensify.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Expensify'
 </Card>
 
 <Card title="Get the Expensify template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/expensify"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/expensify"
       icon="github">
     Get the latest version of the Expensify integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/fireflies.mdx
+++ b/docs-v2/integrations/integration-templates/fireflies.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Fireflies'
 </Card>
 
 <Card title="Get the Fireflies template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/fireflies"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/fireflies"
       icon="github">
     Get the latest version of the Fireflies integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/github.mdx
+++ b/docs-v2/integrations/integration-templates/github.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'GitHub'
 </Card>
 
 <Card title="Get the Github template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/github"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/github"
       icon="github">
     Get the latest version of the Github integration templates from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/google-calendar.mdx
+++ b/docs-v2/integrations/integration-templates/google-calendar.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Google Calendar'
 </Card>
 
 <Card title="Get the Google Calendar template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/google-calendar"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/google-calendar"
       icon="github">
     Get the latest version of the Google Calendar integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/google-drive.mdx
+++ b/docs-v2/integrations/integration-templates/google-drive.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Google Drive'
 </Card>
 
 <Card title="Get the Google Drive template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/google-drive"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/google-drive"
       icon="github">
     Get the latest version of the Google Drive integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/google-mail.mdx
+++ b/docs-v2/integrations/integration-templates/google-mail.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Google Mail'
 </Card>
 
 <Card title="Get the Google Mail template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/google-mail"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/google-mail"
       icon="github">
     Get the latest version of the Google Mail integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/greenhouse-basic.mdx
+++ b/docs-v2/integrations/integration-templates/greenhouse-basic.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Greenhouse Basic'
 </Card>
 
 <Card title="Get the Greenhouse Basic template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/greenhouse-basic"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/greenhouse-basic"
       icon="github">
     Get the latest version of the Greenhouse Basic integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/hackerrank-work.mdx
+++ b/docs-v2/integrations/integration-templates/hackerrank-work.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'HackerRank-Work'
 </Card>
 
 <Card title="Get the HackerRank-Work template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/hackerrank-work"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/hackerrank-work"
       icon="github">
     Get the latest version of the HackerRank-Work integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/hibob-service-user.mdx
+++ b/docs-v2/integrations/integration-templates/hibob-service-user.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'HiBob Service User'
 </Card>
 
 <Card title="Get the HiBob Service User template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/hibob-service-user"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/hibob-service-user"
       icon="github">
     Get the latest version of the HiBob Service User integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/hubspot.mdx
+++ b/docs-v2/integrations/integration-templates/hubspot.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Hubspot'
 </Card>
 
 <Card title="Get the Hubspot template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/hubspot"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot"
       icon="github">
     Get the latest version of the Hubspot integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/instantly.mdx
+++ b/docs-v2/integrations/integration-templates/instantly.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Instantly'
 </Card>
 
 <Card title="Get the Instantly template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/instantly"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/instantly"
       icon="github">
     Get the latest version of the Instantly integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/intercom.mdx
+++ b/docs-v2/integrations/integration-templates/intercom.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Intercom'
 </Card>
 
 <Card title="Get the Intercom template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/intercom"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/intercom"
       icon="github">
     Get the latest version of the Intercom integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/jira.mdx
+++ b/docs-v2/integrations/integration-templates/jira.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Jira'
 </Card>
 
 <Card title="Get the Jira template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/jira"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/jira"
       icon="github">
     Get the latest version of the Jira integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/kustomer.mdx
+++ b/docs-v2/integrations/integration-templates/kustomer.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Kustomer'
 </Card>
 
 <Card title="Get the Kustomer template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/kustomer"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/kustomer"
       icon="github">
     Get the latest version of the Kustomer integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/lever-basic.mdx
+++ b/docs-v2/integrations/integration-templates/lever-basic.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Lever Basic'
 </Card>
 
 <Card title="Get the Lever Basic template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/lever-basic"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-basic"
       icon="github">
     Get the latest version of the Lever Basic integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/linear.mdx
+++ b/docs-v2/integrations/integration-templates/linear.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Linear'
 </Card>
 
 <Card title="Get the Linear template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/linear"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/linear"
       icon="github">
     Get the latest version of the Linear integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/luma.mdx
+++ b/docs-v2/integrations/integration-templates/luma.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Luma'
 </Card>
 
 <Card title="Get the Luma template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/luma"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/luma"
       icon="github">
     Get the latest version of the Luma integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/microsoft-active-directory.mdx
+++ b/docs-v2/integrations/integration-templates/microsoft-active-directory.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'MS Active Directory'
 </Card>
 
 <Card title="Get the Microsoft Active Directory template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/microsoft-active-directory"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/microsoft-active-directory"
       icon="github">
     Get the latest version of the Microsoft Active Directory integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/microsoft-teams.mdx
+++ b/docs-v2/integrations/integration-templates/microsoft-teams.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Microsoft Teams'
 </Card>
 
 <Card title="Get the Microsoft Teams template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/microsoft-teams"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/microsoft-teams"
       icon="github">
     Get the latest version of the Microsoft Teams integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/netsuite-tba.mdx
+++ b/docs-v2/integrations/integration-templates/netsuite-tba.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Netsuite'
 </Card>
 
 <Card title="Get the Netsuite template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/netsuite-tba"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/netsuite-tba"
       icon="github">
     Get the latest version of the Netsuite integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/next-cloud-ocs.mdx
+++ b/docs-v2/integrations/integration-templates/next-cloud-ocs.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'NextCloud OCS'
 </Card>
 
 <Card title="Get the NextCloud OCS template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/next-cloud-ocs"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/next-cloud-ocs"
       icon="github">
     Get the latest version of the NextCloud OCS integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/notion.mdx
+++ b/docs-v2/integrations/integration-templates/notion.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Notion'
 </Card>
 
 <Card title="Get the Notion template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/notion"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/notion"
       icon="github">
     Get the latest version of the Notion integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/pipedrive.mdx
+++ b/docs-v2/integrations/integration-templates/pipedrive.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Pipedrive'
 </Card>
 
 <Card title="Get the Pipedrive template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/pipedrive"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/pipedrive"
       icon="github">
     Get the latest version of the Pipedrive integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/quickbooks.mdx
+++ b/docs-v2/integrations/integration-templates/quickbooks.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Quickbooks'
 </Card>
 
 <Card title="Get the Quickbooks template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/quickbooks"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks"
       icon="github">
     Get the latest version of the Quickbooks integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/salesforce.mdx
+++ b/docs-v2/integrations/integration-templates/salesforce.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Salesforce'
 </Card>
 
 <Card title="Get the Salesforce template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/salesforce"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce"
       icon="github">
     Get the latest version of the Salesforce integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/sharepoint-online.mdx
+++ b/docs-v2/integrations/integration-templates/sharepoint-online.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Sharepoint Online'
 </Card>
 
 <Card title="Get the Sharepoint Online template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/sharepoint-online"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/sharepoint-online"
       icon="github">
     Get the latest version of the Sharepoint Online integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/slack.mdx
+++ b/docs-v2/integrations/integration-templates/slack.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Slack'
 </Card>
 
 <Card title="Get the Slack template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/slack"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/slack"
       icon="github">
     Get the latest version of the Slack integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/teamtailor.mdx
+++ b/docs-v2/integrations/integration-templates/teamtailor.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Teamtailor'
 </Card>
 
 <Card title="Get the Teamtailor template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/teamtailor"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/teamtailor"
       icon="github">
     Get the latest version of the Teamtailor integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/unanet.mdx
+++ b/docs-v2/integrations/integration-templates/unanet.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Unanet'
 </Card>
 
 <Card title="Get the Unanet template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/unanet"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/unanet"
       icon="github">
     Get the latest version of the Unanet integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/wildix-pbx.mdx
+++ b/docs-v2/integrations/integration-templates/wildix-pbx.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Wildix PBX'
 </Card>
 
 <Card title="Get the Wildix PBX template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/wildix-pbx"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/wildix-pbx"
       icon="github">
     Get the latest version of the Wildix PBX integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/woocommerce.mdx
+++ b/docs-v2/integrations/integration-templates/woocommerce.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Woocommerce'
 </Card>
 
 <Card title="Get the Woocommerce template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/woocommerce"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/woocommerce"
       icon="github">
     Get the latest version of the Woocommerce integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/workable.mdx
+++ b/docs-v2/integrations/integration-templates/workable.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Workable'
 </Card>
 
 <Card title="Get the Workable template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/workable"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/workable"
       icon="github">
     Get the latest version of the Workable integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/xero.mdx
+++ b/docs-v2/integrations/integration-templates/xero.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Xero'
 </Card>
 
 <Card title="Get the Xero template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/xero"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/xero"
       icon="github">
     Get the latest version of the Xero integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/zendesk.mdx
+++ b/docs-v2/integrations/integration-templates/zendesk.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Zendesk'
 </Card>
 
 <Card title="Get the Zendesk template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/zendesk"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/zendesk"
       icon="github">
     Get the latest version of the Zendesk integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/zoho-crm.mdx
+++ b/docs-v2/integrations/integration-templates/zoho-crm.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Zoho CRM'
 </Card>
 
 <Card title="Get the Zoho CRM template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/zoho-crm"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/zoho-crm"
       icon="github">
     Get the latest version of the Zoho CRM integration template from GitHub
 </Card>

--- a/docs-v2/integrations/integration-templates/zoho-mail.mdx
+++ b/docs-v2/integrations/integration-templates/zoho-mail.mdx
@@ -12,7 +12,7 @@ sidebarTitle: 'Zoho Mail'
 </Card>
 
 <Card title="Get the Zoho Mail template"
-      href="https://github.com/NangoHQ/nango/tree/master/integration-templates/zoho-mail"
+      href="https://github.com/NangoHQ/integration-templates/tree/main/integrations/zoho-mail"
       icon="github">
     Get the latest version of the Zoho Mail integration template from GitHub
 </Card>

--- a/packages/webapp/src/utils/utils.tsx
+++ b/packages/webapp/src/utils/utils.tsx
@@ -9,8 +9,8 @@ export const stagingUrl: string = 'https://api-staging.nango.dev';
 export const prodUrl: string = 'https://api.nango.dev';
 
 export const syncDocs = 'https://docs.nango.dev/integrate/guides/sync-data-from-an-api';
-export const githubRepo = 'https://github.com/NangoHQ/nango';
-export const githubIntegrationTemplates = `${githubRepo}/tree/master/integration-templates`;
+export const githubRepo = 'https://github.com/NangoHQ/integration-templates';
+export const githubIntegrationTemplates = `${githubRepo}/tree/main/integrations`;
 
 export function isHosted() {
     return process.env.REACT_APP_ENV === 'hosted';


### PR DESCRIPTION
## Describe your changes
Reference https://github.com/NangoHQ/integration-templates for integration templates. Will remove the integration templates here with a later PR

## Issue ticket number and link
NAN-1760

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
