### PR TITLE
fix: use DD_SITE env var instead of hardcoded value

### DIFF
--- a/packages/shared/lib/utils/telemetry.ts
+++ b/packages/shared/lib/utils/telemetry.ts
@@ -44,10 +44,10 @@ class Telemetry {
     private logInstance: v2.LogsApi | undefined;
     constructor() {
         try {
-            if ((isCloud || isEnterprise) && process.env['DD_API_KEY'] && process.env['DD_APP_KEY']) {
+            if ((isCloud || isEnterprise) && process.env['DD_API_KEY'] && process.env['DD_APP_KEY'] && process.env['DD_SITE']) {
                 const configuration = client.createConfiguration();
                 configuration.setServerVariables({
-                    site: 'us3.datadoghq.com'
+                    site: process.env['DD_SITE']
                 });
                 this.logInstance = new v2.LogsApi(configuration);
             }


### PR DESCRIPTION
## Describe your changes

Using the DD_SITE env var in telemetry.ts instead of hardcoded value. 

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1957/solve-datadog-issues

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
