### PR TITLE
fix: fix log copy when setting frequency on script deployment

### DIFF
--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -547,7 +547,7 @@ export class Orchestrator {
                 }
             });
         } else {
-            await logCtx?.info(`Sync frequency for "${syncName}" updated to ${interval}`);
+            await logCtx?.info(`Sync frequency for "${syncName}" is ${interval}`);
         }
         return res;
     }


### PR DESCRIPTION
Log is currently stating `Sync frequency updated to X` on script deployment. Since the frequency update doesn't necessary mean the value has changed this commit is changing the log copy to say `Sync frequency is X` to be less confusing.
We agreed with Khaliq about this simple change instead of changing the internal API to differentiate between a frequency update resulting in a new value instead and a noop one when value is the same

<img width="981" alt="Screenshot 2025-01-13 at 15 52 46" src="https://github.com/user-attachments/assets/b6fbde27-b205-484d-a1ea-fefd1a53d7e7" />

# How to test
Deploy custom integrations and check the Deploy log

