### PR TITLE
fix: lower task heartbeat timeout to 5 mins

### DIFF
--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -696,7 +696,7 @@ export class Orchestrator {
                 timeoutSettingsInSecs: {
                     createdToStarted: 60 * 60, // 1 hour
                     startedToCompleted: 60 * 60 * 24, // 1 day
-                    heartbeat: 30 * 60 // 30 minutes
+                    heartbeat: 5 * 60 // 5 minutes
                 },
                 startsAt: new Date(),
                 args: {


### PR DESCRIPTION
so script executions can recover faster when runner/script becomes unresponsive

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
