### PR TITLE
feat: show records count on connections page

### DIFF
--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -132,7 +132,7 @@ class SyncController {
         if (byModel.isOk()) {
             return syncs.map((sync) => ({
                 ...sync,
-                record_count: sync.models.reduce((sum, model) => sum + (byModel.value[model]?.count ?? 0), 0)
+                record_count: Object.fromEntries(sync.models.map((model) => [model, byModel.value[model]?.count ?? 0]))
             }));
         } else {
             return syncs.map((sync) => ({ ...sync, record_count: null }));

--- a/packages/webapp/src/pages/Connection/Syncs.tsx
+++ b/packages/webapp/src/pages/Connection/Syncs.tsx
@@ -69,8 +69,9 @@ export const Syncs: React.FC<SyncsProps> = ({ syncs, connection, provider }) => 
                             <Table.Head className="w-[120px]">Models</Table.Head>
                             <Table.Head className="w-[120px]">Last Execution</Table.Head>
                             <Table.Head className="w-[80px]">Frequency</Table.Head>
+                            <Table.Head className="w-[80px]">Records</Table.Head>
                             <Table.Head className="w-[120px]">Last Sync Start</Table.Head>
-                            <Table.Head className="w-[130px]">Next Sync Start</Table.Head>
+                            <Table.Head className="w-[140px]">Next Sync Start</Table.Head>
                             <Table.Head className="w-[40px]"></Table.Head>
                         </Table.Row>
                     </Table.Header>

--- a/packages/webapp/src/pages/Connection/components/SyncRow.tsx
+++ b/packages/webapp/src/pages/Connection/components/SyncRow.tsx
@@ -3,7 +3,7 @@ import * as Table from '../../../components/ui/Table';
 import { Tag } from '../../../components/ui/label/Tag';
 import { Link } from 'react-router-dom';
 import { EllipsisHorizontalIcon, QueueListIcon } from '@heroicons/react/24/outline';
-import { formatFrequency, getRunTime, parseLatestSyncResult, formatDateToUSFormat, interpretNextRun, formatRecordsCount } from '../../../utils/utils';
+import { formatFrequency, getRunTime, parseLatestSyncResult, formatDateToUSFormat, interpretNextRun, formatQuantity } from '../../../utils/utils';
 import { getLogsUrl } from '../../../utils/logs';
 import { UserFacingSyncCommand } from '../../../types';
 import type { RunSyncCommand, SyncResponse } from '../../../types';
@@ -136,7 +136,7 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
             </Table.Cell>
             <Table.Cell bordered>{formatFrequency(sync.frequency)}</Table.Cell>
             <Table.Cell bordered>
-                <SimpleTooltip tooltipContent={sync.record_count.toLocaleString()}>{formatRecordsCount(sync.record_count)}</SimpleTooltip>
+                <SimpleTooltip tooltipContent={sync.record_count.toLocaleString()}>{formatQuantity(sync.record_count)}</SimpleTooltip>
             </Table.Cell>
             <Table.Cell bordered>
                 <SimpleTooltip

--- a/packages/webapp/src/pages/Connection/components/SyncRow.tsx
+++ b/packages/webapp/src/pages/Connection/components/SyncRow.tsx
@@ -136,7 +136,9 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
             </Table.Cell>
             <Table.Cell bordered>{formatFrequency(sync.frequency)}</Table.Cell>
             <Table.Cell bordered>
-                <SimpleTooltip tooltipContent={sync.record_count.toLocaleString()}>{formatQuantity(sync.record_count)}</SimpleTooltip>
+                <SimpleTooltip tooltipContent={JSON.stringify(sync.record_count, null, 2)}>
+                    {formatQuantity(Object.entries(sync.record_count).reduce((acc, [, count]) => acc + count, 0))}
+                </SimpleTooltip>
             </Table.Cell>
             <Table.Cell bordered>
                 <SimpleTooltip

--- a/packages/webapp/src/pages/Connection/components/SyncRow.tsx
+++ b/packages/webapp/src/pages/Connection/components/SyncRow.tsx
@@ -3,7 +3,7 @@ import * as Table from '../../../components/ui/Table';
 import { Tag } from '../../../components/ui/label/Tag';
 import { Link } from 'react-router-dom';
 import { EllipsisHorizontalIcon, QueueListIcon } from '@heroicons/react/24/outline';
-import { formatFrequency, getRunTime, parseLatestSyncResult, formatDateToUSFormat, interpretNextRun } from '../../../utils/utils';
+import { formatFrequency, getRunTime, parseLatestSyncResult, formatDateToUSFormat, interpretNextRun, formatRecordsCount } from '../../../utils/utils';
 import { getLogsUrl } from '../../../utils/logs';
 import { UserFacingSyncCommand } from '../../../types';
 import type { RunSyncCommand, SyncResponse } from '../../../types';
@@ -135,6 +135,9 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
                 )}
             </Table.Cell>
             <Table.Cell bordered>{formatFrequency(sync.frequency)}</Table.Cell>
+            <Table.Cell bordered>
+                <SimpleTooltip tooltipContent={sync.record_count.toLocaleString()}>{formatRecordsCount(sync.record_count)}</SimpleTooltip>
+            </Table.Cell>
             <Table.Cell bordered>
                 <SimpleTooltip
                     tooltipContent={

--- a/packages/webapp/src/types.ts
+++ b/packages/webapp/src/types.ts
@@ -34,7 +34,7 @@ export interface SyncResponse {
         models: string[];
     };
     active_logs: Pick<ActiveLog, 'log_id'> | null;
-    record_count: number;
+    record_count: Record<string, number>;
 }
 
 export type RunSyncCommand = 'PAUSE' | 'UNPAUSE' | 'RUN' | 'RUN_FULL' | 'CANCEL';

--- a/packages/webapp/src/utils/utils.tsx
+++ b/packages/webapp/src/utils/utils.tsx
@@ -265,6 +265,27 @@ export function formatFrequency(frequency: string): string {
     return frequency;
 }
 
+export function formatRecordsCount(count: number): string {
+    const thresholds = [
+        { value: 1e12, suffix: 'T' }, // Trillion and above
+        { value: 1e9, suffix: 'B' }, // Billion
+        { value: 1e6, suffix: 'M' }, // Million
+        { value: 1e3, suffix: 'K' } // Thousand
+    ];
+
+    // Handle all cases with the same logic
+    for (const { value, suffix } of thresholds) {
+        if (count >= value) {
+            const number = count / value;
+            if (Number.isInteger(number)) {
+                return `${number.toLocaleString()}${suffix}`;
+            }
+            return `${Number(number.toFixed(1)).toLocaleString()}${suffix}`;
+        }
+    }
+    return count.toLocaleString();
+}
+
 // https://stackoverflow.com/a/42186143
 export function stringArrayEqual(prev: string[], next: string[]) {
     // can't use toSorted yet

--- a/packages/webapp/src/utils/utils.tsx
+++ b/packages/webapp/src/utils/utils.tsx
@@ -265,27 +265,6 @@ export function formatFrequency(frequency: string): string {
     return frequency;
 }
 
-export function formatRecordsCount(count: number): string {
-    const thresholds = [
-        { value: 1e12, suffix: 'T' }, // Trillion and above
-        { value: 1e9, suffix: 'B' }, // Billion
-        { value: 1e6, suffix: 'M' }, // Million
-        { value: 1e3, suffix: 'K' } // Thousand
-    ];
-
-    // Handle all cases with the same logic
-    for (const { value, suffix } of thresholds) {
-        if (count >= value) {
-            const number = count / value;
-            if (Number.isInteger(number)) {
-                return `${number.toLocaleString()}${suffix}`;
-            }
-            return `${Number(number.toFixed(1)).toLocaleString()}${suffix}`;
-        }
-    }
-    return count.toLocaleString();
-}
-
 // https://stackoverflow.com/a/42186143
 export function stringArrayEqual(prev: string[], next: string[]) {
     // can't use toSorted yet


### PR DESCRIPTION
Column is called `Records` cc @bastienbeurier
Count is shorten when greater than 1000. Ex: 1.6K, 3M.
Non-shorten count is always shown in the hover tooltip

![Screenshot 2024-11-01 at 14 13 41](https://github.com/user-attachments/assets/f699e5ac-3480-48c0-ade8-8dd8f37c3f04)

Depends on this [bugfix](https://github.com/NangoHQ/nango/pull/2935) to be merged first and inaccurate rows in the db to be fixed 

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1929/[trial]-show-object-count-in-sync-tab

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
