### PR TITLE
chore: fleet improvements

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -90,7 +90,7 @@ jobs:
                   curl -sS --fail-with-body --request POST "https://$NANGO_API_HOSTNAME/internal/fleet/nango_runners/rollout" \
                     --header "authorization: Bearer $INTERNAL_API_KEY"\
                     --header "content-type: application/json"\
-                    --data "{ \"commitHash\": \"${{ github.sha }}\" }"
+                    --data "{ \"image\": \"nangohq/nango-runner:${{ github.sha }}\" }"
 
     deploy_persist:
         if: inputs.service == 'persist'

--- a/packages/fleet/lib/db/migrations/20250203195014_deployment_image.ts
+++ b/packages/fleet/lib/db/migrations/20250203195014_deployment_image.ts
@@ -1,0 +1,35 @@
+import type { Knex } from 'knex';
+import { NODE_CONFIG_OVERRIDES_TABLE } from '../../models/node_config_overrides.js';
+import { DEPLOYMENTS_TABLE } from '../../models/deployments.js';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`
+        ALTER TABLE ${DEPLOYMENTS_TABLE}
+        ADD COLUMN IF NOT EXISTS "image" character varying(255)
+        DEFAULT 'nangohq/nango-runner:production'
+    `);
+    await knex.raw(`
+        UPDATE ${DEPLOYMENTS_TABLE}
+        SET image = CONCAT('nangohq/nango-runner:', commit_id)
+    `);
+    await knex.raw(`
+        ALTER TABLE ${DEPLOYMENTS_TABLE}
+        ALTER COLUMN "image" DROP DEFAULT,
+        ALTER COLUMN "image" SET NOT NULL
+    `);
+
+    await knex.raw(`
+        ALTER TABLE ${NODE_CONFIG_OVERRIDES_TABLE}
+        ALTER COLUMN "image" DROP NOT NULL,
+        ALTER COLUMN "cpu_milli" DROP NOT NULL,
+        ALTER COLUMN "memory_mb" DROP NOT NULL,
+        ALTER COLUMN "storage_mb" DROP NOT NULL
+    `);
+
+    await knex.raw(`
+        ALTER TABLE ${NODE_CONFIG_OVERRIDES_TABLE}
+        ADD COLUMN IF NOT EXISTS "notes" text
+    `);
+}
+
+export async function down(): Promise<void> {}

--- a/packages/fleet/lib/models/deployments.integration.test.ts
+++ b/packages/fleet/lib/models/deployments.integration.test.ts
@@ -1,7 +1,7 @@
 import { expect, describe, it, beforeEach, afterEach } from 'vitest';
 import * as deployments from './deployments.js';
 import { getTestDbClient } from '../db/helpers.test.js';
-import { generateCommitHash } from './helpers.js';
+import { generateImage } from './helpers.js';
 
 describe('Deployments', () => {
     const dbClient = getTestDbClient('deployments');
@@ -16,19 +16,20 @@ describe('Deployments', () => {
 
     describe('create', () => {
         it('should create a deployment', async () => {
-            const commitId = generateCommitHash().unwrap();
-            const deployment = (await deployments.create(db, commitId)).unwrap();
-            expect(deployment.commitId).toBe(commitId);
+            const image = generateImage().unwrap();
+            const deployment = (await deployments.create(db, image)).unwrap();
+            expect(deployment.commitId).toBe(image.split(':')[1]);
+            expect(deployment.image).toBe(image);
             expect(deployment.createdAt).toBeInstanceOf(Date);
             expect(deployment.supersededAt).toBe(null);
         });
 
         it('should supersede any active deployments', async () => {
-            const commitId1 = generateCommitHash().unwrap();
-            const commitId2 = generateCommitHash().unwrap();
+            const image1 = generateImage().unwrap();
+            const image2 = generateImage().unwrap();
 
-            const deployment1 = (await deployments.create(db, commitId1)).unwrap();
-            const deployment2 = (await deployments.create(db, commitId2)).unwrap();
+            const deployment1 = (await deployments.create(db, image1)).unwrap();
+            const deployment2 = (await deployments.create(db, image2)).unwrap();
 
             expect((await deployments.get(db, deployment1.id)).unwrap().supersededAt).not.toBe(null);
             expect((await deployments.get(db, deployment2.id)).unwrap().supersededAt).toBe(null);

--- a/packages/fleet/lib/models/deployments.ts
+++ b/packages/fleet/lib/models/deployments.ts
@@ -73,7 +73,6 @@ export async function create(db: knex.Knex, image: string): Promise<Result<Deplo
             return Ok(DBDeployment.to(inserted));
         });
     } catch (err) {
-        console.log(err);
         return Err(new FleetError(`deployment_creation_failed`, { cause: err, context: { image } }));
     }
 }

--- a/packages/fleet/lib/models/deployments.ts
+++ b/packages/fleet/lib/models/deployments.ts
@@ -9,6 +9,7 @@ export const DEPLOYMENTS_TABLE = 'deployments';
 interface DBDeployment {
     readonly id: number;
     readonly commit_id: CommitHash;
+    readonly image: string;
     readonly created_at: Date;
     readonly superseded_at: Date | null;
 }
@@ -18,6 +19,7 @@ const DBDeployment = {
         return {
             id: dbDeployment.id,
             commitId: dbDeployment.commit_id,
+            image: dbDeployment.image,
             createdAt: dbDeployment.created_at,
             supersededAt: dbDeployment.superseded_at
         };
@@ -25,6 +27,7 @@ const DBDeployment = {
     from(deployment: Deployment): DBDeployment {
         return {
             id: deployment.id,
+            image: deployment.image,
             commit_id: deployment.commitId,
             created_at: deployment.createdAt,
             superseded_at: deployment.supersededAt
@@ -32,15 +35,15 @@ const DBDeployment = {
     }
 };
 
-export async function create(db: knex.Knex, commitId: CommitHash): Promise<Result<Deployment>> {
+export async function create(db: knex.Knex, image: string): Promise<Result<Deployment>> {
     try {
         return await db.transaction(async (trx) => {
-            // do nothing if commitId is already active deployment
+            // do nothing if already active deployment
             const active = await getActive(db);
             if (active.isErr()) {
                 return Err(active.error);
             }
-            if (active.value?.commitId === commitId) {
+            if (active.value?.image === image) {
                 return Ok(active.value);
             }
 
@@ -53,19 +56,25 @@ export async function create(db: knex.Knex, commitId: CommitHash): Promise<Resul
                 })
                 .update({ superseded_at: now });
             // insert new deployment
+            const commitId = image.split(':')[1];
+            if (!commitId || commitId.length !== 40) {
+                return Err(new Error(`Error: invalid image '${image}'`));
+            }
             const dbDeployment: Omit<DBDeployment, 'id'> = {
-                commit_id: commitId,
+                commit_id: commitId as CommitHash,
+                image,
                 created_at: now,
                 superseded_at: null
             };
             const [inserted] = await trx.into<DBDeployment>(DEPLOYMENTS_TABLE).insert(dbDeployment).returning('*');
             if (!inserted) {
-                return Err(new Error(`Error: no deployment '${commitId}' created`));
+                return Err(new Error(`Error: no deployment for '${image}' created`));
             }
             return Ok(DBDeployment.to(inserted));
         });
     } catch (err) {
-        return Err(new FleetError(`deployment_creation_failed`, { cause: err, context: { commitId } }));
+        console.log(err);
+        return Err(new FleetError(`deployment_creation_failed`, { cause: err, context: { image } }));
     }
 }
 

--- a/packages/fleet/lib/models/helpers.ts
+++ b/packages/fleet/lib/models/helpers.ts
@@ -1,19 +1,18 @@
 import type { Result } from '@nangohq/utils';
 import { Err, Ok } from '@nangohq/utils';
-import type { CommitHash } from '@nangohq/types';
 import crypto from 'crypto';
 
-export function generateCommitHash(): Result<CommitHash> {
+export function generateImage(): Result<string> {
     const charset = '0123456789abcdef';
     const length = 40;
     const randomBytes = new Uint8Array(length);
     crypto.getRandomValues(randomBytes);
 
-    const value = Array.from(randomBytes)
+    const commitHash = Array.from(randomBytes)
         .map((byte) => charset[byte % charset.length])
         .join('');
-    if (value.length !== 40) {
+    if (commitHash.length !== 40) {
         return Err('CommitHash must be exactly 40 characters');
     }
-    return Ok(value as CommitHash);
+    return Ok(`generated/image:${commitHash}`);
 }

--- a/packages/fleet/lib/models/nodes.integration.test.ts
+++ b/packages/fleet/lib/models/nodes.integration.test.ts
@@ -5,7 +5,7 @@ import { nodeStates } from '../types.js';
 import type { NodeState } from '../types.js';
 import type { Deployment } from '@nangohq/types';
 import { getTestDbClient } from '../db/helpers.test.js';
-import { generateCommitHash } from './helpers.js';
+import { generateImage } from './helpers.js';
 import { createNodeWithAttributes } from './helpers.test.js';
 
 describe('Nodes', () => {
@@ -16,8 +16,8 @@ describe('Nodes', () => {
     let activeDeployment: Deployment;
     beforeEach(async () => {
         await dbClient.migrate();
-        previousDeployment = (await deployments.create(db, generateCommitHash().unwrap())).unwrap();
-        activeDeployment = (await deployments.create(db, generateCommitHash().unwrap())).unwrap();
+        previousDeployment = (await deployments.create(db, generateImage().unwrap())).unwrap();
+        activeDeployment = (await deployments.create(db, generateImage().unwrap())).unwrap();
     });
 
     afterEach(async () => {

--- a/packages/fleet/lib/supervisor/supervisor.integration.test.ts
+++ b/packages/fleet/lib/supervisor/supervisor.integration.test.ts
@@ -5,7 +5,7 @@ import { getTestDbClient } from '../db/helpers.test.js';
 import * as deployments from '../models/deployments.js';
 import * as nodes from '../models/nodes.js';
 import * as nodeConfigOverrides from '../models/node_config_overrides.js';
-import { generateCommitHash } from '../models/helpers.js';
+import { generateImage } from '../models/helpers.js';
 import { createNodeWithAttributes } from '../models/helpers.test.js';
 import type { Deployment } from '@nangohq/types';
 import { FleetError } from '../utils/errors.js';
@@ -34,8 +34,8 @@ describe('Supervisor', () => {
 
     beforeEach(async () => {
         await dbClient.migrate();
-        previousDeployment = (await deployments.create(dbClient.db, generateCommitHash().unwrap())).unwrap();
-        activeDeployment = (await deployments.create(dbClient.db, generateCommitHash().unwrap())).unwrap();
+        previousDeployment = (await deployments.create(dbClient.db, generateImage().unwrap())).unwrap();
+        activeDeployment = (await deployments.create(dbClient.db, generateImage().unwrap())).unwrap();
     });
 
     afterEach(async () => {

--- a/packages/fleet/lib/utils/errors.ts
+++ b/packages/fleet/lib/utils/errors.ts
@@ -24,6 +24,8 @@ type FleetErrorCode =
     | 'supervisor_unknown_action'
     | 'supervisor_tick_failed'
     | 'fleet_misconfigured'
+    | 'fleet_rollout_invalid_image'
+    | 'fleet_rollout_image_not_found'
     | 'fleet_node_not_ready_timeout'
     | 'fleet_node_url_not_found'
     | 'fleet_node_outdate_failed'

--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -9,7 +9,7 @@ import db from '@nangohq/database';
 import { getOtlpRoutes } from '@nangohq/shared';
 import { otlp } from '@nangohq/logs';
 import { runnersFleet } from './runner/fleet.js';
-import { generateCommitHash } from '@nangohq/fleet';
+import { generateImage } from '@nangohq/fleet';
 
 const logger = getLogger('Jobs');
 
@@ -78,11 +78,11 @@ try {
         // when running locally, the runners (running as processes) are being killed
         // when the main process is killed and the fleet entries are therefore not associated with any running process
         // we then must fake a new deployment so fleet replaces runners with new ones
-        const commitHash = generateCommitHash();
-        if (commitHash.isErr()) {
-            logger.error(`Unable to generate commit hash`, commitHash.error);
+        const image = generateImage();
+        if (image.isErr()) {
+            logger.error(`Unable to generate commit hash`, image.error);
         } else {
-            await runnersFleet.rollout(commitHash.value);
+            await runnersFleet.rollout(image.value, { verifyImage: false });
         }
     }
     runnersFleet.start();

--- a/packages/types/lib/fleet/api.ts
+++ b/packages/types/lib/fleet/api.ts
@@ -1,11 +1,11 @@
 import type { Endpoint, ApiError } from '../api.js';
-import type { CommitHash, Deployment } from './index.js';
+import type { Deployment } from './index.js';
 
 export type PostRollout = Endpoint<{
     Method: 'POST';
     Path: '/fleet/:fleetId/rollout';
     Body: {
-        commitHash: CommitHash;
+        image: string;
     };
     Params: {
         fleetId: string;

--- a/packages/types/lib/fleet/index.ts
+++ b/packages/types/lib/fleet/index.ts
@@ -3,6 +3,7 @@ export type CommitHash = string & { readonly length: 40 };
 export interface Deployment {
     readonly id: number;
     readonly commitId: CommitHash;
+    readonly image: string;
     readonly createdAt: Date;
     readonly supersededAt: Date | null;
 }


### PR DESCRIPTION
- adding 'image' column to deployment
    - it will make it easy to switch to another image without having to change fleet code (for example if we move runner to the unified image).
    - Note: the column is not used by fleet supervisor yet. Coming in next PR :)
- checking if the image exist when rolling out to avoid rolling out while master is building
- add 'notes' column to node_overrides
    - won't be used by the app but I wanted a text column where we can manually enter useful information like the name of the customer or 'Thomas's runner'
- making image, cpu_mill, memory_mb, storage_mb columns nullable in the node_overrides table. I will change the logic: if value is null, fleet will pick default values instead of having to insert specific values when overriding, especially useful for the image that changes with each deployment

