### PR TITLE
chore: Unit test env fix

### DIFF
--- a/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
@@ -11,6 +11,7 @@ import { Orchestrator } from '../../../clients/orchestrator.js';
 import type { OrchestratorClientInterface } from '../../../clients/orchestrator.js';
 import type { DBTeam, DBEnvironment, CleanedIncomingFlowConfig } from '@nangohq/types';
 import type { SyncConfig } from '../../../models/Sync.js';
+import db from '@nangohq/database';
 
 const orchestratorClientNoop: OrchestratorClientInterface = {
     recurring: () => Promise.resolve({}) as any,
@@ -206,6 +207,8 @@ describe('Sync config create', () => {
         vi.spyOn(SyncService, 'getSyncsByProviderConfigAndSyncName').mockImplementation(() => {
             return Promise.resolve([]);
         });
+
+        vi.spyOn(db.knex, 'from').mockRejectedValue(new Error());
 
         await expect(
             DeployConfigService.deploy({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,8 @@ export default defineConfig({
             NANGO_LOGS_ES_URL: 'http://fake.com',
             NANGO_LOGS_ES_USER: '',
             NANGO_LOGS_ES_PWD: '',
-            NANGO_LOGS_ENABLED: 'false'
+            NANGO_LOGS_ENABLED: 'false',
+            NANGO_DB_NAME: 'nango_test'
         },
         chaiConfig: {
             truncateThreshold: 10000


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
We rely on our unit tests not hitting the DB, but I realized while running tests that they were in fact hitting the db. This updates the code to set a DB_NAME that does't exist in the scope of the unit tests, so that they can't write anywhere and will error instead.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

