### PR TITLE
fix: add application_name to fleet db url + db pool max

### DIFF
--- a/packages/fleet/lib/db/client.ts
+++ b/packages/fleet/lib/db/client.ts
@@ -13,7 +13,7 @@ export class DatabaseClient {
     public url: string;
     private config: knex.Knex.Config;
 
-    constructor({ url, schema, poolMax = 50 }: { url: string; schema: string; poolMax?: number }) {
+    constructor({ url, schema, poolMax = 15 }: { url: string; schema: string; poolMax?: number }) {
         this.url = url;
         this.schema = schema;
         this.config = {

--- a/packages/fleet/lib/fleet.ts
+++ b/packages/fleet/lib/fleet.ts
@@ -17,7 +17,7 @@ import { noopNodeProvider } from './node-providers/noop.js';
 
 const defaultDbUrl =
     envs.NANGO_DATABASE_URL ||
-    `postgres://${encodeURIComponent(envs.NANGO_DB_USER)}:${encodeURIComponent(envs.NANGO_DB_PASSWORD)}@${envs.NANGO_DB_HOST}:${envs.NANGO_DB_PORT}/${envs.NANGO_DB_NAME}${envs.NANGO_DB_SSL ? '?sslmode=no-verify' : ''}`;
+    `postgres://${encodeURIComponent(envs.NANGO_DB_USER)}:${encodeURIComponent(envs.NANGO_DB_PASSWORD)}@${envs.NANGO_DB_HOST}:${envs.NANGO_DB_PORT}/${envs.NANGO_DB_NAME}?application_name=${envs.NANGO_DB_APPLICATION_NAME}${envs.NANGO_DB_SSL ? '&sslmode=no-verify' : ''}`;
 
 export class Fleet {
     public fleetId: string;


### PR DESCRIPTION
Setting db application name for fleet and setting connection pool max to 15

https://linear.app/nango/issue/NAN-2464/add-application-name-to-database-url-for-fleet
