### PR TITLE
chore: call /rollout endpoint in deploy github action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -85,8 +85,15 @@ jobs:
                   API_KEY: ${{ secrets.RENDER_API_KEY }}
                   ENVIRONMENT: ${{ inputs.stage }}
                   RUNNER_OWNER_ID: ${{ secrets.RENDER_RUNNER_OWNER_ID }}
+                  INTERNAL_API_KEY: ${{ inputs.stage == 'production' && secrets.PROD_INTERNAL_API_KEY || secrets.STAGING_INTERNAL_API_KEY }}
               run: |
                   bash ./scripts/deploy/runners.bash
+
+                  NANGO_API_HOSTNAME=${{ fromJson('{ "production": "api.nango.dev", "staging": "api-staging.nango.dev" }')[inputs.stage] }}
+                  curl -sS --fail-with-body --request POST "https://$NANGO_API_HOSTNAME/internal/fleet/nango_runners/rollout" \
+                    --header "authorization: Bearer $INTERNAL_API_KEY"\
+                    --header "content-type: application/json"\
+                    --data "{ \"commitHash\": \"${{ github.sha }}\" }"
 
     deploy_persist:
         if: inputs.service == 'persist'

--- a/scripts/deploy/runners.bash
+++ b/scripts/deploy/runners.bash
@@ -29,7 +29,7 @@ while true; do
       continue
     fi
     name=$(echo "$item" | jq -r '.service.name' 2>/dev/null)
-    if [[ "$name" != "$ENVIRONMENT-runner-"* ]]; then
+    if [[ ! "$name" =~ ^$ENVIRONMENT-runner-account-(default|[0-9]+)$ ]]; then
       continue
     fi
 


### PR DESCRIPTION
Calling the /rollout endpoint when deploying runner via github action.
I've tested in staging: https://github.com/NangoHQ/nango/actions/runs/12300905315