### PR TITLE
fix(active-logs): [nan-2448] remove active logs for disabled syncs

### DIFF
--- a/packages/server/lib/controllers/v1/flows/id/patchDisable.ts
+++ b/packages/server/lib/controllers/v1/flows/id/patchDisable.ts
@@ -3,7 +3,7 @@ import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 import type { PatchFlowDisable } from '@nangohq/types';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 import { flowConfig } from '../../../sync/deploy/validation.js';
-import { configService, disableScriptConfig } from '@nangohq/shared';
+import { configService, disableScriptConfig, errorNotificationService } from '@nangohq/shared';
 import { providerConfigKeySchema, providerSchema, scriptNameSchema } from '../../../../helpers/validation.js';
 
 export const validationBody = z
@@ -53,6 +53,7 @@ export const patchFlowDisable = asyncWrapper<PatchFlowDisable>(async (req, res) 
     }
 
     const updated = await disableScriptConfig({ id: valParams.data.id, environmentId: environment.id });
+    await errorNotificationService.sync.clearBySyncConfig({ sync_config_id: valParams.data.id });
 
     if (updated > 0) {
         res.status(200).send({ data: { success: true } });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
As noticed by @nalanj in #[3222](https://github.com/NangoHQ/nango/pull/3222#issuecomment-2560489365) when a sync is disabled and had a failure it should no longer show as an active log. This adds logic to remove any active logs for a sync that is disabled. 

<!-- Issue ticket number and link (if applicable) -->
NAN-2448

# DB Query Analysis
This table is hit quite often so noting that query plan:
```
Hash Join  (cost=8.17..12.01 rows=1 width=153)
  Hash Cond: (_nango_active_logs.sync_id = _nango_syncs.id)
  ->  Seq Scan on _nango_active_logs  (cost=0.00..3.74 rows=37 width=74)
        Filter: (active AND ((type)::text = 'sync'::text))
  ->  Hash  (cost=8.16..8.16 rows=1 width=79)
        ->  Index Scan using idx_sync_config_id_where_deleted on _nango_syncs  (cost=0.14..8.16 rows=1 width=79)
              Index Cond: (sync_config_id = 698)
```
Note that there is an existing index in the `active_logs` table `idx_activelogs_type_syncid` on `type` `sync_id` and `active` but not just on `active` and `type`. Open to adding an index but my first thought would be to optimize it later if needed.

<!-- Testing instructions (skip if just adding/editing providers) -->

