### PR TITLE
feat(frontend): add sourcemaps to frontend package

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -20,6 +20,7 @@
     "files": [
         "dist/**/*.js",
         "dist/**/*.d.ts",
+        "dist/**/*.map",
         "!**/*.json",
         "README.md"
     ]

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -3,7 +3,10 @@
     "compilerOptions": {
         "lib": ["es2015", "dom"],
         "rootDir": "lib",
-        "outDir": "dist"
+        "outDir": "dist",
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true
     },
     "references": [
         {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
The Nango frontend package does not export sourcemaps. When compiling my frontend using `bun`, I received the following warnings:
```
Compiled with warnings.

Failed to parse source map from '/Users/izak/personal/vigilant/vigilant/dashboard/node_modules/@nangohq/frontend/dist/connectUI.js.map' file: Error: ENOENT: no such file or directory, open '/Users/izak/personal/vigilant/vigilant/dashboard/node_modules/@nangohq/frontend/dist/connectUI.js.map'

Failed to parse source map from '/Users/izak/personal/vigilant/vigilant/dashboard/node_modules/@nangohq/frontend/dist/index.js.map' file: Error: ENOENT: no such file or directory, open '/Users/izak/personal/vigilant/vigilant/dashboard/node_modules/@nangohq/frontend/dist/index.js.map'

Failed to parse source map from '/Users/izak/personal/vigilant/vigilant/dashboard/node_modules/@nangohq/frontend/dist/types.js.map' file: Error: ENOENT: no such file or directory, open '/Users/izak/personal/vigilant/vigilant/dashboard/node_modules/@nangohq/frontend/dist/types.js.map'

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.
```

The fix is to add sourcemap exports when packaging the frontend library.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

