### PR TITLE
fix(docs): Use logos from github rather than our app

### DIFF
--- a/scripts/webflow-api-sync.ts
+++ b/scripts/webflow-api-sync.ts
@@ -150,7 +150,7 @@ for (const [slug, provider] of Object.entries(neededProviders)) {
                     name: provider.display_name,
                     slug: slug,
                     documentation: provider.docs,
-                    logo: `https://app.nango.dev/images/template-logos/${slug}.svg`,
+                    logo: `https://raw.githubusercontent.com/NangoHQ/nango/refs/heads/master/packages/webapp/public/images/template-logos/${slug}.svg`,
                     'api-categories': providerCategories.map((category) => categoriesBySlug[category]?.id)
                 }
             });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
We had an issue where webflow sync was failing because it was trying to use logos before they were deployed. This fixes it by just leaning on github's public URL instead.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

