### PR TITLE
feat(server): Add missing field hints for integrations to api

### DIFF
--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/getIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/getIntegration.ts
@@ -67,7 +67,8 @@ export const getIntegration = asyncWrapper<GetIntegration>(async (req, res) => {
                 connectionsCount: count,
                 webhookSecret,
                 webhookUrl: provider.webhook_routing_script ? `${getGlobalWebhookReceiveUrl()}/${environment.uuid}/${integration.unique_key}` : null
-            }
+            },
+            missingFields: configService.validateProviderConfig(provider.auth_mode, integration)
         }
     });
 });

--- a/packages/shared/lib/services/config.service.integration.test.ts
+++ b/packages/shared/lib/services/config.service.integration.test.ts
@@ -1,0 +1,79 @@
+import { expect, describe, it } from 'vitest';
+import configService from './config.service';
+
+describe('Config service integration tests', () => {
+    describe('validateProviderConfig', () => {
+        it('should return an error for oauth config with no client id', () => {
+            const maybeError = configService.validateProviderConfig('OAUTH1', {
+                unique_key: 'abc123',
+                provider: 'provider',
+                oauth_client_id: '',
+                oauth_client_secret: 'secret',
+                environment_id: 1,
+                created_at: new Date(),
+                updated_at: new Date()
+            });
+
+            expect(maybeError).toEqual(['oauth_client_id']);
+        });
+
+        it('should return an error for oauth config with no client secret', () => {
+            const maybeError = configService.validateProviderConfig('OAUTH1', {
+                unique_key: 'abc123',
+                provider: 'provider',
+                oauth_client_id: 'client',
+                oauth_client_secret: '',
+                environment_id: 1,
+                created_at: new Date(),
+                updated_at: new Date()
+            });
+
+            expect(maybeError).toEqual(['oauth_client_secret']);
+        });
+
+        it('should return an error for app config with no client id', () => {
+            const maybeError = configService.validateProviderConfig('APP', {
+                unique_key: 'abc123',
+                provider: 'provider',
+                oauth_client_id: '',
+                oauth_client_secret: 'secret',
+                app_link: 'link',
+                environment_id: 1,
+                created_at: new Date(),
+                updated_at: new Date()
+            });
+
+            expect(maybeError).toEqual(['oauth_client_id']);
+        });
+
+        it('should return an error for app config with no client secret', () => {
+            const maybeError = configService.validateProviderConfig('APP', {
+                unique_key: 'abc123',
+                provider: 'provider',
+                oauth_client_id: 'id',
+                oauth_client_secret: '',
+                app_link: 'link',
+                environment_id: 1,
+                created_at: new Date(),
+                updated_at: new Date()
+            });
+
+            expect(maybeError).toEqual(['oauth_client_secret']);
+        });
+
+        it('should return an error for app config with no app link', () => {
+            const maybeError = configService.validateProviderConfig('APP', {
+                unique_key: 'abc123',
+                provider: 'provider',
+                oauth_client_id: 'id',
+                oauth_client_secret: 'secret',
+                app_link: '',
+                environment_id: 1,
+                created_at: new Date(),
+                updated_at: new Date()
+            });
+
+            expect(maybeError).toEqual(['app_link']);
+        });
+    });
+});

--- a/packages/shared/lib/services/config.service.ts
+++ b/packages/shared/lib/services/config.service.ts
@@ -8,6 +8,7 @@ import syncManager from './sync/manager.service.js';
 import { deleteSyncFilesForConfig, deleteByConfigId as deleteSyncConfigByConfigId } from '../services/sync/config/config.service.js';
 import environmentService from '../services/environment.service.js';
 import type { Orchestrator } from '../clients/orchestrator.js';
+import type { AuthModeType } from '@nangohq/types';
 
 class ConfigService {
     async getById(id: number): Promise<ProviderConfig | null> {
@@ -72,6 +73,51 @@ class ConfigService {
         }
 
         return encryptionManager.decryptProviderConfig(result);
+    }
+
+    validateProviderConfig(authMode: AuthModeType, providerConfig: ProviderConfig): string[] {
+        const missingFields = [];
+
+        switch (authMode) {
+            case 'OAUTH1':
+            case 'OAUTH2':
+            case 'TBA':
+                if (providerConfig.oauth_client_id === '') {
+                    missingFields.push('oauth_client_id');
+                }
+
+                if (providerConfig.oauth_client_secret === '') {
+                    missingFields.push('oauth_client_secret');
+                }
+                break;
+
+            case 'APP':
+                if (providerConfig.oauth_client_id === '') {
+                    missingFields.push('oauth_client_id');
+                }
+
+                if (providerConfig.oauth_client_secret === '') {
+                    missingFields.push('oauth_client_secret');
+                }
+
+                if (providerConfig.app_link === '') {
+                    missingFields.push('app_link');
+                }
+                break;
+
+            case 'CUSTOM':
+                break;
+
+            case 'BASIC':
+            case 'API_KEY':
+            case 'APP_STORE':
+            case 'TABLEAU':
+            case 'NONE':
+            case 'OAUTH2_CC':
+                break;
+        }
+
+        return missingFields;
     }
 
     async listProviderConfigs(environment_id: number): Promise<ProviderConfig[]> {

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -72,6 +72,7 @@ export type GetIntegration = Endpoint<{
                 webhookUrl: string | null;
                 webhookSecret: string | null;
             };
+            missingFields: string[];
         };
     };
 }>;


### PR DESCRIPTION
## Describe your changes

Adds a new function to `configService` called `validateProviderConfig` that returns a set of missing fields for the given auth type and provider config. Also updates the api to return those missing fields in our payload for `/api/v1/integrations/:providerId` so that we can display a warning about unfilled fields.

This PR only updates the API, it doesn't handle the fields in the UI yet.

At present it's not handling the CUSTOM auth method because there's some code weirdness I'm digging into there and that auth method is only used for one provider, so it's not too big a deal to keep moving forward and backfill it later.

## Issue ticket number and link

https://linear.app/nango/issue/NAN-2168/surface-integrationsconnections-errors-in-nango-ui

## How I Tested This

I wrote tests for the validation bits, but I also did a quick check in inspector to ensure it's sending the new data over the API correctly.

- I went to the integration page for a specific integration.
- Opened inspector.
- Found the integration's request.
- Visually confirmed that it's being returned over the API.
