### PR TITLE
fix(webapp): fix code generation for two_step

### DIFF
--- a/packages/webapp/src/pages/Connection/CreateLegacy.tsx
+++ b/packages/webapp/src/pages/Connection/CreateLegacy.tsx
@@ -570,13 +570,14 @@ export const ConnectionCreateLegacy: React.FC = () => {
             const credentialEntries = Object.entries(credentialsState);
 
             if (credentialEntries.length > 0) {
-                const credentialsString = credentialEntries.map(([key, value]) => `${key}: '${value}'`).join(',\n        ');
+                const credentialsString = credentialEntries.map(([key, value]) => `${key}: '${value}'`).join(',\n      ');
 
                 twoStepCredentialsString = `
-        credentials: {
-            ${credentialsString}
-        }
-        `;
+    credentials: {
+      ${credentialsString},
+      type: 'TWO_STEP'
+    }
+  `;
             }
         }
         const connectionConfigStr =


### PR DESCRIPTION
## Describe the problem and your solution 
The code being generate was missing  the `type: 'TWO_STEP'` property within credentials, which is crucial when creating a new connection using the frontend sdk in `TWO_STEP`.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

