### PR TITLE
fix(runner): do not exit the runner process when a sync is cancelled

### DIFF
--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -359,7 +359,7 @@ export declare class NangoAction {
     });
     protected stringify(): string;
     private proxyConfig;
-    protected exitSyncIfAborted(): void;
+    protected throwIfAborted(): void;
     proxy<T = any>(config: ProxyConfiguration): Promise<AxiosResponse<T>>;
     get<T = any>(config: Omit<ProxyConfiguration, 'method'>): Promise<AxiosResponse<T>>;
     post<T = any>(config: Omit<ProxyConfiguration, 'method'>): Promise<AxiosResponse<T>>;

--- a/packages/jobs/lib/execution/operations/output.ts
+++ b/packages/jobs/lib/execution/operations/output.ts
@@ -34,12 +34,6 @@ export async function handleSuccess({ taskId, nangoProps, output }: { taskId: st
 }
 
 export async function handleError({ taskId, nangoProps, error }: { taskId: string; nangoProps: NangoProps; error: RunnerOutputError }): Promise<void> {
-    const formattedError = toNangoError({
-        err: error,
-        defaultErrorType: `${nangoProps.scriptType}_script_failure`,
-        scriptName: nangoProps.syncConfig.sync_name
-    });
-
     if (error.type === 'script_aborted') {
         // do nothing, the script was aborted and its state already updated
         logger.info(`Script was aborted. Ignoring output.`, {
@@ -51,6 +45,12 @@ export async function handleError({ taskId, nangoProps, error }: { taskId: strin
         });
         return;
     }
+
+    const formattedError = toNangoError({
+        err: error,
+        defaultErrorType: `${nangoProps.scriptType}_script_failure`,
+        scriptName: nangoProps.syncConfig.sync_name
+    });
 
     switch (nangoProps.scriptType) {
         case 'sync':

--- a/packages/runner/lib/abort.ts
+++ b/packages/runner/lib/abort.ts
@@ -5,6 +5,7 @@ export const abort = (taskId: string): boolean => {
     const ac = abortControllers.get(taskId);
     if (ac) {
         ac.abort();
+        abortControllers.delete(taskId);
         logger.info('Aborted task', { taskId });
         return true;
     } else {

--- a/packages/shared/lib/models/Runner.ts
+++ b/packages/shared/lib/models/Runner.ts
@@ -1,5 +1,10 @@
+export interface RunnerOutputError {
+    type: string;
+    payload: Record<string, unknown>;
+    status: number;
+}
 export interface RunnerOutput {
     success: boolean;
-    error: { type: string; payload: Record<string, unknown>; status: number } | null;
+    error: RunnerOutputError | null;
     response?: any; // TODO: define response type
 }

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -556,14 +556,14 @@ export class NangoAction {
         };
     }
 
-    protected exitSyncIfAborted(): void {
+    protected throwIfAborted(): void {
         if (this.abortSignal?.aborted) {
-            process.exit(0);
+            throw new NangoError('script_aborted');
         }
     }
 
     public async proxy<T = any>(config: ProxyConfiguration): Promise<AxiosResponse<T>> {
-        this.exitSyncIfAborted();
+        this.throwIfAborted();
         if (!config.method) {
             config.method = 'GET';
         }
@@ -655,12 +655,12 @@ export class NangoAction {
         | TwoStepCredentials
         | SignatureCredentials
     > {
-        this.exitSyncIfAborted();
+        this.throwIfAborted();
         return this.nango.getToken(this.providerConfigKey, this.connectionId);
     }
 
     public async getConnection(providerConfigKeyOverride?: string, connectionIdOverride?: string): Promise<Connection> {
-        this.exitSyncIfAborted();
+        this.throwIfAborted();
 
         const providerConfigKey = providerConfigKeyOverride || this.providerConfigKey;
         const connectionId = connectionIdOverride || this.connectionId;
@@ -678,7 +678,7 @@ export class NangoAction {
     }
 
     public async setMetadata(metadata: Metadata): Promise<AxiosResponse<MetadataChangeResponse>> {
-        this.exitSyncIfAborted();
+        this.throwIfAborted();
         try {
             return await this.nango.setMetadata(this.providerConfigKey, this.connectionId, metadata);
         } finally {
@@ -687,7 +687,7 @@ export class NangoAction {
     }
 
     public async updateMetadata(metadata: Metadata): Promise<AxiosResponse<MetadataChangeResponse>> {
-        this.exitSyncIfAborted();
+        this.throwIfAborted();
         try {
             return await this.nango.updateMetadata(this.providerConfigKey, this.connectionId, metadata);
         } finally {
@@ -704,12 +704,12 @@ export class NangoAction {
     }
 
     public async getMetadata<T = Metadata>(): Promise<T> {
-        this.exitSyncIfAborted();
+        this.throwIfAborted();
         return (await this.getConnection(this.providerConfigKey, this.connectionId)).metadata as T;
     }
 
     public async getWebhookURL(): Promise<string | null | undefined> {
-        this.exitSyncIfAborted();
+        this.throwIfAborted();
         if (this.memoizedIntegration) {
             return this.memoizedIntegration.webhook_url;
         }
@@ -743,7 +743,7 @@ export class NangoAction {
     public async log(message: any, options?: { level?: LogLevel } | { [key: string]: any; level?: never }): Promise<void>;
     public async log(message: string, ...args: [any, { level?: LogLevel }]): Promise<void>;
     public async log(...args: [...any]): Promise<void> {
-        this.exitSyncIfAborted();
+        this.throwIfAborted();
         if (args.length === 0) {
             return;
         }
@@ -972,7 +972,7 @@ export class NangoSync extends NangoAction {
     }
 
     public async batchSave<T = any>(results: T[], model: string): Promise<boolean | null> {
-        this.exitSyncIfAborted();
+        this.throwIfAborted();
 
         if (!results || results.length === 0) {
             if (this.dryRun) {
@@ -1086,7 +1086,7 @@ export class NangoSync extends NangoAction {
     }
 
     public async batchDelete<T = any>(results: T[], model: string): Promise<boolean | null> {
-        this.exitSyncIfAborted();
+        this.throwIfAborted();
         if (!results || results.length === 0) {
             if (this.dryRun) {
                 logger.info('batchDelete received an empty array. No records to delete.');
@@ -1152,7 +1152,7 @@ export class NangoSync extends NangoAction {
     }
 
     public async batchUpdate<T = any>(results: T[], model: string): Promise<boolean | null> {
-        this.exitSyncIfAborted();
+        this.throwIfAborted();
         if (!results || results.length === 0) {
             if (this.dryRun) {
                 logger.info('batchUpdate received an empty array. No records to update.');
@@ -1212,7 +1212,7 @@ export class NangoSync extends NangoAction {
     }
 
     public override async getMetadata<T = Metadata>(): Promise<T> {
-        this.exitSyncIfAborted();
+        this.throwIfAborted();
         if (this.dryRun && this.stubbedMetadata) {
             return this.stubbedMetadata as T;
         }

--- a/packages/shared/lib/sdk/sync.unit.test.ts
+++ b/packages/shared/lib/sdk/sync.unit.test.ts
@@ -501,3 +501,11 @@ describe('Log', () => {
         await nangoAction.log('hello', { foo: 'bar' });
     });
 });
+describe('Aborted script', () => {
+    it('show throw', () => {
+        const ac = new AbortController();
+        const nango = new NangoSync({ ...nangoProps, abortSignal: ac.signal });
+        ac.abort();
+        expect(nango.log('hello')).rejects.toThrowError(new Error('The script was aborted'));
+    });
+});

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -695,6 +695,11 @@ export class NangoError extends Error {
                 this.message = `An error occured while generating an WSSE token`;
                 break;
 
+            case 'script_aborted':
+                this.status = 410;
+                this.message = `The script was aborted`;
+                break;
+
             default:
                 this.status = 500;
                 this.type = 'unhandled_' + type;


### PR DESCRIPTION
## Describe your changes

I think that at some point we were forking/spawning a new subprocess for each script execution. When aborting we will then exit the process. However we don't do that anymore and scripts simply run in a node vm in the same runner process.
This commit modifies the sync sdk so an error is thrown instead of exiting. Jobs then discard this specific error.

## Issue ticket number and link
https://linear.app/nango/issue/NAN-2195/fix-aborting-a-script-kills-the-runner-process

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
