### PR TITLE
fix: fleet to fetch all nodes at once

### DIFF
--- a/packages/fleet/lib/fleet.ts
+++ b/packages/fleet/lib/fleet.ts
@@ -86,16 +86,16 @@ export class Fleet {
             if (search.isErr()) {
                 return Err(search.error);
             }
-            const running = search.value.nodes.get(routingId)?.RUNNING || [];
+            const running = search.value.get(routingId)?.RUNNING || [];
             if (running[0]) {
                 return Ok(running[0]);
             }
-            const outdated = search.value.nodes.get(routingId)?.OUTDATED || [];
+            const outdated = search.value.get(routingId)?.OUTDATED || [];
             if (outdated[0]) {
                 return Ok(outdated[0]);
             }
-            const starting = search.value.nodes.get(routingId)?.STARTING || [];
-            const pending = search.value.nodes.get(routingId)?.PENDING || [];
+            const starting = search.value.get(routingId)?.STARTING || [];
+            const pending = search.value.get(routingId)?.PENDING || [];
 
             if (!starting[0] && !pending[0]) {
                 await withPgLock({

--- a/packages/fleet/lib/supervisor/supervisor.integration.test.ts
+++ b/packages/fleet/lib/supervisor/supervisor.integration.test.ts
@@ -128,7 +128,7 @@ describe('Supervisor', () => {
 
         await supervisor.tick();
 
-        const newNode = (await nodes.search(dbClient.db, { states: ['PENDING'] })).unwrap().nodes.get(node.routingId)?.PENDING[0];
+        const newNode = (await nodes.search(dbClient.db, { states: ['PENDING'] })).unwrap().get(node.routingId)?.PENDING[0];
         expect(newNode).toMatchObject({
             state: 'PENDING',
             routingId: node.routingId,
@@ -159,7 +159,7 @@ describe('Supervisor', () => {
 
         await supervisor.tick();
 
-        const newNode = (await nodes.search(dbClient.db, { states: ['PENDING'] })).unwrap().nodes.get(node.routingId)?.PENDING[0];
+        const newNode = (await nodes.search(dbClient.db, { states: ['PENDING'] })).unwrap().get(node.routingId)?.PENDING[0];
         expect(newNode).toMatchObject({
             state: 'PENDING',
             routingId: node.routingId,
@@ -175,7 +175,7 @@ describe('Supervisor', () => {
     it('should create new nodes if only OUTDATED', async () => {
         const node = await createNodeWithAttributes(dbClient.db, { state: 'OUTDATED', deploymentId: previousDeployment.id });
         await supervisor.tick();
-        const { nodes: pendingNodes } = (await nodes.search(dbClient.db, { states: ['PENDING'] })).unwrap();
+        const pendingNodes = (await nodes.search(dbClient.db, { states: ['PENDING'] })).unwrap();
         expect(pendingNodes.get(node.routingId)).toMatchObject({
             PENDING: [
                 {
@@ -224,12 +224,11 @@ describe('Supervisor', () => {
     });
 
     it('should remove old TERMINATED nodes', async () => {
-        const sevenDaysAgo = new Date(Date.now() - STATE_TIMEOUT_MS.TERMINATED - 1);
         const terminatedNode = await createNodeWithAttributes(dbClient.db, { state: 'TERMINATED', deploymentId: activeDeployment.id });
         const oldTerminatedNode = await createNodeWithAttributes(dbClient.db, {
             state: 'TERMINATED',
             deploymentId: activeDeployment.id,
-            lastStateTransitionAt: sevenDaysAgo
+            lastStateTransitionAt: new Date(Date.now() - STATE_TIMEOUT_MS.TERMINATED - 1)
         });
 
         await supervisor.tick();
@@ -247,12 +246,11 @@ describe('Supervisor', () => {
     });
 
     it('should remove old ERROR nodes', async () => {
-        const sevenDaysAgo = new Date(Date.now() - STATE_TIMEOUT_MS.ERROR - 1);
         const errorNode = await createNodeWithAttributes(dbClient.db, { state: 'ERROR', deploymentId: activeDeployment.id });
         const oldErrorNode = await createNodeWithAttributes(dbClient.db, {
             state: 'ERROR',
             deploymentId: activeDeployment.id,
-            lastStateTransitionAt: sevenDaysAgo
+            lastStateTransitionAt: new Date(Date.now() - STATE_TIMEOUT_MS.ERROR - 1)
         });
 
         await supervisor.tick();


### PR DESCRIPTION
Fleet supervisor must know about all active nodes to be able to plan correctly. Before this fix, supervisor was planning one page at a time which could lead to starting operations based on missing information (ex: page includes the OUTDATED node for a given routingId but the PENDING entry is not in the same page, leading the supervisor to believe it must create a PENDING node)

