### PR TITLE
fix: db pool acquireTimeoutMillis cannot be zero

### DIFF
--- a/packages/database/lib/getConfig.ts
+++ b/packages/database/lib/getConfig.ts
@@ -20,7 +20,7 @@ export function getDbConfig({ timeoutMs }: { timeoutMs: number }): Knex.Config {
         pool: {
             min: parseInt(process.env['NANGO_DB_POOL_MIN'] || '0'),
             max: parseInt(process.env['NANGO_DB_POOL_MAX'] || '30'),
-            acquireTimeoutMillis: timeoutMs,
+            acquireTimeoutMillis: timeoutMs || 30000,
             createTimeoutMillis: 10000
         },
         // SearchPath needs the current db and public because extension can only be installed once per DB


### PR DESCRIPTION
for migration we don't enforce any timeout (ie: timeout = 0) but acquireTimeoutMillis cannot be zero.
This commit specify a default value if timeout = 0

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

