### PR TITLE
fix(sync status): [nan-2141] also only grab enabled syncs

### DIFF
--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -197,7 +197,8 @@ export const getSyncs = async (
             this.on(`${SYNC_CONFIG_TABLE}.sync_name`, `${TABLE}.name`)
                 .andOn(`${SYNC_CONFIG_TABLE}.deleted`, '=', db.knex.raw('FALSE'))
                 .andOn(`${SYNC_CONFIG_TABLE}.active`, '=', db.knex.raw('TRUE'))
-                .andOn(`${SYNC_CONFIG_TABLE}.type`, '=', db.knex.raw('?', 'sync'));
+                .andOn(`${SYNC_CONFIG_TABLE}.type`, '=', db.knex.raw('?', 'sync'))
+                .andOn(`${SYNC_CONFIG_TABLE}.enabled`, '=', db.knex.raw('?', 'TRUE'));
         })
         .where({
             nango_connection_id: nangoConnection.id,


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Problem: Disabled syncs still show in the sync status table. This is only the case for public templates because custom ones lost their active status. For public templates we also need to filter on enabled.

<!-- Issue ticket number and link (if applicable) -->
Ticket: NAN-2141

<!-- Testing instructions (skip if just adding/editing providers) -->
# Testing
1. Enable a sync that is a public template
2. Kick off a sync run
3. Disable the sync
4. See that the sync result no longer shows in the summary table

@TBonnin might want to specifically take a look at this as I know he's done a lot of work optimizing this query to make sure it is performant as this table gets loaded quite often.

