### PR TITLE
fix(server): Roll back ddtrace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4233,83 +4233,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/@datadog/libdatadog": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.3.0.tgz",
-            "integrity": "sha512-TbP8+WyXfh285T17FnLeLUOPl4SbkRYMqKgcmknID2mXHNrbt5XJgW9bnDgsrrtu31Q7FjWWw2WolgRLWyzLRA=="
-        },
-        "node_modules/@datadog/native-appsec": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-8.4.0.tgz",
-            "integrity": "sha512-LC47AnpVLpQFEUOP/nIIs+i0wLb8XYO+et3ACaJlHa2YJM3asR4KZTqQjDQNy08PTAUbVvYWKwfSR1qVsU/BeA==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "node-gyp-build": "^3.9.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@datadog/native-iast-rewriter": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.6.1.tgz",
-            "integrity": "sha512-zv7cr/MzHg560jhAnHcO7f9pLi4qaYrBEcB+Gla0xkVouYSDsp8cGXIGG4fiGdAMHdt7SpDNS6+NcEAqD/v8Ig==",
-            "dependencies": {
-                "lru-cache": "^7.14.0",
-                "node-gyp-build": "^4.5.0"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
-            "version": "4.8.4",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-            "bin": {
-                "node-gyp-build": "bin.js",
-                "node-gyp-build-optional": "optional.js",
-                "node-gyp-build-test": "build-test.js"
-            }
-        },
-        "node_modules/@datadog/native-iast-taint-tracking": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.2.0.tgz",
-            "integrity": "sha512-Mc6FzCoyvU5yXLMsMS9yKnEqJMWoImAukJXolNWCTm+JQYCMf2yMsJ8pBAm7KyZKliamM9rCn7h7Tr2H3lXwjA==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "node-gyp-build": "^3.9.0"
-            }
-        },
-        "node_modules/@datadog/native-metrics": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-3.1.0.tgz",
-            "integrity": "sha512-yOBi4x0OQRaGNPZ2bx9TGvDIgEdQ8fkudLTFAe7gEM1nAlvFmbE5YfpH8WenEtTSEBwojSau06m2q7axtEEmCg==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "node-addon-api": "^6.1.0",
-                "node-gyp-build": "^3.9.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@datadog/pprof": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.4.1.tgz",
-            "integrity": "sha512-IvpL96e/cuh8ugP5O8Czdup7XQOLHeIDgM5pac5W7Lc1YzGe5zTtebKFpitvb1CPw1YY+1qFx0pWGgKP2kOfHg==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "delay": "^5.0.0",
-                "node-gyp-build": "<4.0",
-                "p-limit": "^3.1.0",
-                "pprof-format": "^2.1.0",
-                "source-map": "^0.7.4"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
         "node_modules/@datadog/sketches-js": {
             "version": "2.1.0",
             "license": "Apache-2.0"
@@ -5333,14 +5256,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/@isaacs/ttlcache": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
-            "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -17357,68 +17272,6 @@
                 "node": ">=12.17"
             }
         },
-        "node_modules/dd-trace": {
-            "version": "5.31.0",
-            "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.31.0.tgz",
-            "integrity": "sha512-KckymPxud3wzIJbctVI8tli5zgab+ovc2r40xofqTBvdKB1p99hly1syqcQc+kqlkT+dN7AxTpb8C+3p8rM2Lw==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "@datadog/libdatadog": "^0.3.0",
-                "@datadog/native-appsec": "8.4.0",
-                "@datadog/native-iast-rewriter": "2.6.1",
-                "@datadog/native-iast-taint-tracking": "3.2.0",
-                "@datadog/native-metrics": "^3.1.0",
-                "@datadog/pprof": "5.4.1",
-                "@datadog/sketches-js": "^2.1.0",
-                "@isaacs/ttlcache": "^1.4.1",
-                "@opentelemetry/api": ">=1.0.0 <1.9.0",
-                "@opentelemetry/core": "^1.14.0",
-                "crypto-randomuuid": "^1.0.0",
-                "dc-polyfill": "^0.1.4",
-                "ignore": "^5.2.4",
-                "import-in-the-middle": "1.11.2",
-                "istanbul-lib-coverage": "3.2.0",
-                "jest-docblock": "^29.7.0",
-                "koalas": "^1.0.2",
-                "limiter": "1.1.5",
-                "lodash.sortby": "^4.7.0",
-                "lru-cache": "^7.14.0",
-                "module-details-from-path": "^1.0.3",
-                "opentracing": ">=0.12.1",
-                "path-to-regexp": "^0.1.12",
-                "pprof-format": "^2.1.0",
-                "protobufjs": "^7.2.5",
-                "retry": "^0.13.1",
-                "rfdc": "^1.3.1",
-                "semver": "^7.5.4",
-                "shell-quote": "^1.8.1",
-                "source-map": "^0.7.4",
-                "tlhunter-sorted-set": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/dd-trace/node_modules/@opentelemetry/api": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
-            "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/dd-trace/node_modules/path-to-regexp": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
-        },
-        "node_modules/dd-trace/node_modules/retry": {
-            "version": "0.13.1",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
         "node_modules/debounce-fn": {
             "version": "5.1.2",
             "license": "MIT",
@@ -19353,6 +19206,12 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/event-lite": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/event-lite/-/event-lite-0.1.3.tgz",
+            "integrity": "sha512-8qz9nOz5VeD2z96elrEKD2U433+L3DWdUdDkOINLGOJvx1GsMBbMn0aCeu28y8/e85A6mCigBiFlYMnTBEGlSw==",
+            "license": "MIT"
         },
         "node_modules/event-target-shim": {
             "version": "5.0.1",
@@ -21500,6 +21359,12 @@
             "dependencies": {
                 "css-in-js-utils": "^3.1.0"
             }
+        },
+        "node_modules/int64-buffer": {
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
+            "integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA==",
+            "license": "MIT"
         },
         "node_modules/internal-slot": {
             "version": "1.1.0",
@@ -25281,6 +25146,27 @@
         },
         "node_modules/ms": {
             "version": "2.1.2",
+            "license": "MIT"
+        },
+        "node_modules/msgpack-lite": {
+            "version": "0.1.26",
+            "resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
+            "integrity": "sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==",
+            "license": "MIT",
+            "dependencies": {
+                "event-lite": "^0.1.1",
+                "ieee754": "^1.1.8",
+                "int64-buffer": "^0.1.9",
+                "isarray": "^1.0.0"
+            },
+            "bin": {
+                "msgpack": "bin/msgpack"
+            }
+        },
+        "node_modules/msgpack-lite/node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
             "license": "MIT"
         },
         "node_modules/multer": {
@@ -29183,7 +29069,8 @@
         "node_modules/rfdc": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
+            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+            "dev": true
         },
         "node_modules/rimraf": {
             "version": "6.0.1",
@@ -35574,12 +35461,149 @@
             "version": "1.0.0",
             "dependencies": {
                 "@nangohq/utils": "file:../utils",
-                "dd-trace": "5.31.0",
+                "dd-trace": "5.21.0",
                 "knex": "3.1.0"
             },
             "devDependencies": {
                 "@nangohq/types": "file:../types",
                 "vitest": "2.1.8"
+            }
+        },
+        "packages/fleet/node_modules/@datadog/native-appsec": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-8.0.1.tgz",
+            "integrity": "sha512-SpWkoo7K4+pwxFze1ogRF1qBaKm8sZjWfZKnQ8Ex67f6L5odLjWOoiiIAs5rp01sLKGXjxU8IJf+X9j4PvI2zQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/fleet/node_modules/@datadog/native-iast-rewriter": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.4.1.tgz",
+            "integrity": "sha512-j3auTmyyn63e2y+SL28CGNy/l+jXQyh+pxqoGTacWaY5FW/dvo5nGQepAismgJ3qJ8VhQfVWRdxBSiT7wu9clw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "lru-cache": "^7.14.0",
+                "node-gyp-build": "^4.5.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "packages/fleet/node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "license": "MIT",
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
+            }
+        },
+        "packages/fleet/node_modules/@datadog/native-iast-taint-tracking": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.1.0.tgz",
+            "integrity": "sha512-rw6qSjmxmu1yFHVvZLXFt/rVq2tUZXocNogPLB8n7MPpA0jijNGb109WokWw5ITImiW91GcGDuBW6elJDVKouQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            }
+        },
+        "packages/fleet/node_modules/@datadog/native-metrics": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-2.0.0.tgz",
+            "integrity": "sha512-YklGVwUtmKGYqFf1MNZuOHvTYdKuR4+Af1XkWcMD8BwOAjxmd9Z+97328rCOY8TFUJzlGUPaXzB8j2qgG/BMwA==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-addon-api": "^6.1.0",
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/fleet/node_modules/@datadog/pprof": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.3.0.tgz",
+            "integrity": "sha512-53z2Q3K92T6Pf4vz4Ezh8kfkVEvLzbnVqacZGgcbkP//q0joFzO8q00Etw1S6NdnCX0XmX08ULaF4rUI5r14mw==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "delay": "^5.0.0",
+                "node-gyp-build": "<4.0",
+                "p-limit": "^3.1.0",
+                "pprof-format": "^2.1.0",
+                "source-map": "^0.7.4"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "packages/fleet/node_modules/@opentelemetry/api": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+            "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "packages/fleet/node_modules/dd-trace": {
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.21.0.tgz",
+            "integrity": "sha512-3jgrYxifuYmSl3kuAxpTSOS7/kKK9DLbw4m85hS/Yn5IFCXer+uvG8sWwFIcBNXOidF/BcyeKC92WX4X87W4Iw==",
+            "hasInstallScript": true,
+            "license": "(Apache-2.0 OR BSD-3-Clause)",
+            "dependencies": {
+                "@datadog/native-appsec": "8.0.1",
+                "@datadog/native-iast-rewriter": "2.4.1",
+                "@datadog/native-iast-taint-tracking": "3.1.0",
+                "@datadog/native-metrics": "^2.0.0",
+                "@datadog/pprof": "5.3.0",
+                "@datadog/sketches-js": "^2.1.0",
+                "@opentelemetry/api": ">=1.0.0 <1.9.0",
+                "@opentelemetry/core": "^1.14.0",
+                "crypto-randomuuid": "^1.0.0",
+                "dc-polyfill": "^0.1.4",
+                "ignore": "^5.2.4",
+                "import-in-the-middle": "^1.8.1",
+                "int64-buffer": "^0.1.9",
+                "istanbul-lib-coverage": "3.2.0",
+                "jest-docblock": "^29.7.0",
+                "koalas": "^1.0.2",
+                "limiter": "1.1.5",
+                "lodash.sortby": "^4.7.0",
+                "lru-cache": "^7.14.0",
+                "module-details-from-path": "^1.0.3",
+                "msgpack-lite": "^0.1.26",
+                "opentracing": ">=0.12.1",
+                "path-to-regexp": "^0.1.2",
+                "pprof-format": "^2.1.0",
+                "protobufjs": "^7.2.5",
+                "retry": "^0.13.1",
+                "semver": "^7.5.4",
+                "shell-quote": "^1.8.1",
+                "tlhunter-sorted-set": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/fleet/node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "packages/frontend": {
@@ -35623,7 +35647,7 @@
                 "@nangohq/utils": "file:../utils",
                 "@nangohq/webhooks": "file:../webhooks",
                 "axios": "^1.7.9",
-                "dd-trace": "5.31.0",
+                "dd-trace": "5.21.0",
                 "express": "4.20.0",
                 "get-port": "7.1.0",
                 "node-cron": "3.0.3",
@@ -35637,6 +35661,134 @@
                 "vitest": "2.1.8"
             }
         },
+        "packages/jobs/node_modules/@datadog/native-appsec": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-8.0.1.tgz",
+            "integrity": "sha512-SpWkoo7K4+pwxFze1ogRF1qBaKm8sZjWfZKnQ8Ex67f6L5odLjWOoiiIAs5rp01sLKGXjxU8IJf+X9j4PvI2zQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/jobs/node_modules/@datadog/native-iast-rewriter": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.4.1.tgz",
+            "integrity": "sha512-j3auTmyyn63e2y+SL28CGNy/l+jXQyh+pxqoGTacWaY5FW/dvo5nGQepAismgJ3qJ8VhQfVWRdxBSiT7wu9clw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "lru-cache": "^7.14.0",
+                "node-gyp-build": "^4.5.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "packages/jobs/node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "license": "MIT",
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
+            }
+        },
+        "packages/jobs/node_modules/@datadog/native-iast-taint-tracking": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.1.0.tgz",
+            "integrity": "sha512-rw6qSjmxmu1yFHVvZLXFt/rVq2tUZXocNogPLB8n7MPpA0jijNGb109WokWw5ITImiW91GcGDuBW6elJDVKouQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            }
+        },
+        "packages/jobs/node_modules/@datadog/native-metrics": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-2.0.0.tgz",
+            "integrity": "sha512-YklGVwUtmKGYqFf1MNZuOHvTYdKuR4+Af1XkWcMD8BwOAjxmd9Z+97328rCOY8TFUJzlGUPaXzB8j2qgG/BMwA==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-addon-api": "^6.1.0",
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/jobs/node_modules/@datadog/pprof": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.3.0.tgz",
+            "integrity": "sha512-53z2Q3K92T6Pf4vz4Ezh8kfkVEvLzbnVqacZGgcbkP//q0joFzO8q00Etw1S6NdnCX0XmX08ULaF4rUI5r14mw==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "delay": "^5.0.0",
+                "node-gyp-build": "<4.0",
+                "p-limit": "^3.1.0",
+                "pprof-format": "^2.1.0",
+                "source-map": "^0.7.4"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "packages/jobs/node_modules/@opentelemetry/api": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+            "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "packages/jobs/node_modules/dd-trace": {
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.21.0.tgz",
+            "integrity": "sha512-3jgrYxifuYmSl3kuAxpTSOS7/kKK9DLbw4m85hS/Yn5IFCXer+uvG8sWwFIcBNXOidF/BcyeKC92WX4X87W4Iw==",
+            "hasInstallScript": true,
+            "license": "(Apache-2.0 OR BSD-3-Clause)",
+            "dependencies": {
+                "@datadog/native-appsec": "8.0.1",
+                "@datadog/native-iast-rewriter": "2.4.1",
+                "@datadog/native-iast-taint-tracking": "3.1.0",
+                "@datadog/native-metrics": "^2.0.0",
+                "@datadog/pprof": "5.3.0",
+                "@datadog/sketches-js": "^2.1.0",
+                "@opentelemetry/api": ">=1.0.0 <1.9.0",
+                "@opentelemetry/core": "^1.14.0",
+                "crypto-randomuuid": "^1.0.0",
+                "dc-polyfill": "^0.1.4",
+                "ignore": "^5.2.4",
+                "import-in-the-middle": "^1.8.1",
+                "int64-buffer": "^0.1.9",
+                "istanbul-lib-coverage": "3.2.0",
+                "jest-docblock": "^29.7.0",
+                "koalas": "^1.0.2",
+                "limiter": "1.1.5",
+                "lodash.sortby": "^4.7.0",
+                "lru-cache": "^7.14.0",
+                "module-details-from-path": "^1.0.3",
+                "msgpack-lite": "^0.1.26",
+                "opentracing": ">=0.12.1",
+                "path-to-regexp": "^0.1.2",
+                "pprof-format": "^2.1.0",
+                "protobufjs": "^7.2.5",
+                "retry": "^0.13.1",
+                "semver": "^7.5.4",
+                "shell-quote": "^1.8.1",
+                "tlhunter-sorted-set": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "packages/jobs/node_modules/get-port": {
             "version": "7.1.0",
             "license": "MIT",
@@ -35647,17 +35799,163 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "packages/jobs/node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
         "packages/keystore": {
             "name": "@nangohq/keystore",
             "version": "1.0.0",
             "dependencies": {
                 "@nangohq/utils": "file:../utils",
-                "dd-trace": "5.31.0",
+                "dd-trace": "5.21.0",
                 "knex": "3.1.0"
             },
             "devDependencies": {
                 "@nangohq/types": "file:../types",
                 "vitest": "2.1.8"
+            }
+        },
+        "packages/keystore/node_modules/@datadog/native-appsec": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-8.0.1.tgz",
+            "integrity": "sha512-SpWkoo7K4+pwxFze1ogRF1qBaKm8sZjWfZKnQ8Ex67f6L5odLjWOoiiIAs5rp01sLKGXjxU8IJf+X9j4PvI2zQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/keystore/node_modules/@datadog/native-iast-rewriter": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.4.1.tgz",
+            "integrity": "sha512-j3auTmyyn63e2y+SL28CGNy/l+jXQyh+pxqoGTacWaY5FW/dvo5nGQepAismgJ3qJ8VhQfVWRdxBSiT7wu9clw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "lru-cache": "^7.14.0",
+                "node-gyp-build": "^4.5.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "packages/keystore/node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "license": "MIT",
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
+            }
+        },
+        "packages/keystore/node_modules/@datadog/native-iast-taint-tracking": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.1.0.tgz",
+            "integrity": "sha512-rw6qSjmxmu1yFHVvZLXFt/rVq2tUZXocNogPLB8n7MPpA0jijNGb109WokWw5ITImiW91GcGDuBW6elJDVKouQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            }
+        },
+        "packages/keystore/node_modules/@datadog/native-metrics": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-2.0.0.tgz",
+            "integrity": "sha512-YklGVwUtmKGYqFf1MNZuOHvTYdKuR4+Af1XkWcMD8BwOAjxmd9Z+97328rCOY8TFUJzlGUPaXzB8j2qgG/BMwA==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-addon-api": "^6.1.0",
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/keystore/node_modules/@datadog/pprof": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.3.0.tgz",
+            "integrity": "sha512-53z2Q3K92T6Pf4vz4Ezh8kfkVEvLzbnVqacZGgcbkP//q0joFzO8q00Etw1S6NdnCX0XmX08ULaF4rUI5r14mw==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "delay": "^5.0.0",
+                "node-gyp-build": "<4.0",
+                "p-limit": "^3.1.0",
+                "pprof-format": "^2.1.0",
+                "source-map": "^0.7.4"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "packages/keystore/node_modules/@opentelemetry/api": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+            "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "packages/keystore/node_modules/dd-trace": {
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.21.0.tgz",
+            "integrity": "sha512-3jgrYxifuYmSl3kuAxpTSOS7/kKK9DLbw4m85hS/Yn5IFCXer+uvG8sWwFIcBNXOidF/BcyeKC92WX4X87W4Iw==",
+            "hasInstallScript": true,
+            "license": "(Apache-2.0 OR BSD-3-Clause)",
+            "dependencies": {
+                "@datadog/native-appsec": "8.0.1",
+                "@datadog/native-iast-rewriter": "2.4.1",
+                "@datadog/native-iast-taint-tracking": "3.1.0",
+                "@datadog/native-metrics": "^2.0.0",
+                "@datadog/pprof": "5.3.0",
+                "@datadog/sketches-js": "^2.1.0",
+                "@opentelemetry/api": ">=1.0.0 <1.9.0",
+                "@opentelemetry/core": "^1.14.0",
+                "crypto-randomuuid": "^1.0.0",
+                "dc-polyfill": "^0.1.4",
+                "ignore": "^5.2.4",
+                "import-in-the-middle": "^1.8.1",
+                "int64-buffer": "^0.1.9",
+                "istanbul-lib-coverage": "3.2.0",
+                "jest-docblock": "^29.7.0",
+                "koalas": "^1.0.2",
+                "limiter": "1.1.5",
+                "lodash.sortby": "^4.7.0",
+                "lru-cache": "^7.14.0",
+                "module-details-from-path": "^1.0.3",
+                "msgpack-lite": "^0.1.26",
+                "opentracing": ">=0.12.1",
+                "path-to-regexp": "^0.1.2",
+                "pprof-format": "^2.1.0",
+                "protobufjs": "^7.2.5",
+                "retry": "^0.13.1",
+                "semver": "^7.5.4",
+                "shell-quote": "^1.8.1",
+                "tlhunter-sorted-set": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/keystore/node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "packages/kvstore": {
@@ -35932,7 +36230,7 @@
             "dependencies": {
                 "@nangohq/scheduler": "file:../scheduler",
                 "@nangohq/utils": "file:../utils",
-                "dd-trace": "5.31.0",
+                "dd-trace": "5.21.0",
                 "express": "4.20.0",
                 "get-port": "7.1.0",
                 "p-queue": "8.0.1",
@@ -35945,6 +36243,134 @@
                 "vitest": "2.1.8"
             }
         },
+        "packages/orchestrator/node_modules/@datadog/native-appsec": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-8.0.1.tgz",
+            "integrity": "sha512-SpWkoo7K4+pwxFze1ogRF1qBaKm8sZjWfZKnQ8Ex67f6L5odLjWOoiiIAs5rp01sLKGXjxU8IJf+X9j4PvI2zQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/orchestrator/node_modules/@datadog/native-iast-rewriter": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.4.1.tgz",
+            "integrity": "sha512-j3auTmyyn63e2y+SL28CGNy/l+jXQyh+pxqoGTacWaY5FW/dvo5nGQepAismgJ3qJ8VhQfVWRdxBSiT7wu9clw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "lru-cache": "^7.14.0",
+                "node-gyp-build": "^4.5.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "packages/orchestrator/node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "license": "MIT",
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
+            }
+        },
+        "packages/orchestrator/node_modules/@datadog/native-iast-taint-tracking": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.1.0.tgz",
+            "integrity": "sha512-rw6qSjmxmu1yFHVvZLXFt/rVq2tUZXocNogPLB8n7MPpA0jijNGb109WokWw5ITImiW91GcGDuBW6elJDVKouQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            }
+        },
+        "packages/orchestrator/node_modules/@datadog/native-metrics": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-2.0.0.tgz",
+            "integrity": "sha512-YklGVwUtmKGYqFf1MNZuOHvTYdKuR4+Af1XkWcMD8BwOAjxmd9Z+97328rCOY8TFUJzlGUPaXzB8j2qgG/BMwA==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-addon-api": "^6.1.0",
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/orchestrator/node_modules/@datadog/pprof": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.3.0.tgz",
+            "integrity": "sha512-53z2Q3K92T6Pf4vz4Ezh8kfkVEvLzbnVqacZGgcbkP//q0joFzO8q00Etw1S6NdnCX0XmX08ULaF4rUI5r14mw==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "delay": "^5.0.0",
+                "node-gyp-build": "<4.0",
+                "p-limit": "^3.1.0",
+                "pprof-format": "^2.1.0",
+                "source-map": "^0.7.4"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "packages/orchestrator/node_modules/@opentelemetry/api": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+            "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "packages/orchestrator/node_modules/dd-trace": {
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.21.0.tgz",
+            "integrity": "sha512-3jgrYxifuYmSl3kuAxpTSOS7/kKK9DLbw4m85hS/Yn5IFCXer+uvG8sWwFIcBNXOidF/BcyeKC92WX4X87W4Iw==",
+            "hasInstallScript": true,
+            "license": "(Apache-2.0 OR BSD-3-Clause)",
+            "dependencies": {
+                "@datadog/native-appsec": "8.0.1",
+                "@datadog/native-iast-rewriter": "2.4.1",
+                "@datadog/native-iast-taint-tracking": "3.1.0",
+                "@datadog/native-metrics": "^2.0.0",
+                "@datadog/pprof": "5.3.0",
+                "@datadog/sketches-js": "^2.1.0",
+                "@opentelemetry/api": ">=1.0.0 <1.9.0",
+                "@opentelemetry/core": "^1.14.0",
+                "crypto-randomuuid": "^1.0.0",
+                "dc-polyfill": "^0.1.4",
+                "ignore": "^5.2.4",
+                "import-in-the-middle": "^1.8.1",
+                "int64-buffer": "^0.1.9",
+                "istanbul-lib-coverage": "3.2.0",
+                "jest-docblock": "^29.7.0",
+                "koalas": "^1.0.2",
+                "limiter": "1.1.5",
+                "lodash.sortby": "^4.7.0",
+                "lru-cache": "^7.14.0",
+                "module-details-from-path": "^1.0.3",
+                "msgpack-lite": "^0.1.26",
+                "opentracing": ">=0.12.1",
+                "path-to-regexp": "^0.1.2",
+                "pprof-format": "^2.1.0",
+                "protobufjs": "^7.2.5",
+                "retry": "^0.13.1",
+                "semver": "^7.5.4",
+                "shell-quote": "^1.8.1",
+                "tlhunter-sorted-set": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "packages/orchestrator/node_modules/get-port": {
             "version": "7.1.0",
             "license": "MIT",
@@ -35953,6 +36379,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/orchestrator/node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "packages/persist": {
@@ -35966,7 +36401,7 @@
                 "@nangohq/shared": "file:../shared",
                 "@nangohq/types": "file:../types",
                 "@nangohq/utils": "file:../utils",
-                "dd-trace": "5.31.0",
+                "dd-trace": "5.21.0",
                 "express": "^4.20.0",
                 "zod": "3.24.1"
             },
@@ -35975,6 +36410,134 @@
                 "node-fetch": "^3.3.2",
                 "typescript": "5.7.3",
                 "vitest": "2.1.8"
+            }
+        },
+        "packages/persist/node_modules/@datadog/native-appsec": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-8.0.1.tgz",
+            "integrity": "sha512-SpWkoo7K4+pwxFze1ogRF1qBaKm8sZjWfZKnQ8Ex67f6L5odLjWOoiiIAs5rp01sLKGXjxU8IJf+X9j4PvI2zQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/persist/node_modules/@datadog/native-iast-rewriter": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.4.1.tgz",
+            "integrity": "sha512-j3auTmyyn63e2y+SL28CGNy/l+jXQyh+pxqoGTacWaY5FW/dvo5nGQepAismgJ3qJ8VhQfVWRdxBSiT7wu9clw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "lru-cache": "^7.14.0",
+                "node-gyp-build": "^4.5.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "packages/persist/node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "license": "MIT",
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
+            }
+        },
+        "packages/persist/node_modules/@datadog/native-iast-taint-tracking": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.1.0.tgz",
+            "integrity": "sha512-rw6qSjmxmu1yFHVvZLXFt/rVq2tUZXocNogPLB8n7MPpA0jijNGb109WokWw5ITImiW91GcGDuBW6elJDVKouQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            }
+        },
+        "packages/persist/node_modules/@datadog/native-metrics": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-2.0.0.tgz",
+            "integrity": "sha512-YklGVwUtmKGYqFf1MNZuOHvTYdKuR4+Af1XkWcMD8BwOAjxmd9Z+97328rCOY8TFUJzlGUPaXzB8j2qgG/BMwA==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-addon-api": "^6.1.0",
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/persist/node_modules/@datadog/pprof": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.3.0.tgz",
+            "integrity": "sha512-53z2Q3K92T6Pf4vz4Ezh8kfkVEvLzbnVqacZGgcbkP//q0joFzO8q00Etw1S6NdnCX0XmX08ULaF4rUI5r14mw==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "delay": "^5.0.0",
+                "node-gyp-build": "<4.0",
+                "p-limit": "^3.1.0",
+                "pprof-format": "^2.1.0",
+                "source-map": "^0.7.4"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "packages/persist/node_modules/@opentelemetry/api": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+            "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "packages/persist/node_modules/dd-trace": {
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.21.0.tgz",
+            "integrity": "sha512-3jgrYxifuYmSl3kuAxpTSOS7/kKK9DLbw4m85hS/Yn5IFCXer+uvG8sWwFIcBNXOidF/BcyeKC92WX4X87W4Iw==",
+            "hasInstallScript": true,
+            "license": "(Apache-2.0 OR BSD-3-Clause)",
+            "dependencies": {
+                "@datadog/native-appsec": "8.0.1",
+                "@datadog/native-iast-rewriter": "2.4.1",
+                "@datadog/native-iast-taint-tracking": "3.1.0",
+                "@datadog/native-metrics": "^2.0.0",
+                "@datadog/pprof": "5.3.0",
+                "@datadog/sketches-js": "^2.1.0",
+                "@opentelemetry/api": ">=1.0.0 <1.9.0",
+                "@opentelemetry/core": "^1.14.0",
+                "crypto-randomuuid": "^1.0.0",
+                "dc-polyfill": "^0.1.4",
+                "ignore": "^5.2.4",
+                "import-in-the-middle": "^1.8.1",
+                "int64-buffer": "^0.1.9",
+                "istanbul-lib-coverage": "3.2.0",
+                "jest-docblock": "^29.7.0",
+                "koalas": "^1.0.2",
+                "limiter": "1.1.5",
+                "lodash.sortby": "^4.7.0",
+                "lru-cache": "^7.14.0",
+                "module-details-from-path": "^1.0.3",
+                "msgpack-lite": "^0.1.26",
+                "opentracing": ">=0.12.1",
+                "path-to-regexp": "^0.1.2",
+                "pprof-format": "^2.1.0",
+                "protobufjs": "^7.2.5",
+                "retry": "^0.13.1",
+                "semver": "^7.5.4",
+                "shell-quote": "^1.8.1",
+                "tlhunter-sorted-set": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "packages/persist/node_modules/node-fetch": {
@@ -35992,6 +36555,15 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/node-fetch"
+            }
+        },
+        "packages/persist/node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "packages/records": {
@@ -36022,7 +36594,7 @@
                 "axios": "^1.7.9",
                 "botbuilder": "4.23.1",
                 "connect-timeout": "1.9.0",
-                "dd-trace": "5.31.0",
+                "dd-trace": "5.21.0",
                 "express": "^4.20.0",
                 "soap": "1.1.2",
                 "superjson": "2.2.1",
@@ -36035,6 +36607,93 @@
                 "@types/node": "20.12.2",
                 "typescript": "5.7.3",
                 "vitest": "2.1.8"
+            }
+        },
+        "packages/runner/node_modules/@datadog/native-appsec": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-8.0.1.tgz",
+            "integrity": "sha512-SpWkoo7K4+pwxFze1ogRF1qBaKm8sZjWfZKnQ8Ex67f6L5odLjWOoiiIAs5rp01sLKGXjxU8IJf+X9j4PvI2zQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/runner/node_modules/@datadog/native-iast-rewriter": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.4.1.tgz",
+            "integrity": "sha512-j3auTmyyn63e2y+SL28CGNy/l+jXQyh+pxqoGTacWaY5FW/dvo5nGQepAismgJ3qJ8VhQfVWRdxBSiT7wu9clw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "lru-cache": "^7.14.0",
+                "node-gyp-build": "^4.5.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "packages/runner/node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "license": "MIT",
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
+            }
+        },
+        "packages/runner/node_modules/@datadog/native-iast-taint-tracking": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.1.0.tgz",
+            "integrity": "sha512-rw6qSjmxmu1yFHVvZLXFt/rVq2tUZXocNogPLB8n7MPpA0jijNGb109WokWw5ITImiW91GcGDuBW6elJDVKouQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            }
+        },
+        "packages/runner/node_modules/@datadog/native-metrics": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-2.0.0.tgz",
+            "integrity": "sha512-YklGVwUtmKGYqFf1MNZuOHvTYdKuR4+Af1XkWcMD8BwOAjxmd9Z+97328rCOY8TFUJzlGUPaXzB8j2qgG/BMwA==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-addon-api": "^6.1.0",
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/runner/node_modules/@datadog/pprof": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.3.0.tgz",
+            "integrity": "sha512-53z2Q3K92T6Pf4vz4Ezh8kfkVEvLzbnVqacZGgcbkP//q0joFzO8q00Etw1S6NdnCX0XmX08ULaF4rUI5r14mw==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "delay": "^5.0.0",
+                "node-gyp-build": "<4.0",
+                "p-limit": "^3.1.0",
+                "pprof-format": "^2.1.0",
+                "source-map": "^0.7.4"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "packages/runner/node_modules/@opentelemetry/api": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+            "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.0.0"
             }
         },
         "packages/runner/node_modules/@trpc/client": {
@@ -36054,18 +36713,205 @@
             ],
             "license": "MIT"
         },
+        "packages/runner/node_modules/dd-trace": {
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.21.0.tgz",
+            "integrity": "sha512-3jgrYxifuYmSl3kuAxpTSOS7/kKK9DLbw4m85hS/Yn5IFCXer+uvG8sWwFIcBNXOidF/BcyeKC92WX4X87W4Iw==",
+            "hasInstallScript": true,
+            "license": "(Apache-2.0 OR BSD-3-Clause)",
+            "dependencies": {
+                "@datadog/native-appsec": "8.0.1",
+                "@datadog/native-iast-rewriter": "2.4.1",
+                "@datadog/native-iast-taint-tracking": "3.1.0",
+                "@datadog/native-metrics": "^2.0.0",
+                "@datadog/pprof": "5.3.0",
+                "@datadog/sketches-js": "^2.1.0",
+                "@opentelemetry/api": ">=1.0.0 <1.9.0",
+                "@opentelemetry/core": "^1.14.0",
+                "crypto-randomuuid": "^1.0.0",
+                "dc-polyfill": "^0.1.4",
+                "ignore": "^5.2.4",
+                "import-in-the-middle": "^1.8.1",
+                "int64-buffer": "^0.1.9",
+                "istanbul-lib-coverage": "3.2.0",
+                "jest-docblock": "^29.7.0",
+                "koalas": "^1.0.2",
+                "limiter": "1.1.5",
+                "lodash.sortby": "^4.7.0",
+                "lru-cache": "^7.14.0",
+                "module-details-from-path": "^1.0.3",
+                "msgpack-lite": "^0.1.26",
+                "opentracing": ">=0.12.1",
+                "path-to-regexp": "^0.1.2",
+                "pprof-format": "^2.1.0",
+                "protobufjs": "^7.2.5",
+                "retry": "^0.13.1",
+                "semver": "^7.5.4",
+                "shell-quote": "^1.8.1",
+                "tlhunter-sorted-set": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/runner/node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
         "packages/scheduler": {
             "name": "@nangohq/scheduler",
             "version": "1.0.0",
             "dependencies": {
                 "@nangohq/utils": "file:../utils",
-                "dd-trace": "5.31.0",
+                "dd-trace": "5.21.0",
                 "knex": "3.1.0",
                 "uuidv7": "0.6.3"
             },
             "devDependencies": {
                 "type-fest": "4.32.0",
                 "vitest": "2.1.8"
+            }
+        },
+        "packages/scheduler/node_modules/@datadog/native-appsec": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-8.0.1.tgz",
+            "integrity": "sha512-SpWkoo7K4+pwxFze1ogRF1qBaKm8sZjWfZKnQ8Ex67f6L5odLjWOoiiIAs5rp01sLKGXjxU8IJf+X9j4PvI2zQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/scheduler/node_modules/@datadog/native-iast-rewriter": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.4.1.tgz",
+            "integrity": "sha512-j3auTmyyn63e2y+SL28CGNy/l+jXQyh+pxqoGTacWaY5FW/dvo5nGQepAismgJ3qJ8VhQfVWRdxBSiT7wu9clw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "lru-cache": "^7.14.0",
+                "node-gyp-build": "^4.5.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "packages/scheduler/node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "license": "MIT",
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
+            }
+        },
+        "packages/scheduler/node_modules/@datadog/native-iast-taint-tracking": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.1.0.tgz",
+            "integrity": "sha512-rw6qSjmxmu1yFHVvZLXFt/rVq2tUZXocNogPLB8n7MPpA0jijNGb109WokWw5ITImiW91GcGDuBW6elJDVKouQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            }
+        },
+        "packages/scheduler/node_modules/@datadog/native-metrics": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-2.0.0.tgz",
+            "integrity": "sha512-YklGVwUtmKGYqFf1MNZuOHvTYdKuR4+Af1XkWcMD8BwOAjxmd9Z+97328rCOY8TFUJzlGUPaXzB8j2qgG/BMwA==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-addon-api": "^6.1.0",
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/scheduler/node_modules/@datadog/pprof": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.3.0.tgz",
+            "integrity": "sha512-53z2Q3K92T6Pf4vz4Ezh8kfkVEvLzbnVqacZGgcbkP//q0joFzO8q00Etw1S6NdnCX0XmX08ULaF4rUI5r14mw==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "delay": "^5.0.0",
+                "node-gyp-build": "<4.0",
+                "p-limit": "^3.1.0",
+                "pprof-format": "^2.1.0",
+                "source-map": "^0.7.4"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "packages/scheduler/node_modules/@opentelemetry/api": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+            "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "packages/scheduler/node_modules/dd-trace": {
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.21.0.tgz",
+            "integrity": "sha512-3jgrYxifuYmSl3kuAxpTSOS7/kKK9DLbw4m85hS/Yn5IFCXer+uvG8sWwFIcBNXOidF/BcyeKC92WX4X87W4Iw==",
+            "hasInstallScript": true,
+            "license": "(Apache-2.0 OR BSD-3-Clause)",
+            "dependencies": {
+                "@datadog/native-appsec": "8.0.1",
+                "@datadog/native-iast-rewriter": "2.4.1",
+                "@datadog/native-iast-taint-tracking": "3.1.0",
+                "@datadog/native-metrics": "^2.0.0",
+                "@datadog/pprof": "5.3.0",
+                "@datadog/sketches-js": "^2.1.0",
+                "@opentelemetry/api": ">=1.0.0 <1.9.0",
+                "@opentelemetry/core": "^1.14.0",
+                "crypto-randomuuid": "^1.0.0",
+                "dc-polyfill": "^0.1.4",
+                "ignore": "^5.2.4",
+                "import-in-the-middle": "^1.8.1",
+                "int64-buffer": "^0.1.9",
+                "istanbul-lib-coverage": "3.2.0",
+                "jest-docblock": "^29.7.0",
+                "koalas": "^1.0.2",
+                "limiter": "1.1.5",
+                "lodash.sortby": "^4.7.0",
+                "lru-cache": "^7.14.0",
+                "module-details-from-path": "^1.0.3",
+                "msgpack-lite": "^0.1.26",
+                "opentracing": ">=0.12.1",
+                "path-to-regexp": "^0.1.2",
+                "pprof-format": "^2.1.0",
+                "protobufjs": "^7.2.5",
+                "retry": "^0.13.1",
+                "semver": "^7.5.4",
+                "shell-quote": "^1.8.1",
+                "tlhunter-sorted-set": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/scheduler/node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "packages/server": {
@@ -36090,7 +36936,7 @@
                 "connect-session-knex": "4.0.0",
                 "cookie-parser": "1.4.6",
                 "cors": "2.8.5",
-                "dd-trace": "5.31.0",
+                "dd-trace": "5.21.0",
                 "dotenv": "16.0.3",
                 "exponential-backoff": "3.1.1",
                 "express": "4.20.0",
@@ -36142,6 +36988,93 @@
                 "npm": ">=6.14.11"
             }
         },
+        "packages/server/node_modules/@datadog/native-appsec": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-8.0.1.tgz",
+            "integrity": "sha512-SpWkoo7K4+pwxFze1ogRF1qBaKm8sZjWfZKnQ8Ex67f6L5odLjWOoiiIAs5rp01sLKGXjxU8IJf+X9j4PvI2zQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/server/node_modules/@datadog/native-iast-rewriter": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.4.1.tgz",
+            "integrity": "sha512-j3auTmyyn63e2y+SL28CGNy/l+jXQyh+pxqoGTacWaY5FW/dvo5nGQepAismgJ3qJ8VhQfVWRdxBSiT7wu9clw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "lru-cache": "^7.14.0",
+                "node-gyp-build": "^4.5.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "packages/server/node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "license": "MIT",
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
+            }
+        },
+        "packages/server/node_modules/@datadog/native-iast-taint-tracking": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.1.0.tgz",
+            "integrity": "sha512-rw6qSjmxmu1yFHVvZLXFt/rVq2tUZXocNogPLB8n7MPpA0jijNGb109WokWw5ITImiW91GcGDuBW6elJDVKouQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            }
+        },
+        "packages/server/node_modules/@datadog/native-metrics": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-2.0.0.tgz",
+            "integrity": "sha512-YklGVwUtmKGYqFf1MNZuOHvTYdKuR4+Af1XkWcMD8BwOAjxmd9Z+97328rCOY8TFUJzlGUPaXzB8j2qgG/BMwA==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-addon-api": "^6.1.0",
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/server/node_modules/@datadog/pprof": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.3.0.tgz",
+            "integrity": "sha512-53z2Q3K92T6Pf4vz4Ezh8kfkVEvLzbnVqacZGgcbkP//q0joFzO8q00Etw1S6NdnCX0XmX08ULaF4rUI5r14mw==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "delay": "^5.0.0",
+                "node-gyp-build": "<4.0",
+                "p-limit": "^3.1.0",
+                "pprof-format": "^2.1.0",
+                "source-map": "^0.7.4"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "packages/server/node_modules/@opentelemetry/api": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+            "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "packages/server/node_modules/@types/express": {
             "version": "4.17.13",
             "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
@@ -36161,6 +37094,47 @@
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
+            }
+        },
+        "packages/server/node_modules/dd-trace": {
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.21.0.tgz",
+            "integrity": "sha512-3jgrYxifuYmSl3kuAxpTSOS7/kKK9DLbw4m85hS/Yn5IFCXer+uvG8sWwFIcBNXOidF/BcyeKC92WX4X87W4Iw==",
+            "hasInstallScript": true,
+            "license": "(Apache-2.0 OR BSD-3-Clause)",
+            "dependencies": {
+                "@datadog/native-appsec": "8.0.1",
+                "@datadog/native-iast-rewriter": "2.4.1",
+                "@datadog/native-iast-taint-tracking": "3.1.0",
+                "@datadog/native-metrics": "^2.0.0",
+                "@datadog/pprof": "5.3.0",
+                "@datadog/sketches-js": "^2.1.0",
+                "@opentelemetry/api": ">=1.0.0 <1.9.0",
+                "@opentelemetry/core": "^1.14.0",
+                "crypto-randomuuid": "^1.0.0",
+                "dc-polyfill": "^0.1.4",
+                "ignore": "^5.2.4",
+                "import-in-the-middle": "^1.8.1",
+                "int64-buffer": "^0.1.9",
+                "istanbul-lib-coverage": "3.2.0",
+                "jest-docblock": "^29.7.0",
+                "koalas": "^1.0.2",
+                "limiter": "1.1.5",
+                "lodash.sortby": "^4.7.0",
+                "lru-cache": "^7.14.0",
+                "module-details-from-path": "^1.0.3",
+                "msgpack-lite": "^0.1.26",
+                "opentracing": ">=0.12.1",
+                "path-to-regexp": "^0.1.2",
+                "pprof-format": "^2.1.0",
+                "protobufjs": "^7.2.5",
+                "retry": "^0.13.1",
+                "semver": "^7.5.4",
+                "shell-quote": "^1.8.1",
+                "tlhunter-sorted-set": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "packages/server/node_modules/dotenv": {
@@ -36201,6 +37175,15 @@
                 "uuid": "dist/bin/uuid"
             }
         },
+        "packages/server/node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
         "packages/server/node_modules/uuid": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
@@ -36230,7 +37213,7 @@
                 "archiver": "^6.0.1",
                 "axios": "^1.7.9",
                 "braintree": "^3.15.0",
-                "dd-trace": "5.31.0",
+                "dd-trace": "5.21.0",
                 "exponential-backoff": "^3.1.1",
                 "fast-xml-parser": "^4.5.0",
                 "form-data": "4.0.0",
@@ -36268,6 +37251,84 @@
             "engines": {
                 "node": ">=18.0",
                 "npm": ">=6.14.11"
+            }
+        },
+        "packages/shared/node_modules/@datadog/native-appsec": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-8.0.1.tgz",
+            "integrity": "sha512-SpWkoo7K4+pwxFze1ogRF1qBaKm8sZjWfZKnQ8Ex67f6L5odLjWOoiiIAs5rp01sLKGXjxU8IJf+X9j4PvI2zQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/shared/node_modules/@datadog/native-iast-rewriter": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.4.1.tgz",
+            "integrity": "sha512-j3auTmyyn63e2y+SL28CGNy/l+jXQyh+pxqoGTacWaY5FW/dvo5nGQepAismgJ3qJ8VhQfVWRdxBSiT7wu9clw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "lru-cache": "^7.14.0",
+                "node-gyp-build": "^4.5.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "packages/shared/node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "license": "MIT",
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
+            }
+        },
+        "packages/shared/node_modules/@datadog/native-iast-taint-tracking": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.1.0.tgz",
+            "integrity": "sha512-rw6qSjmxmu1yFHVvZLXFt/rVq2tUZXocNogPLB8n7MPpA0jijNGb109WokWw5ITImiW91GcGDuBW6elJDVKouQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            }
+        },
+        "packages/shared/node_modules/@datadog/native-metrics": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-2.0.0.tgz",
+            "integrity": "sha512-YklGVwUtmKGYqFf1MNZuOHvTYdKuR4+Af1XkWcMD8BwOAjxmd9Z+97328rCOY8TFUJzlGUPaXzB8j2qgG/BMwA==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-addon-api": "^6.1.0",
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/shared/node_modules/@datadog/pprof": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.3.0.tgz",
+            "integrity": "sha512-53z2Q3K92T6Pf4vz4Ezh8kfkVEvLzbnVqacZGgcbkP//q0joFzO8q00Etw1S6NdnCX0XmX08ULaF4rUI5r14mw==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "delay": "^5.0.0",
+                "node-gyp-build": "<4.0",
+                "p-limit": "^3.1.0",
+                "pprof-format": "^2.1.0",
+                "source-map": "^0.7.4"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "packages/shared/node_modules/@nangohq/database": {
@@ -38566,6 +39627,15 @@
                 "url": "https://github.com/sponsors/colinhacks"
             }
         },
+        "packages/shared/node_modules/@opentelemetry/api": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+            "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "packages/shared/node_modules/@types/uuid": {
             "version": "9.0.1",
             "dev": true,
@@ -38690,6 +39760,47 @@
                 "node": ">= 12.0.0"
             }
         },
+        "packages/shared/node_modules/dd-trace": {
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.21.0.tgz",
+            "integrity": "sha512-3jgrYxifuYmSl3kuAxpTSOS7/kKK9DLbw4m85hS/Yn5IFCXer+uvG8sWwFIcBNXOidF/BcyeKC92WX4X87W4Iw==",
+            "hasInstallScript": true,
+            "license": "(Apache-2.0 OR BSD-3-Clause)",
+            "dependencies": {
+                "@datadog/native-appsec": "8.0.1",
+                "@datadog/native-iast-rewriter": "2.4.1",
+                "@datadog/native-iast-taint-tracking": "3.1.0",
+                "@datadog/native-metrics": "^2.0.0",
+                "@datadog/pprof": "5.3.0",
+                "@datadog/sketches-js": "^2.1.0",
+                "@opentelemetry/api": ">=1.0.0 <1.9.0",
+                "@opentelemetry/core": "^1.14.0",
+                "crypto-randomuuid": "^1.0.0",
+                "dc-polyfill": "^0.1.4",
+                "ignore": "^5.2.4",
+                "import-in-the-middle": "^1.8.1",
+                "int64-buffer": "^0.1.9",
+                "istanbul-lib-coverage": "3.2.0",
+                "jest-docblock": "^29.7.0",
+                "koalas": "^1.0.2",
+                "limiter": "1.1.5",
+                "lodash.sortby": "^4.7.0",
+                "lru-cache": "^7.14.0",
+                "module-details-from-path": "^1.0.3",
+                "msgpack-lite": "^0.1.26",
+                "opentracing": ">=0.12.1",
+                "path-to-regexp": "^0.1.2",
+                "pprof-format": "^2.1.0",
+                "protobufjs": "^7.2.5",
+                "retry": "^0.13.1",
+                "semver": "^7.5.4",
+                "shell-quote": "^1.8.1",
+                "tlhunter-sorted-set": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "packages/shared/node_modules/fast-xml-parser": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz",
@@ -38736,6 +39847,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "packages/shared/node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
         "packages/shared/node_modules/tar-stream": {
             "version": "3.1.6",
             "license": "MIT",
@@ -38778,7 +39898,7 @@
             "dependencies": {
                 "@colors/colors": "1.6.0",
                 "axios": "^1.7.9",
-                "dd-trace": "5.31.0",
+                "dd-trace": "5.21.0",
                 "exponential-backoff": "3.1.1",
                 "fast-safe-stringify": "2.1.1",
                 "http-proxy-agent": "7.0.2",
@@ -38796,6 +39916,93 @@
                 "vitest": "2.1.8"
             }
         },
+        "packages/utils/node_modules/@datadog/native-appsec": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-8.0.1.tgz",
+            "integrity": "sha512-SpWkoo7K4+pwxFze1ogRF1qBaKm8sZjWfZKnQ8Ex67f6L5odLjWOoiiIAs5rp01sLKGXjxU8IJf+X9j4PvI2zQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/utils/node_modules/@datadog/native-iast-rewriter": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.4.1.tgz",
+            "integrity": "sha512-j3auTmyyn63e2y+SL28CGNy/l+jXQyh+pxqoGTacWaY5FW/dvo5nGQepAismgJ3qJ8VhQfVWRdxBSiT7wu9clw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "lru-cache": "^7.14.0",
+                "node-gyp-build": "^4.5.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "packages/utils/node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "license": "MIT",
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
+            }
+        },
+        "packages/utils/node_modules/@datadog/native-iast-taint-tracking": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.1.0.tgz",
+            "integrity": "sha512-rw6qSjmxmu1yFHVvZLXFt/rVq2tUZXocNogPLB8n7MPpA0jijNGb109WokWw5ITImiW91GcGDuBW6elJDVKouQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-gyp-build": "^3.9.0"
+            }
+        },
+        "packages/utils/node_modules/@datadog/native-metrics": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-2.0.0.tgz",
+            "integrity": "sha512-YklGVwUtmKGYqFf1MNZuOHvTYdKuR4+Af1XkWcMD8BwOAjxmd9Z+97328rCOY8TFUJzlGUPaXzB8j2qgG/BMwA==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-addon-api": "^6.1.0",
+                "node-gyp-build": "^3.9.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "packages/utils/node_modules/@datadog/pprof": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.3.0.tgz",
+            "integrity": "sha512-53z2Q3K92T6Pf4vz4Ezh8kfkVEvLzbnVqacZGgcbkP//q0joFzO8q00Etw1S6NdnCX0XmX08ULaF4rUI5r14mw==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "delay": "^5.0.0",
+                "node-gyp-build": "<4.0",
+                "p-limit": "^3.1.0",
+                "pprof-format": "^2.1.0",
+                "source-map": "^0.7.4"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "packages/utils/node_modules/@opentelemetry/api": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+            "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "packages/utils/node_modules/agent-base": {
             "version": "7.1.1",
             "license": "MIT",
@@ -38804,6 +40011,47 @@
             },
             "engines": {
                 "node": ">= 14"
+            }
+        },
+        "packages/utils/node_modules/dd-trace": {
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.21.0.tgz",
+            "integrity": "sha512-3jgrYxifuYmSl3kuAxpTSOS7/kKK9DLbw4m85hS/Yn5IFCXer+uvG8sWwFIcBNXOidF/BcyeKC92WX4X87W4Iw==",
+            "hasInstallScript": true,
+            "license": "(Apache-2.0 OR BSD-3-Clause)",
+            "dependencies": {
+                "@datadog/native-appsec": "8.0.1",
+                "@datadog/native-iast-rewriter": "2.4.1",
+                "@datadog/native-iast-taint-tracking": "3.1.0",
+                "@datadog/native-metrics": "^2.0.0",
+                "@datadog/pprof": "5.3.0",
+                "@datadog/sketches-js": "^2.1.0",
+                "@opentelemetry/api": ">=1.0.0 <1.9.0",
+                "@opentelemetry/core": "^1.14.0",
+                "crypto-randomuuid": "^1.0.0",
+                "dc-polyfill": "^0.1.4",
+                "ignore": "^5.2.4",
+                "import-in-the-middle": "^1.8.1",
+                "int64-buffer": "^0.1.9",
+                "istanbul-lib-coverage": "3.2.0",
+                "jest-docblock": "^29.7.0",
+                "koalas": "^1.0.2",
+                "limiter": "1.1.5",
+                "lodash.sortby": "^4.7.0",
+                "lru-cache": "^7.14.0",
+                "module-details-from-path": "^1.0.3",
+                "msgpack-lite": "^0.1.26",
+                "opentracing": ">=0.12.1",
+                "path-to-regexp": "^0.1.2",
+                "pprof-format": "^2.1.0",
+                "protobufjs": "^7.2.5",
+                "retry": "^0.13.1",
+                "semver": "^7.5.4",
+                "shell-quote": "^1.8.1",
+                "tlhunter-sorted-set": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "packages/utils/node_modules/http-proxy-agent": {
@@ -38834,6 +40082,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12.13"
+            }
+        },
+        "packages/utils/node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "packages/webapp": {

--- a/packages/fleet/package.json
+++ b/packages/fleet/package.json
@@ -18,7 +18,7 @@
     },
     "dependencies": {
         "@nangohq/utils": "file:../utils",
-        "dd-trace": "5.31.0",
+        "dd-trace": "5.21.0",
         "knex": "3.1.0"
     },
     "devDependencies": {

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -28,7 +28,7 @@
         "@nangohq/webhooks": "file:../webhooks",
         "@nangohq/fleet": "file:../fleet",
         "axios": "^1.7.9",
-        "dd-trace": "5.31.0",
+        "dd-trace": "5.21.0",
         "get-port": "7.1.0",
         "express": "4.20.0",
         "node-cron": "3.0.3",

--- a/packages/keystore/package.json
+++ b/packages/keystore/package.json
@@ -18,7 +18,7 @@
     },
     "dependencies": {
         "@nangohq/utils": "file:../utils",
-        "dd-trace": "5.31.0",
+        "dd-trace": "5.21.0",
         "knex": "3.1.0"
     },
     "devDependencies": {

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -16,7 +16,7 @@
     "dependencies": {
         "@nangohq/scheduler": "file:../scheduler",
         "@nangohq/utils": "file:../utils",
-        "dd-trace": "5.31.0",
+        "dd-trace": "5.21.0",
         "express": "4.20.0",
         "get-port": "7.1.0",
         "p-queue": "8.0.1",

--- a/packages/persist/package.json
+++ b/packages/persist/package.json
@@ -24,7 +24,7 @@
         "@nangohq/shared": "file:../shared",
         "@nangohq/types": "file:../types",
         "@nangohq/utils": "file:../utils",
-        "dd-trace": "5.31.0",
+        "dd-trace": "5.21.0",
         "express": "^4.20.0",
         "zod": "3.24.1"
     },

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -25,7 +25,7 @@
         "axios": "^1.7.9",
         "botbuilder": "4.23.1",
         "connect-timeout": "1.9.0",
-        "dd-trace": "5.31.0",
+        "dd-trace": "5.21.0",
         "express": "^4.20.0",
         "soap": "1.1.2",
         "superjson": "2.2.1",

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -18,7 +18,7 @@
     },
     "dependencies": {
         "@nangohq/utils": "file:../utils",
-        "dd-trace": "5.31.0",
+        "dd-trace": "5.21.0",
         "knex": "3.1.0",
         "uuidv7": "0.6.3"
     },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -40,7 +40,7 @@
         "connect-session-knex": "4.0.0",
         "cookie-parser": "1.4.6",
         "cors": "2.8.5",
-        "dd-trace": "5.31.0",
+        "dd-trace": "5.21.0",
         "dotenv": "16.0.3",
         "exponential-backoff": "3.1.1",
         "express": "4.20.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -30,7 +30,7 @@
         "archiver": "^6.0.1",
         "axios": "^1.7.9",
         "braintree": "^3.15.0",
-        "dd-trace": "5.31.0",
+        "dd-trace": "5.21.0",
         "exponential-backoff": "^3.1.1",
         "fast-xml-parser": "^4.5.0",
         "form-data": "4.0.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@colors/colors": "1.6.0",
         "axios": "^1.7.9",
-        "dd-trace": "5.31.0",
+        "dd-trace": "5.21.0",
         "exponential-backoff": "3.1.1",
         "fast-safe-stringify": "2.1.1",
         "http-proxy-agent": "7.0.2",


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Rolls dd-trace back to 5.21.0 since we stopped seeing express traces

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

