### PR TITLE
fix(deploy runner): for doesn't split json lines properly

### DIFF
--- a/scripts/deploy/runners.bash
+++ b/scripts/deploy/runners.bash
@@ -24,7 +24,10 @@ while true; do
   parsed_response=$(echo "$response" | jq -c '.[]' 2>/dev/null)
   CURSOR=$(echo "$response" | jq -r '.[-1].cursor' 2>/dev/null)
 
-  for item in $parsed_response; do
+  while IFS= read -r item; do
+    if [ -z "$item" ]; then
+      continue
+    fi
     name=$(echo "$item" | jq -r '.service.name' 2>/dev/null)
     if [[ "$name" != "$ENVIRONMENT-runner-"* ]]; then
       continue
@@ -40,8 +43,11 @@ while true; do
         --header "accept: application/json" \
         --header "authorization: Bearer $API_KEY" \
         --header "content-type: application/json"
+
+    else
+      echo "Failed to get service ID for service: $item"
     fi
-  done
+  done < <(echo "$parsed_response")
 
   echo $CURSOR
 


### PR DESCRIPTION
It led to some of the runners not being deployed

I have checked that all running runners are now being processed

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1861/3-runners-are-not-being-deployed-when-deploying-runners

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
