### PR TITLE
fix: records update webhook should be sent when coming from webhook exec

### DIFF
--- a/packages/shared/lib/services/sync/job.service.ts
+++ b/packages/shared/lib/services/sync/job.service.ts
@@ -91,18 +91,24 @@ export const getSyncJobByRunId = async (run_id: string): Promise<SyncJob | null>
     return null;
 };
 
-export const updateSyncJobStatus = async (id: number, status: SyncStatus): Promise<void> => {
-    return schema().from<SyncJob>(SYNC_JOB_TABLE).where({ id, deleted: false }).update({
-        status,
-        updated_at: new Date()
-    });
+export const updateSyncJobStatus = async (id: number, status: SyncStatus): Promise<SyncJob | null> => {
+    const [job] = await schema()
+        .from<SyncJob>(SYNC_JOB_TABLE)
+        .where({ id, deleted: false })
+        .update({
+            status,
+            updated_at: new Date()
+        })
+        .returning('*');
+    return job || null;
 };
 
-export const updateLatestJobSyncStatus = async (sync_id: string, status: SyncStatus): Promise<void> => {
+export const updateLatestJobSyncStatus = async (sync_id: string, status: SyncStatus): Promise<SyncJob | null> => {
     const latestJob = await getLatestSyncJob(sync_id);
     if (latestJob && latestJob.id) {
-        updateSyncJobStatus(latestJob.id, status);
+        return updateSyncJobStatus(latestJob.id, status);
     }
+    return null;
 };
 
 /**

--- a/packages/types/lib/scripts/syncs/api.ts
+++ b/packages/types/lib/scripts/syncs/api.ts
@@ -4,4 +4,4 @@ export interface SyncResult {
     deleted: number;
 }
 
-export type SyncType = 'INCREMENTAL' | 'FULL';
+export type SyncType = 'INCREMENTAL' | 'FULL' | 'WEBHOOK';

--- a/packages/types/lib/webhooks/api.ts
+++ b/packages/types/lib/webhooks/api.ts
@@ -19,7 +19,7 @@ export interface NangoSyncWebhookBodyBase extends NangoWebhookBase {
     providerConfigKey: string;
     syncName: string;
     model: string;
-    syncType: 'INCREMENTAL' | 'INITIAL';
+    syncType: 'INCREMENTAL' | 'INITIAL' | 'WEBHOOK';
 }
 
 export interface NangoSyncWebhookBodySuccess extends NangoSyncWebhookBodyBase {

--- a/packages/webhooks/lib/sync.ts
+++ b/packages/webhooks/lib/sync.ts
@@ -58,7 +58,7 @@ export const sendSync = async ({
         syncName,
         model,
         // For backward compatibility reason we are sending the syncType as INITIAL instead of FULL
-        syncType: operation === 'INCREMENTAL' ? 'INCREMENTAL' : 'INITIAL'
+        syncType: operation === 'FULL' ? 'INITIAL' : operation
     };
     let finalBody: NangoSyncWebhookBody;
 


### PR DESCRIPTION
Now sending a webhook to notify about records update (added, update, deleted) from within a webhook script. 
We used to only notify the customer when records where updated via a sync.

## Issue ticket number and link
https://linear.app/nango/issue/NAN-2021/[stacker-poc]-webhook-script-updates-should-trigger-a-nango-webhook

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
