### PR TITLE
fix(connections): add FK to end users

### DIFF
--- a/packages/database/lib/migrations/20241024094439_connections_end_user.cjs
+++ b/packages/database/lib/migrations/20241024094439_connections_end_user.cjs
@@ -1,0 +1,15 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE "_nango_connections" ADD COLUMN "end_user_id" int4`);
+
+    await knex.raw(`ALTER TABLE "_nango_connections" ADD FOREIGN KEY ("end_user_id") REFERENCES "end_users" ("id") ON DELETE SET NULL`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.raw(`ALTER TABLE "_nango_connections" DROP COLUMN "end_user_id"`);
+};

--- a/packages/database/lib/migrations/20241024094439_connections_end_user.cjs
+++ b/packages/database/lib/migrations/20241024094439_connections_end_user.cjs
@@ -3,8 +3,10 @@
  */
 exports.up = async function (knex) {
     await knex.raw(`ALTER TABLE "_nango_connections" ADD COLUMN "end_user_id" int4`);
-
     await knex.raw(`ALTER TABLE "_nango_connections" ADD FOREIGN KEY ("end_user_id") REFERENCES "end_users" ("id") ON DELETE SET NULL`);
+
+    await knex.raw(`ALTER TABLE "_nango_oauth_sessions" ADD COLUMN "connect_session_id" int4`);
+    await knex.raw(`ALTER TABLE "_nango_oauth_sessions" ADD FOREIGN KEY ("connect_session_id") REFERENCES "connect_sessions" ("id") ON DELETE SET NULL`);
 };
 
 /**
@@ -12,4 +14,5 @@ exports.up = async function (knex) {
  */
 exports.down = async function (knex) {
     await knex.raw(`ALTER TABLE "_nango_connections" DROP COLUMN "end_user_id"`);
+    await knex.raw(`ALTER TABLE "_nango_oauth_sessions" DROP COLUMN "connect_session_id"`);
 };

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -146,7 +146,7 @@ class OAuthController {
                 authMode: provider.auth_mode,
                 codeVerifier: crypto.randomBytes(24).toString('hex'),
                 id: uuid.v1(),
-                connect_session_id: null,
+                connectSessionId: null,
                 connectionConfig,
                 environmentId,
                 webSocketClientId: wsClientId,

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -146,6 +146,7 @@ class OAuthController {
                 authMode: provider.auth_mode,
                 codeVerifier: crypto.randomBytes(24).toString('hex'),
                 id: uuid.v1(),
+                connect_session_id: null,
                 connectionConfig,
                 environmentId,
                 webSocketClientId: wsClientId,

--- a/packages/shared/lib/models/Auth.ts
+++ b/packages/shared/lib/models/Auth.ts
@@ -24,7 +24,7 @@ export interface OAuthSession {
     callbackUrl: string;
     authMode: AuthModeType;
     id: string;
-    connect_session_id: string | null;
+    connectSessionId: number | null;
     connectionConfig: Record<string, string>;
     environmentId: number;
     webSocketClientId: string | undefined;

--- a/packages/shared/lib/models/Auth.ts
+++ b/packages/shared/lib/models/Auth.ts
@@ -24,6 +24,7 @@ export interface OAuthSession {
     callbackUrl: string;
     authMode: AuthModeType;
     id: string;
+    connect_session_id: string | null;
     connectionConfig: Record<string, string>;
     environmentId: number;
     webSocketClientId: string | undefined;

--- a/packages/shared/lib/models/Connection.ts
+++ b/packages/shared/lib/models/Connection.ts
@@ -7,6 +7,7 @@ export type ConnectionConfig = Record<string, any>;
 export interface BaseConnection extends TimestampsAndDeleted {
     id?: number;
     config_id?: number;
+    end_user_id?: number;
     provider_config_key: string; // TO deprecate
     connection_id: string;
     connection_config: ConnectionConfig;

--- a/packages/types/lib/connection/db.ts
+++ b/packages/types/lib/connection/db.ts
@@ -10,6 +10,7 @@ export type ConnectionConfig = Record<string, any>;
 export interface BaseConnection extends TimestampsAndDeleted {
     id?: number;
     config_id?: number;
+    end_user_id?: number;
     provider_config_key: string; // TO deprecate
     connection_id: string;
     connection_config: ConnectionConfig;


### PR DESCRIPTION
## Describe your changes

Contributes to https://linear.app/nango/issue/NAN-1944/connect-end-users-to-connections

- Add Foreign Key from connections to end_users
Implementation will come after

- Add Foreign Key from oauth_session to connect_session to be able to get back the session on the callback
Implementation will come after