### PR TITLE
fix(pagination): offset type casting

### DIFF
--- a/packages/shared/lib/services/paginate.service.ts
+++ b/packages/shared/lib/services/paginate.service.ts
@@ -135,11 +135,11 @@ class PaginationService {
     ): AsyncGenerator<T[], undefined, void> {
         const offsetPagination: OffsetPagination = paginationConfig;
         const offsetParameterName: string = offsetPagination.offset_name_in_request;
-        const offsetCalculatioMethod: OffsetCalculationMethod = offsetPagination.offset_calculation_method || 'by-response-size';
+        const offsetCalculationMethod: OffsetCalculationMethod = offsetPagination.offset_calculation_method || 'by-response-size';
         let offset = offsetPagination.offset_start_value || 0;
 
         while (true) {
-            updatedBodyOrParams[offsetParameterName] = `${offset}`;
+            updatedBodyOrParams[offsetParameterName] = offset;
 
             this.updateConfigBodyOrParams(passPaginationParamsInBody, config, updatedBodyOrParams);
 
@@ -161,7 +161,7 @@ class PaginationService {
                 return;
             }
 
-            if (offsetCalculatioMethod === 'per-page') {
+            if (offsetCalculationMethod === 'per-page') {
                 offset++;
             } else {
                 offset += responseData.length;

--- a/packages/shared/lib/services/paginate.service.ts
+++ b/packages/shared/lib/services/paginate.service.ts
@@ -139,7 +139,7 @@ class PaginationService {
         let offset = offsetPagination.offset_start_value || 0;
 
         while (true) {
-            updatedBodyOrParams[offsetParameterName] = offset;
+            updatedBodyOrParams[offsetParameterName] = passPaginationParamsInBody ? offset : String(offset);
 
             this.updateConfigBodyOrParams(passPaginationParamsInBody, config, updatedBodyOrParams);
 


### PR DESCRIPTION
## Describe your changes

- Do not cast offset as `string`
Not sure why it was done this way. I assume that those values were set to URL and supposedly be string only (https://github.com/NangoHQ/nango/pull/1103) but at the same time, it's set as `record<string, any` directly.
To be cautious I have introduced an if. 

