### PR TITLE
feat: expose auth or sync errors when listing connections

### DIFF
--- a/docs-v2/reference/api/connection/list.mdx
+++ b/docs-v2/reference/api/connection/list.mdx
@@ -13,7 +13,8 @@ openapi: 'GET /connection'
       "provider": "slack",
       "provider_config_key": "slack-nango-community",
       "created": "2023-06-03T14:53:22.051Z",
-      "metadata": null
+      "metadata": null,
+      "errors": [{ "type": "auth", "log_id": "VrnbtykXJFckCm3HP93t"}]
     },
     {
       "id": 2,
@@ -23,7 +24,8 @@ openapi: 'GET /connection'
       "created": "2023-06-03T15:00:14.945Z",
       "metadata": {
         "bot_id": "some-uuid"
-      }
+      },
+      "errors": []
     }
   ]
 }

--- a/docs-v2/reference/sdks/node.mdx
+++ b/docs-v2/reference/sdks/node.mdx
@@ -364,7 +364,8 @@ await nango.listConnections();
             "provider": "slack",
             "provider_config_key": "slack-nango-community",
             "created": "2023-06-03T14:53:22.051Z",
-            "metadata": null
+            "metadata": null,
+            "errors": []
         },
         {
             "id": 2,
@@ -373,8 +374,9 @@ await nango.listConnections();
             "provider_config_key": "slack-nango-community",
             "created": "2023-06-03T15:00:14.945Z",
             "metadata": {
-            "bot_id": "some-uuid"
-            }
+                "bot_id": "some-uuid"
+            },
+            errors: [{ "type": "auth", "log_id": "VrnbtykXJFckCm3HP93t"}]
         }
     ]
 }

--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -437,6 +437,21 @@ paths:
                                                 metadata:
                                                     type: object
                                                     description: Custom metadata attached to the connection
+                                                errors:
+                                                    type: array
+                                                    items:
+                                                        type: object
+                                                        properties:
+                                                            type:
+                                                                type: string
+                                                                example: "'auth' or 'sync'"
+                                                            log_id:
+                                                                type: string
+                                                                example: "VrnbtykXJFckCm3HP93t"
+                                                    description: |
+                                                        List of connection errors. Ex:
+                                                        - Connection credentials are invalid (type=auth)
+                                                        - Last sync for the connnection has failed (type=sync)
 
         post:
             description: Adds a connection for which you already have credentials.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36495,36 +36495,10 @@
                 "acorn": "^8"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/agent-base": {
-            "version": "7.1.1",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/async": {
             "version": "3.2.6",
             "inBundle": true,
             "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/asynckit": {
-            "version": "0.4.0",
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/axios": {
-            "version": "1.7.7",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/base64-js": {
             "version": "1.5.1",
@@ -36613,17 +36587,6 @@
                 "text-hex": "1.0.x"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/combined-stream": {
-            "version": "1.0.8",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/crypto-randomuuid": {
             "version": "1.0.0",
             "inBundle": true,
@@ -36677,27 +36640,6 @@
                 "node": ">=18"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/debug": {
-            "version": "4.3.7",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/debug/node_modules/ms": {
-            "version": "2.1.3",
-            "inBundle": true,
-            "license": "MIT"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/delay": {
             "version": "5.0.0",
             "inBundle": true,
@@ -36707,14 +36649,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/detect-newline": {
@@ -36751,16 +36685,6 @@
                 "node": ">=0.8.x"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/exponential-backoff": {
-            "version": "3.1.1",
-            "inBundle": true,
-            "license": "Apache-2.0"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/fast-safe-stringify": {
-            "version": "2.1.1",
-            "inBundle": true,
-            "license": "MIT"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/fecha": {
             "version": "4.2.3",
             "inBundle": true,
@@ -36770,70 +36694,6 @@
             "version": "1.1.0",
             "inBundle": true,
             "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/follow-redirects": {
-            "version": "1.15.9",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/form-data": {
-            "version": "4.0.1",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/guess-json-indent": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/https-proxy-agent": {
-            "version": "7.0.4",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.0.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/ieee754": {
             "version": "1.2.1",
@@ -36968,25 +36828,6 @@
                 "node": ">=12"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/mime-db": {
-            "version": "1.52.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/mime-types": {
-            "version": "2.1.35",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/module-details-from-path": {
             "version": "1.0.3",
             "inBundle": true,
@@ -37109,11 +36950,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "inBundle": true,
-            "license": "MIT"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/readable-stream": {
             "version": "3.6.2",
             "inBundle": true,
@@ -37227,22 +37063,6 @@
                 "safe-buffer": "~5.2.0"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/string-byte-length": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/string-byte-slice": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/text-hex": {
             "version": "1.0.0",
             "inBundle": true,
@@ -37259,19 +37079,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 14.0.0"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/truncate-json": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "guess-json-indent": "^3.0.0",
-                "string-byte-length": "^3.0.0",
-                "string-byte-slice": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=18.18.0"
             }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/type-fest": {

--- a/packages/node-client/bin/list-connection.js
+++ b/packages/node-client/bin/list-connection.js
@@ -6,7 +6,7 @@ const nango = new Nango({ host: 'http://localhost:3003', secretKey: args[0] });
 nango
     .listConnections(args[1])
     .then((response) => {
-        console.log(response);
+        console.log(JSON.stringify(response));
     })
     .catch((err) => {
         console.log(err.response?.data || err.message);

--- a/packages/node-client/bin/list-connections.js
+++ b/packages/node-client/bin/list-connections.js
@@ -6,7 +6,7 @@ const nango = new Nango({ host: 'http://localhost:3003', secretKey: args[0] });
 nango
     .listConnections(args[1])
     .then((response) => {
-        console.log(response);
+        console.log(JSON.stringify(response));
     })
     .catch((err) => {
         console.log(err.response?.data || err.message);

--- a/packages/node-client/lib/types.ts
+++ b/packages/node-client/lib/types.ts
@@ -26,7 +26,8 @@ import type {
     TbaCredentials,
     RecordMetadata,
     RecordLastAction,
-    NangoRecord
+    NangoRecord,
+    ActiveLog
 } from '@nangohq/types';
 
 export type {
@@ -148,6 +149,7 @@ export interface ConnectionList {
     provider: string;
     created: string;
     metadata?: Metadata | null;
+    errors: Pick<ActiveLog, 'log_id' | 'type'>[];
 }
 
 export interface IntegrationWithCreds extends Integration {

--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -112,20 +112,15 @@ class ConnectionController {
             providerConfigKeys.forEach((key: string, i: number) => (uniqueKeyToProvider[key] = configs[i]!.provider));
 
             const result: ConnectionList[] = connections.map((connection) => {
-                const list: ConnectionList = {
+                return {
                     id: connection.id,
                     connection_id: connection.connection_id,
                     provider_config_key: connection.provider,
                     provider: uniqueKeyToProvider[connection.provider] as string,
                     created: connection.created,
-                    metadata: connection.metadata
+                    metadata: connection.metadata,
+                    errors: connection.active_logs
                 };
-
-                if (isWeb) {
-                    list.active_logs = connection.active_logs;
-                }
-
-                return list;
             });
 
             res.status(200).send({

--- a/packages/shared/lib/models/Connection.ts
+++ b/packages/shared/lib/models/Connection.ts
@@ -1,6 +1,6 @@
 import type { ApiKeyCredentials, BasicApiCredentials } from './Auth.js';
 import type { TimestampsAndDeleted } from './Generic.js';
-import type { AuthModeType, Metadata, ActiveLogIds, AuthOperationType, AllAuthCredentials, DBTeam, DBEnvironment } from '@nangohq/types';
+import type { AuthModeType, Metadata, AuthOperationType, AllAuthCredentials, DBTeam, DBEnvironment, ActiveLog } from '@nangohq/types';
 
 export type ConnectionConfig = Record<string, any>;
 
@@ -82,5 +82,5 @@ export interface ConnectionList {
     provider: string;
     created: string;
     metadata?: Metadata | null;
-    active_logs?: ActiveLogIds | null;
+    errors: Pick<ActiveLog, 'log_id' | 'type'>[];
 }

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -3,7 +3,7 @@ import db, { schema, dbNamespace } from '@nangohq/database';
 import type { Sync, SyncConfig, Job as SyncJob } from '../../models/Sync.js';
 import { SyncStatus } from '../../models/Sync.js';
 import type { Connection, NangoConnection } from '../../models/Connection.js';
-import type { ActiveLogIds, IncomingFlowConfig, SlimAction, SlimSync, SyncAndActionDifferences, SyncTypeLiteral } from '@nangohq/types';
+import type { ActiveLog, IncomingFlowConfig, SlimAction, SlimSync, SyncAndActionDifferences, SyncTypeLiteral } from '@nangohq/types';
 import {
     getActiveCustomSyncConfigsByEnvironmentId,
     getSyncConfigsByProviderConfigKey,
@@ -161,7 +161,7 @@ export const getSyncByIdAndName = async (nangoConnectionId: number, name: string
 export const getSyncs = async (
     nangoConnection: Connection,
     orchestrator: Orchestrator
-): Promise<(Sync & { sync_type: SyncTypeLiteral; status: SyncStatus; active_logs: ActiveLogIds })[]> => {
+): Promise<(Sync & { sync_type: SyncTypeLiteral; status: SyncStatus; active_logs: Pick<ActiveLog, 'log_id'> })[]> => {
     const q = db.knex
         .from<Sync>(TABLE)
         .select(

--- a/packages/types/lib/notification/active-logs/db.ts
+++ b/packages/types/lib/notification/active-logs/db.ts
@@ -9,5 +9,3 @@ export interface ActiveLog extends Timestamps {
     active: boolean;
     sync_id: string | null;
 }
-
-export type ActiveLogIds = Pick<ActiveLog, 'log_id'>;

--- a/packages/webapp/src/hooks/useConnections.tsx
+++ b/packages/webapp/src/hooks/useConnections.tsx
@@ -11,7 +11,7 @@ export function useConnections(env: string) {
 
     const loading = !data && !error;
 
-    const errorNotifications = data && data.connections ? data?.connections?.filter((connection) => connection.active_logs)?.length : 0;
+    const errorNotifications = data && data.connections ? data?.connections?.filter((connection) => connection.errors.length > 0)?.length : 0;
 
     return {
         loading,

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -51,7 +51,7 @@ export default function ConnectionList() {
         if (data) {
             setConnections(data.connections);
             setFilteredConnections(data.connections);
-            setNumberOfErroredConnections(data.connections.filter((connection) => connection.active_logs).length);
+            setNumberOfErroredConnections(data.connections.filter((connection) => connection.errors.length > 0).length);
         }
     }, [data]);
 
@@ -68,15 +68,15 @@ export default function ConnectionList() {
 
             if (states.length !== 0 && !states.includes('all') && !(states.includes('ok') && states.includes('error'))) {
                 if (states.includes('error')) {
-                    filtered = filtered?.filter((connection) => connection.active_logs);
+                    filtered = filtered?.filter((connection) => connection.errors.length > 0);
                 }
                 if (states.includes('ok')) {
-                    filtered = filtered?.filter((connection) => !connection.active_logs);
+                    filtered = filtered?.filter((connection) => connection.errors.length === 0);
                 }
             }
 
             setFilteredConnections(filtered || []);
-            setNumberOfErroredConnections((filtered || []).filter((connection) => connection.active_logs).length);
+            setNumberOfErroredConnections((filtered || []).filter((connection) => connection.errors.length > 0).length);
         }
     }, [connectionSearch, selectedIntegration, states, data]);
 
@@ -256,7 +256,7 @@ export default function ConnectionList() {
                                 <div className="w-24">Created</div>
                             </div>
                             {filteredConnections.map(
-                                ({ id, connection_id: connectionId, provider, provider_config_key: providerConfigKey, created: creationDate, active_logs }) => (
+                                ({ id, connection_id: connectionId, provider, provider_config_key: providerConfigKey, created: creationDate, errors }) => (
                                     <div
                                         key={`tr-${id}`}
                                         className={`flex gap-4 ${
@@ -268,7 +268,7 @@ export default function ConnectionList() {
                                     >
                                         <div className="flex items-center w-2/3 gap-2 py-2 truncate">
                                             <span className="break-words break-all truncate">{connectionId}</span>
-                                            {active_logs && <ErrorCircle />}
+                                            {errors.length > 0 && <ErrorCircle />}
                                             <CopyButton text={connectionId} />
                                         </div>
                                         <div className="flex items-center w-1/3 gap-3">

--- a/packages/webapp/src/types.ts
+++ b/packages/webapp/src/types.ts
@@ -1,4 +1,4 @@
-import type { ActiveLogIds, NangoModel, SyncTypeLiteral, AuthModeType, NangoSyncEndpoint } from '@nangohq/types';
+import type { NangoModel, SyncTypeLiteral, AuthModeType, NangoSyncEndpoint, ActiveLog } from '@nangohq/types';
 
 export type SyncResult = Record<string, Result>;
 
@@ -58,7 +58,7 @@ export interface SyncResponse {
         version: string;
         models: string[];
     };
-    active_logs: ActiveLogIds | null;
+    active_logs: Pick<ActiveLog, 'log_id'> | null;
 }
 
 export type RunSyncCommand = 'PAUSE' | 'UNPAUSE' | 'RUN' | 'RUN_FULL' | 'CANCEL';


### PR DESCRIPTION
## Describe your changes

Expose connection errors when listing connections
Errors can be of type `sync` when a sync has failed or `auth` if credentials is not valid (only oauth for now, I have a ticket to check basic and api key auth mode).
Eventually we can add a 'reason` attribute for each error but right now fetching a specific log from ES is not supported

Ex: 
```
{
"connections": [
  {
    "id": 1,
    "connection_id": "test-1",
    "provider": "slack",
    "provider_config_key": "slack-nango-community",
    "created": "2023-06-03T14:53:22.051Z",
    "metadata": null,
    "errors": [{ "type": "auth", "log_id": "VrnbtykXJFckCm3HP93t"}]
  },
  {
    "id": 2,
    "connection_id": "test-2",
    "provider": "slack",
    "provider_config_key": "slack-nango-community",
    "created": "2023-06-03T15:00:14.945Z",
    "metadata": {
      "bot_id": "some-uuid"
    },
    "errors": []
  }
]
}

```

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
