### PR TITLE
fix(jobs): Fix small bug in wehbook code that never closed log

### DIFF
--- a/packages/webhooks/lib/sync.ts
+++ b/packages/webhooks/lib/sync.ts
@@ -87,6 +87,7 @@ export const sendSync = async ({
 
         if (!webhookSettings.on_sync_completion_always && noChanges) {
             await logCtx.info(`There were no added, updated, or deleted results for model ${model}. No webhook sent, as per your environment settings`);
+            await logCtx.success();
 
             return Ok(undefined);
         }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Noticed while testing as I rolled out the new webhook separation PR that when we log that no webhook needed to be sent we didn't close the log (because of changes in my PR). This fixes that.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

