### PR TITLE
feat(api): expose credentials in GET /integrations/:uniqueKey

### DIFF
--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -368,7 +368,7 @@ paths:
                       type: array
                       items:
                           type: string
-                          enum: [webhook]
+                          enum: [webhook, credentials]
                   description: Include additional sensitive data
             responses:
                 '200':
@@ -381,7 +381,7 @@ paths:
                                     - data
                                 properties:
                                     data:
-                                        $ref: '#/components/schemas/Integration'
+                                        $ref: '#/components/schemas/IntegrationFull'
                 '400':
                     $ref: '#/components/responses/BadRequest'
                 '401':
@@ -2077,6 +2077,50 @@ components:
                     type: string
                     format: date
                     description: Last time it was updated
+        IntegrationFull:
+            allOf:
+                - $ref: '#/components/schemas/Integration'
+                - type: object
+                  additionalProperties: false
+                  properties:
+                      webhook_url:
+                          type: string
+                          description: Configure your integration webhooks to point to this URL
+                          nullable: true
+                      credentials:
+                          nullable: true
+                          oneOf:
+                              - type: object
+                                additionalProperties: false
+                                properties:
+                                    type:
+                                        type: string
+                                        enum: ['OAUTH2', 'OAUTH1', 'TBA']
+                                    client_id:
+                                        type: string
+                                        nullable: true
+                                    client_secret:
+                                        type: string
+                                        nullable: true
+                                    scopes:
+                                        type: string
+                                        nullable: true
+
+                              - type: object
+                                additionalProperties: false
+                                properties:
+                                    type:
+                                        type: string
+                                        enum: ['APP']
+                                    app_id:
+                                        type: string
+                                        nullable: true
+                                    private_key:
+                                        type: string
+                                        nullable: true
+                                    app_link:
+                                        type: string
+                                        nullable: true
 
         ConnectSession:
             type: object

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -277,8 +277,6 @@ const initDb = async () => {
             environment_id: env.id,
             oauth_client_id: '',
             oauth_client_secret: '',
-            created_at: now,
-            updated_at: now,
             missing_fields: []
         },
         googleProvider

--- a/packages/server/lib/clients/oauth1.client.ts
+++ b/packages/server/lib/clients/oauth1.client.ts
@@ -28,8 +28,8 @@ export class OAuth1Client {
         this.client = new oAuth1.OAuth(
             this.authConfig.request_url,
             typeof this.authConfig.token_url === 'string' ? this.authConfig.token_url : (this.authConfig.token_url?.['OAUTH1'] as string),
-            this.config.oauth_client_id,
-            this.config.oauth_client_secret,
+            this.config.oauth_client_id!,
+            this.config.oauth_client_secret!,
             '1.0',
             callbackUrl,
             this.authConfig.signature_method,

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.integration.test.ts
@@ -100,4 +100,15 @@ describe(`GET ${endpoint}`, () => {
         isError(res.json);
         expect(res.res.status).toBe(404);
     });
+
+    it('should get credentials', async () => {
+        const env = await seeders.createEnvironmentSeed();
+        await seeders.createConfigSeed(env, 'github', 'github', { oauth_client_id: 'foo', oauth_client_secret: 'bar', oauth_scopes: 'hello, world' });
+
+        const res = await api.fetch(endpoint, { method: 'GET', token: env.secret_key, params: { uniqueKey: 'github' }, query: { include: ['credentials'] } });
+
+        isSuccess(res.json);
+        expect(res.res.status).toBe(200);
+        expect(res.json.data.credentials).toStrictEqual({ client_id: 'foo', client_secret: 'bar', scopes: 'hello, world', type: 'OAUTH2' });
+    });
 });

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
@@ -12,7 +12,7 @@ export const validationParams = z
     })
     .strict();
 
-const valInclude = z.enum(['webhook']);
+const valInclude = z.enum(['webhook', 'credentials']);
 const validationQuery = z
     .object({
         include: z
@@ -35,11 +35,16 @@ export const getPublicIntegration = asyncWrapper<GetPublicIntegration>(async (re
         return;
     }
 
-    const { environment } = res.locals;
+    const { environment, authType } = res.locals;
     const params: GetPublicIntegration['Params'] = valParams.data;
     const query: GetPublicIntegration['Querystring'] = valQuery.data;
 
     const queryInclude = new Set(query.include || []);
+    if (queryInclude.size > 0 && authType !== 'secretKey') {
+        // This is not allowed right now anyway but it's too prevent any mistakes
+        res.status(403).send({ error: { code: 'invalid_permissions', message: "Can't include credentials without a private key" } });
+        return;
+    }
 
     const integration = await configService.getProviderConfig(params.uniqueKey, environment.id);
     if (!integration) {
@@ -56,6 +61,25 @@ export const getPublicIntegration = asyncWrapper<GetPublicIntegration>(async (re
     const include: ApiPublicIntegrationInclude = {};
     if (queryInclude.has('webhook')) {
         include.webhook_url = provider.webhook_routing_script ? `${getGlobalWebhookReceiveUrl()}/${environment.uuid}/${integration.provider}` : null;
+    }
+    if (queryInclude.has('credentials')) {
+        if (provider.auth_mode === 'OAUTH1' || provider.auth_mode === 'OAUTH2' || provider.auth_mode === 'TBA') {
+            include.credentials = {
+                type: provider.auth_mode,
+                client_id: integration.oauth_client_id,
+                client_secret: integration.oauth_client_secret,
+                scopes: integration.oauth_scopes || null
+            };
+        } else if (provider.auth_mode === 'APP') {
+            include.credentials = {
+                type: provider.auth_mode,
+                app_id: integration.oauth_client_id,
+                private_key: integration.oauth_client_secret,
+                app_link: integration.app_link || null
+            };
+        } else {
+            include.credentials = null;
+        }
     }
 
     res.status(200).send({

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
@@ -41,7 +41,7 @@ export const getPublicIntegration = asyncWrapper<GetPublicIntegration>(async (re
 
     const queryInclude = new Set(query.include || []);
     if (queryInclude.size > 0 && authType !== 'secretKey') {
-        // This is not allowed right now anyway but it's too prevent any mistakes
+        // This endpoint is not reachable any other way right now BUT it's to prevent any future mistakes
         res.status(403).send({ error: { code: 'invalid_permissions', message: "Can't include credentials without a private key" } });
         return;
     }

--- a/packages/server/lib/helpers/tba.ts
+++ b/packages/server/lib/helpers/tba.ts
@@ -32,7 +32,7 @@ export async function makeAccessTokenRequest({
     const { nonce, timestamp } = getTbaMetaParams();
 
     const oauthParams = {
-        oauth_consumer_key: config.oauth_client_id,
+        oauth_consumer_key: config.oauth_client_id || '',
         oauth_nonce: nonce,
         oauth_signature_method: SIGNATURE_METHOD,
         oauth_timestamp: timestamp.toString(),
@@ -50,12 +50,12 @@ export async function makeAccessTokenRequest({
 
     const hash = generateSignature({
         baseString,
-        clientSecret: config.oauth_client_secret,
+        clientSecret: config.oauth_client_secret || '',
         tokenSecret: oauth_token_secret as string
     });
 
     const authHeader =
-        `OAuth oauth_consumer_key="${percentEncode(config.oauth_client_id)}",` +
+        `OAuth oauth_consumer_key="${percentEncode(config.oauth_client_id || '')}",` +
         `oauth_token="${oauth_token}",` +
         `oauth_verifier="${oauth_verifier}",` +
         `oauth_nonce="${nonce}",` +

--- a/packages/shared/lib/seeders/config.seeder.ts
+++ b/packages/shared/lib/seeders/config.seeder.ts
@@ -1,6 +1,6 @@
 import configService from '../services/config.service.js';
 import type { Config as ProviderConfig } from '../models/Provider.js';
-import type { DBEnvironment } from '@nangohq/types';
+import type { DBEnvironment, IntegrationConfig } from '@nangohq/types';
 import { getProvider } from '../services/providers.js';
 
 export const createConfigSeeds = async (env: DBEnvironment): Promise<void> => {
@@ -48,7 +48,12 @@ export const createConfigSeeds = async (env: DBEnvironment): Promise<void> => {
     );
 };
 
-export const createConfigSeed = async (env: DBEnvironment, unique_key: string, providerName: string): Promise<ProviderConfig> => {
+export async function createConfigSeed(
+    env: DBEnvironment,
+    unique_key: string,
+    providerName: string,
+    rest?: Partial<IntegrationConfig>
+): Promise<IntegrationConfig> {
     const provider = getProvider(providerName);
     if (!provider) {
         throw new Error(`createConfigSeed: ${providerName} provider not found`);
@@ -58,12 +63,13 @@ export const createConfigSeed = async (env: DBEnvironment, unique_key: string, p
         {
             unique_key,
             provider: providerName,
-            environment_id: env.id
-        } as ProviderConfig,
+            environment_id: env.id,
+            ...rest
+        },
         provider
     );
     if (!created) {
         throw new Error('failed to created to provider config');
     }
     return created;
-};
+}

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -949,7 +949,7 @@ class ConnectionService {
             const { success, error, response } = await this.refreshCredentialsIfNeeded({
                 connectionId: connection.connection_id,
                 environmentId: environment.id,
-                providerConfig: integration,
+                providerConfig: integration as ProviderConfig,
                 provider: provider as ProviderOAuth2,
                 environment_id: environment.id,
                 instantRefresh
@@ -979,7 +979,7 @@ class ConnectionService {
                         },
                         environment,
                         provider,
-                        config: integration,
+                        config: integration as ProviderConfig,
                         action: 'token_refresh'
                     });
                 }
@@ -996,7 +996,7 @@ class ConnectionService {
                 await onRefreshSuccess({
                     connection,
                     environment,
-                    config: integration
+                    config: integration as ProviderConfig
                 });
             }
 
@@ -1004,7 +1004,7 @@ class ConnectionService {
         } else if (connection.credentials?.type === 'BASIC' || connection.credentials?.type === 'API_KEY' || connection.credentials?.type === 'TBA') {
             if (connectionTestHook) {
                 const result = await connectionTestHook({
-                    config: integration,
+                    config: integration as ProviderConfig,
                     provider,
                     connectionConfig: connection.connection_config,
                     connectionId: connection.connection_id,
@@ -1039,7 +1039,7 @@ class ConnectionService {
                         },
                         environment,
                         provider,
-                        config: integration,
+                        config: integration as ProviderConfig,
                         action: 'connection_test'
                     });
 
@@ -1054,7 +1054,7 @@ class ConnectionService {
                     await onRefreshSuccess({
                         connection,
                         environment,
-                        config: integration
+                        config: integration as ProviderConfig
                     });
                 }
             }

--- a/packages/types/lib/api.ts
+++ b/packages/types/lib/api.ts
@@ -25,7 +25,8 @@ export type ResDefaultErrors =
     | ApiError<'malformed_auth_header'>
     | ApiError<'unknown_account'>
     | ApiError<'unknown_connect_session_token'>
-    | ApiError<'invalid_cli_version'>;
+    | ApiError<'invalid_cli_version'>
+    | ApiError<'invalid_permissions'>;
 
 export type EndpointMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 /**

--- a/packages/types/lib/auth/api.ts
+++ b/packages/types/lib/auth/api.ts
@@ -68,8 +68,6 @@ export interface ApiKeyCredentials {
     apiKey: string;
 }
 
-export type AuthCredentials = OAuth2Credentials | OAuth1Credentials | OAuth2ClientCredentials;
-
 export interface AppCredentials {
     type: AuthModes['App'];
     access_token: string;

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -2,7 +2,7 @@ import type { Merge } from 'type-fest';
 import type { ApiTimestamps, Endpoint } from '../api';
 import type { IntegrationConfig } from './db';
 import type { Provider } from '../providers/provider';
-import type { AuthModeType } from '../auth/api';
+import type { AuthModeType, AuthModes } from '../auth/api';
 import type { NangoModel, NangoSyncEndpointV2, ScriptTypeLiteral } from '../nangoYaml';
 import type { LegacySyncModelSchema, NangoConfigMetadata } from '../deploy/incomingFlow';
 import type { JSONSchema7 } from 'json-schema';
@@ -14,6 +14,10 @@ export type ApiPublicIntegration = Merge<Pick<IntegrationConfig, 'created_at' | 
 } & ApiPublicIntegrationInclude;
 export interface ApiPublicIntegrationInclude {
     webhook_url?: string | null;
+    credentials?:
+        | { type: AuthModes['OAuth2'] | AuthModes['OAuth1'] | AuthModes['TBA']; client_id: string | null; client_secret: string | null; scopes: string | null }
+        | { type: AuthModes['App']; app_id: string | null; private_key: string | null; app_link: string | null }
+        | null;
 }
 
 export type GetPublicListIntegrationsLegacy = Endpoint<{
@@ -27,6 +31,7 @@ export type GetPublicListIntegrationsLegacy = Endpoint<{
 export type GetPublicListIntegrations = Endpoint<{
     Method: 'GET';
     Path: '/integrations';
+    Querystring?: { connect_session_token: string };
     Success: {
         data: ApiPublicIntegration[];
     };
@@ -36,7 +41,7 @@ export type GetPublicIntegration = Endpoint<{
     Method: 'GET';
     Path: '/integrations/:uniqueKey';
     Params: { uniqueKey: string };
-    Querystring: { include?: 'webhook'[] | undefined };
+    Querystring: { include?: ('webhook' | 'credentials')[] | undefined };
     Success: { data: ApiPublicIntegration };
 }>;
 

--- a/packages/types/lib/integration/db.ts
+++ b/packages/types/lib/integration/db.ts
@@ -1,16 +1,20 @@
+import type { SetOptional } from 'type-fest';
 import type { TimestampsAndDeleted } from '../db.js';
+import type { NullablePartial } from '../utils.js';
 
 export interface IntegrationConfig extends TimestampsAndDeleted {
     id?: number | undefined;
     unique_key: string;
     provider: string;
-    oauth_client_id: string;
-    oauth_client_secret: string;
-    oauth_scopes?: string | undefined;
+    oauth_client_id: string | null;
+    oauth_client_secret: string | null;
+    oauth_scopes?: string | undefined | null;
     environment_id: number;
     oauth_client_secret_iv?: string | null;
     oauth_client_secret_tag?: string | null;
     app_link?: string | null | undefined;
-    custom?: Record<string, string> | undefined;
+    custom?: Record<string, string> | undefined | null;
     missing_fields: string[];
 }
+
+export type DBCreateIntegration = SetOptional<NullablePartial<Omit<IntegrationConfig, 'created_at' | 'updated_at'>>, 'missing_fields'>;

--- a/packages/types/lib/providers/api.ts
+++ b/packages/types/lib/providers/api.ts
@@ -4,7 +4,7 @@ import type { Provider } from './provider';
 export type GetPublicProviders = Endpoint<{
     Method: 'GET';
     Path: `/providers`;
-    Querystring: { search?: string | undefined };
+    Querystring: { search?: string | undefined; connect_session_token?: string };
     Success: {
         data: ApiProvider[];
     };
@@ -15,6 +15,7 @@ export type GetPublicProvider = Endpoint<{
     Method: 'GET';
     Path: `/providers/:provider`;
     Params: { provider: string };
+    Querystring?: { connect_session_token: string };
     Success: {
         data: ApiProvider;
     };

--- a/packages/types/lib/utils.ts
+++ b/packages/types/lib/utils.ts
@@ -13,8 +13,7 @@ export interface Logger {
 type ValidateSelection<T, U> = U extends T ? U : never;
 export type PickFromUnion<T, U extends T> = ValidateSelection<T, U>;
 
-export type NullablePartial<
-    TBase,
-    NK extends keyof TBase = { [K in keyof TBase]: null extends TBase[K] ? K : never }[keyof TBase],
-    NP = Partial<Pick<TBase, NK>> & Pick<TBase, Exclude<keyof TBase, NK>>
-> = { [K in keyof NP]: NP[K] };
+export type NullablePartial<TBase, TNullableKey extends keyof TBase = { [K in keyof TBase]: null extends TBase[K] ? K : never }[keyof TBase]> = Partial<
+    Pick<TBase, TNullableKey>
+> &
+    Pick<TBase, Exclude<keyof TBase, TNullableKey>>;

--- a/packages/types/lib/utils.ts
+++ b/packages/types/lib/utils.ts
@@ -12,3 +12,9 @@ export interface Logger {
 
 type ValidateSelection<T, U> = U extends T ? U : never;
 export type PickFromUnion<T, U extends T> = ValidateSelection<T, U>;
+
+export type NullablePartial<
+    TBase,
+    NK extends keyof TBase = { [K in keyof TBase]: null extends TBase[K] ? K : never }[keyof TBase],
+    NP = Partial<Pick<TBase, NK>> & Pick<TBase, Exclude<keyof TBase, NK>>
+> = { [K in keyof NP]: NP[K] };

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/App.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/App.tsx
@@ -62,7 +62,7 @@ export const SettingsApp: React.FC<{ data: GetIntegration['Success']['data']; en
                         required
                         minLength={1}
                         variant={'flat'}
-                        after={<CopyButton text={integration.oauth_client_id} />}
+                        after={<CopyButton text={integration.oauth_client_id || ''} />}
                     />
                 </InfoBloc>
                 <InfoBloc title="App Public Link">

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/Custom.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/Custom.tsx
@@ -63,7 +63,7 @@ export const SettingsCustom: React.FC<{ data: GetIntegration['Success']['data'];
                             required
                             minLength={1}
                             variant={'flat'}
-                            after={<CopyButton text={integration.oauth_client_id} />}
+                            after={<CopyButton text={integration.oauth_client_id || ''} />}
                         />
                     </InfoBloc>
                     <InfoBloc title="App Public Link">
@@ -94,7 +94,7 @@ export const SettingsCustom: React.FC<{ data: GetIntegration['Success']['data'];
                         required
                         minLength={1}
                         variant={'flat'}
-                        after={<CopyButton text={integration.oauth_client_id} />}
+                        after={<CopyButton text={integration.oauth_client_id || ''} />}
                     />
                 </InfoBloc>
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuth.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuth.tsx
@@ -61,7 +61,7 @@ export const SettingsOAuth: React.FC<{ data: GetIntegration['Success']['data']; 
                         required
                         minLength={1}
                         variant={'flat'}
-                        after={<CopyButton text={integration.oauth_client_id} />}
+                        after={<CopyButton text={integration.oauth_client_id || ''} />}
                     />
                 </InfoBloc>
 


### PR DESCRIPTION
## Changes

- `GET /integrations/:uniqueKey` now expose credentials (optional)
Some customers need the credentials for internal operations or oauth revoke. This expose optionally the credentials with some added security.

- Try to fix IntegrationConfig type by creating a smaller scope for integration create
This type is annoying, it's used a bit everywhere and everything is marked as undefined except it's null not undefined. Anyway, first steps since I needed better types.

