### PR TITLE
feat: rename post-connection-scripts table to on-event-scripts 

### DIFF
--- a/packages/cli/lib/services/deploy.service.ts
+++ b/packages/cli/lib/services/deploy.service.ts
@@ -6,7 +6,7 @@ import type { AxiosResponse } from 'axios';
 import { AxiosError } from 'axios';
 import type {
     NangoYamlParsed,
-    PostConnectionScriptByProvider,
+    OnEventScriptsByProvider,
     ScriptFileType,
     IncomingFlowConfig,
     NangoConfigMetadata,
@@ -359,15 +359,15 @@ class DeployService {
         version?: string | undefined;
         optionalSyncName?: string | undefined;
         optionalActionName?: string | undefined;
-    }): { flowConfigs: IncomingFlowConfig[]; postConnectionScriptsByProvider: PostConnectionScriptByProvider[]; jsonSchema: JSONSchema7 } | null {
+    }): { flowConfigs: IncomingFlowConfig[]; onEventScriptsByProvider: OnEventScriptsByProvider[]; jsonSchema: JSONSchema7 } | null {
         const postData: IncomingFlowConfig[] = [];
-        const postConnectionScriptsByProvider: PostConnectionScriptByProvider[] = [];
+        const onEventScriptsByProvider: OnEventScriptsByProvider[] = [];
 
         for (const integration of parsed.integrations) {
             const { providerConfigKey, postConnectionScripts } = integration;
 
             if (postConnectionScripts && postConnectionScripts.length > 0) {
-                const scripts: PostConnectionScriptByProvider['scripts'] = [];
+                const scripts: OnEventScriptsByProvider['scripts'] = [];
                 for (const postConnectionScript of postConnectionScripts) {
                     const files = loadScriptFiles({ scriptName: postConnectionScript, providerConfigKey, fullPath, type: 'post-connection-scripts' });
                     if (!files) {
@@ -376,7 +376,7 @@ class DeployService {
 
                     scripts.push({ name: postConnectionScript, fileBody: files });
                 }
-                postConnectionScriptsByProvider.push({ providerConfigKey, scripts });
+                onEventScriptsByProvider.push({ providerConfigKey, scripts });
             }
 
             if (!optionalActionName) {
@@ -468,9 +468,9 @@ class DeployService {
             }
         }
 
-        if (debug && postConnectionScriptsByProvider) {
-            for (const postConnectionScriptByProvider of postConnectionScriptsByProvider) {
-                const { providerConfigKey, scripts } = postConnectionScriptByProvider;
+        if (debug && onEventScriptsByProvider) {
+            for (const onEventScriptByProvider of onEventScriptsByProvider) {
+                const { providerConfigKey, scripts } = onEventScriptByProvider;
 
                 for (const script of scripts) {
                     const { name } = script;
@@ -485,7 +485,7 @@ class DeployService {
             return null;
         }
 
-        return { flowConfigs: postData, postConnectionScriptsByProvider, jsonSchema };
+        return { flowConfigs: postData, onEventScriptsByProvider: onEventScriptsByProvider, jsonSchema };
     }
 }
 

--- a/packages/database/lib/migrations/2024111409170956_on_event_scripts.cjs
+++ b/packages/database/lib/migrations/2024111409170956_on_event_scripts.cjs
@@ -1,0 +1,24 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.schema.raw(`
+        CREATE TYPE script_trigger_event AS ENUM (
+            'ON_CONNECTION_CREATED',
+            'ON_CONNECTION_DELETED'
+        );
+    `);
+    await knex.schema.raw(`ALTER TABLE "_nango_post_connection_scripts" RENAME TO "on_event_scripts"`);
+    await knex.schema.raw(`ALTER TABLE "on_event_scripts" ADD COLUMN "event" script_trigger_event DEFAULT 'ON_CONNECTION_CREATED'`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.schema.raw(`ALTER TABLE "on_event_scripts" DROP COLUMN "event"`);
+    await knex.schema.raw(`ALTER TABLE "on_event_scripts" RENAME TO "_nango_post_connection_scripts"`);
+    await knex.schema.raw(`DROP TYPE IF EXISTS script_trigger_event`);
+};

--- a/packages/server/lib/controllers/sync/deploy/postConfirmation.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postConfirmation.integration.test.ts
@@ -40,7 +40,7 @@ describe(`POST ${endpoint}`, () => {
                 code: 'invalid_body',
                 errors: [
                     { code: 'invalid_type', message: 'Required', path: ['flowConfigs'] },
-                    { code: 'invalid_type', message: 'Required', path: ['postConnectionScriptsByProvider'] },
+                    { code: 'invalid_type', message: 'Required', path: ['onEventScriptsByProvider'] },
                     { code: 'invalid_type', message: 'Required', path: ['reconcile'] },
                     { code: 'invalid_type', message: 'Expected boolean, received string', path: ['debug'] }
                 ]
@@ -57,7 +57,7 @@ describe(`POST ${endpoint}`, () => {
             body: {
                 debug: false,
                 flowConfigs: [],
-                postConnectionScriptsByProvider: [],
+                onEventScriptsByProvider: [],
                 reconcile: false,
                 singleDeployMode: false,
                 jsonSchema: { $comment: '', $schema: 'http://json-schema.org/draft-07/schema#', definitions: {} }

--- a/packages/server/lib/controllers/sync/deploy/postConfirmation.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postConfirmation.integration.test.ts
@@ -40,9 +40,37 @@ describe(`POST ${endpoint}`, () => {
                 code: 'invalid_body',
                 errors: [
                     { code: 'invalid_type', message: 'Required', path: ['flowConfigs'] },
-                    { code: 'invalid_type', message: 'Required', path: ['onEventScriptsByProvider'] },
                     { code: 'invalid_type', message: 'Required', path: ['reconcile'] },
                     { code: 'invalid_type', message: 'Expected boolean, received string', path: ['debug'] }
+                ]
+            }
+        });
+        expect(res.res.status).toBe(400);
+    });
+
+    it('should validate onEventScriptsByProvider', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: env.secret_key,
+            // @ts-expect-error on purpose
+            body: {
+                debug: false,
+                flowConfigs: [],
+                reconcile: false
+            }
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'invalid_body',
+                errors: [
+                    {
+                        code: 'custom',
+                        message: 'Either onEventScriptsByProvider or postConnectionScriptsByProvider must be provided',
+                        path: ['onEventScriptsByProvider or postConnectionScriptsByProvider']
+                    }
                 ]
             }
         });

--- a/packages/server/lib/controllers/sync/deploy/postConfirmation.ts
+++ b/packages/server/lib/controllers/sync/deploy/postConfirmation.ts
@@ -1,111 +1,12 @@
-import { z } from 'zod';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
-import type { NangoModelField, PostDeployConfirmation } from '@nangohq/types';
+import type { PostDeployConfirmation } from '@nangohq/types';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { getAndReconcileDifferences } from '@nangohq/shared';
 import { getOrchestrator } from '../../../utils/utils.js';
 import { logContextGetter } from '@nangohq/logs';
-import { providerConfigKeySchema } from '../../../helpers/validation.js';
+import { validation } from './validation.js';
 
 const orchestrator = getOrchestrator();
-
-export const fileBody = z.object({ js: z.string(), ts: z.string() }).strict();
-export const jsonSchema = z
-    .object({
-        $schema: z.literal('http://json-schema.org/draft-07/schema#'),
-        $comment: z.string(),
-        definitions: z.record(z.string(), z.object({}))
-    })
-    .strict();
-
-export const nangoModelFieldsBase = z.object({
-    name: z.string(),
-    dynamic: z.boolean().optional(),
-    model: z.boolean().optional(),
-    union: z.boolean().optional(),
-    array: z.boolean().optional(),
-    tsType: z.boolean().optional(),
-    optional: z.boolean().optional()
-});
-export const nangoModelFields: z.ZodType<NangoModelField> = nangoModelFieldsBase
-    .extend({
-        value: z.union([z.string(), z.number(), z.boolean(), z.null(), z.lazy(() => nangoModelFields.array())])
-    })
-    .strict();
-export const nangoModel = z
-    .object({
-        name: z.string().max(255),
-        fields: z.array(nangoModelFields),
-        isAnon: z.boolean().optional()
-    })
-    .strict();
-export const flowConfig = z
-    .object({
-        type: z.enum(['action', 'sync']),
-        models: z.array(z.string().min(1).max(255)),
-        runs: z.string(),
-        auto_start: z.boolean().optional().default(false),
-        attributes: z.object({}).optional(),
-        metadata: z
-            .object({
-                scopes: z.array(z.string().max(255)).optional(),
-                description: z.string().max(2000).optional()
-            })
-            .strict()
-            .optional(),
-        model_schema: z.union([z.string(), z.array(nangoModel)]),
-        input: z.union([z.string().max(255), z.any()]).optional(),
-        endpoints: z
-            .array(
-                z.union([
-                    z
-                        .object({
-                            method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
-                            path: z.string(),
-                            group: z.string().min(1).max(64).optional()
-                        })
-                        .strict(),
-                    z
-                        .object({
-                            GET: z.string().optional(),
-                            POST: z.string().optional(),
-                            PATCH: z.string().optional(),
-                            PUT: z.string().optional(),
-                            DELETE: z.string().optional()
-                        })
-                        .strict()
-                ])
-            )
-            .optional(),
-        syncName: z.string(),
-        providerConfigKey: providerConfigKeySchema,
-        fileBody,
-        version: z.string().optional(),
-        track_deletes: z.boolean().optional().default(false),
-        sync_type: z.enum(['incremental', 'full']).optional(),
-        webhookSubscriptions: z.array(z.string().max(255)).optional()
-    })
-    .strict();
-export const flowConfigs = z.array(flowConfig);
-export const postConnectionScriptsByProvider = z.array(
-    z
-        .object({
-            providerConfigKey: providerConfigKeySchema,
-            scripts: z.array(z.object({ name: z.string().min(1).max(255), fileBody }).strict())
-        })
-        .strict()
-);
-
-const validation = z
-    .object({
-        flowConfigs,
-        postConnectionScriptsByProvider,
-        jsonSchema: jsonSchema.optional(),
-        reconcile: z.boolean(),
-        debug: z.boolean(),
-        singleDeployMode: z.boolean().optional().default(false)
-    })
-    .strict();
 
 export const postDeployConfirmation = asyncWrapper<PostDeployConfirmation>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
@@ -45,7 +45,7 @@ describe(`POST ${endpoint}`, () => {
                 code: 'invalid_body',
                 errors: [
                     { code: 'invalid_type', message: 'Required', path: ['flowConfigs'] },
-                    { code: 'invalid_type', message: 'Required', path: ['postConnectionScriptsByProvider'] },
+                    { code: 'invalid_type', message: 'Required', path: ['onEventScriptsByProvider'] },
                     { code: 'invalid_type', message: 'Required', path: ['nangoYamlBody'] },
                     { code: 'invalid_type', message: 'Required', path: ['reconcile'] },
                     { code: 'invalid_type', message: 'Expected boolean, received string', path: ['debug'] }
@@ -64,7 +64,7 @@ describe(`POST ${endpoint}`, () => {
                 debug: false,
                 flowConfigs: [],
                 nangoYamlBody: '',
-                postConnectionScriptsByProvider: [],
+                onEventScriptsByProvider: [],
                 reconcile: false,
                 singleDeployMode: false,
                 jsonSchema: { $comment: '', $schema: 'http://json-schema.org/draft-07/schema#', definitions: {} }
@@ -122,7 +122,7 @@ describe(`POST ${endpoint}`, () => {
                         }
                     ],
                     nangoYamlBody: ``,
-                    postConnectionScriptsByProvider: [],
+                    onEventScriptsByProvider: [],
                     reconcile: false,
                     singleDeployMode: false
                 }
@@ -204,7 +204,7 @@ describe(`POST ${endpoint}`, () => {
                     },
                     flowConfigs: [],
                     nangoYamlBody: ``,
-                    postConnectionScriptsByProvider: [],
+                    onEventScriptsByProvider: [],
                     reconcile: true,
                     singleDeployMode: false
                 }

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
@@ -45,10 +45,39 @@ describe(`POST ${endpoint}`, () => {
                 code: 'invalid_body',
                 errors: [
                     { code: 'invalid_type', message: 'Required', path: ['flowConfigs'] },
-                    { code: 'invalid_type', message: 'Required', path: ['onEventScriptsByProvider'] },
-                    { code: 'invalid_type', message: 'Required', path: ['nangoYamlBody'] },
                     { code: 'invalid_type', message: 'Required', path: ['reconcile'] },
-                    { code: 'invalid_type', message: 'Expected boolean, received string', path: ['debug'] }
+                    { code: 'invalid_type', message: 'Expected boolean, received string', path: ['debug'] },
+                    { code: 'invalid_type', message: 'Required', path: ['nangoYamlBody'] }
+                ]
+            }
+        });
+        expect(res.res.status).toBe(400);
+    });
+
+    it('should validate onEventScriptsByProvider', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: env.secret_key,
+            // @ts-expect-error on purpose
+            body: {
+                debug: false,
+                flowConfigs: [],
+                nangoYamlBody: '',
+                reconcile: false
+            }
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'invalid_body',
+                errors: [
+                    {
+                        code: 'custom',
+                        message: 'Either onEventScriptsByProvider or postConnectionScriptsByProvider must be provided',
+                        path: ['onEventScriptsByProvider or postConnectionScriptsByProvider']
+                    }
                 ]
             }
         });

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.ts
@@ -1,25 +1,12 @@
-import { z } from 'zod';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 import type { PostDeploy } from '@nangohq/types';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { AnalyticsTypes, analytics, cleanIncomingFlow, deploy, errorManager, getAndReconcileDifferences } from '@nangohq/shared';
 import { getOrchestrator } from '../../../utils/utils.js';
 import { logContextGetter } from '@nangohq/logs';
-import { flowConfigs, jsonSchema, postConnectionScriptsByProvider } from './postConfirmation.js';
+import { validationWithNangoYaml as validation } from './validation.js';
 
 const orchestrator = getOrchestrator();
-
-const validation = z
-    .object({
-        flowConfigs: flowConfigs,
-        postConnectionScriptsByProvider: postConnectionScriptsByProvider,
-        jsonSchema: jsonSchema.optional(),
-        nangoYamlBody: z.string(),
-        reconcile: z.boolean(),
-        debug: z.boolean(),
-        singleDeployMode: z.boolean().optional().default(false)
-    })
-    .strict();
 
 export const postDeploy = asyncWrapper<PostDeploy>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
@@ -46,7 +33,7 @@ export const postDeploy = asyncWrapper<PostDeploy>(async (req, res) => {
         account,
         flows: cleanIncomingFlow(body.flowConfigs),
         nangoYamlBody: body.nangoYamlBody,
-        postConnectionScriptsByProvider: body.postConnectionScriptsByProvider,
+        onEventScriptsByProvider: body.onEventScriptsByProvider,
         debug: body.debug,
         jsonSchema: req.body.jsonSchema,
         logContextGetter,

--- a/packages/server/lib/controllers/sync/deploy/postDeployInternal.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeployInternal.ts
@@ -5,21 +5,9 @@ import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { deploy, errorManager, getAndReconcileDifferences, environmentService, configService, connectionService, cleanIncomingFlow } from '@nangohq/shared';
 import { getOrchestrator } from '../../../utils/utils.js';
 import { logContextGetter } from '@nangohq/logs';
-import { flowConfigs, jsonSchema, postConnectionScriptsByProvider } from './postConfirmation.js';
+import { validationWithNangoYaml as validation } from './validation.js';
 
 const orchestrator = getOrchestrator();
-
-const validation = z
-    .object({
-        flowConfigs: flowConfigs,
-        postConnectionScriptsByProvider: postConnectionScriptsByProvider,
-        jsonSchema: jsonSchema.optional(),
-        nangoYamlBody: z.string(),
-        reconcile: z.boolean(),
-        debug: z.boolean(),
-        singleDeployMode: z.boolean().optional().default(false)
-    })
-    .strict();
 
 const queryStringValidation = z
     .object({
@@ -97,7 +85,7 @@ export const postDeployInternal = asyncWrapper<PostDeployInternal>(async (req, r
         account,
         flows: cleanIncomingFlow(body.flowConfigs),
         nangoYamlBody: body.nangoYamlBody,
-        postConnectionScriptsByProvider: body.postConnectionScriptsByProvider,
+        onEventScriptsByProvider: body.onEventScriptsByProvider,
         debug: body.debug,
         jsonSchema: req.body.jsonSchema,
         logContextGetter,

--- a/packages/server/lib/controllers/sync/deploy/validation.ts
+++ b/packages/server/lib/controllers/sync/deploy/validation.ts
@@ -1,0 +1,126 @@
+import { z } from 'zod';
+import type { NangoModelField } from '@nangohq/types';
+import { providerConfigKeySchema } from '../../../helpers/validation.js';
+
+const fileBody = z.object({ js: z.string(), ts: z.string() }).strict();
+const jsonSchema = z
+    .object({
+        $schema: z.literal('http://json-schema.org/draft-07/schema#'),
+        $comment: z.string(),
+        definitions: z.record(z.string(), z.object({}))
+    })
+    .strict();
+
+const nangoModelFieldsBase = z.object({
+    name: z.string(),
+    dynamic: z.boolean().optional(),
+    model: z.boolean().optional(),
+    union: z.boolean().optional(),
+    array: z.boolean().optional(),
+    tsType: z.boolean().optional(),
+    optional: z.boolean().optional()
+});
+const nangoModelFields: z.ZodType<NangoModelField> = nangoModelFieldsBase
+    .extend({
+        value: z.union([z.string(), z.number(), z.boolean(), z.null(), z.lazy(() => nangoModelFields.array())])
+    })
+    .strict();
+const nangoModel = z
+    .object({
+        name: z.string().max(255),
+        fields: z.array(nangoModelFields),
+        isAnon: z.boolean().optional()
+    })
+    .strict();
+export const flowConfig = z
+    .object({
+        type: z.enum(['action', 'sync']),
+        models: z.array(z.string().min(1).max(255)),
+        runs: z.string(),
+        auto_start: z.boolean().optional().default(false),
+        attributes: z.object({}).optional(),
+        metadata: z
+            .object({
+                scopes: z.array(z.string().max(255)).optional(),
+                description: z.string().max(2000).optional()
+            })
+            .strict()
+            .optional(),
+        model_schema: z.union([z.string(), z.array(nangoModel)]),
+        input: z.union([z.string().max(255), z.any()]).optional(),
+        endpoints: z
+            .array(
+                z.union([
+                    z
+                        .object({
+                            method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
+                            path: z.string(),
+                            group: z.string().min(1).max(64).optional()
+                        })
+                        .strict(),
+                    z
+                        .object({
+                            GET: z.string().optional(),
+                            POST: z.string().optional(),
+                            PATCH: z.string().optional(),
+                            PUT: z.string().optional(),
+                            DELETE: z.string().optional()
+                        })
+                        .strict()
+                ])
+            )
+            .optional(),
+        syncName: z.string(),
+        providerConfigKey: providerConfigKeySchema,
+        fileBody,
+        version: z.string().optional(),
+        track_deletes: z.boolean().optional().default(false),
+        sync_type: z.enum(['incremental', 'full']).optional(),
+        webhookSubscriptions: z.array(z.string().max(255)).optional()
+    })
+    .strict();
+const flowConfigs = z.array(flowConfig);
+const onEventScriptsByProvider = z.array(
+    z
+        .object({
+            providerConfigKey: providerConfigKeySchema,
+            scripts: z.array(z.object({ name: z.string().min(1).max(255), fileBody }).strict())
+        })
+        .strict()
+);
+
+const commonValidation = z
+    .object({
+        flowConfigs,
+        onEventScriptsByProvider: onEventScriptsByProvider.optional(),
+        // postConnectionScriptsByProvider is deprecated but still supported for backwards compatibility
+        postConnectionScriptsByProvider: onEventScriptsByProvider.optional(),
+        jsonSchema: jsonSchema.optional(),
+        reconcile: z.boolean(),
+        debug: z.boolean(),
+        singleDeployMode: z.boolean().optional().default(false)
+    })
+    .strict();
+
+export const validation = commonValidation
+    // cannot transform commonValidation because it cannot be merge with another schema
+    // https://github.com/colinhacks/zod/issues/2474
+    // hence the code duplication
+    .transform((data) => ({
+        ...data,
+        onEventScriptsByProvider: data.onEventScriptsByProvider || data.postConnectionScriptsByProvider || []
+    }));
+
+export const validationWithNangoYaml = commonValidation
+    .merge(
+        z.object({
+            nangoYamlBody: z.string()
+        })
+    )
+    // cannot transform commonValidation because it cannot be merge with another schema
+    // https://github.com/colinhacks/zod/issues/2474
+    // hence the code duplication
+    .transform((data) => ({
+        ...data,
+        onEventScriptsByProvider: data.onEventScriptsByProvider || data.postConnectionScriptsByProvider || []
+    }));

--- a/packages/server/lib/controllers/sync/deploy/validation.ts
+++ b/packages/server/lib/controllers/sync/deploy/validation.ts
@@ -102,25 +102,30 @@ const commonValidation = z
     })
     .strict();
 
-export const validation = commonValidation
+const addOnEventScriptsValidation = <T extends z.ZodType>(schema: T) =>
     // cannot transform commonValidation because it cannot be merge with another schema
     // https://github.com/colinhacks/zod/issues/2474
-    // hence the code duplication
-    .transform((data) => ({
-        ...data,
-        onEventScriptsByProvider: data.onEventScriptsByProvider || data.postConnectionScriptsByProvider || []
-    }));
+    schema
+        .refine(
+            (data) => {
+                return data.onEventScriptsByProvider || data.postConnectionScriptsByProvider;
+            },
+            {
+                message: 'Either onEventScriptsByProvider or postConnectionScriptsByProvider must be provided',
+                path: ['onEventScriptsByProvider or postConnectionScriptsByProvider']
+            }
+        )
+        .transform((data) => ({
+            ...data,
+            onEventScriptsByProvider: data.onEventScriptsByProvider || data.postConnectionScriptsByProvider || []
+        }));
 
-export const validationWithNangoYaml = commonValidation
-    .merge(
+export const validation = addOnEventScriptsValidation(commonValidation);
+
+export const validationWithNangoYaml = addOnEventScriptsValidation(
+    commonValidation.merge(
         z.object({
             nangoYamlBody: z.string()
         })
     )
-    // cannot transform commonValidation because it cannot be merge with another schema
-    // https://github.com/colinhacks/zod/issues/2474
-    // hence the code duplication
-    .transform((data) => ({
-        ...data,
-        onEventScriptsByProvider: data.onEventScriptsByProvider || data.postConnectionScriptsByProvider || []
-    }));
+);

--- a/packages/server/lib/controllers/v1/flows/id/patchDisable.ts
+++ b/packages/server/lib/controllers/v1/flows/id/patchDisable.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 import type { PatchFlowDisable } from '@nangohq/types';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
-import { flowConfig } from '../../../sync/deploy/postConfirmation.js';
+import { flowConfig } from '../../../sync/deploy/validation.js';
 import { configService, disableScriptConfig } from '@nangohq/shared';
 import { providerConfigKeySchema, providerSchema, scriptNameSchema } from '../../../../helpers/validation.js';
 

--- a/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.ts
+++ b/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.ts
@@ -5,7 +5,7 @@ import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 import { logContextGetter } from '@nangohq/logs';
 import { configService, connectionService, deployPreBuilt, flowService, syncManager } from '@nangohq/shared';
 import { getOrchestrator } from '../../../../utils/utils.js';
-import { flowConfig } from '../../../sync/deploy/postConfirmation.js';
+import { flowConfig } from '../../../sync/deploy/validation.js';
 import { providerConfigKeySchema, providerSchema, scriptNameSchema } from '../../../../helpers/validation.js';
 
 const validation = z

--- a/packages/server/lib/controllers/v1/flows/preBuilt/putUpgrade.ts
+++ b/packages/server/lib/controllers/v1/flows/preBuilt/putUpgrade.ts
@@ -4,7 +4,7 @@ import type { PutUpgradePreBuiltFlow } from '@nangohq/types';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 import { logContextGetter } from '@nangohq/logs';
 import { configService, flowService, getSyncConfigById, upgradePreBuilt as upgradePrebuiltFlow } from '@nangohq/shared';
-import { flowConfig } from '../../../sync/deploy/postConfirmation.js';
+import { flowConfig } from '../../../sync/deploy/validation.js';
 import { providerConfigKeySchema, providerSchema, scriptNameSchema } from '../../../../helpers/validation.js';
 
 const validation = z

--- a/packages/server/lib/hooks/connection/on/connection-created.ts
+++ b/packages/server/lib/hooks/connection/on/connection-created.ts
@@ -1,13 +1,9 @@
 import type { RecentlyCreatedConnection } from '@nangohq/shared';
-import { postConnectionScriptService } from '@nangohq/shared';
+import { onEventScriptService } from '@nangohq/shared';
 import type { LogContextGetter } from '@nangohq/logs';
-import { getOrchestrator } from '../../utils/utils.js';
+import { getOrchestrator } from '../../../utils/utils.js';
 
-export async function externalPostConnection(
-    createdConnection: RecentlyCreatedConnection,
-    provider: string,
-    logContextGetter: LogContextGetter
-): Promise<void> {
+export async function onConnectionCreated(createdConnection: RecentlyCreatedConnection, provider: string, logContextGetter: LogContextGetter): Promise<void> {
     if (!createdConnection) {
         return;
     }
@@ -18,9 +14,9 @@ export async function externalPostConnection(
         return;
     }
 
-    const postConnectionScripts = await postConnectionScriptService.getByConfig(config_id);
+    const onConnectionCreatedScripts = await onEventScriptService.getByConfig(config_id);
 
-    if (!postConnectionScripts || postConnectionScripts.length === 0) {
+    if (!onConnectionCreatedScripts || onConnectionCreatedScripts.length === 0) {
         return;
     }
 
@@ -35,7 +31,7 @@ export async function externalPostConnection(
     );
 
     let failed = false;
-    for (const postConnectionScript of postConnectionScripts) {
+    for (const postConnectionScript of onConnectionCreatedScripts) {
         const { name, file_location: fileLocation, version } = postConnectionScript;
 
         const res = await getOrchestrator().triggerPostConnectionScript({

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -30,7 +30,7 @@ import type { Result } from '@nangohq/utils';
 import type { LogContext, LogContextGetter } from '@nangohq/logs';
 import { logContextGetter } from '@nangohq/logs';
 import postConnection from './connection/post-connection.js';
-import { externalPostConnection } from './connection/external-post-connection.js';
+import { onConnectionCreated } from './connection/on/connection-created.js';
 import { sendAuth as sendAuthWebhook } from '@nangohq/webhooks';
 import tracer from 'dd-trace';
 
@@ -82,7 +82,7 @@ export const connectionCreated = async (
 
     if (options.runPostConnectionScript === true) {
         await postConnection(createdConnectionPayload, provider, logContextGetter);
-        await externalPostConnection(createdConnectionPayload, provider, logContextGetter);
+        await onConnectionCreated(createdConnectionPayload, provider, logContextGetter);
     }
 
     const webhookSettings = await externalWebhookService.get(environment.id);

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -21,7 +21,7 @@ import featureFlags from './utils/featureflags.js';
 import { Orchestrator } from './clients/orchestrator.js';
 import { SlackService, generateSlackConnectionId } from './services/notification/slack.service.js';
 
-export * from './services/sync/post-connection.service.js';
+export * from './services/sync/on-event-scripts.service.js';
 export * from './services/sync/sync.service.js';
 export * from './services/sync/job.service.js';
 export * from './services/sync/run.utils.js';

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -957,6 +957,10 @@ export class NangoSync extends NangoAction {
         if (config.stubbedMetadata) {
             this.stubbedMetadata = config.stubbedMetadata;
         }
+        if (!config.dryRun) {
+            if (!this.syncId) throw new Error('Parameter syncId is required when not in dryRun');
+            if (!this.syncJobId) throw new Error('Parameter syncJobId is required when not in dryRun');
+        }
     }
 
     /**

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -957,10 +957,6 @@ export class NangoSync extends NangoAction {
         if (config.stubbedMetadata) {
             this.stubbedMetadata = config.stubbedMetadata;
         }
-        if (!config.dryRun) {
-            if (!this.syncId) throw new Error('Parameter syncId is required when not in dryRun');
-            if (!this.syncJobId) throw new Error('Parameter syncJobId is required when not in dryRun');
-        }
     }
 
     /**

--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -13,7 +13,7 @@ import type {
     CleanedIncomingFlowConfig,
     IncomingPreBuiltFlowConfig,
     NangoModel,
-    PostConnectionScriptByProvider,
+    OnEventScriptsByProvider,
     NangoSyncEndpointV2,
     IncomingFlowConfig,
     HTTP_METHOD,
@@ -21,7 +21,7 @@ import type {
     DBSyncEndpointCreate,
     DBSyncEndpoint
 } from '@nangohq/types';
-import { postConnectionScriptService } from '../post-connection.service.js';
+import { onEventScriptService } from '../on-event-scripts.service.js';
 import { NangoError } from '../../../utils/error.js';
 import telemetry, { LogTypes } from '../../../utils/telemetry.js';
 import { env, Ok } from '@nangohq/utils';
@@ -73,7 +73,7 @@ export async function deploy({
     account,
     flows,
     jsonSchema,
-    postConnectionScriptsByProvider,
+    onEventScriptsByProvider,
     nangoYamlBody,
     logContextGetter,
     orchestrator,
@@ -83,7 +83,7 @@ export async function deploy({
     account: DBTeam;
     flows: CleanedIncomingFlowConfig[];
     jsonSchema?: JSONSchema7 | undefined;
-    postConnectionScriptsByProvider: PostConnectionScriptByProvider[];
+    onEventScriptsByProvider: OnEventScriptsByProvider[];
     nangoYamlBody: string;
     logContextGetter: LogContextGetter;
     orchestrator: Orchestrator;
@@ -179,8 +179,8 @@ export async function deploy({
             await db.knex.from<DBSyncEndpoint>(ENDPOINT_TABLE).insert(endpoints);
         }
 
-        if (postConnectionScriptsByProvider.length > 0) {
-            await postConnectionScriptService.update({ environment, account, postConnectionScriptsByProvider });
+        if (onEventScriptsByProvider.length > 0) {
+            await onEventScriptService.update({ environment, account, onEventScriptsByProvider });
         }
 
         for (const id of idsToMarkAsInactive) {

--- a/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
@@ -49,7 +49,7 @@ describe('Sync config create', () => {
             logContextGetter,
             orchestrator: mockOrchestrator,
             debug,
-            postConnectionScriptsByProvider: []
+            onEventScriptsByProvider: []
         });
 
         expect(emptyConfig).not.toBe([]);
@@ -89,7 +89,7 @@ describe('Sync config create', () => {
             logContextGetter,
             orchestrator: mockOrchestrator,
             debug,
-            postConnectionScriptsByProvider: []
+            onEventScriptsByProvider: []
         });
         expect(error?.message).toBe(
             `There is no Provider Configuration matching this key. Please make sure this value exists in the Nango dashboard {
@@ -215,7 +215,7 @@ describe('Sync config create', () => {
                 logContextGetter,
                 orchestrator: mockOrchestrator,
                 debug,
-                postConnectionScriptsByProvider: []
+                onEventScriptsByProvider: []
             })
         ).rejects.toThrowError('Error creating sync config from a deploy. Please contact support with the sync name and connection details');
     });

--- a/packages/types/lib/deploy/api.ts
+++ b/packages/types/lib/deploy/api.ts
@@ -1,7 +1,7 @@
 import type { JSONSchema7 } from 'json-schema';
 
 import type { Endpoint, ApiError } from '../api.js';
-import type { IncomingFlowConfig, PostConnectionScriptByProvider } from './incomingFlow.js';
+import type { IncomingFlowConfig, OnEventScriptsByProvider } from './incomingFlow.js';
 import type { SyncDeploymentResult } from './index.js';
 
 export type PostDeployConfirmation = Endpoint<{
@@ -9,7 +9,7 @@ export type PostDeployConfirmation = Endpoint<{
     Path: '/sync/deploy/confirmation';
     Body: {
         flowConfigs: IncomingFlowConfig[];
-        postConnectionScriptsByProvider: PostConnectionScriptByProvider[];
+        onEventScriptsByProvider: OnEventScriptsByProvider[];
         reconcile: boolean;
         debug: boolean;
         singleDeployMode?: boolean;
@@ -23,7 +23,7 @@ export type PostDeploy = Endpoint<{
     Path: '/sync/deploy';
     Body: {
         flowConfigs: IncomingFlowConfig[];
-        postConnectionScriptsByProvider: PostConnectionScriptByProvider[];
+        onEventScriptsByProvider: OnEventScriptsByProvider[];
         nangoYamlBody: string;
         reconcile: boolean;
         debug: boolean;
@@ -41,7 +41,7 @@ export type PostDeployInternal = Endpoint<{
     };
     Body: {
         flowConfigs: IncomingFlowConfig[];
-        postConnectionScriptsByProvider: PostConnectionScriptByProvider[];
+        onEventScriptsByProvider: OnEventScriptsByProvider[];
         nangoYamlBody: string;
         reconcile: boolean;
         debug: boolean;

--- a/packages/types/lib/deploy/incomingFlow.ts
+++ b/packages/types/lib/deploy/incomingFlow.ts
@@ -5,14 +5,14 @@ export interface IncomingScriptFiles {
     js: string;
     ts: string;
 }
-export interface IncomingPostConnectionScript {
+export interface IncomingOnEventScript {
     name: string;
     fileBody: IncomingScriptFiles;
 }
 
-export interface PostConnectionScriptByProvider {
+export interface OnEventScriptsByProvider {
     providerConfigKey: string;
-    scripts: IncomingPostConnectionScript[];
+    scripts: IncomingOnEventScript[];
 }
 
 export interface NangoConfigMetadata {

--- a/packages/types/lib/scripts/post-connection/db.ts
+++ b/packages/types/lib/scripts/post-connection/db.ts
@@ -1,6 +1,6 @@
 import type { Timestamps } from '../../db.js';
 
-export interface PostConnectionScript extends Timestamps {
+export interface OnEventScript extends Timestamps {
     id: number;
     config_id: number;
     name: string;


### PR DESCRIPTION
## Describe your changes

See Linear ticket for more context

Nango currently allows users to define a custom script that is
executed when a connection is created.
We want to extend this feature to also make it possible to execute
a custom script when a connection is deleted.
In order to do so we are going to implement a generic solution where a
custom script can be executed based on a Nango event like connection
creation or deletion
This first PR is not introducing any new behaviour but rename the
`post-connection-scripts table` to `on-event-scripts` and adding an event column
where the type of event associated with the script is being stored.
The PR is also renaming things related to the deployment, making sure
the old `postConnectionScriptsByProvider` param sent by old CLI is still
supported for backward compatibility

In next PRs I will:
- rename all things related to postConnnection in the orchestrator/scheduler
- add support for ON_CONNECTION_DELETED event
- refactor CLI to allow definition of both events/scripts

## Issue ticket number and link
https://linear.app/nango/issue/NAN-1962/connect-lifecycle-scripts

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
