### PR TITLE
fix: scope in google drive docs

### DIFF
--- a/docs-v2/integrations/all/google-drive.mdx
+++ b/docs-v2/integrations/all/google-drive.mdx
@@ -29,7 +29,7 @@ Nango's pre-built Google drive integration only syncs whitelisted files & folder
 
 <Steps>
   <Step title="Auth & Show Google Drive Picker">
-    Scope to set in Nango: `https://www.googleapis.com/auth/drive.readonly`
+    Scope to set in Nango: `https://www.googleapis.com/auth/drive.file`
 
     In your frontend, run the OAuth flow with `nango.auth` and show the Google drive picker to your user.
 


### PR DESCRIPTION
We advertised the wrong scope before.
`https://www.googleapis.com/auth/drive.file` only lets you access files & folders the user selected, but that's precisely why we have the picker

https://developers.google.com/drive/api/guides/api-specific-auth

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

