### PR TITLE
fix(webhook-forward): [nan-1813] when we arent able to validate a connection the headers should still forward

### DIFF
--- a/packages/webhooks/lib/forward.ts
+++ b/packages/webhooks/lib/forward.ts
@@ -56,7 +56,8 @@ export const forwardWebhook = async ({
             body: payload,
             webhookType: 'forward',
             environment,
-            logCtx
+            logCtx,
+            incomingHeaders: webhookOriginalHeaders
         });
 
         result ? await logCtx.success() : await logCtx.failed();

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -127,9 +127,10 @@ export const deliver = async ({
         const { url, type } = webhook;
 
         try {
+            const filteredHeaders = filterHeaders(incomingHeaders || {});
             const headers = {
                 ...getSignatureHeader(environment.secret_key, body),
-                ...filterHeaders(incomingHeaders || {})
+                ...filteredHeaders
             };
 
             const response = await retryWithBackoff(
@@ -143,12 +144,12 @@ export const deliver = async ({
                 if (response.status >= 200 && response.status < 300) {
                     await logCtx.info(
                         `${webhookType} webhook sent successfully to the ${type} ${url} and received with a ${response.status} response code${endingMessage ? ` ${endingMessage}` : ''}.`,
-                        body as Record<string, unknown>
+                        { headers: filteredHeaders, body }
                     );
                 } else {
                     await logCtx.error(
                         `${webhookType} sent webhook successfully to the ${type} ${url} but received a ${response.status} response code${endingMessage ? ` ${endingMessage}` : ''}. Please send a 2xx on successful receipt.`,
-                        body as Record<string, unknown>
+                        { headers: filteredHeaders, body }
                     );
                     success = false;
                 }


### PR DESCRIPTION
## Describe your changes
Headers weren't being forwarded when we couldn't validate the connection + add the headers to the logs

## Issue ticket number and link
NAN-1813

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
