### PR TITLE
fix(ui): add missing script name, webhook secret update

### DIFF
--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
@@ -10,7 +10,8 @@ import { validationParams } from './getIntegration.js';
 const privateKey = z.string().startsWith('-----BEGIN RSA PRIVATE KEY----').endsWith('-----END RSA PRIVATE KEY-----');
 const validationBody = z
     .object({
-        integrationId: providerConfigKeySchema.optional()
+        integrationId: providerConfigKeySchema.optional(),
+        webhookSecret: z.string().min(0).max(255).optional()
     })
     .strict()
     .or(
@@ -111,6 +112,19 @@ export const patchIntegration = asyncWrapper<PatchIntegration>(async (req, res) 
             integration.app_link = body.appLink;
             // This is a legacy thing
             integration.custom = { private_key: Buffer.from(body.privateKey).toString('base64') };
+        }
+    }
+
+    // webhook secrets
+    if ('webhookSecret' in body) {
+        if (!integration.custom) {
+            integration.custom = {};
+        }
+        if (!body.webhookSecret) {
+            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+            delete integration.custom['webhookSecret'];
+        } else {
+            integration.custom['webhookSecret'] = body.webhookSecret;
         }
     }
 

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -79,7 +79,7 @@ export type PatchIntegration = Endpoint<{
     Path: '/api/v1/integrations/:providerConfigKey';
     Params: { providerConfigKey: string };
     Body:
-        | { integrationId?: string | undefined }
+        | { integrationId?: string | undefined; webhookSecret?: string | undefined }
         | {
               authType: Extract<AuthModeType, 'OAUTH1' | 'OAUTH2' | 'TBA'>;
               clientId: string;

--- a/packages/webapp/src/components/InfoBloc.tsx
+++ b/packages/webapp/src/components/InfoBloc.tsx
@@ -10,7 +10,7 @@ export const InfoBloc: React.FC<{ title: string; help?: React.ReactNode; childre
     className
 }) => {
     return (
-        <div className={cn('flex flex-col gap-1 relative min-w-[468px]', className)}>
+        <div className={cn('flex flex-col gap-1 relative', className)}>
             <div className="flex items-center gap-2">
                 <div className="text-gray-400 text-xs uppercase">{title}</div>
                 {help && (

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Endpoints/components/ScriptSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Endpoints/components/ScriptSettings.tsx
@@ -138,20 +138,20 @@ export const ScriptSettings: React.FC<{
                         </DrawerClose>
                     </div>
                     <h2 className="text-xl font-semibold">Endpoint Configuration</h2>
-                    <div className="flex flex-wrap gap-10 pt-7">
-                        <div className="text-s text-text-light-gray">
-                            Nango endpoints are powered by integration scripts. Some of the following configurations can only be changed by modifying this
-                            underlying script. If the source is a template, you will need to extend it to change certain configurations (
-                            <Link to="https://docs.nango.dev/customize/guides/extend-an-integration-template" className="underline">
-                                guide
-                            </Link>
-                            ).
-                        </div>
-                        <InfoBloc title="Enabled" className="min-w-[230px]">
+                    <div className="text-s text-text-light-gray pt-7">
+                        Nango endpoints are powered by integration scripts. Some of the following configurations can only be changed by modifying this
+                        underlying script. If the source is a template, you will need to extend it to change certain configurations (
+                        <Link to="https://docs.nango.dev/customize/guides/extend-an-integration-template" className="underline">
+                            guide
+                        </Link>
+                        ).
+                    </div>
+                    <div className="grid grid-cols-2 gap-10 pt-7">
+                        <InfoBloc title="Enabled">
                             <ScriptToggle flow={flow} integration={integration} />
                         </InfoBloc>
                         {flow.is_public ? (
-                            <InfoBloc title="Source" className="min-w-[230px]">
+                            <InfoBloc title="Source">
                                 <div className="flex flex-col gap-1">
                                     <div>
                                         Template{' '}
@@ -217,19 +217,23 @@ export const ScriptSettings: React.FC<{
                                 </div>
                             </InfoBloc>
                         ) : (
-                            <InfoBloc title="Source" className="min-w-[230px]">
-                                Custom v{flow.version}
+                            <InfoBloc title="Source">Custom v{flow.version}</InfoBloc>
+                        )}
+                        <InfoBloc title="Script Type">
+                            <code className="font-code text-text-light-gray text-s bg-dark-600 px-2 rounded-md uppercase">{isSync ? 'Sync' : 'Action'}</code>
+                        </InfoBloc>
+
+                        {!flow.is_public && (
+                            <InfoBloc title="Script Name">
+                                <code className="font-code max-w-full break-all text-text-light-gray bg-dark-600 px-2 rounded-md text-xs">
+                                    {integration.integration.unique_key}/{flow.type}/{flow.name}.ts
+                                </code>
                             </InfoBloc>
                         )}
-                        <InfoBloc title="Script Type" className="min-w-[230px]">
-                            {isSync ? 'Sync' : 'Action'}
-                        </InfoBloc>
                         {isSync && (
                             <>
-                                <InfoBloc title="Sync Type" className="min-w-[230px]">
-                                    {flow.sync_type === 'FULL' ? 'Full refresh only' : 'Incremental sync'}
-                                </InfoBloc>
-                                <InfoBloc title="Sync Frequency" className="min-w-[230px]">
+                                <InfoBloc title="Sync Type">{flow.sync_type === 'FULL' ? 'Full refresh only' : 'Incremental sync'}</InfoBloc>
+                                <InfoBloc title="Sync Frequency">
                                     <div className="capitalize">{flow.runs}</div>
                                     {!flow.is_public && (
                                         <Tooltip.Tooltip delayDuration={0}>
@@ -284,27 +288,21 @@ export const ScriptSettings: React.FC<{
                                         </Dialog>
                                     )}
                                 </InfoBloc>
-                                <InfoBloc title="Sync Metadata" className="min-w-[230px]">
+                                <InfoBloc title="Sync Metadata">
                                     {flow.input ? (
                                         <code className="font-code text-xs border border-border-gray rounded-md px-1">{flow.input.name}</code>
                                     ) : (
                                         'n/a'
                                     )}
                                 </InfoBloc>
-                                <InfoBloc title="Detect Deletions" className="min-w-[230px]">
-                                    {flow.track_deletes === true ? 'Yes' : 'No'}
-                                </InfoBloc>
+                                <InfoBloc title="Detect Deletions">{flow.track_deletes === true ? 'Yes' : 'No'}</InfoBloc>
                                 {flow.webhookSubscriptions && flow.webhookSubscriptions.length > 0 && (
-                                    <InfoBloc title="Webhooks Subscriptions" className="min-w-[230px]">
-                                        {flow.webhookSubscriptions.join(', ')}
-                                    </InfoBloc>
+                                    <InfoBloc title="Webhooks Subscriptions">{flow.webhookSubscriptions.join(', ')}</InfoBloc>
                                 )}
-                                <InfoBloc title="Starts on new connection" className="min-w-[230px]">
-                                    {flow.auto_start === true ? 'Yes' : 'No'}
-                                </InfoBloc>
+                                <InfoBloc title="Starts on new connection">{flow.auto_start === true ? 'Yes' : 'No'}</InfoBloc>
                             </>
                         )}
-                        <InfoBloc title="Necessary scopes" className="min-w-[230px]">
+                        <InfoBloc title="Necessary scopes">
                             {flow.scopes && flow.scopes.length > 0
                                 ? flow.scopes.map((scope) => (
                                       <div className="font-code text-xs border border-border-gray rounded-md px-1" key={scope}>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/App.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/App.tsx
@@ -40,7 +40,7 @@ export const SettingsApp: React.FC<{ data: GetIntegration['Success']['data']; en
     };
 
     return (
-        <div className="mt-10 flex flex-col gap-10">
+        <div className="mt-10 flex gap-10">
             {environment.callback_url && (
                 <InfoBloc
                     title="Setup URL"
@@ -50,7 +50,7 @@ export const SettingsApp: React.FC<{ data: GetIntegration['Success']['data']; en
                     <CopyButton text={environment.callback_url.replace('oauth/callback', 'app-auth/connect')} />
                 </InfoBloc>
             )}
-            <div className="flex gap-10">
+            <div className="grid grid-cols-2 gap-10">
                 <InfoBloc title="App ID">
                     <Input
                         id="app_id"

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/Custom.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/Custom.tsx
@@ -51,7 +51,7 @@ export const SettingsCustom: React.FC<{ data: GetIntegration['Success']['data'];
             </InfoBloc>
 
             <div className="flex flex-col gap-10 mt-10">
-                <div className="flex gap-10">
+                <div className="grid grid-cols-2 gap-10">
                     <InfoBloc title="App ID">
                         <Input
                             id="app_id"


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1910/add-script-name-to-endpoint-configuration
Fixes https://linear.app/nango/issue/NAN-1882/integration-page-saving-webhooks-secret-doesnt-work

- Add missing script name in script settings page
Took the opportunity to fix bad CSS I wrote and use a proper grid
- Webhook secret update was not coded
Only available for linear