### PR TITLE
fix(jobs): Try to use a check loop to make that one supervisor test not fail

### DIFF
--- a/packages/fleet/lib/supervisor/supervisor.integration.test.ts
+++ b/packages/fleet/lib/supervisor/supervisor.integration.test.ts
@@ -57,7 +57,11 @@ describe('Supervisor', () => {
             const tickSpy2 = vi.spyOn(supervisor2, 'tick');
             void supervisor1.start();
             void supervisor2.start();
-            await new Promise((resolve) => setTimeout(resolve, 50));
+
+            await vi.waitUntil(() => tickSpy1.mock.calls.length > 0, {
+                timeout: 5000
+            });
+
             expect(tickSpy1).toHaveBeenCalled();
             expect(tickSpy2).toHaveBeenCalledTimes(0);
         });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
We've had a supervisor test acting flaky. This attempts to put it into a loop in the test to give it longer to succeed or fail.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

