### PR TITLE
fix(webapp): Show separate icons for connection error types

### DIFF
--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -25,7 +25,6 @@ import { Skeleton } from '../../components/ui/Skeleton';
 import type { ColumnDef } from '@tanstack/react-table';
 import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import IntegrationLogo from '../../components/ui/IntegrationLogo';
-import type { ErrorCircleIcon } from '../../components/ErrorCircle';
 import { ErrorCircle } from '../../components/ErrorCircle';
 import Spinner from '../../components/ui/Spinner';
 import { AvatarOrganization } from '../../components/AvatarCustom';
@@ -62,19 +61,6 @@ const columns: ColumnDef<ApiConnectionSimple>[] = [
                 { auth: 0, sync: 0 }
             );
 
-            let errorTooltip = '';
-            let errorIcon: ErrorCircleIcon = '!';
-            if (errorCounts.auth > 0 && errorCounts.sync > 0) {
-                errorTooltip = 'Expired credentials, failed syncs';
-                errorIcon = '!';
-            } else if (errorCounts.auth > 0) {
-                errorTooltip = 'Expired credentials';
-                errorIcon = 'auth';
-            } else if (errorCounts.sync > 0) {
-                errorTooltip = 'Failed syncs';
-                errorIcon = 'sync';
-            }
-
             return (
                 <div className="flex gap-3 items-center">
                     <AvatarOrganization
@@ -94,9 +80,15 @@ const columns: ColumnDef<ApiConnectionSimple>[] = [
                     ) : (
                         <span className="break-words break-all truncate">{data.connection_id}</span>
                     )}
-                    {data.errors.length > 0 && (
-                        <SimpleTooltip tooltipContent={errorTooltip}>
-                            <ErrorCircle icon={errorIcon} />
+                    {errorCounts.auth > 0 && (
+                        <SimpleTooltip tooltipContent="Expired credentials">
+                            <ErrorCircle icon="auth" />
+                        </SimpleTooltip>
+                    )}
+
+                    {errorCounts.sync > 0 && (
+                        <SimpleTooltip tooltipContent="Failed syncs">
+                            <ErrorCircle icon="sync" />
                         </SimpleTooltip>
                     )}
                 </div>


### PR DESCRIPTION
I was thinking it made more sense to unify the connection error icons when it was multiple types to help with visual consistency, but that was completely against the spirit of the design update, so this fixes it to be what it was supposed to be from the start:

<img width="250" alt="Screenshot 2024-11-22 at 10 17 19 AM" src="https://github.com/user-attachments/assets/74580d99-fb15-430e-a968-1838f2ec8582">

https://linear.app/nango/issue/NAN-2168/surface-integrationsconnections-errors-in-nango-ui

To test:

- get some connections into the various error states and then review

