### PR TITLE
fix(jobs): do not exit on unhandledRejection

### DIFF
--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -57,8 +57,7 @@ try {
 
     process.on('unhandledRejection', (reason) => {
         logger.error('Received unhandledRejection...', reason);
-        process.exitCode = 1;
-        void close();
+        // not closing on purpose
     });
 
     process.on('uncaughtException', (e) => {


### PR DESCRIPTION
Change introduced in d695be3 was supposed to help us better handle the main db connections exhaustion. It seems to make thing worse by exiting the app as soon as an unhandledRejection happens which can be caused itself by the connections exhaustion
For now just logging the same we do for uncaughtException

