### PR TITLE
fix(integrations): configure Discourse rate limit header

### DIFF
--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -1874,6 +1874,8 @@ discourse:
     auth_mode: API_KEY
     proxy:
         base_url: https://${connectionConfig.defaultHost}
+        retry:
+            after: 'Retry-After'
         headers:
             Api-Username: ${connectionConfig.apiUsername}
             Api-Key: ${apiKey}


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-2278/provider-configure-discourse-retry-header

- Configure Discourse rate limit header


