### PR TITLE
feat(server): Add instance identifier when logging in cloud

### DIFF
--- a/packages/utils/lib/logger.ts
+++ b/packages/utils/lib/logger.ts
@@ -3,6 +3,7 @@ import winston from 'winston';
 import type { Logform, Logger } from 'winston';
 import colors from '@colors/colors';
 import { isCloud, isEnterprise, isTest } from './environment/detection.js';
+import { nanoid } from 'nanoid';
 
 const SPLAT = Symbol.for('splat');
 const level = process.env['LOG_LEVEL'] ? process.env['LOG_LEVEL'] : isTest ? 'error' : 'info';
@@ -41,10 +42,12 @@ if (!isCloud && !isEnterprise) {
         })
     ];
 } else {
+    const instanceId = isCloud ? nanoid(10) : '';
+
     formatters = [
         winston.format.printf((info) => {
             const splat = info[SPLAT] && info[SPLAT].length > 0 ? JSON.stringify(info[SPLAT]) : '';
-            return `[${info.level.toUpperCase()}]${info['service'] ? ` [${info['service']}] ` : ''}${info.message} ${splat}`;
+            return `[${info.level.toUpperCase()}] ${instanceId}${info['service'] ? ` [${info['service']}] ` : ''}${info.message} ${splat}`;
         })
     ];
 }

--- a/packages/utils/lib/logger.ts
+++ b/packages/utils/lib/logger.ts
@@ -42,12 +42,12 @@ if (!isCloud && !isEnterprise) {
         })
     ];
 } else {
-    const instanceId = isCloud ? nanoid(10) : '';
+    const instanceId = isCloud ? ` ${nanoid(6)}` : '';
 
     formatters = [
         winston.format.printf((info) => {
             const splat = info[SPLAT] && info[SPLAT].length > 0 ? JSON.stringify(info[SPLAT]) : '';
-            return `[${info.level.toUpperCase()}] ${instanceId}${info['service'] ? ` [${info['service']}] ` : ''}${info.message} ${splat}`;
+            return `[${info.level.toUpperCase()}]${instanceId}${info['service'] ? ` [${info['service']}] ` : ''}${info.message} ${splat}`;
         })
     ];
 }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
When reviewing logs in Render right now it's difficult to know what instance of server logged what. This adds a random identifier at startup that will help us filter logs to specific instances.

I thought about using hostnames but the hostnames on render are super long and not that helpful, and I'm not 100% sure they're guaranteed to be unique on their infra.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

