### PR TITLE
feat: return records count in /sync/status endpoint/sdk

### DIFF
--- a/docs-v2/reference/sdks/node.mdx
+++ b/docs-v2/reference/sdks/node.mdx
@@ -993,7 +993,17 @@ await nango.syncStatus('<INTEGRATION-ID>', ['SYNC_NAME1', 'SYNC_NAME2'], '<CONNE
             "finishedAt": "<string>",
             "nextScheduledSyncAt": "<string>",
             "frequency": "<string>",
-            "latestResult": {}
+            "latestResult": {
+                "<string>": {
+                    "added": <number>,
+                    "updated": <number>,
+                    "deleted": <number>,
+                }
+            },
+            "recordCount": {
+                "<string>": <number>
+                ...
+            }
         }
     ]
 }

--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -1275,6 +1275,9 @@ paths:
                                                 latestResult:
                                                     type: object
                                                     description: Additional information regarding the latest result of the sync. Contains a model name with added, updated and deleted records
+                                                recordCount:
+                                                    type: object
+                                                    description: Total count of records for each model synced by the sync
                 '400':
                     description: Invalid request
                     content:

--- a/packages/node-client/lib/types.ts
+++ b/packages/node-client/lib/types.ts
@@ -217,6 +217,7 @@ export interface SyncStatus {
     status: 'RUNNING' | 'SUCCESS' | 'ERROR' | 'PAUSED' | 'STOPPED';
     frequency: string;
     latestResult: Record<string, StatusAction>;
+    recordCount: Record<string, number>;
 }
 
 export interface StatusAction {

--- a/packages/server/lib/controllers/onboarding.controller.ts
+++ b/packages/server/lib/controllers/onboarding.controller.ts
@@ -244,7 +244,15 @@ class OnboardingController {
                 success,
                 error,
                 response: status
-            } = await syncManager.getSyncStatus(environment.id, DEMO_GITHUB_CONFIG_KEY, [DEMO_SYNC_NAME], orchestrator, req.body.connectionId, true);
+            } = await syncManager.getSyncStatus(
+                environment.id,
+                DEMO_GITHUB_CONFIG_KEY,
+                [DEMO_SYNC_NAME],
+                orchestrator,
+                recordsService,
+                req.body.connectionId,
+                true
+            );
 
             if (!success || !status) {
                 void analytics.track(AnalyticsTypes.DEMO_4_ERR, account.id, { user_id: user.id });

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -523,6 +523,7 @@ class SyncController {
                 provider_config_key as string,
                 syncNames,
                 orchestrator,
+                recordsService,
                 connection_id as string,
                 false,
                 connection

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -30,6 +30,7 @@ import { isSyncJobRunning, updateSyncJobStatus } from '../services/sync/job.serv
 import { getSyncConfigRaw, getSyncConfigBySyncId } from '../services/sync/config/config.service.js';
 import environmentService from '../services/environment.service.js';
 import type { DBEnvironment, DBTeam } from '@nangohq/types';
+import type { RecordCount } from '@nangohq/records';
 
 export interface RecordsServiceInterface {
     deleteRecordsBySyncId({
@@ -43,6 +44,7 @@ export interface RecordsServiceInterface {
         model: string;
         syncId: string;
     }): Promise<{ totalDeletedRecords: number }>;
+    getRecordCountsByModel({ connectionId, environmentId }: { connectionId: number; environmentId: number }): Promise<Result<Record<string, RecordCount>>>;
 }
 
 export interface OrchestratorClientInterface {

--- a/packages/shared/lib/models/Sync.ts
+++ b/packages/shared/lib/models/Sync.ts
@@ -59,15 +59,16 @@ export interface Job extends TimestampsAndDeleted {
 
 export interface ReportedSyncJobStatus {
     id?: string;
-    type: SyncType;
+    type: SyncType | 'INITIAL';
     name?: string;
     status: SyncStatus;
-    latestResult?: SyncResultByModel;
+    latestResult?: SyncResultByModel | undefined;
     jobStatus?: SyncStatus;
-    frequency: string;
-    finishedAt: Date;
+    frequency: string | null;
+    finishedAt: Date | undefined;
     nextScheduledSyncAt: Date | null;
-    latestExecutionStatus: SyncStatus;
+    latestExecutionStatus: SyncStatus | undefined;
+    recordCount: Record<string, number>;
 }
 
 // TODO: change that to use Parsed type

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -468,7 +468,7 @@ export class SyncManagerService {
             latestExecutionStatus: latestJob?.status,
             recordCount,
             ...(includeJobStatus ? { jobStatus: latestJob?.status as SyncStatus } : {})
-        } as ReportedSyncJobStatus;
+        };
     }
 }
 

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -445,7 +445,7 @@ export class SyncManagerService {
 
         const countRes = await recordsService.getRecordCountsByModel({ connectionId: sync.nango_connection_id, environmentId });
         if (countRes.isErr()) {
-            logger.error(`Failed to get record count for sync ${sync.id} in environment ${environmentId}: ${stringifyError(countRes.error)}`);
+            throw new Error(`Failed to get records count for sync ${sync.id} in environment ${environmentId}: ${stringifyError(countRes.error)}`);
         }
         const recordCount: Record<string, number> =
             syncConfig?.models.reduce(


### PR DESCRIPTION
<img width="528" alt="Screenshot 2024-11-07 at 14 34 38" src="https://github.com/user-attachments/assets/825bb1de-dd9a-4a76-865a-77a2d745054f">

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1928/return-sync-object-count-from-api

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
