### PR TITLE
fix(github-app): public links are set in the integration

### DIFF
--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -3116,6 +3116,7 @@ github-app:
             description: The public link of your GitHub App
             format: uri
             pattern: '^https?://.*$'
+            automated: true
         installation_id:
             type: string
             title: Installation ID
@@ -3146,6 +3147,7 @@ github-app-oauth:
             description: The public link of your GitHub App
             format: uri
             pattern: '^https?://.*$'
+            automated: true
         installation_id:
             type: string
             title: Installation ID


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
As reported in the community the public link is set in the integration so isn't needed in the modal.

<img width="1016" alt="image" src="https://github.com/user-attachments/assets/d525ba43-4a75-4bb3-acdd-b3016e7a29b8" />


<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

