### PR TITLE
feat: expose connection error in getConnection response

### DIFF
--- a/docs-v2/reference/api/connection/get.mdx
+++ b/docs-v2/reference/api/connection/get.mdx
@@ -32,8 +32,14 @@ openapi: 'GET /connection/{connectionId}'
     "metadata": {                                 // Custom metadata stored by you
         "myProperty": "yes",
         "filter": "closed=true"
-    }
-}                              
+    },
+    "errors": [
+        {
+            "type": "sync",
+            "log_id": "VrnbtykXJFckCm3HP93t"
+        }
+    ]
+}
   ```
 </ResponseExample>
 

--- a/docs-v2/reference/scripts.mdx
+++ b/docs-v2/reference/scripts.mdx
@@ -335,8 +335,14 @@ We recommend not caching tokens for longer than 5 minutes to ensure they are fre
     "metadata": {                                 
         "myProperty": "yes",
         "filter": "closed=true"
-    }
-}                              
+    },
+    "errors": [
+        {
+            "type": "sync",
+            "log_id": "VrnbtykXJFckCm3HP93t"
+        }
+    ]
+}
 ```
 </Expandable>
 

--- a/docs-v2/reference/sdks/node.mdx
+++ b/docs-v2/reference/sdks/node.mdx
@@ -451,7 +451,13 @@ We recommend not caching tokens for longer than 5 minutes to ensure they are fre
     "metadata": {
         "myProperty": "yes",
         "filter": "closed=true"
-    }
+    },
+    "errors": [
+        {
+            "type": "sync",
+            "log_id": "VrnbtykXJFckCm3HP93t"
+        }
+    ]
 }
 ```
 </Expandable>

--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -79,7 +79,22 @@ class ConnectionController {
                 }
             }
 
-            res.status(200).send(connection);
+            const errors = [];
+            if (connection.id) {
+                const activeLogs = await connectionService.getActiveLogs(connection.id);
+                errors.push(
+                    ...activeLogs.map((log) => {
+                        return {
+                            type: log.type,
+                            log_id: log.log_id
+                        };
+                    })
+                );
+            }
+            res.status(200).send({
+                ...connection,
+                errors
+            });
         } catch (err) {
             next(err);
         }

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -12,7 +12,18 @@ import { getFreshOAuth2Credentials } from '../clients/oauth2.client.js';
 import { NangoError } from '../utils/error.js';
 
 import type { ConnectionConfig, Connection, StoredConnection, NangoConnection } from '../models/Connection.js';
-import type { Metadata, Provider, ProviderOAuth2, AuthModeType, TbaCredentials, TableauCredentials, MaybePromise, DBTeam, DBEnvironment } from '@nangohq/types';
+import type {
+    Metadata,
+    Provider,
+    ProviderOAuth2,
+    AuthModeType,
+    TbaCredentials,
+    TableauCredentials,
+    MaybePromise,
+    DBTeam,
+    DBEnvironment,
+    ActiveLog
+} from '@nangohq/types';
 import { getLogger, stringifyError, Ok, Err, axiosInstance as axios } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
 import type { ServiceResponse } from '../models/Generic.js';
@@ -1598,6 +1609,10 @@ class ConnectionService {
 
             return { success, error, response: success ? (creds as OAuth2Credentials) : null };
         }
+    }
+
+    public async getActiveLogs(connectionId: number): Promise<ActiveLog[]> {
+        return db.knex.from<ActiveLog>(ACTIVE_LOG_TABLE).select('*').where({ connection_id: connectionId, active: true });
     }
 }
 


### PR DESCRIPTION
## Describe your changes

Follow up of https://github.com/NangoHQ/nango/pull/2851
Adding an `errors` attribute to the connection endpoint to expose sync or auth failure for a given connection

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
