### PR TITLE
feat(api): track request content length

### DIFF
--- a/packages/server/lib/utils/asyncWrapper.ts
+++ b/packages/server/lib/utils/asyncWrapper.ts
@@ -19,7 +19,7 @@ export function asyncWrapper<TEndpoint extends Endpoint<any>, Locals extends Rec
             const contentLength = req.header('content-length');
             if (contentLength) {
                 const int = parseInt(contentLength, 10);
-                active.setTag('http.request.content_length', `${(int / 1024).toPrecision(2)}kb`);
+                active.setTag('http.request.body.size', int);
                 metrics.histogram(metrics.Types.API_REQUEST_CONTENT_LENGTH, int);
             }
         }

--- a/packages/server/lib/utils/asyncWrapper.ts
+++ b/packages/server/lib/utils/asyncWrapper.ts
@@ -3,6 +3,7 @@ import type { Endpoint } from '@nangohq/types';
 import type { RequestHandler, Request, Response, NextFunction } from 'express';
 import { isAsyncFunction } from 'util/types';
 import type { RequestLocals } from './express.js';
+import { metrics } from '@nangohq/utils';
 
 export function asyncWrapper<TEndpoint extends Endpoint<any>, Locals extends Record<string, any> = Required<RequestLocals>>(
     fn: (
@@ -13,7 +14,15 @@ export function asyncWrapper<TEndpoint extends Endpoint<any>, Locals extends Rec
 ): RequestHandler<any, TEndpoint['Reply'], any, any, any> {
     return (req, res, next) => {
         const active = tracer.scope().active();
-        active?.setTag('http.route', req.route?.path || req.originalUrl);
+        if (active) {
+            active.setTag('http.route', req.route?.path || req.originalUrl);
+            const contentLength = req.header('content-length');
+            if (contentLength) {
+                const int = parseInt(contentLength, 10);
+                active.setTag('http.request.content_length', `${(int / 1024).toPrecision(2)}kb`);
+                metrics.histogram(metrics.Types.API_REQUEST_CONTENT_LENGTH, int);
+            }
+        }
         if (isAsyncFunction(fn)) {
             return (fn(req, res, next) as unknown as Promise<any>).catch((err: unknown) => {
                 next(err);

--- a/packages/utils/lib/express/route.ts
+++ b/packages/utils/lib/express/route.ts
@@ -24,7 +24,7 @@ export const createRoute = <E extends Endpoint<any>>(server: Express, rh: RouteH
             const contentLength = req.header('content-length');
             if (contentLength) {
                 const int = parseInt(contentLength, 10);
-                active.setTag('http.request.content_length', `${(int / 1024).toPrecision(2)}kb`);
+                active.setTag('http.request.body.size', int);
                 metrics.histogram(metrics.Types.API_REQUEST_CONTENT_LENGTH, int);
             }
         }

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -54,7 +54,9 @@ export enum Types {
     ORCH_TASKS_SUCCEEDED = 'nango.orch.tasks.succeeded',
     ORCH_TASKS_FAILED = 'nango.orch.tasks.failed',
     ORCH_TASKS_EXPIRED = 'nango.orch.tasks.expired',
-    ORCH_TASKS_CANCELLED = 'nango.orch.tasks.cancelled'
+    ORCH_TASKS_CANCELLED = 'nango.orch.tasks.cancelled',
+
+    API_REQUEST_CONTENT_LENGTH = 'nango.api.request.content_length'
 }
 
 export function increment(metricName: Types, value = 1, dimensions?: Record<string, string | number>): void {
@@ -67,6 +69,10 @@ export function decrement(metricName: Types, value = 1, dimensions?: Record<stri
 
 export function gauge(metricName: Types, value?: number): void {
     tracer.dogstatsd.gauge(metricName, value ?? 1);
+}
+
+export function histogram(metricName: Types, value: number): void {
+    tracer.dogstatsd.histogram(metricName, value);
 }
 
 export function duration(metricName: Types, value: number): void {


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-2540/track-request-content-length


- API track request content length
Inside traces as tag and as a metric to be able to graph it properly. I'm not the best at math so hopefully the computation is correct.

![Screenshot 2025-01-16 at 11 31 05](https://github.com/user-attachments/assets/1732262f-c8a0-4891-b42d-458920ce214b)
![Screenshot 2025-01-16 at 11 24 19](https://github.com/user-attachments/assets/cedd961c-56e8-490c-9004-6d61438dfe1f)
