### PR TITLE
fix: out of sync between task state and sync_job status

### DIFF
--- a/packages/database/lib/migrations/20241007172859_sync_jobs_run_id_index.cjs
+++ b/packages/database/lib/migrations/20241007172859_sync_jobs_run_id_index.cjs
@@ -1,0 +1,15 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.schema.raw(`CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_sync_jobs_run_id" ON "_nango_sync_jobs" USING BTREE ("run_id") WHERE (deleted=false)`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.schema.raw(`DROP INDEX CONCURRENTLY IF EXISTS "idx_sync_jobs_run_id"`);
+};

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -21,7 +21,7 @@ import {
     configService,
     createSyncJob,
     getSyncConfigRaw,
-    isSyncJobRunning
+    getSyncJobByRunId
 } from '@nangohq/shared';
 import { Err, Ok, metrics } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
@@ -463,7 +463,7 @@ export async function abortSync(task: TaskSyncAbort): Promise<Result<void>> {
             logger.error(`failed to abort script for task ${task.abortedTask.id}: ${abortedScript.error}`);
         }
 
-        const syncJob = await isSyncJobRunning(task.syncId);
+        const syncJob = await getSyncJobByRunId(task.abortedTask.id);
         if (!syncJob) {
             throw new Error(`Sync job not found for syncId: ${task.syncId}`);
         }

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -23,10 +23,10 @@ import type {
     OrchestratorSchedule
 } from '@nangohq/nango-orchestrator';
 import type { NangoIntegrationData, Sync, SyncConfig } from '../models/index.js';
-import { SyncCommand } from '../models/index.js';
+import { SyncCommand, SyncStatus } from '../models/index.js';
 import tracer from 'dd-trace';
 import { clearLastSyncDate } from '../services/sync/sync.service.js';
-import { isSyncJobRunning } from '../services/sync/job.service.js';
+import { isSyncJobRunning, updateSyncJobStatus } from '../services/sync/job.service.js';
 import { getSyncConfigRaw, getSyncConfigBySyncId } from '../services/sync/config/config.service.js';
 import environmentService from '../services/environment.service.js';
 import type { DBEnvironment, DBTeam } from '@nangohq/types';
@@ -562,6 +562,7 @@ export class Orchestrator {
                 if (!syncJob || !syncJob?.run_id) {
                     return Err(`Sync job not found for syncId: ${syncId}`);
                 }
+                await updateSyncJobStatus(syncJob.id, SyncStatus.STOPPED);
                 await this.client.cancel({ taskId: syncJob?.run_id, reason: initiator });
                 return Ok(undefined);
             };

--- a/packages/shared/lib/services/sync/job.service.ts
+++ b/packages/shared/lib/services/sync/job.service.ts
@@ -81,6 +81,16 @@ export const getLatestSyncJob = async (sync_id: string): Promise<SyncJob | null>
     return null;
 };
 
+export const getSyncJobByRunId = async (run_id: string): Promise<SyncJob | null> => {
+    const result = await schema().from<SyncJob>(SYNC_JOB_TABLE).where({ run_id, deleted: false }).first();
+
+    if (result) {
+        return result;
+    }
+
+    return null;
+};
+
 export const updateSyncJobStatus = async (id: number, status: SyncStatus): Promise<void> => {
     return schema().from<SyncJob>(SYNC_JOB_TABLE).where({ id, deleted: false }).update({
         status,


### PR DESCRIPTION
When user currently cancels a task we only update the sync_job entry if the abort task is successfully processed by jobs.
However if jobs for some reason is having issue, the customer is left with seeing the task still running in the dashboard. With this commit the sync job is always updated when cancellation is clicked and doesn't depend on Job actually aborting the task. Even if jobs is misbehaving the scheduler will eventually recover by cancelling/timing out the task

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1865/fix-sync-status-out-of-sync-on-connections-page

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
