### PR TITLE
feat: basic/apikey credentials check cron job

### DIFF
--- a/packages/logs/lib/models/helpers.ts
+++ b/packages/logs/lib/models/helpers.ts
@@ -126,6 +126,7 @@ export const operationTypeToMessage: Record<ConcatOperationList, string> = {
     'auth:create_connection': 'Create connection',
     'auth:post_connection': 'Post connection script execution',
     'auth:refresh_token': 'Token refresh',
+    'auth:connection_test': 'Connection test',
     'deploy:custom': 'Deploying custom scripts',
     'deploy:prebuilt': 'Deploying pre-built flow',
     'proxy:call': 'Proxy call',

--- a/packages/server/lib/controllers/apiAuth.controller.ts
+++ b/packages/server/lib/controllers/apiAuth.controller.ts
@@ -1,5 +1,4 @@
 import type { Request, Response, NextFunction } from 'express';
-import tracer from 'dd-trace';
 import type { ApiKeyCredentials, BasicApiCredentials } from '@nangohq/shared';
 import {
     errorManager,
@@ -122,8 +121,7 @@ class ApiAuthController {
                 connectionId,
                 providerConfigKey,
                 environment.id,
-                connectionConfig,
-                tracer
+                connectionConfig
             );
 
             if (connectionResponse.isErr()) {
@@ -296,8 +294,7 @@ class ApiAuthController {
                 connectionId,
                 providerConfigKey,
                 environment.id,
-                connectionConfig,
-                tracer
+                connectionConfig
             );
 
             if (connectionResponse.isErr()) {

--- a/packages/server/lib/controllers/auth/postJwt.ts
+++ b/packages/server/lib/controllers/auth/postJwt.ts
@@ -1,5 +1,4 @@
 import type { NextFunction } from 'express';
-import tracer from 'dd-trace';
 import { z } from 'zod';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 import { zodErrorToHTTP, stringifyError } from '@nangohq/utils';
@@ -157,8 +156,7 @@ export const postPublicJwtAuthorization = asyncWrapper<PostPublicJwtAuthorizatio
             connectionId,
             providerConfigKey,
             environment.id,
-            connectionConfig,
-            tracer
+            connectionConfig
         );
 
         if (connectionResponse.isErr()) {

--- a/packages/server/lib/controllers/auth/postTba.ts
+++ b/packages/server/lib/controllers/auth/postTba.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import tracer from 'dd-trace';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 import { zodErrorToHTTP } from '@nangohq/utils';
 import { analytics, configService, AnalyticsTypes, getConnectionConfig, connectionService, getProvider } from '@nangohq/shared';
@@ -149,8 +148,7 @@ export const postPublicTbaAuthorization = asyncWrapper<PostPublicTbaAuthorizatio
         connectionId,
         providerConfigKey,
         environment.id,
-        connectionConfig,
-        tracer
+        connectionConfig
     );
 
     if (connectionResponse.isErr()) {

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -155,7 +155,8 @@ export const connectionRefreshFailed = async ({
     authError,
     environment,
     provider,
-    config
+    config,
+    action
 }: {
     connection: Connection;
     environment: DBEnvironment;
@@ -163,10 +164,11 @@ export const connectionRefreshFailed = async ({
     config: IntegrationConfig;
     authError: { type: string; description: string };
     logCtx: LogContext;
+    action: 'token_refresh' | 'connection_test';
 }): Promise<void> => {
     await errorNotificationService.auth.create({
         type: 'auth',
-        action: 'token_refresh',
+        action,
         connection_id: connection.id!,
         log_id: logCtx.id,
         active: true

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import type { Span, Tracer } from 'dd-trace';
+import type { Span } from 'dd-trace';
 import {
     CONNECTIONS_WITH_SCRIPTS_CAP_LIMIT,
     NangoError,
@@ -32,6 +32,7 @@ import { logContextGetter } from '@nangohq/logs';
 import postConnection from './connection/post-connection.js';
 import { externalPostConnection } from './connection/external-post-connection.js';
 import { sendAuth as sendAuthWebhook } from '@nangohq/webhooks';
+import tracer from 'dd-trace';
 
 const logger = getLogger('hooks');
 const orchestrator = getOrchestrator();
@@ -201,8 +202,7 @@ export const connectionTest = async (
     connectionId: string,
     providerConfigKey: string,
     environment_id: number,
-    connection_config: ConnectionConfig,
-    tracer: Tracer
+    connection_config: ConnectionConfig
 ): Promise<Result<boolean, NangoError>> => {
     const providerVerification = provider?.proxy?.verification;
 

--- a/packages/server/lib/refreshConnections.ts
+++ b/packages/server/lib/refreshConnections.ts
@@ -1,20 +1,18 @@
 import * as cron from 'node-cron';
-import type { Lock, NangoError } from '@nangohq/shared';
+import type { Lock } from '@nangohq/shared';
 import { errorManager, ErrorSourceEnum, connectionService, locking } from '@nangohq/shared';
-import type { Result } from '@nangohq/utils';
 import { stringifyError, getLogger, metrics } from '@nangohq/utils';
 import { logContextGetter } from '@nangohq/logs';
 import {
     connectionRefreshFailed as connectionRefreshFailedHook,
     connectionRefreshSuccess as connectionRefreshSuccessHook,
-    connectionTest
+    connectionTest as connectionTestHook
 } from './hooks/hooks.js';
 import tracer from 'dd-trace';
-import type { ApiKeyCredentials, BasicApiCredentials, ConnectionConfig, Provider, TbaCredentials } from '@nangohq/types';
 
 const logger = getLogger('Server');
 const cronName = '[refreshConnections]';
-const cronMinutes = 1;
+const cronMinutes = 10;
 
 export function refreshConnectionsCron(): void {
     cron.schedule(`*/${cronMinutes} * * * *`, () => {
@@ -105,16 +103,4 @@ export async function exec(): Promise<void> {
             }
         }
     });
-}
-
-function connectionTestHook(
-    providerName: string,
-    provider: Provider,
-    credentials: ApiKeyCredentials | BasicApiCredentials | TbaCredentials,
-    connectionId: string,
-    providerConfigKey: string,
-    environment_id: number,
-    connection_config: ConnectionConfig
-): Promise<Result<boolean, NangoError>> {
-    return connectionTest(providerName, provider, credentials, connectionId, providerConfigKey, environment_id, connection_config, tracer);
 }

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -16,7 +16,7 @@ import { migrate as migrateKeystore } from '@nangohq/keystore';
 
 import publisher from './clients/publisher.client.js';
 import { router } from './routes.js';
-import { refreshTokens } from './refreshTokens.js';
+import { refreshConnectionsCron } from './refreshConnections.js';
 
 const { NANGO_MIGRATE_AT_START = 'true' } = process.env;
 const logger = getLogger('Server');
@@ -58,7 +58,7 @@ if (NANGO_MIGRATE_AT_START === 'true') {
 }
 
 await oAuthSessionService.clearStaleSessions();
-refreshTokens();
+refreshConnectionsCron();
 
 const port = getServerPort();
 server.listen(port, () => {

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -33,6 +33,8 @@ export * from './services/invitations.js';
 export * from './services/providers.js';
 
 export * as oauth2Client from './clients/oauth2.client.js';
+
+export * from './utils/lock/locking.js';
 export * from './clients/locking.js';
 
 export * from './utils/lock/locking.js';

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -45,7 +45,7 @@ export interface OperationAction {
 }
 export interface OperationAuth {
     type: 'auth';
-    action: 'create_connection' | 'refresh_token' | 'post_connection';
+    action: 'create_connection' | 'refresh_token' | 'post_connection' | 'connection_test';
 }
 export interface OperationAdmin {
     type: 'admin';

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -30,9 +30,9 @@ export enum Types {
     PROXY_SUCCESS = 'nango.server.proxy.success',
     PROXY_FAILURE = 'nango.server.proxy.failure',
 
-    REFRESH_TOKENS = 'nango.server.cron.refreshTokens',
-    REFRESH_TOKENS_FAILED = 'nango.server.cron.refreshTokens.failed',
-    REFRESH_TOKENS_SUCCESS = 'nango.server.cron.refreshTokens.success',
+    REFRESH_CONNECTIONS = 'nango.server.cron.refreshConnections',
+    REFRESH_CONNECTIONS_FAILED = 'nango.server.cron.refreshConnections.failed',
+    REFRESH_CONNECTIONS_SUCCESS = 'nango.server.cron.refreshConnections.success',
 
     RUNNER_SDK = 'nango.runner.sdk',
     RUNNER_INVALID_ACTION_INPUT = 'nango.runner.invalidActionInput',


### PR DESCRIPTION
## Describe your changes
I decided to piggy-back on the refreshTokens cron job (renamed refreshConnections even though I am not sure with the naming. Recommendations are welcomed) to benefit from logging of errors, etc... and not have another dedicated background jobs that is very similar.

A failed check shows in the logs like this, the same way a token refresh error cc @bastienbeurier :
![Screenshot 2024-10-21 at 08 53 34](https://github.com/user-attachments/assets/6f190150-c4c0-46f7-aee9-e84344e03f03)

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1404/periodically-test-for-invalid-api-keys-and-basic-creds

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
