### PR TITLE
feat(basecamp): store basecamp response in the connection config

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -821,6 +821,7 @@ basecamp:
             type: string
             title: Account ID
             description: Your Account ID
+            optional: true
             example: '5899981'
             pattern: '^[0-9]+$'
             doc_section: '#step-1-finding-your-account-id'

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -810,6 +810,7 @@ basecamp:
             after: 'retry-after'
     docs: https://docs.nango.dev/integrations/all/basecamp
     docs_connect: https://docs.nango.dev/integrations/all/basecamp/connect
+    post_connection_script: basecampPostConnection
     connection_config:
         appDetails:
             type: string
@@ -2329,7 +2330,7 @@ document360:
             type: string
             title: API Key
             description: The API key for your Document360 account
-            
+
 docusign:
     display_name: DocuSign
     categories:
@@ -6066,7 +6067,7 @@ prive:
             title: API Key
             description: The API key for your Prive account
             doc_section: '#step-1-requesting-your-prive-api-key'
-           
+
 productboard:
     display_name: Productboard
     categories:

--- a/packages/server/lib/hooks/connection/basecamp-post-connection.ts
+++ b/packages/server/lib/hooks/connection/basecamp-post-connection.ts
@@ -1,0 +1,24 @@
+import type { InternalNango as Nango } from './post-connection.js';
+import type { BasecampAuthorizationResponse } from '../response-types/basecamp.js';
+import { isAxiosError } from 'axios';
+
+export default async function execute(nango: Nango) {
+    const connection = await nango.getConnection();
+
+    const response = await nango.proxy<BasecampAuthorizationResponse>({
+        baseUrlOverride: 'https://launchpad.37signals.com',
+        endpoint: '/authorization.json',
+        connectionId: connection.connection_id,
+        providerConfigKey: connection.provider_config_key
+    });
+
+    if (isAxiosError(response)) {
+        return;
+    }
+
+    const { data } = response;
+
+    const { accounts } = data;
+
+    await nango.updateConnectionConfig({ accounts });
+}

--- a/packages/server/lib/hooks/connection/index.ts
+++ b/packages/server/lib/hooks/connection/index.ts
@@ -11,3 +11,4 @@ export { default as docusignPostConnection } from './docusign-post-connection.js
 export { default as gustoPostConnection } from './gusto-post-connection.js';
 export { default as workablePostConnection } from './workable-post-connection.js';
 export { default as adobeUmapiPostConnection } from './adobe-umapi-post-connection.js';
+export { default as basecampPostConnection } from './basecamp-post-connection.js';

--- a/packages/server/lib/hooks/response-types/basecamp.ts
+++ b/packages/server/lib/hooks/response-types/basecamp.ts
@@ -1,0 +1,16 @@
+export interface BasecampAuthorizationResponse {
+    expires_at: string;
+    identity: {
+        id: number;
+        first_name: string;
+        last_name: string;
+        email_address: string;
+    };
+    accounts: {
+        product: string;
+        id: number;
+        name: string;
+        href: string;
+        app_href: string;
+    }[];
+}


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Basecamp has an endpoint to retrieve account information. Related to https://github.com/NangoHQ/integration-templates/pull/212

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

