### PR TITLE
docs: otlp export

### DIFF
--- a/docs-v2/features/otlp-export.mdx
+++ b/docs-v2/features/otlp-export.mdx
@@ -16,7 +16,7 @@ Nango provides OpenTelemetry export to help you monitor and analyze your integra
 The following integration events are currently exported (as of November 2024):
 - Sync executions
 - Action executions
-- Webhook executions
+- 3rd-party API webhooks executions
 - Proxied requests
 
 ### Configuration
@@ -29,4 +29,4 @@ Log into the Nango dashboard and navigate to the Environment settings page.
 
 In the Environment Settings, provide the following information:
 - OpenTelemetry endpoint: The endpoint URL of your OpenTelemetry collector. Ex: https://my.otlp.collector:4318/v1/
-- Headers (Optional): Any authentication headers or additional headers required to access your collector
+- Headers (Optional): Any authorization headers or additional headers required to access your collector.

--- a/docs-v2/features/otlp-export.mdx
+++ b/docs-v2/features/otlp-export.mdx
@@ -1,0 +1,32 @@
+---
+title: 'OpenTelemetry export'
+---
+
+### Overview
+
+Nango provides OpenTelemetry export to help you monitor and analyze your integration activities. By exporting integration events as traces to your OpenTelemetry collector, you can gain valuable insights into your Nango usage and track various operations in real-time.
+
+<Info>
+**Prerequisites**
+- An active Nango Scale plan subscription
+- Access to an OpenTelemetry collector
+</Info>
+
+### Supported Events
+The following integration events are currently exported (as of November 2024):
+- Sync executions
+- Action executions
+- Webhook executions
+- Proxied requests
+
+### Configuration
+
+**Step 1**: Access your Environment settings
+
+Log into the Nango dashboard and navigate to the Environment settings page.
+
+**Step 2**: Configure OpenTelemetry Export
+
+In the Environment Settings, provide the following information:
+- OpenTelemetry endpoint: The endpoint URL of your OpenTelemetry collector. Ex: https://my.otlp.collector:4318/v1/
+- Headers (Optional): Any authentication headers or additional headers required to access your collector

--- a/docs-v2/mint.json
+++ b/docs-v2/mint.json
@@ -217,6 +217,12 @@
             ]
         },
         {
+            "group": "Other Features",
+            "pages": [
+                "features/otlp-export"
+            ]
+        },
+        {
             "group": "APIs & Templates",
             "pages": [
                 "integrations/overview",


### PR DESCRIPTION
## Describe your changes

Let me know what you think @bastienbeurier Do we want to go more in depth or is it enough doc for now?

Adding doc page for OTLP export feature

<img width="1480" alt="Screenshot 2024-11-12 at 13 57 38" src="https://github.com/user-attachments/assets/31e99fed-8a3c-4d05-bd27-5c1eb10e8872">

## Issue ticket number and link
https://linear.app/nango/issue/NAN-2084/docs-for-otel-export