### PR TITLE
fix: first requests to runner fails when new runner comes online

### DIFF
--- a/packages/runner/lib/app.ts
+++ b/packages/runner/lib/app.ts
@@ -10,8 +10,13 @@ const providersMonitorCleanup = await monitorProviders();
 try {
     const port = parseInt(process.argv[2] || '') || 3006;
     const id = process.argv[3] || process.env['RUNNER_ID'] || 'unknown-id';
-    const srv = server.listen(port, () => {
+    const srv = server.listen(port, async () => {
         logger.info(`🏃‍♀️ '${id}' ready at http://localhost:${port}`);
+
+        const res = await register();
+        if (res.isErr()) {
+            logger.error(`${id} Unable to register`, res.error);
+        }
     });
 
     const close = () => {
@@ -43,12 +48,6 @@ try {
         logger.error(`${id} Received uncaughtException...`, e);
         // not closing on purpose
     });
-
-    const res = await register();
-    if (res.isErr()) {
-        logger.error(`${id} Unable to register`, res.error);
-        // not exiting on purpose because REMOTE runner are not registering
-    }
 } catch (err) {
     logger.error(`Unable to start runner: ${stringifyError(err)}`);
     process.exit(1);

--- a/packages/runner/lib/register.ts
+++ b/packages/runner/lib/register.ts
@@ -2,6 +2,7 @@ import type { Result } from '@nangohq/utils';
 import { Err, Ok, retryWithBackoff } from '@nangohq/utils';
 import { envs, jobsServiceUrl } from './env.js';
 import { httpFetch } from './utils.js';
+import { setTimeout } from 'node:timers/promises';
 
 export async function register(): Promise<Result<void>> {
     if (!envs.RUNNER_NODE_ID) {
@@ -11,6 +12,27 @@ export async function register(): Promise<Result<void>> {
         return Err('RUNNER_URL is not set');
     }
     try {
+        // In Render, network configuration can take up to 30 seconds to be applied to the service
+        // so we need to wait for the runner to be reachable from the outside before registering
+        const startTime = Date.now();
+        const timeoutMs = 120_000;
+        const waitMs = 1000;
+        let isReachable = false;
+        while (!isReachable && Date.now() - startTime < timeoutMs) {
+            try {
+                const res = await fetch(`${envs.RUNNER_URL}/health`);
+                if (res.ok) {
+                    isReachable = true;
+                } else {
+                    await setTimeout(waitMs);
+                }
+            } catch {
+                await setTimeout(waitMs);
+            }
+        }
+        if (!isReachable) {
+            return Err(new Error(`Runner at ${envs.RUNNER_URL} is not reachable after ${timeoutMs}ms`));
+        }
         await retryWithBackoff(
             async () => {
                 return await httpFetch({


### PR DESCRIPTION
Network configuration of the newly created service in Render can take up to 30s. 
This commit ensures the runner is reachable from the outside before it registers

