### PR TITLE
fix(sdk): More strongly type ProxyConfiguration

### DIFF
--- a/packages/shared/lib/models/Proxy.ts
+++ b/packages/shared/lib/models/Proxy.ts
@@ -11,6 +11,7 @@ import type {
 } from './Auth.js';
 import type { Connection } from './Connection.js';
 import type { Provider, TwoStepCredentials } from '@nangohq/types';
+import type { JsonValue } from 'type-fest';
 
 export interface File {
     fieldname: string;
@@ -29,7 +30,7 @@ interface BaseProxyConfiguration {
     connectionId: string;
     endpoint: string;
     retries?: number;
-    data?: unknown;
+    data?: JsonValue | string | Buffer | undefined;
     files?: File[];
     headers?: Record<string, string>;
     params?: string | Record<string, string | number>;

--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -23,6 +23,7 @@ import { validateData } from './dataValidation.js';
 import { NangoError } from '../utils/error.js';
 import type { DBTeam, GetPublicIntegration, MessageRowInsert, RunnerFlags } from '@nangohq/types';
 import { getProvider } from '../services/providers.js';
+import type { JsonValue } from 'type-fest';
 
 const logger = getLogger('SDK');
 
@@ -146,7 +147,7 @@ export interface ProxyConfiguration {
     headers?: Record<string, string>;
     params?: string | Record<string, string | number>;
     paramsSerializer?: ParamsSerializerOptions;
-    data?: unknown;
+    data?: JsonValue | string | Buffer | undefined;
     retries?: number;
     baseUrlOverride?: string;
     paginate?: Partial<CursorPagination> | Partial<LinkPagination> | Partial<OffsetPagination>;

--- a/packages/shared/lib/services/proxy.service.ts
+++ b/packages/shared/lib/services/proxy.service.ts
@@ -159,7 +159,7 @@ class ProxyService {
                 });
             }
 
-            data = formData;
+            data = formData.getBuffer();
         }
 
         const configBody: ApplicationConstructedProxyConfiguration = {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Right now the SDK allows a ton of different types of input for the request body (`data`) on proxy calls. This locks it down a bit more, specifically blocking streams as request bodies, so that it's easier for us to capture request bodies.

This came up as part of https://linear.app/nango/issue/NAN-1902/fix-integration-unit-test-pagination because I realized while working on it that we don't handle the streaming body situation very cleanly.

<!-- Issue ticket number and link (if applicable) -->

See https://linear.app/nango/issue/NAN-1902/fix-integration-unit-test-pagination

<!-- Testing instructions (skip if just adding/editing providers) -->

This is a type only update, so it should just be a matter of everything building cleanly. I need to see what @khaliqgant thinks about the change as well since it'll change types in integrations.

