### PR TITLE
fix(dockerfile): do not clean up source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN true \
 # Clean src
 RUN true \
   && rm -rf packages/*/src \
-  && rm -rf packages/*/lib \
+  # && rm -rf packages/*/lib will break database migrations because they are not compiled; barely saves a few MBs
   && rm -rf packages/*/public \
   && rm -rf packages/*/node_modules
 


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1946/fix-helm-charts-for-server

- Do not remove source on build
Ideally we don't keep them but the migrations folder is not compiled. I tried already to fix that but it's more complicated thn it seems; The helm charts were wrongly set to use this image here (with my warnings) so I'm just going with the simplest solution https://github.com/NangoHQ/nango-helm-charts/pull/2
