### PR TITLE
fix: not using setInterval for otlp export config refresh

### DIFF
--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -35,6 +35,7 @@ try {
         logger.info('Closing...');
         clearTimeout(healthCheck);
         processor.stop();
+        otlp.stop();
         await db.knex.destroy();
         srv.close(() => {
             process.exit();


### PR DESCRIPTION
We want to make sure no more than one updateRoutes occurs simultaneously.

Logs seems to indicate that otlp.updateRoutes was running multiple times concurrently on jobs service.
This commit gets rid of `setInterval` in favor of a simple loop with sleep

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

