### PR TITLE
docs: add docs for on-events scripts

### DIFF
--- a/docs-v2/mint.json
+++ b/docs-v2/mint.json
@@ -143,6 +143,7 @@
                         "understand/concepts/syncs",
                         "understand/concepts/actions",
                         "understand/concepts/webhooks",
+                        "understand/concepts/events",
                         "understand/concepts/proxy",
                         "understand/concepts/environments"
                     ]

--- a/docs-v2/reference/integration-configuration.mdx
+++ b/docs-v2/reference/integration-configuration.mdx
@@ -48,6 +48,12 @@ integrations:
           - scope1
           - scope2
 
+    on-events:
+        post-connection-creation:
+            - setup
+            - moreSetup
+        pre-connection-deletion:
+            - cleanup
 
 models:
   AsanaTask: # Schema for sync output AND action input/output.
@@ -72,6 +78,10 @@ Integration configuration fields are under `integrations.<INTEGRATION-ID>`.
 
 <ResponseField name="actions" type="object">
     Lists the actions for a given integration.
+</ResponseField>
+
+<ResponseField name="on-events" type="object">
+    Lists the events and scripts executed when those events occur.
 </ResponseField>
 
 ### Sync fields
@@ -218,9 +228,39 @@ Action configuration fields are under `integrations.<INTEGRATION-ID>.actions.<AC
     Defaults to no scope.
 </ResponseField>
 
-# Model types
+### On-Events fields
 
-The `models` section contains the schemas referenced in the inputs & outputs of the above `integrations` section.
+`on-events` configuration fields are under `integrations.<INTEGRATION-ID>.on-events.<EVENT-NAME>`.
+
+<Tip>
+    Nango currently supports the following events:
+    - post-connection-creation
+    - pre-connection-deletion
+</Tip>
+
+<ResponseField name="post-connection-creation" type="string[]">
+    Lists the scripts to execute after a new connection is created.
+
+    Example:
+    ```yaml
+    on-events:
+      post-connection-creation:
+        - setup
+        - initialize-webhooks
+    ```
+</ResponseField>
+
+<ResponseField name="pre-connection-deletion" type="string[]">
+    Lists the scripts to execute before a connection is deleted.
+
+    Example:
+    ```yaml
+    on-events:
+      pre-connection-deletion:
+        - cleanup
+        - remove-webhooks
+    ```
+</ResponseField>
 
 ### Basic types
 

--- a/docs-v2/understand/concepts/events.mdx
+++ b/docs-v2/understand/concepts/events.mdx
@@ -1,0 +1,43 @@
+---
+title: 'Event-based scripts'
+sidebarTitle: 'Events'
+description: 'Learn more about event-based scripts.'
+---
+
+# Overview
+...
+
+# Use cases
+...
+
+# Main characteristics
+
+## Supported events
+...
+
+## Triggers
+...
+
+## No input or output
+...
+
+# Scripts
+Event-bassed executions are powered by [integration scripts](/understand/concepts/scripts) that encapsulate the logic for interfacing with external APIs. While Nango provides [script templates](understand/concepts/templates) for common use cases, there's also support for custom scripting to meet specific integration needs.
+
+Scripts have the following structure:
+
+```typescript
+import type { NangoAction } from '../../models';
+
+export default async function onEvent(nango: NangoAction): Promise<void> {
+    // Your integration code goes here.
+}
+```
+
+The `onEvent` function kicks off when the event the script is associated to is triggered.
+
+Event-based scripts focus solely on immediate tasks without persisting data to Nango's cache, thus calls to `nango.batchSave()`, `nango.batchUpdate()`, and `nango.batchDelete()` are not applicable. However, scripts can call actions, enabling complex workflows through the composition of multiple actions.
+
+<Tip>
+**Questions, problems, feedback?** Please reach out in the [Slack community](https://nango.dev/slack).
+</Tip>

--- a/docs-v2/understand/concepts/events.mdx
+++ b/docs-v2/understand/concepts/events.mdx
@@ -5,21 +5,42 @@ description: 'Learn more about event-based scripts.'
 ---
 
 # Overview
-...
+Nango events are specific occurrences within the Nango system that can trigger custom actions. These events allow you to execute integration scripts in response to particular situations, enabling more dynamic and responsive integrations.
+
+# Types of Nango Events
+
+Nango currently supports the following events:
+- `post-connection-creation` occurs when a connection has been created.
+- `pre-connection-deletion` occurs before a connection is deleted.
 
 # Use cases
-...
+Event-based scripts are particularly useful for:
+1. __Connection setup__. Ex:
+    - Setting up webhooks with the external service.
+    - Creating default resources or configurations.
+2. __Cleanup operations__. Ex:
+    - Removing webhooks from external services.
+    - Notifying external systems about the connection termination.
+    - Cleaning up associated resources.
 
 # Main characteristics
 
-## Supported events
-...
+## Trigger
+Event-based Scripts are __automatically__ triggered by Nango:
+    - They execute immediately when the event occurs.
+    - No manual intervention is required.
+    - They cannot be scheduled or delayed.
+    - Events are triggered exactly once per occurrence.
+    - Their executions are logged and can be monitored.
 
-## Triggers
-...
-
-## No input or output
-...
+## Constraints
+Event-based scripts operate under specific __constraints__:
+    - They cannot save, update or delete records.
+    - They focus on side effects and external system interactions.
+    - They can make API calls to external systems.
+    - They can read existing connection data.
+    - They can log information for monitoring.
+    - They can modify external resource states.
 
 # Scripts
 Event-bassed executions are powered by [integration scripts](/understand/concepts/scripts) that encapsulate the logic for interfacing with external APIs. While Nango provides [script templates](understand/concepts/templates) for common use cases, there's also support for custom scripting to meet specific integration needs.
@@ -34,9 +55,9 @@ export default async function onEvent(nango: NangoAction): Promise<void> {
 }
 ```
 
-The `onEvent` function kicks off when the event the script is associated to is triggered.
+The `onEvent` function kicks off when the event the script is associated to occurs.
 
-Event-based scripts focus solely on immediate tasks without persisting data to Nango's cache, thus calls to `nango.batchSave()`, `nango.batchUpdate()`, and `nango.batchDelete()` are not applicable. However, scripts can call actions, enabling complex workflows through the composition of multiple actions.
+Event-based scripts focus solely on immediate tasks. Calls to `nango.batchSave()`, `nango.batchUpdate()`, and `nango.batchDelete()` are not applicable. However, scripts can call actions, enabling complex workflows through the composition of multiple actions.
 
 <Tip>
 **Questions, problems, feedback?** Please reach out in the [Slack community](https://nango.dev/slack).

--- a/docs-v2/understand/concepts/scripts.mdx
+++ b/docs-v2/understand/concepts/scripts.mdx
@@ -10,11 +10,12 @@ Scripts are a key differentiator of Nango, enabling you to customize interaction
 
 # Types of integration scripts
 
-You can use three main types of integration scripts in Nango:
+You can use four main types of integration scripts in Nango:
 
 - **[Syncs](/understand/concepts/syncs):** Synchronize data from external APIs into your application automatically.
 - **[Actions](/understand/concepts/actions):** Perform specific tasks with an external API, like creating a contact.
 - **[Webhooks](/understand/concepts/webhooks):** Manage incoming webhooks for immediate updates from external APIs.
+- **[Event-based](/understand/concepts/events):** Execute specific tasks when some Nango events occurs.
 
 # Integration script execution & management
 
@@ -60,7 +61,7 @@ We will build support for both as soon as possible.
 The `nango.yaml` file is where you'll define your integration configurations. This crucial file outlines:
 
 - The integrations your app connects to.
-- The actions, syncs, and webhooks involved in these integrations.
+- The actions, syncs, webhooks and event-based scripts involved in these integrations.
 - The input and output models for each action, sync, and webhook.
 
 ### Configuration details


### PR DESCRIPTION
- Update integration configuration doc page to describe `on-events` syntax in nango.yaml
- Adds a concept page to the docs to explain `on-events` scripts

<!-- Issue ticket number and link (if applicable) -->
https://linear.app/nango/issue/NAN-2219/on-events-script-follow-up

<!-- Testing instructions (skip if just adding/editing providers) -->
How to test: `npm run docs`
