### PR TITLE
fix: improve on-events script logs

### DIFF
--- a/packages/logs/lib/models/helpers.ts
+++ b/packages/logs/lib/models/helpers.ts
@@ -140,7 +140,8 @@ export const operationTypeToMessage: Record<ConcatOperationList, string> = {
     'sync:unpause': 'Sync schedule started',
     'webhook:incoming': 'Received a webhook',
     'webhook:forward': 'Forwarding Webhook',
-    'events:run': 'On-event script execution'
+    'events:post_connection_creation': 'Post connection creation script execution',
+    'events:pre_connection_deletion': 'Pre connection creation script execution'
 };
 
 /**

--- a/packages/logs/lib/models/helpers.ts
+++ b/packages/logs/lib/models/helpers.ts
@@ -13,7 +13,7 @@ export interface FormatMessageData {
     environment?: { id: number; name: string } | undefined;
     connection?: { id: number; name: string } | undefined;
     integration?: { id: number; name: string; provider: string } | undefined;
-    syncConfig?: { id: number; name: string } | undefined;
+    syncConfig?: { id: number; name: string } | undefined; // TODO: rename to script or something similar because it also apply to actions and on-events scripts
     meta?: MessageRow['meta'];
 }
 

--- a/packages/logs/lib/models/helpers.ts
+++ b/packages/logs/lib/models/helpers.ts
@@ -125,7 +125,6 @@ export const operationTypeToMessage: Record<ConcatOperationList, string> = {
     'action:run': 'Action execution',
     'admin:impersonation': 'Admin logged into another account',
     'auth:create_connection': 'Create connection',
-    'auth:delete_connection': 'Delete connection',
     'auth:post_connection': 'post connection execution',
     'auth:refresh_token': 'Token refresh',
     'auth:connection_test': 'Connection test',
@@ -140,7 +139,8 @@ export const operationTypeToMessage: Record<ConcatOperationList, string> = {
     'sync:run': 'Sync execution',
     'sync:unpause': 'Sync schedule started',
     'webhook:incoming': 'Received a webhook',
-    'webhook:forward': 'Forwarding Webhook'
+    'webhook:forward': 'Forwarding Webhook',
+    'events:run': 'On-event script execution'
 };
 
 /**

--- a/packages/logs/lib/otlp/otlpSpan.ts
+++ b/packages/logs/lib/otlp/otlpSpan.ts
@@ -105,5 +105,8 @@ function shouldTrace(operation: OperationRow): boolean {
     if (operation.operation.type === 'webhook') {
         return true;
     }
+    if (operation.operation.type === 'events') {
+        return true;
+    }
     return false;
 }

--- a/packages/server/lib/controllers/v1/logs/searchOperations.ts
+++ b/packages/server/lib/controllers/v1/logs/searchOperations.ts
@@ -18,6 +18,7 @@ const validation = z
                     'all',
                     'action',
                     'sync',
+                    'events',
                     'sync:init',
                     'sync:cancel',
                     'sync:pause',

--- a/packages/server/lib/hooks/connection/on/connection-created.ts
+++ b/packages/server/lib/hooks/connection/on/connection-created.ts
@@ -31,7 +31,7 @@ export async function postConnectionCreation(
         const { name, file_location: fileLocation, version } = script;
 
         const logCtx = await logContextGetter.create(
-            { operation: { type: 'events', action: 'run' }, expiresAt: defaultOperationExpiration.action() },
+            { operation: { type: 'events', action: 'post_connection_creation' }, expiresAt: defaultOperationExpiration.action() },
             {
                 account,
                 environment,

--- a/packages/server/lib/hooks/connection/on/connection-created.ts
+++ b/packages/server/lib/hooks/connection/on/connection-created.ts
@@ -1,6 +1,7 @@
 import type { RecentlyCreatedConnection } from '@nangohq/shared';
 import { onEventScriptService } from '@nangohq/shared';
 import type { LogContextGetter } from '@nangohq/logs';
+import { defaultOperationExpiration } from '@nangohq/logs';
 import { getOrchestrator } from '../../../utils/utils.js';
 
 export async function postConnectionCreation(
@@ -18,26 +19,28 @@ export async function postConnectionCreation(
         return;
     }
 
-    const postConnectionCreationScripts = await onEventScriptService.getByConfig(config_id, 'post-connection-creation');
+    const event = 'post-connection-creation';
+
+    const postConnectionCreationScripts = await onEventScriptService.getByConfig(config_id, event);
 
     if (postConnectionCreationScripts.length === 0) {
         return;
     }
 
-    const logCtx = await logContextGetter.create(
-        { operation: { type: 'auth', action: 'post_connection' } },
-        {
-            account,
-            environment,
-            integration: { id: config_id, name: connection.provider_config_key, provider },
-            connection: { id: connection.id, name: connection.connection_id }
-        }
-    );
-
-    let failed = false;
     for (const script of postConnectionCreationScripts) {
         const { name, file_location: fileLocation, version } = script;
 
+        const logCtx = await logContextGetter.create(
+            { operation: { type: 'events', action: 'run' }, expiresAt: defaultOperationExpiration.action() },
+            {
+                account,
+                environment,
+                integration: { id: config_id, name: connection.provider_config_key, provider: provider },
+                connection: { id: connection.id, name: connection.connection_id },
+                syncConfig: { id: script.id, name: script.name },
+                meta: { event }
+            }
+        );
         const res = await getOrchestrator().triggerOnEventScript({
             connection: createdConnection.connection,
             version,
@@ -46,13 +49,9 @@ export async function postConnectionCreation(
             logCtx
         });
         if (res.isErr()) {
-            failed = true;
+            await logCtx.failed();
+        } else {
+            await logCtx.success();
         }
-    }
-
-    if (failed) {
-        await logCtx.failed();
-    } else {
-        await logCtx.success();
     }
 }

--- a/packages/server/lib/hooks/connection/on/connection-deleted.ts
+++ b/packages/server/lib/hooks/connection/on/connection-deleted.ts
@@ -32,7 +32,7 @@ export async function preConnectionDeletion({
         const { name, file_location: fileLocation, version } = script;
 
         const logCtx = await logContextGetter.create(
-            { operation: { type: 'events', action: 'run' }, expiresAt: defaultOperationExpiration.action() },
+            { operation: { type: 'events', action: 'pre_connection_deletion' }, expiresAt: defaultOperationExpiration.action() },
             {
                 account: team,
                 environment: environment,

--- a/packages/server/lib/hooks/connection/on/connection-deleted.ts
+++ b/packages/server/lib/hooks/connection/on/connection-deleted.ts
@@ -1,5 +1,6 @@
 import { configService, onEventScriptService } from '@nangohq/shared';
 import type { LogContextGetter } from '@nangohq/logs';
+import { defaultOperationExpiration } from '@nangohq/logs';
 import { getOrchestrator } from '../../../utils/utils.js';
 import type { DBTeam, DBEnvironment, Connection } from '@nangohq/types';
 
@@ -17,26 +18,30 @@ export async function preConnectionDeletion({
     if (!connection.config_id || !connection.id) {
         return;
     }
-    const preConnectionDeletionScripts = await onEventScriptService.getByConfig(connection.config_id, 'pre-connection-deletion');
+
+    const event = 'pre-connection-deletion';
+    const preConnectionDeletionScripts = await onEventScriptService.getByConfig(connection.config_id, event);
 
     if (preConnectionDeletionScripts.length === 0) {
         return;
     }
 
     const provider = await configService.getProviderName(connection.provider_config_key);
-    const logCtx = await logContextGetter.create(
-        { operation: { type: 'auth', action: 'delete_connection' } },
-        {
-            account: team,
-            environment: environment,
-            integration: { id: connection.config_id, name: connection.provider_config_key, provider: provider || 'unknown' },
-            connection: { id: connection.id, name: connection.connection_id }
-        }
-    );
 
-    let failed = false;
     for (const script of preConnectionDeletionScripts) {
         const { name, file_location: fileLocation, version } = script;
+
+        const logCtx = await logContextGetter.create(
+            { operation: { type: 'events', action: 'run' }, expiresAt: defaultOperationExpiration.action() },
+            {
+                account: team,
+                environment: environment,
+                integration: { id: connection.config_id, name: connection.provider_config_key, provider: provider || 'unknown' },
+                connection: { id: connection.id, name: connection.connection_id },
+                syncConfig: { id: script.id, name: script.name },
+                meta: { event }
+            }
+        );
 
         const res = await getOrchestrator().triggerOnEventScript({
             connection,
@@ -46,13 +51,9 @@ export async function preConnectionDeletion({
             logCtx
         });
         if (res.isErr()) {
-            failed = true;
+            await logCtx.failed();
+        } else {
+            await logCtx.success();
         }
-    }
-
-    if (failed) {
-        await logCtx.failed();
-    } else {
-        await logCtx.success();
     }
 }

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -46,7 +46,7 @@ export interface OperationAction {
 
 export interface OperationOnEvents {
     type: 'events';
-    action: 'run';
+    action: 'post_connection_creation' | 'pre_connection_deletion';
 }
 
 // TODO: rename to OperationConnection

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -43,10 +43,16 @@ export interface OperationAction {
     type: 'action';
     action: 'run';
 }
+
+export interface OperationOnEvents {
+    type: 'events';
+    action: 'run';
+}
+
 // TODO: rename to OperationConnection
 export interface OperationAuth {
     type: 'auth';
-    action: 'create_connection' | 'delete_connection' | 'refresh_token' | 'post_connection' | 'connection_test';
+    action: 'create_connection' | 'refresh_token' | 'post_connection' | 'connection_test';
 }
 export interface OperationAdmin {
     type: 'admin';
@@ -60,7 +66,15 @@ export interface OperationDeploy {
     type: 'deploy';
     action: 'prebuilt' | 'custom';
 }
-export type OperationList = OperationSync | OperationProxy | OperationAction | OperationWebhook | OperationDeploy | OperationAuth | OperationAdmin;
+export type OperationList =
+    | OperationSync
+    | OperationProxy
+    | OperationAction
+    | OperationWebhook
+    | OperationOnEvents
+    | OperationDeploy
+    | OperationAuth
+    | OperationAdmin;
 
 /**
  * Full schema

--- a/packages/webapp/src/pages/Logs/constants.tsx
+++ b/packages/webapp/src/pages/Logs/constants.tsx
@@ -106,6 +106,7 @@ export const typesOptions = [
         ]
     },
     { value: 'action', name: 'Action' },
+    { value: 'events', name: 'Events' },
     { value: 'proxy', name: 'Proxy' },
     { value: 'deploy', name: 'Deploy' },
     { value: 'auth', name: 'Auth' },


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
- each scripts has its own logs operation
- can filter by `Type = Events`

![Screenshot 2024-11-22 at 16 36 59](https://github.com/user-attachments/assets/dd9a33e3-36b2-43bb-8c5b-bbad53b8eec5)

<!-- Issue ticket number and link (if applicable) -->
https://linear.app/nango/issue/NAN-2219/on-events-script-follow-up

<!-- Testing instructions (skip if just adding/editing providers) -->
### How to tests:
1. Set `on-events` scripts in your nango.yaml
```
        on-events:
            post-connection-creation:
                - setup
            pre-connection-deletion:
                - cleanup

```
2. run `nango generate` and modify the scripts
3. run `nango deploy dev`
4. Go to the dashboard and create/delete a connection for the integration you added the scripts into
5. Check the logs

