### PR TITLE
chore: Use computed matrix for clients tests

### DIFF
--- a/.github/workflows/tests-clients.yaml
+++ b/.github/workflows/tests-clients.yaml
@@ -9,12 +9,27 @@ on:
     merge_group:
 
 jobs:
+    compute-matrix:
+        runs-on: ubuntu-latest
+        outputs:
+            os_matrix: ${{ steps.set-matrix.outputs.matrix }}
+        steps:
+            - name: Set Matrix
+              id: set-os-matrix
+              run: |
+
+                  if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
+                    echo "::set-output name=os_matrix::[\"ubuntu-latest\",\"windows-latest\"]"
+                  else
+                    echo "::set-output name=os_matrix::[\"ubuntu-latest\"]"
+                  fi
     tests:
+        needs: compute-matrix
         strategy:
             fail-fast: false
             matrix:
                 node-version: [18.x, 20.x, 22.x]
-                os: [ubuntu-latest, windows-latest]
+                os: ${{ fromJson(needs.compute-matrix.outputs.os_matrix) }}
 
         runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/tests-clients.yaml
+++ b/.github/workflows/tests-clients.yaml
@@ -19,9 +19,9 @@ jobs:
               run: |
 
                   if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
-                    echo "::set-output name=os_matrix::[\"ubuntu-latest\",\"windows-latest\"]"
+                    echo "os_matrix=[\"ubuntu-latest\",\"windows-latest\"]" >> $GITHUB_OUTPUT
                   else
-                    echo "::set-output name=os_matrix::[\"ubuntu-latest\"]"
+                    echo "os_matrix=[\"ubuntu-latest\"]" >> $GITHUB_OUTPUT
                   fi
     tests:
         needs: compute-matrix

--- a/.github/workflows/tests-clients.yaml
+++ b/.github/workflows/tests-clients.yaml
@@ -17,7 +17,7 @@ jobs:
             - name: Set Matrix
               id: set-os-matrix
               run: |
-                  echo "os-matrix='[\"ubuntu-latest\"]'" >> $GITHUB_OUTPUT
+                  echo "testing"
                   # if [[ '${{ github.ref }}' == 'refs/heads/master' ]]; then
                   #   echo "os-matrix='[\"ubuntu-latest\",\"windows-latest\"]'" >> $GITHUB_OUTPUT
                   # else

--- a/.github/workflows/tests-clients.yaml
+++ b/.github/workflows/tests-clients.yaml
@@ -22,11 +22,6 @@ jobs:
                   else
                     echo "os-matrix=[\"ubuntu-latest\"]" >> $GITHUB_OUTPUT
                   fi
-    debug-matrix:
-        needs: compute-matrix
-        runs-on: ubuntu-latest
-        steps:
-            - run: echo ${{ needs.compute-matrix.outputs.os-matrix }}
     tests:
         needs: compute-matrix
         strategy:

--- a/.github/workflows/tests-clients.yaml
+++ b/.github/workflows/tests-clients.yaml
@@ -17,12 +17,11 @@ jobs:
             - name: Set OS Matrix
               id: set-os-matrix
               run: |
-                  echo "os-matrix=[\"ubuntu-latest\"]" >> $GITHUB_OUTPUT
-                  # if [[ '${{ github.ref }}' == 'refs/heads/master' ]]; then
-                  #   echo "os-matrix='[\"ubuntu-latest\",\"windows-latest\"]'" >> $GITHUB_OUTPUT
-                  # else
-                  #   echo "os-matrix='[\"ubuntu-latest\"]'" >> $GITHUB_OUTPUT
-                  # fi
+                  if [[ '${{ github.ref }}' == 'refs/heads/master' ]]; then
+                    echo "os-matrix=[\"ubuntu-latest\",\"windows-latest\"]" >> $GITHUB_OUTPUT
+                  else
+                    echo "os-matrix=[\"ubuntu-latest\"]" >> $GITHUB_OUTPUT
+                  fi
     debug-matrix:
         needs: compute-matrix
         runs-on: ubuntu-latest

--- a/.github/workflows/tests-clients.yaml
+++ b/.github/workflows/tests-clients.yaml
@@ -17,11 +17,10 @@ jobs:
             - name: Set Matrix
               id: set-os-matrix
               run: |
-
-                  if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
-                    echo "os_matrix=[\"ubuntu-latest\",\"windows-latest\"]" >> $GITHUB_OUTPUT
+                  if [[ '${{ github.ref }}' == 'refs/heads/master' ]]; then
+                    echo "os-matrix='[\"ubuntu-latest\",\"windows-latest\"]'" >> $GITHUB_OUTPUT
                   else
-                    echo "os_matrix=[\"ubuntu-latest\"]" >> $GITHUB_OUTPUT
+                    echo "os-matrix='[\"ubuntu-latest\"]'" >> $GITHUB_OUTPUT
                   fi
     tests:
         needs: compute-matrix
@@ -29,7 +28,7 @@ jobs:
             fail-fast: false
             matrix:
                 node-version: [18.x, 20.x, 22.x]
-                os: ${{ fromJson(needs.compute-matrix.outputs.os_matrix) }}
+                os: ${{ fromJson(needs.compute-matrix.outputs.os-matrix) }}
 
         runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/tests-clients.yaml
+++ b/.github/workflows/tests-clients.yaml
@@ -12,9 +12,9 @@ jobs:
     compute-matrix:
         runs-on: ubuntu-latest
         outputs:
-            os-matrix: ${{ steps.set-matrix.outputs.matrix }}
+            os-matrix: ${{ steps.set-os-matrix.outputs.os-matrix }}
         steps:
-            - name: Set Matrix
+            - name: Set OS Matrix
               id: set-os-matrix
               run: |
                   echo "os-matrix=[\"ubuntu-latest\"]" >> $GITHUB_OUTPUT

--- a/.github/workflows/tests-clients.yaml
+++ b/.github/workflows/tests-clients.yaml
@@ -22,6 +22,11 @@ jobs:
                   else
                     echo "os-matrix='[\"ubuntu-latest\"]'" >> $GITHUB_OUTPUT
                   fi
+    debug-matrix:
+        needs: compute-matrix
+        runs-on: ubuntu-latest
+        steps:
+            - run: echo ${{ needs.compute-matrix.outputs.os-matrix }}
     tests:
         needs: compute-matrix
         strategy:

--- a/.github/workflows/tests-clients.yaml
+++ b/.github/workflows/tests-clients.yaml
@@ -17,11 +17,12 @@ jobs:
             - name: Set Matrix
               id: set-os-matrix
               run: |
-                  if [[ '${{ github.ref }}' == 'refs/heads/master' ]]; then
-                    echo "os-matrix='[\"ubuntu-latest\",\"windows-latest\"]'" >> $GITHUB_OUTPUT
-                  else
-                    echo "os-matrix='[\"ubuntu-latest\"]'" >> $GITHUB_OUTPUT
-                  fi
+                  echo "os-matrix='[\"ubuntu-latest\"]'" >> $GITHUB_OUTPUT
+                  # if [[ '${{ github.ref }}' == 'refs/heads/master' ]]; then
+                  #   echo "os-matrix='[\"ubuntu-latest\",\"windows-latest\"]'" >> $GITHUB_OUTPUT
+                  # else
+                  #   echo "os-matrix='[\"ubuntu-latest\"]'" >> $GITHUB_OUTPUT
+                  # fi
     debug-matrix:
         needs: compute-matrix
         runs-on: ubuntu-latest

--- a/.github/workflows/tests-clients.yaml
+++ b/.github/workflows/tests-clients.yaml
@@ -12,7 +12,7 @@ jobs:
     compute-matrix:
         runs-on: ubuntu-latest
         outputs:
-            os_matrix: ${{ steps.set-matrix.outputs.matrix }}
+            os-matrix: ${{ steps.set-matrix.outputs.matrix }}
         steps:
             - name: Set Matrix
               id: set-os-matrix

--- a/.github/workflows/tests-clients.yaml
+++ b/.github/workflows/tests-clients.yaml
@@ -17,7 +17,7 @@ jobs:
             - name: Set Matrix
               id: set-os-matrix
               run: |
-                  echo "testing"
+                  echo "os-matrix=[\"ubuntu-latest\"]" >> $GITHUB_OUTPUT
                   # if [[ '${{ github.ref }}' == 'refs/heads/master' ]]; then
                   #   echo "os-matrix='[\"ubuntu-latest\",\"windows-latest\"]'" >> $GITHUB_OUTPUT
                   # else


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Computes a matrix of what os should be tested for client tests, and then runs those:

<img width="925" alt="image" src="https://github.com/user-attachments/assets/da055dbd-0d7d-4cac-bb78-a5a307f16bfe" />

It only runs windows on master, so we still run it after merge, but on PRs just runs on linux, where things are faster. On PRs this cuts time down to 3m10s (on just one run) from a prior runtime of 8m+

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

