### PR TITLE
feat(persist): Enable filtering records by external id

### DIFF
--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -524,7 +524,7 @@ describe('Records service', () => {
             expect(allFetchedRecords.length).toBe(numOfRecords);
         });
 
-        it('Should retreive records by external_id', async () => {
+        it('Should retrieve records by external_id', async () => {
             const { connectionId, model } = await upsertNRecords(10);
 
             const response = await Records.getRecords({

--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -218,6 +218,41 @@ describe('Records service', () => {
                 });
             });
         });
+
+        it('Should return correct added records count when upserting concurrently', async () => {
+            const connectionId = rnd.number();
+            const environmentId = rnd.number();
+            const model = rnd.string();
+            const records = formatRecords({
+                data: [{ id: '1', name: 'John Doe' }],
+                connectionId,
+                model,
+                syncId: '00000000-0000-0000-0000-000000000000',
+                syncJobId: 1,
+                softDelete: false
+            }).unwrap();
+
+            // upserting the same record concurrently
+            const res = (
+                await Promise.all([
+                    Records.upsert({ records, connectionId, environmentId, model }),
+                    Records.upsert({ records, connectionId, environmentId, model }),
+                    Records.upsert({ records, connectionId, environmentId, model }),
+                    Records.upsert({ records, connectionId, environmentId, model }),
+                    Records.upsert({ records, connectionId, environmentId, model })
+                ])
+            ).map((r) => r.unwrap());
+            const agg = res.reduce((acc, curr) => {
+                return {
+                    addedKeys: acc.addedKeys.concat(curr.addedKeys),
+                    updatedKeys: acc.updatedKeys.concat(curr.updatedKeys),
+                    deletedKeys: (acc.deletedKeys || []).concat(curr.deletedKeys || []),
+                    nonUniqueKeys: acc.nonUniqueKeys.concat(curr.nonUniqueKeys),
+                    nextMerging: curr.nextMerging
+                };
+            });
+            expect(agg).toStrictEqual({ addedKeys: ['1'], updatedKeys: [], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
+        });
     });
 
     describe('updating records', () => {
@@ -431,134 +466,120 @@ describe('Records service', () => {
         expect(res2).toStrictEqual({ addedKeys: [], updatedKeys: [], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
     });
 
-    it('Should retrieve records', async () => {
-        const n = 10;
-        const { connectionId, model } = await upsertNRecords(n);
-        const response = await Records.getRecords({ connectionId, model });
-        if (response.isErr()) {
-            throw new Error('Response is undefined');
-        }
-        const { records, next_cursor } = response.value;
-        expect(records.length).toBe(n);
-        expect(records[0]?.['_nango_metadata']).toMatchObject({
-            first_seen_at: expect.toBeIsoDateTimezone(),
-            last_modified_at: expect.toBeIsoDateTimezone(),
-            last_action: 'ADDED',
-            deleted_at: null,
-            cursor: expect.stringMatching(/^[A-Za-z0-9+/]+={0,2}$/) // base64 encoded string
+    describe('getRecords', () => {
+        it('Should retrieve records', async () => {
+            const n = 10;
+            const { connectionId, model } = await upsertNRecords(n);
+            const response = await Records.getRecords({ connectionId, model });
+            if (response.isErr()) {
+                throw new Error('Response is undefined');
+            }
+            const { records, next_cursor } = response.value;
+            expect(records.length).toBe(n);
+            expect(records[0]?.['_nango_metadata']).toMatchObject({
+                first_seen_at: expect.toBeIsoDateTimezone(),
+                last_modified_at: expect.toBeIsoDateTimezone(),
+                last_action: 'ADDED',
+                deleted_at: null,
+                cursor: expect.stringMatching(/^[A-Za-z0-9+/]+={0,2}$/) // base64 encoded string
+            });
+            expect(next_cursor).toBe(null); // no next page
         });
-        expect(next_cursor).toBe(null); // no next page
-    });
-    it('Should paginate the records to retrieve all records', async () => {
-        const numOfRecords = 3000;
-        const limit = 100;
-        const { connectionId, model } = await upsertNRecords(numOfRecords);
 
-        let cursor: string | undefined | null = null;
-        const allFetchedRecords = [];
-        do {
+        it('Should paginate the records to retrieve all records', async () => {
+            const numOfRecords = 3000;
+            const limit = 100;
+            const { connectionId, model } = await upsertNRecords(numOfRecords);
+
+            let cursor: string | undefined | null = null;
+            const allFetchedRecords = [];
+            do {
+                const response = await Records.getRecords({
+                    connectionId,
+                    model,
+                    limit,
+                    ...(cursor && { cursor })
+                });
+
+                if (response.isErr() || !response.value) {
+                    throw new Error('Fail to fetch records');
+                }
+
+                const { records, next_cursor } = response.value;
+
+                allFetchedRecords.push(...records);
+
+                cursor = next_cursor;
+
+                expect(records).not.toBe(undefined);
+                expect(records?.length).toBeLessThanOrEqual(limit);
+            } while (cursor);
+
+            for (let i = 1; i < allFetchedRecords.length; i++) {
+                const currentRecordDate = dayjs(allFetchedRecords[i]?._nango_metadata.first_seen_at);
+                const previousRecordDate = dayjs(allFetchedRecords[i - 1]?._nango_metadata.first_seen_at);
+
+                expect(currentRecordDate.isAfter(previousRecordDate) || currentRecordDate.isSame(previousRecordDate)).toBe(true);
+            }
+            expect(allFetchedRecords.length).toBe(numOfRecords);
+        });
+
+        it('Should retreive records by external_id', async () => {
+            const { connectionId, model } = await upsertNRecords(10);
+
             const response = await Records.getRecords({
                 connectionId,
                 model,
-                limit,
-                ...(cursor && { cursor })
+                externalIds: ['1', '3', '5']
             });
 
-            if (response.isErr() || !response.value) {
-                throw new Error('Fail to fetch records');
-            }
+            expect(response.isOk()).toBe(true);
+            const { records } = response.unwrap();
 
-            const { records, next_cursor } = response.value;
-
-            allFetchedRecords.push(...records);
-
-            cursor = next_cursor;
-
-            expect(records).not.toBe(undefined);
-            expect(records?.length).toBeLessThanOrEqual(limit);
-        } while (cursor);
-
-        for (let i = 1; i < allFetchedRecords.length; i++) {
-            const currentRecordDate = dayjs(allFetchedRecords[i]?._nango_metadata.first_seen_at);
-            const previousRecordDate = dayjs(allFetchedRecords[i - 1]?._nango_metadata.first_seen_at);
-
-            expect(currentRecordDate.isAfter(previousRecordDate) || currentRecordDate.isSame(previousRecordDate)).toBe(true);
-        }
-        expect(allFetchedRecords.length).toBe(numOfRecords);
-    });
-
-    it('Should be able to retrieve 20K records in under 5s with a cursor', async () => {
-        const numOfRecords = 20000;
-        const limit = 1000;
-        const { connectionId, model } = await upsertNRecords(numOfRecords);
-
-        let cursor: string | undefined | null = null;
-        let allRecordsLength = 0;
-
-        const startTime = Date.now();
-        do {
-            const response = await Records.getRecords({
-                connectionId,
-                model,
-                limit,
-                ...(cursor && { cursor })
-            });
-
-            if (response.isErr() || !response.value) {
-                throw new Error('Error fetching records');
-            }
-
-            const { records, next_cursor } = response.value;
-
-            allRecordsLength += records.length;
-
-            cursor = next_cursor;
-
-            expect(records).not.toBe(undefined);
-            expect(records?.length).toBeLessThanOrEqual(limit);
-        } while (cursor);
-
-        const endTime = Date.now();
-
-        const runTime = endTime - startTime;
-        expect(runTime).toBeLessThan(5000);
-
-        expect(allRecordsLength).toBe(numOfRecords);
-    });
-
-    it('Should return correct added records count when upserting concurrently', async () => {
-        const connectionId = rnd.number();
-        const environmentId = rnd.number();
-        const model = rnd.string();
-        const records = formatRecords({
-            data: [{ id: '1', name: 'John Doe' }],
-            connectionId,
-            model,
-            syncId: '00000000-0000-0000-0000-000000000000',
-            syncJobId: 1,
-            softDelete: false
-        }).unwrap();
-
-        // upserting the same record concurrently
-        const res = (
-            await Promise.all([
-                Records.upsert({ records, connectionId, environmentId, model }),
-                Records.upsert({ records, connectionId, environmentId, model }),
-                Records.upsert({ records, connectionId, environmentId, model }),
-                Records.upsert({ records, connectionId, environmentId, model }),
-                Records.upsert({ records, connectionId, environmentId, model })
-            ])
-        ).map((r) => r.unwrap());
-        const agg = res.reduce((acc, curr) => {
-            return {
-                addedKeys: acc.addedKeys.concat(curr.addedKeys),
-                updatedKeys: acc.updatedKeys.concat(curr.updatedKeys),
-                deletedKeys: (acc.deletedKeys || []).concat(curr.deletedKeys || []),
-                nonUniqueKeys: acc.nonUniqueKeys.concat(curr.nonUniqueKeys),
-                nextMerging: curr.nextMerging
-            };
+            expect(records.length).toBe(3);
+            expect(records).toContainEqual(expect.objectContaining({ id: '1' }));
+            expect(records).toContainEqual(expect.objectContaining({ id: '3' }));
+            expect(records).toContainEqual(expect.objectContaining({ id: '5' }));
         });
-        expect(agg).toStrictEqual({ addedKeys: ['1'], updatedKeys: [], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
+
+        it('Should be able to retrieve 20K records in under 5s with a cursor', async () => {
+            const numOfRecords = 20000;
+            const limit = 1000;
+            const { connectionId, model } = await upsertNRecords(numOfRecords);
+
+            let cursor: string | undefined | null = null;
+            let allRecordsLength = 0;
+
+            const startTime = Date.now();
+            do {
+                const response = await Records.getRecords({
+                    connectionId,
+                    model,
+                    limit,
+                    ...(cursor && { cursor })
+                });
+
+                if (response.isErr() || !response.value) {
+                    throw new Error('Error fetching records');
+                }
+
+                const { records, next_cursor } = response.value;
+
+                allRecordsLength += records.length;
+
+                cursor = next_cursor;
+
+                expect(records).not.toBe(undefined);
+                expect(records?.length).toBeLessThanOrEqual(limit);
+            } while (cursor);
+
+            const endTime = Date.now();
+
+            const runTime = endTime - startTime;
+            expect(runTime).toBeLessThan(5000);
+
+            expect(allRecordsLength).toBe(numOfRecords);
+        });
     });
 });
 

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -47,7 +47,8 @@ export async function getRecords({
     modifiedAfter,
     limit,
     filter,
-    cursor
+    cursor,
+    externalIds
 }: {
     connectionId: number;
     model: string;
@@ -55,6 +56,7 @@ export async function getRecords({
     limit?: number | string;
     filter?: LastAction;
     cursor?: string;
+    externalIds?: string[];
 }): Promise<Result<GetRecordsResponse>> {
     try {
         if (!model) {
@@ -87,6 +89,10 @@ export async function getRecords({
                         .where('updated_at', '>', decodedCursor.sort)
                         .orWhere((builder) => void builder.where('updated_at', '=', decodedCursor.sort).andWhere('id', '>', decodedCursor.id))
             );
+        }
+
+        if (externalIds) {
+            query = query.whereIn('external_id', externalIds);
         }
 
         if (limit) {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
We'll use this for a few new features where we can load records by id.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->
## How I tested it

- Ran the tests!
- Also dumped the generated query with the new filter to a string and ran it through EXPLAIN ANALYZE to make sure there were no sequential scans. Looks good.

