### PR TITLE
feat(fleet): add Render NodeProvider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37864,36 +37864,10 @@
                 "acorn": "^8"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/agent-base": {
-            "version": "7.1.1",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/async": {
             "version": "3.2.6",
             "inBundle": true,
             "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/asynckit": {
-            "version": "0.4.0",
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/axios": {
-            "version": "1.7.9",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/cjs-module-lexer": {
             "version": "1.4.1",
@@ -37938,17 +37912,6 @@
             "dependencies": {
                 "color": "^3.1.3",
                 "text-hex": "1.0.x"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/combined-stream": {
-            "version": "1.0.8",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
             }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/crypto-randomuuid": {
@@ -38004,27 +37967,6 @@
                 "node": ">=18"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/debug": {
-            "version": "4.4.0",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/debug/node_modules/ms": {
-            "version": "2.1.3",
-            "inBundle": true,
-            "license": "MIT"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/delay": {
             "version": "5.0.0",
             "inBundle": true,
@@ -38034,14 +37976,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/detect-newline": {
@@ -38062,16 +37996,6 @@
             "inBundle": true,
             "license": "MIT"
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/exponential-backoff": {
-            "version": "3.1.1",
-            "inBundle": true,
-            "license": "Apache-2.0"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/fast-safe-stringify": {
-            "version": "2.1.1",
-            "inBundle": true,
-            "license": "MIT"
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/fecha": {
             "version": "4.2.3",
             "inBundle": true,
@@ -38081,70 +38005,6 @@
             "version": "1.1.0",
             "inBundle": true,
             "license": "MIT"
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/follow-redirects": {
-            "version": "1.15.9",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/form-data": {
-            "version": "4.0.1",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/guess-json-indent": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/https-proxy-agent": {
-            "version": "7.0.4",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.0.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/ieee754": {
             "version": "1.2.1",
@@ -38279,25 +38139,6 @@
                 "node": ">=12"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/mime-db": {
-            "version": "1.52.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/mime-types": {
-            "version": "2.1.35",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/module-details-from-path": {
             "version": "1.0.3",
             "inBundle": true,
@@ -38411,11 +38252,6 @@
             "engines": {
                 "node": ">=12.0.0"
             }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "inBundle": true,
-            "license": "MIT"
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/readable-stream": {
             "version": "3.6.2",
@@ -38533,22 +38369,6 @@
                 "safe-buffer": "~5.2.0"
             }
         },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/string-byte-length": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/string-byte-slice": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
         "packages/shared/node_modules/@nangohq/utils/node_modules/text-hex": {
             "version": "1.0.0",
             "inBundle": true,
@@ -38565,19 +38385,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 14.0.0"
-            }
-        },
-        "packages/shared/node_modules/@nangohq/utils/node_modules/truncate-json": {
-            "version": "3.0.0",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "guess-json-indent": "^3.0.0",
-                "string-byte-length": "^3.0.0",
-                "string-byte-slice": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=18.18.0"
             }
         },
         "packages/shared/node_modules/@nangohq/utils/node_modules/type-fest": {

--- a/packages/fleet/lib/fleet.integration.test.ts
+++ b/packages/fleet/lib/fleet.integration.test.ts
@@ -2,14 +2,14 @@ import { expect, describe, it, beforeAll, afterAll, afterEach } from 'vitest';
 import { Fleet } from './fleet.js';
 import { getTestDbClient, testDbUrl } from './db/helpers.test.js';
 import { generateCommitHash } from './models/helpers.js';
-import { noopNodeConfig, noopNodeProvider } from './node-providers/noop.js';
+import { noopNodeProvider } from './node-providers/noop.js';
 
 describe('fleet', () => {
     const fleetId = 'nango_runners';
     const fleet = new Fleet({
         fleetId,
         dbUrl: testDbUrl,
-        nodeSetup: { nodeProvider: noopNodeProvider, defaultNodeConfig: noopNodeConfig }
+        nodeProvider: noopNodeProvider
     });
 
     beforeAll(async () => {

--- a/packages/fleet/lib/fleet.integration.test.ts
+++ b/packages/fleet/lib/fleet.integration.test.ts
@@ -2,11 +2,15 @@ import { expect, describe, it, beforeAll, afterAll, afterEach } from 'vitest';
 import { Fleet } from './fleet.js';
 import { getTestDbClient, testDbUrl } from './db/helpers.test.js';
 import { generateCommitHash } from './models/helpers.js';
-import { noopNodeProvider } from './node-providers/noop.js';
+import { noopNodeConfig, noopNodeProvider } from './node-providers/noop.js';
 
 describe('fleet', () => {
     const fleetId = 'nango_runners';
-    const fleet = new Fleet({ fleetId, dbUrl: testDbUrl, nodeProvider: noopNodeProvider });
+    const fleet = new Fleet({
+        fleetId,
+        dbUrl: testDbUrl,
+        nodeSetup: { nodeProvider: noopNodeProvider, defaultNodeConfig: noopNodeConfig }
+    });
 
     beforeAll(async () => {
         await fleet.migrate();

--- a/packages/fleet/lib/fleet.ts
+++ b/packages/fleet/lib/fleet.ts
@@ -4,14 +4,14 @@ import { DatabaseClient } from './db/client.js';
 import * as deployments from './models/deployments.js';
 import * as nodes from './models/nodes.js';
 import type { Node } from './types.js';
-import type { CommitHash, Deployment, RoutingId } from '@nangohq/types';
+import type { CommitHash, Deployment, NodeConfig, RoutingId } from '@nangohq/types';
 import { FleetError } from './utils/errors.js';
 import { setTimeout } from 'node:timers/promises';
 import { Supervisor } from './supervisor.js';
 import type { NodeProvider } from './node-providers/node_provider.js';
 import type { FleetId } from './instances.js';
-import { noopNodeProvider } from './node-providers/noop.js';
 import { envs } from './env.js';
+import { withPgLock } from './utils/locking.js';
 
 const defaultDbUrl =
     envs.NANGO_DATABASE_URL ||
@@ -20,21 +20,21 @@ const defaultDbUrl =
 export class Fleet {
     public fleetId: string;
     private dbClient: DatabaseClient;
-    private supervisor: Supervisor;
-    private nodeProvider: NodeProvider;
+    private supervisor: Supervisor | undefined = undefined;
     constructor({
         fleetId,
         dbUrl = defaultDbUrl,
-        nodeProvider = noopNodeProvider
+        nodeSetup
     }: {
         fleetId: FleetId;
         dbUrl?: string | undefined;
-        nodeProvider?: NodeProvider | undefined;
+        nodeSetup?: { nodeProvider: NodeProvider; defaultNodeConfig: NodeConfig } | undefined;
     }) {
         this.fleetId = fleetId;
         this.dbClient = new DatabaseClient({ url: dbUrl, schema: fleetId });
-        this.nodeProvider = nodeProvider;
-        this.supervisor = new Supervisor({ dbClient: this.dbClient, nodeProvider });
+        if (nodeSetup) {
+            this.supervisor = new Supervisor({ dbClient: this.dbClient, defaultNodeConfig: nodeSetup.defaultNodeConfig, nodeProvider: nodeSetup.nodeProvider });
+        }
     }
 
     public async migrate(): Promise<void> {
@@ -42,11 +42,15 @@ export class Fleet {
     }
 
     public start(): void {
-        void this.supervisor.start();
+        if (this.supervisor) {
+            void this.supervisor.start();
+        }
     }
 
     public async stop(): Promise<void> {
-        await this.supervisor.stop();
+        if (this.supervisor) {
+            await this.supervisor.stop();
+        }
     }
 
     public async rollout(commitId: CommitHash): Promise<Result<Deployment>> {
@@ -54,7 +58,10 @@ export class Fleet {
     }
 
     public async getRunningNode(routingId: RoutingId): Promise<Result<Node>> {
-        const recurse = async (start: Date): Promise<Result<Node>> => {
+        const recurse = async (supervisor: Supervisor | undefined, start: Date): Promise<Result<Node>> => {
+            if (!supervisor) {
+                return Err(new FleetError('fleet_misconfigured', { context: { fleetId: this.fleetId } }));
+            }
             if (new Date().getTime() - start.getTime() > envs.FLEET_TIMEOUT_GET_RUNNING_NODE_MS) {
                 return Err(new FleetError('fleet_node_not_ready_timeout', { context: { routingId } }));
             }
@@ -65,26 +72,43 @@ export class Fleet {
             if (search.isErr()) {
                 return Err(search.error);
             }
-            const running = search.value.nodes.get(routingId)?.RUNNING[0];
-            if (running) {
-                return Ok(running);
+            const running = search.value.nodes.get(routingId)?.RUNNING || [];
+            if (running[0]) {
+                return Ok(running[0]);
             }
-            const starting = search.value.nodes.get(routingId)?.STARTING[0];
-            const pending = search.value.nodes.get(routingId)?.PENDING[0];
+            const starting = search.value.nodes.get(routingId)?.STARTING || [];
+            const pending = search.value.nodes.get(routingId)?.PENDING || [];
 
-            if (!starting && !pending) {
-                await this.supervisor.createNodeForCurrentDeployment(routingId);
+            if (!starting[0] && !pending[0]) {
+                await withPgLock({
+                    db: this.dbClient.db,
+                    lockKey: `create_node_${routingId}`,
+                    fn: async (trx): Promise<Result<Node>> => {
+                        const deployment = await deployments.getActive(trx);
+                        if (deployment.isErr()) {
+                            return Err(deployment.error);
+                        }
+                        if (!deployment.value) {
+                            return Err(new FleetError('no_active_deployment'));
+                        }
+                        return supervisor.createNode(trx, { type: 'CREATE', routingId, deployment: deployment.value });
+                    },
+                    timeoutMs: 10 * 1000
+                });
             }
 
             // wait for node to be ready
-            await setTimeout(1000);
-            return recurse(start);
+            await setTimeout(envs.FLEET_RETRY_DELAY_GET_RUNNING_NODE_MS);
+            return recurse(supervisor, start);
         };
-        return recurse(new Date());
+        return recurse(this.supervisor, new Date());
     }
 
     public async registerNode({ nodeId, url }: { nodeId: number; url: string }): Promise<Result<Node>> {
-        const valid = await this.nodeProvider.verifyUrl(url);
+        if (!this.supervisor) {
+            return Err(new FleetError('fleet_misconfigured', { context: { fleetId: this.fleetId } }));
+        }
+        const valid = await this.supervisor.nodeProvider.verifyUrl(url);
         if (valid.isErr()) {
             return Err(valid.error);
         }

--- a/packages/fleet/lib/node-providers/node_provider.ts
+++ b/packages/fleet/lib/node-providers/node_provider.ts
@@ -1,7 +1,9 @@
+import type { NodeConfig } from '@nangohq/types';
 import type { Node } from '../types';
 import type { Result } from '@nangohq/utils';
 
 export interface NodeProvider {
+    defaultNodeConfig: NodeConfig;
     start(node: Node): Promise<Result<void>>;
     terminate(node: Node): Promise<Result<void>>;
     verifyUrl(url: string): Promise<Result<void>>;

--- a/packages/fleet/lib/node-providers/noop.ts
+++ b/packages/fleet/lib/node-providers/noop.ts
@@ -1,8 +1,13 @@
 import { Ok } from '@nangohq/utils';
 import type { NodeProvider } from './node_provider';
-import type { NodeConfig } from '@nangohq/types';
 
 export const noopNodeProvider: NodeProvider = {
+    defaultNodeConfig: {
+        image: 'my-image',
+        cpuMilli: 1000,
+        memoryMb: 1000,
+        storageMb: 1000
+    },
     start: () => {
         return Promise.resolve(Ok(undefined));
     },
@@ -12,11 +17,4 @@ export const noopNodeProvider: NodeProvider = {
     verifyUrl: () => {
         return Promise.resolve(Ok(undefined));
     }
-};
-
-export const noopNodeConfig: NodeConfig = {
-    image: 'my-image',
-    cpuMilli: 1000,
-    memoryMb: 1000,
-    storageMb: 1000
 };

--- a/packages/fleet/lib/node-providers/noop.ts
+++ b/packages/fleet/lib/node-providers/noop.ts
@@ -1,5 +1,6 @@
 import { Ok } from '@nangohq/utils';
 import type { NodeProvider } from './node_provider';
+import type { NodeConfig } from '@nangohq/types';
 
 export const noopNodeProvider: NodeProvider = {
     start: () => {
@@ -11,4 +12,11 @@ export const noopNodeProvider: NodeProvider = {
     verifyUrl: () => {
         return Promise.resolve(Ok(undefined));
     }
+};
+
+export const noopNodeConfig: NodeConfig = {
+    image: 'my-image',
+    cpuMilli: 1000,
+    memoryMb: 1000,
+    storageMb: 1000
 };

--- a/packages/fleet/lib/supervisor.integration.test.ts
+++ b/packages/fleet/lib/supervisor.integration.test.ts
@@ -19,9 +19,16 @@ const mockNodeProvider = {
     }
 };
 
+const defaultNodeConfig = {
+    image: 'image',
+    cpuMilli: 1000,
+    memoryMb: 1000,
+    storageMb: 1000
+};
+
 describe('Supervisor', () => {
     const dbClient = getTestDbClient('supervisor');
-    const supervisor = new Supervisor({ dbClient, nodeProvider: mockNodeProvider });
+    const supervisor = new Supervisor({ dbClient, defaultNodeConfig, nodeProvider: mockNodeProvider });
     let previousDeployment: Deployment;
     let activeDeployment: Deployment;
 
@@ -37,8 +44,8 @@ describe('Supervisor', () => {
     });
 
     describe('instances', () => {
-        const supervisor1 = new Supervisor({ dbClient, nodeProvider: mockNodeProvider });
-        const supervisor2 = new Supervisor({ dbClient, nodeProvider: mockNodeProvider });
+        const supervisor1 = new Supervisor({ dbClient, defaultNodeConfig, nodeProvider: mockNodeProvider });
+        const supervisor2 = new Supervisor({ dbClient, defaultNodeConfig, nodeProvider: mockNodeProvider });
 
         afterEach(async () => {
             await supervisor1.stop();

--- a/packages/fleet/lib/supervisor.integration.test.ts
+++ b/packages/fleet/lib/supervisor.integration.test.ts
@@ -10,6 +10,12 @@ import type { Deployment } from '@nangohq/types';
 import { FleetError } from './utils/errors.js';
 
 const mockNodeProvider = {
+    defaultNodeConfig: {
+        image: 'image',
+        cpuMilli: 1000,
+        memoryMb: 1000,
+        storageMb: 1000
+    },
     start: vi.fn().mockResolvedValue(Ok(undefined)),
     terminate: vi.fn().mockResolvedValue(Ok(undefined)),
     verifyUrl: vi.fn().mockResolvedValue(Ok(undefined)),
@@ -19,16 +25,9 @@ const mockNodeProvider = {
     }
 };
 
-const defaultNodeConfig = {
-    image: 'image',
-    cpuMilli: 1000,
-    memoryMb: 1000,
-    storageMb: 1000
-};
-
 describe('Supervisor', () => {
     const dbClient = getTestDbClient('supervisor');
-    const supervisor = new Supervisor({ dbClient, defaultNodeConfig, nodeProvider: mockNodeProvider });
+    const supervisor = new Supervisor({ dbClient, nodeProvider: mockNodeProvider });
     let previousDeployment: Deployment;
     let activeDeployment: Deployment;
 
@@ -44,8 +43,8 @@ describe('Supervisor', () => {
     });
 
     describe('instances', () => {
-        const supervisor1 = new Supervisor({ dbClient, defaultNodeConfig, nodeProvider: mockNodeProvider });
-        const supervisor2 = new Supervisor({ dbClient, defaultNodeConfig, nodeProvider: mockNodeProvider });
+        const supervisor1 = new Supervisor({ dbClient, nodeProvider: mockNodeProvider });
+        const supervisor2 = new Supervisor({ dbClient, nodeProvider: mockNodeProvider });
 
         afterEach(async () => {
             await supervisor1.stop();

--- a/packages/fleet/lib/types.ts
+++ b/packages/fleet/lib/types.ts
@@ -1,4 +1,4 @@
-import type { RoutingId } from '@nangohq/types';
+import type { RoutingId, NodeConfig } from '@nangohq/types';
 
 export const nodeStates = ['PENDING', 'STARTING', 'RUNNING', 'OUTDATED', 'FINISHING', 'IDLE', 'TERMINATED', 'ERROR'] as const;
 export type NodeState = (typeof nodeStates)[number];
@@ -9,10 +9,10 @@ export interface Node {
     readonly deploymentId: number;
     readonly url: string | null;
     readonly state: NodeState;
-    readonly image: string;
-    readonly cpuMilli: number;
-    readonly memoryMb: number;
-    readonly storageMb: number;
+    readonly image: NodeConfig['image'];
+    readonly cpuMilli: NodeConfig['cpuMilli'];
+    readonly memoryMb: NodeConfig['memoryMb'];
+    readonly storageMb: NodeConfig['storageMb'];
     readonly error: string | null;
     readonly createdAt: Date;
     readonly lastStateTransitionAt: Date;

--- a/packages/fleet/lib/utils/errors.ts
+++ b/packages/fleet/lib/utils/errors.ts
@@ -17,11 +17,12 @@ type FleetErrorCode =
     | 'supervisor_search_nodes_failed'
     | 'supervisor_unknown_action'
     | 'supervisor_tick_failed'
+    | 'fleet_misconfigured'
     | 'fleet_node_not_ready_timeout'
     | 'fleet_node_url_not_found'
     | 'fleet_node_outdate_failed'
-    | 'fleet_tick_timeout'
     | 'fleet_cannot_acquire_lock'
+    | 'fleet_lock_timeout'
     | 'fleet_lock_error'
     | 'local_runner_start_failed';
 

--- a/packages/fleet/lib/utils/locking.ts
+++ b/packages/fleet/lib/utils/locking.ts
@@ -4,7 +4,7 @@ import { setTimeout } from 'node:timers/promises';
 import type { Result } from '@nangohq/utils';
 import { FleetError } from './errors.js';
 
-export async function withPgLock({
+export async function withPgLock<T>({
     db,
     lockKey,
     fn,
@@ -13,10 +13,10 @@ export async function withPgLock({
 }: {
     db: Knex;
     lockKey: string;
-    fn: () => Promise<Result<void>>;
+    fn: (db: Knex) => Promise<Result<T>>;
     onTimeout?: () => Promise<void>;
     timeoutMs?: number;
-}): Promise<Result<void>> {
+}): Promise<Result<T>> {
     let trx: Knex.Transaction | undefined = undefined;
     try {
         trx = await db.transaction();
@@ -27,12 +27,12 @@ export async function withPgLock({
             return Err(new FleetError('fleet_cannot_acquire_lock'));
         }
 
-        const processingTimeout = async (): Promise<Result<void>> => {
+        const processingTimeout = async (): Promise<Result<T>> => {
             await setTimeout(timeoutMs);
             await onTimeout();
-            return Err(new FleetError('fleet_tick_timeout'));
+            return Err(new FleetError('fleet_lock_timeout'));
         };
-        const res = await Promise.race([fn(), processingTimeout()]);
+        const res = await Promise.race([fn(trx), processingTimeout()]);
         await trx.commit();
         return res;
     } catch (error) {

--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -77,10 +77,7 @@ try {
             await runnersFleet.rollout(commitHash.value);
         }
     }
-    // TODO: change to `!== REMOTE` when fleet is ready to be deployed to PROD
-    if (envs.RUNNER_TYPE === 'LOCAL') {
-        runnersFleet.start();
-    }
+    runnersFleet.start();
 
     processor.start();
 

--- a/packages/jobs/lib/runner/fleet.ts
+++ b/packages/jobs/lib/runner/fleet.ts
@@ -1,8 +1,23 @@
-import type { NodeProvider } from '@nangohq/fleet';
 import { Fleet } from '@nangohq/fleet';
 import { envs } from '../env.js';
 import { localNodeProvider } from './local.js';
+import { renderNodeProvider } from './render.js';
 
-const nodeProvider: NodeProvider | undefined = envs.RUNNER_TYPE === 'LOCAL' ? localNodeProvider : undefined;
+const defaultNodeConfig = {
+    image: 'nangohq/nango-runner',
+    cpuMilli: 500,
+    memoryMb: 512,
+    storageMb: 20000
+};
 
-export const runnersFleet = new Fleet({ fleetId: 'nango_runners', nodeProvider });
+const fleetId = 'nango_runners';
+export const runnersFleet = (() => {
+    switch (envs.RUNNER_TYPE) {
+        case 'LOCAL':
+            return new Fleet({ fleetId, nodeSetup: { nodeProvider: localNodeProvider, defaultNodeConfig } });
+        case 'RENDER':
+            return new Fleet({ fleetId, nodeSetup: { nodeProvider: renderNodeProvider, defaultNodeConfig } });
+        default:
+            return new Fleet({ fleetId });
+    }
+})();

--- a/packages/jobs/lib/runner/fleet.ts
+++ b/packages/jobs/lib/runner/fleet.ts
@@ -3,20 +3,13 @@ import { envs } from '../env.js';
 import { localNodeProvider } from './local.js';
 import { renderNodeProvider } from './render.js';
 
-const defaultNodeConfig = {
-    image: 'nangohq/nango-runner',
-    cpuMilli: 500,
-    memoryMb: 512,
-    storageMb: 20000
-};
-
 const fleetId = 'nango_runners';
 export const runnersFleet = (() => {
     switch (envs.RUNNER_TYPE) {
         case 'LOCAL':
-            return new Fleet({ fleetId, nodeSetup: { nodeProvider: localNodeProvider, defaultNodeConfig } });
+            return new Fleet({ fleetId, nodeProvider: localNodeProvider });
         case 'RENDER':
-            return new Fleet({ fleetId, nodeSetup: { nodeProvider: renderNodeProvider, defaultNodeConfig } });
+            return new Fleet({ fleetId, nodeProvider: renderNodeProvider });
         default:
             return new Fleet({ fleetId });
     }

--- a/packages/jobs/lib/runner/local.ts
+++ b/packages/jobs/lib/runner/local.ts
@@ -27,6 +27,7 @@ export const localNodeProvider: NodeProvider = {
                 env: {
                     ...process.env,
                     RUNNER_NODE_ID: node.id.toString(),
+                    RUNNER_URL: `http://localhost:${port}`,
                     IDLE_MAX_DURATION_MS: '0',
                     PROVIDERS_URL: getProvidersUrl(),
                     PROVIDERS_RELOAD_INTERVAL: envs.PROVIDERS_RELOAD_INTERVAL.toString(),

--- a/packages/jobs/lib/runner/local.ts
+++ b/packages/jobs/lib/runner/local.ts
@@ -10,6 +10,13 @@ import { getProvidersUrl } from '@nangohq/shared';
 const localRunnerPids = new Map<number, number>(); // Mapping Node.id to process PID
 
 export const localNodeProvider: NodeProvider = {
+    defaultNodeConfig: {
+        // irrelevant for local runner
+        image: 'my-image',
+        cpuMilli: 500,
+        memoryMb: 512,
+        storageMb: 20000
+    },
     start: async (node) => {
         try {
             // Random port to avoid conflicts with other fleet runners accross local execution

--- a/packages/jobs/lib/runner/render.api.ts
+++ b/packages/jobs/lib/runner/render.api.ts
@@ -35,4 +35,8 @@ export class RenderAPI {
     async resumeService(params: { serviceId: string }): Promise<AxiosResponse> {
         return await this.httpClient.post(`/services/${params.serviceId}/resume`, {});
     }
+
+    async deleteService(params: { serviceId: string }): Promise<AxiosResponse> {
+        return await this.httpClient.delete(`/services/${params.serviceId}`, {});
+    }
 }

--- a/packages/jobs/lib/runner/render.ts
+++ b/packages/jobs/lib/runner/render.ts
@@ -10,6 +10,12 @@ import { isAxiosError } from 'axios';
 const render: RenderAPI = new RenderAPI(envs.RENDER_API_KEY || '');
 
 export const renderNodeProvider: NodeProvider = {
+    defaultNodeConfig: {
+        image: 'nangohq/nango-runner',
+        cpuMilli: 500,
+        memoryMb: 512,
+        storageMb: 20000
+    },
     start: async (node) => {
         if (!envs.RUNNER_OWNER_ID) {
             throw new Error('RUNNER_OWNER_ID is not set');

--- a/packages/jobs/lib/runner/render.ts
+++ b/packages/jobs/lib/runner/render.ts
@@ -1,0 +1,119 @@
+import type { Node, NodeProvider } from '@nangohq/fleet';
+import type { Result } from '@nangohq/utils';
+import { Err, Ok } from '@nangohq/utils';
+import { RenderAPI } from './render.api.js';
+import { envs } from '../env.js';
+import { getPersistAPIUrl, getProvidersUrl } from '@nangohq/shared';
+import type { AxiosResponse } from 'axios';
+import { isAxiosError } from 'axios';
+
+const render: RenderAPI = new RenderAPI(envs.RENDER_API_KEY || '');
+
+export const renderNodeProvider: NodeProvider = {
+    start: async (node) => {
+        if (!envs.RUNNER_OWNER_ID) {
+            throw new Error('RUNNER_OWNER_ID is not set');
+        }
+        const ownerId = envs.RUNNER_OWNER_ID;
+        const name = serviceName(node);
+        const res = await withRateLimitHandling<{ service: { id: string; suspended: string } }>('create', () =>
+            render.createService({
+                type: 'private_service',
+                name,
+                ownerId,
+                image: { ownerId, imagePath: node.image },
+                serviceDetails: { env: 'image' },
+                envVars: [
+                    { key: 'NODE_ENV', value: envs.NODE_ENV },
+                    { key: 'NANGO_CLOUD', value: String(envs.NANGO_CLOUD) },
+                    { key: 'NODE_OPTIONS', value: `--max-old-space-size=${Math.floor((node.memoryMb / 4) * 3)}` },
+                    { key: 'RUNNER_NODE_ID', value: `${node.id}` },
+                    { key: 'RUNNER_URL', value: `http://${name}` },
+                    { key: 'IDLE_MAX_DURATION_MS', value: `${25 * 60 * 60 * 1000}` }, // 25 hours
+                    { key: 'PERSIST_SERVICE_URL', value: getPersistAPIUrl() },
+                    { key: 'NANGO_TELEMETRY_SDK', value: process.env['NANGO_TELEMETRY_SDK'] || 'false' },
+                    ...(envs.DD_ENV ? [{ key: 'DD_ENV', value: envs.DD_ENV }] : []),
+                    ...(envs.DD_SITE ? [{ key: 'DD_SITE', value: envs.DD_SITE }] : []),
+                    ...(envs.DD_TRACE_AGENT_URL ? [{ key: 'DD_TRACE_AGENT_URL', value: envs.DD_TRACE_AGENT_URL }] : []),
+                    { key: 'JOBS_SERVICE_URL', value: envs.JOBS_SERVICE_URL },
+                    { key: 'PROVIDERS_URL', value: getProvidersUrl() },
+                    { key: 'PROVIDERS_RELOAD_INTERVAL', value: envs.PROVIDERS_RELOAD_INTERVAL.toString() }
+                ]
+            })
+        );
+        if (res.isErr()) {
+            return Err(new Error('Failed to create service', { cause: res.error }));
+        }
+        if (!res.value.service) {
+            return Err('Failed to create service, no service in response');
+        }
+        const svc = res.value.service;
+        if (svc.suspended === 'suspended') {
+            const res = await withRateLimitHandling('resume', () => render.resumeService({ serviceId: svc.id }));
+            if (isAxiosError(res)) {
+                return Err('Failed to render resume service');
+            }
+        }
+        return Ok(undefined);
+    },
+    terminate: async (node) => {
+        const serviceId = await getServiceId(node);
+        if (serviceId.isErr()) {
+            return Err(new Error('Failed to get service', { cause: serviceId.error }));
+        }
+        const res = await withRateLimitHandling('delete', () => render.deleteService({ serviceId: serviceId.value }));
+        if (res.isErr()) {
+            return Err(new Error('Failed to delete service', { cause: res.error }));
+        }
+        return Ok(undefined);
+    },
+    verifyUrl: (url) => {
+        if (!url.match(/^http:\/\/(production|staging)-runner-account-(\d+|default)-\d+/)) {
+            return Promise.resolve(Err('Invalid URL'));
+        }
+        return Promise.resolve(Ok(undefined));
+    }
+};
+
+async function getServiceId(node: Node): Promise<Result<string>> {
+    const res = await withRateLimitHandling<{ service: { id: string } }[]>('get', () =>
+        render.getServices({ name: serviceName(node), type: 'private_service', limit: '1' })
+    );
+    if (res.isErr()) {
+        return Err(new Error('Failed to get service', { cause: res.error }));
+    }
+    const svc = res.value[0];
+    if (!svc) {
+        return Err('Service not found');
+    }
+    return Ok(svc.service.id);
+}
+
+function serviceName(node: Node) {
+    return `${node.routingId}-${node.id}`;
+}
+
+const rateLimitResetTimestamps = new Map<string, Date>();
+
+async function withRateLimitHandling<T>(rateLimitGroup: 'create' | 'delete' | 'resume' | 'get', fn: () => Promise<AxiosResponse>): Promise<Result<T>> {
+    const rateLimitReset = rateLimitResetTimestamps.get(rateLimitGroup);
+    if (rateLimitReset && rateLimitReset > new Date()) {
+        return Err(`Render rate limit exceeded. Resetting at ${rateLimitReset.toISOString()}`);
+    }
+    try {
+        const res = await fn();
+        return Ok(res.data);
+    } catch (err) {
+        if (isAxiosError(err)) {
+            if (err.response?.status === 429) {
+                let resetInMs = parseInt(err.response?.headers['ratelimit-reset']) * 1000;
+                if (resetInMs <= 0) {
+                    resetInMs = 10_000;
+                }
+                rateLimitResetTimestamps.set(rateLimitGroup, new Date(Date.now() + resetInMs));
+            }
+            return Err(`Request to Render API failed with status ${err.response?.status}: ${JSON.stringify(err.response?.data)}`);
+        }
+        return Err(new Error('Request to Render API failed', { cause: err }));
+    }
+}

--- a/packages/runner/lib/app.ts
+++ b/packages/runner/lib/app.ts
@@ -44,7 +44,7 @@ try {
         // not closing on purpose
     });
 
-    const res = await register({ port });
+    const res = await register();
     if (res.isErr()) {
         logger.error(`${id} Unable to register: ${res.error}`);
         // not exiting on purpose because REMOTE runner are not registering

--- a/packages/runner/lib/register.ts
+++ b/packages/runner/lib/register.ts
@@ -3,13 +3,12 @@ import { Err, Ok, retryWithBackoff } from '@nangohq/utils';
 import { envs, jobsServiceUrl } from './env.js';
 import { httpFetch } from './utils.js';
 
-export async function register({ port }: { port: number }): Promise<Result<void>> {
+export async function register(): Promise<Result<void>> {
     if (!envs.RUNNER_NODE_ID) {
         return Err('NODE_ID is not set');
     }
-    const nodeUrl = `http://localhost:${port}`;
-    if (envs.RUNNER_TYPE === 'RENDER') {
-        // TODO
+    if (!envs.RUNNER_URL) {
+        return Err('RUNNER_URL is not set');
     }
     try {
         await retryWithBackoff(
@@ -17,7 +16,7 @@ export async function register({ port }: { port: number }): Promise<Result<void>
                 return await httpFetch({
                     method: 'POST',
                     url: `${jobsServiceUrl}/runners/${envs.RUNNER_NODE_ID}/register`,
-                    data: JSON.stringify({ url: nodeUrl })
+                    data: JSON.stringify({ url: envs.RUNNER_URL })
                 });
             },
             {

--- a/packages/types/lib/fleet/index.ts
+++ b/packages/types/lib/fleet/index.ts
@@ -8,3 +8,10 @@ export interface Deployment {
 }
 
 export type RoutingId = string;
+
+export interface NodeConfig {
+    readonly image: string;
+    readonly cpuMilli: number;
+    readonly memoryMb: number;
+    readonly storageMb: number;
+}

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -43,7 +43,7 @@ export const ENVS = z.object({
     ORCHESTRATOR_DATABASE_SCHEMA: z.string().optional().default('nango_scheduler'),
 
     // Jobs
-    JOBS_SERVICE_URL: z.string().url().optional(),
+    JOBS_SERVICE_URL: z.string().url().optional().default('http://localhost:3005'),
     NANGO_JOBS_PORT: z.coerce.number().optional().default(3005),
     PROVIDERS_URL: z.string().url().optional(),
     PROVIDERS_RELOAD_INTERVAL: z.coerce.number().optional().default(60000),
@@ -56,8 +56,13 @@ export const ENVS = z.object({
     RUNNER_ID: z.string().optional(), // TODO: remove once fleet is fully released
     IDLE_MAX_DURATION_MS: z.coerce.number().default(0),
     RUNNER_NODE_ID: z.coerce.number().optional(),
+    RUNNER_URL: z.string().url().optional(),
 
     // FLEET
+    FLEET_TIMEOUT_PENDING_MS: z.coerce
+        .number()
+        .optional()
+        .default(15 * 60 * 1000), // 15 minutes
     FLEET_TIMEOUT_STARTING_MS: z.coerce
         .number()
         .optional()
@@ -66,6 +71,10 @@ export const ENVS = z.object({
         .number()
         .optional()
         .default(24 * 60 * 60 * 1000), // 24 hours
+    FLEET_TIMEOUT_IDLE_MS: z.coerce
+        .number()
+        .optional()
+        .default(15 * 60 * 1000), // 15 minutes
     FLEET_TIMEOUT_TERMINATED_MS: z.coerce
         .number()
         .optional()
@@ -78,6 +87,7 @@ export const ENVS = z.object({
         .number()
         .optional()
         .default(60 * 1000), // 1 minute
+    FLEET_RETRY_DELAY_GET_RUNNING_NODE_MS: z.coerce.number().optional().default(1000), // 1 sec
     FLEET_SUPERVISOR_TIMEOUT_TICK_MS: z.coerce
         .number()
         .optional()


### PR DESCRIPTION
- adding Render node provider. This is highly dependent on lifting the rate limit for creating service. Otherwise we are gonna need to go to AWS directly
- do not fail node when node provider errors and rely on the nature of the control loop to retry. Adding some timeout to deal with never ending errors
- adding a lock around the node creation to prevent race condition that could happen the first time a runner is created if multiple scripts are executed around the same time
- fixing some bugs

# How to test
Unfortunately you cannot test locally, only in staging

