### PR TITLE
chore(fleet): simplify node config overrides

### DIFF
--- a/packages/fleet/lib/fleet.integration.test.ts
+++ b/packages/fleet/lib/fleet.integration.test.ts
@@ -49,7 +49,7 @@ describe('fleet', () => {
             expect(nodeConfigOverride.get('test')).toStrictEqual({
                 id: expect.any(Number),
                 routingId: props.routingId,
-                image,
+                image: null,
                 cpuMilli: props.cpuMilli,
                 memoryMb: props.memoryMb,
                 storageMb: props.storageMb,

--- a/packages/fleet/lib/fleet.integration.test.ts
+++ b/packages/fleet/lib/fleet.integration.test.ts
@@ -29,7 +29,6 @@ describe('fleet', () => {
         it('should create a new deployment', async () => {
             const image = generateImage().unwrap();
             const deployment = (await fleet.rollout(image, { verifyImage: false })).unwrap();
-            expect(deployment.commitId).toBe(image.split(':')[1]);
             expect(deployment.image).toBe(image);
             expect(deployment.createdAt).toBeInstanceOf(Date);
             expect(deployment.supersededAt).toBe(null);

--- a/packages/fleet/lib/fleet.ts
+++ b/packages/fleet/lib/fleet.ts
@@ -76,7 +76,7 @@ export class Fleet {
             }
 
             // rolling out cancels all nodeConfigOverrides images
-            await nodeConfigOverrides.resetImage(trx, { image });
+            await nodeConfigOverrides.resetImage(trx);
 
             return deployment;
         });

--- a/packages/fleet/lib/models/deployments.integration.test.ts
+++ b/packages/fleet/lib/models/deployments.integration.test.ts
@@ -18,7 +18,6 @@ describe('Deployments', () => {
         it('should create a deployment', async () => {
             const image = generateImage().unwrap();
             const deployment = (await deployments.create(db, image)).unwrap();
-            expect(deployment.commitId).toBe(image.split(':')[1]);
             expect(deployment.image).toBe(image);
             expect(deployment.createdAt).toBeInstanceOf(Date);
             expect(deployment.supersededAt).toBe(null);

--- a/packages/fleet/lib/models/deployments.ts
+++ b/packages/fleet/lib/models/deployments.ts
@@ -18,7 +18,6 @@ const DBDeployment = {
     to(dbDeployment: DBDeployment): Deployment {
         return {
             id: dbDeployment.id,
-            commitId: dbDeployment.commit_id,
             image: dbDeployment.image,
             createdAt: dbDeployment.created_at,
             supersededAt: dbDeployment.superseded_at
@@ -28,7 +27,7 @@ const DBDeployment = {
         return {
             id: deployment.id,
             image: deployment.image,
-            commit_id: deployment.commitId,
+            commit_id: '0000000000000000000000000000000000000000' as CommitHash, //TODO: remove
             created_at: deployment.createdAt,
             superseded_at: deployment.supersededAt
         };
@@ -56,12 +55,8 @@ export async function create(db: knex.Knex, image: string): Promise<Result<Deplo
                 })
                 .update({ superseded_at: now });
             // insert new deployment
-            const commitId = image.split(':')[1];
-            if (!commitId || commitId.length !== 40) {
-                return Err(new Error(`Error: invalid image '${image}'`));
-            }
             const dbDeployment: Omit<DBDeployment, 'id'> = {
-                commit_id: commitId as CommitHash,
+                commit_id: '0000000000000000000000000000000000000000' as CommitHash, // TODO remove
                 image,
                 created_at: now,
                 superseded_at: null

--- a/packages/fleet/lib/models/node_config_overrides.integration.test.ts
+++ b/packages/fleet/lib/models/node_config_overrides.integration.test.ts
@@ -2,7 +2,7 @@ import { expect, describe, it, beforeEach, afterEach } from 'vitest';
 import * as node_config_overrides from './node_config_overrides.js';
 import { getTestDbClient } from '../db/helpers.test.js';
 
-describe('Nodes', () => {
+describe('NodeConfgOverrides', () => {
     const dbClient = getTestDbClient('nodes');
 
     beforeEach(async () => {
@@ -30,6 +30,28 @@ describe('Nodes', () => {
             cpuMilli: props.cpuMilli,
             memoryMb: props.memoryMb,
             storageMb: props.storageMb,
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date)
+        });
+    });
+
+    it('should accept null attributes', async () => {
+        const nodeConfigOverride = (
+            await node_config_overrides.create(dbClient.db, {
+                routingId: 'routing-id',
+                image: null,
+                cpuMilli: null,
+                memoryMb: null,
+                storageMb: null
+            })
+        ).unwrap();
+        expect(nodeConfigOverride).toStrictEqual({
+            id: expect.any(Number),
+            routingId: props.routingId,
+            image: null,
+            cpuMilli: null,
+            memoryMb: null,
+            storageMb: null,
             createdAt: expect.any(Date),
             updatedAt: expect.any(Date)
         });

--- a/packages/fleet/lib/models/node_config_overrides.ts
+++ b/packages/fleet/lib/models/node_config_overrides.ts
@@ -131,17 +131,17 @@ export async function search(
     }
 }
 
-export async function resetImage(db: knex.Knex, props: Pick<NodeConfigOverride, 'image'>): Promise<Result<NodeConfigOverride[], FleetError>> {
+export async function resetImage(db: knex.Knex): Promise<Result<NodeConfigOverride[], FleetError>> {
     try {
         const toUpdate: Partial<DBNodeConfigOverride> = {
-            image: props.image
+            image: null
         };
         const updated = await db.from<DBNodeConfigOverride>(NODE_CONFIG_OVERRIDES_TABLE).update(toUpdate).returning('*');
         if (!updated) {
-            return Err(new FleetError('node_config_override_reset_image_failed', { context: props }));
+            return Err(new FleetError('node_config_override_reset_image_failed'));
         }
         return Ok(updated.map(DBNodeConfigOverride.from));
     } catch (err) {
-        return Err(new FleetError('node_config_override_reset_image_failed', { cause: err, context: props }));
+        return Err(new FleetError('node_config_override_reset_image_failed', { cause: err }));
     }
 }

--- a/packages/fleet/lib/models/node_config_overrides.ts
+++ b/packages/fleet/lib/models/node_config_overrides.ts
@@ -10,10 +10,10 @@ export const NODE_CONFIG_OVERRIDES_TABLE = 'node_config_overrides';
 interface DBNodeConfigOverride {
     readonly id: number;
     readonly routing_id: RoutingId;
-    readonly image: string;
-    readonly cpu_milli: number;
-    readonly memory_mb: number;
-    readonly storage_mb: number;
+    readonly image: string | null;
+    readonly cpu_milli: number | null;
+    readonly memory_mb: number | null;
+    readonly storage_mb: number | null;
     readonly created_at: Date;
     readonly updated_at: Date;
 }

--- a/packages/fleet/lib/node-providers/node_provider.ts
+++ b/packages/fleet/lib/node-providers/node_provider.ts
@@ -3,7 +3,7 @@ import type { Node } from '../types';
 import type { Result } from '@nangohq/utils';
 
 export interface NodeProvider {
-    defaultNodeConfig: NodeConfig;
+    defaultNodeConfig: Omit<NodeConfig, 'image'>;
     start(node: Node): Promise<Result<void>>;
     terminate(node: Node): Promise<Result<void>>;
     verifyUrl(url: string): Promise<Result<void>>;

--- a/packages/fleet/lib/node-providers/noop.ts
+++ b/packages/fleet/lib/node-providers/noop.ts
@@ -3,7 +3,6 @@ import type { NodeProvider } from './node_provider';
 
 export const noopNodeProvider: NodeProvider = {
     defaultNodeConfig: {
-        image: 'nangohq/nango-runner',
         cpuMilli: 1000,
         memoryMb: 1000,
         storageMb: 1000

--- a/packages/fleet/lib/types.ts
+++ b/packages/fleet/lib/types.ts
@@ -21,10 +21,10 @@ export interface Node {
 export interface NodeConfigOverride {
     readonly id: number;
     readonly routingId: Node['routingId'];
-    readonly image: NodeConfig['image'];
-    readonly cpuMilli: NodeConfig['cpuMilli'];
-    readonly memoryMb: NodeConfig['memoryMb'];
-    readonly storageMb: NodeConfig['storageMb'];
+    readonly image: NodeConfig['image'] | null;
+    readonly cpuMilli: NodeConfig['cpuMilli'] | null;
+    readonly memoryMb: NodeConfig['memoryMb'] | null;
+    readonly storageMb: NodeConfig['storageMb'] | null;
     readonly createdAt: Date;
     readonly updatedAt: Date;
 }

--- a/packages/jobs/lib/runner/local.ts
+++ b/packages/jobs/lib/runner/local.ts
@@ -11,8 +11,6 @@ const localRunnerPids = new Map<number, number>(); // Mapping Node.id to process
 
 export const localNodeProvider: NodeProvider = {
     defaultNodeConfig: {
-        // irrelevant for local runner
-        image: 'my-image',
         cpuMilli: 500,
         memoryMb: 512,
         storageMb: 20000

--- a/packages/jobs/lib/runner/render.ts
+++ b/packages/jobs/lib/runner/render.ts
@@ -17,7 +17,6 @@ const render: RenderAPI = new RenderAPI(envs.RENDER_API_KEY || '');
 
 export const renderNodeProvider: NodeProvider = {
     defaultNodeConfig: {
-        image: 'nangohq/nango-runner',
         cpuMilli: 500,
         memoryMb: 512,
         storageMb: 20000

--- a/packages/types/lib/fleet/index.ts
+++ b/packages/types/lib/fleet/index.ts
@@ -2,7 +2,6 @@ export type CommitHash = string & { readonly length: 40 };
 
 export interface Deployment {
     readonly id: number;
-    readonly commitId: CommitHash;
     readonly image: string;
     readonly createdAt: Date;
     readonly supersededAt: Date | null;


### PR DESCRIPTION
NodeConfigOverride values are now either null (ie: don't override) or a given value. It simplifies adding new override since we don't have to worry about what are the default values, just enter null for the attributes that don't need to be overridden. Also no special default value for image (nangohq/nango-runner without commitHash)

I still need to remove the commit_id column in deployment which won't be used anymore once this commit is deployed. Will do it in next PR.

# How to test:
Add/modify node_config_overrides rows in your dev db and check that fleet supervisor correctly rolls out new node

