### PR TITLE
feat(connect): open beta

### DIFF
--- a/packages/connect-ui/src/lib/api.ts
+++ b/packages/connect-ui/src/lib/api.ts
@@ -7,7 +7,7 @@ import { useGlobal } from './store';
 
 // Temp solution, ideally we can launch this without having to rebuild the whole UI
 // TODO: remove hardcoded value
-export const API_HOSTNAME = import.meta.env.VITE_API_HOSTNAME || 'http://localhost:3003';
+export const API_HOSTNAME: string = import.meta.env.VITE_API_HOSTNAME || 'http://localhost:3003';
 
 function uriParamsReplacer(tpl: string, data: Record<string, any>) {
     let res = tpl;

--- a/packages/connect-ui/src/lib/api.ts
+++ b/packages/connect-ui/src/lib/api.ts
@@ -5,7 +5,9 @@ import type { ApiError, Endpoint, GetConnectSession, GetPublicListIntegrations, 
 
 import { useGlobal } from './store';
 
-const API_HOSTNAME = 'http://localhost:3003'; // TODO: remove hardcoded value
+// Temp solution, ideally we can launch this without having to rebuild the whole UI
+// TODO: remove hardcoded value
+export const API_HOSTNAME = import.meta.env.VITE_API_HOSTNAME || 'http://localhost:3003';
 
 function uriParamsReplacer(tpl: string, data: Record<string, any>) {
     let res = tpl;

--- a/packages/connect-ui/src/lib/events.ts
+++ b/packages/connect-ui/src/lib/events.ts
@@ -9,6 +9,7 @@ export function triggerReady() {
 
 export function triggerClose() {
     const isDirty = useGlobal.getState().isDirty;
+    const nango = useGlobal.getState().nango;
     if (isDirty) {
         const leave = confirm('Are you sure you want to leave?');
         if (!leave) {
@@ -18,6 +19,7 @@ export function triggerClose() {
 
     const event: ConnectUIEventClose = { type: 'close' };
     parent.postMessage(event, '*');
+    nango?.clear();
 }
 
 export function triggerConnection(results: AuthResult) {

--- a/packages/connect-ui/src/lib/nango.ts
+++ b/packages/connect-ui/src/lib/nango.ts
@@ -7,9 +7,11 @@ export function useNango(sessionToken: string | null) {
             return;
         }
 
+        // Temp solution, ideally we can launch this without having to rebuild the whole UI
+        const hostname = import.meta.env.VITE_API_HOSTNAME || 'http://localhost:3003';
         return new Nango({
             connectSessionToken: sessionToken,
-            host: import.meta.env.VITE_LOCAL_HOSTNAME
+            host: hostname
         });
     }, [sessionToken]);
 

--- a/packages/connect-ui/src/lib/nango.ts
+++ b/packages/connect-ui/src/lib/nango.ts
@@ -1,17 +1,17 @@
 import Nango from '@nangohq/frontend';
 import { useMemo } from 'react';
 
+import { API_HOSTNAME } from './api';
+
 export function useNango(sessionToken: string | null) {
     const nango = useMemo(() => {
         if (!sessionToken) {
             return;
         }
 
-        // Temp solution, ideally we can launch this without having to rebuild the whole UI
-        const hostname = import.meta.env.VITE_API_HOSTNAME || 'http://localhost:3003';
         return new Nango({
             connectSessionToken: sessionToken,
-            host: hostname
+            host: API_HOSTNAME
         });
     }, [sessionToken]);
 

--- a/packages/connect-ui/src/lib/nango.ts
+++ b/packages/connect-ui/src/lib/nango.ts
@@ -1,18 +1,26 @@
 import Nango from '@nangohq/frontend';
-import { useMemo } from 'react';
+import { useEffect } from 'react';
 
 import { API_HOSTNAME } from './api';
+import { useGlobal } from './store';
 
-export function useNango(sessionToken: string | null) {
-    const nango = useMemo(() => {
+export function useNango() {
+    const sessionToken = useGlobal((state) => state.sessionToken);
+    const setNango = useGlobal((state) => state.setNango);
+    const nango = useGlobal((state) => state.nango);
+
+    // Create a singleton
+    useEffect(() => {
         if (!sessionToken) {
             return;
         }
 
-        return new Nango({
-            connectSessionToken: sessionToken,
-            host: API_HOSTNAME
-        });
+        setNango(
+            new Nango({
+                connectSessionToken: sessionToken,
+                host: API_HOSTNAME
+            })
+        );
     }, [sessionToken]);
 
     return nango;

--- a/packages/connect-ui/src/lib/store.ts
+++ b/packages/connect-ui/src/lib/store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 
+import type Nango from '@nangohq/frontend';
 import type { ConnectSessionPayload, GetPublicIntegration, GetPublicProvider } from '@nangohq/types';
 
 interface State {
@@ -8,8 +9,10 @@ interface State {
     integration: GetPublicIntegration['Success']['data'] | null;
     isDirty: boolean;
     session: ConnectSessionPayload | null;
+    nango: Nango | null;
     setSessionToken: (value: string) => void;
     setSession: (value: ConnectSessionPayload) => void;
+    setNango: (value: Nango) => void;
     setIsDirty: (value: boolean) => void;
     set: (provider: GetPublicProvider['Success']['data'], integration: GetPublicIntegration['Success']['data']) => void;
     reset: () => void;
@@ -21,8 +24,10 @@ export const useGlobal = create<State>((set) => ({
     integration: null,
     isDirty: false,
     session: null,
+    nango: null,
     setSessionToken: (value) => set({ sessionToken: value }),
     setSession: (value) => set({ session: value }),
+    setNango: (value) => set({ nango: value }),
     setIsDirty: (value) => set({ isDirty: value }),
     set: (provider, integration) => {
         set({ provider, integration });

--- a/packages/connect-ui/src/views/Go.tsx
+++ b/packages/connect-ui/src/views/Go.tsx
@@ -62,8 +62,8 @@ const defaultConfiguration: Record<string, { secret: boolean; title: string; exa
 };
 
 export const Go: React.FC = () => {
-    const { provider, integration, session, sessionToken, setIsDirty } = useGlobal();
-    const nango = useNango(sessionToken);
+    const { provider, integration, session, setIsDirty } = useGlobal();
+    const nango = useNango();
 
     const [loading, setLoading] = useState(false);
     const [result, setResult] = useState<AuthResult>();
@@ -334,7 +334,9 @@ export const Go: React.FC = () => {
                                 );
                             })}
                         </div>
-                        {shouldAutoTrigger && <div className="text-sm text-dark-500 w-full text-center">{loading && 'A popup is opened...'}</div>}
+                        {shouldAutoTrigger && provider.auth_mode !== 'NONE' && (
+                            <div className="text-sm text-dark-500 w-full text-center">{loading && 'A popup is opened...'}</div>
+                        )}
                         <div className="flex flex-col gap-4">
                             {error && (
                                 <div className="border border-red-base bg-red-base-35 text-red-base flex items-center py-1 px-4 rounded-md gap-2">

--- a/packages/connect-ui/src/views/Go.tsx
+++ b/packages/connect-ui/src/views/Go.tsx
@@ -298,7 +298,7 @@ export const Go: React.FC = () => {
                                     <FormField
                                         key={name}
                                         control={form.control}
-                                        defaultValue={isPreconfigured ?? definition?.default_value ?? undefined}
+                                        defaultValue={isPreconfigured ?? definition?.default_value ?? ''}
                                         // disabled={Boolean(definition?.hidden)} DO NOT disable it breaks the form
                                         name={name}
                                         render={({ field }) => {

--- a/packages/server/lib/controllers/v1/getEnvJs.ts
+++ b/packages/server/lib/controllers/v1/getEnvJs.ts
@@ -17,7 +17,7 @@ export const getEnvJs = asyncWrapper<any, any>((_, res) => {
             auth: flagHasAuth,
             managedAuth: flagHasManagedAuth,
             interactiveDemo: isCloud || isLocal,
-            connectUI: isLocal
+            connectUI: isCloud || isLocal
         }
     };
     res.setHeader('content-type', 'text/javascript');

--- a/packages/server/lib/controllers/v1/getEnvJs.ts
+++ b/packages/server/lib/controllers/v1/getEnvJs.ts
@@ -1,4 +1,4 @@
-import { basePublicUrl, baseUrl, flagHasAuth, flagHasManagedAuth, flagHasScripts, isCloud, isLocal } from '@nangohq/utils';
+import { basePublicUrl, baseUrl, connectUrl, flagHasAuth, flagHasManagedAuth, flagHasScripts, isCloud, isLocal } from '@nangohq/utils';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 import type { WindowEnv } from '@nangohq/types';
 import { envs } from '@nangohq/logs';
@@ -7,6 +7,7 @@ export const getEnvJs = asyncWrapper<any, any>((_, res) => {
     const configObject: WindowEnv = {
         apiUrl: baseUrl,
         publicUrl: basePublicUrl,
+        connectUrl: connectUrl,
         publicSentryKey: process.env['PUBLIC_SENTRY_KEY'] || '',
         publicPosthogKey: process.env['PUBLIC_POSTHOG_KEY'] || '',
         publicPosthogPost: process.env['PUBLIC_POSTHOG_HOST'] || '',

--- a/packages/server/lib/middleware/security.ts
+++ b/packages/server/lib/middleware/security.ts
@@ -1,4 +1,4 @@
-import { basePublicUrl, baseUrl } from '@nangohq/utils';
+import { basePublicUrl, baseUrl, connectUrl } from '@nangohq/utils';
 import type { RequestHandler } from 'express';
 import helmet from 'helmet';
 
@@ -26,7 +26,7 @@ export function securityMiddlewares(): RequestHandler[] {
                 childSrc: "'self'",
                 connectSrc: ["'self'", 'https://*.google-analytics.com', 'https://*.sentry.io', hostPublic, hostApi, hostWs.href, 'https://*.posthog.com'],
                 fontSrc: ["'self'", 'https://*.googleapis.com', 'https://*.gstatic.com'],
-                frameSrc: ["'self'", 'https://accounts.google.com'],
+                frameSrc: ["'self'", 'https://accounts.google.com', hostPublic, hostApi, connectUrl],
                 imgSrc: ["'self'", 'data:', hostPublic, hostApi, 'https://*.google-analytics.com', 'https://*.googleapis.com', 'https://*.posthog.com'],
                 manifestSrc: "'self'",
                 mediaSrc: "'self'",

--- a/packages/types/lib/web/env.ts
+++ b/packages/types/lib/web/env.ts
@@ -1,6 +1,7 @@
 export interface WindowEnv {
     apiUrl: string;
     publicUrl: string;
+    connectUrl: string;
     publicSentryKey: string;
     publicPosthogKey: string;
     publicPosthogPost: string;

--- a/packages/utils/lib/environment/detection.ts
+++ b/packages/utils/lib/environment/detection.ts
@@ -2,6 +2,7 @@ import { NodeEnv, localhostUrl } from './constants.js';
 
 export const baseUrl = process.env['NANGO_SERVER_URL'] || localhostUrl;
 export const basePublicUrl = process.env['NANGO_PUBLIC_SERVER_URL'] || baseUrl;
+export const connectUrl = process.env['NANGO_PUBLIC_CONNECT_URL'] || 'http://localhost:5173';
 
 export const isDocker = process.env['SERVER_RUN_MODE'] === 'DOCKERIZED';
 export const isStaging = process.env['NODE_ENV'] === NodeEnv.Staging;

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -127,6 +127,7 @@ export default function ConnectionList() {
         });
 
         connectUI.current = nango.openConnectUI({
+            baseURL: globalEnv.connectUrl,
             sessionToken: res.json.data.token,
             onEvent: (event) => {
                 if (event.type === 'close') {

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -187,11 +187,7 @@ export default function ConnectionList() {
             <div className="flex justify-between mb-8 items-center">
                 <h2 className="flex text-left text-3xl font-semibold tracking-tight text-white">Connections</h2>
                 <div className="flex gap-2">
-                    {globalEnv.features.connectUI && (
-                        <Button onClick={onClickConnectUI} variant={'emptyFaded'}>
-                            Open Connect UI (alpha)
-                        </Button>
-                    )}
+                    {globalEnv.features.connectUI && <Button onClick={onClickConnectUI}>Open Connect UI (beta)</Button>}
                     {connections && connections.length > 0 && (
                         <Link
                             to={`/${env}/connections/create`}


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1853/productize

- Enable UI in cloud env
- Allow UI to open Connect UI in an iframe
- Less hardcoding of api hostname
Still not good though, it will be impossible to not pass an env var at compile time. It's the same issue for the current dashboard, the trick I used to load dynamic env with `/env.js` is only working because it's loaded in the same subdomain. I guess that means we'll still need to build two docker image staging + prod unless we remove frontend from the docker image.

- Clear open popup on early exit


It's currently accessible in staging