### PR TITLE
fix(connections): update last fetched at to be 33%

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -954,6 +954,9 @@ class ConnectionService {
                     environment,
                     config
                 });
+
+                // if the credentials were refreshed be sure to set the last fetched date
+                await this.updateLastFetched(connection.id);
             }
 
             connection.credentials = response.credentials as OAuth2Credentials;
@@ -1176,7 +1179,7 @@ class ConnectionService {
             }
 
             connectionToRefresh.credentials = newCredentials;
-            await this.updateConnection(connectionToRefresh);
+            await this.updateConnection({ ...connectionToRefresh, updated_at: new Date() });
 
             await telemetry.log(LogTypes.AUTH_TOKEN_REFRESH_SUCCESS, 'Token refresh was successful', LogActionEnum.AUTH, {
                 environmentId: String(environment_id),

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -959,7 +959,10 @@ class ConnectionService {
             connection.credentials = response.credentials as OAuth2Credentials;
         }
 
-        await this.updateLastFetched(connection.id);
+        // sample this to reduce writes and load on the db
+        if (Math.random() < 0.33) {
+            await this.updateLastFetched(connection.id);
+        }
 
         return Ok(connection);
     }


### PR DESCRIPTION
## Describe your changes
Last fetched at is used to to check for token refresh. Reduce the setting of this value to 33% of the time. This will mean that more connections will be refreshed in the cron but since this call is made every time a connection is retrieved even if it isn't refreshed is a little excessive. Every time the credentials are actually refreshed then update last fetched at.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
