### PR TITLE
fix(orch): timeout to orchestrator /task/output must equal task timeout

### DIFF
--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -38,10 +38,13 @@ export class OrchestratorClient {
     }
 
     private routeFetch<E extends Endpoint<any>>(
-        route: Route<E>
+        route: Route<E>,
+        config?: {
+            timeoutMs: number;
+        }
     ): (props: { query?: E['Querystring']; body?: E['Body']; params?: E['Params'] }) => Promise<E['Reply']> {
         return (props) => {
-            return retryWithBackoff(() => routeFetch(this.baseUrl, route)(props), { retry: httpRetryStrategy, numOfAttempts: 3, maxDelay: 50 });
+            return retryWithBackoff(() => routeFetch(this.baseUrl, route, config)(props), { retry: httpRetryStrategy, numOfAttempts: 3, maxDelay: 50 });
         };
     }
 
@@ -161,7 +164,8 @@ export class OrchestratorClient {
             return res;
         }
         const taskId = res.value.taskId;
-        const getOutput = await this.routeFetch(getOutputRoute)({ params: { taskId }, query: { longPolling: true } });
+        const fetchTimeoutSecs = scheduleProps.timeoutSettingsInSecs.createdToStarted + scheduleProps.timeoutSettingsInSecs.startedToCompleted;
+        const getOutput = await this.routeFetch(getOutputRoute, { timeoutMs: fetchTimeoutSecs * 1000 })({ params: { taskId }, query: { longPolling: true } });
         if ('error' in getOutput) {
             return Err({
                 name: getOutput.error.code,


### PR DESCRIPTION
task timeout for action is 15minutes but the timeout for the internal longpolling request fetching the output of the task was 120s

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1871/action-timeout-issue

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
