### PR TITLE
fix(ui): integration rename, env switch when showing one integration

### DIFF
--- a/packages/webapp/src/components/LeftNavBar.tsx
+++ b/packages/webapp/src/components/LeftNavBar.tsx
@@ -103,7 +103,7 @@ export default function LeftNavBar(props: LeftNavBarProps) {
         let newPath = `/${pathSegments.join('/')}`;
 
         // If on 'integration' or 'connections' subpages beyond the second level, redirect to their parent page
-        if (pathSegments[1] === 'integration' && pathSegments.length > 2) {
+        if (pathSegments[1] === 'integrations' && pathSegments.length > 2) {
             newPath = `/${newEnv}/integrations`;
         } else if (pathSegments[1] === 'connections' && pathSegments.length > 2) {
             newPath = `/${newEnv}/connections`;

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/General.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/General.tsx
@@ -30,7 +30,7 @@ export const SettingsGeneral: React.FC<{ data: GetIntegration['Success']['data']
     const onSaveIntegrationID = async () => {
         setLoading(true);
 
-        const updated = await apiPatchIntegration(env, integration.unique_key, { webhookSecret });
+        const updated = await apiPatchIntegration(env, integration.unique_key, { integrationId });
 
         setLoading(false);
         if ('error' in updated.json) {


### PR DESCRIPTION
## Describe your changes

- Fix integration rename
I wrongly modified the function to rename when fixing the webhookSecret update

- Fix switching env when showing one integration
The path changed to plural and was not updated here
