### PR TITLE
fix(environment-id): environmentId not required for getEnvironmentVariables call

### DIFF
--- a/packages/shared/lib/sdk/sync.ts
+++ b/packages/shared/lib/sdk/sync.ts
@@ -801,10 +801,6 @@ export class NangoAction {
     }
 
     public async getEnvironmentVariables(): Promise<EnvironmentVariable[] | null> {
-        if (!this.environmentId) {
-            throw new Error('There is no current environment to get variables from');
-        }
-
         return await this.nango.getEnvironmentVariables();
     }
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Reported by a customer: https://nangohq.slack.com/archives/C07242ZTXCK/p1734637795666279?thread_ts=1734536836.183739&cid=C07242ZTXCK -- environmnentId isn't required to make the call

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

