### PR TITLE
fix(runner): Remove setInterval from providers reload

### DIFF
--- a/packages/shared/lib/services/providers.ts
+++ b/packages/shared/lib/services/providers.ts
@@ -6,6 +6,7 @@ import { NangoError } from '../utils/error.js';
 import { dirname } from '../utils/utils.js';
 import { getLogger, ENVS, parseEnvs } from '@nangohq/utils';
 import { createHash } from 'node:crypto';
+import { setTimeout } from 'node:timers/promises';
 
 const logger = getLogger('providers');
 
@@ -62,7 +63,7 @@ async function pollProviders() {
     const reloadInterval = envs.PROVIDERS_RELOAD_INTERVAL;
 
     while (polling) {
-        await new Promise((resolve) => setTimeout(resolve, reloadInterval));
+        await setTimeout(reloadInterval);
 
         try {
             const providersRaw = await fetchProvidersRaw(providersUrl);

--- a/packages/shared/lib/services/providers.ts
+++ b/packages/shared/lib/services/providers.ts
@@ -43,7 +43,6 @@ export async function monitorProviders(): Promise<() => void> {
     logger.info(`Providers loaded from url ${providersUrl} (${providersHash})`);
 
     let running = true;
-    logger.debug(reloadInterval);
     void (async function () {
         while (running) {
             await new Promise((resolve) => setTimeout(resolve, reloadInterval));


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
`setInterval` can cause problems because it doesn't ensure that multiple callbacks don't run at the same time. This removes `setInterval` from provider reloading.

Note: I'm not sure if it's worth it in this case to deploy runners or just wait until we deploy them next time.

<!-- Issue ticket number and link (if applicable) -->

See https://linear.app/nango/issue/NAN-2245/fix-do-not-use-setinterval



<!-- Testing instructions (skip if just adding/editing providers) -->


## How I tested it:

- Make sure a runner has started
- Edit the providers.yaml
- Wait for the reloadInterval (60s by default) to ensure you get a message that it was updated

