### PR TITLE
fix(connection page): tooltips and trigger menu action

### DIFF
--- a/packages/webapp/src/pages/Connection/components/SyncRow.tsx
+++ b/packages/webapp/src/pages/Connection/components/SyncRow.tsx
@@ -14,6 +14,7 @@ import type { ApiConnectionFull } from '@nangohq/types';
 import Button from '../../../components/ui/button/Button';
 import { Popover, PopoverTrigger } from '../../../components/ui/Popover';
 import { PopoverContent } from '@radix-ui/react-popover';
+import { QuestionMarkCircledIcon } from '@radix-ui/react-icons';
 import { SimpleTooltip } from '../../../components/SimpleTooltip';
 import { IconClockPause, IconClockPlay, IconPlayerPlay, IconRefresh, IconX } from '@tabler/icons-react';
 import { useToast } from '../../../hooks/useToast';
@@ -171,7 +172,7 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
                     </PopoverTrigger>
                     <PopoverContent align="end" className="z-10">
                         <div className="bg-active-gray rounded">
-                            <div className="flex flex-col w-[260px] p-[10px]">
+                            <div className="flex flex-col w-[240px] p-[10px]">
                                 <Button
                                     variant="popoverItem"
                                     disabled={syncCommandButtonsDisabled}
@@ -224,7 +225,14 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
                                         }}
                                     >
                                         <IconPlayerPlay className="flex h-4 w-4" />
-                                        <div className="pl-2 flex gap-2 items-center">Trigger Incremental</div>
+                                        <div className="pl-2 flex gap-2 items-center">
+                                            Trigger {sync.sync_type === 'incremental' ? 'Incremental' : 'Execution'}
+                                            {sync.sync_type === 'incremental' && (
+                                                <SimpleTooltip tooltipContent="Incremental: the existing cache and the last sync date will be preserved, only new/updated data will be synced.">
+                                                    {!syncCommandButtonsDisabled && <QuestionMarkCircledIcon />}
+                                                </SimpleTooltip>
+                                            )}
+                                        </div>
                                     </Button>
                                 )}
 
@@ -233,7 +241,12 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
                                         <DialogTrigger asChild>
                                             <Button variant="popoverItem" disabled={syncCommandButtonsDisabled} isLoading={modalSpinner}>
                                                 <IconRefresh className="flex h-4 w-4" />
-                                                <div className="pl-2 flex gap-2 items-center">Trigger Refresh</div>
+                                                <div className="pl-2 flex gap-2 items-center">
+                                                    Trigger Full Refresh
+                                                    <SimpleTooltip tooltipContent="Full refresh: the existing cache and last sync date will be deleted, all historical data will be resynced.">
+                                                        {!syncCommandButtonsDisabled && <QuestionMarkCircledIcon />}
+                                                    </SimpleTooltip>
+                                                </div>
                                             </Button>
                                         </DialogTrigger>
                                         <DialogContent>


### PR DESCRIPTION
regression issues introduced in 0607a92c41ae21c9adf9f788e804654c3d211675

- Menu action should be `Trigger Incremental` if incremental sync or `Trigger Execution` if full sync
- Reintroduce the tooltip giving more details about trigger incremental and trigger full refresh

cc @bastienbeurier 

Trigger Incremental vs Trigger Execution
<img width="313" alt="Screenshot 2024-11-01 at 16 05 53" src="https://github.com/user-attachments/assets/4ecaad5b-75eb-42f6-b1c6-b393105b1ba4">
<img width="316" alt="Screenshot 2024-11-01 at 16 05 49" src="https://github.com/user-attachments/assets/4b18ae4c-71ac-4477-b9bb-fd2a40105913">

With tooltip
<img width="828" alt="Screenshot 2024-11-01 at 16 05 58" src="https://github.com/user-attachments/assets/ed3bbcbb-db68-4754-a432-a5ac5b5b42f8">
<img width="731" alt="Screenshot 2024-11-01 at 16 06 04" src="https://github.com/user-attachments/assets/807f41f3-c4bf-4f36-a989-1936eea173b7">


## Issue ticket number and link

https://linear.app/nango/issue/NAN-2031/regression-bugs-on-connection-page

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
