### PR TITLE
feat: add OpenTelemetry export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5615,28 +5615,31 @@
             }
         },
         "node_modules/@opentelemetry/api": {
-            "version": "1.4.1",
-            "license": "Apache-2.0",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+            "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
             "engines": {
                 "node": ">=8.0.0"
             }
         },
         "node_modules/@opentelemetry/core": {
-            "version": "1.18.1",
-            "license": "Apache-2.0",
+            "version": "1.26.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.26.0.tgz",
+            "integrity": "sha512-1iKxXXE8415Cdv0yjG3G6hQnB5eVEsJce3QaawX8SjDn0mAS0ZM8fAbZZJD4ajvhC15cePvosSCut404KrIIvQ==",
             "dependencies": {
-                "@opentelemetry/semantic-conventions": "1.18.1"
+                "@opentelemetry/semantic-conventions": "1.27.0"
             },
             "engines": {
                 "node": ">=14"
             },
             "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.8.0"
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.18.1",
-            "license": "Apache-2.0",
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
+            "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
             "engines": {
                 "node": ">=14"
             }
@@ -16321,6 +16324,14 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/dd-trace/node_modules/@opentelemetry/api": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+            "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+            "engines": {
+                "node": ">=8.0.0"
             }
         },
         "node_modules/dd-trace/node_modules/lru-cache": {
@@ -27053,9 +27064,10 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.2.5",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+            "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
             "hasInstallScript": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
@@ -34291,12 +34303,216 @@
                 "@elastic/elasticsearch": "8.13.1",
                 "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/utils": "file:../utils",
+                "@opentelemetry/api": "^1.9.0",
+                "@opentelemetry/exporter-trace-otlp-http": "^0.54.0",
+                "@opentelemetry/resources": "^1.27.0",
+                "@opentelemetry/sdk-trace-base": "^1.27.0",
+                "@opentelemetry/sdk-trace-node": "^1.27.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0",
                 "zod": "3.23.8"
             },
             "devDependencies": {
                 "@nangohq/types": "file:../types",
                 "type-fest": "4.25.0",
                 "vitest": "1.6.0"
+            }
+        },
+        "packages/logs/node_modules/@opentelemetry/api-logs": {
+            "version": "0.54.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.54.0.tgz",
+            "integrity": "sha512-9HhEh5GqFrassUndqJsyW7a0PzfyWr2eV2xwzHLIS+wX3125+9HE9FMRAKmJRwxZhgZGwH3HNQQjoMGZqmOeVA==",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "packages/logs/node_modules/@opentelemetry/context-async-hooks": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.27.0.tgz",
+            "integrity": "sha512-CdZ3qmHCwNhFAzjTgHqrDQ44Qxcpz43cVxZRhOs+Ns/79ug+Mr84Bkb626bkJLkA3+BLimA5YAEVRlJC6pFb7g==",
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "packages/logs/node_modules/@opentelemetry/core": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.27.0.tgz",
+            "integrity": "sha512-yQPKnK5e+76XuiqUH/gKyS8wv/7qITd5ln56QkBTf3uggr0VkXOXfcaAuG330UfdYu83wsyoBwqwxigpIG+Jkg==",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "packages/logs/node_modules/@opentelemetry/exporter-trace-otlp-http": {
+            "version": "0.54.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.54.0.tgz",
+            "integrity": "sha512-00X6rtr6Ew59+MM9pPSH7Ww5ScpWKBLiBA49awbPqQuVL/Bp0qp7O1cTxKHgjWdNkhsELzJxAEYwuRnDGrMXyA==",
+            "dependencies": {
+                "@opentelemetry/core": "1.27.0",
+                "@opentelemetry/otlp-exporter-base": "0.54.0",
+                "@opentelemetry/otlp-transformer": "0.54.0",
+                "@opentelemetry/resources": "1.27.0",
+                "@opentelemetry/sdk-trace-base": "1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "packages/logs/node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.54.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.54.0.tgz",
+            "integrity": "sha512-g+H7+QleVF/9lz4zhaR9Dt4VwApjqG5WWupy5CTMpWJfHB/nLxBbX73GBZDgdiNfh08nO3rNa6AS7fK8OhgF5g==",
+            "dependencies": {
+                "@opentelemetry/core": "1.27.0",
+                "@opentelemetry/otlp-transformer": "0.54.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "packages/logs/node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.54.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.54.0.tgz",
+            "integrity": "sha512-jRexIASQQzdK4AjfNIBfn94itAq4Q8EXR9d3b/OVbhd3kKQKvMr7GkxYDjbeTbY7hHCOLcLfJ3dpYQYGOe8qOQ==",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.54.0",
+                "@opentelemetry/core": "1.27.0",
+                "@opentelemetry/resources": "1.27.0",
+                "@opentelemetry/sdk-logs": "0.54.0",
+                "@opentelemetry/sdk-metrics": "1.27.0",
+                "@opentelemetry/sdk-trace-base": "1.27.0",
+                "protobufjs": "^7.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "packages/logs/node_modules/@opentelemetry/propagator-b3": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.27.0.tgz",
+            "integrity": "sha512-pTsko3gnMioe3FeWcwTQR3omo5C35tYsKKwjgTCTVCgd3EOWL9BZrMfgLBmszrwXABDfUrlAEFN/0W0FfQGynQ==",
+            "dependencies": {
+                "@opentelemetry/core": "1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "packages/logs/node_modules/@opentelemetry/propagator-jaeger": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.27.0.tgz",
+            "integrity": "sha512-EI1bbK0wn0yIuKlc2Qv2LKBRw6LiUWevrjCF80fn/rlaB+7StAi8Y5s8DBqAYNpY7v1q86+NjU18v7hj2ejU3A==",
+            "dependencies": {
+                "@opentelemetry/core": "1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "packages/logs/node_modules/@opentelemetry/resources": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.27.0.tgz",
+            "integrity": "sha512-jOwt2VJ/lUD5BLc+PMNymDrUCpm5PKi1E9oSVYAvz01U/VdndGmrtV3DU1pG4AwlYhJRHbHfOUIlpBeXCPw6QQ==",
+            "dependencies": {
+                "@opentelemetry/core": "1.27.0",
+                "@opentelemetry/semantic-conventions": "1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "packages/logs/node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.54.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.54.0.tgz",
+            "integrity": "sha512-HeWvOPiWhEw6lWvg+lCIi1WhJnIPbI4/OFZgHq9tKfpwF3LX6/kk3+GR8sGUGAEZfbjPElkkngzvd2s03zbD7Q==",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.54.0",
+                "@opentelemetry/core": "1.27.0",
+                "@opentelemetry/resources": "1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "packages/logs/node_modules/@opentelemetry/sdk-metrics": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.27.0.tgz",
+            "integrity": "sha512-JzWgzlutoXCydhHWIbLg+r76m+m3ncqvkCcsswXAQ4gqKS+LOHKhq+t6fx1zNytvLuaOUBur7EvWxECc4jPQKg==",
+            "dependencies": {
+                "@opentelemetry/core": "1.27.0",
+                "@opentelemetry/resources": "1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "packages/logs/node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.27.0.tgz",
+            "integrity": "sha512-btz6XTQzwsyJjombpeqCX6LhiMQYpzt2pIYNPnw0IPO/3AhT6yjnf8Mnv3ZC2A4eRYOjqrg+bfaXg9XHDRJDWQ==",
+            "dependencies": {
+                "@opentelemetry/core": "1.27.0",
+                "@opentelemetry/resources": "1.27.0",
+                "@opentelemetry/semantic-conventions": "1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "packages/logs/node_modules/@opentelemetry/sdk-trace-node": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.27.0.tgz",
+            "integrity": "sha512-dWZp/dVGdUEfRBjBq2BgNuBlFqHCxyyMc8FsN0NX15X07mxSUO0SZRLyK/fdAVrde8nqFI/FEdMH4rgU9fqJfQ==",
+            "dependencies": {
+                "@opentelemetry/context-async-hooks": "1.27.0",
+                "@opentelemetry/core": "1.27.0",
+                "@opentelemetry/propagator-b3": "1.27.0",
+                "@opentelemetry/propagator-jaeger": "1.27.0",
+                "@opentelemetry/sdk-trace-base": "1.27.0",
+                "semver": "^7.5.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
         "packages/logs/node_modules/type-fest": {

--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -7,6 +7,8 @@ import { getLogger, stringifyError } from '@nangohq/utils';
 import { timeoutLogsOperations } from './crons/timeoutLogsOperations.js';
 import { envs } from './env.js';
 import db from '@nangohq/database';
+import { getOtlpRoutes } from '@nangohq/shared';
+import { otlp } from '@nangohq/logs';
 
 const logger = getLogger('Jobs');
 
@@ -67,6 +69,8 @@ try {
     cronAutoIdleDemo();
     deleteSyncsData();
     timeoutLogsOperations();
+
+    otlp.register(getOtlpRoutes);
 } catch (err) {
     logger.error(stringifyError(err));
     process.exit(1);

--- a/packages/logs/lib/index.ts
+++ b/packages/logs/lib/index.ts
@@ -4,4 +4,5 @@ export * from './models/helpers.js';
 export * from './models/logContextGetter.js';
 export * as model from './models/messages.js';
 export * as modelOperations from './models/insights.js';
+export * from './otlp/otlp.js';
 export { envs, defaultOperationExpiration } from './env.js';

--- a/packages/logs/lib/otlp/otlp.ts
+++ b/packages/logs/lib/otlp/otlp.ts
@@ -32,7 +32,9 @@ function registerRoutes(routes: RouteConfig[]) {
             routingProcessor.updateRoutes(routes);
         } else {
             routingProcessor = new RoutingSpanProcessor(routes);
-            const provider = new NodeTracerProvider({ resource: new Resource({ [ATTR_SERVICE_NAME]: 'nango-otlp' }) });
+            const provider = new NodeTracerProvider({
+                resource: new Resource({ [ATTR_SERVICE_NAME]: 'nango-otlp' })
+            });
             provider.addSpanProcessor(routingProcessor);
             provider.register();
         }

--- a/packages/logs/lib/otlp/otlp.ts
+++ b/packages/logs/lib/otlp/otlp.ts
@@ -1,0 +1,60 @@
+import { trace } from '@opentelemetry/api';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { Resource } from '@opentelemetry/resources';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { once, stringifyError } from '@nangohq/utils';
+import { logger } from '../utils.js';
+import { RoutingSpanProcessor } from './otlpSpanProcessor.js';
+import { setInterval } from 'timers';
+
+// Enable OpenTelemetry console logging
+// import { DiagLogLevel, DiagConsoleLogger, diag } from '@opentelemetry/api';
+// diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+
+export const otlpRoutingAttributeKey = 'otlp.internal.routingKey';
+
+export interface RouteConfig {
+    routingId: string;
+    routingEndpoint: string;
+    routingHeaders: Record<string, string>;
+}
+
+let routingProcessor: RoutingSpanProcessor | null = null;
+process.on('SIGTERM', async () => {
+    if (routingProcessor) {
+        await routingProcessor.shutdown();
+    }
+});
+
+function registerRoutes(routes: RouteConfig[]) {
+    try {
+        if (routingProcessor) {
+            routingProcessor.updateRoutes(routes);
+        } else {
+            routingProcessor = new RoutingSpanProcessor(routes);
+            const provider = new NodeTracerProvider({ resource: new Resource({ [ATTR_SERVICE_NAME]: 'nango-otlp' }) });
+            provider.addSpanProcessor(routingProcessor);
+            provider.register();
+        }
+    } catch (err) {
+        logger.error(`failed_to_register_otlp_routes ${stringifyError(err)}`);
+    }
+}
+
+async function updateRoutes(getRoutes: () => Promise<RouteConfig[]>) {
+    try {
+        const routes = await getRoutes();
+        registerRoutes(routes);
+    } catch (err) {
+        logger.error(`failed_to_update_otlp_routes ${stringifyError(err)}`);
+    }
+}
+
+export const otlp = {
+    register: once(async (getRoutes: () => Promise<RouteConfig[]>) => {
+        await updateRoutes(getRoutes);
+        setInterval(async () => await updateRoutes(getRoutes), 10000);
+    }),
+    tracer: trace.getTracer('nango-otlp'),
+    routingAttributeKey: 'otlp.internal.routingKey'
+};

--- a/packages/logs/lib/otlp/otlpSpan.ts
+++ b/packages/logs/lib/otlp/otlpSpan.ts
@@ -1,0 +1,109 @@
+import type { MessageRow, MessageState, OperationRow } from '@nangohq/types';
+import { SpanStatusCode } from '@opentelemetry/api';
+import type { Span } from '@opentelemetry/api';
+import { otlp, otlpRoutingAttributeKey } from './otlp.js';
+import { envs } from '../env.js';
+
+export class OtlpSpan {
+    private span: Span | null = null;
+
+    constructor(operation: OperationRow) {
+        if (!envs.NANGO_LOGS_ENABLED || !shouldTrace(operation)) {
+            return;
+        }
+        // if no environmentId, we cannot route the span to the correct exporter so we don't start it
+        if (operation.environmentId) {
+            const attributes: Record<string, any> = {
+                [otlpRoutingAttributeKey]: `environment:${operation.environmentId}`,
+                'nango.operation.id': operation.id,
+                'nango.operation.type': operation.operation.type,
+                'nango.operation.action': operation.operation.action,
+                'nango.operation.message': operation.message,
+                'nango.account': operation.accountName
+            };
+            if (operation.environmentName) {
+                attributes['nango.environment'] = operation.environmentName;
+            }
+            if (operation.providerName) {
+                attributes['nango.provider'] = operation.providerName;
+            }
+            if (operation.integrationName) {
+                attributes['nango.integration'] = operation.integrationName;
+            }
+            if (operation.connectionName) {
+                attributes['nango.connection'] = operation.connectionName;
+            }
+            if (operation.syncConfigName) {
+                attributes['nango.sync'] = operation.syncConfigName;
+            }
+
+            const spanName = `nango.${operation.operation.type}.${operation.operation.action}`.toLowerCase();
+            this.span = otlp.tracer.startSpan(spanName, { attributes });
+        }
+    }
+
+    fail(err: Error): void {
+        if (this.span) {
+            this.span.recordException(err);
+            this.span.setStatus({ code: SpanStatusCode.ERROR });
+        }
+    }
+
+    end(state: MessageState): void {
+        if (this.span) {
+            this.span.setAttribute('nango.operation.status', state);
+            this.span.setStatus({ code: ['success', 'waiting', 'running'].includes(state) ? SpanStatusCode.OK : SpanStatusCode.ERROR });
+            this.span.end();
+        }
+    }
+
+    enrich(data: Partial<MessageRow>): void {
+        if (this.span) {
+            const attrs: Record<string, any> = {};
+            if (data.error) {
+                attrs['nango.error.message'] = data.error.message;
+                if (data.error.type) {
+                    attrs['nango.error.type'] = data.error.type;
+                }
+                if (data.error.payload) {
+                    attrs['nango.error.payload'] = data.error.payload;
+                }
+            }
+            if (data.environmentName) {
+                attrs['nango.environment'] = data.environmentName;
+            }
+            if (data.providerName) {
+                attrs['nango.provider'] = data.providerName;
+            }
+            if (data.integrationName) {
+                attrs['nango.integration'] = data.integrationName;
+            }
+            if (data.connectionName) {
+                attrs['nango.connection'] = data.connectionName;
+            }
+            if (data.syncConfigName) {
+                attrs['nango.sync'] = data.syncConfigName;
+            }
+            this.span.setAttributes(attrs);
+        }
+    }
+}
+
+function shouldTrace(operation: OperationRow): boolean {
+    if (!operation || !operation.operation) {
+        return false;
+    }
+    if (operation.operation.type === 'sync' && operation.operation.action === 'run') {
+        return true;
+    }
+    if (operation.operation.type === 'proxy') {
+        return true;
+    }
+    if (operation.operation.type === 'action') {
+        return true;
+    }
+    if (operation.operation.type === 'webhook') {
+        return true;
+    }
+    return false;
+}

--- a/packages/logs/lib/otlp/otlpSpan.ts
+++ b/packages/logs/lib/otlp/otlpSpan.ts
@@ -38,7 +38,7 @@ export class OtlpSpan {
             }
 
             const spanName = `nango.${operation.operation.type}.${operation.operation.action}`.toLowerCase();
-            this.span = otlp.tracer.startSpan(spanName, { attributes });
+            this.span = otlp.tracer.startSpan(spanName, { attributes, root: true });
         }
     }
 

--- a/packages/logs/lib/otlp/otlpSpanProcessor.ts
+++ b/packages/logs/lib/otlp/otlpSpanProcessor.ts
@@ -20,7 +20,7 @@ export class RoutingSpanProcessor implements SpanProcessor {
             for (const route of routes) {
                 const processor = new BatchSpanProcessor(
                     new OTLPTraceExporter({
-                        url: `${route.routingEndpoint.replace(/\/$/, '')}/traces`, // trim trailing slash if present
+                        url: `${route.routingEndpoint}/traces`,
                         headers: route.routingHeaders
                     })
                 );
@@ -48,7 +48,7 @@ export class RoutingSpanProcessor implements SpanProcessor {
                 }
 
                 const traceExporter = new OTLPTraceExporter({
-                    url: `${route.routingEndpoint.replace(/\/$/, '')}/traces`,
+                    url: `${route.routingEndpoint}/traces`,
                     headers: route.routingHeaders
                 });
                 const newProcessor = new BatchSpanProcessor(traceExporter);

--- a/packages/logs/lib/otlp/otlpSpanProcessor.ts
+++ b/packages/logs/lib/otlp/otlpSpanProcessor.ts
@@ -80,6 +80,14 @@ export class RoutingSpanProcessor implements SpanProcessor {
                 this.processors.set(route.routingId, { processor: newProcessor, routeHash: routeHash });
             }
 
+            // remove processors that are no longer needed
+            for (const [routingId, processor] of this.processors) {
+                if (!routes.find((r) => r.routingId === routingId)) {
+                    toShutdown.push(processor.processor);
+                    this.processors.delete(routingId);
+                }
+            }
+
             // Shutdown old processors
             await Promise.all(toShutdown.map((p) => p.shutdown()));
         } catch (err) {

--- a/packages/logs/lib/otlp/otlpSpanProcessor.ts
+++ b/packages/logs/lib/otlp/otlpSpanProcessor.ts
@@ -1,0 +1,116 @@
+import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import type { Attributes, Context } from '@opentelemetry/api';
+import { stringToHash, stringifyError } from '@nangohq/utils';
+import { logger } from '../utils.js';
+import { otlpRoutingAttributeKey } from './otlp.js';
+import type { RouteConfig } from './otlp.js';
+
+interface BatchSpanProcessorWithRouteHash {
+    processor: BatchSpanProcessor;
+    routeHash: number;
+}
+
+export class RoutingSpanProcessor implements SpanProcessor {
+    private processors = new Map<string, BatchSpanProcessorWithRouteHash>();
+
+    constructor(routes: RouteConfig[]) {
+        try {
+            for (const route of routes) {
+                const processor = new BatchSpanProcessor(
+                    new OTLPTraceExporter({
+                        url: `${route.routingEndpoint.replace(/\/$/, '')}/traces`, // trim trailing slash if present
+                        headers: route.routingHeaders
+                    })
+                );
+                const routeHash = stringToHash(JSON.stringify(route));
+                this.processors.set(route.routingId, { processor, routeHash: routeHash });
+            }
+        } catch (err) {
+            logger.error(`failed_to_created_routing_span_processor ${stringifyError(err)}`);
+        }
+    }
+
+    async updateRoutes(routes: RouteConfig[]) {
+        try {
+            const toShutdown: BatchSpanProcessor[] = [];
+
+            for (const route of routes) {
+                const routeHash = stringToHash(JSON.stringify(route));
+                const existing = this.processors.get(route.routingId);
+                if (existing) {
+                    // Skip if the route hasn't changed
+                    if (existing.routeHash === routeHash) {
+                        continue;
+                    }
+                    toShutdown.push(existing.processor);
+                }
+
+                const traceExporter = new OTLPTraceExporter({
+                    url: `${route.routingEndpoint.replace(/\/$/, '')}/traces`,
+                    headers: route.routingHeaders
+                });
+                const newProcessor = new BatchSpanProcessor(traceExporter);
+                this.processors.set(route.routingId, { processor: newProcessor, routeHash: routeHash });
+            }
+
+            // Shutdown old processors
+            await Promise.all(toShutdown.map((p) => p.shutdown()));
+        } catch (err) {
+            logger.error(`failed_to_update_routing_span_processor ${stringifyError(err)}`);
+        }
+    }
+
+    private getProcessorForSpan(span: { attributes: Attributes }): BatchSpanProcessor | undefined {
+        const routingId = span.attributes[otlpRoutingAttributeKey];
+        if (routingId && typeof routingId === 'string') {
+            return this.processors.get(routingId)?.processor;
+        }
+        return undefined;
+    }
+
+    onStart(span: Span, context: Context): void {
+        try {
+            const processor = this.getProcessorForSpan(span);
+            if (processor) {
+                processor.onStart(span, context);
+            }
+        } catch (err) {
+            logger.error(`failed_to_start_span ${stringifyError(err)}`);
+        }
+    }
+
+    onEnd(span: ReadableSpan): void {
+        try {
+            const processor = this.getProcessorForSpan(span);
+            if (processor) {
+                span.spanContext();
+                if (span.attributes[otlpRoutingAttributeKey]) {
+                    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+                    delete span.attributes[otlpRoutingAttributeKey];
+                }
+                processor.onEnd(span);
+            }
+        } catch (err) {
+            logger.error(`failed_to_end_span ${stringifyError(err)}`);
+        }
+    }
+
+    async shutdown(): Promise<void> {
+        try {
+            const shutdownPromises = Array.from(this.processors.values()).map((p) => p.processor.shutdown());
+            await Promise.all(shutdownPromises);
+        } catch (err) {
+            logger.error(`failed_to_shutdown_routing_span_processor ${stringifyError(err)}`);
+        }
+    }
+    async forceFlush(): Promise<void> {
+        try {
+            const flushPromises = Array.from(this.processors.values()).map((p) => p.processor.forceFlush());
+            await Promise.all(flushPromises);
+        } catch (err) {
+            logger.error(`failed_to_flush_routing_span_processor ${stringifyError(err)}`);
+        }
+    }
+}

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -17,6 +17,12 @@
         "@elastic/elasticsearch": "8.13.1",
         "@nangohq/kvstore": "file:../kvstore",
         "@nangohq/utils": "file:../utils",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.54.0",
+        "@opentelemetry/resources": "^1.27.0",
+        "@opentelemetry/sdk-trace-base": "^1.27.0",
+        "@opentelemetry/sdk-trace-node": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
         "zod": "3.23.8"
     },
     "devDependencies": {

--- a/packages/persist/lib/app.ts
+++ b/packages/persist/lib/app.ts
@@ -2,6 +2,8 @@ import './tracer.js';
 import { getLogger } from '@nangohq/utils';
 import { server } from './server.js';
 import { envs } from './env.js';
+import { getOtlpRoutes } from '@nangohq/shared';
+import { otlp } from '@nangohq/logs';
 
 const logger = getLogger('Persist');
 
@@ -10,6 +12,8 @@ try {
     server.listen(port, () => {
         logger.info(`🚀 API ready at http://localhost:${port}`);
     });
+
+    otlp.register(getOtlpRoutes);
 } catch (err) {
     console.error(`Persist API error: ${err}`);
     process.exit(1);

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -5,13 +5,13 @@ import express from 'express';
 import type { WebSocket } from 'ws';
 import { WebSocketServer } from 'ws';
 import http from 'node:http';
-import { NANGO_VERSION, getGlobalOAuthCallbackUrl, getServerPort, getWebsocketsPath } from '@nangohq/shared';
+import { NANGO_VERSION, getGlobalOAuthCallbackUrl, getOtlpRoutes, getServerPort, getWebsocketsPath } from '@nangohq/shared';
 import { getLogger, requestLoggerMiddleware } from '@nangohq/utils';
 import oAuthSessionService from './services/oauth-session.service.js';
 import { KnexDatabase } from '@nangohq/database';
 import migrate from './utils/migrate.js';
 import { migrate as migrateRecords } from '@nangohq/records';
-import { start as migrateLogs } from '@nangohq/logs';
+import { start as migrateLogs, otlp } from '@nangohq/logs';
 import { migrate as migrateKeystore } from '@nangohq/keystore';
 
 import publisher from './clients/publisher.client.js';
@@ -59,6 +59,7 @@ if (NANGO_MIGRATE_AT_START === 'true') {
 
 await oAuthSessionService.clearStaleSessions();
 refreshConnectionsCron();
+otlp.register(getOtlpRoutes);
 
 const port = getServerPort();
 server.listen(port, () => {

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -51,6 +51,8 @@ export * from './constants.js';
 export * from './sdk/sync.js';
 export * from './sdk/dataValidation.js';
 
+export { getRoutes as getOtlpRoutes } from './otlp/otlp.js';
+
 export { NANGO_VERSION } from './version.js';
 
 export {

--- a/packages/shared/lib/otlp/otlp.ts
+++ b/packages/shared/lib/otlp/otlp.ts
@@ -1,0 +1,18 @@
+import type { RouteConfig } from '@nangohq/logs';
+import environmentService from '../services/environment.service.js';
+
+export async function getRoutes(): Promise<RouteConfig[]> {
+    const environments = await environmentService.getEnvironmentsWithOtlpSettings();
+    return environments.flatMap((env) => {
+        if (env.otlp_settings?.endpoint && env.otlp_settings?.headers) {
+            return [
+                {
+                    routingId: `environment:${env.id}`,
+                    routingEndpoint: env.otlp_settings?.endpoint,
+                    routingHeaders: env.otlp_settings?.headers || {}
+                }
+            ];
+        }
+        return [];
+    });
+}

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -302,6 +302,14 @@ class EnvironmentService {
         return result[0].id;
     }
 
+    async getEnvironmentsWithOtlpSettings(): Promise<DBEnvironment[]> {
+        const result = await db.knex.select('*').from<DBEnvironment>(TABLE).whereNotNull('otlp_settings');
+        if (result == null) {
+            return [];
+        }
+        return result.map((env) => encryptionManager.decryptEnvironment(env));
+    }
+
     async editCallbackUrl(callbackUrl: string, id: number): Promise<DBEnvironment | null> {
         return db.knex.from<DBEnvironment>(TABLE).where({ id }).update({ callback_url: callbackUrl }, ['id']);
     }

--- a/packages/types/lib/environment/db.ts
+++ b/packages/types/lib/environment/db.ts
@@ -39,7 +39,7 @@ export interface DBEnvironment extends Timestamps {
     slack_notifications: boolean;
 
     webhook_receive_url?: string;
-    otlp_settings?: { endpoint: string; headers: Record<string, string> } | null;
+    otlp_settings: { endpoint: string; headers: Record<string, string> } | null;
 }
 
 export interface ExternalWebhook extends Timestamps {

--- a/packages/utils/lib/index.ts
+++ b/packages/utils/lib/index.ts
@@ -17,3 +17,4 @@ export * from './express/headers.js';
 export * from './workflows.js';
 export * from './axios.js';
 export * from './auth.js';
+export * from './once.js';

--- a/packages/utils/lib/once.ts
+++ b/packages/utils/lib/once.ts
@@ -1,0 +1,11 @@
+// Ensures a function is only called once.
+export function once<T extends any[]>(fn: (...args: T) => void): (...args: T) => void {
+    let called = false;
+
+    return function (...args: T) {
+        if (!called) {
+            called = true;
+            fn(...args);
+        }
+    };
+}


### PR DESCRIPTION
Log operations are sent as OpenTelemetry traces to a otlp backend set by customers on the environment level
It is using a custom SpanProcessor from opentelemetry-js lib with one exporter per customers. I assume this feature will only be available to scale plan customers and therefore the number of exporters will stay low
Another thing to note is that operation must be started and ended on the same service, which is the case today but could become a limitation in the future.
It could be extended later on by also exporting otlp logs and attach them to the traces, the same way we attach logs to operation in Nango

I have tested with an oltp collector like jaeger running on my machine and with Honeycomb. 
To export to Datadog, one must go via a recent version of the datadog-agent

## Issue ticket number and link

https://linear.app/nango/issue/NAN-1782/opentelemetry-export

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
