### PR TITLE
Patch records

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16420,7 +16420,8 @@
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -34647,6 +34648,7 @@
             "dependencies": {
                 "@nangohq/utils": "file:../utils",
                 "dayjs": "1.11.10",
+                "deepmerge": "4.3.1",
                 "knex": "3.1.0",
                 "md5": "2.3.0",
                 "pg": "8.11.3",
@@ -36711,36 +36713,10 @@
                 "acorn": "^8"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/agent-base": {
-            "version": "7.1.1",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/async": {
             "version": "3.2.6",
             "inBundle": true,
             "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/asynckit": {
-            "version": "0.4.0",
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/axios": {
-            "version": "1.7.7",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/base64-js": {
             "version": "1.5.1",
@@ -36829,17 +36805,6 @@
                 "text-hex": "1.0.x"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/combined-stream": {
-            "version": "1.0.8",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/crypto-randomuuid": {
             "version": "1.0.0",
             "inBundle": true,
@@ -36893,27 +36858,6 @@
                 "node": ">=18"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/debug": {
-            "version": "4.3.7",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/debug/node_modules/ms": {
-            "version": "2.1.3",
-            "inBundle": true,
-            "license": "MIT"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/delay": {
             "version": "5.0.0",
             "inBundle": true,
@@ -36923,14 +36867,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/detect-newline": {
@@ -36967,16 +36903,6 @@
                 "node": ">=0.8.x"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/exponential-backoff": {
-            "version": "3.1.1",
-            "inBundle": true,
-            "license": "Apache-2.0"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/fast-safe-stringify": {
-            "version": "2.1.1",
-            "inBundle": true,
-            "license": "MIT"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/fecha": {
             "version": "4.2.3",
             "inBundle": true,
@@ -36986,70 +36912,6 @@
             "version": "1.1.0",
             "inBundle": true,
             "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/follow-redirects": {
-            "version": "1.15.9",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/form-data": {
-            "version": "4.0.1",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/guess-json-indent": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/https-proxy-agent": {
-            "version": "7.0.4",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.0.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/ieee754": {
             "version": "1.2.1",
@@ -37184,25 +37046,6 @@
                 "node": ">=12"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/mime-db": {
-            "version": "1.52.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/mime-types": {
-            "version": "2.1.35",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/module-details-from-path": {
             "version": "1.0.3",
             "inBundle": true,
@@ -37325,11 +37168,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "inBundle": true,
-            "license": "MIT"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/readable-stream": {
             "version": "3.6.2",
             "inBundle": true,
@@ -37443,22 +37281,6 @@
                 "safe-buffer": "~5.2.0"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/string-byte-length": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/string-byte-slice": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/text-hex": {
             "version": "1.0.0",
             "inBundle": true,
@@ -37475,19 +37297,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 14.0.0"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/truncate-json": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "guess-json-indent": "^3.0.0",
-                "string-byte-length": "^3.0.0",
-                "string-byte-slice": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=18.18.0"
             }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/type-fest": {

--- a/packages/persist/lib/records.ts
+++ b/packages/persist/lib/records.ts
@@ -69,6 +69,12 @@ export async function persistRecords({
                 return recordsService.update({ records, connectionId: nangoConnectionId, model });
             };
             break;
+        case 'patch':
+            softDelete = false;
+            persistFunction = async (records: FormattedRecord[]) => {
+                return recordsService.patch({ records, connectionId: nangoConnectionId, model });
+            };
+            break;
     }
 
     const formatting = recordsFormatter.formatRecords({

--- a/packages/persist/lib/records.ts
+++ b/packages/persist/lib/records.ts
@@ -7,7 +7,7 @@ import { logContextGetter } from '@nangohq/logs';
 import type { Result } from '@nangohq/utils';
 import { Err, Ok, metrics, stringifyError } from '@nangohq/utils';
 
-export type PersistType = 'save' | 'delete' | 'update';
+export type PersistType = 'save' | 'delete' | 'update' | 'patch';
 export const recordsPath = '/environment/:environmentId/connection/:nangoConnectionId/sync/:syncId/job/:syncJobId/records';
 
 export async function persistRecords({

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/patchRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/patchRecords.ts
@@ -1,0 +1,61 @@
+import type { ApiError, Endpoint } from '@nangohq/types';
+import type { EndpointRequest, EndpointResponse, RouteHandler } from '@nangohq/utils';
+import { persistRecords, recordsPath } from '../../../../../../../../../records.js';
+import { validateRecords } from './validate.js';
+
+type PatchRecords = Endpoint<{
+    Method: typeof method;
+    Path: typeof path;
+    Params: {
+        environmentId: number;
+        nangoConnectionId: number;
+        syncId: string;
+        syncJobId: number;
+    };
+    Body: {
+        model: string;
+        records: Record<string, any>[];
+        providerConfigKey: string;
+        connectionId: string;
+        activityLogId: string;
+    };
+    Error: ApiError<'patch_records_failed'>;
+    Success: never;
+}>;
+
+const path = recordsPath;
+const method = 'PATCH';
+
+const validate = validateRecords<PatchRecords>();
+
+const handler = async (req: EndpointRequest<PatchRecords>, res: EndpointResponse<PatchRecords>) => {
+    const {
+        params: { environmentId, nangoConnectionId, syncId, syncJobId },
+        body: { model, records, providerConfigKey, connectionId, activityLogId }
+    } = req;
+    const result = await persistRecords({
+        persistType: 'patch',
+        environmentId,
+        connectionId,
+        providerConfigKey,
+        nangoConnectionId,
+        syncId,
+        syncJobId,
+        model,
+        records,
+        activityLogId
+    });
+    if (result.isOk()) {
+        res.status(204).send();
+    } else {
+        res.status(500).json({ error: { code: 'patch_records_failed', message: `Failed to save records: ${result.error.message}` } });
+    }
+    return;
+};
+
+export const routeHandler: RouteHandler<PatchRecords> = {
+    method,
+    path,
+    validate,
+    handler
+};

--- a/packages/persist/lib/server.ts
+++ b/packages/persist/lib/server.ts
@@ -7,6 +7,7 @@ import { routeHandler as postLogHandler, path as logsPath } from './routes/envir
 import { routeHandler as postRecordsHandler } from './routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/postRecords.js';
 import { routeHandler as putRecordsHandler } from './routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/putRecords.js';
 import { routeHandler as deleteRecordsHandler } from './routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteRecords.js';
+import { routeHandler as patchRecordsHandler } from './routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/patchRecords.js';
 import { recordsPath } from './records.js';
 
 const logger = getLogger('Persist');
@@ -29,6 +30,7 @@ createRoute(server, postLogHandler);
 createRoute(server, postRecordsHandler);
 createRoute(server, deleteRecordsHandler);
 createRoute(server, putRecordsHandler);
+createRoute(server, patchRecordsHandler);
 
 server.use((_req: Request, res: Response, next: NextFunction) => {
     res.status(404);

--- a/packages/records/package.json
+++ b/packages/records/package.json
@@ -19,6 +19,7 @@
     "dependencies": {
         "@nangohq/utils": "file:../utils",
         "dayjs": "1.11.10",
+        "deepmerge": "4.3.1",
         "knex": "3.1.0",
         "md5": "2.3.0",
         "pg": "8.11.3",


### PR DESCRIPTION
## Describe your changes

This adds basically a copy of the `batchUpdate` flow that instead does a deep merge. Right now it uses the `deepmerge` package to handle it, and isn't super smart, but I think adding an array comparison check via deepmerge that is configurable through the call with a set of possible checks could make a ton of sense. That could allow people do do things like say "Hey, merge this, and if you see an array, merge objects in the array based on their id" and that kind of thing.

I didn't dig into updating docs or anything else here yet since it's more a proof of concept that we could talk through.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
