### PR TITLE
fix(templates): missing some fields when upgrading 

### DIFF
--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -264,6 +264,7 @@ export async function upgradePreBuilt({
         created_at: now,
         updated_at: now,
         version: flow.version!,
+        file_location,
         model_schema: JSON.stringify(flow.models) as any
     };
     delete flowData.id;

--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -265,7 +265,11 @@ export async function upgradePreBuilt({
         updated_at: now,
         version: flow.version!,
         file_location,
-        model_schema: JSON.stringify(flow.models) as any
+        model_schema: JSON.stringify(flow.models) as any,
+        metadata: flow.metadata || {},
+        auto_start: flow.auto_start === true,
+        track_deletes: flow.track_deletes === true,
+        models: flow.returns
     };
     delete flowData.id;
 


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1854/template-upgrade-does-not-work

- Missing some fields when upgrading
Most importantly `file_location` was not updated. When I refactored this file, I added the `...syncConfig` to inherit from previous version but I didn't realized more fields could change from A to B during an upgrade