### PR TITLE
fix(cli): Remove directory requirement in verification service

### DIFF
--- a/packages/cli/lib/constants.ts
+++ b/packages/cli/lib/constants.ts
@@ -1,5 +1,4 @@
 export const TYPES_FILE_NAME = 'models.ts';
-export const NANGO_INTEGRATIONS_NAME = 'nango-integrations';
 export const exampleSyncName = 'github-issue-example';
 
 export const port = process.env['NANGO_PORT'] || process.env['SERVER_PORT'] || '3003';

--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -96,7 +96,7 @@ program
         const ok = init({ absolutePath, debug });
 
         if (ok) {
-            console.log(chalk.green(`Nango integrations initialized!`));
+            console.log(chalk.green(`Nango integrations initialized in ${absolutePath}!`));
         }
     });
 

--- a/packages/cli/lib/services/verification.service.ts
+++ b/packages/cli/lib/services/verification.service.ts
@@ -2,12 +2,10 @@ import fs from 'fs';
 import chalk from 'chalk';
 import promptly from 'promptly';
 import path from 'path';
-
 import { nangoConfigFile } from '@nangohq/nango-yaml';
 import { parse } from './config.service.js';
 import { compileAllFiles, listFilesToCompile } from './compile.service.js';
 import { printDebug } from '../utils.js';
-import { NANGO_INTEGRATIONS_NAME } from '../constants.js';
 import { generate } from '../cli.js';
 import { init } from './init.service.js';
 
@@ -30,11 +28,6 @@ class VerificationService {
         const currentDirectory = path.basename(fullPath);
         if (debug) {
             printDebug(`Current stripped directory is read as: ${currentDirectory}`);
-        }
-
-        if (currentDirectory !== NANGO_INTEGRATIONS_NAME) {
-            console.log(chalk.red(`You must run this command in the ${NANGO_INTEGRATIONS_NAME} directory.`));
-            process.exit(1);
         }
 
         if (!fs.existsSync(path.join(fullPath, nangoConfigFile))) {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Mentioned by Samuel. Also adds output of the init directory:

<img width="912" alt="image" src="https://github.com/user-attachments/assets/bf733a50-2caf-48ff-86f3-810b959b0062" />


<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

