### PR TITLE
fix(cli): migrate-to-directories parsing issue

### DIFF
--- a/packages/cli/lib/services/migration.service.ts
+++ b/packages/cli/lib/services/migration.service.ts
@@ -87,16 +87,16 @@ export const directoryMigration = async (loadLocation: string, debug?: boolean):
         return;
     }
 
-    for (const [providerConfigKey, integration] of Object.entries(response.parsed.integrations)) {
-        const integrationPath = path.join(loadLocation, providerConfigKey);
+    for (const integration of response.parsed.integrations) {
+        const integrationPath = path.join(loadLocation, integration.providerConfigKey);
         await createDirectory(integrationPath, debug);
 
         if (integration.syncs) {
             const syncsPath: string = path.join(integrationPath, 'syncs');
             await createDirectory(syncsPath, debug);
-            for (const sync of Object.keys(integration.syncs)) {
-                const syncPath: string = path.join(syncsPath, `${sync}.ts`);
-                const moved = await moveFile(path.join(loadLocation, `${sync}.ts`), syncPath, debug);
+            for (const sync of integration.syncs) {
+                const syncPath: string = path.join(syncsPath, `${sync.name}.ts`);
+                const moved = await moveFile(path.join(loadLocation, `${sync.name}.ts`), syncPath, debug);
                 if (moved) {
                     await updateModelImport(syncPath, debug);
                 }
@@ -106,9 +106,9 @@ export const directoryMigration = async (loadLocation: string, debug?: boolean):
         if (integration.actions) {
             const actionsPath: string = path.join(integrationPath, 'actions');
             await createDirectory(actionsPath, debug);
-            for (const action of Object.keys(integration.actions)) {
-                const actionPath: string = path.join(actionsPath, `${action}.ts`);
-                const moved = await moveFile(path.join(loadLocation, `${action}.ts`), actionPath, debug);
+            for (const action of integration.actions) {
+                const actionPath: string = path.join(actionsPath, `${action.name}.ts`);
+                const moved = await moveFile(path.join(loadLocation, `${action.name}.ts`), actionPath, debug);
                 if (moved) {
                     await updateModelImport(actionPath, debug);
                 }

--- a/packages/cli/lib/sync.unit.cli-test.ts
+++ b/packages/cli/lib/sync.unit.cli-test.ts
@@ -472,7 +472,7 @@ describe('generate function tests', () => {
 
         await directoryMigration(dir);
         expect(fs.existsSync(join(dir, 'hubspot/syncs/contacts.ts'))).toBe(true);
-        expect(fs.existsSync(join(dir, 'hubspot/actions/create-contacts.ts'))).toBe(true);
+        expect(fs.existsSync(join(dir, 'hubspot/actions/create-contact.ts'))).toBe(true);
         expect(fs.existsSync(join(dir, 'contacts.ts'))).toBe(false);
         expect(fs.existsSync(join(dir, 'create-contacts.ts'))).toBe(false);
 

--- a/packages/cli/lib/sync.unit.cli-test.ts
+++ b/packages/cli/lib/sync.unit.cli-test.ts
@@ -471,13 +471,13 @@ describe('generate function tests', () => {
         await copyDirectoryAndContents(join(fixturesPath, 'nango-yaml/v2/non-nested-integrations'), dir);
 
         await directoryMigration(dir);
-        expect(fs.existsSync(join(dir, 'models.ts'))).toBe(true);
         expect(fs.existsSync(join(dir, 'hubspot/syncs/contacts.ts'))).toBe(true);
         expect(fs.existsSync(join(dir, 'hubspot/actions/create-contacts.ts'))).toBe(true);
         expect(fs.existsSync(join(dir, 'contacts.ts'))).toBe(false);
         expect(fs.existsSync(join(dir, 'create-contacts.ts'))).toBe(false);
 
         const success = await compileAllFiles({ fullPath: dir, debug: false });
+        expect(fs.existsSync(join(dir, 'models.ts'))).toBe(true);
         expect(fs.existsSync(join(dir, 'dist/contacts-hubspot.js'))).toBe(true);
 
         expect(success).toBe(true);

--- a/packages/cli/lib/sync.unit.cli-test.ts
+++ b/packages/cli/lib/sync.unit.cli-test.ts
@@ -464,7 +464,7 @@ describe('generate function tests', () => {
         expect(success).toBe(true);
     });
 
-    it('should be able to migrate-to-directories ', async () => {
+    it('should be able to migrate-to-directories', async () => {
         const dir = await getTestDirectory('old-directory-migrate');
         init({ absolutePath: dir });
 

--- a/packages/cli/lib/sync.unit.cli-test.ts
+++ b/packages/cli/lib/sync.unit.cli-test.ts
@@ -9,6 +9,7 @@ import { compileAllFiles, compileSingleFile, getFileToCompile } from './services
 import parserService from './services/parser.service.js';
 import { copyDirectoryAndContents, removeVersion, fixturesPath, getTestDirectory } from './tests/helpers.js';
 import { parse } from './services/config.service.js';
+import { directoryMigration } from './services/migration.service.js';
 
 describe('generate function tests', () => {
     // Not the best but until we have a logger it will work
@@ -460,6 +461,25 @@ describe('generate function tests', () => {
         expect(fs.existsSync(join(dir, 'models.ts'))).toBe(true);
         expect(fs.existsSync(join(dir, 'contacts.ts'))).toBe(true);
         expect(fs.existsSync(join(dir, 'dist/contacts-hubspot.js'))).toBe(true);
+        expect(success).toBe(true);
+    });
+
+    it('should be able to migrate-to-directories ', async () => {
+        const dir = await getTestDirectory('old-directory-migrate');
+        init({ absolutePath: dir });
+
+        await copyDirectoryAndContents(join(fixturesPath, 'nango-yaml/v2/non-nested-integrations'), dir);
+
+        await directoryMigration(dir);
+        expect(fs.existsSync(join(dir, 'models.ts'))).toBe(true);
+        expect(fs.existsSync(join(dir, 'hubspot/syncs/contacts.ts'))).toBe(true);
+        expect(fs.existsSync(join(dir, 'hubspot/actions/create-contacts.ts'))).toBe(true);
+        expect(fs.existsSync(join(dir, 'contacts.ts'))).toBe(false);
+        expect(fs.existsSync(join(dir, 'create-contacts.ts'))).toBe(false);
+
+        const success = await compileAllFiles({ fullPath: dir, debug: false });
+        expect(fs.existsSync(join(dir, 'dist/contacts-hubspot.js'))).toBe(true);
+
         expect(success).toBe(true);
     });
 


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-2064/nango-migration-command-is-broken

- Fix migrate-to-directories command
It was broken since we changed the parser. Object.keys, Object.values and Object.entries are really a footgun.