### PR TITLE
fix(aircall): aircall alias doesn't work for nested objects

### DIFF
--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -176,6 +176,10 @@ aircall-basic:
         verification:
             method: GET
             endpoint: /v1/ping
+        paginate:
+            type: link
+            link_path_in_response_body: meta.next_page_link
+            response_path: results
     docs_connect: https://docs.nango.dev/integrations/all/aircall-basic/connect
     docs: https://docs.nango.dev/integrations/all/aircall
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
`alias` doesn't take into account nested properties so the pagination settings from the aliased `aircall` didn't apply to `aircall-basic`

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

