### PR TITLE
fix(scripts): Add more resilient rate limit handling in runner-update-env

### DIFF
--- a/scripts/runner-update-env.js
+++ b/scripts/runner-update-env.js
@@ -73,6 +73,10 @@ async function fetchRunners() {
 
         services = services.concat(filteredServices);
 
+        if (!response.headers.get('ratelimit-remaining') || !response.headers.get('ratelimit-reset')) {
+            throw new Error('Unexpected API format: no rate limit headers');
+        }
+
         const remaining = parseInt(response.headers.get('ratelimit-remaining'));
         const resetMs = (parseInt(response.headers.get('ratelimit-reset')) + 1) * 1000;
 
@@ -98,6 +102,10 @@ async function updateEnvVar(serviceId, key, value) {
     if (!response.ok) {
         const body = await response.text();
         throw new Error(`Failed to update env var ${key} for service ${serviceId}\n${body}`);
+    }
+
+    if (!response.headers.get('ratelimit-remaining') || !response.headers.get('ratelimit-reset')) {
+        throw new Error('Unexpected API format: no rate limit headers');
     }
 
     const remaining = parseInt(response.headers.get('ratelimit-remaining'));

--- a/scripts/runner-update-env.js
+++ b/scripts/runner-update-env.js
@@ -80,7 +80,7 @@ async function fetchRunners() {
         const remaining = parseInt(response.headers.get('ratelimit-remaining'));
         const resetMs = (parseInt(response.headers.get('ratelimit-reset')) + 1) * 1000;
 
-        await sleep(Math.ceil((resetMs + 1) / remaining));
+        await sleep(Math.ceil(resetMs / remaining));
     }
 
     return services;
@@ -111,5 +111,5 @@ async function updateEnvVar(serviceId, key, value) {
     const remaining = parseInt(response.headers.get('ratelimit-remaining'));
     const resetMs = (parseInt(response.headers.get('ratelimit-reset')) + 1) * 1000;
 
-    await sleep(Math.ceil((resetMs + 1) / remaining));
+    await sleep(Math.ceil(resetMs / remaining));
 }

--- a/scripts/runner-update-env.js
+++ b/scripts/runner-update-env.js
@@ -73,7 +73,10 @@ async function fetchRunners() {
 
         services = services.concat(filteredServices);
 
-        await sleep(1000);
+        const remaining = parseInt(response.headers.get('ratelimit-remaining'));
+        const resetMs = (parseInt(response.headers.get('ratelimit-reset')) + 1) * 1000;
+
+        await sleep(Math.ceil((resetMs + 1) / remaining));
     }
 
     return services;
@@ -96,4 +99,9 @@ async function updateEnvVar(serviceId, key, value) {
         const body = await response.text();
         throw new Error(`Failed to update env var ${key} for service ${serviceId}\n${body}`);
     }
+
+    const remaining = parseInt(response.headers.get('ratelimit-remaining'));
+    const resetMs = (parseInt(response.headers.get('ratelimit-reset')) + 1) * 1000;
+
+    await sleep(Math.ceil((resetMs + 1) / remaining));
 }


### PR DESCRIPTION
## Describe your changes

I ran into an issue while rolling out the updated env vars that I bumped into rate limits with Render against our prod data that I hadn't bumped into in staging due to the lower number of runners in staging.

This PR updates the network calls to sleep against their rate limit so that they'll run fast but not too fast.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
