### PR TITLE
chore: update docs/openapi spec to describe connect session endpoints

### DIFF
--- a/docs-v2/mint.json
+++ b/docs-v2/mint.json
@@ -650,6 +650,14 @@
                                 "reference/api/proxy/patch",
                                 "reference/api/proxy/delete"
                             ]
+                        },
+                        {
+                            "group": "Connect",
+                            "pages": [
+                                "reference/api/connect/sessions/create",
+                                "reference/api/connect/session/get",
+                                "reference/api/connect/session/delete"
+                            ]
                         }
                     ]
                 },

--- a/docs-v2/reference/api/connect/session/delete.mdx
+++ b/docs-v2/reference/api/connect/session/delete.mdx
@@ -1,0 +1,6 @@
+---
+title: 'Delete a connect session'
+openapi: 'DELETE /connect/session'
+---
+
+Deletes a connect session

--- a/docs-v2/reference/api/connect/session/get.mdx
+++ b/docs-v2/reference/api/connect/session/get.mdx
@@ -1,0 +1,6 @@
+---
+title: 'Get a connect session'
+openapi: 'GET /connect/session'
+---
+
+Retrieves a connect session information (end user details, allowed integrations, default connection configurations)

--- a/docs-v2/reference/api/connect/sessions/create.mdx
+++ b/docs-v2/reference/api/connect/sessions/create.mdx
@@ -1,0 +1,7 @@
+---
+title: 'Create a connect session'
+openapi: 'POST /connect/sessions'
+---
+
+Creates a short-live connect session for a given end user.
+The returned token can be used for instance to create connections for this end user.

--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -1645,6 +1645,75 @@ paths:
             responses:
                 '200':
                     description: The response exactly as returned by the external API
+    /connect/sessions:
+        post:
+            description: Create a new connect session
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ConnectSession'
+            responses:
+                '201':
+                    description: Successfully created a connect session
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                required:
+                                    - data
+                                properties:
+                                    data:
+                                        type: object
+                                        required:
+                                            - token
+                                            - expires_at
+                                        properties:
+                                            token:
+                                                type: string
+                                                description: The connect session token
+                                            expires_at:
+                                                type: string
+                                                description: When the token expires
+                                                format: date
+                '400':
+                    $ref: '#/components/responses/BadRequest'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+    /connect/session:
+        get:
+            description: Retrieve a connect session
+            responses:
+                '200':
+                    description: Successfully retrieved a connect session
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                required:
+                                    - data
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/ConnectSession'
+                '400':
+                    $ref: '#/components/responses/BadRequest'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+                '404':
+                    $ref: '#/components/responses/NotFound'
+        delete:
+            description: Delete a connect session
+            responses:
+                '204':
+                    description: Successfully retrieved a connect session
+                '400':
+                    $ref: '#/components/responses/BadRequest'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+                '404':
+                    $ref: '#/components/responses/NotFound'
+
 
 components:
 
@@ -1973,3 +2042,42 @@ components:
                 type: string
                 format: date
                 description: Last time it was updated
+    ConnectSession:
+        type: object
+        required:
+            - end_user
+        properties:
+            end_user:
+                type: object
+                required:
+                    - id
+                    - email
+                properties:
+                    id:
+                        type: string
+                        description: Uniquely identifies the end user.
+                    email:
+                        type: string
+                    display_name:
+                        type: string
+            organization:
+                type: object
+                properties:
+                    id:
+                        type: string
+                        description: Uniquely identifies the organization the end user belongs to
+                    display_name:
+                        type: string
+            allowed_integrations:
+                type: array
+                description: Session would only be able to interact with allowed integrations
+                items:
+                    type: string
+            integrations_config_defaults:
+                type: object
+                additionalProperties:
+                    type: object
+                    description: the unique name of an integration
+                    properties:
+                        connection_config:
+                            type: object

--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -1706,7 +1706,7 @@ paths:
             description: Delete a connect session
             responses:
                 '204':
-                    description: Successfully retrieved a connect session
+                    description: Successfully deleted a connect session
                 '400':
                     $ref: '#/components/responses/BadRequest'
                 '401':
@@ -2070,7 +2070,7 @@ components:
                         type: string
             allowed_integrations:
                 type: array
-                description: Session would only be able to interact with allowed integrations
+                description: Filters which integrations the end user can interact with
                 items:
                     type: string
             integrations_config_defaults:


### PR DESCRIPTION
Adding doc pages and openapi specs for the newly added `GET/DELETE/POST /connect/sessions` endpoints

## Issue ticket number and link

https://linear.app/nango/issue/NAN-1807/document-connectsessions-endpoints

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
