### PR TITLE
fix(sdk): remove axiosError.config to avoid huge payload

### DIFF
--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -4,7 +4,7 @@ import type { AdminAxiosProps } from '@nangohq/node';
 import paginateService from '../services/paginate.service.js';
 import proxyService from '../services/proxy.service.js';
 import type { AxiosInstance, AxiosInterceptorManager, AxiosRequestConfig } from 'axios';
-import axios, { AxiosError } from 'axios';
+import axios, { AxiosError, isAxiosError } from 'axios';
 import { getPersistAPIUrl } from '../utils/utils.js';
 import type { UserProvidedProxyConfiguration } from '../models/Proxy.js';
 import {
@@ -594,6 +594,10 @@ export class NangoAction {
                     await this.sendLogToPersist(log);
                 })
             );
+            if (isAxiosError(response)) {
+                // remove axiosError.config to avoid huge payload/logs
+                delete response.config;
+            }
 
             if (response instanceof Error) {
                 throw response;


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
When proxying in a script fails, the axiosError being thrown and potentially returned by the runner could be huge. Jobs then struggle to deserialize this huge output from the runner.
This commit removes the axiosError.config before throwing it so we avoid huge runner output payload and logs

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

