### PR TITLE
fix: lock can be released even when not holding the lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36495,36 +36495,10 @@
                 "acorn": "^8"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/agent-base": {
-            "version": "7.1.1",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/async": {
             "version": "3.2.6",
             "inBundle": true,
             "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/asynckit": {
-            "version": "0.4.0",
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/axios": {
-            "version": "1.7.7",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/base64-js": {
             "version": "1.5.1",
@@ -36613,17 +36587,6 @@
                 "text-hex": "1.0.x"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/combined-stream": {
-            "version": "1.0.8",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/crypto-randomuuid": {
             "version": "1.0.0",
             "inBundle": true,
@@ -36677,27 +36640,6 @@
                 "node": ">=18"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/debug": {
-            "version": "4.3.7",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/debug/node_modules/ms": {
-            "version": "2.1.3",
-            "inBundle": true,
-            "license": "MIT"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/delay": {
             "version": "5.0.0",
             "inBundle": true,
@@ -36707,14 +36649,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/detect-newline": {
@@ -36751,16 +36685,6 @@
                 "node": ">=0.8.x"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/exponential-backoff": {
-            "version": "3.1.1",
-            "inBundle": true,
-            "license": "Apache-2.0"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/fast-safe-stringify": {
-            "version": "2.1.1",
-            "inBundle": true,
-            "license": "MIT"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/fecha": {
             "version": "4.2.3",
             "inBundle": true,
@@ -36770,70 +36694,6 @@
             "version": "1.1.0",
             "inBundle": true,
             "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/follow-redirects": {
-            "version": "1.15.9",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/form-data": {
-            "version": "4.0.1",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/guess-json-indent": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/https-proxy-agent": {
-            "version": "7.0.4",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.0.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/ieee754": {
             "version": "1.2.1",
@@ -36968,25 +36828,6 @@
                 "node": ">=12"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/mime-db": {
-            "version": "1.52.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/mime-types": {
-            "version": "2.1.35",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/module-details-from-path": {
             "version": "1.0.3",
             "inBundle": true,
@@ -37109,11 +36950,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "inBundle": true,
-            "license": "MIT"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/readable-stream": {
             "version": "3.6.2",
             "inBundle": true,
@@ -37227,22 +37063,6 @@
                 "safe-buffer": "~5.2.0"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/string-byte-length": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/string-byte-slice": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/text-hex": {
             "version": "1.0.0",
             "inBundle": true,
@@ -37259,19 +37079,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 14.0.0"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/truncate-json": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "guess-json-indent": "^3.0.0",
-                "string-byte-length": "^3.0.0",
-                "string-byte-slice": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=18.18.0"
             }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/type-fest": {

--- a/packages/shared/lib/clients/locking.ts
+++ b/packages/shared/lib/clients/locking.ts
@@ -1,0 +1,17 @@
+import { getRedisUrl } from '../utils/utils.js';
+import { Locking } from '../utils/lock/locking.js';
+import type { KVStore } from '../utils/kvstore/KVStore.js';
+import { RedisKVStore } from '../utils/kvstore/RedisStore.js';
+import { InMemoryKVStore } from '../utils/kvstore/InMemoryStore.js';
+
+export const locking = await (async () => {
+    let store: KVStore;
+    const url = getRedisUrl();
+    if (url) {
+        store = new RedisKVStore(url);
+        await (store as RedisKVStore).connect();
+    } else {
+        store = new InMemoryKVStore();
+    }
+    return new Locking(store);
+})();

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -33,6 +33,7 @@ export * from './services/invitations.js';
 export * from './services/providers.js';
 
 export * as oauth2Client from './clients/oauth2.client.js';
+export * from './clients/locking.js';
 
 export * from './services/nango-config.service.js';
 

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -40,24 +40,15 @@ import type {
     BasicApiCredentials,
     ConnectionUpsertResponse
 } from '../models/Auth.js';
-import {
-    interpolateStringFromObject,
-    interpolateString,
-    parseTokenExpirationDate,
-    isTokenExpired,
-    getRedisUrl,
-    parseTableauTokenExpirationDate
-} from '../utils/utils.js';
-import { Locking } from '../utils/lock/locking.js';
-import { InMemoryKVStore } from '../utils/kvstore/InMemoryStore.js';
-import { RedisKVStore } from '../utils/kvstore/RedisStore.js';
-import type { KVStore } from '../utils/kvstore/KVStore.js';
+import { interpolateStringFromObject, interpolateString, parseTokenExpirationDate, isTokenExpired, parseTableauTokenExpirationDate } from '../utils/utils.js';
 import type { LogContext, LogContextGetter } from '@nangohq/logs';
 import { CONNECTIONS_WITH_SCRIPTS_CAP_LIMIT } from '../constants.js';
 import type { Orchestrator } from '../clients/orchestrator.js';
 import { SlackService } from './notification/slack.service.js';
 import { getProvider } from './providers.js';
 import { v4 as uuidv4 } from 'uuid';
+import { locking } from '../clients/locking.js';
+import type { Lock, Locking } from '../utils/lock/locking.js';
 
 const logger = getLogger('Connection');
 const ACTIVE_LOG_TABLE = dbNamespace + 'active_logs';
@@ -1283,14 +1274,15 @@ class ConnectionService {
         // NOTES:
         // - This is not a distributed lock and will not work in a multi-redis environment.
         // - It could also be unsafe in case of a Redis crash.
-        const lockKey = `lock:refresh:${environment_id}:${providerConfigKey}:${connectionId}`;
+        let lock: Lock | null = null;
         try {
             const ttlInMs = 10000;
             const acquisitionTimeoutMs = ttlInMs * 1.2; // giving some extra time for the lock to be released
 
             let connectionToRefresh: Connection;
             try {
-                await this.locking.tryAcquire(lockKey, ttlInMs, acquisitionTimeoutMs);
+                const lockKey = `lock:refresh:${environment_id}:${providerConfigKey}:${connectionId}`;
+                lock = await this.locking.tryAcquire(lockKey, ttlInMs, acquisitionTimeoutMs);
                 // Another refresh was running so we check if the credentials were refreshed
                 // If yes, we return the new credentials
                 // If not, we proceed with the refresh
@@ -1357,7 +1349,9 @@ class ConnectionService {
 
             return { success: false, error, response: null };
         } finally {
-            await this.locking.release(lockKey);
+            if (lock) {
+                await this.locking.release(lock);
+            }
         }
     }
 
@@ -1910,17 +1904,5 @@ class ConnectionService {
         }
     }
 }
-
-const locking = await (async () => {
-    let store: KVStore;
-    const url = getRedisUrl();
-    if (url) {
-        store = new RedisKVStore(url);
-        await (store as RedisKVStore).connect();
-    } else {
-        store = new InMemoryKVStore();
-    }
-    return new Locking(store);
-})();
 
 export default new ConnectionService(locking);

--- a/packages/shared/lib/utils/lock/locking.ts
+++ b/packages/shared/lib/utils/lock/locking.ts
@@ -1,6 +1,10 @@
 import { stringifyError } from '@nangohq/utils';
 import type { KVStore } from '../kvstore/KVStore.js';
 
+export interface Lock {
+    readonly key: string;
+}
+
 export class Locking {
     private store: KVStore;
 
@@ -8,7 +12,7 @@ export class Locking {
         this.store = store;
     }
 
-    public async tryAcquire(key: string, ttlInMs: number, acquisitionTimeoutMs: number): Promise<{ tries: number }> {
+    public async tryAcquire(key: string, ttlInMs: number, acquisitionTimeoutMs: number): Promise<Lock> {
         if (ttlInMs <= 0) {
             throw new Error(`lock's TTL must be greater than 0`);
         }
@@ -17,20 +21,18 @@ export class Locking {
         }
 
         const start = Date.now();
-        let tries = 0;
         while (Date.now() - start < acquisitionTimeoutMs) {
             try {
                 await this.acquire(key, ttlInMs);
-                return { tries };
+                return { key };
             } catch {
-                tries += 1;
                 await new Promise((resolve) => setTimeout(resolve, 50));
             }
         }
         throw new Error(`Acquiring lock for key: ${key} timed out after ${acquisitionTimeoutMs}ms`);
     }
 
-    public async acquire(key: string, ttlInMs: number): Promise<void> {
+    public async acquire(key: string, ttlInMs: number): Promise<Lock> {
         if (ttlInMs <= 0) {
             throw new Error(`lock's TTL must be greater than 0`);
         }
@@ -39,9 +41,10 @@ export class Locking {
         } catch (err) {
             throw new Error(`Failed to acquire lock for key: ${key} ${stringifyError(err)}`);
         }
+        return { key };
     }
 
-    public async release(key: string): Promise<void> {
-        await this.store.delete(key);
+    public async release(lock: Lock): Promise<void> {
+        await this.store.delete(lock.key);
     }
 }

--- a/packages/shared/lib/utils/lock/locking.unit.test.ts
+++ b/packages/shared/lib/utils/lock/locking.unit.test.ts
@@ -17,8 +17,8 @@ describe('Locking', () => {
     });
 
     it('should acquire and release a lock', async () => {
-        await locking.acquire(KEY, 1000);
-        await locking.release(KEY);
+        const lock = await locking.acquire(KEY, 1000);
+        await locking.release(lock);
     });
 
     it('should throws an error if ttlInMs is not positive', async () => {
@@ -43,9 +43,9 @@ describe('Locking', () => {
     });
 
     it('should wait and acquire a released lock', async () => {
-        await locking.acquire(KEY, 1000);
+        const lock = await locking.acquire(KEY, 1000);
         setTimeout(() => {
-            locking.release(KEY);
+            locking.release(lock);
         }, 500);
         await expect(locking.tryAcquire(KEY, 200, 1000)).resolves.not.toThrow();
     });


### PR DESCRIPTION
## Describe your changes

I wanted to use the redis based locking mechanism to refactor the refresh tokens logic but I found out a pretty big flow where a lock can be released by a process that doesn't hold it. That's a pretty bad design flow but I am not sure of magnitude of the impact since we are using it only to prevent concurrent token refresh and the issue would only materialize in the very specific scenario where the lock holding process is still trying to refresh the token after the lock timeout (10s)

Anyway this fix ensures that to release it, a lock must first be acquired. 
I have also moved the instantiation of the kvstore so it can be reused outside of the connection service. (I am gonna use it in the refreshTokens cron job)

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
