### PR TITLE
fix: determine nango yaml version

### DIFF
--- a/packages/nango-yaml/lib/helpers.ts
+++ b/packages/nango-yaml/lib/helpers.ts
@@ -21,7 +21,7 @@ export function determineVersion(configData: NangoYaml): 'v1' | 'v2' {
 
     const firstProviderConfig = configData.integrations[keys[0]!];
 
-    if (firstProviderConfig && ('syncs' in firstProviderConfig || 'actions' in firstProviderConfig)) {
+    if (firstProviderConfig && ('syncs' in firstProviderConfig || 'actions' in firstProviderConfig || 'on-events' in firstProviderConfig)) {
         return 'v2';
     } else {
         return 'v1';


### PR DESCRIPTION
if nango.yaml only contains on-events script definition the version of the nango.yaml file is wrongly determined to be v1, which prevents the generation of on-events scripts that only works when v2

# how to test 
run `nango generate` with following nango.yaml 
```
integrations:
  hubspot:
    on-events:
      post-connection-creation:
        - add-whoami
```
with current CLI version, nothing is generated. After applying this patch you should see the `hubspot/on-events/add-whoami.ts` file be generated
