### PR TITLE
fix(insights): clarify UTC

### DIFF
--- a/packages/webapp/src/pages/Homepage/Show.tsx
+++ b/packages/webapp/src/pages/Homepage/Show.tsx
@@ -52,7 +52,9 @@ export const Homepage: React.FC = () => {
 
                     <div className="text-text-light-gray text-sm">Here’s your recent activity on Nango.</div>
                 </div>
-                <div className="text-white text-sm">Last 14 days</div>
+                <div className="text-white text-sm">
+                    Last 14 days <code className="font-code text-xs text-dark-500">(UTC)</code>
+                </div>
             </div>
             <div className="grid gap-8 grid-cols-[repeat(auto-fill,minmax(300px,470px))] mt-8">
                 {globalEnv.features.scripts && (


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-1541/insight-date-are-utc-it-should-be-locale

- Clarify that insights are computed in UTC
It's not perfect but changing to return raw dates would drastically changes the API and code

- Fix display when you are in the future or past