### PR TITLE
chore(fleet): remove deployment commit_id column

### DIFF
--- a/packages/fleet/lib/db/migrations/20250204215701_deployment_remove_commit_id.ts
+++ b/packages/fleet/lib/db/migrations/20250204215701_deployment_remove_commit_id.ts
@@ -1,0 +1,8 @@
+import type { Knex } from 'knex';
+import { DEPLOYMENTS_TABLE } from '../../models/deployments.js';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`ALTER TABLE ${DEPLOYMENTS_TABLE} DROP COLUMN commit_id`);
+}
+
+export async function down(): Promise<void> {}

--- a/packages/fleet/lib/fleet.integration.test.ts
+++ b/packages/fleet/lib/fleet.integration.test.ts
@@ -27,7 +27,7 @@ describe('fleet', () => {
 
     describe('rollout', () => {
         it('should create a new deployment', async () => {
-            const image = generateImage().unwrap();
+            const image = generateImage();
             const deployment = (await fleet.rollout(image, { verifyImage: false })).unwrap();
             expect(deployment.image).toBe(image);
             expect(deployment.createdAt).toBeInstanceOf(Date);
@@ -43,7 +43,7 @@ describe('fleet', () => {
                 storageMb: 100
             };
             await nodeConfigOverrides.create(dbClient.db, props);
-            const image = generateImage().unwrap();
+            const image = generateImage();
             await fleet.rollout(image, { verifyImage: false });
             const nodeConfigOverride = (await nodeConfigOverrides.search(dbClient.db, { routingIds: [props.routingId] })).unwrap();
             expect(nodeConfigOverride.get('test')).toStrictEqual({
@@ -61,7 +61,7 @@ describe('fleet', () => {
 
     describe('getRunningNode', () => {
         it('should return a running node', async () => {
-            const image = generateImage().unwrap();
+            const image = generateImage();
             const deployment = (await fleet.rollout(image, { verifyImage: false })).unwrap();
             const routingId = nanoid();
             const runningNode = await createNodeWithAttributes(dbClient.db, {
@@ -73,7 +73,7 @@ describe('fleet', () => {
             expect(res.unwrap()).toStrictEqual(runningNode);
         });
         it('should return an outdated node', async () => {
-            const image = generateImage().unwrap();
+            const image = generateImage();
             const deployment = (await fleet.rollout(image, { verifyImage: false })).unwrap();
             const routingId = nanoid();
             await createNodeWithAttributes(dbClient.db, {

--- a/packages/fleet/lib/models/deployments.integration.test.ts
+++ b/packages/fleet/lib/models/deployments.integration.test.ts
@@ -16,7 +16,7 @@ describe('Deployments', () => {
 
     describe('create', () => {
         it('should create a deployment', async () => {
-            const image = generateImage().unwrap();
+            const image = generateImage();
             const deployment = (await deployments.create(db, image)).unwrap();
             expect(deployment.image).toBe(image);
             expect(deployment.createdAt).toBeInstanceOf(Date);
@@ -24,8 +24,8 @@ describe('Deployments', () => {
         });
 
         it('should supersede any active deployments', async () => {
-            const image1 = generateImage().unwrap();
-            const image2 = generateImage().unwrap();
+            const image1 = generateImage();
+            const image2 = generateImage();
 
             const deployment1 = (await deployments.create(db, image1)).unwrap();
             const deployment2 = (await deployments.create(db, image2)).unwrap();

--- a/packages/fleet/lib/models/deployments.ts
+++ b/packages/fleet/lib/models/deployments.ts
@@ -1,14 +1,13 @@
 import type knex from 'knex';
 import type { Result } from '@nangohq/utils';
 import { Err, Ok } from '@nangohq/utils';
-import type { CommitHash, Deployment } from '@nangohq/types';
+import type { Deployment } from '@nangohq/types';
 import { FleetError } from '../utils/errors.js';
 
 export const DEPLOYMENTS_TABLE = 'deployments';
 
 interface DBDeployment {
     readonly id: number;
-    readonly commit_id: CommitHash;
     readonly image: string;
     readonly created_at: Date;
     readonly superseded_at: Date | null;
@@ -27,7 +26,6 @@ const DBDeployment = {
         return {
             id: deployment.id,
             image: deployment.image,
-            commit_id: '0000000000000000000000000000000000000000' as CommitHash, //TODO: remove
             created_at: deployment.createdAt,
             superseded_at: deployment.supersededAt
         };
@@ -56,7 +54,6 @@ export async function create(db: knex.Knex, image: string): Promise<Result<Deplo
                 .update({ superseded_at: now });
             // insert new deployment
             const dbDeployment: Omit<DBDeployment, 'id'> = {
-                commit_id: '0000000000000000000000000000000000000000' as CommitHash, // TODO remove
                 image,
                 created_at: now,
                 superseded_at: null

--- a/packages/fleet/lib/models/helpers.ts
+++ b/packages/fleet/lib/models/helpers.ts
@@ -1,8 +1,6 @@
-import type { Result } from '@nangohq/utils';
-import { Err, Ok } from '@nangohq/utils';
 import crypto from 'crypto';
 
-export function generateImage(): Result<string> {
+export function generateImage(): string {
     const charset = '0123456789abcdef';
     const length = 40;
     const randomBytes = new Uint8Array(length);
@@ -11,8 +9,5 @@ export function generateImage(): Result<string> {
     const commitHash = Array.from(randomBytes)
         .map((byte) => charset[byte % charset.length])
         .join('');
-    if (commitHash.length !== 40) {
-        return Err('CommitHash must be exactly 40 characters');
-    }
-    return Ok(`generated/image:${commitHash}`);
+    return `generated/image:${commitHash}`;
 }

--- a/packages/fleet/lib/models/nodes.integration.test.ts
+++ b/packages/fleet/lib/models/nodes.integration.test.ts
@@ -16,8 +16,8 @@ describe('Nodes', () => {
     let activeDeployment: Deployment;
     beforeEach(async () => {
         await dbClient.migrate();
-        previousDeployment = (await deployments.create(db, generateImage().unwrap())).unwrap();
-        activeDeployment = (await deployments.create(db, generateImage().unwrap())).unwrap();
+        previousDeployment = (await deployments.create(db, generateImage())).unwrap();
+        activeDeployment = (await deployments.create(db, generateImage())).unwrap();
     });
 
     afterEach(async () => {

--- a/packages/fleet/lib/supervisor/supervisor.integration.test.ts
+++ b/packages/fleet/lib/supervisor/supervisor.integration.test.ts
@@ -34,8 +34,8 @@ describe('Supervisor', () => {
 
     beforeEach(async () => {
         await dbClient.migrate();
-        previousDeployment = (await deployments.create(dbClient.db, generateImage().unwrap())).unwrap();
-        activeDeployment = (await deployments.create(dbClient.db, generateImage().unwrap())).unwrap();
+        previousDeployment = (await deployments.create(dbClient.db, generateImage())).unwrap();
+        activeDeployment = (await deployments.create(dbClient.db, generateImage())).unwrap();
     });
 
     afterEach(async () => {

--- a/packages/fleet/lib/supervisor/supervisor.ts
+++ b/packages/fleet/lib/supervisor/supervisor.ts
@@ -182,9 +182,7 @@ export class Supervisor {
                     if (!configOverride) {
                         return false;
                     }
-                    // TODO: remove once values in node_config_overrides are updated to NULL in the db
-                    const imageOverride = configOverride.image?.includes(':') ? configOverride.image : undefined;
-                    if (imageOverride && imageOverride !== node.image) {
+                    if (configOverride.image && configOverride.image !== node.image) {
                         return true;
                     }
                     if (configOverride.cpuMilli && configOverride.cpuMilli !== node.cpuMilli) {
@@ -334,16 +332,8 @@ export class Supervisor {
         if (nodeConfigOverride.isErr()) {
             return Err(nodeConfigOverride.error);
         }
-        let nodeConfigOverrideValue = nodeConfigOverride.value.get(routingId);
+        const nodeConfigOverrideValue = nodeConfigOverride.value.get(routingId);
         if (nodeConfigOverrideValue) {
-            // TODO: remove once values in node_config_overrides are updated to NULL in the db
-            // to indicate image is not overriden
-            if (!nodeConfigOverrideValue.image?.includes(':')) {
-                nodeConfigOverrideValue = {
-                    ...nodeConfigOverrideValue,
-                    image: null
-                };
-            }
             newNodeConfig = {
                 image: nodeConfigOverrideValue.image || newNodeConfig.image,
                 cpuMilli: nodeConfigOverrideValue.cpuMilli || newNodeConfig.cpuMilli,

--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -78,12 +78,7 @@ try {
         // when running locally, the runners (running as processes) are being killed
         // when the main process is killed and the fleet entries are therefore not associated with any running process
         // we then must fake a new deployment so fleet replaces runners with new ones
-        const image = generateImage();
-        if (image.isErr()) {
-            logger.error(`Unable to generate commit hash`, image.error);
-        } else {
-            await runnersFleet.rollout(image.value, { verifyImage: false });
-        }
+        await runnersFleet.rollout(generateImage(), { verifyImage: false });
     }
     runnersFleet.start();
 

--- a/packages/types/lib/fleet/index.ts
+++ b/packages/types/lib/fleet/index.ts
@@ -1,5 +1,3 @@
-export type CommitHash = string & { readonly length: 40 };
-
 export interface Deployment {
     readonly id: number;
     readonly image: string;


### PR DESCRIPTION
deployments.commit_id column is not being used anymore.

Depends on https://github.com/NangoHQ/nango/pull/3450 and setting non overriden values to `NULL` in `node_config_overrides`

