### PR TITLE
fix(webapp): Handle null sync_type to stop ui error

### DIFF
--- a/packages/webapp/src/pages/Connection/components/SyncRow.tsx
+++ b/packages/webapp/src/pages/Connection/components/SyncRow.tsx
@@ -30,7 +30,7 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
 
     const [showPauseStartLoader, setShowPauseStartLoader] = useState(false);
     const [showInterruptLoader, setShowInterruptLoader] = useState(false);
-    const [triggerMode, setTriggerMode] = useState<'incremental' | 'full'>(sync.sync_type.toLocaleLowerCase() === 'full' ? 'full' : 'incremental');
+    const [triggerMode, setTriggerMode] = useState<'incremental' | 'full'>(sync.sync_type?.toLocaleLowerCase() === 'full' ? 'full' : 'incremental');
     const [deleteRecords, setDeleteRecords] = useState(false);
     const [modalSpinner, setModalShowSpinner] = useState(false);
     const [openConfirm, setOpenConfirm] = useState(false);


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Came from a customer report. We had a `sync_type` coming over the API as null, and that caused errors in this condition.

![image](https://github.com/user-attachments/assets/466ff329-a9ec-4261-9be6-55f2b6b186ee)

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

