### PR TITLE
feat(records): add upserting/updating records merging strategy

### DIFF
--- a/packages/records/lib/cursor.ts
+++ b/packages/records/lib/cursor.ts
@@ -1,0 +1,18 @@
+export interface Cursor {
+    sort: string;
+    id: string;
+}
+
+export const Cursor = {
+    new({ last_modified_at, id }: { last_modified_at: string; id: string }): string {
+        return Buffer.from(`${last_modified_at}||${id}`).toString('base64');
+    },
+    from(encoded: string): Cursor | undefined {
+        const decoded = Buffer.from(encoded, 'base64').toString('ascii');
+        const [cursorSort, cursorId] = decoded.split('||');
+        if (cursorSort && cursorId) {
+            return { sort: cursorSort, id: cursorId };
+        }
+        return undefined;
+    }
+};


### PR DESCRIPTION
Currently, all entries saved/updated by a script override existing records.
We want to allow scripts to be able to define a merging strategy where records that have been modified during the execution of the script would not be overwritten.
To allow such behavior, this commit adds a parameter to the `Records.upsert` and `Records.update` function to pass a cursor. Any entry that would overwrite an existing record modified after this cursor will be ignored instead of overwriting the record.

# How to test
It is not wired yet so we'll have to rely on the tests

