### PR TITLE
fix(cli): Fix order of cleaning up headers

### DIFF
--- a/packages/cli/lib/services/response-saver.service.ts
+++ b/packages/cli/lib/services/response-saver.service.ts
@@ -148,13 +148,16 @@ function computeConfigIdentity(config: AxiosRequestConfig): ConfigIdentity {
     const url = new URL(config.url!);
     const endpoint = url.pathname.replace(/^\/proxy\//, '');
 
+    console.debug('Processing', method, endpoint);
     const dataIdentity = computeDataIdentity(config);
 
     let headers: [string, string][] = [];
     if (config.headers !== undefined) {
+        console.debug(Object.entries(config.headers));
         const filteredHeaders = Object.entries(config.headers)
-            .filter(([key]) => !FILTER_HEADERS.includes(key.toLowerCase()))
-            .map<[string, string]>(([key, value]) => (key.toLowerCase().startsWith('nango-proxy-') ? [key.slice(12), String(value)] : [key, String(value)]));
+            .map<[string, string]>(([key, value]) => (key.toLowerCase().startsWith('nango-proxy-') ? [key.slice(12), String(value)] : [key, String(value)]))
+            .filter(([key]) => !FILTER_HEADERS.includes(key.toLowerCase()));
+
         sortEntries(filteredHeaders);
         headers = filteredHeaders;
     }

--- a/packages/cli/lib/services/response-saver.service.ts
+++ b/packages/cli/lib/services/response-saver.service.ts
@@ -148,12 +148,10 @@ function computeConfigIdentity(config: AxiosRequestConfig): ConfigIdentity {
     const url = new URL(config.url!);
     const endpoint = url.pathname.replace(/^\/proxy\//, '');
 
-    console.debug('Processing', method, endpoint);
     const dataIdentity = computeDataIdentity(config);
 
     let headers: [string, string][] = [];
     if (config.headers !== undefined) {
-        console.debug(Object.entries(config.headers));
         const filteredHeaders = Object.entries(config.headers)
             .map<[string, string]>(([key, value]) => (key.toLowerCase().startsWith('nango-proxy-') ? [key.slice(12), String(value)] : [key, String(value)]))
             .filter(([key]) => !FILTER_HEADERS.includes(key.toLowerCase()));


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Because we were filtering headers before mapping them, we would end up with headers in the saved response that get filtered in the tests.

This came up due to a test that Kelvin was working with that ended up with headers that should not have been there as part of the request identity. I realized it was because they started as `Nango-Proxy-` headers and were cleaned up to remove that prefix but still stuck around.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

