### PR TITLE
fix(harvest): default harvest app details

### DIFF
--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -3374,7 +3374,7 @@ harvest:
             type: string
             title: App Details
             description: The details of your app
-            hidden: true
+            automated: true
 
 health-gorilla:
     display_name: Health Gorilla

--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -3364,7 +3364,7 @@ harvest:
         grant_type: refresh_token
     proxy:
         headers:
-            user-agent: ${connectionConfig.appDetails}
+            user-agent: ${connectionConfig.appDetails} || App (support@nango.dev)
         retry:
             after: 'retry-after'
         base_url: https://api.harvestapp.com
@@ -3374,6 +3374,7 @@ harvest:
             type: string
             title: App Details
             description: The details of your app
+            hidden: true
 
 health-gorilla:
     display_name: Health Gorilla


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Harvest requires an app details header to be sent. This can be set programmatically but should not be set by the end user or even be exposed to the end user. This PR replaces https://github.com/NangoHQ/nango/pull/3148

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

