### PR TITLE
chore: temporarely adding a github action deploy_fleet

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,6 +24,7 @@ on:
                     - persist
                     - orchestrator
                     - connect_ui
+                    - fleet
 
 jobs:
     deploy_server:
@@ -89,6 +90,20 @@ jobs:
               run: |
                   bash ./scripts/deploy/runners.bash
 
+                  NANGO_API_HOSTNAME=${{ fromJson('{ "production": "api.nango.dev", "staging": "api-staging.nango.dev" }')[inputs.stage] }}
+                  curl -sS --fail-with-body --request POST "https://$NANGO_API_HOSTNAME/internal/fleet/nango_runners/rollout" \
+                    --header "authorization: Bearer $INTERNAL_API_KEY"\
+                    --header "content-type: application/json"\
+                    --data "{ \"commitHash\": \"${{ github.sha }}\" }"
+
+    deploy_fleet:
+        if: inputs.service == 'fleet'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Fleet rollout
+              env:
+                  INTERNAL_API_KEY: ${{ inputs.stage == 'production' && secrets.PROD_INTERNAL_API_KEY || secrets.STAGING_INTERNAL_API_KEY }}
+              run: |
                   NANGO_API_HOSTNAME=${{ fromJson('{ "production": "api.nango.dev", "staging": "api-staging.nango.dev" }')[inputs.stage] }}
                   curl -sS --fail-with-body --request POST "https://$NANGO_API_HOSTNAME/internal/fleet/nango_runners/rollout" \
                     --header "authorization: Bearer $INTERNAL_API_KEY"\


### PR DESCRIPTION
in order to be able to test fleet migration and deployment without having to deploy all runners

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

