### PR TITLE
chore: hard delete sync jobs when a sync is deleted

### DIFF
--- a/packages/jobs/lib/crons/deleteSyncsData.ts
+++ b/packages/jobs/lib/crons/deleteSyncsData.ts
@@ -1,6 +1,6 @@
 import * as cron from 'node-cron';
 import db from '@nangohq/database';
-import { errorManager, ErrorSourceEnum, softDeleteJobs, findRecentlyDeletedSync, Orchestrator } from '@nangohq/shared';
+import { errorManager, ErrorSourceEnum, hardDeleteJobs, findRecentlyDeletedSync, Orchestrator } from '@nangohq/shared';
 import { records } from '@nangohq/records';
 import { getLogger, metrics } from '@nangohq/utils';
 import tracer from 'dd-trace';
@@ -48,10 +48,10 @@ export async function exec(): Promise<void> {
     for (const sync of syncs) {
         logger.info(`[deleteSyncs] deleting syncId: ${sync.id}`);
 
-        // Soft delete jobs
+        // hard delete jobs
         let countJobs = 0;
         do {
-            countJobs = await softDeleteJobs({ syncId: sync.id, limit: limitJobs });
+            countJobs = await hardDeleteJobs({ syncId: sync.id, limit: limitJobs });
             logger.info(`[deleteSyncs] soft deleted ${countJobs} jobs`);
             metrics.increment(metrics.Types.JOBS_DELETE_SYNCS_DATA_JOBS, countJobs);
         } while (countJobs >= limitJobs);

--- a/packages/shared/lib/services/sync/job.service.ts
+++ b/packages/shared/lib/services/sync/job.service.ts
@@ -179,14 +179,11 @@ export const isSyncJobRunning = async (sync_id: string): Promise<Pick<SyncJob, '
     return null;
 };
 
-export async function softDeleteJobs({ syncId, limit }: { syncId: string; limit: number }): Promise<number> {
+export async function hardDeleteJobs({ syncId, limit }: { syncId: string; limit: number }): Promise<number> {
     return db
         .knex('_nango_sync_jobs')
-        .update({
-            deleted: true,
-            deleted_at: db.knex.fn.now()
-        })
+        .delete()
         .whereIn('id', function (sub) {
-            sub.select('id').from('_nango_sync_jobs').where({ deleted: false, sync_id: syncId }).limit(limit);
+            sub.select('id').from('_nango_sync_jobs').where({ sync_id: syncId }).limit(limit);
         });
 }


### PR DESCRIPTION
Sync jobs table is growing rapidely and could become a problem at some point. The only advantage of doing a soft delete is debugging but we rarely need it. We could also have a more complex 2 steps delete (immediate soft + hard later) but I don't think it is worth it.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
