### PR TITLE
fix: track_deletes only deletes records from previous jobs

### DIFF
--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -224,7 +224,7 @@ export async function handleSyncSuccess({ nangoProps }: { nangoProps: NangoProps
         for (const model of nangoProps.syncConfig.models) {
             let deletedKeys: string[] = [];
             if (nangoProps.syncConfig.track_deletes) {
-                deletedKeys = await records.markNonCurrentGenerationRecordsAsDeleted({
+                deletedKeys = await records.markPreviousGenerationRecordsAsDeleted({
                     connectionId: nangoProps.nangoConnectionId,
                     model,
                     syncId: nangoProps.syncId,

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -447,9 +447,9 @@ export async function deleteRecordCount({ connectionId, environmentId, model }: 
     await db.from(RECORD_COUNTS_TABLE).where({ connection_id: connectionId, environment_id: environmentId, model }).del();
 }
 
-// Mark all non-deleted records that don't belong to currentGeneration as deleted
+// Mark all non-deleted records from previous generations as deleted
 // returns the ids of records being deleted
-export async function markNonCurrentGenerationRecordsAsDeleted({
+export async function markPreviousGenerationRecordsAsDeleted({
     connectionId,
     model,
     syncId,
@@ -471,9 +471,7 @@ export async function markNonCurrentGenerationRecordsAsDeleted({
                 sync_id: syncId,
                 deleted_at: null
             })
-            .whereNot({
-                sync_job_id: generation
-            })
+            .where('sync_job_id', '<', generation)
             .update({
                 deleted_at: now,
                 updated_at: now,


### PR DESCRIPTION
If records were added via a webhook while the full sync is running we don't want to delete those records.
This commit ensures that only records from jobs older than the current one are deleted when track_deletes=true

