### PR TITLE
fix(api): reup search in /connections

### DIFF
--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -397,7 +397,7 @@ paths:
                   in: query
                   schema:
                       type: string
-                  description: Filter the list of connections based on this connection ID.
+                  description: Search in the list of connections (will search in connection ID or end user profile).
             responses:
                 '200':
                     description: Successfully returned a list of connections

--- a/packages/server/lib/controllers/connection/getConnections.ts
+++ b/packages/server/lib/controllers/connection/getConnections.ts
@@ -1,20 +1,30 @@
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { zodErrorToHTTP } from '@nangohq/utils';
 import type { GetPublicConnections } from '@nangohq/types';
 import { AnalyticsTypes, analytics, connectionService } from '@nangohq/shared';
 import { connectionToPublicApi } from '../../formatters/connection.js';
+import { z } from 'zod';
+
+const validationQuery = z
+    .object({
+        connectionId: z.string().max(255).optional()
+    })
+    .strict();
 
 export const getPublicConnections = asyncWrapper<GetPublicConnections>(async (req, res) => {
-    const emptyQuery = requireEmptyQuery(req);
-    if (emptyQuery) {
-        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+    const queryParamValues = validationQuery.safeParse(req.query);
+    if (!queryParamValues.success) {
+        res.status(400).send({
+            error: { code: 'invalid_query_params', errors: zodErrorToHTTP(queryParamValues.error) }
+        });
         return;
     }
 
     const { environment, account } = res.locals;
+    const queryParam: GetPublicConnections['Querystring'] = queryParamValues.data;
 
     void analytics.track(AnalyticsTypes.CONNECTION_LIST_FETCHED, account.id);
-    const connections = await connectionService.listConnections({ environmentId: environment.id, limit: 10000 });
+    const connections = await connectionService.listConnections({ environmentId: environment.id, search: queryParam.connectionId, limit: 10000 });
 
     res.status(200).send({
         connections: connections.map((data) => {

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -51,7 +51,6 @@ export type ApiPublicConnection = Pick<Connection, 'id' | 'connection_id' | 'pro
 export type GetPublicConnections = Endpoint<{
     Method: 'GET';
     Querystring: {
-        env: string;
         connectionId?: string | undefined;
     };
     Path: '/connection';


### PR DESCRIPTION
## Describe your changes

Closes #2920 

- Reup search in `GET /connections`
This feature was forgotten will moving the endpoint code to the new format in #2897
Note that the behavior is slightly different now, not sure if I should introduce a new `search` prop to filter on everything and keep `connectionId` as it was before (filtering only connectionId)