### PR TITLE
fix(runner): always truncate errors

### DIFF
--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -9,7 +9,7 @@ import * as zod from 'zod';
 import * as soap from 'soap';
 import * as botbuilder from 'botbuilder';
 import tracer from 'dd-trace';
-import { errorToObject, metrics } from '@nangohq/utils';
+import { errorToObject, metrics, truncateJson } from '@nangohq/utils';
 import { logger } from './utils.js';
 import type { RunnerOutput } from '@nangohq/types';
 
@@ -154,7 +154,9 @@ export async function exec(
                     success: false,
                     error: {
                         type,
-                        payload: Array.isArray(payload) || (typeof payload !== 'object' && payload !== null) ? { message: payload } : payload || {}, // TODO: fix ActionError so payload is always an object
+                        payload: truncateJson(
+                            Array.isArray(payload) || (typeof payload !== 'object' && payload !== null) ? { message: payload } : payload || {}
+                        ), // TODO: fix ActionError so payload is always an object
                         status: 500
                     },
                     response: null
@@ -180,7 +182,7 @@ export async function exec(
                         success: false,
                         error: {
                             type: 'script_http_error',
-                            payload: typeof errorResponse === 'string' ? { message: errorResponse } : errorResponse,
+                            payload: truncateJson(typeof errorResponse === 'string' ? { message: errorResponse } : errorResponse),
                             status: error.response.status
                         },
                         response: null
@@ -204,7 +206,7 @@ export async function exec(
                     success: false,
                     error: {
                         type: 'script_internal_error',
-                        payload: { name: tmp.name || 'Error', code: tmp.code, message: tmp.message },
+                        payload: truncateJson({ name: tmp.name || 'Error', code: tmp.code, message: tmp.message }),
                         status: 500
                     },
                     response: null
@@ -216,7 +218,7 @@ export async function exec(
                     success: false,
                     error: {
                         type: 'script_internal_error',
-                        payload: { name: tmp.name || 'Error', code: tmp.code, message: tmp.message },
+                        payload: truncateJson({ name: tmp.name || 'Error', code: tmp.code, message: tmp.message }),
                         status: 500
                     },
                     response: null

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -169,7 +169,7 @@ export async function exec(
                     success: false,
                     error: {
                         type: error.type,
-                        payload: error.payload,
+                        payload: truncateJson(error.payload),
                         status: error.status
                     },
                     response: null
@@ -193,7 +193,7 @@ export async function exec(
                         success: false,
                         error: {
                             type: 'script_http_error',
-                            payload: { name: tmp.name || 'Error', code: tmp.code, message: tmp.message },
+                            payload: truncateJson({ name: tmp.name || 'Error', code: tmp.code, message: tmp.message }),
                             status: 500
                         },
                         response: null

--- a/packages/runner/lib/exec.unit.test.ts
+++ b/packages/runner/lib/exec.unit.test.ts
@@ -251,8 +251,8 @@ describe('Exec', () => {
                         xsrfCookieName: 'XSRF-TOKEN',
                         xsrfHeaderName: 'X-XSRF-TOKEN'
                     },
-                    message: '',
-                    name: 'AggregateError',
+                    message: expect.any(String),
+                    name: expect.any(String),
                     status: null
                 }
             },

--- a/packages/runner/lib/exec.unit.test.ts
+++ b/packages/runner/lib/exec.unit.test.ts
@@ -229,7 +229,7 @@ describe('Exec', () => {
                             'Content-Type': 'application/json',
                             'Nango-Is-Dry-Run': 'true',
                             'Nango-Is-Sync': 'true',
-                            'User-Agent': 'nango-node-client/0.45.0 (darwin/23.2.0; node.js/20.12.2); sdk'
+                            'User-Agent': expect.any(String)
                         },
                         maxBodyLength: -1,
                         maxContentLength: -1,

--- a/packages/utils/lib/json.ts
+++ b/packages/utils/lib/json.ts
@@ -15,6 +15,10 @@ export function stringifyObject(value: any): string {
             }
             if (key === 'Authorization') {
                 return '[Redacted]';
+            } else if (key === 'httpAgent' || key === 'httpsAgent') {
+                return undefined;
+            } else if (key === 'stack') {
+                return undefined;
             }
             return value;
         },

--- a/packages/utils/lib/json.ts
+++ b/packages/utils/lib/json.ts
@@ -3,7 +3,7 @@ import truncateJsonPkg from 'truncate-json';
 
 export const MAX_LOG_PAYLOAD = 99_000; // in  bytes
 
-const ignoredKeys = ['httpAgent', 'httpsAgent', 'trace', '_sessionCache'];
+const ignoredKeys = ['httpAgent', 'httpsAgent', 'trace', '_sessionCache', 'stack'];
 /**
  * Safely stringify an object (mostly handle circular ref and known problematic keys)
  */

--- a/packages/utils/lib/json.ts
+++ b/packages/utils/lib/json.ts
@@ -3,6 +3,7 @@ import truncateJsonPkg from 'truncate-json';
 
 export const MAX_LOG_PAYLOAD = 99_000; // in  bytes
 
+const ignoredKeys = ['httpAgent', 'httpsAgent', 'trace', '_sessionCache'];
 /**
  * Safely stringify an object (mostly handle circular ref and known problematic keys)
  */
@@ -10,14 +11,12 @@ export function stringifyObject(value: any): string {
     return safeStringify.stableStringify(
         value,
         (key, value) => {
-            if (value instanceof Buffer || key === '_sessionCache') {
+            if (value instanceof Buffer) {
                 return '[Buffer]';
             }
             if (key === 'Authorization') {
                 return '[Redacted]';
-            } else if (key === 'httpAgent' || key === 'httpsAgent') {
-                return undefined;
-            } else if (key === 'stack') {
+            } else if (ignoredKeys.includes(key)) {
                 return undefined;
             }
             return value;
@@ -51,7 +50,7 @@ export function stringifyAndTruncateValue(value: any, maxSize: number = MAX_LOG_
  * Truncate a JSON
  * Will entirely remove properties that are too big
  */
-export function truncateJson(value: Record<string, any>, maxSize: number = MAX_LOG_PAYLOAD) {
+export function truncateJson<TObject extends Record<string, any>>(value: TObject, maxSize: number = MAX_LOG_PAYLOAD): TObject {
     return JSON.parse(truncateJsonPkg(stringifyObject(value), maxSize).jsonString);
 }
 


### PR DESCRIPTION
# Changes

We can't control what the content of errors, even the one feel like they are correct might still be too big.

- Fix runner should always truncate errors
- Remove more keys by default