### PR TITLE
feat(connections): link to end_user on success

### DIFF
--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -248,6 +248,7 @@ interface Connection {
     credentials_iv?: string | null;
     credentials_tag?: string | null;
     credentials: AuthCredentials;
+    end_user_id: number | null;
 }
 export declare class ActionError<T = Record<string, unknown>> extends Error {
     type: string;

--- a/packages/node-client/lib/types.ts
+++ b/packages/node-client/lib/types.ts
@@ -130,6 +130,7 @@ export interface MetadataChangeResponse {
 
 export interface Connection {
     id?: number;
+    end_user_id: number | null;
     created_at: Date;
     updated_at: Date;
     provider_config_key: string;

--- a/packages/server/lib/controllers/apiAuth.controller.ts
+++ b/packages/server/lib/controllers/apiAuth.controller.ts
@@ -21,10 +21,12 @@ import {
     connectionCreationFailed as connectionCreationFailedHook,
     connectionTest as connectionTestHook
 } from '../hooks/hooks.js';
+import { linkConnection } from '../services/endUser.service.js';
+import db from '@nangohq/database';
 
 class ApiAuthController {
     async apiKey(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
-        const { account, environment } = res.locals;
+        const { account, environment, authType } = res.locals;
         const { providerConfigKey } = req.params;
         const receivedConnectionId = req.query['connection_id'] as string | undefined;
         const connectionConfig = req.query['params'] != null ? getConnectionConfig(req.query['params']) : {};
@@ -133,9 +135,6 @@ class ApiAuthController {
                 return;
             }
 
-            await logCtx.info('API key auth creation was successful');
-            await logCtx.success();
-
             const [updatedConnection] = await connectionService.upsertApiConnection({
                 connectionId,
                 providerConfigKey,
@@ -145,23 +144,35 @@ class ApiAuthController {
                 environment,
                 account
             });
-
-            if (updatedConnection) {
-                await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
-                void connectionCreatedHook(
-                    {
-                        connection: updatedConnection.connection,
-                        environment,
-                        account,
-                        auth_mode: 'API_KEY',
-                        operation: updatedConnection.operation
-                    },
-                    config.provider,
-                    logContextGetter,
-                    undefined,
-                    logCtx
-                );
+            if (!updatedConnection) {
+                res.status(500).send({ error: { code: 'server_error', message: 'failed to create connection' } });
+                await logCtx.error('Failed to create connection');
+                await logCtx.failed();
+                return;
             }
+
+            if (authType === 'connectSession') {
+                const session = res.locals.connectSession;
+                await linkConnection(db.knex, { endUserId: session.endUserId, connection: updatedConnection.connection });
+            }
+
+            await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
+            await logCtx.info('API key auth creation was successful');
+            await logCtx.success();
+
+            void connectionCreatedHook(
+                {
+                    connection: updatedConnection.connection,
+                    environment,
+                    account,
+                    auth_mode: 'API_KEY',
+                    operation: updatedConnection.operation
+                },
+                config.provider,
+                logContextGetter,
+                undefined,
+                logCtx
+            );
 
             res.status(200).send({ providerConfigKey: providerConfigKey, connectionId: connectionId });
         } catch (err) {
@@ -202,7 +213,7 @@ class ApiAuthController {
     }
 
     async basic(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
-        const { account, environment } = res.locals;
+        const { account, environment, authType } = res.locals;
         const { providerConfigKey } = req.params;
         const receivedConnectionId = req.query['connection_id'] as string | undefined;
         const connectionConfig = req.query['params'] != null ? getConnectionConfig(req.query['params']) : {};
@@ -306,9 +317,6 @@ class ApiAuthController {
                 return;
             }
 
-            await logCtx.info('Basic API key auth creation was successful', { username });
-            await logCtx.success();
-
             const [updatedConnection] = await connectionService.upsertApiConnection({
                 connectionId,
                 providerConfigKey,
@@ -319,22 +327,35 @@ class ApiAuthController {
                 account
             });
 
-            if (updatedConnection) {
-                await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
-                void connectionCreatedHook(
-                    {
-                        connection: updatedConnection.connection,
-                        environment,
-                        account,
-                        auth_mode: 'API_KEY',
-                        operation: updatedConnection.operation
-                    },
-                    config.provider,
-                    logContextGetter,
-                    undefined,
-                    logCtx
-                );
+            if (!updatedConnection) {
+                res.status(500).send({ error: { code: 'server_error', message: 'failed to create connection' } });
+                await logCtx.error('Failed to create connection');
+                await logCtx.failed();
+                return;
             }
+
+            if (authType === 'connectSession') {
+                const session = res.locals.connectSession;
+                await linkConnection(db.knex, { endUserId: session.endUserId, connection: updatedConnection.connection });
+            }
+
+            await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
+            await logCtx.info('Basic API key auth creation was successful', { username });
+            await logCtx.success();
+
+            void connectionCreatedHook(
+                {
+                    connection: updatedConnection.connection,
+                    environment,
+                    account,
+                    auth_mode: 'API_KEY',
+                    operation: updatedConnection.operation
+                },
+                config.provider,
+                logContextGetter,
+                undefined,
+                logCtx
+            );
 
             res.status(200).send({ providerConfigKey: providerConfigKey, connectionId: connectionId });
         } catch (err) {

--- a/packages/server/lib/controllers/auth/postJwt.ts
+++ b/packages/server/lib/controllers/auth/postJwt.ts
@@ -23,6 +23,8 @@ import {
     connectionTest as connectionTestHook
 } from '../../hooks/hooks.js';
 import { connectSessionTokenSchema, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { linkConnection } from '../../services/endUser.service.js';
+import db from '@nangohq/database';
 
 const bodyValidation = z
     .object({
@@ -80,7 +82,7 @@ export const postPublicJwtAuthorization = asyncWrapper<PostPublicJwtAuthorizatio
         return;
     }
 
-    const { account, environment } = res.locals;
+    const { account, environment, authType } = res.locals;
     const { privateKeyId = '', issuerId = '', privateKey } = val.data as PostPublicJwtAuthorization['Body'];
     const { connection_id: receivedConnectionId, params, hmac }: PostPublicJwtAuthorization['Querystring'] = queryStringVal.data;
     const { providerConfigKey }: PostPublicJwtAuthorization['Params'] = paramVal.data;
@@ -144,9 +146,6 @@ export const postPublicJwtAuthorization = asyncWrapper<PostPublicJwtAuthorizatio
             return;
         }
 
-        await logCtx.info('JWT connection creation was successful');
-        await logCtx.success();
-
         const connectionId = receivedConnectionId || connectionService.generateConnectionId();
 
         const connectionResponse = await connectionTestHook(
@@ -168,9 +167,6 @@ export const postPublicJwtAuthorization = asyncWrapper<PostPublicJwtAuthorizatio
             return;
         }
 
-        await logCtx.info('JWT connection creation was successful');
-        await logCtx.success();
-
         const [updatedConnection] = await connectionService.upsertJwtConnection({
             connectionId,
             providerConfigKey,
@@ -181,23 +177,35 @@ export const postPublicJwtAuthorization = asyncWrapper<PostPublicJwtAuthorizatio
             environment,
             account
         });
-
-        if (updatedConnection) {
-            await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
-            void connectionCreatedHook(
-                {
-                    connection: updatedConnection.connection,
-                    environment,
-                    account,
-                    auth_mode: 'JWT',
-                    operation: updatedConnection.operation
-                },
-                config.provider,
-                logContextGetter,
-                undefined,
-                logCtx
-            );
+        if (!updatedConnection) {
+            res.status(500).send({ error: { code: 'server_error', message: 'failed to create connection' } });
+            await logCtx.error('Failed to create connection');
+            await logCtx.failed();
+            return;
         }
+
+        if (authType === 'connectSession') {
+            const session = res.locals.connectSession;
+            await linkConnection(db.knex, { endUserId: session.endUserId, connection: updatedConnection.connection });
+        }
+
+        await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
+        await logCtx.info('JWT connection creation was successful');
+        await logCtx.success();
+
+        void connectionCreatedHook(
+            {
+                connection: updatedConnection.connection,
+                environment,
+                account,
+                auth_mode: 'JWT',
+                operation: updatedConnection.operation
+            },
+            config.provider,
+            logContextGetter,
+            undefined,
+            logCtx
+        );
 
         res.status(200).send({ providerConfigKey, connectionId });
     } catch (err) {

--- a/packages/server/lib/controllers/auth/postTba.ts
+++ b/packages/server/lib/controllers/auth/postTba.ts
@@ -7,6 +7,8 @@ import { defaultOperationExpiration, logContextGetter } from '@nangohq/logs';
 import { hmacCheck } from '../../utils/hmac.js';
 import { connectionCreated as connectionCreatedHook, connectionTest as connectionTestHook } from '../../hooks/hooks.js';
 import { connectSessionTokenSchema, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { linkConnection } from '../../services/endUser.service.js';
+import db from '@nangohq/database';
 
 const bodyValidation = z
     .object({
@@ -58,7 +60,7 @@ export const postPublicTbaAuthorization = asyncWrapper<PostPublicTbaAuthorizatio
         return;
     }
 
-    const { account, environment } = res.locals;
+    const { account, environment, authType } = res.locals;
 
     const body: PostPublicTbaAuthorization['Body'] = val.data;
 
@@ -162,9 +164,6 @@ export const postPublicTbaAuthorization = asyncWrapper<PostPublicTbaAuthorizatio
         return;
     }
 
-    await logCtx.info('Tba connection creation was successful');
-    await logCtx.success();
-
     const [updatedConnection] = await connectionService.upsertTbaConnection({
         connectionId,
         providerConfigKey,
@@ -179,23 +178,35 @@ export const postPublicTbaAuthorization = asyncWrapper<PostPublicTbaAuthorizatio
         environment,
         account
     });
-
-    if (updatedConnection) {
-        await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
-        void connectionCreatedHook(
-            {
-                connection: updatedConnection.connection,
-                environment,
-                account,
-                auth_mode: 'TBA',
-                operation: updatedConnection.operation
-            },
-            config.provider,
-            logContextGetter,
-            undefined,
-            logCtx
-        );
+    if (!updatedConnection) {
+        res.status(500).send({ error: { code: 'server_error', message: 'failed to create connection' } });
+        await logCtx.error('Failed to create connection');
+        await logCtx.failed();
+        return;
     }
+
+    if (authType === 'connectSession') {
+        const session = res.locals.connectSession;
+        await linkConnection(db.knex, { endUserId: session.endUserId, connection: updatedConnection.connection });
+    }
+
+    await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
+    await logCtx.info('Tba connection creation was successful');
+    await logCtx.success();
+
+    void connectionCreatedHook(
+        {
+            connection: updatedConnection.connection,
+            environment,
+            account,
+            auth_mode: 'TBA',
+            operation: updatedConnection.operation
+        },
+        config.provider,
+        logContextGetter,
+        undefined,
+        logCtx
+    );
 
     res.status(200).send({ providerConfigKey, connectionId });
 });

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -47,6 +47,9 @@ import { defaultOperationExpiration, logContextGetter } from '@nangohq/logs';
 import { errorToObject, stringifyError } from '@nangohq/utils';
 import type { RequestLocals } from '../utils/express.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../hooks/hooks.js';
+import { linkConnection } from '../services/endUser.service.js';
+import db from '@nangohq/database';
+import { getConnectSession } from '../services/connectSession.service.js';
 
 class OAuthController {
     public async oauthRequest(req: Request, res: Response<any, Required<RequestLocals>>, _next: NextFunction) {
@@ -146,7 +149,7 @@ class OAuthController {
                 authMode: provider.auth_mode,
                 codeVerifier: crypto.randomBytes(24).toString('hex'),
                 id: uuid.v1(),
-                connectSessionId: null,
+                connectSessionId: res.locals.connectSession ? res.locals.connectSession.id : null,
                 connectionConfig,
                 environmentId,
                 webSocketClientId: wsClientId,
@@ -243,7 +246,7 @@ class OAuthController {
     }
 
     public async oauth2RequestCC(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
-        const { environment, account } = res.locals;
+        const { environment, account, authType } = res.locals;
         const { providerConfigKey } = req.params;
         const receivedConnectionId = req.query['connection_id'] as string | undefined;
         const connectionConfig = req.query['params'] != null ? getConnectionConfig(req.query['params']) : {};
@@ -362,9 +365,6 @@ class OAuthController {
                 return;
             }
 
-            await logCtx.info('OAuth2 client credentials creation was successful');
-            await logCtx.success();
-
             const [updatedConnection] = await connectionService.upsertConnection({
                 connectionId,
                 providerConfigKey,
@@ -374,23 +374,34 @@ class OAuthController {
                 environmentId: environment.id,
                 accountId: account.id
             });
-
-            if (updatedConnection) {
-                await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
-                void connectionCreatedHook(
-                    {
-                        connection: updatedConnection.connection,
-                        environment,
-                        account,
-                        auth_mode: 'OAUTH2_CC',
-                        operation: updatedConnection.operation
-                    },
-                    config.provider,
-                    logContextGetter,
-                    undefined,
-                    logCtx
-                );
+            if (!updatedConnection) {
+                res.status(500).send({ error: { code: 'server_error', message: 'failed to create connection' } });
+                await logCtx.error('Failed to create connection');
+                await logCtx.failed();
+                return;
             }
+
+            if (authType === 'connectSession') {
+                const session = res.locals.connectSession;
+                await linkConnection(db.knex, { endUserId: session.endUserId, connection: updatedConnection.connection });
+            }
+
+            await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
+            await logCtx.info('OAuth2 client credentials creation was successful');
+            await logCtx.success();
+            void connectionCreatedHook(
+                {
+                    connection: updatedConnection.connection,
+                    environment,
+                    account,
+                    auth_mode: 'OAUTH2_CC',
+                    operation: updatedConnection.operation
+                },
+                config.provider,
+                logContextGetter,
+                undefined,
+                logCtx
+            );
 
             res.status(200).send({ providerConfigKey: providerConfigKey, connectionId: connectionId });
         } catch (err) {
@@ -1079,6 +1090,22 @@ class OAuthController {
                 environmentId: session.environmentId,
                 accountId: account.id
             });
+            if (!updatedConnection) {
+                await logCtx.error('Failed to create connection');
+                await logCtx.failed();
+                return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.UnknownError('failed to create connection'));
+            }
+
+            if (session.connectSessionId) {
+                const connectSession = await getConnectSession(db.knex, { id: session.connectSessionId, accountId: account.id, environmentId: environment.id });
+                if (connectSession.isErr()) {
+                    await logCtx.error('Failed to get session');
+                    await logCtx.failed();
+                    return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.UnknownError('failed to get session'));
+                }
+
+                await linkConnection(db.knex, { endUserId: connectSession.value.endUserId, connection: updatedConnection.connection });
+            }
 
             await logCtx.debug(
                 `OAuth connection successful${provider.auth_mode === 'CUSTOM' && !installationId ? ' and request for app approval is pending' : ''}`,
@@ -1091,25 +1118,23 @@ class OAuthController {
                 }
             );
 
-            if (updatedConnection) {
-                await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
-                // don't initiate a sync if custom because this is the first step of the oauth flow
-                const initiateSync = provider.auth_mode === 'CUSTOM' ? false : true;
-                const runPostConnectionScript = true;
-                void connectionCreatedHook(
-                    {
-                        connection: updatedConnection.connection,
-                        environment,
-                        account,
-                        auth_mode: provider.auth_mode,
-                        operation: updatedConnection.operation
-                    },
-                    session.provider,
-                    logContextGetter,
-                    { initiateSync, runPostConnectionScript },
-                    logCtx
-                );
-            }
+            await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id!, connectionName: updatedConnection.connection.connection_id });
+            // don't initiate a sync if custom because this is the first step of the oauth flow
+            const initiateSync = provider.auth_mode === 'CUSTOM' ? false : true;
+            const runPostConnectionScript = true;
+            void connectionCreatedHook(
+                {
+                    connection: updatedConnection.connection,
+                    environment,
+                    account,
+                    auth_mode: provider.auth_mode,
+                    operation: updatedConnection.operation
+                },
+                session.provider,
+                logContextGetter,
+                { initiateSync, runPostConnectionScript },
+                logCtx
+            );
 
             if (provider.auth_mode === 'CUSTOM' && installationId) {
                 pending = false;
@@ -1251,6 +1276,26 @@ class OAuthController {
                     environmentId: environment.id,
                     accountId: account.id
                 });
+                if (!updatedConnection) {
+                    await logCtx.error('Failed to create connection');
+                    await logCtx.failed();
+                    return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.UnknownError('failed to create connection'));
+                }
+
+                if (session.connectSessionId) {
+                    const connectSession = await getConnectSession(db.knex, {
+                        id: session.connectSessionId,
+                        accountId: account.id,
+                        environmentId: environment.id
+                    });
+                    if (connectSession.isErr()) {
+                        await logCtx.error('Failed to get session');
+                        await logCtx.failed();
+                        return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.UnknownError('failed to get session'));
+                    }
+
+                    await linkConnection(db.knex, { endUserId: connectSession.value.endUserId, connection: updatedConnection.connection });
+                }
 
                 await logCtx.info('OAuth connection was successful', { url: session.callbackUrl, providerConfigKey });
 
@@ -1262,28 +1307,26 @@ class OAuthController {
                     authMode: String(provider.auth_mode)
                 });
 
-                if (updatedConnection) {
-                    await logCtx.enrichOperation({
-                        connectionId: updatedConnection.connection.id!,
-                        connectionName: updatedConnection.connection.connection_id
-                    });
-                    // syncs not support for oauth1
-                    const initiateSync = false;
-                    const runPostConnectionScript = true;
-                    void connectionCreatedHook(
-                        {
-                            connection: updatedConnection.connection,
-                            environment,
-                            account,
-                            auth_mode: provider.auth_mode,
-                            operation: updatedConnection.operation
-                        },
-                        session.provider,
-                        logContextGetter,
-                        { initiateSync, runPostConnectionScript },
-                        logCtx
-                    );
-                }
+                await logCtx.enrichOperation({
+                    connectionId: updatedConnection.connection.id!,
+                    connectionName: updatedConnection.connection.connection_id
+                });
+                // syncs not support for oauth1
+                const initiateSync = false;
+                const runPostConnectionScript = true;
+                void connectionCreatedHook(
+                    {
+                        connection: updatedConnection.connection,
+                        environment,
+                        account,
+                        auth_mode: provider.auth_mode,
+                        operation: updatedConnection.operation
+                    },
+                    session.provider,
+                    logContextGetter,
+                    { initiateSync, runPostConnectionScript },
+                    logCtx
+                );
                 await logCtx.success();
 
                 return publisher.notifySuccess(res, channel, providerConfigKey, connectionId);

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -224,6 +224,7 @@ export const connectionTest = async (
 
     const connection: Connection = {
         id: -1,
+        end_user_id: null,
         provider_config_key: providerConfigKey,
         connection_id: connectionId,
         credentials,

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -163,7 +163,6 @@ publicAPI.options('*', publicAPICorsHandler); // Pre-flight
 
 // API routes (Public key auth).
 publicAPI.route('/oauth/callback').get(oauthController.oauthCallback.bind(oauthController));
-publicAPI.route('/webhook/:environmentUuid/:providerConfigKey').post(webhookController.receive.bind(proxyController));
 publicAPI.route('/app-auth/connect').get(appAuthController.connect.bind(appAuthController));
 
 publicAPI.route('/oauth/connect/:providerConfigKey').get(connectSessionOrPublicAuth, oauthController.oauthRequest.bind(oauthController));
@@ -179,6 +178,8 @@ publicAPI.route('/auth/unauthenticated/:providerConfigKey').post(connectSessionO
 
 // @deprecated
 publicAPI.route('/unauth/:providerConfigKey').post(connectSessionOrPublicAuth, postPublicUnauthenticated);
+
+publicAPI.route('/webhook/:environmentUuid/:providerConfigKey').post(webhookController.receive.bind(proxyController));
 
 // API Admin routes
 publicAPI.route('/admin/flow/deploy/pre-built').post(adminAuth, flowController.adminDeployPrivateFlow.bind(flowController));

--- a/packages/server/lib/services/endUser.service.ts
+++ b/packages/server/lib/services/endUser.service.ts
@@ -1,5 +1,5 @@
 import type knex from 'knex';
-import type { EndUser } from '@nangohq/types';
+import type { EndUser, StoredConnection } from '@nangohq/types';
 import { Err, Ok } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
 
@@ -163,4 +163,12 @@ export async function deleteEndUser(
         return Err(new EndUserError({ code: 'not_found', message: `End user '${endUserId}' not found`, payload: { endUserId, accountId, environmentId } }));
     }
     return Ok(undefined);
+}
+
+export async function linkConnection(db: knex.Knex, { endUserId, connection }: { endUserId: number; connection: Pick<StoredConnection, 'id'> }) {
+    await db<StoredConnection>('_nango_connections').where({ id: connection.id! }).update({ end_user_id: endUserId });
+}
+
+export async function unlinkConnection(db: knex.Knex, { connection }: { connection: Pick<StoredConnection, 'id'> }) {
+    await db<StoredConnection>('_nango_connections').where({ id: connection.id! }).update({ end_user_id: null });
 }

--- a/packages/shared/lib/models/Connection.ts
+++ b/packages/shared/lib/models/Connection.ts
@@ -7,7 +7,7 @@ export type ConnectionConfig = Record<string, any>;
 export interface BaseConnection extends TimestampsAndDeleted {
     id?: number;
     config_id?: number;
-    end_user_id?: number;
+    end_user_id: number | null;
     provider_config_key: string; // TO deprecate
     connection_id: string;
     connection_config: ConnectionConfig;

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -314,6 +314,7 @@ interface Connection {
     credentials_iv?: string | null;
     credentials_tag?: string | null;
     credentials: AuthCredentials;
+    end_user_id: number | null;
 }
 
 export class ActionError<T = Record<string, unknown>> extends Error {

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -349,7 +349,7 @@ class ConnectionService {
         const connection = await db.knex
             .from<StoredConnection>(`_nango_connections`)
             .insert(
-                encryptionManager.encryptApiConnection({
+                encryptionManager.encryptConnection({
                     connection_id: connectionId,
                     provider_config_key: providerConfigKey,
                     config_id: config_id as number,

--- a/packages/shared/lib/services/proxy.service.unit.test.ts
+++ b/packages/shared/lib/services/proxy.service.unit.test.ts
@@ -564,6 +564,7 @@ describe('Proxy service configure', () => {
             providerName: 'provider-1',
             connection: {
                 environment_id: 1,
+                end_user_id: null,
                 connection_id: 'connection-1',
                 provider_config_key: 'provider-config-key-1',
                 credentials: {} as OAuth2Credentials,
@@ -598,6 +599,7 @@ describe('Proxy service configure', () => {
             providerName: 'provider-1',
             connection: {
                 environment_id: 1,
+                end_user_id: null,
                 connection_id: 'connection-1',
                 provider_config_key: 'provider-config-key-1',
                 credentials: {} as OAuth2Credentials,
@@ -633,6 +635,7 @@ describe('Proxy service configure', () => {
             providerName: 'provider-1',
             connection: {
                 environment_id: 1,
+                end_user_id: null,
                 connection_id: 'connection-1',
                 provider_config_key: 'provider-config-key-1',
                 credentials: {} as OAuth2Credentials,
@@ -668,6 +671,7 @@ describe('Proxy service configure', () => {
             providerName: 'unknown',
             connection: {
                 environment_id: 1,
+                end_user_id: null,
                 connection_id: 'connection-1',
                 provider_config_key: 'provider-config-key-1',
                 credentials: {} as OAuth2Credentials,
@@ -709,6 +713,7 @@ describe('Proxy service configure', () => {
             providerName: 'github',
             connection: {
                 environment_id: 1,
+                end_user_id: null,
                 connection_id: 'connection-1',
                 provider_config_key: 'provider-config-key-1',
                 credentials: {} as OAuth2Credentials,

--- a/packages/shared/lib/utils/encryption.manager.ts
+++ b/packages/shared/lib/utils/encryption.manager.ts
@@ -4,7 +4,7 @@ import { getLogger, Encryption } from '@nangohq/utils';
 import type { Config as ProviderConfig } from '../models/Provider';
 import type { DBConfig } from '../models/Generic.js';
 import type { DBEnvironment, DBEnvironmentVariable } from '@nangohq/types';
-import type { Connection, ApiConnection, StoredConnection } from '../models/Connection.js';
+import type { Connection, StoredConnection } from '../models/Connection.js';
 import db from '@nangohq/database';
 import { hashSecretKey } from '../services/environment.service.js';
 
@@ -64,29 +64,14 @@ export class EncryptionManager extends Encryption {
         return decryptedEnvironment;
     }
 
-    public encryptApiConnection(connection: ApiConnection): Omit<StoredConnection, 'created_at' | 'updated_at'> {
+    public encryptConnection(
+        connection: Omit<Connection, 'created_at' | 'updated_at' | 'end_user_id'>
+    ): Omit<StoredConnection, 'created_at' | 'updated_at' | 'end_user_id'> {
         if (!this.shouldEncrypt()) {
             return connection;
         }
 
-        const storedConnection = Object.assign({}, connection) as Omit<StoredConnection, 'created_at' | 'updated_at'>;
-
-        const [encryptedClientSecret, iv, authTag] = this.encrypt(JSON.stringify(connection.credentials));
-        const encryptedCreds = { encrypted_credentials: encryptedClientSecret };
-
-        storedConnection.credentials = encryptedCreds;
-        storedConnection.credentials_iv = iv;
-        storedConnection.credentials_tag = authTag;
-
-        return storedConnection;
-    }
-
-    public encryptConnection(connection: Omit<Connection, 'created_at' | 'updated_at'>): Omit<StoredConnection, 'created_at' | 'updated_at'> {
-        if (!this.shouldEncrypt()) {
-            return connection;
-        }
-
-        const storedConnection = Object.assign({}, connection) as Omit<StoredConnection, 'created_at' | 'updated_at'>;
+        const storedConnection = Object.assign({}, connection) as Omit<StoredConnection, 'created_at' | 'updated_at' | 'end_user_id'>;
 
         const [encryptedClientSecret, iv, authTag] = this.encrypt(JSON.stringify(connection.credentials));
         const encryptedCreds = { encrypted_credentials: encryptedClientSecret };

--- a/packages/types/lib/connection/db.ts
+++ b/packages/types/lib/connection/db.ts
@@ -10,7 +10,7 @@ export type ConnectionConfig = Record<string, any>;
 export interface BaseConnection extends TimestampsAndDeleted {
     id?: number;
     config_id?: number;
-    end_user_id?: number;
+    end_user_id: number | null;
     provider_config_key: string; // TO deprecate
     connection_id: string;
     connection_config: ConnectionConfig;


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-1944/connect-end-users-to-connections

- Link end_user on every connection creation (:|) 


## Tests

Easiest is to use the connect-ui right now, it should populate the end_user_id correctly on a successful flow
