### PR TITLE
fix: zoom scope delimiter is now ','

### DIFF
--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -5235,6 +5235,7 @@ zoom:
     auth_mode: OAUTH2
     authorization_url: https://zoom.us/oauth/authorize
     token_url: https://zoom.us/oauth/token
+    scope_separator: ','
     authorization_params:
         response_type: code
     refresh_params:


### PR DESCRIPTION
## Describe your changes

passing multiple scopes to zoom `/authorize` endpoint separated by the default space separator leads to a `Oops! We were unable to complete your request. Please try again. (4,700) `. 
Tested with comma separator is working

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1830/zoom-oauth-trigger-doesnt-work-if-requesting-multiple-scopes

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
