### PR TITLE
fix(auth): incorrect validation

### DIFF
--- a/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
@@ -1,0 +1,52 @@
+import { seeders } from '@nangohq/shared';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { isSuccess, runServer } from '../../utils/tests.js';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+const endpoint = '/auth/unauthenticated/:providerConfigKey';
+
+describe(`GET ${endpoint}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should create one connection with connection_id', async () => {
+        const env = await seeders.createEnvironmentSeed();
+        const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: env.secret_key,
+            query: { connection_id: 'a', public_key: env.public_key },
+            params: { providerConfigKey: config.unique_key }
+        });
+
+        isSuccess(res);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            connectionId: 'a',
+            providerConfigKey: 'unauthenticated'
+        });
+    });
+
+    it('should create one connection without connection_id', async () => {
+        const env = await seeders.createEnvironmentSeed();
+        const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: env.secret_key,
+            query: { public_key: env.public_key },
+            params: { providerConfigKey: config.unique_key }
+        });
+
+        isSuccess(res);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            connectionId: expect.any(String),
+            providerConfigKey: 'unauthenticated'
+        });
+    });
+});

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -28,6 +28,6 @@ export const connectSessionTokenPrefix = 'nango_connect_session_';
 export const connectSessionTokenSchema = z.string().regex(new RegExp(`^${connectSessionTokenPrefix}[a-f0-9]{64}$`));
 
 export const connectionCredential = z.union([
-    z.object({ public_key: z.string().uuid(), hmac: z.string().optional() }).strict(),
-    z.object({ connect_session_token: connectSessionTokenSchema }).strict()
+    z.object({ public_key: z.string().uuid(), hmac: z.string().optional() }),
+    z.object({ connect_session_token: connectSessionTokenSchema })
 ]);

--- a/packages/types/lib/auth/http.api.ts
+++ b/packages/types/lib/auth/http.api.ts
@@ -24,7 +24,7 @@ export type PostPublicTbaAuthorization = Endpoint<{
     Params: {
         providerConfigKey: string;
     };
-    Path: '/auth/tba';
+    Path: '/auth/tba/:providerConfigKey';
     Error:
         | ApiError<'invalid_body'>
         | ApiError<'invalid_query_params'>
@@ -49,7 +49,7 @@ export type PostPublicTableauAuthorization = Endpoint<{
     Params: {
         providerConfigKey: string;
     };
-    Path: '/auth/tableau';
+    Path: '/auth/tableau/:providerConfigKey';
     Error:
         | ApiError<'invalid_body'>
         | ApiError<'invalid_query_params'>
@@ -79,7 +79,7 @@ export type PostPublicJwtAuthorization = Endpoint<{
     Params: {
         providerConfigKey: string;
     };
-    Path: '/auth/jwt';
+    Path: '/auth/jwt/:providerConfigKey';
     Error:
         | ApiError<'invalid_body'>
         | ApiError<'invalid_query_params'>
@@ -99,7 +99,7 @@ export type PostPublicUnauthenticatedAuthorization = Endpoint<{
     Params: {
         providerConfigKey: string;
     };
-    Path: '/auth/unauthenticated';
+    Path: '/auth/unauthenticated/:providerConfigKey';
     Error:
         | ApiError<'invalid_body'>
         | ApiError<'invalid_query_params'>
@@ -125,7 +125,7 @@ export type PostPublicBillAuthorization = Endpoint<{
     Params: {
         providerConfigKey: string;
     };
-    Path: '/auth/bill';
+    Path: '/auth/bill/:providerConfigKey';
     Error:
         | ApiError<'invalid_body'>
         | ApiError<'invalid_query_params'>
@@ -146,7 +146,7 @@ export type PostPublicTwoStepAuthorization = Endpoint<{
     Params: {
         providerConfigKey: string;
     };
-    Path: '/auth/two-step';
+    Path: '/auth/two-step/:providerConfigKey';
     Error:
         | ApiError<'invalid_body'>
         | ApiError<'invalid_query_params'>
@@ -174,7 +174,7 @@ export type PostPublicSignatureAuthorization = Endpoint<{
     Params: {
         providerConfigKey: string;
     };
-    Path: '/auth/signature-based';
+    Path: '/auth/signature-based/:providerConfigKey';
     Error:
         | ApiError<'invalid_body'>
         | ApiError<'invalid_query_params'>


### PR DESCRIPTION
## Describe your changes

- Fix auth validation
While refactoring auth validation I added `strict` which works weirdly when merging (it add stricts but only on the last object, removing all others objects before 😢 ). It was working with Nango Connect because it doesn't take any other params but when using regular headless it was only allowing `public_key`

- Added one simple integration test to avoid regression

Thanks @hassan254-prog for reporting