### PR TITLE
fix(providers): change greenhouse api key validation

### DIFF
--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -3030,7 +3030,7 @@ greenhouse-basic:
             type: string
             title: API key
             description: The API Key of your Greenhouse account
-            pattern: '^[a-zA-Z0-9]+$'
+            pattern: '^[a-zA-Z0-9-]+$'
             secret: true
         password:
             type: string


### PR DESCRIPTION
## Changes

- Fix greenhouse api key validation
It can contain a dash for some reason https://support.greenhouse.io/hc/en-us/articles/115000521723-Manage-Harvest-API-key-permissions

