### PR TITLE
feat(fleet): add control loop and state management

### DIFF
--- a/packages/fleet/lib/models/deployments.integration.test.ts
+++ b/packages/fleet/lib/models/deployments.integration.test.ts
@@ -22,6 +22,7 @@ describe('Deployments', () => {
             expect(deployment.createdAt).toBeInstanceOf(Date);
             expect(deployment.supersededAt).toBe(null);
         });
+
         it('should supersede any active deployments', async () => {
             const commitId1 = generateCommitHash();
             const commitId2 = generateCommitHash();

--- a/packages/fleet/lib/models/helpers.test.ts
+++ b/packages/fleet/lib/models/helpers.test.ts
@@ -1,5 +1,9 @@
 import type { CommitHash } from '../types';
 import crypto from 'crypto';
+import type { NodeState, Node, RoutingId } from '../types.js';
+import type { knex } from 'knex';
+import { nanoid } from '@nangohq/utils';
+import * as nodes from './nodes.js';
 
 export function generateCommitHash(): CommitHash {
     const charset = '0123456789abcdef';
@@ -14,4 +18,56 @@ export function generateCommitHash(): CommitHash {
         throw new Error('CommitHash must be exactly 40 characters');
     }
     return value as CommitHash;
+}
+
+export async function createNodeWithAttributes(
+    db: knex.Knex,
+    {
+        state,
+        deploymentId,
+        routingId = nanoid(),
+        lastStateTransitionAt
+    }: { state: NodeState; deploymentId: number; routingId?: RoutingId; lastStateTransitionAt?: Date }
+): Promise<Node> {
+    return db.transaction(async (trx) => {
+        let node = await createNode(trx, { routingId, deploymentId });
+        if (state == 'ERROR') {
+            node = (await nodes.fail(trx, { nodeId: node.id, reason: 'my error' })).unwrap();
+        }
+        // transition to the desired state
+        while (node.state !== state) {
+            const nextState = nodes.validNodeStateTransitions.find((v) => v.from === node.state && v.to !== 'ERROR')?.to;
+            if (nextState === 'RUNNING') {
+                node = (await nodes.register(trx, { nodeId: node.id, url: 'http://my-url' })).unwrap();
+            } else if (nextState && nextState !== 'ERROR') {
+                node = (await nodes.transitionTo(trx, { nodeId: node.id, newState: nextState })).unwrap();
+            } else {
+                throw new Error(`Cannot transition node to state '${state}'`);
+            }
+        }
+        if (lastStateTransitionAt) {
+            await trx
+                .from(nodes.NODES_TABLE)
+                .update({ created_at: lastStateTransitionAt, last_state_transition_at: lastStateTransitionAt })
+                .where('id', node.id);
+            node = {
+                ...node,
+                createdAt: lastStateTransitionAt,
+                lastStateTransitionAt
+            };
+        }
+        return node;
+    });
+}
+
+async function createNode(db: knex.Knex, { routingId, deploymentId }: { routingId: RoutingId; deploymentId: number }): Promise<Node> {
+    const node = await nodes.create(db, {
+        routingId,
+        deploymentId,
+        image: 'nangohq/my-image:latest',
+        cpuMilli: 500,
+        memoryMb: 1024,
+        storageMb: 512
+    });
+    return node.unwrap();
 }

--- a/packages/fleet/lib/models/nodes.integration.test.ts
+++ b/packages/fleet/lib/models/nodes.integration.test.ts
@@ -54,7 +54,7 @@ describe('Nodes', () => {
         const routingId = 'my-routing-id';
         await nodes.create(db, {
             routingId,
-            deploymentId: activeDeployment,
+            deploymentId: activeDeployment.id,
             url: 'http://localhost:3000',
             image: 'nangohq/my-image:latest',
             cpuMilli: 500,
@@ -63,7 +63,7 @@ describe('Nodes', () => {
         });
         const result = await nodes.create(db, {
             routingId,
-            deploymentId: activeDeployment,
+            deploymentId: activeDeployment.id,
             url: 'http://localhost:3000',
             image: 'nangohq/my-image:latest',
             cpuMilli: 500,

--- a/packages/fleet/lib/models/nodes.integration.test.ts
+++ b/packages/fleet/lib/models/nodes.integration.test.ts
@@ -50,28 +50,6 @@ describe('Nodes', () => {
             lastStateTransitionAt: expect.any(Date)
         });
     });
-    it('should fail to create a node with the same routingId and deploymentId', async () => {
-        const routingId = 'my-routing-id';
-        await nodes.create(db, {
-            routingId,
-            deploymentId: activeDeployment.id,
-            url: 'http://localhost:3000',
-            image: 'nangohq/my-image:latest',
-            cpuMilli: 500,
-            memoryMb: 1024,
-            storageMb: 512
-        });
-        const result = await nodes.create(db, {
-            routingId,
-            deploymentId: activeDeployment.id,
-            url: 'http://localhost:3000',
-            image: 'nangohq/my-image:latest',
-            cpuMilli: 500,
-            memoryMb: 1024,
-            storageMb: 512
-        });
-        expect(result.isErr()).toBe(true);
-    });
     it('should transition between valid states and error when transitioning between invalid states', async () => {
         for (const from of nodeStates) {
             for (const to of nodeStates) {

--- a/packages/fleet/lib/models/nodes.integration.test.ts
+++ b/packages/fleet/lib/models/nodes.integration.test.ts
@@ -2,15 +2,14 @@ import { expect, describe, it, beforeEach, afterEach } from 'vitest';
 import * as nodes from './nodes.js';
 import * as deployments from './deployments.js';
 import { nodeStates } from '../types.js';
-import type { NodeState, Node, RoutingId, Deployment } from '../types.js';
+import type { NodeState, Deployment } from '../types.js';
 import { getTestDbClient } from '../db/helpers.test.js';
-import type { knex } from 'knex';
-import { nanoid } from '@nangohq/utils';
-import { generateCommitHash } from './helpers.test.js';
+import { generateCommitHash, createNodeWithAttributes } from './helpers.test.js';
 
 describe('Nodes', () => {
     const dbClient = getTestDbClient('nodes');
     const db = dbClient.db;
+
     let previousDeployment: Deployment;
     let activeDeployment: Deployment;
     beforeEach(async () => {
@@ -28,7 +27,6 @@ describe('Nodes', () => {
             await nodes.create(db, {
                 routingId: 'my-routing-id',
                 deploymentId: activeDeployment.id,
-                url: 'http://localhost:3000',
                 image: 'nangohq/my-image:latest',
                 cpuMilli: 500,
                 memoryMb: 1024,
@@ -39,7 +37,7 @@ describe('Nodes', () => {
             id: expect.any(Number),
             routingId: 'my-routing-id',
             deploymentId: activeDeployment.id,
-            url: 'http://localhost:3000',
+            url: null,
             state: 'PENDING',
             image: 'nangohq/my-image:latest',
             cpuMilli: 500,
@@ -51,58 +49,67 @@ describe('Nodes', () => {
         });
     });
     it('should transition between valid states and error when transitioning between invalid states', async () => {
+        const doTransition = async ({ nodeId, newState }: { nodeId: number; newState: NodeState }) => {
+            if (newState === 'RUNNING') {
+                return await nodes.register(db, { nodeId, url: 'http://my-url' });
+            } else if (newState === 'ERROR') {
+                return await nodes.fail(db, { nodeId, reason: 'my error' });
+            } else {
+                return await nodes.transitionTo(db, { nodeId, newState });
+            }
+        };
         for (const from of nodeStates) {
             for (const to of nodeStates) {
-                const t = await createNodeWithState(db, { state: from, deploymentId: activeDeployment.id });
+                const t = await createNodeWithAttributes(db, { state: from, deploymentId: activeDeployment.id });
                 if (nodes.validNodeStateTransitions.find((v) => v.from === from && v.to === to)) {
                     // sleep to ensure lastStateTransitionAt is different from the previous state
                     await new Promise((resolve) => void setTimeout(resolve, 2));
-                    const updated = await nodes.transitionTo(db, { nodeId: t.id, newState: to });
+                    const updated = await doTransition({ nodeId: t.id, newState: to });
                     expect(updated.unwrap().state).toBe(to);
                     expect(updated.unwrap().lastStateTransitionAt.getTime()).toBeGreaterThan(t.lastStateTransitionAt.getTime());
                 } else {
-                    const updated = await nodes.transitionTo(db, { nodeId: t.id, newState: to });
+                    const updated = await doTransition({ nodeId: t.id, newState: to });
                     expect(updated.isErr(), `transition from ${from} to ${to} failed`).toBe(true);
                 }
             }
         }
     });
     it('should be searchable', async () => {
-        const route1PendingNode = await createNodeWithState(db, { state: 'PENDING', routingId: '1', deploymentId: activeDeployment.id });
-        const route1RunningNode = await createNodeWithState(db, {
+        const route1PendingNode = await createNodeWithAttributes(db, { state: 'PENDING', routingId: '1', deploymentId: activeDeployment.id });
+        const route1RunningNode = await createNodeWithAttributes(db, {
             state: 'RUNNING',
             routingId: route1PendingNode.routingId,
             deploymentId: previousDeployment.id
         });
-        const startingNode = await createNodeWithState(db, { state: 'STARTING', deploymentId: activeDeployment.id });
-        const runningNode = await createNodeWithState(db, { state: 'RUNNING', deploymentId: activeDeployment.id });
-        const outdatedNode = await createNodeWithState(db, { state: 'OUTDATED', deploymentId: activeDeployment.id });
-        const finishingNode = await createNodeWithState(db, { state: 'FINISHING', deploymentId: activeDeployment.id });
-        const idleNode = await createNodeWithState(db, { state: 'IDLE', deploymentId: activeDeployment.id });
-        const terminatedNode = await createNodeWithState(db, { state: 'TERMINATED', deploymentId: activeDeployment.id });
-        const errorNode = await createNodeWithState(db, { state: 'ERROR', deploymentId: activeDeployment.id });
+        const startingNode = await createNodeWithAttributes(db, { state: 'STARTING', deploymentId: activeDeployment.id });
+        const runningNode = await createNodeWithAttributes(db, { state: 'RUNNING', deploymentId: activeDeployment.id });
+        const outdatedNode = await createNodeWithAttributes(db, { state: 'OUTDATED', deploymentId: activeDeployment.id });
+        const finishingNode = await createNodeWithAttributes(db, { state: 'FINISHING', deploymentId: activeDeployment.id });
+        const idleNode = await createNodeWithAttributes(db, { state: 'IDLE', deploymentId: activeDeployment.id });
+        const terminatedNode = await createNodeWithAttributes(db, { state: 'TERMINATED', deploymentId: activeDeployment.id });
+        const errorNode = await createNodeWithAttributes(db, { state: 'ERROR', deploymentId: activeDeployment.id });
 
         const searchAllStates = await nodes.search(db, {
             states: ['PENDING', 'STARTING', 'RUNNING', 'OUTDATED', 'FINISHING', 'IDLE', 'TERMINATED', 'ERROR']
         });
         expect(searchAllStates.unwrap().nodes).toEqual(
             new Map([
-                [route1PendingNode.routingId, [route1PendingNode, route1RunningNode]],
-                [startingNode.routingId, [startingNode]],
-                [runningNode.routingId, [runningNode]],
-                [outdatedNode.routingId, [outdatedNode]],
-                [finishingNode.routingId, [finishingNode]],
-                [idleNode.routingId, [idleNode]],
-                [terminatedNode.routingId, [terminatedNode]],
-                [errorNode.routingId, [errorNode]]
+                [route1PendingNode.routingId, { PENDING: [route1PendingNode], RUNNING: [route1RunningNode] }],
+                [startingNode.routingId, { STARTING: [startingNode] }],
+                [runningNode.routingId, { RUNNING: [runningNode] }],
+                [outdatedNode.routingId, { OUTDATED: [outdatedNode] }],
+                [finishingNode.routingId, { FINISHING: [finishingNode] }],
+                [idleNode.routingId, { IDLE: [idleNode] }],
+                [terminatedNode.routingId, { TERMINATED: [terminatedNode] }],
+                [errorNode.routingId, { ERROR: [errorNode] }]
             ])
         );
 
         const searchRunning = await nodes.search(db, { states: ['RUNNING'] });
         expect(searchRunning.unwrap().nodes).toEqual(
             new Map([
-                [route1RunningNode.routingId, [route1RunningNode]],
-                [runningNode.routingId, [runningNode]]
+                [route1RunningNode.routingId, { RUNNING: [route1RunningNode] }],
+                [runningNode.routingId, { RUNNING: [runningNode] }]
             ])
         );
 
@@ -111,7 +118,7 @@ describe('Nodes', () => {
     });
     it('should be searchable (with pagination support)', async () => {
         for (let i = 0; i < 12; i++) {
-            await createNodeWithState(db, { state: 'PENDING', routingId: i.toString(), deploymentId: activeDeployment.id });
+            await createNodeWithAttributes(db, { state: 'PENDING', routingId: i.toString(), deploymentId: activeDeployment.id });
         }
         const searchFirstPage = (await nodes.search(db, { states: ['PENDING'], limit: 5 })).unwrap();
         expect(searchFirstPage.nodes.size).toBe(5);
@@ -125,37 +132,22 @@ describe('Nodes', () => {
         expect(searchThirdPage.nodes.size).toBe(2);
         expect(searchThirdPage.nextCursor).toBe(undefined);
     });
-});
-
-async function createNodeWithState(
-    db: knex.Knex,
-    { state, deploymentId, routingId = nanoid() }: { state: NodeState; deploymentId: number; routingId?: RoutingId }
-): Promise<Node> {
-    let node = await createNode(db, { routingId, deploymentId });
-    if (state == 'ERROR') {
-        return (await nodes.fail(db, { nodeId: node.id, error: 'my error' })).unwrap();
-    }
-    // transition to the desired state
-    while (node.state !== state) {
-        const nextState = nodes.validNodeStateTransitions.find((v) => v.from === node.state)?.to;
-        if (nextState) {
-            node = (await nodes.transitionTo(db, { nodeId: node.id, newState: nextState })).unwrap();
-        } else {
-            throw new Error(`Cannot transition node to state '${state}'`);
-        }
-    }
-    return node;
-}
-
-async function createNode(db: knex.Knex, { routingId, deploymentId }: { routingId: RoutingId; deploymentId: number }): Promise<Node> {
-    const node = await nodes.create(db, {
-        routingId,
-        deploymentId,
-        url: 'http://localhost:1234',
-        image: 'nangohq/my-image:latest',
-        cpuMilli: 500,
-        memoryMb: 1024,
-        storageMb: 512
+    it('should be able to fail a node', async () => {
+        const node = await createNodeWithAttributes(db, { state: 'PENDING', deploymentId: activeDeployment.id });
+        const failedNode = (await nodes.fail(db, { nodeId: node.id, reason: 'my error' })).unwrap();
+        expect(failedNode.state).toBe('ERROR');
+        expect(failedNode.error).toBe('my error');
     });
-    return node.unwrap();
-}
+    it('should be able to register a node', async () => {
+        const node = await createNodeWithAttributes(db, { state: 'STARTING', deploymentId: activeDeployment.id });
+        expect(node.url).toBe(null);
+        const registeredNode = (await nodes.register(db, { nodeId: node.id, url: 'http://my-url' })).unwrap();
+        expect(registeredNode.state).toBe('RUNNING');
+        expect(registeredNode.url).toBe('http://my-url');
+    });
+    it('should be able to idle a node', async () => {
+        const node = await createNodeWithAttributes(db, { state: 'FINISHING', deploymentId: activeDeployment.id });
+        const idledNode = (await nodes.idle(db, { nodeId: node.id })).unwrap();
+        expect(idledNode.state).toBe('IDLE');
+    });
+});

--- a/packages/fleet/lib/models/nodes.integration.test.ts
+++ b/packages/fleet/lib/models/nodes.integration.test.ts
@@ -48,6 +48,7 @@ describe('Nodes', () => {
             lastStateTransitionAt: expect.any(Date)
         });
     });
+
     it('should transition between valid states and error when transitioning between invalid states', async () => {
         const doTransition = async ({ nodeId, newState }: { nodeId: number; newState: NodeState }) => {
             if (newState === 'RUNNING') {
@@ -74,6 +75,7 @@ describe('Nodes', () => {
             }
         }
     });
+
     it('should be searchable', async () => {
         const route1PendingNode = await createNodeWithAttributes(db, { state: 'PENDING', routingId: '1', deploymentId: activeDeployment.id });
         const route1RunningNode = await createNodeWithAttributes(db, {
@@ -116,6 +118,7 @@ describe('Nodes', () => {
         const searchWithWrongRoute = await nodes.search(db, { states: ['PENDING'], routingId: terminatedNode.routingId });
         expect(searchWithWrongRoute.unwrap().nodes).toEqual(new Map());
     });
+
     it('should be searchable (with pagination support)', async () => {
         for (let i = 0; i < 12; i++) {
             await createNodeWithAttributes(db, { state: 'PENDING', routingId: i.toString(), deploymentId: activeDeployment.id });
@@ -132,12 +135,14 @@ describe('Nodes', () => {
         expect(searchThirdPage.nodes.size).toBe(2);
         expect(searchThirdPage.nextCursor).toBe(undefined);
     });
+
     it('should be able to fail a node', async () => {
         const node = await createNodeWithAttributes(db, { state: 'PENDING', deploymentId: activeDeployment.id });
         const failedNode = (await nodes.fail(db, { nodeId: node.id, reason: 'my error' })).unwrap();
         expect(failedNode.state).toBe('ERROR');
         expect(failedNode.error).toBe('my error');
     });
+
     it('should be able to register a node', async () => {
         const node = await createNodeWithAttributes(db, { state: 'STARTING', deploymentId: activeDeployment.id });
         expect(node.url).toBe(null);
@@ -145,6 +150,7 @@ describe('Nodes', () => {
         expect(registeredNode.state).toBe('RUNNING');
         expect(registeredNode.url).toBe('http://my-url');
     });
+
     it('should be able to idle a node', async () => {
         const node = await createNodeWithAttributes(db, { state: 'FINISHING', deploymentId: activeDeployment.id });
         const idledNode = (await nodes.idle(db, { nodeId: node.id })).unwrap();

--- a/packages/fleet/lib/models/nodes.integration.test.ts
+++ b/packages/fleet/lib/models/nodes.integration.test.ts
@@ -50,6 +50,28 @@ describe('Nodes', () => {
             lastStateTransitionAt: expect.any(Date)
         });
     });
+    it('should fail to create a node with the same routingId and deploymentId', async () => {
+        const routingId = 'my-routing-id';
+        await nodes.create(db, {
+            routingId,
+            deploymentId: activeDeployment,
+            url: 'http://localhost:3000',
+            image: 'nangohq/my-image:latest',
+            cpuMilli: 500,
+            memoryMb: 1024,
+            storageMb: 512
+        });
+        const result = await nodes.create(db, {
+            routingId,
+            deploymentId: activeDeployment,
+            url: 'http://localhost:3000',
+            image: 'nangohq/my-image:latest',
+            cpuMilli: 500,
+            memoryMb: 1024,
+            storageMb: 512
+        });
+        expect(result.isErr()).toBe(true);
+    });
     it('should transition between valid states and error when transitioning between invalid states', async () => {
         for (const from of nodeStates) {
             for (const to of nodeStates) {

--- a/packages/fleet/lib/node-providers/node_provider.ts
+++ b/packages/fleet/lib/node-providers/node_provider.ts
@@ -1,0 +1,7 @@
+import type { Node } from '../types';
+import type { Result } from '@nangohq/utils';
+
+export interface NodeProvider {
+    start(node: Node): Promise<Result<void>>;
+    terminate(node: Node): Promise<Result<void>>;
+}

--- a/packages/fleet/lib/supervisor.integration.test.ts
+++ b/packages/fleet/lib/supervisor.integration.test.ts
@@ -1,0 +1,165 @@
+import { expect, describe, it, beforeEach, afterEach, vi } from 'vitest';
+import { Ok } from '@nangohq/utils';
+import { Supervisor } from './supervisor.js';
+import { getTestDbClient } from './db/helpers.test.js';
+import * as deployments from './models/deployments.js';
+import * as nodes from './models/nodes.js';
+import { generateCommitHash, createNodeWithAttributes } from './models/helpers.test.js';
+import type { Deployment } from './types.js';
+import { FleetError } from './utils/errors.js';
+
+const mockNodeProvider = {
+    start: vi.fn().mockResolvedValue(Ok(undefined)),
+    terminate: vi.fn().mockResolvedValue(Ok(undefined)),
+    mockClear: () => {
+        mockNodeProvider.start.mockClear();
+        mockNodeProvider.terminate.mockClear();
+    }
+};
+
+describe('Supervisor', () => {
+    const dbClient = getTestDbClient('supervisor');
+    const supervisor = new Supervisor({ dbClient, nodeProvider: mockNodeProvider });
+    let previousDeployment: Deployment;
+    let activeDeployment: Deployment;
+
+    beforeEach(async () => {
+        await dbClient.migrate();
+        previousDeployment = (await deployments.create(dbClient.db, generateCommitHash())).unwrap();
+        activeDeployment = (await deployments.create(dbClient.db, generateCommitHash())).unwrap();
+    });
+
+    afterEach(async () => {
+        await dbClient.clearDatabase();
+        mockNodeProvider.mockClear();
+    });
+
+    it('should not have more than one instance processing at a time', async () => {
+        const supervisor1 = new Supervisor({ dbClient, nodeProvider: mockNodeProvider });
+        const supervisor2 = new Supervisor({ dbClient, nodeProvider: mockNodeProvider });
+        supervisor1.start();
+        supervisor2.start();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        expect(true).toBe(true);
+        await supervisor1.stop();
+        await supervisor2.stop();
+    });
+    it('should start PENDING nodes', async () => {
+        const node1 = await createNodeWithAttributes(dbClient.db, { state: 'PENDING', deploymentId: activeDeployment.id });
+        const node2 = await createNodeWithAttributes(dbClient.db, { state: 'PENDING', deploymentId: activeDeployment.id });
+
+        await supervisor.tick();
+
+        expect(mockNodeProvider.start).toHaveBeenCalledTimes(2);
+        expect(mockNodeProvider.start).toHaveBeenCalledWith(node1);
+        expect(mockNodeProvider.start).toHaveBeenCalledWith(node2);
+
+        const node1After = (await nodes.get(dbClient.db, node1.id)).unwrap();
+        expect(node1After.state).toBe('STARTING');
+
+        const node2After = (await nodes.get(dbClient.db, node2.id)).unwrap();
+        expect(node2After.state).toBe('STARTING');
+    });
+    it('should timeout STARTING nodes', async () => {
+        const tenMinutesAgo = new Date(Date.now() - supervisor.STATE_TIMEOUT_MS.STARTING - 1);
+        const startingNode = await createNodeWithAttributes(dbClient.db, { state: 'STARTING', deploymentId: activeDeployment.id });
+        const oldStartingNode = await createNodeWithAttributes(dbClient.db, {
+            state: 'STARTING',
+            deploymentId: activeDeployment.id,
+            lastStateTransitionAt: tenMinutesAgo
+        });
+
+        await supervisor.tick();
+
+        // only the old node should be timed out
+        const startingNodeAfter = (await nodes.get(dbClient.db, startingNode.id)).unwrap();
+        expect(startingNodeAfter.state).toBe('STARTING');
+
+        const oldStartingNodeAfter = (await nodes.get(dbClient.db, oldStartingNode.id)).unwrap();
+        expect(oldStartingNodeAfter.state).toBe('ERROR');
+    });
+    it('should mark OUTDATED nodes', async () => {
+        const node = await createNodeWithAttributes(dbClient.db, { state: 'RUNNING', deploymentId: previousDeployment.id });
+
+        await supervisor.tick();
+
+        const nodeAfter = (await nodes.get(dbClient.db, node.id)).unwrap();
+        expect(nodeAfter.state).toBe('OUTDATED');
+    });
+    it('should create new nodes if only OUTDATED', async () => {
+        const node = await createNodeWithAttributes(dbClient.db, { state: 'OUTDATED', deploymentId: previousDeployment.id });
+        await supervisor.tick();
+        const { nodes: pendingNodes } = (await nodes.search(dbClient.db, { states: ['PENDING'] })).unwrap();
+        expect(pendingNodes.get(node.routingId)).toMatchObject({
+            PENDING: [
+                {
+                    id: expect.any(Number),
+                    state: 'PENDING',
+                    routingId: node.routingId,
+                    deploymentId: activeDeployment.id,
+                    error: null
+                }
+            ]
+        });
+    });
+    it('should terminate IDLE nodes', async () => {
+        const node1 = await createNodeWithAttributes(dbClient.db, { state: 'IDLE', deploymentId: activeDeployment.id });
+        const node2 = await createNodeWithAttributes(dbClient.db, { state: 'IDLE', deploymentId: activeDeployment.id });
+
+        await supervisor.tick();
+
+        expect(mockNodeProvider.terminate).toHaveBeenCalledTimes(2);
+        expect(mockNodeProvider.terminate).toHaveBeenCalledWith(node1);
+        expect(mockNodeProvider.terminate).toHaveBeenCalledWith(node2);
+
+        const node1After = (await nodes.get(dbClient.db, node1.id)).unwrap();
+        expect(node1After.state).toBe('TERMINATED');
+
+        const node2After = (await nodes.get(dbClient.db, node2.id)).unwrap();
+        expect(node2After.state).toBe('TERMINATED');
+    });
+    it('should remove old TERMINATED nodes', async () => {
+        const sevenDaysAgo = new Date(Date.now() - supervisor.STATE_TIMEOUT_MS.TERMINATED - 1);
+        const terminatedNode = await createNodeWithAttributes(dbClient.db, { state: 'TERMINATED', deploymentId: activeDeployment.id });
+        const oldTerminatedNode = await createNodeWithAttributes(dbClient.db, {
+            state: 'TERMINATED',
+            deploymentId: activeDeployment.id,
+            lastStateTransitionAt: sevenDaysAgo
+        });
+
+        await supervisor.tick();
+
+        // only the old node should be removed
+        const terminatedNodeAfter = (await nodes.get(dbClient.db, terminatedNode.id)).unwrap();
+        expect(terminatedNodeAfter.state).toBe('TERMINATED');
+
+        const oldTerminatedNodeAfter = await nodes.get(dbClient.db, oldTerminatedNode.id);
+        if (oldTerminatedNodeAfter.isErr()) {
+            expect(oldTerminatedNodeAfter.error).toStrictEqual(new FleetError('node_not_found'));
+        } else {
+            throw new Error('expected old terminated to be removed');
+        }
+    });
+    it('should remove old ERROR nodes', async () => {
+        const sevenDaysAgo = new Date(Date.now() - supervisor.STATE_TIMEOUT_MS.ERROR - 1);
+        const errorNode = await createNodeWithAttributes(dbClient.db, { state: 'ERROR', deploymentId: activeDeployment.id });
+        const oldErrorNode = await createNodeWithAttributes(dbClient.db, {
+            state: 'ERROR',
+            deploymentId: activeDeployment.id,
+            lastStateTransitionAt: sevenDaysAgo
+        });
+
+        await supervisor.tick();
+
+        // only the old node should be removed
+        const errorNodeAfter = (await nodes.get(dbClient.db, errorNode.id)).unwrap();
+        expect(errorNodeAfter.state).toBe('ERROR');
+
+        const oldErrorNodeAfter = await nodes.get(dbClient.db, oldErrorNode.id);
+        if (oldErrorNodeAfter.isErr()) {
+            expect(oldErrorNodeAfter.error).toStrictEqual(new FleetError('node_not_found'));
+        } else {
+            throw new Error('expected old terminated to be removed');
+        }
+    });
+});

--- a/packages/fleet/lib/supervisor.integration.test.ts
+++ b/packages/fleet/lib/supervisor.integration.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, it, beforeEach, afterEach, vi } from 'vitest';
 import { Ok } from '@nangohq/utils';
-import { Supervisor } from './supervisor.js';
+import { STATE_TIMEOUT_MS, Supervisor } from './supervisor.js';
 import { getTestDbClient } from './db/helpers.test.js';
 import * as deployments from './models/deployments.js';
 import * as nodes from './models/nodes.js';
@@ -51,7 +51,7 @@ describe('Supervisor', () => {
         expect(node2After.state).toBe('STARTING');
     });
     it('should timeout STARTING nodes', async () => {
-        const tenMinutesAgo = new Date(Date.now() - supervisor.STATE_TIMEOUT_MS.STARTING - 1);
+        const tenMinutesAgo = new Date(Date.now() - STATE_TIMEOUT_MS.STARTING - 1);
         const startingNode = await createNodeWithAttributes(dbClient.db, { state: 'STARTING', deploymentId: activeDeployment.id });
         const oldStartingNode = await createNodeWithAttributes(dbClient.db, {
             state: 'STARTING',
@@ -109,7 +109,7 @@ describe('Supervisor', () => {
         expect(node2After.state).toBe('TERMINATED');
     });
     it('should remove old TERMINATED nodes', async () => {
-        const sevenDaysAgo = new Date(Date.now() - supervisor.STATE_TIMEOUT_MS.TERMINATED - 1);
+        const sevenDaysAgo = new Date(Date.now() - STATE_TIMEOUT_MS.TERMINATED - 1);
         const terminatedNode = await createNodeWithAttributes(dbClient.db, { state: 'TERMINATED', deploymentId: activeDeployment.id });
         const oldTerminatedNode = await createNodeWithAttributes(dbClient.db, {
             state: 'TERMINATED',
@@ -131,7 +131,7 @@ describe('Supervisor', () => {
         }
     });
     it('should remove old ERROR nodes', async () => {
-        const sevenDaysAgo = new Date(Date.now() - supervisor.STATE_TIMEOUT_MS.ERROR - 1);
+        const sevenDaysAgo = new Date(Date.now() - STATE_TIMEOUT_MS.ERROR - 1);
         const errorNode = await createNodeWithAttributes(dbClient.db, { state: 'ERROR', deploymentId: activeDeployment.id });
         const oldErrorNode = await createNodeWithAttributes(dbClient.db, {
             state: 'ERROR',

--- a/packages/fleet/lib/supervisor.integration.test.ts
+++ b/packages/fleet/lib/supervisor.integration.test.ts
@@ -50,6 +50,7 @@ describe('Supervisor', () => {
         const node2After = (await nodes.get(dbClient.db, node2.id)).unwrap();
         expect(node2After.state).toBe('STARTING');
     });
+
     it('should timeout STARTING nodes', async () => {
         const tenMinutesAgo = new Date(Date.now() - STATE_TIMEOUT_MS.STARTING - 1);
         const startingNode = await createNodeWithAttributes(dbClient.db, { state: 'STARTING', deploymentId: activeDeployment.id });
@@ -68,6 +69,7 @@ describe('Supervisor', () => {
         const oldStartingNodeAfter = (await nodes.get(dbClient.db, oldStartingNode.id)).unwrap();
         expect(oldStartingNodeAfter.state).toBe('ERROR');
     });
+
     it('should mark OUTDATED nodes', async () => {
         const node = await createNodeWithAttributes(dbClient.db, { state: 'RUNNING', deploymentId: previousDeployment.id });
 
@@ -76,6 +78,7 @@ describe('Supervisor', () => {
         const nodeAfter = (await nodes.get(dbClient.db, node.id)).unwrap();
         expect(nodeAfter.state).toBe('OUTDATED');
     });
+
     it('should create new nodes if only OUTDATED', async () => {
         const node = await createNodeWithAttributes(dbClient.db, { state: 'OUTDATED', deploymentId: previousDeployment.id });
         await supervisor.tick();
@@ -92,6 +95,7 @@ describe('Supervisor', () => {
             ]
         });
     });
+
     it('should terminate IDLE nodes', async () => {
         const node1 = await createNodeWithAttributes(dbClient.db, { state: 'IDLE', deploymentId: activeDeployment.id });
         const node2 = await createNodeWithAttributes(dbClient.db, { state: 'IDLE', deploymentId: activeDeployment.id });
@@ -108,6 +112,7 @@ describe('Supervisor', () => {
         const node2After = (await nodes.get(dbClient.db, node2.id)).unwrap();
         expect(node2After.state).toBe('TERMINATED');
     });
+
     it('should remove old TERMINATED nodes', async () => {
         const sevenDaysAgo = new Date(Date.now() - STATE_TIMEOUT_MS.TERMINATED - 1);
         const terminatedNode = await createNodeWithAttributes(dbClient.db, { state: 'TERMINATED', deploymentId: activeDeployment.id });
@@ -130,6 +135,7 @@ describe('Supervisor', () => {
             throw new Error('expected old terminated to be removed');
         }
     });
+
     it('should remove old ERROR nodes', async () => {
         const sevenDaysAgo = new Date(Date.now() - STATE_TIMEOUT_MS.ERROR - 1);
         const errorNode = await createNodeWithAttributes(dbClient.db, { state: 'ERROR', deploymentId: activeDeployment.id });

--- a/packages/fleet/lib/supervisor.integration.test.ts
+++ b/packages/fleet/lib/supervisor.integration.test.ts
@@ -34,16 +34,6 @@ describe('Supervisor', () => {
         mockNodeProvider.mockClear();
     });
 
-    it('should not have more than one instance processing at a time', async () => {
-        const supervisor1 = new Supervisor({ dbClient, nodeProvider: mockNodeProvider });
-        const supervisor2 = new Supervisor({ dbClient, nodeProvider: mockNodeProvider });
-        supervisor1.start();
-        supervisor2.start();
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        expect(true).toBe(true);
-        await supervisor1.stop();
-        await supervisor2.stop();
-    });
     it('should start PENDING nodes', async () => {
         const node1 = await createNodeWithAttributes(dbClient.db, { state: 'PENDING', deploymentId: activeDeployment.id });
         const node2 = await createNodeWithAttributes(dbClient.db, { state: 'PENDING', deploymentId: activeDeployment.id });

--- a/packages/fleet/lib/supervisor.ts
+++ b/packages/fleet/lib/supervisor.ts
@@ -1,0 +1,278 @@
+import type { DatabaseClient } from './db/client.js';
+import { logger } from './utils/logger.js';
+import * as nodes from './models/nodes.js';
+import * as deployments from './models/deployments.js';
+import { Err, Ok } from '@nangohq/utils';
+import type { Result } from '@nangohq/utils';
+import { FleetError } from './utils/errors.js';
+import type { Deployment, Node } from './types.js';
+import { setTimeout } from 'node:timers/promises';
+import type { NodeProvider } from './node-providers/node_provider.js';
+
+type Action =
+    | { type: 'CREATE'; routingId: Node['routingId']; deployment: Deployment }
+    | { type: 'START'; node: Node }
+    | { type: 'FAIL'; node: Node; reason: 'starting_timeout_reached' }
+    | { type: 'OUTDATE'; node: Node }
+    | { type: 'TERMINATE'; node: Node }
+    | { type: 'REMOVE'; node: Node }
+    | { type: 'WARN'; node: Node };
+
+type SupervisorState = 'stopped' | 'running' | 'stopping';
+
+export class Supervisor {
+    private state: SupervisorState = 'stopped';
+    private dbClient: DatabaseClient;
+    private nodeProvider: NodeProvider;
+    public STATE_TIMEOUT_MS = {
+        STARTING: 5 * 60 * 1000,
+        FINISHING: 24 * 60 * 60 * 1000,
+        TERMINATED: 7 * 24 * 60 * 60 * 1000,
+        ERROR: 7 * 24 * 60 * 60 * 1000
+    };
+
+    constructor({ dbClient, nodeProvider }: { dbClient: DatabaseClient; nodeProvider: NodeProvider }) {
+        this.dbClient = dbClient;
+        this.nodeProvider = nodeProvider;
+    }
+
+    public async start(): Promise<void> {
+        if (this.state === 'running') {
+            logger.warn('Supervisor is already running');
+            return;
+        }
+
+        this.state = 'running';
+        await this.loop();
+    }
+
+    public async stop(): Promise<void> {
+        this.state = 'stopping';
+        logger.info('Supervisor stopped');
+
+        // wait for the loop to finish or timeout
+        const waitForStopped = async () => {
+            while (this.state !== 'stopped') {
+                await setTimeout(100);
+            }
+        };
+        await Promise.race([waitForStopped(), setTimeout(60000)]);
+    }
+
+    public async tick(): Promise<void> {
+        // TODO: trace
+        try {
+            const plan = await this.plan();
+            if (plan.isOk()) {
+                await this.executePlan(plan.value);
+            } else {
+                logger.error('Supervision error:', plan.error);
+                await setTimeout(1000);
+            }
+        } catch (error) {
+            logger.error('Supervision error:', error);
+        }
+    }
+
+    private async loop(): Promise<void> {
+        while (this.state === 'running') {
+            // TODO: Lock to prevent multiple instances from running
+            await this.tick();
+        }
+        this.state = 'stopped';
+    }
+
+    private async plan(cursor?: number): Promise<Result<Action[]>> {
+        const getDeployment = await deployments.getActive(this.dbClient.db);
+        if (getDeployment.isErr()) {
+            return Err(getDeployment.error);
+        }
+        if (!getDeployment.value) {
+            return Err(new FleetError('no_active_deployment'));
+        }
+        const deployment = getDeployment.value;
+        const plan: Action[] = [];
+
+        const search = await nodes.search(this.dbClient.db, {
+            states: ['PENDING', 'STARTING', 'RUNNING', 'OUTDATED', 'FINISHING', 'IDLE', 'TERMINATED', 'ERROR'],
+            ...(cursor ? { cursor } : {})
+        });
+        if (search.isErr()) {
+            return Err(search.error);
+        }
+        for (const [routingId, nodes] of search.value.nodes) {
+            // Start pending nodes
+            plan.push(...(nodes.PENDING || []).map((node) => ({ type: 'START' as const, node })));
+
+            // Timeout STARTING nodes if they are taking too long
+            plan.push(
+                ...(nodes.STARTING || []).flatMap((node) => {
+                    if (Date.now() - node.lastStateTransitionAt.getTime() > this.STATE_TIMEOUT_MS.STARTING) {
+                        return [{ type: 'FAIL' as const, node, reason: 'starting_timeout_reached' as const }];
+                    }
+                    return [];
+                })
+            );
+
+            // Mark OUTDATED nodes
+            plan.push(
+                ...(nodes.RUNNING || []).flatMap((node) => {
+                    if (node.deploymentId !== deployment.id) {
+                        return [{ type: 'OUTDATE' as const, node }];
+                    }
+                    return [];
+                })
+            );
+
+            // if OUTDATED node but no RUNNING or upcoming nodes then create a new one
+            if ((nodes.OUTDATED?.length || 0) > 0 && (nodes.RUNNING?.length || 0) + (nodes.STARTING?.length || 0) + (nodes.PENDING?.length || 0) === 0) {
+                plan.push({ type: 'CREATE' as const, routingId, deployment });
+            }
+
+            // Warn about old finishing nodes
+            plan.push(
+                ...(nodes.FINISHING || []).flatMap((node) => {
+                    if (Date.now() - node.lastStateTransitionAt.getTime() > this.STATE_TIMEOUT_MS.FINISHING) {
+                        return [{ type: 'WARN' as const, node }];
+                    }
+                    return [];
+                })
+            );
+
+            // Terminate IDLE nodes
+            plan.push(...(nodes.IDLE || []).map((node) => ({ type: 'TERMINATE' as const, node })));
+
+            // Remove old terminated nodes
+            plan.push(
+                ...(nodes.TERMINATED || []).flatMap((node) => {
+                    if (Date.now() - node.lastStateTransitionAt.getTime() > this.STATE_TIMEOUT_MS.TERMINATED) {
+                        return [{ type: 'REMOVE' as const, node }];
+                    }
+                    return [];
+                })
+            );
+
+            // Remove old error nodes
+            plan.push(
+                ...(nodes.ERROR || []).flatMap((node) => {
+                    if (Date.now() - node.lastStateTransitionAt.getTime() > this.STATE_TIMEOUT_MS.ERROR) {
+                        return [{ type: 'REMOVE' as const, node }];
+                    }
+                    return [];
+                })
+            );
+        }
+
+        // Recursively fetch next page of nodes
+        if (search.value.nextCursor) {
+            const nextPagePlan = await this.plan(search.value.nextCursor);
+            if (nextPagePlan.isErr()) {
+                logger.error('Failed to get next plan:', nextPagePlan.error);
+            } else {
+                plan.push(...nextPagePlan.value);
+            }
+        }
+
+        return Ok(plan);
+    }
+
+    private async executePlan(plan: Action[]): Promise<void> {
+        for (const action of plan) {
+            const result = await this.execute(action);
+            if (result.isErr()) {
+                logger.error('Failed to execute action:', result.error);
+            }
+        }
+    }
+
+    private async execute(action: Action): Promise<Result<Node>> {
+        switch (action.type) {
+            case 'CREATE':
+                return this.createNode(action);
+            case 'START':
+                return this.startNode(action);
+            case 'OUTDATE':
+                return this.outdateNode(action);
+            case 'TERMINATE':
+                return this.terminateNode(action);
+            case 'REMOVE':
+                return this.removeNode(action);
+            case 'WARN':
+                return this.warnNode(action);
+            case 'FAIL':
+                return this.failNode(action);
+        }
+    }
+
+    private async createNode({ routingId, deployment }: { type: 'CREATE'; routingId: Node['routingId']; deployment: Deployment }): Promise<Result<Node>> {
+        return nodes.create(this.dbClient.db, {
+            routingId,
+            deploymentId: deployment.id,
+            // TODO
+            image: `nangohq/my-image:${deployment.commitId}`,
+            cpuMilli: 500,
+            memoryMb: 512,
+            storageMb: 1024
+        });
+    }
+
+    private async startNode({ node }: { type: 'START'; node: Node }): Promise<Result<Node>> {
+        const res = await this.nodeProvider.start(node);
+        if (res.isErr()) {
+            await this.failNode({
+                type: 'FAIL',
+                node,
+                reason: res.error.message
+            });
+            return Err(res.error);
+        }
+        return nodes.transitionTo(this.dbClient.db, {
+            nodeId: node.id,
+            newState: 'STARTING'
+        });
+    }
+
+    private async failNode({ node, reason }: { type: 'FAIL'; node: Node; reason: string }): Promise<Result<Node>> {
+        const res = await this.nodeProvider.terminate(node);
+        if (res.isErr()) {
+            logger.error('Failed to terminate node:', res.error);
+        }
+        return nodes.fail(this.dbClient.db, {
+            nodeId: node.id,
+            reason
+        });
+    }
+
+    private async outdateNode({ node }: { type: 'OUTDATE'; node: Node }): Promise<Result<Node>> {
+        return nodes.transitionTo(this.dbClient.db, {
+            nodeId: node.id,
+            newState: 'OUTDATED'
+        });
+    }
+
+    private async terminateNode({ node }: { type: 'TERMINATE'; node: Node }): Promise<Result<Node>> {
+        const res = await this.nodeProvider.terminate(node);
+        if (res.isErr()) {
+            await this.failNode({
+                type: 'FAIL',
+                node,
+                reason: res.error.message
+            });
+            return Err(res.error);
+        }
+        return nodes.transitionTo(this.dbClient.db, {
+            nodeId: node.id,
+            newState: 'TERMINATED'
+        });
+    }
+
+    private async removeNode({ node }: { type: 'REMOVE'; node: Node }): Promise<Result<Node>> {
+        return nodes.remove(this.dbClient.db, { nodeId: node.id });
+    }
+
+    private async warnNode({ node }: { type: 'WARN'; node: Node }): Promise<Result<Node>> {
+        // TODO: find a better way to warn and alert
+        logger.warn('Node is taking too long to finish:', node);
+        return Promise.resolve(Ok(node));
+    }
+}

--- a/packages/fleet/lib/utils/errors.ts
+++ b/packages/fleet/lib/utils/errors.ts
@@ -1,6 +1,7 @@
 import type { Jsonable } from '@nangohq/types';
 
 type FleetErrorCode =
+    | 'no_active_deployment'
     | 'deployment_creation_error'
     | 'deployment_get_active_error'
     | 'deployment_not_found'
@@ -9,7 +10,12 @@ type FleetErrorCode =
     | 'node_creation_error'
     | 'node_search_error'
     | 'node_transition_error'
-    | 'node_fail_error';
+    | 'node_fail_error'
+    | 'node_register_error'
+    | 'node_delete_error'
+    | 'node_delete_non_terminated'
+    | 'supervisor_search_nodes_error'
+    | 'supervisor_unknown_action';
 
 export class FleetError extends Error {
     public readonly context?: Jsonable;


### PR DESCRIPTION
- Implement Supervisor class to manage node states and transitions
- Add methods to start, fail, outdate, terminate, and remove nodes
- Introduce NodeProvider interface for node operations
- Update node state transitions and error handling
- Add integration tests for Supervisor functionality

What's not yet implemented:
- routing logic
- Render NodeProvider
- wiring fleet in jobs

There are still a few TODOs that I will address in following PRs

# How to test
Still not wired. You can run the tests ;)

