### PR TITLE
fix(webhooks): Regression where body wasn't logged after webhook log enrichment

### DIFF
--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -131,6 +131,7 @@ export interface MessageRow {
         url: string;
         method: string;
         headers: Record<string, string>;
+        body?: unknown;
     } | null;
     response: {
         code: number;

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -148,7 +148,8 @@ export const deliver = async ({
         const logRequest: MessageRow['request'] = {
             method: 'POST',
             url,
-            headers: redactHeaders({ headers: filteredHeaders })
+            headers: redactHeaders({ headers: filteredHeaders }),
+            body
         };
 
         try {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
In the recent [webhook enrichment PR](https://github.com/NangoHQ/nango/pull/3319/files#diff-8face0f177f50ba86b04ad2e2c400cfb8df03497f4ceaf5e16222d9468f8b4f1L147-R168) I moved to our standard http logging mechanism. Unfortunately in doing so we removed logging the body of the request. This adds the appropriate mechanism to log the body when desired and adds it back to webhook logs.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->
## How I tested it

- Run a webhook and confirm the body is recorded
