### PR TITLE
feat(server): Add sync errors to connection count

### DIFF
--- a/packages/server/lib/controllers/v1/connections/getConnectionsCount.ts
+++ b/packages/server/lib/controllers/v1/connections/getConnectionsCount.ts
@@ -24,7 +24,7 @@ export const getConnectionsCount = asyncWrapper<GetConnectionsCount>(async (req,
 
     const count = await connectionService.count({ environmentId: environment.id });
     if (count.isErr()) {
-        res.status(200).send({ data: { total: 0, withAuthError: 0 } });
+        res.status(200).send({ data: { total: 0, withAuthError: 0, withSyncError: 0, withError: 0 } });
         return;
     }
 

--- a/packages/shared/lib/services/connection.service.integration.test.ts
+++ b/packages/shared/lib/services/connection.service.integration.test.ts
@@ -245,8 +245,8 @@ describe('Connection service integration tests', () => {
             });
 
             const countResult = await connectionService.count({ environmentId: env.id });
-            expect(countResult.isOk()).toBeTruthy();
             const count = countResult.unwrap();
+
             expect(count.total).toBe(3);
             expect(count.withAuthError).toBe(1);
             expect(count.withSyncError).toBe(1);

--- a/packages/shared/lib/services/connection.service.integration.test.ts
+++ b/packages/shared/lib/services/connection.service.integration.test.ts
@@ -250,6 +250,7 @@ describe('Connection service integration tests', () => {
             expect(count.total).toBe(3);
             expect(count.withAuthError).toBe(1);
             expect(count.withSyncError).toBe(1);
+            expect(count.withError).toBe(2);
         });
     });
 });

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -742,10 +742,14 @@ class ConnectionService {
         return result.map((connection) => encryptionManager.decryptConnection(connection) as Connection);
     }
 
-    public async count({ environmentId }: { environmentId: number }): Promise<Result<{ total: number; withAuthError: number; withSyncError: number }>> {
+    public async count({
+        environmentId
+    }: {
+        environmentId: number;
+    }): Promise<Result<{ total: number; withAuthError: number; withSyncError: number; withError: number }>> {
         const query = db.knex
             .from(`_nango_connections`)
-            .select<{ total_connection: string; with_auth_error: string; with_sync_error: string }>(
+            .select<{ total_connection: string; with_auth_error: string; with_sync_error: string; with_error: string }>(
                 db.knex.raw('COUNT(_nango_connections.*) as total_connection'),
                 db.knex.raw("COUNT(_nango_connections.*) FILTER (WHERE _nango_active_logs.type = 'auth') as with_auth_error"),
                 db.knex.raw("COUNT(_nango_connections.*) FILTER (WHERE _nango_active_logs.type = 'sync') as with_sync_error"),
@@ -764,7 +768,12 @@ class ConnectionService {
             return Err('failed_to_count');
         }
 
-        return Ok({ total: Number(res.total_connection), withAuthError: Number(res.with_auth_error), withSyncError: Number(res.with_sync_error) });
+        return Ok({
+            total: Number(res.total_connection),
+            withAuthError: Number(res.with_auth_error),
+            withSyncError: Number(res.with_sync_error),
+            withError: Number(res.with_error)
+        });
     }
 
     /**

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -31,7 +31,7 @@ export type GetConnectionsCount = Endpoint<{
     };
     Path: '/api/v1/connections/count';
     Success: {
-        data: { total: number; withAuthError: number };
+        data: { total: number; withAuthError: number; withSyncError: number; withError: number };
     };
 }>;
 


### PR DESCRIPTION
## Describe your changes

Adds sync errors to response from connection count so we can show it in the UI

## Issue ticket number and link

https://linear.app/nango/issue/NAN-2168/surface-integrationsconnections-errors-in-nango-ui

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
