### PR TITLE
fix: delete aws IAM verification

### DIFF
--- a/packages/shared/providers.yaml
+++ b/packages/shared/providers.yaml
@@ -694,9 +694,6 @@ aws-iam:
     auth_mode: BASIC
     proxy:
         base_url: https://iam.amazonaws.com
-        verification:
-            method: GET
-            endpoint: /?Action=ListUsers
         connection_config:
             region: ${connectionConfig.region}
         retry:


### PR DESCRIPTION
aws iam verification doesn't work. Removing it for now to unblock customers

