### PR TITLE
feat: add settings for OpenTelemetry export

### DIFF
--- a/packages/server/lib/controllers/v1/environment/otlp/postSettings.ts
+++ b/packages/server/lib/controllers/v1/environment/otlp/postSettings.ts
@@ -6,7 +6,7 @@ import { environmentService, featureFlags } from '@nangohq/shared';
 
 const bodyValidation = z
     .object({
-        endpoint: z.string(),
+        endpoint: z.string().url(),
         headers: z.record(z.string())
     })
     .strict();

--- a/packages/server/lib/controllers/v1/environment/otlp/postSettings.ts
+++ b/packages/server/lib/controllers/v1/environment/otlp/postSettings.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import type { DBTeam, UpdateOtlpSettings } from '@nangohq/types';
+import { requireEmptyQuery, zodErrorToHTTP, isEnterprise } from '@nangohq/utils';
+import { environmentService, featureFlags } from '@nangohq/shared';
+
+const bodyValidation = z
+    .object({
+        endpoint: z.string(),
+        headers: z.record(z.string())
+    })
+    .strict();
+
+export const postSettings = asyncWrapper<UpdateOtlpSettings>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req, { withEnv: true });
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const val = bodyValidation.safeParse(req.body);
+
+    if (!val.success) {
+        res.status(400).send({
+            error: { code: 'invalid_body', errors: zodErrorToHTTP(val.error) }
+        });
+        return;
+    }
+
+    const { environment, account } = res.locals;
+
+    const isEnabled = await isOtlpEnabled({ account });
+    if (!isEnabled) {
+        res.status(403).send({ error: { code: 'forbidden', message: 'OpenTelemetry export is not enabled for this account' } });
+        return;
+    }
+
+    const { data: settings } = val;
+
+    settings.endpoint = settings.endpoint.trim().replace(/\/$/, '');
+
+    const newSettings = settings.endpoint.length > 0 ? settings : null;
+    await environmentService.editOtlpSettings(environment.id, newSettings);
+
+    res.send(settings);
+});
+
+const isOtlpEnabled = async ({ account }: { account: DBTeam }): Promise<boolean> => {
+    if (isEnterprise) {
+        return true;
+    }
+    return featureFlags.isEnabled('feature:otlp:account', account.uuid, false);
+};

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -32,7 +32,8 @@ import tracer from 'dd-trace';
 import { getConnection as getConnectionWeb } from './controllers/v1/connections/connectionId/getConnection.js';
 import { searchOperations } from './controllers/v1/logs/searchOperations.js';
 import { getOperation } from './controllers/v1/logs/getOperation.js';
-import { patchSettings } from './controllers/v1/environment/webhook/patchSettings.js';
+import { postSettings as postOtlpSettings } from './controllers/v1/environment/otlp/postSettings.js';
+import { patchSettings as patchWebhookSettings } from './controllers/v1/environment/webhook/patchSettings.js';
 import { updatePrimaryUrl } from './controllers/v1/environment/webhook/updatePrimaryUrl.js';
 import { updateSecondaryUrl } from './controllers/v1/environment/webhook/updateSecondaryUrl.js';
 import {
@@ -301,7 +302,8 @@ web.route('/api/v1/environment/hmac-key').post(webAuth, environmentController.up
 web.route('/api/v1/environment/environment-variables').post(webAuth, environmentController.updateEnvironmentVariables.bind(environmentController));
 web.route('/api/v1/environment/rotate-key').post(webAuth, environmentController.rotateKey.bind(accountController));
 web.route('/api/v1/environment/revert-key').post(webAuth, environmentController.revertKey.bind(accountController));
-web.route('/api/v1/environment/webhook/settings').patch(webAuth, patchSettings);
+web.route('/api/v1/environment/webhook/settings').patch(webAuth, patchWebhookSettings);
+web.route('/api/v1/environment/otlp/settings').post(webAuth, postOtlpSettings);
 web.route('/api/v1/environment/activate-key').post(webAuth, environmentController.activateKey.bind(accountController));
 web.route('/api/v1/environment/admin-auth').get(webAuth, environmentController.getAdminAuthInfo.bind(environmentController));
 

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -336,6 +336,10 @@ class EnvironmentService {
         return db.knex.from<DBEnvironment>(TABLE).where({ id }).update({ hmac_key: hmacKey }, ['id']);
     }
 
+    async editOtlpSettings(environmentId: number, otlpSettings: { endpoint: string; headers: Record<string, string> } | null): Promise<DBEnvironment | null> {
+        return db.knex.from<DBEnvironment>(TABLE).where({ id: environmentId }).update({ otlp_settings: otlpSettings }, ['id']);
+    }
+
     async getEnvironmentVariables(environment_id: number): Promise<DBEnvironmentVariable[] | null> {
         const result = await db.knex.select('*').from<DBEnvironmentVariable>(`_nango_environment_variables`).where({ environment_id });
 

--- a/packages/types/lib/environment/api/otlp.ts
+++ b/packages/types/lib/environment/api/otlp.ts
@@ -1,0 +1,17 @@
+import type { ApiError, Endpoint } from '../../api.js';
+
+export interface OtlpSettings {
+    endpoint: string;
+    headers: Record<string, string>;
+}
+
+export type UpdateOtlpSettings = Endpoint<{
+    Method: 'POST';
+    Querystring: {
+        env: string;
+    };
+    Path: '/api/v1/environment/otlp/settings';
+    Body: OtlpSettings;
+    Success: OtlpSettings;
+    Error: ApiError<'forbidden'>;
+}>;

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -47,6 +47,7 @@ export type * from './nangoYaml/index.js';
 
 export type * from './environment/db.js';
 export type * from './environment/api/webhook.js';
+export type * from './environment/api/otlp.js';
 export type * from './webhooks/api.js';
 export type * from './flow/http.api.js';
 

--- a/packages/webapp/src/pages/Environment/Settings.tsx
+++ b/packages/webapp/src/pages/Environment/Settings.tsx
@@ -1073,6 +1073,7 @@ export const EnvironmentSettings: React.FC = () => {
                                         <div className="flex">
                                             <input
                                                 id="otlp_endpoint"
+                                                placeholder="https://my.otlp.collector:4318/v1/"
                                                 name="otlp_endpoint"
                                                 autoComplete="new-password"
                                                 type="url"

--- a/packages/webapp/src/utils/api.tsx
+++ b/packages/webapp/src/utils/api.tsx
@@ -319,6 +319,40 @@ export function useEditWebhookSecondaryUrlAPI(env: string) {
     };
 }
 
+export function useEditOtlpSettingsAPI(env: string) {
+    const signout = useSignout();
+
+    return async ({ endpoint, headers }: { endpoint: string; headers: Record<string, string> }) => {
+        try {
+            const options = {
+                method: 'POST',
+                body: JSON.stringify({ endpoint, headers })
+            };
+
+            const res = await apiFetch(`/api/v1/environment/otlp/settings?env=${env}`, options);
+
+            if (res.status === 401) {
+                return signout();
+            }
+
+            if (res.status === 403) {
+                const { error } = await res.json();
+                const msg = 'message' in error ? error.message : 'Forbidden';
+                toast.error(msg, { position: toast.POSITION.BOTTOM_CENTER });
+                return;
+            }
+
+            if (res.status !== 200) {
+                return serverErrorToast();
+            }
+
+            return res;
+        } catch {
+            requestErrorToast();
+        }
+    };
+}
+
 export function useGetIntegrationListAPI(env: string) {
     const signout = useSignout();
 


### PR DESCRIPTION
## Describe your changes

Add environment settings to input OpenTelemetry endpoint and headers
![Screenshot 2024-10-30 at 13 22 26](https://github.com/user-attachments/assets/4050d7d7-f5e2-4d9d-8735-ac7a1456b371)

Note: 
- an empty endpoint is considered as disabled. I don't think adding an extra checkmark is actually useful
- The OpenTelemetry feature is only enabled for enterprise setup or via feature flag. I was thinking I would hide the settings if not enabled but I think it is nice to promote the feature even if not enabled. Editing the settings would show `OpenTelemetry export is not enabled for this account` error. I am happy to also make a mention of it being a paid feature in the environment setting page. Let me know @bastienbeurier 

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
