### PR TITLE
chore(fleet): add tracing around supervisor plan/execute

### DIFF
--- a/packages/fleet/lib/fleet.ts
+++ b/packages/fleet/lib/fleet.ts
@@ -8,7 +8,7 @@ import type { Node } from './types.js';
 import type { CommitHash, Deployment, RoutingId } from '@nangohq/types';
 import { FleetError } from './utils/errors.js';
 import { setTimeout } from 'node:timers/promises';
-import { Supervisor } from './supervisor.js';
+import { Supervisor } from './supervisor/supervisor.js';
 import type { NodeProvider } from './node-providers/node_provider.js';
 import type { FleetId } from './instances.js';
 import { envs } from './env.js';

--- a/packages/fleet/lib/supervisor/operation.ts
+++ b/packages/fleet/lib/supervisor/operation.ts
@@ -1,0 +1,45 @@
+import type { Node } from '../types.js';
+import type { Deployment, NodeConfig } from '@nangohq/types';
+
+export type Operation =
+    | { type: 'CREATE'; routingId: Node['routingId']; deployment: Deployment; nodeConfig?: NodeConfig | undefined }
+    | { type: 'START'; node: Node }
+    | { type: 'FAIL'; node: Node; reason: 'starting_timeout_reached' | 'pending_timeout_reached' | 'idle_timeout_reached' }
+    | { type: 'OUTDATE'; node: Node }
+    | { type: 'FINISHING'; node: Node }
+    | { type: 'FINISHING_TIMEOUT'; node: Node }
+    | { type: 'TERMINATE'; node: Node }
+    | { type: 'REMOVE'; node: Node };
+
+export const Operation = {
+    asSpanTags: (o: Operation): Record<string, string | number> => {
+        switch (o.type) {
+            case 'CREATE':
+                return {
+                    operation: o.type,
+                    routingId: o.routingId,
+                    deploymentId: o.deployment.id
+                };
+            case 'FAIL':
+                return {
+                    operation: o.type,
+                    nodeId: o.node.id,
+                    reason: o.reason
+                };
+            case 'START':
+                return {
+                    operation: o.type,
+                    nodeId: o.node.id
+                };
+            case 'OUTDATE':
+            case 'FINISHING':
+            case 'FINISHING_TIMEOUT':
+            case 'TERMINATE':
+            case 'REMOVE':
+                return {
+                    operation: o.type,
+                    nodeId: o.node.id
+                };
+        }
+    }
+};

--- a/packages/fleet/lib/supervisor/supervisor.integration.test.ts
+++ b/packages/fleet/lib/supervisor/supervisor.integration.test.ts
@@ -1,14 +1,14 @@
 import { expect, describe, it, beforeEach, afterEach, vi } from 'vitest';
 import { Ok } from '@nangohq/utils';
 import { STATE_TIMEOUT_MS, Supervisor } from './supervisor.js';
-import { getTestDbClient } from './db/helpers.test.js';
-import * as deployments from './models/deployments.js';
-import * as nodes from './models/nodes.js';
-import * as nodeConfigOverrides from './models/node_config_overrides.js';
-import { generateCommitHash } from './models/helpers.js';
-import { createNodeWithAttributes } from './models/helpers.test.js';
+import { getTestDbClient } from '../db/helpers.test.js';
+import * as deployments from '../models/deployments.js';
+import * as nodes from '../models/nodes.js';
+import * as nodeConfigOverrides from '../models/node_config_overrides.js';
+import { generateCommitHash } from '../models/helpers.js';
+import { createNodeWithAttributes } from '../models/helpers.test.js';
 import type { Deployment } from '@nangohq/types';
-import { FleetError } from './utils/errors.js';
+import { FleetError } from '../utils/errors.js';
 
 const mockNodeProvider = {
     defaultNodeConfig: {


### PR DESCRIPTION
also adding a try/catch around getRunner logic

Ex: https://us3.datadoghq.com/apm/traces?query=env%3Astaging%20service%3Anango-jobs%20resource_name%3Afleet.supervisor.operation.%2A&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code&fromUser=false&graphType=waterfall&historicalData=true&panel_tab=flamegraph&query_translation_version=v0&shouldShowLegend=true&sort=time&spanID=2784596772656159614&spanType=all&spanViewType=metadata&storage=hot&timeHint=1734038729494&trace=AwAAAZO8wzMW-LOLIwAAABhBWk84dzBweUFBRGl2WlZhLTB0dUhGeGcAAAAkMDE5M2JjYzMtYTMxMC00NWU1LWFjOTQtM2NkMWY3OGYyNTU3AAAidQ&traceID=675b54c900000000605c5601b90448c3&traceQuery=&view=spans&viz=stream&start=1734038206501&end=1734039106501&paused=false

# How to test
The easiest way is to deploy to staging and check the traces in DD

