### PR TITLE
fix(logs): correctly truncate logs based on bytes size

### DIFF
--- a/packages/utils/lib/json.ts
+++ b/packages/utils/lib/json.ts
@@ -1,5 +1,6 @@
 import safeStringify from 'fast-safe-stringify';
 import truncateJsonPkg from 'truncate-json';
+import { truncateBytes } from './string.js';
 
 export const MAX_LOG_PAYLOAD = 99_000; // in  bytes
 
@@ -37,10 +38,11 @@ export function stringifyAndTruncateValue(value: any, maxSize: number = MAX_LOG_
         return 'undefined';
     }
 
-    let msg = typeof value === 'string' ? value : truncateJsonString(stringifyObject(value), maxSize);
+    const msg = typeof value === 'string' ? value : truncateJsonString(stringifyObject(value), maxSize);
 
-    if (msg && msg.length > maxSize) {
-        msg = `${msg.substring(0, maxSize)}... (truncated)`;
+    const truncated = truncateBytes(msg, maxSize);
+    if (truncated !== msg) {
+        return `${truncated}... (truncated)`;
     }
 
     return msg;

--- a/packages/utils/lib/json.unit.test.ts
+++ b/packages/utils/lib/json.unit.test.ts
@@ -12,6 +12,11 @@ describe('stringifyAndTruncateValue', () => {
         expect(str).toStrictEqual('he... (truncated)');
     });
 
+    it('should limit a string with multi-bytes characters', () => {
+        const str = stringifyAndTruncateValue('👋👋👋', 7); // 4 bytes each
+        expect(str).toStrictEqual('👋... (truncated)'); // 7 bytes limit is not enough for 2 characters => truncating after the first one
+    });
+
     it('should limit an object', () => {
         const str = stringifyAndTruncateValue({ foo: 'bar' }, 10);
         expect(str).toStrictEqual('{}');

--- a/packages/utils/lib/string.ts
+++ b/packages/utils/lib/string.ts
@@ -20,3 +20,42 @@ export function stringTimingSafeEqual(a: string, b: string): boolean {
         return false;
     }
 }
+
+export function truncateBytes(str: string, maxBytes: number): string {
+    const encoder = new TextEncoder();
+    if (encoder.encode(str).length <= maxBytes) {
+        return str;
+    }
+
+    let left = 0;
+    let right = str.length;
+
+    // Find how many characters fit within the byte limit
+    while (right - left > 1) {
+        const mid = Math.floor((left + right) / 2);
+        const slice = str.slice(0, mid);
+        const bytes = encoder.encode(slice).length;
+
+        if (bytes <= maxBytes) {
+            left = mid;
+        } else {
+            right = mid;
+        }
+    }
+
+    let result = str.slice(0, left);
+
+    // Making sure we haven't truncated in the middle of a multi-bytes character
+    // by reducing length until we can encode the string
+    while (left > 0) {
+        try {
+            encodeURIComponent(result);
+            break;
+        } catch {
+            left--;
+            result = str.slice(0, left);
+        }
+    }
+
+    return result;
+}


### PR DESCRIPTION
truncation logic was based on characters length which led to long string containing unicode characters being truncated but still be above the size limit in bytes and therefore be rejected by 'persist' with 'entity too large' error. 

This commit modifies the truncation logic to take into account the string size in bytes and correctly handled 4 bytes characters

# how to test
Run a sync with the following code before and after this patch. Doesn't fail anymore
```
const longString = Array.from({ length: 500_000 }, () => '😀').join('');
await nango.log(longString);
```

