### PR TITLE
fix(connect): fields ordering

### DIFF
--- a/packages/connect-ui/src/App.tsx
+++ b/packages/connect-ui/src/App.tsx
@@ -1,19 +1,15 @@
 import { QueryClientProvider, QueryErrorResetBoundary } from '@tanstack/react-query';
 import { RouterProvider } from '@tanstack/react-router';
-import { ErrorBoundary } from 'react-error-boundary';
 
-import { ErrorFallback } from './components/ErrorFallback.js';
 import { queryClient } from './lib/query.js';
 import { router } from './lib/routes.js';
 
 export const App: React.FC = () => {
     return (
         <QueryErrorResetBoundary>
-            <ErrorBoundary FallbackComponent={ErrorFallback}>
-                <QueryClientProvider client={queryClient}>
-                    <RouterProvider router={router} />
-                </QueryClientProvider>
-            </ErrorBoundary>
+            <QueryClientProvider client={queryClient}>
+                <RouterProvider router={router} />
+            </QueryClientProvider>
         </QueryErrorResetBoundary>
     );
 };

--- a/packages/connect-ui/src/lib/routes.ts
+++ b/packages/connect-ui/src/lib/routes.ts
@@ -3,7 +3,7 @@ import { createRootRoute, createRoute, createRouter } from '@tanstack/react-rout
 import { Go } from '@/views/Go';
 import { IntegrationsList } from '@/views/IntegrationsList';
 
-const rootRoute = createRootRoute();
+const rootRoute = createRootRoute({});
 export const indexRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/',

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -119,6 +119,7 @@ algolia:
             description: The application ID for your Algolia account
             example: ERBSOWZO32
             pattern: '^[A-Z0-9]{10}$'
+            order: 1
     credentials:
         apiKey:
             type: string

--- a/packages/types/lib/providers/provider.ts
+++ b/packages/types/lib/providers/provider.ts
@@ -28,6 +28,7 @@ export interface SimplifiedJSONSchema {
     example?: string;
     pattern?: string;
     format?: string;
+    order: number;
 }
 
 export interface BaseProvider {

--- a/scripts/validation/providers/schema.json
+++ b/scripts/validation/providers/schema.json
@@ -346,6 +346,9 @@
                                 },
                                 "format": {
                                     "type": "string"
+                                },
+                                "order": {
+                                    "type": "number"
                                 }
                             }
                         }


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1808/find-a-solution-to-have-a-field-order-in-the-ui

- Providers: Add optional order in the field schema
- UI: Order fields automatically if order is provided
The algo is simple and allows to put some `connectionConfig` before credentials (but not having a mix of both).

- UI: auto generate all fields

### Example

> Algolia where app id is now more logically placed before api key
<img width="572" alt="Screenshot 2024-09-30 at 14 29 18" src="https://github.com/user-attachments/assets/65c8e6ff-b224-4328-a50e-0bde2036b71c">
