### PR TITLE
fix(ui): allow to dismiss slack banner

### DIFF
--- a/packages/webapp/src/components/Info.tsx
+++ b/packages/webapp/src/components/Info.tsx
@@ -3,22 +3,41 @@ import { Alert, AlertDescription, AlertTitle } from './ui/Alert';
 import { InfoCircledIcon } from '@radix-ui/react-icons';
 import type { ComponentProps } from 'react';
 import { cn } from '../utils/utils';
+import Button from './ui/button/Button';
+import { IconX } from '@tabler/icons-react';
 
-export const Info: React.FC<{ children: React.ReactNode; title?: string } & ComponentProps<typeof Alert>> = ({ children, title, ...props }) => {
+export const Info: React.FC<{ children: React.ReactNode; icon?: React.ReactNode; title?: string; onClose?: () => void } & ComponentProps<typeof Alert>> = ({
+    children,
+    title,
+    icon,
+    onClose,
+    ...props
+}) => {
     return (
         <Alert variant={'default'} {...props}>
-            <div
-                className={cn(
-                    'rounded-full p-1',
-                    props.variant === 'destructive' && 'bg-red-base-35',
-                    props.variant === 'warning' && 'bg-yellow-base-35',
-                    (!props.variant || props.variant === 'default') && 'bg-blue-base-35'
+            {icon ?? (
+                <div
+                    className={cn(
+                        'rounded-full p-1',
+                        props.variant === 'destructive' && 'bg-red-base-35',
+                        props.variant === 'warning' && 'bg-yellow-base-35',
+                        (!props.variant || props.variant === 'default') && 'bg-blue-base-35'
+                    )}
+                >
+                    <InfoCircledIcon className="h-4 w-4" />
+                </div>
+            )}
+            <div className="w-full flex items-center justify-between">
+                <div>
+                    {title && <AlertTitle>{title}</AlertTitle>}
+                    <AlertDescription>{children}</AlertDescription>
+                </div>
+                {onClose && (
+                    <Button size={'xs'} variant={'icon'} onClick={onClose}>
+                        <IconX stroke={1}></IconX>
+                    </Button>
                 )}
-            >
-                <InfoCircledIcon className="h-4 w-4" />
             </div>
-            {title && <AlertTitle>{title}</AlertTitle>}
-            <AlertDescription>{children}</AlertDescription>
         </Alert>
     );
 };

--- a/packages/webapp/src/components/ui/Alert.tsx
+++ b/packages/webapp/src/components/ui/Alert.tsx
@@ -3,7 +3,7 @@ import { cva } from 'class-variance-authority';
 import type { VariantProps } from 'class-variance-authority';
 import { cn } from '../../utils/utils';
 
-const alertVariants = cva('relative w-full rounded-lg border px-3 py-1.5 text-sm flex gap-2 items-center', {
+const alertVariants = cva('relative w-full rounded-lg border px-3 py-1.5 text-sm flex gap-2 items-center flex items-center', {
     variants: {
         variant: {
             default: 'bg-blue-base-35 border-blue-base text-blue-base',

--- a/packages/webapp/src/pages/Connection/Show.tsx
+++ b/packages/webapp/src/pages/Connection/Show.tsx
@@ -25,6 +25,7 @@ import type { GetConnection } from '@nangohq/types';
 import { useStore } from '../../store';
 import { getLogsUrl } from '../../utils/logs';
 import { apiDeleteConnection } from '../../hooks/useConnections';
+import { useLocalStorage } from 'react-use';
 
 export enum Tabs {
     Syncs,
@@ -35,6 +36,7 @@ export default function ShowIntegration() {
     const { mutate } = useSWRConfig();
     const env = useStore((state) => state.env);
     const { environmentAndAccount, mutate: environmentMutate } = useEnvironment(env);
+    const [showSlackBanner, setShowSlackBanner] = useLocalStorage(`nango:connection:slack_banner_show`, true);
 
     const [loaded, setLoaded] = useState(false);
     const [connectionResponse, setConnectionResponse] = useState<GetConnection['Success'] | null>(null);
@@ -296,19 +298,16 @@ We could not retrieve and/or refresh your access token due to the following erro
                 </div>
             )}
 
-            {!slackIsConnected && !isHosted() && (
-                <Info className="mt-4">
-                    <div className="flex text-sm items-center">
-                        <IntegrationLogo provider="slack" height={6} width={6} classNames="flex mr-2" />
-                        Receive instant monitoring alerts on Slack.{' '}
-                        <button
-                            disabled={slackIsConnecting}
-                            onClick={createSlackConnection}
-                            className={`ml-1 ${!slackIsConnecting ? 'cursor-pointer underline' : 'text-text-light-gray'}`}
-                        >
-                            Set up now for the {env} environment.
-                        </button>
-                    </div>
+            {!slackIsConnected && !isHosted() && showSlackBanner && (
+                <Info className="mt-4" onClose={() => setShowSlackBanner(false)} icon={<IntegrationLogo provider="slack" height={6} width={6} />}>
+                    Receive instant monitoring alerts on Slack.{' '}
+                    <button
+                        disabled={slackIsConnecting}
+                        onClick={createSlackConnection}
+                        className={`ml-1 ${!slackIsConnecting ? 'cursor-pointer underline' : 'text-text-light-gray'}`}
+                    >
+                        Set up now for the {env} environment.
+                    </button>
                 </Info>
             )}
 

--- a/packages/webapp/src/pages/Environment/Settings.tsx
+++ b/packages/webapp/src/pages/Environment/Settings.tsx
@@ -26,9 +26,11 @@ import { connectSlack } from '../../utils/slack-connection';
 import WebhookCheckboxes from './WebhookCheckboxes';
 import type { WebhookSettings as CheckboxState } from '@nangohq/types';
 import { globalEnv } from '../../utils/env';
+import { useLocalStorage } from 'react-use';
 
 export const EnvironmentSettings: React.FC = () => {
     const env = useStore((state) => state.env);
+    const [, setShowSlackBanner] = useLocalStorage(`nango:connection:slack_banner_show`, true);
 
     const [secretKey, setSecretKey] = useState('');
     const [secretKeyRotatable, setSecretKeyRotatable] = useState(true);
@@ -354,6 +356,7 @@ export const EnvironmentSettings: React.FC = () => {
             toast.success('Slack was disconnected successfully.', { position: toast.POSITION.BOTTOM_CENTER });
             setSlackIsConnected(false);
             void mutate();
+            setShowSlackBanner(true);
         }
     };
 


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1811/make-slack-banner-dismissable-per-environment

- Allow dismissing slack banner
It's done on the frontend side only, we can improve that later by storing the flag somewhere in the backend but we don't have such a feature and it's a massive job for not much value.