### PR TITLE
fix(records): Fix id comparison check in update

### DIFF
--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -333,7 +333,7 @@ export async function update({
 
                     const { record: oldRecord, ...oldRecordRest } = rawOldRecord;
 
-                    const record = records.find((record) => record.external_id === oldRecord.id);
+                    const record = records.find((record) => record.external_id === rawOldRecord.external_id);
 
                     const newRecord: FormattedRecord = {
                         ...oldRecordRest,


### PR DESCRIPTION
## Describe your changes

In the `update` function within records, if the id over the wire is an integer, the comparison always fails because it checks the external id of the new record with the id of the old record. This small fix compares external ids for both so that they're converted to strings.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
