### PR TITLE
fix(providers): allow fields to be marked as automated

### DIFF
--- a/packages/connect-ui/src/views/Go.tsx
+++ b/packages/connect-ui/src/views/Go.tsx
@@ -150,6 +150,10 @@ export const Go: React.FC = () => {
         // Append connectionConfig object
         const additionalFields: z.ZodRawShape = {};
         for (const [name, schema] of Object.entries(provider.connection_config || [])) {
+            if (schema.automated) {
+                continue;
+            }
+
             additionalFields[name] = jsonSchemaToZod(schema);
 
             if (schema.order) {
@@ -345,7 +349,7 @@ export const Go: React.FC = () => {
                                             name={name}
                                             render={({ field }) => {
                                                 return (
-                                                    <FormItem className={cn(isPreconfigured || definition?.hidden ? 'hidden' : null)}>
+                                                    <FormItem className={cn(isPreconfigured || definition?.hidden || definition?.automated ? 'hidden' : null)}>
                                                         <div>
                                                             <div className="flex gap-2 items-center pb-1">
                                                                 <FormLabel className="leading-5">

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -5169,7 +5169,7 @@ salesforce:
             description: The instance URL of your Salesforce account
             format: uri
             pattern: '^https?://.*$'
-            optional: true
+            automated: true
 
 salesforce-sandbox:
     display_name: Salesforce (sandbox)
@@ -5190,6 +5190,7 @@ salesforce-sandbox:
             description: The instance URL of your Salesforce account
             format: uri
             pattern: '^https?://.*$'
+            automated: true
 
 salesforce-experience-cloud:
     display_name: Salesforce Experience Cloud

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -2645,6 +2645,7 @@ github-app:
             title: Installation ID
             description: The installation ID of your GitHub App
             example: '38631545'
+            automated: true
 
 github-app-oauth:
     display_name: GitHub App (oauth)
@@ -2674,6 +2675,7 @@ github-app-oauth:
             title: Installation ID
             description: The installation ID of your GitHub App
             example: '38631545'
+            automated: true
 
 gitlab:
     display_name: GitLab

--- a/packages/types/lib/providers/provider.ts
+++ b/packages/types/lib/providers/provider.ts
@@ -36,6 +36,7 @@ export interface SimplifiedJSONSchema {
     suffix?: string;
     doc_section?: string;
     secret?: string;
+    automated: boolean;
 }
 
 export interface BaseProvider {

--- a/scripts/validation/providers/schema.json
+++ b/scripts/validation/providers/schema.json
@@ -323,7 +323,14 @@
                             "enum": ["authorization_code", "client_credentials"]
                         },
                         "request": {
-                            "anyOf": [{ "type": "string" }, { "type": "object" }]
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
                         }
                     }
                 },
@@ -462,6 +469,9 @@
                                 "doc_section": {
                                     "type": "string",
                                     "pattern": "^#[a-z0-9-]+$"
+                                },
+                                "automated": {
+                                    "type": "boolean"
                                 }
                             }
                         }


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-2280/ability-to-set-connectionconfig-as-automated

- Allow fields to be marked as automated
- Set salesforce instance url as automated

## Tests

I don't have a Salesforce account, if you have one I would appreciate a local test please (@khaliqgant or @hassan254-prog)