### PR TITLE
fix(connection): reintroduce copy connectionId in the UI

### DIFF
--- a/packages/webapp/src/components/CopyText.tsx
+++ b/packages/webapp/src/components/CopyText.tsx
@@ -1,0 +1,67 @@
+import { useState, useEffect, useRef } from 'react';
+import type { ClassValue } from 'clsx';
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/Tooltip';
+import { IconCopy } from '@tabler/icons-react';
+import { cn } from '../utils/utils';
+
+export const CopyText: React.FC<{ text: string; showOnHover?: boolean; className?: ClassValue }> = ({ text, showOnHover, className }) => {
+    const [tooltipText, setTooltipText] = useState('Copy');
+    const triggerRef = useRef(null);
+
+    const copyToClipboard = async (e: React.MouseEvent) => {
+        try {
+            e.stopPropagation();
+            e.preventDefault();
+            await navigator.clipboard.writeText(text);
+            setTooltipText('Copied');
+        } catch (err) {
+            //this should never happen!
+            console.error('Failed to copy:', err);
+        }
+    };
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            setTooltipText('Copy');
+        }, 1000);
+
+        return () => {
+            clearTimeout(timer);
+        };
+    }, [tooltipText]);
+
+    return (
+        <Tooltip delayDuration={0}>
+            <TooltipTrigger asChild>
+                <button
+                    className={cn(
+                        'group transition-colors inline-flex max-w-full items-center gap-1.5 text-dark-400 border border-transparent px-2 py-0.5 rounded-md hover:border-dark-500 hover:text-white',
+                        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                        className
+                    )}
+                    onClick={copyToClipboard}
+                    ref={triggerRef}
+                >
+                    <div className="truncate">{text}</div>
+                    <div className={cn('text-xs text-white', showOnHover && 'transition-opacity opacity-0 group-hover:opacity-100')}>
+                        <IconCopy stroke={1} size={15} />
+                    </div>
+                </button>
+            </TooltipTrigger>
+            <TooltipContent
+                sideOffset={10}
+                align="end"
+                className="text-white"
+                onPointerDownOutside={(event) => {
+                    // Radix assume a click on a tooltip should close it
+                    // https://github.com/radix-ui/primitives/issues/2029
+                    if (event.target === triggerRef.current || (event.target as any).parentNode === triggerRef.current) {
+                        event.preventDefault();
+                    }
+                }}
+            >
+                {tooltipText}
+            </TooltipContent>
+        </Tooltip>
+    );
+};

--- a/packages/webapp/src/pages/Connection/Authorization.tsx
+++ b/packages/webapp/src/pages/Connection/Authorization.tsx
@@ -4,7 +4,6 @@ import PrismPlus from '../../components/ui/prism/PrismPlus';
 import type { ActiveLog, ApiConnectionFull, ApiEndUser } from '@nangohq/types';
 import { formatDateToShortUSFormat } from '../../utils/utils';
 import SecretInput from '../../components/ui/input/SecretInput';
-import { CopyButton } from '../../components/ui/button/CopyButton';
 import TagsInput from '../../components/ui/input/TagsInput';
 import type React from 'react';
 import { apiRefreshConnection } from '../../hooks/useConnections';
@@ -15,6 +14,7 @@ import { mutate } from 'swr';
 import { getLogsUrl } from '../../utils/logs';
 import { Info } from '../../components/Info';
 import { Link } from 'react-router-dom';
+import { CopyText } from '../../components/CopyText';
 
 interface AuthorizationProps {
     connection: ApiConnectionFull;
@@ -58,6 +58,13 @@ export const Authorization: React.FC<AuthorizationProps> = ({ connection, errorL
                 </div>
             )}
             <div className="grid grid-cols-3 gap-5">
+                <div className="flex flex-col">
+                    <span className="text-gray-400 text-xs uppercase mb-1">Connection ID</span>
+                    <div className="text-s -ml-2">
+                        <CopyText text={connection.connection_id} className=" text-white" />
+                    </div>
+                </div>
+
                 {endUser?.id && (
                     <div className="flex flex-col">
                         <span className="text-gray-400 text-xs uppercase mb-1">User ID</span>
@@ -110,13 +117,6 @@ export const Authorization: React.FC<AuthorizationProps> = ({ connection, errorL
                         <span className="text-white">{formatDateToShortUSFormat(connection.credentials.expires_at.toString())}</span>
                     </div>
                 )}
-                <div className="flex flex-col">
-                    <span className="text-gray-400 text-xs uppercase mb-1">Connection ID</span>
-                    <div className="flex items-center gap-2">
-                        <span className="text-white break-all font-code text-xs">{connection.connection_id}</span>
-                        <CopyButton text={connection.connection_id} />
-                    </div>
-                </div>
             </div>
 
             {connection.credentials &&

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -32,6 +32,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger, DropdownMenuIte
 import { IconChevronDown } from '@tabler/icons-react';
 import { useToast } from '../../hooks/useToast';
 import type { ApiConnectionSimple } from '@nangohq/types';
+import { CopyText } from '../../components/CopyText';
 
 const defaultFilter = ['all'];
 const filterErrors = [
@@ -81,6 +82,14 @@ const columns: ColumnDef<ApiConnectionSimple>[] = [
                     <p className="break-words break-all">{row.original.provider_config_key}</p>
                 </div>
             );
+        }
+    },
+    {
+        accessorKey: 'connection_id',
+        header: 'Connection ID',
+        size: 130,
+        cell: ({ row }) => {
+            return <CopyText className="text-s font-code" text={row.original.connection_id} showOnHover />;
         }
     },
     {


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/nango/issue/NAN-2083/bring-back-connection-id-in-the-list

- Reintroduce copy `connectionId` in the UI

<img width="1182" alt="Screenshot 2024-11-07 at 11 48 41" src="https://github.com/user-attachments/assets/bdce08e8-432d-4faa-9c57-4de6d0e8bc74">
<img width="1065" alt="Screenshot 2024-11-07 at 11 48 35" src="https://github.com/user-attachments/assets/9ce7f8b8-6beb-4e2f-bd78-72adfd0b756c">
