### PR TITLE
fix(fleet): wait 

### DIFF
--- a/packages/fleet/lib/supervisor/supervisor.ts
+++ b/packages/fleet/lib/supervisor/supervisor.ts
@@ -88,6 +88,8 @@ export class Supervisor {
             } catch (err) {
                 span.setTag('error', err);
                 return Err(new FleetError('supervisor_tick_failed', { cause: err }));
+            } finally {
+                await setTimeout(envs.FLEET_SUPERVISOR_WAIT_TICK_MS);
             }
         });
     }

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -100,6 +100,7 @@ export const ENVS = z.object({
         .number()
         .optional()
         .default(5 * 1000), // 5 seconds
+    FLEET_SUPERVISOR_WAIT_TICK_MS: z.coerce.number().optional().default(1000), // 1 sec
 
     // --- Third parties
     // AWS
@@ -161,6 +162,7 @@ export const ENVS = z.object({
     RENDER_API_KEY: z.string().optional(),
     RENDER_SERVICE_CREATION_MAX_PER_MINUTE: z.coerce.number().optional(),
     RENDER_SERVICE_CREATION_MAX_PER_HOUR: z.coerce.number().optional(),
+    RENDER_WAIT_WHEN_THROTTLED_MS: z.coerce.number().default(1000),
     IS_RENDER: bool,
 
     // Sentry


### PR DESCRIPTION
wait on each execution instead of trying to plan/execute as fast as possible
wait when render api is throttled/rate-limited

