### PR TITLE
feat(fleet): ensure only one fleet supervisor is running

### DIFF
--- a/packages/fleet/lib/fleet.ts
+++ b/packages/fleet/lib/fleet.ts
@@ -52,7 +52,7 @@ export class Fleet {
 
     public async getRunningNode(routingId: RoutingId): Promise<Result<Node>> {
         const recurse = async (start: Date): Promise<Result<Node>> => {
-            if (new Date().getTime() - start.getTime() > envs.FLEET_TIMEOUT_GET_RUNNING_NODE) {
+            if (new Date().getTime() - start.getTime() > envs.FLEET_TIMEOUT_GET_RUNNING_NODE_MS) {
                 return Err(new FleetError('fleet_node_not_ready_timeout', { context: { routingId } }));
             }
             const search = await nodes.search(this.dbClient.db, {

--- a/packages/fleet/lib/supervisor.ts
+++ b/packages/fleet/lib/supervisor.ts
@@ -71,7 +71,7 @@ export class Supervisor {
                 await setTimeout(1000);
             }
         };
-        await Promise.race([waitForStopped(), setTimeout(60000)]);
+        await Promise.race([waitForStopped(), setTimeout(envs.FLEET_SUPERVISOR_TIMEOUT_STOP_MS)]);
 
         logger.info('Fleet supervisor stopped');
     }
@@ -107,15 +107,15 @@ export class Supervisor {
                 fn: async () => {
                     return await this.tick();
                 },
-                timeoutMs: envs.FLEET_TIMEOUT_TICK_MS,
+                timeoutMs: envs.FLEET_SUPERVISOR_TIMEOUT_TICK_MS,
                 onTimeout: () => {
                     this.tickCancelled = true;
                     return Promise.resolve();
                 }
             });
             if (res.isErr()) {
-                await setTimeout(1000);
-                logger.error('Supervisor error:', res.error);
+                await setTimeout(envs.FLEET_SUPERVISOR_RETRY_DELAY_MS);
+                logger.warning('Fleet supervisor:', res.error);
             }
         }
         this.state = 'stopped';

--- a/packages/fleet/lib/utils/errors.ts
+++ b/packages/fleet/lib/utils/errors.ts
@@ -21,6 +21,8 @@ type FleetErrorCode =
     | 'fleet_node_url_not_found'
     | 'fleet_node_outdate_failed'
     | 'fleet_tick_timeout'
+    | 'fleet_cannot_acquire_lock'
+    | 'fleet_lock_error'
     | 'local_runner_start_failed';
 
 export class FleetError extends Error {

--- a/packages/fleet/lib/utils/errors.ts
+++ b/packages/fleet/lib/utils/errors.ts
@@ -20,6 +20,7 @@ type FleetErrorCode =
     | 'fleet_node_not_ready_timeout'
     | 'fleet_node_url_not_found'
     | 'fleet_node_outdate_failed'
+    | 'fleet_tick_timeout'
     | 'local_runner_start_failed';
 
 export class FleetError extends Error {

--- a/packages/fleet/lib/utils/locking.ts
+++ b/packages/fleet/lib/utils/locking.ts
@@ -1,5 +1,5 @@
 import type { Knex } from 'knex';
-import { Ok, Err, stringToHash } from '@nangohq/utils';
+import { Err, stringToHash } from '@nangohq/utils';
 import { setTimeout } from 'node:timers/promises';
 import type { Result } from '@nangohq/utils';
 import { FleetError } from './errors.js';
@@ -24,8 +24,7 @@ export async function withPgLock({
 
         if (!rows?.[0]?.lock) {
             await trx.rollback();
-            await setTimeout(1000);
-            return Ok(undefined);
+            return Err(new FleetError('fleet_cannot_acquire_lock'));
         }
 
         const processingTimeout = async (): Promise<Result<void>> => {
@@ -40,6 +39,6 @@ export async function withPgLock({
         if (trx) {
             await trx.rollback();
         }
-        throw error;
+        return Err(new FleetError('fleet_lock_error', { cause: error }));
     }
 }

--- a/packages/fleet/lib/utils/locking.ts
+++ b/packages/fleet/lib/utils/locking.ts
@@ -1,0 +1,45 @@
+import type { Knex } from 'knex';
+import { Ok, Err, stringToHash } from '@nangohq/utils';
+import { setTimeout } from 'node:timers/promises';
+import type { Result } from '@nangohq/utils';
+import { FleetError } from './errors.js';
+
+export async function withPgLock({
+    db,
+    lockKey,
+    fn,
+    onTimeout = async () => {},
+    timeoutMs = 60000
+}: {
+    db: Knex;
+    lockKey: string;
+    fn: () => Promise<Result<void>>;
+    onTimeout?: () => Promise<void>;
+    timeoutMs?: number;
+}): Promise<Result<void>> {
+    let trx: Knex.Transaction | undefined = undefined;
+    try {
+        trx = await db.transaction();
+        const { rows } = await trx.raw<{ rows: { lock: boolean }[] }>(`SELECT pg_try_advisory_xact_lock(?) as lock`, [stringToHash(lockKey)]);
+
+        if (!rows?.[0]?.lock) {
+            await trx.rollback();
+            await setTimeout(1000);
+            return Ok(undefined);
+        }
+
+        const processingTimeout = async (): Promise<Result<void>> => {
+            await setTimeout(timeoutMs);
+            await onTimeout();
+            return Err(new FleetError('fleet_tick_timeout'));
+        };
+        const res = await Promise.race([fn(), processingTimeout()]);
+        await trx.commit();
+        return res;
+    } catch (error) {
+        if (trx) {
+            await trx.rollback();
+        }
+        throw error;
+    }
+}

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -78,10 +78,18 @@ export const ENVS = z.object({
         .number()
         .optional()
         .default(60 * 1000), // 1 minute
-    FLEET_TIMEOUT_TICK_MS: z.coerce
+    FLEET_SUPERVISOR_TIMEOUT_TICK_MS: z.coerce
         .number()
         .optional()
         .default(60 * 1000), // 1 minute
+    FLEET_SUPERVISOR_TIMEOUT_STOP_MS: z.coerce
+        .number()
+        .optional()
+        .default(60 * 1000), // 1 minute
+    FLEET_SUPERVISOR_RETRY_DELAY_MS: z.coerce
+        .number()
+        .optional()
+        .default(5 * 1000), // 5 seconds
 
     // --- Third parties
     // AWS

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -74,7 +74,11 @@ export const ENVS = z.object({
         .number()
         .optional()
         .default(24 * 60 * 60 * 1000), // 24 hours
-    FLEET_TIMEOUT_GET_RUNNING_NODE: z.coerce
+    FLEET_TIMEOUT_GET_RUNNING_NODE_MS: z.coerce
+        .number()
+        .optional()
+        .default(60 * 1000), // 1 minute
+    FLEET_TIMEOUT_TICK_MS: z.coerce
         .number()
         .optional()
         .default(60 * 1000), // 1 minute


### PR DESCRIPTION
only one fleet supervisor must run at anytime, otherwise it can lead to race conditions when managing the lifecycle of nodes.
This PR adds a locking mechanism using pg advisory lock to ensure only one supervisor is running at any given point in time.

