### PR TITLE
feat(connect): require session token to load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33937,7 +33937,7 @@
                 "react": "18.3.1",
                 "react-dom": "18.3.1",
                 "react-error-boundary": "4.0.13",
-                "react-hook-form": "^7.53.0",
+                "react-hook-form": "7.53.0",
                 "react-use": "17.5.1",
                 "tailwind-merge": "2.5.2",
                 "tailwindcss": "3.4.11",

--- a/packages/connect-ui/src/lib/events.ts
+++ b/packages/connect-ui/src/lib/events.ts
@@ -1,6 +1,11 @@
-import type { AuthResult, ConnectUIEventClose, ConnectUIEventConnect } from '@nangohq/frontend';
+import type { AuthResult, ConnectUIEventClose, ConnectUIEventConnect, ConnectUIEventReady } from '@nangohq/frontend';
 
 import { useGlobal } from './store';
+
+export function triggerReady() {
+    const event: ConnectUIEventReady = { type: 'ready' };
+    parent.postMessage(event, '*');
+}
 
 export function triggerClose() {
     const isDirty = useGlobal.getState().isDirty;

--- a/packages/connect-ui/src/lib/store.ts
+++ b/packages/connect-ui/src/lib/store.ts
@@ -3,19 +3,23 @@ import { create } from 'zustand';
 import type { GetPublicIntegration, GetPublicProvider } from '@nangohq/types';
 
 interface State {
+    sessionToken: string | null;
     provider: GetPublicProvider['Success']['data'] | null;
     integration: GetPublicIntegration['Success']['data'] | null;
     isDirty: boolean;
+    setSessionToken: (value: string) => void;
     setIsDirty: (value: boolean) => void;
     set: (provider: GetPublicProvider['Success']['data'], integration: GetPublicIntegration['Success']['data']) => void;
     reset: () => void;
 }
 
 export const useGlobal = create<State>((set) => ({
+    sessionToken: null,
     provider: null,
     integration: null,
     isDirty: false,
     setIsDirty: (value) => set({ isDirty: value }),
+    setSessionToken: (value) => set({ sessionToken: value }),
     set: (provider, integration) => {
         set({ provider, integration });
     },

--- a/packages/connect-ui/src/views/IntegrationsList.tsx
+++ b/packages/connect-ui/src/views/IntegrationsList.tsx
@@ -2,20 +2,50 @@
 import { IconArrowRight, IconExclamationCircle, IconX } from '@tabler/icons-react';
 import { QueryErrorResetBoundary, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { Suspense, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
+import type { ConnectUIEventToken } from '@nangohq/frontend';
 import type { ApiPublicIntegration, GetPublicProvider } from '@nangohq/types';
 
 import { ErrorFallback } from '@/components/ErrorFallback';
 import { Layout } from '@/components/Layout';
 import { Button } from '@/components/ui/button';
 import { getIntegrations, getProvider } from '@/lib/api';
-import { triggerClose } from '@/lib/events';
+import { triggerClose, triggerReady } from '@/lib/events';
 import { useGlobal } from '@/lib/store';
 import NoIntegrationSVG from '@/svg/nointegrations.svg?react';
 
 export const IntegrationsList: React.FC = () => {
+    const sessionToken = useGlobal((state) => state.sessionToken);
+    const setSessionToken = useGlobal((state) => state.setSessionToken);
+
+    useEffect(() => {
+        // Listen to parent
+        // the parent will send the sessionToken through post message
+        const listener: (this: Window, ev: MessageEvent) => void = (evt) => {
+            if (!evt.data || !('type' in evt.data) || evt.data.type !== 'session_token') {
+                return;
+            }
+
+            const data = evt.data as ConnectUIEventToken;
+            setSessionToken(data.sessionToken);
+        };
+        window.addEventListener('message', listener, false);
+
+        // Tell the parent we are ready to receive message
+        triggerReady();
+
+        return () => {
+            window.removeEventListener('message', listener, false);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    if (!sessionToken) {
+        return null;
+    }
+
     return (
         <QueryErrorResetBoundary>
             {({ reset }) => (

--- a/packages/frontend/lib/types.ts
+++ b/packages/frontend/lib/types.ts
@@ -88,6 +88,16 @@ export const enum WSMessageType {
     Success = 'success'
 }
 
+// This one is sent by parent only
+export interface ConnectUIEventToken {
+    type: 'session_token';
+    sessionToken: string;
+}
+
+export interface ConnectUIEventReady {
+    type: 'ready';
+}
+
 export interface ConnectUIEventClose {
     type: 'close';
 }
@@ -97,4 +107,4 @@ export interface ConnectUIEventConnect {
     payload: AuthResult;
 }
 
-export type ConnectUIEvent = ConnectUIEventClose | ConnectUIEventConnect;
+export type ConnectUIEvent = ConnectUIEventReady | ConnectUIEventClose | ConnectUIEventConnect;

--- a/packages/server/lib/controllers/v1/connect/sessions/postConnectSessions.ts
+++ b/packages/server/lib/controllers/v1/connect/sessions/postConnectSessions.ts
@@ -1,0 +1,31 @@
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { requireEmptyBody, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import type { PostConnectSessions, PostInternalConnectSessions } from '@nangohq/types';
+import { postConnectSessions } from '../../../connect/postSessions.js';
+
+export const postInternalConnectSessions = asyncWrapper<PostInternalConnectSessions>((req, res, next) => {
+    const valQuery = requireEmptyQuery(req, { withEnv: true });
+    if (valQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valQuery.error) } });
+        return;
+    }
+
+    const valBody = requireEmptyBody(req);
+    if (valBody) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+        return;
+    }
+
+    const { user } = res.locals;
+
+    // @ts-expect-error req.body is never but we want to fake it on purpose
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    req.body = {
+        end_user: { id: `nango_${user.id}`, email: user.email, display_name: user.name }
+    } satisfies PostConnectSessions['Body'];
+
+    // @ts-expect-error yes I know
+    req.query = {};
+
+    postConnectSessions(req as any, res, next);
+});

--- a/packages/server/lib/controllers/v1/connect/sessions/postConnectSessions.ts
+++ b/packages/server/lib/controllers/v1/connect/sessions/postConnectSessions.ts
@@ -21,10 +21,10 @@ export const postInternalConnectSessions = asyncWrapper<PostInternalConnectSessi
     // @ts-expect-error req.body is never but we want to fake it on purpose
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     req.body = {
-        end_user: { id: `nango_${user.id}`, email: user.email, display_name: user.name }
+        end_user: { id: `nango_dashboard_${user.id}`, email: user.email, display_name: user.name }
     } satisfies PostConnectSessions['Body'];
 
-    // @ts-expect-error yes I know
+    // @ts-expect-error on internal api we pass ?env= but it's not allowed in public api
     req.query = {};
 
     postConnectSessions(req as any, res, next);

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -94,6 +94,7 @@ import { getPublicListIntegrations } from './controllers/integrations/getListInt
 import { postConnectSessions } from './controllers/connect/postSessions.js';
 import { getConnectSession } from './controllers/connect/getSession.js';
 import { deleteConnectSession } from './controllers/connect/deleteSession.js';
+import { postInternalConnectSessions } from './controllers/v1/connect/sessions/postConnectSessions.js';
 
 export const router = express.Router();
 
@@ -286,7 +287,8 @@ web.route('/api/v1/environment/webhook/settings').patch(webAuth, patchSettings);
 web.route('/api/v1/environment/activate-key').post(webAuth, environmentController.activateKey.bind(accountController));
 web.route('/api/v1/environment/admin-auth').get(webAuth, environmentController.getAdminAuthInfo.bind(environmentController));
 
-web.route('/api/v1/integrations').get(webAuth, configController.listProviderConfigsWeb.bind(configController));
+web.route('/api/v1/connect/sessions').post(webAuth, postInternalConnectSessions);
+
 web.route('/api/v1/integrations/:providerConfigKey/connections').get(webAuth, configController.getConnections.bind(connectionController));
 web.route('/api/v1/integrations').post(webAuth, postIntegration);
 web.route('/api/v1/integrations/:providerConfigKey').get(webAuth, getIntegration);

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -10,7 +10,7 @@ import type { GetUser, PatchUser } from './user/api';
 import type { DeletePublicIntegration, GetPublicIntegration, GetPublicListIntegrations, GetPublicListIntegrationsLegacy } from './integration/api';
 import type { PostPublicTableauAuthorization, PostPublicTbaAuthorization, PostPublicUnauthenticatedAuthorization } from './auth/http.api';
 import type { GetPublicProvider, GetPublicProviders } from './providers/api';
-import type { PostConnectSessions } from './connect/api';
+import type { PostConnectSessions, PostInternalConnectSessions } from './connect/api';
 
 export type PublicApiEndpoints =
     | SetMetadata
@@ -44,7 +44,8 @@ export type PrivateApiEndpoints =
     | GetOperation
     | SearchMessages
     | SearchFilters
-    | GetOnboardingStatus;
+    | GetOnboardingStatus
+    | PostInternalConnectSessions;
 export type APIEndpoints = PrivateApiEndpoints | PublicApiEndpoints;
 
 /**

--- a/packages/types/lib/connect/api.ts
+++ b/packages/types/lib/connect/api.ts
@@ -57,10 +57,5 @@ export type DeleteConnectSession = Endpoint<{
 export type PostInternalConnectSessions = Endpoint<{
     Method: 'POST';
     Path: '/api/v1/connect/sessions';
-    Success: {
-        data: {
-            token: string;
-            expires_at: Date;
-        };
-    };
+    Success: PostConnectSessions['Success'];
 }>;

--- a/packages/types/lib/connect/api.ts
+++ b/packages/types/lib/connect/api.ts
@@ -53,3 +53,14 @@ export type DeleteConnectSession = Endpoint<{
     Path: '/connect/session';
     Success: never;
 }>;
+
+export type PostInternalConnectSessions = Endpoint<{
+    Method: 'POST';
+    Path: '/api/v1/connect/sessions';
+    Success: {
+        data: {
+            token: string;
+            expires_at: Date;
+        };
+    };
+}>;

--- a/packages/webapp/src/hooks/useConnect.tsx
+++ b/packages/webapp/src/hooks/useConnect.tsx
@@ -1,0 +1,13 @@
+import type { PostInternalConnectSessions } from '@nangohq/types';
+import { apiFetch } from '../utils/api';
+
+export async function apiConnectSessions(env: string) {
+    const res = await apiFetch(`/api/v1/connect/sessions?env=${env}`, {
+        method: 'POST'
+    });
+
+    return {
+        res,
+        json: (await res.json()) as PostInternalConnectSessions['Reply']
+    };
+}


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1822/enforce-sessiontoken-usage

- Enforce session token to load UI
We request the sessionToken, open the modal, the modal sends "ready" when react is loaded, and the parent sends back the sessionToken. It's not passed in the UI to avoid leaking the token in logs.

- Add `POST /api/v1/connect/sessions`
We needed a quick way to generate this token for the dashboard, it"s better to assume the UI do not have access to the private key (it's the case but that's not good imo). This endpoint is actually calling the public one by faking the request.
