### PR TITLE
fix(server): Actually only update fields that are missing data

### DIFF
--- a/packages/database/lib/migrations/20241122212401_integration_backfill_missing_fields.cjs
+++ b/packages/database/lib/migrations/20241122212401_integration_backfill_missing_fields.cjs
@@ -27,6 +27,7 @@ exports.up = async function (knex) {
         .from('_nango_configs')
         .whereIn('provider', clientIdProviders)
         .whereRaw("NOT (missing_fields @> '{oauth_client_id}')")
+        .where('oauth_client_id', null)
         .update({ missing_fields: knex.raw("array_append(missing_fields, 'oauth_client_id')") });
 
     const needsClientSecret = ['OAUTH1', 'OAUTH2', 'TBA', 'APP'];
@@ -38,6 +39,7 @@ exports.up = async function (knex) {
         .from('_nango_configs')
         .whereIn('provider', clientSecretProviders)
         .whereRaw("NOT (missing_fields @> '{oauth_client_secret}')")
+        .where('oauth_client_secret', null)
         .update({ missing_fields: knex.raw("array_append(missing_fields, 'oauth_client_secret')") });
 
     const needsAppLink = ['APP'];
@@ -49,6 +51,7 @@ exports.up = async function (knex) {
         .from('_nango_configs')
         .whereIn('provider', appLinkProviders)
         .whereRaw("NOT (missing_fields @> '{app_link}')")
+        .where('app_link', null)
         .update({ missing_fields: knex.raw("array_append(missing_fields, 'app_link')") });
 };
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
I managed to write the migration to not filter to only the rows missing the data, so every row of a particular auth_mode got all the errors it didn't already have. This fixes that filtering.

## Deployment plan:

- [x] I already ran a query to empty all the `missing_fields` fields as a quick hotfix.
- [ ] Remove the previous migration row
- [ ] Redeploy so the migration runs again

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

