### PR TITLE
fix(connection): getConnectionCredentials should return credentials even on error

### DIFF
--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -1,7 +1,15 @@
 import type { Request, Response, NextFunction } from 'express';
 import type { Config as ProviderConfig, OAuth2Credentials, AuthCredentials, ConnectionList, ConnectionUpsertResponse } from '@nangohq/shared';
 import db from '@nangohq/database';
-import type { TbaCredentials, ApiKeyCredentials, BasicApiCredentials, ConnectionConfig, OAuth1Credentials, OAuth2ClientCredentials } from '@nangohq/types';
+import type {
+    TbaCredentials,
+    ApiKeyCredentials,
+    BasicApiCredentials,
+    ConnectionConfig,
+    OAuth1Credentials,
+    OAuth2ClientCredentials,
+    Connection
+} from '@nangohq/types';
 import {
     configService,
     connectionService,
@@ -59,6 +67,9 @@ class ConnectionController {
             });
 
             if (credentialResponse.isErr()) {
+                if (credentialResponse.error.payload['connection']) {
+                    delete (credentialResponse.error.payload['connection'] as unknown as Partial<Connection>).credentials;
+                }
                 errorManager.errResFromNangoErr(res, credentialResponse.error);
 
                 return;

--- a/packages/server/lib/controllers/proxy.controller.ts
+++ b/packages/server/lib/controllers/proxy.controller.ts
@@ -15,7 +15,7 @@ import { logContextGetter } from '@nangohq/logs';
 import { connectionRefreshFailed as connectionRefreshFailedHook, connectionRefreshSuccess as connectionRefreshSuccessHook } from '../hooks/hooks.js';
 import type { LogContext } from '@nangohq/logs';
 import type { RequestLocals } from '../utils/express.js';
-import type { MessageRowInsert } from '@nangohq/types';
+import type { Connection, MessageRowInsert } from '@nangohq/types';
 
 type ForwardedHeaders = Record<string, string>;
 
@@ -96,6 +96,9 @@ class ProxyController {
             });
 
             if (credentialResponse.isErr()) {
+                if (credentialResponse.error.payload['connection']) {
+                    delete (credentialResponse.error.payload['connection'] as unknown as Partial<Connection>).credentials;
+                }
                 await logCtx.error('Failed to get connection credentials', { error: credentialResponse.error });
                 await logCtx.failed();
                 metrics.increment(metrics.Types.PROXY_FAILURE);

--- a/packages/server/lib/controllers/v1/connection/get.ts
+++ b/packages/server/lib/controllers/v1/connection/get.ts
@@ -106,7 +106,11 @@ export const getConnection = asyncWrapper<GetConnection>(async (req, res) => {
 
     if (credentialResponse.isErr()) {
         const errorLog = await errorNotificationService.auth.get(connectionRes.response.id as number);
+
+        // When we failed to refresh we still return a 200 because the connection is used in the UI
+        // Ultimately this could be a second endpoint so the UI displays faster and no confusion between error code
         res.status(200).send({ errorLog, provider: integration.provider, connection: connectionRes.response });
+
         return;
     }
 

--- a/packages/server/lib/controllers/v1/connection/get.ts
+++ b/packages/server/lib/controllers/v1/connection/get.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { requireEmptyBody, zodErrorToHTTP } from '@nangohq/utils';
-import type { Connection, GetConnection, IntegrationConfig } from '@nangohq/types';
+import type { GetConnection, IntegrationConfig } from '@nangohq/types';
 import { connectionService, configService, errorNotificationService } from '@nangohq/shared';
 import { connectionRefreshFailed as connectionRefreshFailedHook, connectionRefreshSuccess as connectionRefreshSuccessHook } from '../../../hooks/hooks.js';
 import { logContextGetter } from '@nangohq/logs';
@@ -53,67 +53,8 @@ export const getConnection = asyncWrapper<GetConnection>(async (req, res) => {
     const instantRefresh = force_refresh === 'true';
     const { connectionId } = params;
 
-    const credentialResponse = await connectionService.getConnectionCredentials({
-        account,
-        environment,
-        connectionId,
-        providerConfigKey,
-        logContextGetter,
-        instantRefresh,
-        onRefreshSuccess: connectionRefreshSuccessHook,
-        onRefreshFailed: connectionRefreshFailedHook
-    });
-
-    // getConnection can create 2 types of error:
-    // - critical (e.g:missing_connection)
-    // - non-critical (failed to refresh token)
-    // In the second case we still want to return the connection, which creates this weird branching
-    const isError = credentialResponse.isErr();
-
-    if (isError && !credentialResponse.error.payload['connection']) {
-        switch (credentialResponse.error.type) {
-            case 'missing_connection':
-                res.status(400).send({
-                    error: {
-                        code: 'missing_connection',
-                        message: credentialResponse.error.message
-                    }
-                });
-                break;
-            case 'missing_provider_config':
-                res.status(400).send({
-                    error: {
-                        code: 'missing_provider_config',
-                        message: credentialResponse.error.message
-                    }
-                });
-                break;
-            case 'unknown_connection':
-                res.status(404).send({
-                    error: {
-                        code: 'unknown_connection',
-                        message: credentialResponse.error.message
-                    }
-                });
-                break;
-            case 'unknown_provider_config':
-                res.status(404).send({
-                    error: {
-                        code: 'unknown_provider_config',
-                        message: credentialResponse.error.message
-                    }
-                });
-                break;
-            default:
-                res.status(500).send({ error: { code: 'server_error' } });
-        }
-        return;
-    }
-
-    const connection = credentialResponse.isOk() ? credentialResponse.value : (credentialResponse.error.payload['connection'] as Connection);
-
-    const config: IntegrationConfig | null = await configService.getProviderConfig(connection.provider_config_key, environment.id);
-    if (!config) {
+    const integration: IntegrationConfig | null = await configService.getProviderConfig(providerConfigKey, environment.id);
+    if (!integration) {
         res.status(404).send({
             error: {
                 code: 'unknown_provider_config',
@@ -123,11 +64,53 @@ export const getConnection = asyncWrapper<GetConnection>(async (req, res) => {
         return;
     }
 
-    if (isError) {
-        const errorLog = await errorNotificationService.auth.get(connection.id as number);
-        res.status(200).send({ errorLog, provider: config.provider, connection });
+    const connectionRes = await connectionService.getConnection(connectionId, providerConfigKey, environment.id);
+    if (connectionRes.error || !connectionRes.response) {
+        switch (connectionRes.error?.type) {
+            case 'missing_connection':
+                res.status(400).send({
+                    error: { code: 'missing_connection', message: connectionRes.error.message }
+                });
+                break;
+            case 'missing_provider_config':
+                res.status(400).send({
+                    error: { code: 'missing_provider_config', message: connectionRes.error.message }
+                });
+                break;
+            case 'unknown_connection':
+                res.status(404).send({
+                    error: { code: 'unknown_connection', message: connectionRes.error.message }
+                });
+                break;
+            case 'unknown_provider_config':
+                res.status(404).send({
+                    error: { code: 'unknown_provider_config', message: connectionRes.error.message }
+                });
+                break;
+            default:
+                res.status(500).send({ error: { code: 'server_error' } });
+        }
         return;
     }
+
+    const credentialResponse = await connectionService.refreshOrTestCredentials({
+        account,
+        environment,
+        connection: connectionRes.response,
+        integration,
+        logContextGetter,
+        instantRefresh,
+        onRefreshSuccess: connectionRefreshSuccessHook,
+        onRefreshFailed: connectionRefreshFailedHook
+    });
+
+    if (credentialResponse.isErr()) {
+        const errorLog = await errorNotificationService.auth.get(connectionRes.response.id as number);
+        res.status(200).send({ errorLog, provider: integration.provider, connection: connectionRes.response });
+        return;
+    }
+
+    const connection = credentialResponse.value;
 
     if (instantRefresh) {
         // If we force the refresh we also specifically log a success operation (we usually only log error)
@@ -136,7 +119,7 @@ export const getConnection = asyncWrapper<GetConnection>(async (req, res) => {
             {
                 account,
                 environment,
-                integration: { id: config.id!, name: config.unique_key, provider: config.provider },
+                integration: { id: integration.id!, name: integration.unique_key, provider: integration.provider },
                 connection: { id: connection.id!, name: connection.connection_id }
             }
         );
@@ -145,7 +128,7 @@ export const getConnection = asyncWrapper<GetConnection>(async (req, res) => {
     }
 
     res.status(200).send({
-        provider: config.provider,
+        provider: integration.provider,
         connection,
         errorLog: null
     });

--- a/packages/server/lib/hooks/connection/post-connection.ts
+++ b/packages/server/lib/hooks/connection/post-connection.ts
@@ -4,7 +4,6 @@ import { LogActionEnum, LogTypes, proxyService, connectionService, telemetry, ge
 import * as postConnectionHandlers from './index.js';
 import type { LogContext, LogContextGetter } from '@nangohq/logs';
 import { stringifyError } from '@nangohq/utils';
-import { connectionRefreshFailed as connectionRefreshFailedHook, connectionRefreshSuccess as connectionRefreshSuccessHook } from '../hooks.js';
 import type { InternalProxyConfiguration } from '@nangohq/types';
 
 type PostConnectionHandler = (internalNango: InternalNango) => Promise<void>;
@@ -23,22 +22,12 @@ async function execute(createdConnection: RecentlyCreatedConnection, providerNam
     const { connection: upsertedConnection, environment, account } = createdConnection;
     let logCtx: LogContext | undefined;
     try {
-        const credentialResponse = await connectionService.getConnectionCredentials({
-            account,
-            environment,
-            connectionId: upsertedConnection.connection_id,
-            providerConfigKey: upsertedConnection.provider_config_key,
-            logContextGetter,
-            instantRefresh: false,
-            onRefreshSuccess: connectionRefreshSuccessHook,
-            onRefreshFailed: connectionRefreshFailedHook
-        });
-
-        if (credentialResponse.isErr()) {
+        const connectionRes = await connectionService.getConnection(upsertedConnection.connection_id, upsertedConnection.provider_config_key, environment.id);
+        if (connectionRes.error || !connectionRes.response) {
             return;
         }
 
-        const { value: connection } = credentialResponse;
+        const connection = connectionRes.response;
 
         const internalConfig: InternalProxyConfiguration = {
             connection,

--- a/packages/server/lib/refreshConnections.ts
+++ b/packages/server/lib/refreshConnections.ts
@@ -36,7 +36,7 @@ export function refreshConnectionsCron(): void {
 }
 
 export async function exec(): Promise<void> {
-    return await tracer.trace<Promise<void>>('nango.server.cron.refreshConnections', async (span) => {
+    await tracer.trace<Promise<void>>('nango.server.cron.refreshConnections', async (span) => {
         let lock: Lock | undefined;
         try {
             logger.info(`${cronName} starting`);

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1068,13 +1068,15 @@ class ConnectionService {
                     });
                 }
 
-                const { credentials, ...connectionWithoutCredentials } = connection;
-                const errorWithPayload = new NangoError(error!.type, connectionWithoutCredentials);
+                const errorWithPayload = new NangoError(error!.type, { connection });
 
                 // there was an attempt to refresh the token so clear it from the queue
                 // of connections to refresh if it failed
                 await this.updateLastFetched(connection.id);
 
+                /**
+                 * Be careful this Error contains credentials
+                 */
                 return Err(errorWithPayload);
             } else if (response.refreshed) {
                 await onRefreshSuccess({

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -24,7 +24,8 @@ import type {
     DBTeam,
     DBEnvironment,
     JwtCredentials,
-    BillCredentials
+    BillCredentials,
+    IntegrationConfig
 } from '@nangohq/types';
 import { getLogger, stringifyError, Ok, Err, axiosInstance as axios } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
@@ -776,7 +777,7 @@ class ConnectionService {
         days: number;
         limit: number;
         cursor?: number | undefined;
-    }): Promise<{ connection_id: string; provider_config_key: string; account: DBTeam; environment: DBEnvironment; cursor: number }[]> {
+    }): Promise<{ connection: Connection; account: DBTeam; environment: DBEnvironment; cursor: number; integration: ProviderConfig }[]> {
         const dateThreshold = new Date();
         dateThreshold.setDate(dateThreshold.getDate() - days);
 
@@ -788,11 +789,10 @@ class ConnectionService {
             .join('_nango_environments', '_nango_connections.environment_id', '_nango_environments.id')
             .join('_nango_accounts', '_nango_environments.account_id', '_nango_accounts.id')
             .select<T>(
-                '_nango_connections.connection_id as connection_id',
-                '_nango_connections.provider_config_key as provider_config_key',
+                db.knex.raw('row_to_json(_nango_connections.*) as connection'),
+                db.knex.raw('row_to_json(_nango_configs.*) as integration'),
                 db.knex.raw('row_to_json(_nango_environments.*) as environment'),
-                db.knex.raw('row_to_json(_nango_accounts.*) as account'),
-                '_nango_connections.id as cursor'
+                db.knex.raw('row_to_json(_nango_accounts.*) as account')
             )
             .where('_nango_connections.deleted', false)
             .andWhere((builder) => builder.where('last_fetched_at', '<', dateThreshold).orWhereNull('last_fetched_at'))
@@ -946,11 +946,11 @@ class ConnectionService {
         return del;
     }
 
-    public async getConnectionCredentials({
+    public async refreshOrTestCredentials({
         account,
         environment,
-        connectionId,
-        providerConfigKey,
+        connection,
+        integration,
         logContextGetter,
         instantRefresh,
         onRefreshSuccess,
@@ -959,8 +959,8 @@ class ConnectionService {
     }: {
         account: DBTeam;
         environment: DBEnvironment;
-        connectionId: string;
-        providerConfigKey: string;
+        connection: Connection;
+        integration: IntegrationConfig;
         logContextGetter: LogContextGetter;
         instantRefresh: boolean;
         onRefreshSuccess: (args: { connection: Connection; environment: DBEnvironment; config: ProviderConfig }) => Promise<void>;
@@ -985,55 +985,26 @@ class ConnectionService {
               ) => Promise<Result<boolean, NangoError>>)
             | undefined;
     }): Promise<Result<Connection, NangoError>> {
-        if (connectionId === null) {
-            const error = new NangoError('missing_connection');
-
-            return Err(error);
-        }
-
-        if (providerConfigKey === null) {
-            const error = new NangoError('missing_provider_config');
-
-            return Err(error);
-        }
-
-        const { success, error, response: connection } = await this.getConnection(connectionId, providerConfigKey, environment.id);
-
-        if (!success && error) {
-            return Err(error);
-        }
-
-        if (connection === null || !connection.id) {
-            const error = new NangoError('unknown_connection', { connectionId, providerConfigKey, environmentName: environment.name });
-
-            return Err(error);
-        }
-
-        const config: ProviderConfig | null = await configService.getProviderConfig(connection?.provider_config_key, environment.id);
-
-        if (config === null || !config.id) {
-            const error = new NangoError('unknown_provider_config');
-            return Err(error);
-        }
-
-        const provider = getProvider(config?.provider);
+        const provider = getProvider(integration.provider);
         if (!provider) {
             const error = new NangoError('unknown_provider_config');
             return Err(error);
         }
 
+        const copy = { ...connection };
+
         if (
-            connection?.credentials?.type === 'OAUTH2' ||
-            connection?.credentials?.type === 'APP' ||
-            connection?.credentials?.type === 'OAUTH2_CC' ||
-            connection?.credentials?.type === 'TABLEAU' ||
-            connection?.credentials?.type === 'JWT' ||
-            connection?.credentials?.type === 'BILL'
+            connection.credentials?.type === 'OAUTH2' ||
+            connection.credentials?.type === 'APP' ||
+            connection.credentials?.type === 'OAUTH2_CC' ||
+            connection.credentials?.type === 'TABLEAU' ||
+            connection.credentials?.type === 'JWT' ||
+            connection.credentials?.type === 'BILL'
         ) {
             const { success, error, response } = await this.refreshCredentialsIfNeeded({
                 connectionId: connection.connection_id,
                 environmentId: environment.id,
-                providerConfig: config,
+                providerConfig: integration,
                 provider: provider as ProviderOAuth2,
                 environment_id: environment.id,
                 instantRefresh
@@ -1045,8 +1016,8 @@ class ConnectionService {
                     {
                         account,
                         environment,
-                        integration: config ? { id: config.id, name: config.unique_key, provider: config.provider } : undefined,
-                        connection: { id: connection.id, name: connection.connection_id }
+                        integration: integration ? { id: integration.id!, name: integration.unique_key, provider: integration.provider } : undefined,
+                        connection: { id: connection.id!, name: connection.connection_id }
                     }
                 );
 
@@ -1063,16 +1034,17 @@ class ConnectionService {
                         },
                         environment,
                         provider,
-                        config,
+                        config: integration,
                         action: 'token_refresh'
                     });
                 }
 
-                const errorWithPayload = new NangoError(error!.type, { connection });
+                const { credentials, ...connectionWithoutCredentials } = copy;
+                const errorWithPayload = new NangoError(error!.type, { connection: connectionWithoutCredentials });
 
                 // there was an attempt to refresh the token so clear it from the queue
                 // of connections to refresh if it failed
-                await this.updateLastFetched(connection.id);
+                await this.updateLastFetched(connection.id!);
 
                 /**
                  * Be careful this Error contains credentials
@@ -1082,19 +1054,19 @@ class ConnectionService {
                 await onRefreshSuccess({
                     connection,
                     environment,
-                    config
+                    config: integration
                 });
             }
 
-            connection.credentials = response.credentials as OAuth2Credentials;
-        } else if (connection?.credentials?.type === 'BASIC' || connection?.credentials?.type === 'API_KEY' || connection?.credentials?.type === 'TBA') {
+            copy.credentials = response.credentials as OAuth2Credentials;
+        } else if (connection.credentials?.type === 'BASIC' || connection.credentials?.type === 'API_KEY' || connection.credentials?.type === 'TBA') {
             if (connectionTestHook) {
                 const result = await connectionTestHook(
-                    config.provider,
+                    integration.provider,
                     provider,
                     connection.credentials,
                     connection.connection_id,
-                    providerConfigKey,
+                    integration.unique_key,
                     environment.id,
                     connection.connection_config
                 );
@@ -1104,8 +1076,8 @@ class ConnectionService {
                         {
                             account,
                             environment,
-                            integration: config ? { id: config.id, name: config.unique_key, provider: config.provider } : undefined,
-                            connection: { id: connection.id, name: connection.connection_id }
+                            integration: integration ? { id: integration.id!, name: integration.unique_key, provider: integration.provider } : undefined,
+                            connection: { id: connection.id!, name: connection.connection_id }
                         }
                     );
 
@@ -1120,30 +1092,30 @@ class ConnectionService {
                         },
                         environment,
                         provider,
-                        config,
+                        config: integration,
                         action: 'connection_test'
                     });
 
                     // there was an attempt to test the credentials
                     // so clear it from the queue if it failed
-                    await this.updateLastFetched(connection.id);
+                    await this.updateLastFetched(connection.id!);
 
-                    const { credentials, ...connectionWithoutCredentials } = connection;
+                    const { credentials, ...connectionWithoutCredentials } = copy;
                     const errorWithPayload = new NangoError(result.error.type, connectionWithoutCredentials);
                     return Err(errorWithPayload);
                 } else {
                     await onRefreshSuccess({
                         connection,
                         environment,
-                        config
+                        config: integration
                     });
                 }
             }
         }
 
-        await this.updateLastFetched(connection.id);
+        await this.updateLastFetched(connection.id!);
 
-        return Ok(connection);
+        return Ok(copy);
     }
 
     public async updateLastFetched(id: number) {

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1046,9 +1046,6 @@ class ConnectionService {
                 // of connections to refresh if it failed
                 await this.updateLastFetched(connection.id!);
 
-                /**
-                 * Be careful this Error contains credentials
-                 */
                 return Err(errorWithPayload);
             } else if (response.refreshed) {
                 await onRefreshSuccess({


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1933/fix-ui-crash-when-loading-a-connection-with-token-refresh-error

- Split getConnectionCredentials and initial connection fetch
For the /connections/:id endpoint we still want to return the connection even if the refresh failed but if there was an error we stripped the credentials to avoid leaking stuff. Initially, I had just reverted this and stripped the credentials outside of the function at multiple places but the code was even more crappier.
So I split the function, this allows us to not repeat call to fetch the integration on the API and correctly output the errors. It's a bit less straightforward but more granular

