### PR TITLE
fix(providers): greenhouse api domain wording

### DIFF
--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -2994,10 +2994,10 @@ greenhouse:
     connection_config:
         resource:
             type: string
-            title: Greenhouse Domain
-            description: The subdomain of your Greenhouse account
+            title: Greenhouse API Domain
+            description: The Greenhouse API Domain you want to connect to
             pattern: '^[a-z0-9_-]+$'
-            example: domain
+            example: harvest
             suffix: .greenhouse.io
             prefix: https://
 
@@ -3020,10 +3020,10 @@ greenhouse-basic:
     connection_config:
         resource:
             type: string
-            title: Greenhouse Domain
-            description: The subdomain of your Greenhouse account
+            title: Greenhouse API Domain
+            description: The Greenhouse API Domain you want to connect to
             pattern: '^[a-z0-9_-]+$'
-            example: domain
+            example: harvest
             suffix: .greenhouse.io
             prefix: https://
             order: 1

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -3014,8 +3014,6 @@ greenhouse-basic:
             type: link
             limit_name_in_request: per_page
             link_rel_in_response_header: next
-        verification:
-            endpoint: /v1/applications
     docs: https://docs.nango.dev/integrations/all/greenhouse
     connection_config:
         resource:


### PR DESCRIPTION
## Changes

This provider is doomed, greenhouse has 7 different APIs with 7 different domains and their own Auth method and routes.
We should have been more careful but it was easy to miss at the time. 
https://developers.greenhouse.io/

- Remove confusion around which domain we request

- Remove key verification
Ideally, we create an alias for each of them, stop asking for the domain, and re-up verification
