### PR TITLE
fix: batchUpdate fails with query is empty if no records

### DIFF
--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -345,8 +345,10 @@ export async function update({
                     };
                     recordsToUpdate.push(newRecord);
                 }
-                const encryptedRecords = encryptRecords(recordsToUpdate);
-                await trx.from(RECORDS_TABLE).insert(encryptedRecords).onConflict(['connection_id', 'external_id', 'model']).merge();
+                if (recordsToUpdate.length > 0) {
+                    const encryptedRecords = encryptRecords(recordsToUpdate);
+                    await trx.from(RECORDS_TABLE).insert(encryptedRecords).onConflict(['connection_id', 'external_id', 'model']).merge();
+                }
             }
         });
 


### PR DESCRIPTION
not executing the sql query if there is no records to update.

It shows that `batchUpdate` is definitely not used. Otherwise more customers would have reported the bug before.

## Issue ticket number and link
https://linear.app/nango/issue/NAN-2030/batchupdate-query-is-empty-error

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
