### PR TITLE
fix(docker): Fix up docker-compose in root of repo to handle empty vars correctly

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,29 +19,29 @@ services:
         container_name: nango-server
         platform: linux/amd64
         environment:
-            - NANGO_ENCRYPTION_KEY=${NANGO_ENCRYPTION_KEY}
-            - NANGO_DB_USER=${NANGO_DB_USER}
-            - NANGO_DB_PASSWORD=${NANGO_DB_PASSWORD}
-            - NANGO_DB_HOST=${NANGO_DB_HOST}
-            - NANGO_DB_NAME=${NANGO_DB_NAME}
-            - NANGO_DB_SSL=${NANGO_DB_SSL}
-            - NANGO_DB_ADDITIONAL_SCHEMAS=${NANGO_DB_ADDITIONAL_SCHEMAS}
-            - NANGO_DB_POOL_MIN=${NANGO_DB_POOL_MIN}
-            - NANGO_DB_POOL_MAX=${NANGO_DB_POOL_MAX}
+            - NANGO_ENCRYPTION_KEY
+            - NANGO_DB_USER
+            - NANGO_DB_PASSWORD
+            - NANGO_DB_HOST=${NANGO_DB_HOST:-nango-db}
+            - NANGO_DB_NAME
+            - NANGO_DB_SSL
+            - NANGO_DB_ADDITIONAL_SCHEMAS
+            - NANGO_DB_POOL_MIN
+            - NANGO_DB_POOL_MAX
             - RECORDS_DATABASE_URL=${RECORDS_DATABASE_URL:-postgresql://nango:nango@nango-db:5432/nango}
-            - SERVER_PORT=${SERVER_PORT}
+            - SERVER_PORT
             - CSP_REPORT_ONLY=true
             - NANGO_SERVER_URL=${NANGO_SERVER_URL:-http://localhost:3003}
-            - FLAG_AUTH_ENABLED=${FLAG_AUTH_ENABLED}
-            - NANGO_DASHBOARD_USERNAME=${NANGO_DASHBOARD_USERNAME}
-            - NANGO_DASHBOARD_PASSWORD=${NANGO_DASHBOARD_PASSWORD}
+            - FLAG_AUTH_ENABLED
+            - NANGO_DASHBOARD_USERNAME
+            - NANGO_DASHBOARD_PASSWORD
             - LOG_LEVEL=${LOG_LEVEL:-info}
-            - TELEMETRY=${TELEMETRY}
-            - NANGO_SERVER_WEBSOCKETS_PATH=${NANGO_SERVER_WEBSOCKETS_PATH}
+            - TELEMETRY
+            - NANGO_SERVER_WEBSOCKETS_PATH
             - NANGO_LOGS_ENABLED=${NANGO_LOGS_ENABLED:-false}
             - NANGO_LOGS_ES_URL=${NANGO_LOGS_ES_URL:-http://nango-elasticsearch:9200}
-            - NANGO_LOGS_ES_USER=${NANGO_LOGS_ES_USER}
-            - NANGO_LOGS_ES_PWD=${NANGO_LOGS_ES_PWD}
+            - NANGO_LOGS_ES_USER
+            - NANGO_LOGS_ES_PWD
             - FLAG_SERVE_CONNECT_UI=${FLAG_SERVE_CONNECT_UI:-true}
         volumes:
             - './packages/shared/providers.yaml:/usr/nango-server/src/packages/shared/providers.yaml'


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Empty strings were being passed through when some variables weren't set, which was causing them to flow as empty values through the system.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

