### PR TITLE
fix(api): better check for json content-type 

### DIFF
--- a/packages/server/lib/middleware/json.middleware.ts
+++ b/packages/server/lib/middleware/json.middleware.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from 'express';
 
 export const jsonContentTypeMiddleware: RequestHandler = (req, res, next) => {
-    if (req.headers['content-type'] && req.headers['content-type'] !== 'application/json') {
+    if (req.headers['content-type'] && !req.is('application/json')) {
         // Send error here
         res.status(415).json({ error: { code: 'invalid_content_type', message: 'Content-Type header must be application/json' } });
         return;


### PR DESCRIPTION
## Changes

- better check for json content-type 
Header can have the charset specified but we only checked exact match, express has a function to handle this check so it simplifies this condition `content-type: application/json; charset=utf-8`
