### PR TITLE
fix(sync-status): [nan-2207] add connection_id to response

### DIFF
--- a/docs-v2/reference/sdks/node.mdx
+++ b/docs-v2/reference/sdks/node.mdx
@@ -1002,6 +1002,7 @@ await nango.syncStatus('<INTEGRATION-ID>', ['SYNC_NAME1', 'SYNC_NAME2'], '<CONNE
     "syncs": [
         {
             "id": "<string>",
+            "connection_id": "<string>",
             "name": "<string>",
             "status": "RUNNING",
             "type": "INCREMENTAL",

--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -1265,6 +1265,9 @@ paths:
                                                 id:
                                                     type: string
                                                     description: The unique identifier for the sync.
+                                                connection_id:
+                                                    type: string
+                                                    description: The ID of the connection
                                                 name:
                                                     type: string
                                                     description: The name of the sync.

--- a/packages/shared/lib/models/Sync.ts
+++ b/packages/shared/lib/models/Sync.ts
@@ -26,6 +26,8 @@ export interface SyncResult {
 
 export type SyncResultByModel = Record<string, SyncResult>;
 
+export type SyncWithConnectionId = Sync & { connection_id: string };
+
 export interface Sync extends TimestampsAndDeleted {
     id: string;
     nango_connection_id: number;
@@ -60,6 +62,7 @@ export interface ReportedSyncJobStatus {
     id?: string;
     type: SyncType | 'INITIAL';
     name?: string;
+    connection_id?: string;
     status: SyncStatus;
     latestResult?: SyncResultByModel | undefined;
     jobStatus?: SyncStatus;

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -334,8 +334,13 @@ export class SyncManagerService {
                     continue;
                 }
 
+                const syncWithConnectionId: SyncWithConnectionId = {
+                    ...sync,
+                    connection_id: connection.connection_id
+                };
+
                 const reportedStatus = await this.syncStatus({
-                    sync: { ...sync, connection_id: connection.connection_id },
+                    sync: syncWithConnectionId,
                     environmentId,
                     providerConfigKey,
                     includeJobStatus,
@@ -346,7 +351,7 @@ export class SyncManagerService {
                 syncsWithStatus.push(reportedStatus);
             }
         } else {
-            const syncs =
+            const syncs: SyncWithConnectionId[] =
                 syncNames.length > 0
                     ? await getSyncsByProviderConfigAndSyncNames(environmentId, providerConfigKey, syncNames)
                     : await getSyncsByProviderConfigKey(environmentId, providerConfigKey);

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -13,7 +13,7 @@ import {
 import { errorNotificationService } from '../notification/error.service.js';
 import configService from '../config.service.js';
 import type { Connection, NangoConnection } from '../../models/Connection.js';
-import type { Sync, ReportedSyncJobStatus, SyncCommand } from '../../models/Sync.js';
+import type { SyncWithConnectionId, ReportedSyncJobStatus, SyncCommand } from '../../models/Sync.js';
 import { SyncType, SyncStatus } from '../../models/Sync.js';
 import { NangoError } from '../../utils/error.js';
 import type { Config as ProviderConfig } from '../../models/Provider.js';
@@ -334,7 +334,14 @@ export class SyncManagerService {
                     continue;
                 }
 
-                const reportedStatus = await this.syncStatus({ sync, environmentId, providerConfigKey, includeJobStatus, orchestrator, recordsService });
+                const reportedStatus = await this.syncStatus({
+                    sync: { ...sync, connection_id: connection.connection_id },
+                    environmentId,
+                    providerConfigKey,
+                    includeJobStatus,
+                    orchestrator,
+                    recordsService
+                });
 
                 syncsWithStatus.push(reportedStatus);
             }
@@ -421,7 +428,7 @@ export class SyncManagerService {
         orchestrator,
         recordsService
     }: {
-        sync: Sync;
+        sync: SyncWithConnectionId;
         environmentId: number;
         providerConfigKey: string;
         includeJobStatus: boolean;
@@ -458,6 +465,7 @@ export class SyncManagerService {
 
         return {
             id: sync.id,
+            connection_id: sync.connection_id,
             type: latestJob?.type === SyncType.INCREMENTAL ? latestJob.type : 'INITIAL',
             finishedAt: latestJob?.updated_at,
             nextScheduledSyncAt: schedule.nextDueDate,

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import db, { schema, dbNamespace } from '@nangohq/database';
-import type { Sync, SyncConfig, Job as SyncJob } from '../../models/Sync.js';
+import type { Sync, SyncWithConnectionId, SyncConfig, Job as SyncJob } from '../../models/Sync.js';
 import { SyncStatus } from '../../models/Sync.js';
 import type { Connection, NangoConnection } from '../../models/Connection.js';
 import type { ActiveLog, IncomingFlowConfig, SlimAction, SlimSync, SyncAndActionDifferences, SyncTypeLiteral } from '@nangohq/types';
@@ -241,8 +241,6 @@ export const getSyncsByConnectionId = async (nangoConnectionId: number): Promise
     return null;
 };
 
-type SyncWithConnectionId = Sync & { connection_id: string };
-
 export const getSyncsByProviderConfigKey = async (environment_id: number, providerConfigKey: string): Promise<SyncWithConnectionId[]> => {
     const results = await db.knex
         .select(`${TABLE}.*`, `${TABLE}.name`, `_nango_connections.connection_id`, `${TABLE}.created_at`, `${TABLE}.updated_at`, `${TABLE}.last_sync_date`)
@@ -284,9 +282,13 @@ export const getSyncNamesByConnectionId = async (nangoConnectionId: number): Pro
     return [];
 };
 
-export const getSyncsByProviderConfigAndSyncNames = async (environment_id: number, providerConfigKey: string, syncNames: string[]): Promise<Sync[]> => {
+export const getSyncsByProviderConfigAndSyncNames = async (
+    environment_id: number,
+    providerConfigKey: string,
+    syncNames: string[]
+): Promise<SyncWithConnectionId[]> => {
     const results = await db.knex
-        .select(`${TABLE}.*`)
+        .select(`${TABLE}.*`, '_nango_connections.connection_id')
         .from<Sync>(TABLE)
         .join('_nango_connections', '_nango_connections.id', `${TABLE}.nango_connection_id`)
         .where({


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Currently, we can request sync statuses from all connection IDs, but we don't know to which connection they belong to, making them unusable. This adds the `connection_id` to the response:
```
{
    "syncs": [
        {
            "id": "4d8069c7-71d7-4147-b36a-01b7c0327718",
            "connection_id": "u-1",
            "type": "INITIAL",
            "nextScheduledSyncAt": null,
            "name": "fake-data",
            "status": "PAUSED",
            "frequency": "every 5m",
            "recordCount": {
                "Test2": 0
            }
        }
    ]
}
```
Updates docs to reflect the update.
<!-- Issue ticket number and link (if applicable) -->
NAN-2207

<!-- Testing instructions (skip if just adding/editing providers) -->

