### PR TITLE
fix: post-connection-script

### DIFF
--- a/packages/cli/lib/templates/post-connection.ejs
+++ b/packages/cli/lib/templates/post-connection.ejs
@@ -1,5 +1,5 @@
-import type { NangoSync } from '../../<%= interfaceFileName %>';
+import type { NangoAction } from '../../<%= interfaceFileName %>';
 
-export default async function postConnection(nango: NangoSync): Promise<void> {
+export default async function postConnection(nango: NangoAction): Promise<void> {
     // post connection logic goes here
 }

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -18,7 +18,16 @@ export async function exec(
     codeParams?: object,
     abortController: AbortController = new AbortController()
 ): Promise<RunnerOutput> {
-    const rawNango = nangoProps.scriptType === 'action' ? new NangoAction(nangoProps) : new NangoSync(nangoProps);
+    const rawNango = (() => {
+        switch (nangoProps.scriptType) {
+            case 'sync':
+            case 'webhook':
+                return new NangoSync(nangoProps);
+            case 'action':
+            case 'post-connection-script':
+                return new NangoAction(nangoProps);
+        }
+    })();
     const nango = process.env['NANGO_TELEMETRY_SDK'] ? instrumentSDK(rawNango) : rawNango;
     nango.abortSignal = abortController.signal;
 


### PR DESCRIPTION
## Describe your changes
post-connection-script have been failing to execute since the introduction of this change: https://github.com/NangoHQ/nango/pull/2457/files#diff-f52f0d61cd6802499f5a31aca89d3aec3df278a751065390c02b6bbdb24c0840R813-R81 (they don't have a syncId or a syncJobId)
I first thought about removing this check but after reflecting on it I came to the conclusion that post-connection-scripts (soon to become on-event-scripts) should not be `sync` that can save records and should be limited to external side effects like calling some APIs to do some setup/cleanup for instance.

This is a breaking change but I have checked in the db and there is only 2 active post-connection-scripts: one is my own test one and the 2nd one is a customer that is only calling `nango.proxy` and `nango.getMetadata` and anyway those scripts have been failing to execute for the past 4 months so I don't think it is being used.

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
