### PR TITLE
feat(persist): add support for merging strategy

### DIFF
--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getCursor.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getCursor.ts
@@ -1,0 +1,54 @@
+import type { ApiError, Endpoint } from '@nangohq/types';
+import type { EndpointRequest, EndpointResponse, RouteHandler, Route } from '@nangohq/utils';
+import type { CursorOffset } from '@nangohq/records';
+import { records } from '@nangohq/records';
+import { validateCursor } from './validate.js';
+
+type GetCursor = Endpoint<{
+    Method: typeof method;
+    Path: typeof path;
+    Params: {
+        environmentId: number;
+        nangoConnectionId: number;
+    };
+    Querystring: {
+        model: string;
+        offset: CursorOffset;
+    };
+    Error: ApiError<'get_cursor_failed' | 'cursor_not_found'>;
+    Success: {
+        cursor?: string;
+    };
+}>;
+
+const path = '/environment/:environmentId/connection/:nangoConnectionId/cursor';
+const method = 'GET';
+
+const validate = validateCursor<GetCursor>();
+
+const handler = async (req: EndpointRequest<GetCursor>, res: EndpointResponse<GetCursor>) => {
+    const {
+        params: { nangoConnectionId },
+        query: { model, offset }
+    } = req;
+    const result = await records.getCursor({
+        connectionId: nangoConnectionId,
+        model,
+        offset
+    });
+    if (result.isOk()) {
+        res.json(result.value ? { cursor: result.value } : {});
+    } else {
+        res.status(500).json({ error: { code: 'get_cursor_failed', message: `Failed to get cursor: ${result.error.message}` } });
+    }
+    return;
+};
+
+export const route: Route<GetCursor> = { path, method };
+
+export const routeHandler: RouteHandler<GetCursor> = {
+    method,
+    path,
+    validate,
+    handler
+};

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteRecords.ts
@@ -2,6 +2,7 @@ import type { ApiError, Endpoint } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, RouteHandler, Route } from '@nangohq/utils';
 import { persistRecords, recordsPath } from '../../../../../../../../../records.js';
 import { validateRecords } from './validate.js';
+import type { MergingStrategy } from '@nangohq/records';
 
 type DeleteRecords = Endpoint<{
     Method: typeof method;
@@ -18,9 +19,12 @@ type DeleteRecords = Endpoint<{
         providerConfigKey: string;
         connectionId: string;
         activityLogId: string;
+        merging: MergingStrategy;
     };
     Error: ApiError<'delete_records_failed'>;
-    Success: never;
+    Success: {
+        nextMerging: MergingStrategy;
+    };
 }>;
 
 const path = recordsPath;
@@ -31,7 +35,7 @@ const validate = validateRecords<DeleteRecords>();
 const handler = async (req: EndpointRequest<DeleteRecords>, res: EndpointResponse<DeleteRecords>) => {
     const {
         params: { environmentId, nangoConnectionId, syncId, syncJobId },
-        body: { model, records, providerConfigKey, connectionId, activityLogId }
+        body: { model, records, providerConfigKey, connectionId, activityLogId, merging }
     } = req;
     const result = await persistRecords({
         persistType: 'delete',
@@ -43,10 +47,11 @@ const handler = async (req: EndpointRequest<DeleteRecords>, res: EndpointRespons
         syncJobId,
         model,
         records,
-        activityLogId
+        activityLogId,
+        merging
     });
     if (result.isOk()) {
-        res.status(204).send();
+        res.status(200).send({ nextMerging: result.value });
     } else {
         res.status(500).json({ error: { code: 'delete_records_failed', message: `Failed to delete records: ${result.error.message}` } });
     }

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/putRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/putRecords.ts
@@ -2,6 +2,7 @@ import type { ApiError, Endpoint } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, RouteHandler } from '@nangohq/utils';
 import { persistRecords, recordsPath } from '../../../../../../../../../records.js';
 import { validateRecords } from './validate.js';
+import type { MergingStrategy } from '@nangohq/records';
 
 type PutRecords = Endpoint<{
     Method: typeof method;
@@ -18,9 +19,12 @@ type PutRecords = Endpoint<{
         providerConfigKey: string;
         connectionId: string;
         activityLogId: string;
+        merging: MergingStrategy;
     };
     Error: ApiError<'put_records_failed'>;
-    Success: never;
+    Success: {
+        nextMerging: MergingStrategy;
+    };
 }>;
 
 const path = recordsPath;
@@ -31,7 +35,7 @@ const validate = validateRecords<PutRecords>();
 const handler = async (req: EndpointRequest<PutRecords>, res: EndpointResponse<PutRecords>) => {
     const {
         params: { environmentId, nangoConnectionId, syncId, syncJobId },
-        body: { model, records, providerConfigKey, connectionId, activityLogId }
+        body: { model, records, providerConfigKey, connectionId, activityLogId, merging }
     } = req;
     const result = await persistRecords({
         persistType: 'update',
@@ -43,10 +47,11 @@ const handler = async (req: EndpointRequest<PutRecords>, res: EndpointResponse<P
         syncJobId,
         model,
         records,
-        activityLogId
+        activityLogId,
+        merging
     });
     if (result.isOk()) {
-        res.status(204).send();
+        res.status(200).send({ nextMerging: result.value });
     } else {
         res.status(500).json({ error: { code: 'put_records_failed', message: `Failed to update records: ${result.error.message}` } });
     }

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/validate.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/validate.ts
@@ -2,6 +2,16 @@ import { z } from 'zod';
 import { validateRequest } from '@nangohq/utils';
 import type { Endpoint } from '@nangohq/types';
 
+const mergingStrategySchema = z.discriminatedUnion('strategy', [
+    z.object({
+        strategy: z.literal('override')
+    }),
+    z.object({
+        strategy: z.literal('ignore_if_modified_after_cursor'),
+        cursor: z.string()
+    })
+]);
+
 export const validateRecords = <E extends Endpoint<any>>() =>
     validateRequest<E>({
         parseBody: (data: unknown) =>
@@ -21,7 +31,8 @@ export const validateRecords = <E extends Endpoint<any>>() =>
                     environmentId: z.coerce.number().int().positive(),
                     nangoConnectionId: z.coerce.number().int().positive(),
                     syncId: z.string(),
-                    syncJobId: z.coerce.number().int().positive()
+                    syncJobId: z.coerce.number().int().positive(),
+                    merging: mergingStrategySchema.default({ strategy: 'override' })
                 })
                 .strict()
                 .parse(data)

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/validate.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/validate.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+import { validateRequest } from '@nangohq/utils';
+import type { Endpoint } from '@nangohq/types';
+
+export const validateCursor = <E extends Endpoint<any>>() =>
+    validateRequest<E>({
+        parseQuery: (data: unknown) =>
+            z
+                .object({
+                    model: z.string(),
+                    offset: z.union([z.literal('first'), z.literal('last')])
+                })
+                .strict()
+                .parse(data),
+        parseParams: (data: unknown) =>
+            z
+                .object({
+                    environmentId: z.coerce.number().int().positive(),
+                    nangoConnectionId: z.coerce.number().int().positive()
+                })
+                .strict()
+                .parse(data)
+    });

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -15,7 +15,7 @@ import {
     getProvider
 } from '@nangohq/shared';
 import { logContextGetter, migrateLogsMapping } from '@nangohq/logs';
-import { migrate as migrateRecords } from '@nangohq/records';
+import { migrate as migrateRecords, records } from '@nangohq/records';
 import type { DBEnvironment, DBTeam } from '@nangohq/types';
 
 const mockSecretKey = 'secret-key';
@@ -145,7 +145,7 @@ describe('Persist API', () => {
                     }
                 }
             );
-            expect(response.status).toEqual(204);
+            expect(response.status).toEqual(200);
         });
     });
 
@@ -172,7 +172,7 @@ describe('Persist API', () => {
                 }
             }
         );
-        expect(response.status).toEqual(204);
+        expect(response.status).toEqual(200);
     });
 
     it('should update records ', async () => {
@@ -198,7 +198,7 @@ describe('Persist API', () => {
                 }
             }
         );
-        expect(response.status).toEqual(204);
+        expect(response.status).toEqual(200);
     });
 
     it('should fail if passing incorrect authorization header ', async () => {
@@ -251,6 +251,108 @@ describe('Persist API', () => {
                     }
                 ]
             }
+        });
+    });
+
+    describe('getCursor', () => {
+        it('should return an empty response if no records', async () => {
+            const model = 'does-not-exist';
+            const cursorUrl = `${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/cursor?model=${model}&offset=last`;
+            const response = await fetch(cursorUrl, {
+                method: 'GET',
+                headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+            expect(response.status).toEqual(200);
+            expect(await response.json()).toStrictEqual({});
+        });
+        it('should return first cursor', async () => {
+            const model = 'ModelFirstCursor';
+
+            // Save records
+            await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/sync/${seed.sync.id}/job/${seed.syncJob.id}/records`, {
+                method: 'POST',
+                body: JSON.stringify({
+                    model,
+                    records: [
+                        { id: 1, name: 'r1' },
+                        { id: 2, name: 'r2' },
+                        { id: 3, name: 'r3' }
+                    ],
+                    providerConfigKey: seed.connection.provider_config_key,
+                    connectionId: seed.connection.connection_id,
+                    activityLogId: seed.activityLogId
+                }),
+                headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+            const allRecords = (
+                await records.getRecords({
+                    connectionId: seed.connection.id!,
+                    model
+                })
+            ).unwrap();
+            const firstRecord = allRecords.records[0];
+
+            const cursorUrl = `${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/cursor?model=${model}&offset=first`;
+            const response = await fetch(cursorUrl, {
+                method: 'GET',
+                headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+            expect(response.status).toEqual(200);
+            expect(await response.json()).toStrictEqual({
+                cursor: firstRecord?._nango_metadata.cursor
+            });
+        });
+        it('should return last cursor', async () => {
+            const model = 'ModelLastCursor';
+
+            // Save records
+            await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/sync/${seed.sync.id}/job/${seed.syncJob.id}/records`, {
+                method: 'POST',
+                body: JSON.stringify({
+                    model,
+                    records: [
+                        { id: 1, name: 'r1' },
+                        { id: 2, name: 'r2' },
+                        { id: 3, name: 'r3' }
+                    ],
+                    providerConfigKey: seed.connection.provider_config_key,
+                    connectionId: seed.connection.connection_id,
+                    activityLogId: seed.activityLogId
+                }),
+                headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+            const allRecords = (
+                await records.getRecords({
+                    connectionId: seed.connection.id!,
+                    model
+                })
+            ).unwrap();
+            const lastRecord = allRecords.records[allRecords.records.length - 1];
+
+            const cursorUrl = `${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/cursor?model=${model}&offset=last`;
+            const response = await fetch(cursorUrl, {
+                method: 'GET',
+                headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+            expect(response.status).toEqual(200);
+            expect(await response.json()).toStrictEqual({
+                cursor: lastRecord?._nango_metadata.cursor
+            });
         });
     });
 });

--- a/packages/persist/lib/server.ts
+++ b/packages/persist/lib/server.ts
@@ -7,6 +7,7 @@ import { routeHandler as postLogHandler, path as logsPath } from './routes/envir
 import { routeHandler as postRecordsHandler } from './routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/postRecords.js';
 import { routeHandler as putRecordsHandler } from './routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/putRecords.js';
 import { routeHandler as deleteRecordsHandler } from './routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteRecords.js';
+import { routeHandler as getCursorHandler } from './routes/environment/environmentId/connection/connectionId/getCursor.js';
 import { recordsPath } from './records.js';
 
 const logger = getLogger('Persist');
@@ -20,7 +21,7 @@ if (process.env['ENABLE_REQUEST_LOG'] !== 'false') {
     server.use(requestLoggerMiddleware({ logger }));
 }
 
-server.use('/environment/:environmentId/*', authMiddleware);
+server.use('/environment/:environmentId/*', authMiddleware, express.json());
 server.use(logsPath, express.json({ limit: maxSizeJsonLog }));
 server.use(recordsPath, express.json({ limit: maxSizeJsonRecords }));
 
@@ -29,6 +30,7 @@ createRoute(server, postLogHandler);
 createRoute(server, postRecordsHandler);
 createRoute(server, deleteRecordsHandler);
 createRoute(server, putRecordsHandler);
+createRoute(server, getCursorHandler);
 
 server.use((_req: Request, res: Response, next: NextFunction) => {
     res.status(404);

--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -6,7 +6,7 @@ import { RECORDS_TABLE } from '../constants.js';
 import { db } from '../db/client.js';
 import * as Records from '../models/records.js';
 import { formatRecords } from '../helpers/format.js';
-import type { FormattedRecord, UnencryptedRecordData, UpsertSummary } from '../types.js';
+import type { FormattedRecord, UnencryptedRecordData, UpsertSummary, MergingStrategy } from '../types.js';
 
 describe('Records service', () => {
     beforeAll(async () => {
@@ -68,14 +68,27 @@ describe('Records service', () => {
             { id: '4', name: 'Mike Doe' }
         ];
         const inserted = await upsertRecords({ records, connectionId, environmentId, model, syncId, syncJobId: 1 });
-        expect(inserted).toStrictEqual({ addedKeys: ['1', '2', '3', '4'], updatedKeys: [], deletedKeys: [], nonUniqueKeys: ['1'] });
+        expect(inserted).toStrictEqual({
+            addedKeys: ['1', '2', '3', '4'],
+            updatedKeys: [],
+            deletedKeys: [],
+            nonUniqueKeys: ['1'],
+            nextMerging: { strategy: 'override' }
+        });
 
         const newRecords = [
             { id: '1', name: 'John Doe' }, // same
             { id: '2', name: 'Jane Moe' } // updated
         ];
         const upserted = await upsertRecords({ records: newRecords, connectionId, environmentId, model, syncId, syncJobId: 2 });
-        expect(upserted).toStrictEqual({ addedKeys: [], updatedKeys: ['2'], deletedKeys: [], nonUniqueKeys: [] });
+        expect(upserted).toStrictEqual({
+            addedKeys: [],
+            updatedKeys: ['2'],
+            deletedKeys: [],
+            nonUniqueKeys: [],
+
+            nextMerging: { strategy: 'override' }
+        });
 
         const after = await db.select<FormattedRecord[]>('*').from('nango_records.records').where({ connection_id: connectionId, model });
         expect(after.find((r) => r.external_id === '1')?.sync_job_id).toBe(2);
@@ -84,7 +97,7 @@ describe('Records service', () => {
         expect(after.find((r) => r.external_id === '4')?.sync_job_id).toBe(1);
 
         const updated = await updateRecords({ records: [{ id: '1', name: 'Maurice Doe' }], connectionId, model, syncId, syncJobId: 3 });
-        expect(updated).toStrictEqual({ addedKeys: [], updatedKeys: ['1'], deletedKeys: [], nonUniqueKeys: [] });
+        expect(updated).toStrictEqual({ addedKeys: [], updatedKeys: ['1'], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
     });
 
     describe('upserting records', () => {
@@ -102,14 +115,26 @@ describe('Records service', () => {
                     { id: '4', name: 'Mike Doe' }
                 ];
                 const inserted = await upsertRecords({ records, connectionId, environmentId, model, syncId, syncJobId: 1 });
-                expect(inserted).toStrictEqual({ addedKeys: ['1', '2', '3', '4'], updatedKeys: [], deletedKeys: [], nonUniqueKeys: ['1'] });
+                expect(inserted).toStrictEqual({
+                    addedKeys: ['1', '2', '3', '4'],
+                    updatedKeys: [],
+                    deletedKeys: [],
+                    nonUniqueKeys: ['1'],
+                    nextMerging: { strategy: 'override' }
+                });
 
                 const newRecords = [
                     { id: '1', name: 'John Doe' }, // same
                     { id: '2', name: 'Jane Moe' } // updated
                 ];
                 const upserted = await upsertRecords({ records: newRecords, connectionId, environmentId, model, syncId, syncJobId: 2 });
-                expect(upserted).toStrictEqual({ addedKeys: [], updatedKeys: ['2'], deletedKeys: [], nonUniqueKeys: [] });
+                expect(upserted).toStrictEqual({
+                    addedKeys: [],
+                    updatedKeys: ['2'],
+                    deletedKeys: [],
+                    nonUniqueKeys: [],
+                    nextMerging: { strategy: 'override' }
+                });
 
                 const after = await db.select<FormattedRecord[]>('*').from('nango_records.records').where({ connection_id: connectionId, model });
                 expect(after.find((r) => r.external_id === '1')?.sync_job_id).toBe(2);
@@ -130,7 +155,13 @@ describe('Records service', () => {
                 ];
                 // insert initial records
                 const inserted = await upsertRecords({ records, connectionId, environmentId, model, syncId, syncJobId: 1 });
-                expect(inserted).toStrictEqual({ addedKeys: ['1', '2', '3', '4'], updatedKeys: [], deletedKeys: [], nonUniqueKeys: [] });
+                expect(inserted).toStrictEqual({
+                    addedKeys: ['1', '2', '3', '4'],
+                    updatedKeys: [],
+                    deletedKeys: [],
+                    nonUniqueKeys: [],
+                    nextMerging: { strategy: 'override' }
+                });
 
                 // Get cursor of last record
                 const cursor = (await Records.getCursor({ connectionId, model, offset: 'last' })).unwrap();
@@ -144,7 +175,13 @@ describe('Records service', () => {
                     { id: '5', name: 'Another Doe' }
                 ];
                 const added = await upsertRecords({ records: moreRecords, connectionId, environmentId, model, syncId, syncJobId: 2 });
-                expect(added).toStrictEqual({ addedKeys: ['5'], updatedKeys: ['4'], deletedKeys: [], nonUniqueKeys: [] });
+                expect(added).toStrictEqual({
+                    addedKeys: ['5'],
+                    updatedKeys: ['4'],
+                    deletedKeys: [],
+                    nonUniqueKeys: [],
+                    nextMerging: { strategy: 'override' }
+                });
 
                 // upsert records with merging strategy 'ignore_if_modified_after_cursor'
                 const upserted = await upsertRecords({
@@ -161,7 +198,14 @@ describe('Records service', () => {
                     merging: { strategy: 'ignore_if_modified_after_cursor', cursor }
                 });
                 // only '1' should be updated because '4' and '5' were modified after the cursor
-                expect(upserted).toStrictEqual({ addedKeys: [], updatedKeys: ['1'], deletedKeys: [], nonUniqueKeys: [] });
+                const nextCursor = (await Records.getCursor({ connectionId, model, offset: 'last' })).unwrap();
+                expect(upserted).toStrictEqual({
+                    addedKeys: [],
+                    updatedKeys: ['1'],
+                    deletedKeys: [],
+                    nonUniqueKeys: [],
+                    nextMerging: { strategy: 'ignore_if_modified_after_cursor', cursor: nextCursor }
+                });
             });
         });
     });
@@ -181,10 +225,16 @@ describe('Records service', () => {
                     { id: '4', name: 'Mike Doe' }
                 ];
                 const inserted = await upsertRecords({ records, connectionId, environmentId, model, syncId, syncJobId: 1 });
-                expect(inserted).toStrictEqual({ addedKeys: ['1', '2', '3', '4'], updatedKeys: [], deletedKeys: [], nonUniqueKeys: ['1'] });
+                expect(inserted).toStrictEqual({
+                    addedKeys: ['1', '2', '3', '4'],
+                    updatedKeys: [],
+                    deletedKeys: [],
+                    nonUniqueKeys: ['1'],
+                    nextMerging: { strategy: 'override' }
+                });
 
                 const updated = await updateRecords({ records: [{ id: '1', name: 'Maurice Doe' }], connectionId, model, syncId, syncJobId: 2 });
-                expect(updated).toStrictEqual({ addedKeys: [], updatedKeys: ['1'], deletedKeys: [], nonUniqueKeys: [] });
+                expect(updated).toStrictEqual({ addedKeys: [], updatedKeys: ['1'], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
             });
             it('when strategy = ignore_if_modified_after_cursor', async () => {
                 const connectionId = rnd.number();
@@ -200,7 +250,13 @@ describe('Records service', () => {
 
                 // insert initial records
                 const inserted = await upsertRecords({ records, connectionId, environmentId, model, syncId, syncJobId: 1 });
-                expect(inserted).toStrictEqual({ addedKeys: ['1', '2', '3', '4'], updatedKeys: [], deletedKeys: [], nonUniqueKeys: [] });
+                expect(inserted).toStrictEqual({
+                    addedKeys: ['1', '2', '3', '4'],
+                    updatedKeys: [],
+                    deletedKeys: [],
+                    nonUniqueKeys: [],
+                    nextMerging: { strategy: 'override' }
+                });
 
                 // Get cursor of last record
                 const cursor = (await Records.getCursor({ connectionId, model, offset: 'last' })).unwrap();
@@ -216,7 +272,7 @@ describe('Records service', () => {
                     syncId,
                     syncJobId: 2
                 });
-                expect(updated).toStrictEqual({ addedKeys: [], updatedKeys: ['4'], deletedKeys: [], nonUniqueKeys: [] });
+                expect(updated).toStrictEqual({ addedKeys: [], updatedKeys: ['4'], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
 
                 // update records with merging strategy 'ignore_if_modified_after_cursor'
                 const upserted = await updateRecords({
@@ -231,7 +287,14 @@ describe('Records service', () => {
                     merging: { strategy: 'ignore_if_modified_after_cursor', cursor }
                 });
                 // only '1' should be updated because '4' were modified after the cursor
-                expect(upserted).toStrictEqual({ addedKeys: [], updatedKeys: ['1'], deletedKeys: [], nonUniqueKeys: [] });
+                const nextCursor = (await Records.getCursor({ connectionId, model, offset: 'last' })).unwrap();
+                expect(upserted).toStrictEqual({
+                    addedKeys: [],
+                    updatedKeys: ['1'],
+                    deletedKeys: [],
+                    nonUniqueKeys: [],
+                    nextMerging: { strategy: 'ignore_if_modified_after_cursor', cursor: nextCursor }
+                });
             });
         });
     });
@@ -279,12 +342,12 @@ describe('Records service', () => {
             { id: '2', name: 'Jane Doe' }
         ];
         const res1 = await upsertRecords({ records: toDelete, connectionId, environmentId, model, syncId, softDelete: true });
-        expect(res1).toStrictEqual({ addedKeys: [], updatedKeys: [], deletedKeys: ['1', '2'], nonUniqueKeys: [] });
+        expect(res1).toStrictEqual({ addedKeys: [], updatedKeys: [], deletedKeys: ['1', '2'], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
 
         // Try to delete the same records again
         // Should not have any effect
         const res2 = await upsertRecords({ records: toDelete, connectionId, environmentId, model, syncId, softDelete: true });
-        expect(res2).toStrictEqual({ addedKeys: [], updatedKeys: [], deletedKeys: [], nonUniqueKeys: [] });
+        expect(res2).toStrictEqual({ addedKeys: [], updatedKeys: [], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
     });
 
     it('Should retrieve records', async () => {
@@ -410,10 +473,11 @@ describe('Records service', () => {
                 addedKeys: acc.addedKeys.concat(curr.addedKeys),
                 updatedKeys: acc.updatedKeys.concat(curr.updatedKeys),
                 deletedKeys: (acc.deletedKeys || []).concat(curr.deletedKeys || []),
-                nonUniqueKeys: acc.nonUniqueKeys.concat(curr.nonUniqueKeys)
+                nonUniqueKeys: acc.nonUniqueKeys.concat(curr.nonUniqueKeys),
+                nextMerging: curr.nextMerging
             };
         });
-        expect(agg).toStrictEqual({ addedKeys: ['1'], updatedKeys: [], deletedKeys: [], nonUniqueKeys: [] });
+        expect(agg).toStrictEqual({ addedKeys: ['1'], updatedKeys: [], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
     });
 });
 
@@ -449,7 +513,7 @@ async function upsertRecords({
     syncId: string;
     syncJobId?: number;
     softDelete?: boolean;
-    merging?: Records.MergingStrategy;
+    merging?: MergingStrategy;
 }): Promise<UpsertSummary> {
     const formatRes = formatRecords({ data: records, connectionId, model, syncId, syncJobId, softDelete });
     if (formatRes.isErr()) {
@@ -475,7 +539,7 @@ async function updateRecords({
     model: string;
     syncId: string;
     syncJobId?: number;
-    merging?: Records.MergingStrategy;
+    merging?: MergingStrategy;
 }) {
     const formatRes = formatRecords({ data: records, connectionId, model, syncId, syncJobId });
     if (formatRes.isErr()) {

--- a/packages/records/lib/types.ts
+++ b/packages/records/lib/types.ts
@@ -55,6 +55,7 @@ export interface UpsertSummary {
     updatedKeys: string[];
     deletedKeys?: string[];
     nonUniqueKeys: string[];
+    nextMerging: MergingStrategy;
 }
 
 export interface RecordCount {
@@ -64,3 +65,7 @@ export interface RecordCount {
     count: number;
     updated_at: string;
 }
+
+export type MergingStrategy = { strategy: 'override' } | { strategy: 'ignore_if_modified_after_cursor'; cursor: string };
+
+export type CursorOffset = 'first' | 'last';


### PR DESCRIPTION
- add an endpoint to fetch the last cursor for a given connection/model
- pass merging strategy to records.upsert/update
- modify records.upsert/update to return the next merging strategy

Next step will be to 
- add a `setMergingStrategy()` function to the runner SDK. This function would potentially fetches the last cursor.
- modify `batch...` functions to send the merging strategy and update its current value from persist response.
- 
Note: I am gonna wait for you @bodinsamuel to merge the runner SDK changes

