### PR TITLE
fix(authorization): authorization url encoding

### DIFF
--- a/packages/shared/lib/clients/oauth2.client.ts
+++ b/packages/shared/lib/clients/oauth2.client.ts
@@ -18,8 +18,8 @@ export function getSimpleOAuth2ClientConfig(
     connectionConfig: Record<string, string>
 ): Merge<ModuleOptions, { http: WreckHttpOptions }> {
     const templateTokenUrl = typeof provider.token_url === 'string' ? provider.token_url : (provider.token_url!['OAUTH2'] as string);
-    const tokenUrl = makeUrl(templateTokenUrl, connectionConfig, provider.token_url_encode);
-    const authorizeUrl = makeUrl(provider.authorization_url!, connectionConfig, provider.authorization_url_encode);
+    const tokenUrl = makeUrl(templateTokenUrl, connectionConfig, provider.token_url_skip_encode);
+    const authorizeUrl = makeUrl(provider.authorization_url!, connectionConfig, provider.authorization_url_skip_encode);
 
     const headers = { 'User-Agent': 'Nango' };
 
@@ -157,9 +157,9 @@ export async function getFreshOAuth2Credentials(
     }
 }
 
-function makeUrl(template: string, config: Record<string, any>, encodeAllParams = true): URL {
+function makeUrl(template: string, config: Record<string, any>, skipEncodeKeys: string[] = []): URL {
     const cleanTemplate = template.replace(/connectionConfig\./g, '');
-    const encodedParams = encodeAllParams ? encodeParameters(config) : config;
+    const encodedParams = skipEncodeKeys.includes('base_url') ? config : encodeParameters(config);
     const interpolatedUrl = interpolateString(cleanTemplate, encodedParams);
     return new URL(interpolatedUrl);
 }

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -2591,7 +2591,8 @@ github-app-oauth:
     alias: github
     auth_mode: CUSTOM
     authorization_url: ${connectionConfig.appPublicLink}/installations/new
-    authorization_url_encode: false
+    authorization_url_skip_encode:
+        - base_url
     token_url:
         OAUTH2: https://github.com/login/oauth/access_token
         APP: https://api.github.com/app/installations/${connectionConfig.installation_id}/access_tokens
@@ -4469,6 +4470,8 @@ pennylane:
         grant_type: authorization_code
     refresh_params:
         grant_type: refresh_token
+    authorization_url_skip_encode:
+        - scopes
     docs: https://docs.nango.dev/integrations/all/pennylane
 
 peopledatalabs:

--- a/packages/types/lib/providers/provider.ts
+++ b/packages/types/lib/providers/provider.ts
@@ -59,13 +59,13 @@ export interface BaseProvider {
         };
     };
     authorization_url?: string;
-    authorization_url_encode?: boolean;
+    authorization_url_skip_encode?: string[];
     access_token_url?: string;
     authorization_params?: Record<string, string>;
     scope_separator?: string;
     default_scopes?: string[];
     token_url?: string | TokenUrlObject;
-    token_url_encode?: boolean;
+    token_url_skip_encode?: string[];
     token_params?: Record<string, string>;
     authorization_url_replacements?: Record<string, string>;
     redirect_uri_metadata?: string[];

--- a/scripts/validation/providers/schema.json
+++ b/scripts/validation/providers/schema.json
@@ -88,8 +88,12 @@
                 "authorization_url": {
                     "type": "string"
                 },
-                "authorization_url_encode": {
-                    "type": "boolean"
+                "authorization_url_skip_encode": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "enum": ["base_url", "scopes"]
                 },
                 "authorization_url_replacements": {
                     "type": "object",
@@ -397,8 +401,11 @@
                         }
                     ]
                 },
-                "token_url_encode": {
-                    "type": "boolean"
+                "token_url_skip_encode": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "webhook_user_defined_secret": {
                     "type": "boolean"

--- a/scripts/validation/providers/schema.json
+++ b/scripts/validation/providers/schema.json
@@ -92,8 +92,7 @@
                     "type": "array",
                     "items": {
                         "type": "string"
-                    },
-                    "enum": ["base_url", "scopes"]
+                    }
                 },
                 "authorization_url_replacements": {
                     "type": "object",


### PR DESCRIPTION
### Describe the problem and your solution
Turns out some of the providers don't like it when we encode some of the url parts, i.e `scopes`, `base_url` when we are interpolating with `connectionConfigs`. To help with this, the PR introduces a way we can handle this within the various parts. Currently we can skip authorization_url encoding within the `scopes`, or when interpolating the `base_url` with `connectionConfig`.
<!-- Issue ticket number and link (if applicable) -->

### Testing instructions
When creating a new connection for `Pennylane`, the scopes aren't encoded `customer_invoices+supplier_invoices+ledger+accounting`