### PR TITLE
fix(api): reup previous behavior of connectionId for GET /connection

### DIFF
--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -397,7 +397,12 @@ paths:
                   in: query
                   schema:
                       type: string
-                  description: Search in the list of connections (will search in connection ID or end user profile).
+                  description: Will exactly match a given connectionId. Can return multiple connections with the same ID across integrations
+                - name: search
+                  in: query
+                  schema:
+                      type: string
+                  description: Search connections. Will search in connection ID or end user profile.
             responses:
                 '200':
                     description: Successfully returned a list of connections

--- a/packages/server/lib/controllers/connection/getConnections.ts
+++ b/packages/server/lib/controllers/connection/getConnections.ts
@@ -7,7 +7,8 @@ import { z } from 'zod';
 
 const validationQuery = z
     .object({
-        connectionId: z.string().max(255).optional()
+        connectionId: z.string().min(1).max(255).optional(),
+        search: z.string().min(1).max(255).optional()
     })
     .strict();
 
@@ -24,7 +25,12 @@ export const getPublicConnections = asyncWrapper<GetPublicConnections>(async (re
     const queryParam: GetPublicConnections['Querystring'] = queryParamValues.data;
 
     void analytics.track(AnalyticsTypes.CONNECTION_LIST_FETCHED, account.id);
-    const connections = await connectionService.listConnections({ environmentId: environment.id, search: queryParam.connectionId, limit: 10000 });
+    const connections = await connectionService.listConnections({
+        environmentId: environment.id,
+        connectionId: queryParam.connectionId,
+        search: queryParam.search,
+        limit: 10000
+    });
 
     res.status(200).send({
         connections: connections.map((data) => {

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -988,6 +988,7 @@ class ConnectionService {
      */
     public async listConnections({
         environmentId,
+        connectionId,
         integrationIds,
         withError,
         search,
@@ -995,6 +996,7 @@ class ConnectionService {
         page = 0
     }: {
         environmentId: number;
+        connectionId?: string | undefined;
         integrationIds?: string[] | undefined;
         withError?: boolean | undefined;
         search?: string | undefined;
@@ -1035,6 +1037,9 @@ class ConnectionService {
         }
         if (integrationIds) {
             subQuery.whereIn('_nango_configs.unique_key', integrationIds);
+        }
+        if (connectionId) {
+            subQuery.where('_nango_connections.connection_id', connectionId);
         }
 
         subQuery.limit(limit);

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -52,6 +52,7 @@ export type GetPublicConnections = Endpoint<{
     Method: 'GET';
     Querystring: {
         connectionId?: string | undefined;
+        search?: string | undefined;
     };
     Path: '/connection';
     Success: {


### PR DESCRIPTION
## Describe your changes

- Correctly reup previous behavior of connectionId for GET /connection
After digging up the git history, managed to find the origin of this if https://github.com/NangoHQ/nango/pull/596
The `connectionId` was an exact match, not a search, so splitting the two behaviors and clarifying the doc.
