### PR TITLE
fix(webapp): Crash when env switching on teams page

### DIFF
--- a/packages/webapp/src/pages/Team/components/Users.tsx
+++ b/packages/webapp/src/pages/Team/components/Users.tsx
@@ -6,6 +6,7 @@ import { useStore } from '../../../store';
 import * as Table from '../../../components/ui/Table';
 import { InvitationAction, UserAction } from './Actions';
 import { Tag } from '../../../components/ui/label/Tag';
+import { useMemo } from 'react';
 
 export const columns: ColumnDef<ApiUser | ApiInvitation>[] = [
     {
@@ -57,9 +58,10 @@ export const columns: ColumnDef<ApiUser | ApiInvitation>[] = [
 export const TeamUsers: React.FC = () => {
     const env = useStore((state) => state.env);
     const { users, invitedUsers } = useTeam(env);
+    const tableData = useMemo(() => (users && invitedUsers ? [...users, ...invitedUsers] : []), [users, invitedUsers]);
 
     const table = useReactTable({
-        data: users && invitedUsers ? [...users, ...invitedUsers] : [],
+        data: tableData,
         columns,
         getCoreRowModel: getCoreRowModel()
     });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Switching environments on the teams page crashed when switching between environments. It was due to a react hooks issue.

<!-- Issue ticket number and link (if applicable) -->
See https://github.com/NangoHQ/nango/issues/3284

<!-- Testing instructions (skip if just adding/editing providers) -->
## How I reproduced the issue:

- Switch from one env to another, and then back to the first.

