### PR TITLE
fix: do not wait for on-event script to finish when triggering them

### DIFF
--- a/packages/jobs/lib/execution/onEvent.ts
+++ b/packages/jobs/lib/execution/onEvent.ts
@@ -110,7 +110,7 @@ export async function startOnEvent(task: TaskOnEvent): Promise<Result<void>> {
 }
 
 export async function handleOnEventSuccess({ nangoProps }: { nangoProps: NangoProps }): Promise<void> {
-    const content = `Webhook "${nangoProps.syncConfig.sync_name}" has been run successfully.`;
+    const content = `Script "${nangoProps.syncConfig.sync_name}" has been run successfully.`;
     void bigQueryClient.insert({
         executionType: 'on-event',
         connectionId: nangoProps.connectionId,

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -254,17 +254,28 @@ export class OrchestratorClient {
         return this.execute(schedulingProps);
     }
 
-    public async executeOnEvent(props: ExecuteOnEventProps): Promise<ExecuteReturn> {
+    public async executeOnEvent(props: ExecuteOnEventProps): Promise<VoidReturn> {
         const { args, ...rest } = props;
         const schedulingProps = {
+            retry: { count: 0, max: 0 },
+            timeoutSettingsInSecs: {
+                createdToStarted: 30,
+                startedToCompleted: 5 * 60,
+                heartbeat: 99999
+            },
             ...rest,
             args: {
                 ...args,
                 type: 'on-event' as const
             }
         };
-        return this.execute(schedulingProps);
+        const res = await this.immediate(schedulingProps);
+        if (res.isErr()) {
+            return Err(res.error);
+        }
+        return Ok(undefined);
     }
+
     public async searchTasks({
         ids,
         groupKey,

--- a/packages/server/lib/hooks/connection/on/connection-created.ts
+++ b/packages/server/lib/hooks/connection/on/connection-created.ts
@@ -50,8 +50,6 @@ export async function postConnectionCreation(
         });
         if (res.isErr()) {
             await logCtx.failed();
-        } else {
-            await logCtx.success();
         }
     }
 }

--- a/packages/server/lib/hooks/connection/on/connection-deleted.ts
+++ b/packages/server/lib/hooks/connection/on/connection-deleted.ts
@@ -52,8 +52,6 @@ export async function preConnectionDeletion({
         });
         if (res.isErr()) {
             await logCtx.failed();
-        } else {
-            await logCtx.success();
         }
     }
 }

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -52,7 +52,7 @@ export interface OrchestratorClientInterface {
     recurring(props: RecurringProps): Promise<Result<{ scheduleId: string }>>;
     executeAction(props: ExecuteActionProps): Promise<ExecuteReturn>;
     executeWebhook(props: ExecuteWebhookProps): Promise<ExecuteReturn>;
-    executeOnEvent(props: ExecuteOnEventProps): Promise<ExecuteReturn>;
+    executeOnEvent(props: ExecuteOnEventProps): Promise<VoidReturn>;
     executeSync(props: ExecuteSyncProps): Promise<VoidReturn>;
     pauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn>;
     unpauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn>;


### PR DESCRIPTION
on-event scripts don't have output so waiting for them to finish is not necessary.
Also modifying the max duration timeout to 5mins for on-event script

How to test:
- modify your on-event script to sleep. Ex:
```
    const waitTime = 10;
    for (let i = 0; i < waitTime; i++) {
        await nango.log(`Countdown: ${waitTime - i}`);
        await new Promise((resolve) => setTimeout(resolve, 1000));
    }
```
- create/delete a connection and then check in the logs dashboard that the script is still running and you didn't have to wait for it

