### PR TITLE
fix(cli): Update dry run to exclude nango prop on output.json files

### DIFF
--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import promptly from 'promptly';
 import fs from 'node:fs';
 import { AxiosError } from 'axios';
@@ -380,7 +379,8 @@ export class DryRunService {
                         const directoryName = `${responseDirectoryPrefix}${providerConfigKey}`;
                         responseSaver.ensureDirectoryExists(`${directoryName}/mocks/${syncName}`);
                         const filePath = `${directoryName}/mocks/${syncName}/output.json`;
-                        fs.writeFileSync(filePath, JSON.stringify(results.response, null, 2));
+                        const { nango, ...responseWithoutNango } = results.response;
+                        fs.writeFileSync(filePath, JSON.stringify(responseWithoutNango, null, 2));
                     }
                     resultOutput.push(JSON.stringify(results.response, null, 2));
                 }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
We started including a `nango` prop on dry run responses as part of the shared removal, but unfortunately it started dumping to disk and shouldn't be. This PR removes that nango prop from the output.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

## How I tested it

Make sure this code is built and that cli is linked, and then run the following from integration-templates:

```
npm run dryrun -- basecamp create-todo 4f3b3cee-7593-400e-b42e-dbaf5a48e9c1 -i @basecamp/fixtures/create-todo.json --save-responses
```

I did have to update the input temporarily to use Andrew's email address instead of the given one.

