### PR TITLE
fix(base-url): fix lastpass base url

### DIFF
--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -3909,7 +3909,7 @@ lastpass:
         - productivity
     auth_mode: BASIC
     proxy:
-        base_url: https://lastpass.com/enterpriseapi.php
+        base_url: https://lastpass.com
     docs: https://docs.nango.dev/integrations/all/lastpass
     docs_connect: https://docs.nango.dev/integrations/all/lastpass/connect
     credentials:


### PR DESCRIPTION
## Describe the problem and your solution

All requests from LastPass postman collection have the same `base-url`, since it is not possible to have an empty string as an endpoint value in Nango, this PR fixes that for LastPass.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

