### PR TITLE
fix: 'window is already open' bug

### DIFF
--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -168,6 +168,11 @@ export default class Nango {
         }
 
         return new Promise<AuthResult>((resolve, reject) => {
+            // Clear state if the modal is closed
+            if (this.win?.modal?.closed) {
+                this.clear();
+            }
+
             const successHandler = (providerConfigKey: string, connectionId: string, isPending = false) => {
                 if (this.status !== AuthorizationStatus.BUSY) {
                     return;


### PR DESCRIPTION
Closing the auth popup and calling nango.auth again results in the `window is already open` error. It doesn't prevent the new popup to open but it is visually annoying and confusing.
With this commit, before opening the popup again we check if previous one is closed and clear the state

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1773/fix-the-authorization-window-is-already-opened

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
