### PR TITLE
fix: sync frequency can be edited to be 30s or more

### DIFF
--- a/packages/server/lib/controllers/v1/flows/id/patchFrequency.ts
+++ b/packages/server/lib/controllers/v1/flows/id/patchFrequency.ts
@@ -13,7 +13,7 @@ export const validationBody = validationBodyBase.extend({
     frequency: z
         .string()
         .regex(
-            /^(?<every>every )?((?<amount>[0-9]+)?\s?(?<unit>(m|mins?|minutes?|h|hrs?|hours?|d|days?))|(?<unit2>(month|week|half day|half hour|quarter hour)))$/
+            /^(?<every>every )?((?<amount>[0-9]+)?\s?(?<unit>(s|secs?|seconds?|m|mins?|minutes?|h|hrs?|hours?|d|days?))|(?<unit2>(month|week|half day|half hour|quarter hour)))$/
         )
 });
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Endpoints/components/ScriptSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Endpoints/components/ScriptSettings.tsx
@@ -19,7 +19,7 @@ import { Link } from 'react-router-dom';
 const drawerWidth = '630px';
 // To sync with patchFrequency
 const frequencyRegex =
-    /^(?<every>every )?((?<amount>[0-9]+)?\s?(?<unit>(m|mins?|minutes?|h|hrs?|hours?|d|days?))|(?<unit2>(month|week|half day|half hour|quarter hour)))$/;
+    /^(?<every>every )?((?<amount>[0-9]+)?\s?(?<unit>(s|secs?|seconds?|m|mins?|minutes?|h|hrs?|hours?|d|days?))|(?<unit2>(month|week|half day|half hour|quarter hour)))$/;
 
 export const ScriptSettings: React.FC<{
     integration: GetIntegration['Success']['data'];
@@ -94,15 +94,15 @@ export const ScriptSettings: React.FC<{
 
         const reg = value.match(frequencyRegex);
         if (!reg || !reg.groups) {
-            setFrequencyError('Format should be "every (number) (minutes|hours|days)", e.g: "every 1 hour", "every 20 days"r');
+            setFrequencyError('Format should be "every (number) (seconds|minutes|hours|days)", e.g: "every 1 hour", "every 20 days"');
             return;
         }
 
         const unit = reg.groups['unit'];
         const amount = parseInt(reg.groups['amount'], 10);
 
-        if (unit.startsWith('m') && (amount < 5 || !amount)) {
-            setFrequencyError('The minimum frequency is 5 minutes');
+        if (unit.startsWith('s') && (amount < 30 || !amount)) {
+            setFrequencyError('The minimum frequency is 30 seconds');
             return;
         }
         setFrequencyError(null);


### PR DESCRIPTION
This is a regression issue
When revamping the integration UI https://github.com/NangoHQ/nango/pull/2594, the [change](https://github.com/NangoHQ/nango/pull/2690/files#diff-5c0e007ca978cb035dcb1b4c38cacc650a268098a324a043d807fc7e2311ff78R203-R242) to allow sync frequency lower than 5mins was lost 


## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
