### PR TITLE
fix(cli): show on-events scripts in nango deploy output

### DIFF
--- a/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
@@ -141,7 +141,8 @@ describe(`POST ${endpoint}`, () => {
             isSuccess(res.json);
 
             expect(res.json).toStrictEqual<typeof res.json>([
-                { models: ['Output'], name: 'test', providerConfigKey: 'unauthenticated', type: 'sync', version: '1' }
+                { models: ['Output'], name: 'test', providerConfigKey: 'unauthenticated', type: 'sync', version: '1' },
+                { models: [], name: 'test', providerConfigKey: 'unauthenticated', type: 'on-event', version: '0.0.1' }
             ]);
             expect(res.res.status).toBe(200);
 
@@ -151,6 +152,7 @@ describe(`POST ${endpoint}`, () => {
             expect(syncConfigs).toStrictEqual([
                 {
                     actions: [],
+                    'on-events': [],
                     provider: 'unauthenticated',
                     providerConfigKey: 'unauthenticated',
                     syncs: [

--- a/packages/shared/lib/models/NangoConfig.ts
+++ b/packages/shared/lib/models/NangoConfig.ts
@@ -139,4 +139,5 @@ export interface StandardNangoConfig {
     provider?: string;
     syncs: NangoSyncConfig[];
     actions: NangoSyncConfig[];
+    [`on-events`]: NangoSyncConfig[];
 }

--- a/packages/shared/lib/services/flow.service.ts
+++ b/packages/shared/lib/services/flow.service.ts
@@ -62,7 +62,8 @@ class FlowService {
             const std: StandardNangoConfig = {
                 providerConfigKey,
                 actions: [],
-                syncs: []
+                syncs: [],
+                [`on-events`]: []
             };
 
             for (const item of [...integration.actions, ...integration.syncs]) {

--- a/packages/shared/lib/services/sync/config/config.service.ts
+++ b/packages/shared/lib/services/sync/config/config.service.ts
@@ -24,7 +24,8 @@ function convertSyncConfigToStandardConfig(syncConfigs: ExtendedSyncConfig[]): S
                 actions: [],
                 providerConfigKey: syncConfig.unique_key,
                 provider: syncConfig.provider,
-                syncs: []
+                syncs: [],
+                [`on-events`]: []
             };
         }
 

--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -180,7 +180,17 @@ export async function deploy({
         }
 
         if (onEventScriptsByProvider) {
-            await onEventScriptService.update({ environment, account, onEventScriptsByProvider });
+            const updated = await onEventScriptService.update({ environment, account, onEventScriptsByProvider });
+            const result: SyncDeploymentResult[] = updated.map((u) => {
+                return {
+                    name: u.name,
+                    version: u.version,
+                    providerConfigKey: u.providerConfigKey,
+                    type: 'on-event',
+                    models: []
+                };
+            });
+            deployResults.push(...result);
         }
 
         for (const id of idsToMarkAsInactive) {

--- a/packages/types/lib/nangoYaml/index.ts
+++ b/packages/types/lib/nangoYaml/index.ts
@@ -1,7 +1,7 @@
 export type HTTP_METHOD = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 export type SyncTypeLiteral = 'incremental' | 'full';
 export type ScriptFileType = 'actions' | 'syncs' | 'on-events' | 'post-connection-scripts'; // post-connection-scripts is deprecated
-export type ScriptTypeLiteral = 'action' | 'sync';
+export type ScriptTypeLiteral = 'action' | 'sync' | 'on-event';
 
 // --------------
 // YAML V1


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
`on-events` scripts were not shown in the CLI `nango deploy` output.
Now:
<img width="1394" alt="Screenshot 2024-11-26 at 13 26 38" src="https://github.com/user-attachments/assets/7e8679c9-66e4-4eda-afd0-19cbb0dc4b58">
`setup` and `cleanup` are the on-event scripts. Note that the versioning scheme for `on-events` is different from syncs/actions, not sure why.

How to test:
1. install cli local package: `npm install PATH/TO/REPO/packages/cli -g`. Might need to uninstall it before.
2. Have a integration setup with some `on-events` scripts
3. Run `nango deploy dev`

