### PR TITLE
fix(api): rename internal api connection->connections

### DIFF
--- a/packages/server/lib/controllers/v1/connections/connectionId/deleteConnection.ts
+++ b/packages/server/lib/controllers/v1/connections/connectionId/deleteConnection.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 import { zodErrorToHTTP } from '@nangohq/utils';
 import type { DeleteConnection } from '@nangohq/types';
 import { connectionService } from '@nangohq/shared';
-import { getOrchestrator } from '../../../utils/utils.js';
+import { getOrchestrator } from '../../../../utils/utils.js';
 import { logContextGetter } from '@nangohq/logs';
-import { connectionIdSchema, envSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
+import { connectionIdSchema, envSchema, providerConfigKeySchema } from '../../../../helpers/validation.js';
 
 const validationQuery = z
     .object({

--- a/packages/server/lib/controllers/v1/connections/connectionId/getConnection.ts
+++ b/packages/server/lib/controllers/v1/connections/connectionId/getConnection.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 import { requireEmptyBody, zodErrorToHTTP } from '@nangohq/utils';
 import type { GetConnection, IntegrationConfig } from '@nangohq/types';
 import { connectionService, configService, errorNotificationService } from '@nangohq/shared';
-import { connectionRefreshFailed as connectionRefreshFailedHook, connectionRefreshSuccess as connectionRefreshSuccessHook } from '../../../hooks/hooks.js';
+import { connectionRefreshFailed as connectionRefreshFailedHook, connectionRefreshSuccess as connectionRefreshSuccessHook } from '../../../../hooks/hooks.js';
 import { logContextGetter } from '@nangohq/logs';
-import { connectionIdSchema, envSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
+import { connectionIdSchema, envSchema, providerConfigKeySchema } from '../../../../helpers/validation.js';
 
 const queryStringValidation = z
     .object({

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -29,7 +29,7 @@ import type { Response, Request, RequestHandler } from 'express';
 import { isCloud, isEnterprise, isBasicAuthEnabled, isTest, isLocal, basePublicUrl, baseUrl, flagHasAuth, flagHasManagedAuth } from '@nangohq/utils';
 import { errorManager } from '@nangohq/shared';
 import tracer from 'dd-trace';
-import { getConnection as getConnectionWeb } from './controllers/v1/connection/get.js';
+import { getConnection as getConnectionWeb } from './controllers/v1/connections/connectionId/getConnection.js';
 import { searchOperations } from './controllers/v1/logs/searchOperations.js';
 import { getOperation } from './controllers/v1/logs/getOperation.js';
 import { patchSettings } from './controllers/v1/environment/webhook/patchSettings.js';
@@ -87,7 +87,7 @@ import { patchFlowFrequency } from './controllers/v1/flows/id/patchFrequency.js'
 import { postPublicMetadata } from './controllers/connection/connectionId/metadata/postMetadata.js';
 import { patchPublicMetadata } from './controllers/connection/connectionId/metadata/patchMetadata.js';
 import { deletePublicConnection } from './controllers/connection/connectionId/deleteConnection.js';
-import { deleteConnection } from './controllers/v1/connection/deleteConnection.js';
+import { deleteConnection } from './controllers/v1/connections/connectionId/deleteConnection.js';
 import { getPublicProviders } from './controllers/providers/getProviders.js';
 import { getPublicProvider } from './controllers/providers/getProvider.js';
 import { postPublicUnauthenticated } from './controllers/auth/postUnauthenticated.js';
@@ -310,10 +310,10 @@ web.route('/api/v1/integrations/:providerConfigKey/flows').get(webAuth, getInteg
 
 web.route('/api/v1/provider').get(configController.listProvidersFromYaml.bind(configController));
 
-web.route('/api/v1/connection').get(webAuth, connectionController.listConnections.bind(connectionController));
-web.route('/api/v1/connection/:connectionId').get(webAuth, getConnectionWeb);
-web.route('/api/v1/connection/:connectionId').delete(webAuth, deleteConnection);
-web.route('/api/v1/connection/admin/:connectionId').delete(webAuth, connectionController.deleteAdminConnection.bind(connectionController));
+web.route('/api/v1/connections').get(webAuth, connectionController.listConnections.bind(connectionController));
+web.route('/api/v1/connections/:connectionId').get(webAuth, getConnectionWeb);
+web.route('/api/v1/connections/:connectionId').delete(webAuth, deleteConnection);
+web.route('/api/v1/connections/admin/:connectionId').delete(webAuth, connectionController.deleteAdminConnection.bind(connectionController));
 
 web.route('/api/v1/user').get(webAuth, getUser);
 web.route('/api/v1/user').patch(webAuth, patchUser);

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -12,7 +12,7 @@ export type GetConnection = Endpoint<{
         provider_config_key: string;
         force_refresh?: 'true' | 'false';
     };
-    Path: '/api/v1/connection/:connectionId';
+    Path: '/api/v1/connections/:connectionId';
     Error:
         | ApiError<'unknown_connection'>
         | ApiError<'missing_provider_config'>
@@ -37,7 +37,7 @@ export type DeletePublicConnection = Endpoint<{
 
 export type DeleteConnection = Endpoint<{
     Method: 'DELETE';
-    Path: '/connection/:connectionId';
+    Path: '/api/v1/connections/:connectionId';
     Params: { connectionId: string };
     Querystring: { provider_config_key: string; env: string };
     Error: ApiError<'unknown_connection'> | ApiError<'unknown_provider_config'>;

--- a/packages/webapp/src/hooks/useConnections.tsx
+++ b/packages/webapp/src/hooks/useConnections.tsx
@@ -4,7 +4,7 @@ import { apiFetch, swrFetcher } from '../utils/api';
 import type { DeleteConnection } from '@nangohq/types';
 
 export function useConnections(env: string) {
-    const { data, error, mutate } = useSWR<{ connections: ConnectionList[] }>(`/api/v1/connection?env=${env}`, swrFetcher, {
+    const { data, error, mutate } = useSWR<{ connections: ConnectionList[] }>(`/api/v1/connections?env=${env}`, swrFetcher, {
         refreshInterval: 10000,
         keepPreviousData: false
     });
@@ -23,7 +23,7 @@ export function useConnections(env: string) {
 }
 
 export async function apiDeleteConnection(params: DeleteConnection['Params'], query: DeleteConnection['Querystring']) {
-    const res = await apiFetch(`/api/v1/connection/${params.connectionId}?${new URLSearchParams(query).toString()}`, {
+    const res = await apiFetch(`/api/v1/connections/${params.connectionId}?${new URLSearchParams(query).toString()}`, {
         method: 'DELETE'
     });
 

--- a/packages/webapp/src/pages/Connection/Create.tsx
+++ b/packages/webapp/src/pages/Connection/Create.tsx
@@ -254,7 +254,7 @@ export default function IntegrationCreate() {
             .then(() => {
                 toast.success('Connection created!', { position: toast.POSITION.BOTTOM_CENTER });
                 analyticsTrack('web:connection_created', { provider: integration?.provider || 'unknown' });
-                void mutate((key) => typeof key === 'string' && key.startsWith('/api/v1/connection'), undefined);
+                void mutate((key) => typeof key === 'string' && key.startsWith('/api/v1/connections'), undefined);
                 navigate(`/${env}/connections`, { replace: true });
             })
             .catch((err: unknown) => {

--- a/packages/webapp/src/pages/Connection/Show.tsx
+++ b/packages/webapp/src/pages/Connection/Show.tsx
@@ -131,7 +131,7 @@ We could not retrieve and/or refresh your access token due to the following erro
 
         if (res.res.status === 200) {
             toast.success('Connection deleted!', { position: toast.POSITION.BOTTOM_CENTER });
-            void mutate((key) => typeof key === 'string' && key.startsWith('/api/v1/connection'), undefined);
+            void mutate((key) => typeof key === 'string' && key.startsWith('/api/v1/connections'), undefined);
             navigate(`/${env}/connections`, { replace: true });
         } else {
             toast.error('Failed to delete connection', { position: toast.POSITION.BOTTOM_CENTER });

--- a/packages/webapp/src/pages/Environment/Settings.tsx
+++ b/packages/webapp/src/pages/Environment/Settings.tsx
@@ -346,7 +346,7 @@ export const EnvironmentSettings: React.FC = () => {
     const disconnectSlack = async () => {
         await updateSlackNotifications(false);
 
-        const res = await apiFetch(`/api/v1/connection/admin/account-${accountUUID}-${env}?env=${env}`, {
+        const res = await apiFetch(`/api/v1/connections/admin/account-${accountUUID}-${env}?env=${env}`, {
             method: 'DELETE'
         });
 

--- a/packages/webapp/src/utils/api.tsx
+++ b/packages/webapp/src/utils/api.tsx
@@ -368,7 +368,7 @@ export function useGetConnectionListAPI(env: string) {
 
     return async () => {
         try {
-            const res = await apiFetch(`/api/v1/connection?env=${env}`);
+            const res = await apiFetch(`/api/v1/connections?env=${env}`);
 
             if (res.status === 401) {
                 return signout();
@@ -391,7 +391,7 @@ export function useGetConnectionDetailsAPI(env: string) {
     return async (connectionId: string, providerConfigKey: string, force_refresh: boolean) => {
         try {
             const res = await apiFetch(
-                `/api/v1/connection/${encodeURIComponent(connectionId)}?env=${env}&provider_config_key=${encodeURIComponent(
+                `/api/v1/connections/${encodeURIComponent(connectionId)}?env=${env}&provider_config_key=${encodeURIComponent(
                     providerConfigKey
                 )}&force_refresh=${force_refresh}`
             );


### PR DESCRIPTION
## Describe your changes

Contributes to https://linear.app/nango/issue/NAN-1812/ui-for-userorganization-info-connections-screen

- Rename internal api `/connection` to `/connections` (with an s)