### PR TITLE
feat(connect): allow passing oauth_scopes

### DIFF
--- a/docs-v2/reference/sdks/node.mdx
+++ b/docs-v2/reference/sdks/node.mdx
@@ -1197,8 +1197,7 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     <INTEGRATION-ID-1>: {
       connection_config: {
-        <CONFIG-KEY>: '<VALUE>',
-        oauth_scopes: '<COMMA_SEPARATED_STRING>'
+        <CONFIG-KEY>: '<VALUE>'
       }
     }
   }

--- a/docs-v2/reference/sdks/node.mdx
+++ b/docs-v2/reference/sdks/node.mdx
@@ -1197,7 +1197,8 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     <INTEGRATION-ID-1>: {
       connection_config: {
-        <CONFIG-KEY>: '<VALUE>'
+        <CONFIG-KEY>: '<VALUE>',
+        oauth_scopes: '<COMMA_SEPARATED_STRING>'
       }
     }
   }

--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -2158,6 +2158,15 @@ components:
                     additionalProperties:
                         type: object
                         description: the unique name of an integration
+                        additionalProperties: false
                         properties:
+                            user_scopes:
+                                type: string
+                                description: User scopes (for Slack only)
                             connection_config:
                                 type: object
+                                additionalProperties: true
+                                properties:
+                                    oauth_scopes_override:
+                                        type: string
+                                        description: Override oauth scopes

--- a/packages/server/lib/controllers/auth/postUnauthenticated.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.ts
@@ -15,8 +15,7 @@ import { isIntegrationAllowed } from '../../utils/auth.js';
 const queryStringValidation = z
     .object({
         connection_id: connectionIdSchema.optional(),
-        params: z.record(z.any()).optional(),
-        user_scope: z.string().optional()
+        params: z.record(z.any()).optional()
     })
     .and(connectionCredential);
 

--- a/packages/server/lib/controllers/connect/postSessions.ts
+++ b/packages/server/lib/controllers/connect/postSessions.ts
@@ -28,7 +28,7 @@ const bodySchema = z
             .record(
                 z
                     .object({
-                        connection_config: z.record(z.unknown())
+                        connection_config: z.object({ oauth_scopes: z.string().optional() }).passthrough()
                     })
                     .strict()
             )

--- a/packages/server/lib/controllers/connect/postSessions.ts
+++ b/packages/server/lib/controllers/connect/postSessions.ts
@@ -28,7 +28,12 @@ const bodySchema = z
             .record(
                 z
                     .object({
-                        connection_config: z.object({ oauth_scopes: z.string().optional() }).passthrough()
+                        user_scopes: z.string().optional(),
+                        connection_config: z
+                            .object({
+                                oauth_scopes_override: z.string().optional()
+                            })
+                            .passthrough()
                     })
                     .strict()
             )
@@ -120,7 +125,10 @@ export const postConnectSessions = asyncWrapper<PostConnectSessions>(async (req,
             allowedIntegrations: req.body.allowed_integrations || null,
             integrationsConfigDefaults: req.body.integrations_config_defaults
                 ? Object.fromEntries(
-                      Object.entries(req.body.integrations_config_defaults).map(([key, value]) => [key, { connectionConfig: value.connection_config }])
+                      Object.entries(req.body.integrations_config_defaults).map(([key, value]) => [
+                          key,
+                          { user_scopes: value.user_scopes, connectionConfig: value.connection_config }
+                      ])
                   )
                 : null
         });

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -202,9 +202,10 @@ class OAuthController {
             }
 
             if (isConnectSession) {
-                // Session token always win
                 const defaults = res.locals.connectSession.integrationsConfigDefaults?.[config.unique_key];
-                config.oauth_scopes = defaults?.connectionConfig.oauth_scopes_override || undefined;
+                if (defaults?.connectionConfig.oauth_scopes_override) {
+                    config.oauth_scopes = defaults?.connectionConfig.oauth_scopes_override;
+                }
             } else if (connectionConfig['oauth_scopes_override']) {
                 config.oauth_scopes = connectionConfig['oauth_scopes_override'];
             }

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -150,10 +150,9 @@ class OAuthController {
             }
 
             if (isConnectSession) {
+                // Session token always win
                 const defaults = res.locals.connectSession.integrationsConfigDefaults?.[config.unique_key];
-                // No matter what we don't want ill intentioned users to specify their own oauth_scopes
-                // session token always win
-                userScope = defaults?.connectionConfig.oauth_scopes || undefined;
+                userScope = defaults?.user_scopes || undefined;
             }
 
             const session: OAuthSession = {
@@ -202,7 +201,11 @@ class OAuthController {
                 });
             }
 
-            if (connectionConfig['oauth_scopes_override']) {
+            if (isConnectSession) {
+                // Session token always win
+                const defaults = res.locals.connectSession.integrationsConfigDefaults?.[config.unique_key];
+                config.oauth_scopes = defaults?.connectionConfig.oauth_scopes_override || undefined;
+            } else if (connectionConfig['oauth_scopes_override']) {
                 config.oauth_scopes = connectionConfig['oauth_scopes_override'];
             }
 
@@ -930,7 +933,7 @@ class OAuthController {
             return publisher.notifySuccess(res, channel, providerConfigKey, connectionId);
         }
 
-        // check for oauth overrides in the connnection config
+        // check for oauth overrides in the connection config
         if (session.connectionConfig['oauth_client_id_override']) {
             config.oauth_client_id = session.connectionConfig['oauth_client_id_override'];
         }

--- a/packages/types/lib/connect/api.ts
+++ b/packages/types/lib/connect/api.ts
@@ -6,9 +6,10 @@ export interface ConnectSessionPayload {
         | Record<
               string,
               {
+                  user_scopes?: string | undefined;
                   connection_config: {
                       [key: string]: unknown;
-                      oauth_scopes?: string | undefined;
+                      oauth_scopes_override?: string | undefined;
                   };
               }
           >

--- a/packages/types/lib/connect/api.ts
+++ b/packages/types/lib/connect/api.ts
@@ -2,7 +2,17 @@ import type { Endpoint } from '../api.js';
 
 export interface ConnectSessionPayload {
     allowed_integrations?: string[] | undefined;
-    integrations_config_defaults?: Record<string, { connection_config: Record<string, unknown> }> | undefined;
+    integrations_config_defaults?:
+        | Record<
+              string,
+              {
+                  connection_config: {
+                      [key: string]: unknown;
+                      oauth_scopes?: string | undefined;
+                  };
+              }
+          >
+        | undefined;
     end_user: {
         id: string;
         email: string;

--- a/packages/types/lib/connect/session.ts
+++ b/packages/types/lib/connect/session.ts
@@ -4,7 +4,15 @@ export interface ConnectSession {
     readonly accountId: number;
     readonly environmentId: number;
     readonly allowedIntegrations?: string[] | null;
-    readonly integrationsConfigDefaults?: Record<string, { connectionConfig: Record<string, unknown> }> | null;
+    readonly integrationsConfigDefaults?: Record<
+        string,
+        {
+            connectionConfig: {
+                [key: string]: unknown;
+                oauth_scopes?: string | undefined;
+            };
+        }
+    > | null;
     readonly createdAt: Date;
     readonly updatedAt: Date | null;
 }

--- a/packages/types/lib/connect/session.ts
+++ b/packages/types/lib/connect/session.ts
@@ -7,9 +7,11 @@ export interface ConnectSession {
     readonly integrationsConfigDefaults?: Record<
         string,
         {
+            /** Only used by Slack */
+            user_scopes?: string | undefined;
             connectionConfig: {
                 [key: string]: unknown;
-                oauth_scopes?: string | undefined;
+                oauth_scopes_override?: string | undefined;
             };
         }
     > | null;


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-2304/connect-support-oauth-scopes

- Support passing `oauth_scopes_override`  and `user_scopes`


## Tests

I don't know, if you have an idea of an integration that supports this let me know :D 