### PR TITLE
fix(fleet): RUNNING to IDLE is a valid state transition

### DIFF
--- a/packages/fleet/lib/models/nodes.ts
+++ b/packages/fleet/lib/models/nodes.ts
@@ -19,6 +19,7 @@ export const validNodeStateTransitions = [
     { from: 'STARTING', to: 'ERROR' },
     { from: 'RUNNING', to: 'OUTDATED' },
     { from: 'RUNNING', to: 'ERROR' },
+    { from: 'RUNNING', to: 'IDLE' },
     { from: 'OUTDATED', to: 'FINISHING' },
     { from: 'OUTDATED', to: 'ERROR' },
     { from: 'FINISHING', to: 'IDLE' },


### PR DESCRIPTION
RUNNING node should be terminated when they haven't executed a script in the last 24h. 
Right now the RUNNING -> IDLE transition results in an error
