### PR TITLE
fix: acquireTimeoutMillis to equal statement timeout

### DIFF
--- a/packages/database/lib/getConfig.ts
+++ b/packages/database/lib/getConfig.ts
@@ -20,7 +20,7 @@ export function getDbConfig({ timeoutMs }: { timeoutMs: number }): Knex.Config {
         pool: {
             min: parseInt(process.env['NANGO_DB_POOL_MIN'] || '0'),
             max: parseInt(process.env['NANGO_DB_POOL_MAX'] || '30'),
-            acquireTimeoutMillis: 20000,
+            acquireTimeoutMillis: timeoutMs,
             createTimeoutMillis: 10000
         },
         // SearchPath needs the current db and public because extension can only be installed once per DB


### PR DESCRIPTION
'acquire connection timeout' lower than 'statement timeout' could lead to query timing out  because they cannot acquire a connection before a long running query has the chance to return/timeout

This is not solving any issue with connection leaks but could prevent cascading failures when it happens.
There is also an open question about the duration of the timeout which is 60s (too long) for the moment but that's for another PR 😄 

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

