### PR TITLE
fix(webapp): Layout bug on app integration settings page

### DIFF
--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/App.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/App.tsx
@@ -40,7 +40,7 @@ export const SettingsApp: React.FC<{ data: GetIntegration['Success']['data']; en
     };
 
     return (
-        <div className="mt-10 flex gap-10">
+        <div className="mt-10 flex flex-col gap-10">
             {environment.callback_url && (
                 <InfoBloc
                     title="Setup URL"


### PR DESCRIPTION
Noticed this while working on integration errors.

Before:

<img width="1381" alt="Screenshot 2024-11-22 at 7 36 27 AM" src="https://github.com/user-attachments/assets/29d1a422-568b-4d96-9698-02d51d92f0bf">

And after:

<img width="1381" alt="Screenshot 2024-11-22 at 7 40 33 AM" src="https://github.com/user-attachments/assets/d5d74452-9fdb-4083-913b-98046fe0d668">


## To test:

Go to http://localhost:3000/dev/integrations/github-app/settings

