### PR TITLE
feat: add support for connect session token auth in frontend sdk

### DIFF
--- a/packages/frontend/lib/types.ts
+++ b/packages/frontend/lib/types.ts
@@ -1,5 +1,5 @@
 export type AuthErrorType =
-    | 'missingPublicKey'
+    | 'missingAuthToken'
     | 'blocked_by_browser'
     | 'invalidHostUrl'
     | 'windowIsOpened'

--- a/packages/server/lib/controllers/auth/postTableau.ts
+++ b/packages/server/lib/controllers/auth/postTableau.ts
@@ -18,7 +18,7 @@ import type { LogContext } from '@nangohq/logs';
 import { defaultOperationExpiration, logContextGetter } from '@nangohq/logs';
 import { hmacCheck } from '../../utils/hmac.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
-import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { connectSessionTokenSchema, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 
 const bodyValidation = z
     .object({
@@ -33,7 +33,7 @@ const queryStringValidation = z
         connection_id: connectionIdSchema.optional(),
         params: z.record(z.any()).optional(),
         public_key: z.string().uuid().optional(),
-        connect_session_token: z.string().startsWith('nango_connect_session_').optional(),
+        connect_session_token: connectSessionTokenSchema.optional(),
         hmac: z.string().optional()
     })
     .strict();

--- a/packages/server/lib/controllers/auth/postTableau.ts
+++ b/packages/server/lib/controllers/auth/postTableau.ts
@@ -32,7 +32,8 @@ const queryStringValidation = z
     .object({
         connection_id: connectionIdSchema.optional(),
         params: z.record(z.any()).optional(),
-        public_key: z.string().uuid(),
+        public_key: z.string().uuid().optional(),
+        connect_session_token: z.string().startsWith('nango_connect_session_').optional(),
         hmac: z.string().optional()
     })
     .strict();

--- a/packages/server/lib/controllers/auth/postTba.ts
+++ b/packages/server/lib/controllers/auth/postTba.ts
@@ -7,7 +7,7 @@ import type { TbaCredentials, PostPublicTbaAuthorization } from '@nangohq/types'
 import { defaultOperationExpiration, logContextGetter } from '@nangohq/logs';
 import { hmacCheck } from '../../utils/hmac.js';
 import { connectionCreated as connectionCreatedHook, connectionTest as connectionTestHook } from '../../hooks/hooks.js';
-import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { connectSessionTokenSchema, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 
 const bodyValidation = z
     .object({
@@ -24,7 +24,7 @@ const queryStringValidation = z
         params: z.record(z.any()).optional(),
         hmac: z.string().optional(),
         public_key: z.string().uuid().optional(),
-        connect_session_token: z.string().startsWith('nango_connect_session_').optional()
+        connect_session_token: connectSessionTokenSchema.optional()
     })
     .strict();
 

--- a/packages/server/lib/controllers/auth/postTba.ts
+++ b/packages/server/lib/controllers/auth/postTba.ts
@@ -23,7 +23,8 @@ const queryStringValidation = z
         connection_id: connectionIdSchema.optional(),
         params: z.record(z.any()).optional(),
         hmac: z.string().optional(),
-        public_key: z.string().uuid()
+        public_key: z.string().uuid().optional(),
+        connect_session_token: z.string().startsWith('nango_connect_session_').optional()
     })
     .strict();
 

--- a/packages/server/lib/controllers/auth/postUnauthenticated.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.ts
@@ -13,7 +13,8 @@ import { connectionCreated, connectionCreationFailed } from '../../hooks/hooks.j
 const queryStringValidation = z
     .object({
         connection_id: connectionIdSchema.optional(),
-        public_key: z.string().uuid(),
+        public_key: z.string().uuid().optional(),
+        connect_session_token: z.string().startsWith('nango_connect_session_').optional(),
         user_scope: z.string().optional(),
         hmac: z.string().optional()
     })

--- a/packages/server/lib/controllers/auth/postUnauthenticated.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 import { requireEmptyBody, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
-import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { connectSessionTokenSchema, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import type { PostPublicUnauthenticatedAuthorization } from '@nangohq/types';
 import { AnalyticsTypes, analytics, configService, connectionService, errorManager, getProvider } from '@nangohq/shared';
 import { logContextGetter } from '@nangohq/logs';
@@ -14,7 +14,7 @@ const queryStringValidation = z
     .object({
         connection_id: connectionIdSchema.optional(),
         public_key: z.string().uuid().optional(),
-        connect_session_token: z.string().startsWith('nango_connect_session_').optional(),
+        connect_session_token: connectSessionTokenSchema.optional(),
         user_scope: z.string().optional(),
         hmac: z.string().optional()
     })

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -24,3 +24,5 @@ export const envSchema = z
     .string()
     .regex(/^[a-zA-Z0-9_-]+$/)
     .max(255);
+export const connectSessionTokenPrefix = 'nango_connect_session_';
+export const connectSessionTokenSchema = z.string().regex(new RegExp(`^${connectSessionTokenPrefix}[a-f0-9]{64}$`));

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -8,12 +8,11 @@ import { NANGO_ADMIN_UUID } from '../controllers/account.controller.js';
 import tracer from 'dd-trace';
 import type { RequestLocals } from '../utils/express.js';
 import type { ConnectSession, DBEnvironment, DBTeam } from '@nangohq/types';
+import { connectSessionTokenSchema, connectSessionTokenPrefix } from '../helpers/validation.js';
 
 const logger = getLogger('AccessMiddleware');
 
 const keyRegex = /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
-const connectSessionTokenPrefix = 'nango_connect_session_';
-const connectSessionTokenRegex = new RegExp(`^${connectSessionTokenPrefix}[a-f0-9]{64}$`, 'i');
 const ignoreEnvPaths = ['/api/v1/meta', '/api/v1/user', '/api/v1/user/name', '/api/v1/signin', '/api/v1/invite/:id'];
 
 export class AccessMiddleware {
@@ -172,7 +171,8 @@ export class AccessMiddleware {
             connectSession: ConnectSession;
         }>
     > {
-        if (!connectSessionTokenRegex.test(token)) {
+        const parsedToken = connectSessionTokenSchema.safeParse(token);
+        if (!parsedToken.success) {
             return Err('invalid_connect_session_token_format');
         }
 

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -67,6 +67,7 @@ export class AccessMiddleware {
             next();
         } catch (err) {
             logger.error(`failed_get_env_by_secret_key ${stringifyError(err)}`);
+            span.setTag('error', err);
             return errorManager.errRes(res, 'malformed_auth_header');
         } finally {
             metrics.duration(metrics.Types.AUTH_GET_ENV_BY_SECRET_KEY, Date.now() - start);
@@ -87,42 +88,20 @@ export class AccessMiddleware {
         next();
     }
 
-    async publicKeyAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
-        const active = tracer.scope().active();
-        const span = tracer.startSpan('publicKeyAuth', {
-            childOf: active!
-        });
-
-        const start = Date.now();
-        try {
-            const publicKey = req.query['public_key'] as string;
-
-            if (!publicKey) {
-                return errorManager.errRes(res, 'missing_public_key');
-            }
-
-            if (!keyRegex.test(publicKey)) {
-                return errorManager.errRes(res, 'invalid_public_key');
-            }
-
-            const result = await environmentService.getAccountAndEnvironmentByPublicKey(publicKey);
-            if (!result) {
-                res.status(401).send({ error: { code: 'unknown_user_account' } });
-                return;
-            }
-
-            res.locals['authType'] = 'publicKey';
-            res.locals['account'] = result.account;
-            res.locals['environment'] = result.environment;
-            tracer.setUser({ id: String(result.account.id), environmentId: String(result.environment.id) });
-            next();
-        } catch (e) {
-            errorManager.report(e, { source: ErrorSourceEnum.PLATFORM, operation: LogActionEnum.INTERNAL_AUTHORIZATION });
-            return errorManager.errRes(res, 'unknown_account');
-        } finally {
-            metrics.duration(metrics.Types.AUTH_PUBLIC_KEY, Date.now() - start);
-            span.finish();
+    private async validatePublicKey(publicKey: string): Promise<
+        Result<{
+            account: DBTeam;
+            environment: DBEnvironment;
+        }>
+    > {
+        if (!keyRegex.test(publicKey)) {
+            return Err('invalid_secret_key_format');
         }
+        const result = await environmentService.getAccountAndEnvironmentByPublicKey(publicKey);
+        if (!result) {
+            return Err('unknown_user_account');
+        }
+        return Ok(result);
     }
 
     async sessionAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
@@ -255,8 +234,9 @@ export class AccessMiddleware {
                 connectSessionId: String(result.value.connectSession.id)
             });
             next();
-        } catch (e) {
-            logger.error(`failed_get_env_by_connect_session ${stringifyError(e)}`);
+        } catch (err) {
+            logger.error(`failed_get_env_by_connect_session ${stringifyError(err)}`);
+            span.setTag('error', err);
             return errorManager.errRes(res, 'unknown_account');
         } finally {
             metrics.duration(metrics.Types.AUTH_GET_ENV_BY_CONNECT_SESSION, Date.now() - start);
@@ -320,11 +300,68 @@ export class AccessMiddleware {
                 });
             }
             next();
-        } catch (e) {
-            logger.error(`failed_get_env_by_connect_session_or_secret ${stringifyError(e)}`);
+        } catch (err) {
+            logger.error(`failed_get_env_by_connect_session_or_secret ${stringifyError(err)}`);
+            span.setTag('error', err);
             return errorManager.errRes(res, 'unknown_account');
         } finally {
             metrics.duration(metrics.Types.AUTH_GET_ENV_BY_CONNECT_SESSION_OR_SECRET_KEY, Date.now() - start);
+            span.finish();
+        }
+    }
+
+    async connectSessionOrPublicKeyAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
+        const active = tracer.scope().active();
+        const span = tracer.startSpan('connectSessionOrSecretKeyAuth', {
+            childOf: active!
+        });
+
+        const start = Date.now();
+        try {
+            const token = req.query['connect_session_token'] as string;
+            if (token) {
+                const connectSessionResult = await this.validateConnectSessionToken(token);
+                if (connectSessionResult.isErr()) {
+                    errorManager.errRes(res, connectSessionResult.error.message);
+                    return;
+                }
+                res.locals['authType'] = 'connectSession';
+                res.locals['account'] = connectSessionResult.value.account;
+                res.locals['environment'] = connectSessionResult.value.environment;
+                res.locals['connectSession'] = connectSessionResult.value.connectSession;
+                tracer.setUser({
+                    id: String(connectSessionResult.value.account.id),
+                    environmentId: String(connectSessionResult.value.environment.id),
+                    connectSessionId: String(connectSessionResult.value.connectSession.id)
+                });
+            } else {
+                const publicKey = req.query['public_key'] as string;
+
+                if (!publicKey) {
+                    return errorManager.errRes(res, 'missing_public_key');
+                }
+
+                if (!keyRegex.test(publicKey)) {
+                    return errorManager.errRes(res, 'invalid_public_key');
+                }
+
+                const result = await this.validatePublicKey(publicKey);
+                if (result.isErr()) {
+                    errorManager.errRes(res, result.error.message);
+                    return;
+                }
+                res.locals['authType'] = 'publicKey';
+                res.locals['account'] = result.value.account;
+                res.locals['environment'] = result.value.environment;
+                tracer.setUser({ id: String(result.value.account.id), environmentId: String(result.value.environment.id) });
+            }
+            next();
+        } catch (err) {
+            errorManager.report(err, { source: ErrorSourceEnum.PLATFORM, operation: LogActionEnum.INTERNAL_AUTHORIZATION });
+            span.setTag('error', err);
+            return errorManager.errRes(res, 'unknown_account');
+        } finally {
+            metrics.duration(metrics.Types.AUTH_GET_ENV_BY_CONNECT_SESSION_OR_PUBLIC_KEY, Date.now() - start);
             span.finish();
         }
     }

--- a/packages/types/lib/auth/http.api.ts
+++ b/packages/types/lib/auth/http.api.ts
@@ -10,7 +10,6 @@ export type PostPublicTbaAuthorization = Endpoint<{
     };
     Querystring: {
         connection_id?: string | undefined;
-        public_key: string;
         params?: Record<string, any> | undefined;
         hmac?: string | undefined;
     };
@@ -40,7 +39,6 @@ export type PostPublicTableauAuthorization = Endpoint<{
     };
     Querystring: {
         connection_id?: string | undefined;
-        public_key: string;
         params?: Record<string, any> | undefined;
         hmac?: string | undefined;
     };

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -9,7 +9,7 @@ export enum Types {
     AUTH_GET_ENV_BY_CONNECT_SESSION = 'nango.auth.getEnvByConnectSession',
     AUTH_GET_ENV_BY_SECRET_KEY = 'nango.auth.getEnvBySecretKey',
     AUTH_GET_ENV_BY_CONNECT_SESSION_OR_SECRET_KEY = 'nango.auth.getEnvByConnectSessionOrSecretKey',
-    AUTH_PUBLIC_KEY = 'nango.auth.publicKey',
+    AUTH_GET_ENV_BY_CONNECT_SESSION_OR_PUBLIC_KEY = 'nango.auth.getEnvByConnectSessionOrPublicKey',
     AUTH_SESSION = 'nango.auth.session',
     GET_CONNECTION = 'nango.server.getConnection',
     JOBS_DELETE_SYNCS_DATA = 'nango.jobs.cron.deleteSyncsData',


### PR DESCRIPTION
- Adding support for connect session token in frontend sdk
- Adding auth middleware to authorize via either public key or connnect session token

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1837/sdk-support-for-sessiontoken

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
