### PR TITLE
feat: add migration for otlp settings

### DIFF
--- a/packages/database/lib/migrations/20241024164559_add_otlp_column_to_environments.cjs
+++ b/packages/database/lib/migrations/20241024164559_add_otlp_column_to_environments.cjs
@@ -1,0 +1,19 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.schema.raw(`ALTER TABLE _nango_environments ADD COLUMN otlp_settings JSONB DEFAULT NULL;`);
+    await knex.schema.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_environment_otlp_settings" ON "_nango_environments" USING BTREE ("id") WHERE "otlp_settings" IS NOT NULL;`
+    );
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.schema.raw(`ALTER TABLE _nango_environments DROP COLUMN otlp_settings;`);
+    await knex.schema.raw(`DROP INDEX CONCURRENTLY IF EXISTS "idx_environment_otlp_settings"`);
+};

--- a/packages/shared/lib/services/environment.service.integration.test.ts
+++ b/packages/shared/lib/services/environment.service.integration.test.ts
@@ -40,7 +40,8 @@ describe('Environment service', () => {
             updated_at: expect.toBeIsoDate(),
             uuid: expect.any(String),
             webhook_url: null,
-            webhook_url_secondary: null
+            webhook_url_secondary: null,
+            otlp_settings: null
         });
 
         expect(env.secret_key).not.toEqual(env.secret_key_hashed);

--- a/packages/types/lib/environment/db.ts
+++ b/packages/types/lib/environment/db.ts
@@ -39,6 +39,7 @@ export interface DBEnvironment extends Timestamps {
     slack_notifications: boolean;
 
     webhook_receive_url?: string;
+    otlp_settings?: { endpoint: string; headers: Record<string, string> } | null;
 }
 
 export interface ExternalWebhook extends Timestamps {


### PR DESCRIPTION
## Describe your changes

Adding column otlp_settings to environment table. Will be used in my next PR
It will contains info about where to send the openTelemetry data. ex:
```
{
   'endpoint': 'http://otlp.agent:4318/v1',
   'headers': { 'x-api-key': 'xxx'}
}
```

## Issue ticket number and link

https://linear.app/nango/issue/NAN-1782/opentelemetry-export

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
