### PR TITLE
fix: enable possibility to run remote runner

### DIFF
--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -1,6 +1,5 @@
 import { expect, describe, it, beforeAll, afterAll, vi } from 'vitest';
 import db, { multipleMigrations } from '@nangohq/database';
-import { envs } from '@nangohq/logs';
 import type { UnencryptedRecordData, ReturnedRecord } from '@nangohq/records';
 import { records as recordsService, format as recordsFormatter, migrate as migrateRecords, clearDbTestsOnly as clearRecordsDb } from '@nangohq/records';
 import { handleSyncSuccess, startSync } from './sync.js';
@@ -8,6 +7,7 @@ import type { TaskSync } from '@nangohq/nango-orchestrator';
 import type { Connection, Sync, SyncResult, Job as SyncJob, SyncConfig } from '@nangohq/shared';
 import { isSyncJobRunning, seeders, getLatestSyncJob, updateSyncJobResult } from '@nangohq/shared';
 import { Ok } from '@nangohq/utils';
+import { envs } from '../env.js';
 
 const mockStartScript = vi.fn(() => Promise.resolve(Ok(undefined)));
 

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -43,6 +43,7 @@ export const ENVS = z.object({
     NANGO_JOBS_PORT: z.coerce.number().optional().default(3005),
 
     // Runner
+    RUNNER_TYPE: z.enum(['LOCAL', 'REMOTE', 'RENDER']).default('LOCAL'),
     RUNNER_SERVICE_URL: z.string().url().optional(),
     NANGO_RUNNER_PATH: z.string().optional(),
     RUNNER_OWNER_ID: z.string().optional(),

--- a/vite.integration.config.ts
+++ b/vite.integration.config.ts
@@ -13,7 +13,8 @@ export default defineConfig({
         testTimeout: 20000,
         env: {
             NANGO_ENCRYPTION_KEY: 'RzV4ZGo5RlFKMm0wYWlXdDhxTFhwb3ZrUG5KNGg3TmU=',
-            NANGO_LOGS_ENABLED: 'true'
+            NANGO_LOGS_ENABLED: 'true',
+            ORCHESTRATOR_SERVICE_URL: 'http://orchestrator'
         },
         fileParallelism: false,
         pool: 'forks'


### PR DESCRIPTION
For enterprise customers who want to be able to run remote runner:
- Starting/Getting runner based on REMOTE_RUNNER_TYPE env var

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
