### PR TITLE
feat: introducing the fleet package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ COPY packages/connect-ui/package.json ./packages/connect-ui/package.json
 COPY packages/utils/package.json ./packages/utils/package.json
 COPY packages/webapp/package.json ./packages/webapp/package.json
 COPY packages/webhooks/package.json ./packages/webhooks/package.json
+COPY packages/fleet/package.json ./packages/fleet/package.json
 COPY package*.json  ./
 
 # Install every dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -5789,6 +5789,10 @@
             "resolved": "packages/database",
             "link": true
         },
+        "node_modules/@nangohq/fleet": {
+            "resolved": "packages/fleet",
+            "link": true
+        },
         "node_modules/@nangohq/frontend": {
             "resolved": "packages/frontend",
             "link": true
@@ -35213,6 +35217,17 @@
             },
             "devDependencies": {
                 "typescript": "5.3.3",
+                "vitest": "1.6.0"
+            }
+        },
+        "packages/fleet": {
+            "version": "1.0.0",
+            "dependencies": {
+                "@nangohq/utils": "file:../utils",
+                "dd-trace": "5.21.0",
+                "knex": "3.1.0"
+            },
+            "devDependencies": {
                 "vitest": "1.6.0"
             }
         },

--- a/packages/fleet/lib/db/client.ts
+++ b/packages/fleet/lib/db/client.ts
@@ -1,0 +1,65 @@
+import path from 'node:path';
+import knex from 'knex';
+import { fileURLToPath } from 'node:url';
+import { logger } from '../utils/logger.js';
+import { isTest } from '@nangohq/utils';
+
+const runningMigrationOnly = process.argv.some((v) => v === 'migrate:latest');
+const isJS = !runningMigrationOnly;
+
+export class DatabaseClient {
+    public db: knex.Knex;
+    public schema: string;
+    public url: string;
+    private config: knex.Knex.Config;
+
+    constructor({ url, schema, poolMax = 50 }: { url: string; schema: string; poolMax?: number }) {
+        this.url = url;
+        this.schema = schema;
+        this.config = {
+            client: 'postgres',
+            connection: {
+                connectionString: url,
+                statement_timeout: 60000
+            },
+            searchPath: schema,
+            pool: { min: 2, max: poolMax },
+            migrations: {
+                extension: isJS ? 'js' : 'ts',
+                directory: 'migrations',
+                tableName: 'migrations',
+                loadExtensions: [isJS ? '.js' : '.ts'],
+                schemaName: schema
+            }
+        };
+        this.db = knex(this.config);
+    }
+
+    async migrate(): Promise<void> {
+        logger.info(`[fleet - ${this.schema}] migration`);
+
+        const filename = fileURLToPath(import.meta.url);
+        const dirname = path.dirname(path.join(filename, '../../'));
+        const dir = path.join(dirname, 'dist/db/migrations');
+        await this.db.raw(`CREATE SCHEMA IF NOT EXISTS ${this.schema}`);
+
+        const [, pendingMigrations] = (await this.db.migrate.list({ ...this.config.migrations, directory: dir })) as [unknown, string[]];
+
+        if (pendingMigrations.length === 0) {
+            logger.info(`[fleet - ${this.schema}] nothing to do`);
+            return;
+        }
+
+        await this.db.migrate.latest({ ...this.config.migrations, directory: dir });
+        logger.info(`[fleet - ${this.schema}] migrations completed.`);
+    }
+
+    /*********************************/
+    /* WARNING: to use only in tests */
+    /*********************************/
+    async clearDatabase(): Promise<void> {
+        if (isTest) {
+            await this.db.raw(`DROP SCHEMA IF EXISTS ${this.schema} CASCADE`);
+        }
+    }
+}

--- a/packages/fleet/lib/db/helpers.test.ts
+++ b/packages/fleet/lib/db/helpers.test.ts
@@ -1,0 +1,9 @@
+import { DatabaseClient } from './client.js';
+
+export const testDbUrl = `postgres://${process.env['NANGO_DB_USER']}:${process.env['NANGO_DB_PASSWORD']}@${process.env['NANGO_DB_HOST']}:${process.env['NANGO_DB_PORT']}`;
+
+export const getTestDbClient = (schema: string) =>
+    new DatabaseClient({
+        url: testDbUrl,
+        schema
+    });

--- a/packages/fleet/lib/db/migrations/20241102115903_initial_fleet_models.ts
+++ b/packages/fleet/lib/db/migrations/20241102115903_initial_fleet_models.ts
@@ -44,10 +44,6 @@ export async function up(knex: Knex): Promise<void> {
             );
         `);
         await trx.raw(`
-            CREATE UNIQUE INDEX idx_${NODES_TABLE}_routingId_deploymentId
-                ON ${NODES_TABLE}(routing_id, deployment_id);
-        `);
-        await trx.raw(`
             CREATE INDEX idx_${NODES_TABLE}_routingId_state
                 ON ${NODES_TABLE}(routing_id, state)
                 WHERE state IN ('PENDING', 'STARTING', 'RUNNING', 'OUTDATED');

--- a/packages/fleet/lib/db/migrations/20241102115903_initial_fleet_models.ts
+++ b/packages/fleet/lib/db/migrations/20241102115903_initial_fleet_models.ts
@@ -43,6 +43,10 @@ export async function up(knex: Knex): Promise<void> {
             );
         `);
         await trx.raw(`
+            CREATE UNIQUE INDEX idx_${NODES_TABLE}_routingId_deploymentId
+                ON ${NODES_TABLE}(routing_id, deployment_id);
+        `);
+        await trx.raw(`
             CREATE INDEX idx_${NODES_TABLE}_routingId_state
                 ON ${NODES_TABLE}(routing_id, state)
                 WHERE state IN ('PENDING', 'STARTING', 'RUNNING', 'OUTDATED');

--- a/packages/fleet/lib/db/migrations/20241102115903_initial_fleet_models.ts
+++ b/packages/fleet/lib/db/migrations/20241102115903_initial_fleet_models.ts
@@ -6,7 +6,8 @@ export async function up(knex: Knex): Promise<void> {
     await knex.transaction(async (trx) => {
         await trx.raw(`
             CREATE TABLE ${DEPLOYMENTS_TABLE} (
-                commit_id char(40) PRIMARY KEY,
+                id SERIAL PRIMARY KEY,
+                commit_id char(40) NOT NULL,
                 created_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 superseded_at timestamp with time zone
             );
@@ -30,7 +31,7 @@ export async function up(knex: Knex): Promise<void> {
             CREATE TABLE ${NODES_TABLE} (
                 id SERIAL PRIMARY KEY,
                 routing_id varchar(255) NOT NULL,
-                deployment_id char(40) NOT NULL REFERENCES deployments(commit_id) ON DELETE CASCADE,
+                deployment_id int NOT NULL REFERENCES deployments(id) ON DELETE CASCADE,
                 url varchar(1024),
                 state node_states NOT NULL,
                 image varchar(255) NOT NULL,

--- a/packages/fleet/lib/db/migrations/20241102115903_initial_fleet_models.ts
+++ b/packages/fleet/lib/db/migrations/20241102115903_initial_fleet_models.ts
@@ -1,0 +1,57 @@
+import type { Knex } from 'knex';
+import { NODES_TABLE } from '../../models/nodes.js';
+import { DEPLOYMENTS_TABLE } from '../../models/deployments.js';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.transaction(async (trx) => {
+        await trx.raw(`
+            CREATE TABLE ${DEPLOYMENTS_TABLE} (
+                commit_id char(40) PRIMARY KEY,
+                created_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                superseded_at timestamp with time zone
+            );
+        `);
+        await trx.raw(`
+            CREATE INDEX idx_${DEPLOYMENTS_TABLE}_active ON ${DEPLOYMENTS_TABLE}(superseded_at) WHERE superseded_at IS NULL;
+        `);
+        await trx.raw(`
+            CREATE TYPE node_states AS ENUM (
+                'PENDING',
+                'STARTING',
+                'RUNNING',
+                'OUTDATED',
+                'FINISHING',
+                'IDLE',
+                'TERMINATED',
+                'ERROR'
+            );
+        `);
+        await trx.raw(`
+            CREATE TABLE ${NODES_TABLE} (
+                id SERIAL PRIMARY KEY,
+                routing_id varchar(255) NOT NULL,
+                deployment_id char(40) NOT NULL REFERENCES deployments(commit_id) ON DELETE CASCADE,
+                url varchar(1024),
+                state node_states NOT NULL,
+                image varchar(255) NOT NULL,
+                cpu_milli int NOT NULL,
+                memory_mb int NOT NULL,
+                storage_mb int NOT NULL,
+                error text,
+                created_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                last_state_transition_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+        `);
+        await trx.raw(`
+            CREATE INDEX idx_${NODES_TABLE}_routingId_state
+                ON ${NODES_TABLE}(routing_id, state)
+                WHERE state IN ('PENDING', 'STARTING', 'RUNNING', 'OUTDATED');
+        `);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`DROP TABLE IF EXISTS ${DEPLOYMENTS_TABLE}`);
+    await knex.raw(`DROP TABLE IF EXISTS ${NODES_TABLE}`);
+    await knex.raw(`DROP TYPE IF EXISTS node_states`);
+}

--- a/packages/fleet/lib/fleet.integration.test.ts
+++ b/packages/fleet/lib/fleet.integration.test.ts
@@ -1,0 +1,29 @@
+import { expect, describe, it, beforeAll, afterAll, afterEach } from 'vitest';
+import { Fleet } from './fleet.js';
+import { getTestDbClient, testDbUrl } from './db/helpers.test.js';
+import { generateCommitHash } from './models/helpers.test.js';
+
+describe('fleet', () => {
+    const fleetId = 'my_fleet';
+    const fleet = new Fleet({ fleetId, dbUrl: testDbUrl });
+
+    beforeAll(async () => {
+        await fleet.migrate();
+    });
+
+    afterEach(() => {});
+
+    afterAll(async () => {
+        await getTestDbClient(fleetId).clearDatabase();
+    });
+
+    describe('deploy', () => {
+        it('should create a new deployment', async () => {
+            const commitId = generateCommitHash();
+            const deployment = (await fleet.deploy(commitId)).unwrap();
+            expect(deployment.commitId).toBe(commitId);
+            expect(deployment.createdAt).toBeInstanceOf(Date);
+            expect(deployment.supersededAt).toBe(null);
+        });
+    });
+});

--- a/packages/fleet/lib/fleet.ts
+++ b/packages/fleet/lib/fleet.ts
@@ -1,0 +1,19 @@
+import type { Result } from '@nangohq/utils';
+import { DatabaseClient } from './db/client.js';
+import * as deployments from './models/deployments.js';
+import type { CommitHash, Deployment } from './types.js';
+
+export class Fleet {
+    private dbClient: DatabaseClient;
+    constructor({ fleetId, dbUrl }: { fleetId: string; dbUrl: string }) {
+        this.dbClient = new DatabaseClient({ url: dbUrl, schema: fleetId });
+    }
+
+    public async migrate(): Promise<void> {
+        await this.dbClient.migrate();
+    }
+
+    public async deploy(commitId: CommitHash): Promise<Result<Deployment>> {
+        return deployments.create(this.dbClient.db, commitId);
+    }
+}

--- a/packages/fleet/lib/index.ts
+++ b/packages/fleet/lib/index.ts
@@ -1,0 +1,2 @@
+export * from './fleet.js';
+export * from './types.js';

--- a/packages/fleet/lib/models/deployments.integration.test.ts
+++ b/packages/fleet/lib/models/deployments.integration.test.ts
@@ -26,14 +26,11 @@ describe('Deployments', () => {
             const commitId1 = generateCommitHash();
             const commitId2 = generateCommitHash();
 
-            await deployments.create(db, commitId1);
-            await deployments.create(db, commitId2);
+            const deployment1 = (await deployments.create(db, commitId1)).unwrap();
+            const deployment2 = (await deployments.create(db, commitId2)).unwrap();
 
-            const deployment1 = (await deployments.get(db, commitId1)).unwrap();
-            const deployment2 = (await deployments.get(db, commitId2)).unwrap();
-
-            expect(deployment1.supersededAt).not.toBe(null);
-            expect(deployment2.supersededAt).toBe(null);
+            expect((await deployments.get(db, deployment1.id)).unwrap().supersededAt).not.toBe(null);
+            expect((await deployments.get(db, deployment2.id)).unwrap().supersededAt).toBe(null);
         });
     });
 

--- a/packages/fleet/lib/models/deployments.integration.test.ts
+++ b/packages/fleet/lib/models/deployments.integration.test.ts
@@ -1,0 +1,46 @@
+import { expect, describe, it, beforeEach, afterEach } from 'vitest';
+import * as deployments from './deployments.js';
+import { getTestDbClient } from '../db/helpers.test.js';
+import { generateCommitHash } from './helpers.test.js';
+
+describe('Deployments', () => {
+    const dbClient = getTestDbClient('deployments');
+    const db = dbClient.db;
+    beforeEach(async () => {
+        await dbClient.migrate();
+    });
+
+    afterEach(async () => {
+        await dbClient.clearDatabase();
+    });
+
+    describe('create', () => {
+        it('should create a deployment', async () => {
+            const commitId = generateCommitHash();
+            const deployment = (await deployments.create(db, commitId)).unwrap();
+            expect(deployment.commitId).toBe(commitId);
+            expect(deployment.createdAt).toBeInstanceOf(Date);
+            expect(deployment.supersededAt).toBe(null);
+        });
+        it('should supersede any active deployments', async () => {
+            const commitId1 = generateCommitHash();
+            const commitId2 = generateCommitHash();
+
+            await deployments.create(db, commitId1);
+            await deployments.create(db, commitId2);
+
+            const deployment1 = (await deployments.get(db, commitId1)).unwrap();
+            const deployment2 = (await deployments.get(db, commitId2)).unwrap();
+
+            expect(deployment1.supersededAt).not.toBe(null);
+            expect(deployment2.supersededAt).toBe(null);
+        });
+    });
+
+    describe('getActive', () => {
+        it('should return undefined if no deployments yet', async () => {
+            const active = (await deployments.getActive(db)).unwrap();
+            expect(active).toBe(undefined);
+        });
+    });
+});

--- a/packages/fleet/lib/models/deployments.ts
+++ b/packages/fleet/lib/models/deployments.ts
@@ -1,0 +1,78 @@
+import type knex from 'knex';
+import type { Result } from '@nangohq/utils';
+import { Err, Ok, stringifyError } from '@nangohq/utils';
+import type { CommitHash, Deployment } from '../types.js';
+
+export const DEPLOYMENTS_TABLE = 'deployments';
+
+export interface DBDeployment {
+    readonly commit_id: CommitHash;
+    readonly created_at: Date;
+    readonly superseded_at: Date | null;
+}
+
+const DBDeployment = {
+    to(dbDeployment: DBDeployment): Deployment {
+        return {
+            commitId: dbDeployment.commit_id,
+            createdAt: dbDeployment.created_at,
+            supersededAt: dbDeployment.superseded_at
+        };
+    },
+    from(deployment: Deployment): DBDeployment {
+        return {
+            commit_id: deployment.commitId,
+            created_at: deployment.createdAt,
+            superseded_at: deployment.supersededAt
+        };
+    }
+};
+
+export async function create(db: knex.Knex, commitId: CommitHash): Promise<Result<Deployment>> {
+    try {
+        return db.transaction(async (trx) => {
+            const now = new Date();
+            // supersede any active deployments
+            await trx
+                .from<DBDeployment>(DEPLOYMENTS_TABLE)
+                .where({
+                    superseded_at: null
+                })
+                .update({ superseded_at: now });
+            // insert new deployment
+            const dbDeployment: DBDeployment = {
+                commit_id: commitId,
+                created_at: now,
+                superseded_at: null
+            };
+            const [inserted] = await trx.into<DBDeployment>(DEPLOYMENTS_TABLE).insert(dbDeployment).returning('*');
+            if (!inserted) {
+                return Err(new Error(`Error: no deployment '${commitId}' created`));
+            }
+            return Ok(DBDeployment.to(inserted));
+        });
+    } catch (err: unknown) {
+        return Err(new Error(`Error creating deployment '${commitId}': ${stringifyError(err)}`));
+    }
+}
+
+export async function getActive(db: knex.Knex): Promise<Result<Deployment | undefined>> {
+    try {
+        const active = await db.select<DBDeployment>('*').from(DEPLOYMENTS_TABLE).where({ superseded_at: null }).first();
+        return Ok(active ? DBDeployment.to(active) : undefined);
+    } catch (err: unknown) {
+        return Err(new Error(`Error getting active deployments: ${stringifyError(err)}`));
+    }
+}
+
+export async function get(db: knex.Knex, commitId: CommitHash): Promise<Result<Deployment>> {
+    try {
+        const deployment = await db.select<DBDeployment>('*').from(DEPLOYMENTS_TABLE).where({ commit_id: commitId }).first();
+        if (!deployment) {
+            return Err(new Error(`Error: no deployment '${commitId}' found`));
+        }
+        return Ok(DBDeployment.to(deployment));
+    } catch (err: unknown) {
+        return Err(new Error(`Error getting deployment '${commitId}': ${stringifyError(err)}`));
+    }
+}

--- a/packages/fleet/lib/models/helpers.test.ts
+++ b/packages/fleet/lib/models/helpers.test.ts
@@ -1,0 +1,17 @@
+import type { CommitHash } from '../types';
+import crypto from 'crypto';
+
+export function generateCommitHash(): CommitHash {
+    const charset = '0123456789abcdef';
+    const length = 40;
+    const randomBytes = new Uint8Array(length);
+    crypto.getRandomValues(randomBytes);
+
+    const value = Array.from(randomBytes)
+        .map((byte) => charset[byte % charset.length])
+        .join('');
+    if (value.length !== 40) {
+        throw new Error('CommitHash must be exactly 40 characters');
+    }
+    return value as CommitHash;
+}

--- a/packages/fleet/lib/models/nodes.integration.test.ts
+++ b/packages/fleet/lib/models/nodes.integration.test.ts
@@ -50,28 +50,6 @@ describe('Nodes', () => {
             lastStateTransitionAt: expect.any(Date)
         });
     });
-    it('should fail to create a node with the same routingId and deploymentId', async () => {
-        const routingId = 'my-routing-id';
-        await nodes.create(db, {
-            routingId,
-            deploymentId: activeDeployment.id,
-            url: 'http://localhost:3000',
-            image: 'nangohq/my-image:latest',
-            cpuMilli: 500,
-            memoryMb: 1024,
-            storageMb: 512
-        });
-        const result = await nodes.create(db, {
-            routingId,
-            deploymentId: activeDeployment.id,
-            url: 'http://localhost:3000',
-            image: 'nangohq/my-image:latest',
-            cpuMilli: 500,
-            memoryMb: 1024,
-            storageMb: 512
-        });
-        expect(result.isErr()).toBe(true);
-    });
     it('should transition between valid states and error when transitioning between invalid states', async () => {
         for (const from of nodeStates) {
             for (const to of nodeStates) {

--- a/packages/fleet/lib/models/nodes.integration.test.ts
+++ b/packages/fleet/lib/models/nodes.integration.test.ts
@@ -1,0 +1,151 @@
+import { expect, describe, it, beforeEach, afterEach } from 'vitest';
+import * as nodes from './nodes.js';
+import * as deployments from './deployments.js';
+import { nodeStates } from '../types.js';
+import type { NodeState, Node, RoutingId } from '../types.js';
+import { getTestDbClient } from '../db/helpers.test.js';
+import type { knex } from 'knex';
+import { nanoid } from '@nangohq/utils';
+import { generateCommitHash } from './helpers.test.js';
+
+const activeDeployment = generateCommitHash();
+
+describe('Nodes', () => {
+    const dbClient = getTestDbClient('nodes');
+    const db = dbClient.db;
+    beforeEach(async () => {
+        await dbClient.migrate();
+        await deployments.create(db, activeDeployment);
+    });
+
+    afterEach(async () => {
+        await dbClient.clearDatabase();
+    });
+
+    it('should be successfully created', async () => {
+        const node = (
+            await nodes.create(db, {
+                routingId: 'my-routing-id',
+                deploymentId: activeDeployment,
+                url: 'http://localhost:3000',
+                image: 'nangohq/my-image:latest',
+                cpuMilli: 500,
+                memoryMb: 1024,
+                storageMb: 512
+            })
+        ).unwrap();
+        expect(node).toMatchObject({
+            id: expect.any(Number),
+            routingId: 'my-routing-id',
+            deploymentId: activeDeployment,
+            url: 'http://localhost:3000',
+            state: 'PENDING',
+            image: 'nangohq/my-image:latest',
+            cpuMilli: 500,
+            memoryMb: 1024,
+            storageMb: 512,
+            error: null
+        });
+    });
+    it('should transition between valid states and error when transitioning between invalid states', async () => {
+        for (const from of nodeStates) {
+            for (const to of nodeStates) {
+                const t = await createNodeWithState(db, from);
+                if (nodes.validNodeStateTransitions.find((v) => v.from === from && v.to === to)) {
+                    // sleep to ensure lastStateTransitionAt is different from the previous state
+                    await new Promise((resolve) => void setTimeout(resolve, 2));
+                    const updated = await nodes.transitionTo(db, { nodeId: t.id, newState: to });
+                    expect(updated.unwrap().state).toBe(to);
+                    expect(updated.unwrap().lastStateTransitionAt.getTime()).toBeGreaterThan(t.lastStateTransitionAt.getTime());
+                } else {
+                    const updated = await nodes.transitionTo(db, { nodeId: t.id, newState: to });
+                    expect(updated.isErr(), `transition from ${from} to ${to} failed`).toBe(true);
+                }
+            }
+        }
+    });
+    it('should be searchable', async () => {
+        const route1PendingNode = await createNodeWithState(db, 'PENDING', '1');
+        const route1RunningNode = await createNodeWithState(db, 'RUNNING', route1PendingNode.routingId);
+        const startingNode = await createNodeWithState(db, 'STARTING');
+        const runningNode = await createNodeWithState(db, 'RUNNING');
+        const outdatedNode = await createNodeWithState(db, 'OUTDATED');
+        const finishingNode = await createNodeWithState(db, 'FINISHING');
+        const idleNode = await createNodeWithState(db, 'IDLE');
+        const terminatedNode = await createNodeWithState(db, 'TERMINATED');
+        const errorNode = await createNodeWithState(db, 'ERROR');
+
+        const searchAllStates = await nodes.search(db, {
+            states: ['PENDING', 'STARTING', 'RUNNING', 'OUTDATED', 'FINISHING', 'IDLE', 'TERMINATED', 'ERROR']
+        });
+        expect(searchAllStates.unwrap().nodes).toEqual(
+            new Map([
+                [route1PendingNode.routingId, [route1PendingNode, route1RunningNode]],
+                [startingNode.routingId, [startingNode]],
+                [runningNode.routingId, [runningNode]],
+                [outdatedNode.routingId, [outdatedNode]],
+                [finishingNode.routingId, [finishingNode]],
+                [idleNode.routingId, [idleNode]],
+                [terminatedNode.routingId, [terminatedNode]],
+                [errorNode.routingId, [errorNode]]
+            ])
+        );
+
+        const searchRunning = await nodes.search(db, { states: ['RUNNING'] });
+        expect(searchRunning.unwrap().nodes).toEqual(
+            new Map([
+                [route1RunningNode.routingId, [route1RunningNode]],
+                [runningNode.routingId, [runningNode]]
+            ])
+        );
+
+        const searchWithWrongRoute = await nodes.search(db, { states: ['PENDING'], routingId: terminatedNode.routingId });
+        expect(searchWithWrongRoute.unwrap().nodes).toEqual(new Map());
+    });
+    it('should be searchable (with pagination support)', async () => {
+        for (let i = 0; i < 12; i++) {
+            await createNodeWithState(db, 'PENDING', i.toString());
+        }
+        const searchFirstPage = (await nodes.search(db, { states: ['PENDING'], limit: 5 })).unwrap();
+        expect(searchFirstPage.nodes.size).toBe(5);
+        expect(searchFirstPage.nextCursor).toBe(6);
+
+        const searchSecondPage = (await nodes.search(db, { states: ['PENDING'], limit: 5, cursor: searchFirstPage.nextCursor! })).unwrap();
+        expect(searchSecondPage.nodes.size).toBe(5);
+        expect(searchSecondPage.nextCursor).toBe(11);
+
+        const searchThirdPage = (await nodes.search(db, { states: ['PENDING'], limit: 5, cursor: searchSecondPage.nextCursor! })).unwrap();
+        expect(searchThirdPage.nodes.size).toBe(2);
+        expect(searchThirdPage.nextCursor).toBe(undefined);
+    });
+});
+
+async function createNodeWithState(db: knex.Knex, state: NodeState, routingId: RoutingId = nanoid()): Promise<Node> {
+    let node = await createNode(db, routingId);
+    if (state == 'ERROR') {
+        return (await nodes.fail(db, { nodeId: node.id, error: 'my error' })).unwrap();
+    }
+    // transition to the desired state
+    while (node.state !== state) {
+        const nextState = nodes.validNodeStateTransitions.find((v) => v.from === node.state)?.to;
+        if (nextState) {
+            node = (await nodes.transitionTo(db, { nodeId: node.id, newState: nextState })).unwrap();
+        } else {
+            throw new Error(`Cannot transition node to state '${state}'`);
+        }
+    }
+    return node;
+}
+
+async function createNode(db: knex.Knex, routingId: RoutingId): Promise<Node> {
+    const node = await nodes.create(db, {
+        routingId,
+        deploymentId: activeDeployment,
+        url: 'http://localhost:1234',
+        image: 'nangohq/my-image:latest',
+        cpuMilli: 500,
+        memoryMb: 1024,
+        storageMb: 512
+    });
+    return node.unwrap();
+}

--- a/packages/fleet/lib/models/nodes.ts
+++ b/packages/fleet/lib/models/nodes.ts
@@ -1,7 +1,7 @@
 import type knex from 'knex';
 import type { Result } from '@nangohq/utils';
 import { Ok, Err, stringifyError } from '@nangohq/utils';
-import type { NodeState, Node, CommitHash, RoutingId } from '../types.js';
+import type { NodeState, Node, RoutingId } from '../types.js';
 
 export const NODES_TABLE = 'nodes';
 
@@ -33,7 +33,7 @@ const NodeStateTransition = {
 export interface DBNode {
     readonly id: number;
     readonly routing_id: RoutingId;
-    readonly deployment_id: CommitHash;
+    readonly deployment_id: number;
     readonly url: string | null;
     readonly state: NodeState;
     readonly image: string;
@@ -101,8 +101,8 @@ export async function create(db: knex.Knex, nodeProps: Omit<Node, 'id' | 'create
             return Err(new Error(`Error: no node '${nodeProps.routingId}' created`));
         }
         return Ok(DBNode.from(inserted[0]));
-    } catch (err: unknown) {
-        return Err(new Error(`Error creating node '${nodeProps.routingId}': ${stringifyError(err)}`));
+    } catch (err) {
+        return Err(new Error(`Error creating node '${JSON.stringify(nodeProps)}': ${stringifyError(err)}`));
     }
 }
 export async function get(db: knex.Knex, nodeId: number, options: { forUpdate: boolean } = { forUpdate: false }): Promise<Result<Node>> {

--- a/packages/fleet/lib/models/nodes.ts
+++ b/packages/fleet/lib/models/nodes.ts
@@ -19,7 +19,6 @@ export const validNodeStateTransitions = [
     { from: 'IDLE', to: 'TERMINATED' }
 ] as const;
 export type ValidNodeStateTransitions = (typeof validNodeStateTransitions)[number];
-
 const NodeStateTransition = {
     validate({ from, to }: { from: NodeState; to: Omit<NodeState, 'ERROR'> }): Result<ValidNodeStateTransitions> {
         const transition = validNodeStateTransitions.find((t) => t.from === from && t.to === to);

--- a/packages/fleet/lib/models/nodes.ts
+++ b/packages/fleet/lib/models/nodes.ts
@@ -1,0 +1,218 @@
+import type knex from 'knex';
+import type { Result } from '@nangohq/utils';
+import { Ok, Err, stringifyError } from '@nangohq/utils';
+import type { NodeState, Node, CommitHash, RoutingId } from '../types.js';
+
+export const NODES_TABLE = 'nodes';
+
+interface NodeStateTransition {
+    from: NodeState;
+    to: NodeState;
+}
+
+export const validNodeStateTransitions = [
+    { from: 'PENDING', to: 'STARTING' },
+    { from: 'STARTING', to: 'RUNNING' },
+    { from: 'RUNNING', to: 'OUTDATED' },
+    { from: 'OUTDATED', to: 'FINISHING' },
+    { from: 'FINISHING', to: 'IDLE' },
+    { from: 'IDLE', to: 'TERMINATED' }
+] as const;
+export type ValidNodeStateTransitions = (typeof validNodeStateTransitions)[number];
+
+const NodeStateTransition = {
+    validate({ from, to }: { from: NodeState; to: Omit<NodeState, 'ERROR'> }): Result<ValidNodeStateTransitions> {
+        const transition = validNodeStateTransitions.find((t) => t.from === from && t.to === to);
+        if (transition) {
+            return Ok(transition);
+        } else {
+            return Err(new Error(`Invalid state transition from ${from} to ${to}`));
+        }
+    }
+};
+
+export interface DBNode {
+    readonly id: number;
+    readonly routing_id: RoutingId;
+    readonly deployment_id: CommitHash;
+    readonly url: string | null;
+    readonly state: NodeState;
+    readonly image: string;
+    readonly cpu_milli: number;
+    readonly memory_mb: number;
+    readonly storage_mb: number;
+    readonly error: string | null;
+    readonly created_at: Date;
+    readonly last_state_transition_at: Date;
+}
+
+export const DBNode = {
+    to: (node: Node): DBNode => {
+        return {
+            id: node.id,
+            routing_id: node.routingId,
+            deployment_id: node.deploymentId,
+            url: node.url,
+            state: node.state,
+            image: node.image,
+            cpu_milli: node.cpuMilli,
+            memory_mb: node.memoryMb,
+            storage_mb: node.storageMb,
+            error: node.error,
+            created_at: node.createdAt,
+            last_state_transition_at: node.lastStateTransitionAt
+        };
+    },
+    from: (dbNode: DBNode): Node => {
+        return {
+            id: dbNode.id,
+            routingId: dbNode.routing_id,
+            deploymentId: dbNode.deployment_id,
+            url: dbNode.url,
+            state: dbNode.state,
+            image: dbNode.image,
+            cpuMilli: dbNode.cpu_milli,
+            memoryMb: dbNode.memory_mb,
+            storageMb: dbNode.storage_mb,
+            error: dbNode.error,
+            createdAt: dbNode.created_at,
+            lastStateTransitionAt: dbNode.last_state_transition_at
+        };
+    }
+};
+
+export async function create(db: knex.Knex, nodeProps: Omit<Node, 'id' | 'createdAt' | 'state' | 'lastStateTransitionAt' | 'error'>): Promise<Result<Node>> {
+    const now = new Date();
+    const newNode: Omit<DBNode, 'id'> = {
+        routing_id: nodeProps.routingId,
+        deployment_id: nodeProps.deploymentId,
+        url: nodeProps.url,
+        state: 'PENDING',
+        image: nodeProps.image,
+        cpu_milli: nodeProps.cpuMilli,
+        memory_mb: nodeProps.memoryMb,
+        storage_mb: nodeProps.storageMb,
+        error: null,
+        created_at: now,
+        last_state_transition_at: now
+    };
+    try {
+        const inserted = await db.from<DBNode>(NODES_TABLE).insert(newNode).returning('*');
+        if (!inserted?.[0]) {
+            return Err(new Error(`Error: no node '${nodeProps.routingId}' created`));
+        }
+        return Ok(DBNode.from(inserted[0]));
+    } catch (err: unknown) {
+        return Err(new Error(`Error creating node '${nodeProps.routingId}': ${stringifyError(err)}`));
+    }
+}
+export async function get(db: knex.Knex, nodeId: number, options: { forUpdate: boolean } = { forUpdate: false }): Promise<Result<Node>> {
+    const query = db.select<DBNode>('*').from(NODES_TABLE).where({ id: nodeId }).first();
+    if (options.forUpdate) {
+        query.forUpdate();
+    }
+    const node = await query;
+    if (!node) {
+        return Err(new Error(`Node with id '${nodeId}' not found`));
+    }
+    return Ok(DBNode.from(node));
+}
+
+export async function search(
+    db: knex.Knex,
+    params: {
+        states: [NodeState, ...NodeState[]]; // non-empty array
+        routingId?: RoutingId;
+        cursor?: number;
+        limit?: number;
+    }
+): Promise<
+    Result<{
+        nodes: Map<RoutingId, Node[]>;
+        nextCursor?: number;
+    }>
+> {
+    const limit = params.limit || 1000;
+    const query = db
+        .select<DBNode[]>('*')
+        .from(NODES_TABLE)
+        .whereIn('state', params.states)
+        .orderBy('id')
+        .limit(limit + 1); // fetch one more than limit to determine if there are more results
+
+    if (params.routingId) {
+        query.where({ routing_id: params.routingId });
+    }
+    if (params.cursor) {
+        query.where('id', '>=', params.cursor);
+    }
+
+    const nodes = await query;
+
+    const nextCursor = nodes.length > limit ? nodes.pop()?.id : undefined;
+
+    const nodesMap = new Map<RoutingId, Node[]>();
+
+    for (const node of nodes) {
+        const routingId = node.routing_id;
+        const existingNodes = nodesMap.get(routingId) || [];
+        existingNodes.push(DBNode.from(node));
+        nodesMap.set(routingId, existingNodes);
+    }
+
+    return Ok({
+        nodes: nodesMap,
+        ...(nextCursor ? { nextCursor } : {})
+    });
+}
+
+export async function transitionTo(
+    db: knex.Knex,
+    props: {
+        nodeId: number;
+        newState: Omit<NodeState, 'ERROR'>;
+    }
+): Promise<Result<Node>> {
+    return db.transaction(async (trx) => {
+        const node = await get(trx, props.nodeId, { forUpdate: true });
+        if (node.isErr()) {
+            return Err(new Error(`Node '${props.nodeId}' not found`));
+        }
+
+        const transition = NodeStateTransition.validate({ from: node.value.state, to: props.newState });
+        if (transition.isErr()) {
+            return Err(transition.error);
+        }
+
+        const updated = await trx
+            .from<DBNode>(NODES_TABLE)
+            .where('id', props.nodeId)
+            .update({
+                state: transition.value.to,
+                last_state_transition_at: new Date()
+            })
+            .returning('*');
+        if (!updated?.[0]) {
+            return Err(new Error(`Node '${props.nodeId}' not updated`));
+        }
+        return Ok(DBNode.from(updated[0]));
+    });
+}
+
+export async function fail(
+    db: knex.Knex,
+    props: {
+        nodeId: number;
+        error: string;
+    }
+): Promise<Result<Node>> {
+    const updated = await db
+        .from<DBNode>(NODES_TABLE)
+        .where({ id: props.nodeId })
+        .update({ state: 'ERROR', error: props.error, last_state_transition_at: new Date() })
+        .returning('*');
+    if (!updated?.[0]) {
+        return Err(new Error(`Node '${props.nodeId}' not failed`));
+    }
+    return Ok(DBNode.from(updated[0]));
+}

--- a/packages/fleet/lib/tracer.ts
+++ b/packages/fleet/lib/tracer.ts
@@ -1,0 +1,11 @@
+import tracer from 'dd-trace';
+
+tracer.init({
+    service: 'nango-fleet'
+});
+tracer.use('pg', {
+    service: (params: { database: string }) => `postgres-${params.database}`
+});
+tracer.use('dns', {
+    enabled: false
+});

--- a/packages/fleet/lib/types.ts
+++ b/packages/fleet/lib/types.ts
@@ -1,6 +1,7 @@
 export type CommitHash = string & { readonly length: 40 };
 
 export interface Deployment {
+    readonly id: number;
     readonly commitId: CommitHash;
     readonly createdAt: Date;
     readonly supersededAt: Date | null;
@@ -14,7 +15,7 @@ export type NodeState = (typeof nodeStates)[number];
 export interface Node {
     readonly id: number;
     readonly routingId: RoutingId;
-    readonly deploymentId: CommitHash;
+    readonly deploymentId: number;
     readonly url: string | null;
     readonly state: NodeState;
     readonly image: string;

--- a/packages/fleet/lib/types.ts
+++ b/packages/fleet/lib/types.ts
@@ -1,0 +1,27 @@
+export type CommitHash = string & { readonly length: 40 };
+
+export interface Deployment {
+    readonly commitId: CommitHash;
+    readonly createdAt: Date;
+    readonly supersededAt: Date | null;
+}
+
+export type RoutingId = string;
+
+export const nodeStates = ['PENDING', 'STARTING', 'RUNNING', 'OUTDATED', 'FINISHING', 'IDLE', 'TERMINATED', 'ERROR'] as const;
+export type NodeState = (typeof nodeStates)[number];
+
+export interface Node {
+    readonly id: number;
+    readonly routingId: RoutingId;
+    readonly deploymentId: CommitHash;
+    readonly url: string | null;
+    readonly state: NodeState;
+    readonly image: string;
+    readonly cpuMilli: number;
+    readonly memoryMb: number;
+    readonly storageMb: number;
+    readonly error: string | null;
+    readonly createdAt: Date;
+    readonly lastStateTransitionAt: Date;
+}

--- a/packages/fleet/lib/utils/errors.ts
+++ b/packages/fleet/lib/utils/errors.ts
@@ -1,4 +1,4 @@
-type Jsonable = string | number | boolean | null | undefined | readonly Jsonable[] | { readonly [key: string]: Jsonable } | { toJSON(): Jsonable };
+import type { Jsonable } from '@nangohq/types';
 
 type FleetErrorCode =
     | 'deployment_creation_error'

--- a/packages/fleet/lib/utils/errors.ts
+++ b/packages/fleet/lib/utils/errors.ts
@@ -1,0 +1,23 @@
+type Jsonable = string | number | boolean | null | undefined | readonly Jsonable[] | { readonly [key: string]: Jsonable } | { toJSON(): Jsonable };
+
+type FleetErrorCode =
+    | 'deployment_creation_error'
+    | 'deployment_get_active_error'
+    | 'deployment_not_found'
+    | 'node_invalid_state_transition'
+    | 'node_not_found'
+    | 'node_creation_error'
+    | 'node_search_error'
+    | 'node_transition_error'
+    | 'node_fail_error';
+
+export class FleetError extends Error {
+    public readonly context?: Jsonable;
+
+    constructor(code: FleetErrorCode, options: { cause?: unknown; context?: Jsonable } = {}) {
+        const { cause, context } = options;
+        super(code, { cause });
+        this.name = this.constructor.name;
+        this.context = context;
+    }
+}

--- a/packages/fleet/lib/utils/logger.ts
+++ b/packages/fleet/lib/utils/logger.ts
@@ -1,0 +1,3 @@
+import { getLogger } from '@nangohq/utils';
+
+export const logger = getLogger('fleet');

--- a/packages/fleet/package.json
+++ b/packages/fleet/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "@nangohq/fleet",
+    "version": "1.0.0",
+    "type": "module",
+    "main": "dist/index.js",
+    "private": true,
+    "scripts": {
+        "dev:migration:create": "npm run knex -- migrate:make",
+        "dev:migration:run": "npm run knex -- migrate:latest",
+        "knex": "tsx ../../node_modules/knex/bin/cli.js --knexfile lib/db/knexfile.ts",
+        "prod:migration:run": "knex --knexfile dist/db/knexfile.js migrate:latest"
+    },
+    "keywords": [],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/NangoHQ/nango.git",
+        "directory": "packages/fleet"
+    },
+    "dependencies": {
+        "@nangohq/utils": "file:../utils",
+        "dd-trace": "5.21.0",
+        "knex": "3.1.0"
+    },
+    "devDependencies": {
+        "vitest": "1.6.0"
+    }
+}

--- a/packages/fleet/tsconfig.json
+++ b/packages/fleet/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "lib",
+        "outDir": "dist"
+    },
+    "references": [{ "path": "../utils" }],
+    "include": ["lib/**/*", "../utils/lib/vitest.d.ts"]
+}

--- a/packages/types/lib/utils.ts
+++ b/packages/types/lib/utils.ts
@@ -17,3 +17,5 @@ export type NullablePartial<TBase, TNullableKey extends keyof TBase = { [K in ke
     Pick<TBase, TNullableKey>
 > &
     Pick<TBase, Exclude<keyof TBase, TNullableKey>>;
+
+export type Jsonable = string | number | boolean | null | undefined | readonly Jsonable[] | { readonly [key: string]: Jsonable } | { toJSON(): Jsonable };

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -63,6 +63,9 @@
         },
         {
             "path": "packages/keystore"
+        },
+        {
+            "path": "packages/fleet"
         }
     ]
 }


### PR DESCRIPTION
The fleet package will be used to managed the lifecycle of runners 

This commit includes:
- migration for deployments and nodes tables
- deployments and nodes models (with tests) 

This commit DOESN'T include (I though that would be enough for a first PR):
- the control loop to handle nodes state transition
- the routing logic

<!-- Testing instructions (skip if just adding/editing providers) -->
# How to test
The code is not used so it is not possible to run it manually. There is tests though :)
