### PR TITLE
chore: update pull_request_template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,6 @@
-<!-- Describe your changes --> 
+<!-- Describe the problem and your solution --> 
 
 <!-- Issue ticket number and link (if applicable) -->
 
-<!-- Testing -->
-- [ ] I have tested those changes 
-- [ ] I have added tests (skip if just adding/editing providers)
-
-<!-- Testing instructions (if applicable) -->
+<!-- Testing instructions (skip if just adding/editing providers) -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,10 @@
-## Describe your changes
+<!-- Describe your changes --> 
 
-## Issue ticket number and link
+<!-- Issue ticket number and link (if applicable) -->
 
-## Checklist before requesting a review (skip if just adding/editing APIs & templates)
-- [ ] I added tests, otherwise the reason is: 
-- [ ] I added observability, otherwise the reason is:
-- [ ] I added analytics, otherwise the reason is: 
+<!-- Testing -->
+- [ ] I have tested those changes 
+- [ ] I have added tests (skip if just adding/editing providers)
+
+<!-- Testing instructions (if applicable) -->
+


### PR DESCRIPTION
My take: having a checklist of things that rarely apply is pretty useless. I (and I am sure not the only one) just always ignore the observability and analytics points. I propose this change to focus on the things that matter: description of the changes, testing and ticket. All of them almost always applies.

Also changing to comments so the template instructions don't show once the PR is submitted

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is: not applicable 🤔 
- [ ] I added observability, otherwise the reason is: not applicable 🙄 
- [ ] I added analytics, otherwise the reason is: not applicable 😝 
