### PR TITLE
fix(api): get records filter should accept uppercase and combined

### DIFF
--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -1,7 +1,16 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc.js';
 import { db } from '../db/client.js';
-import type { FormattedRecord, FormattedRecordWithMetadata, GetRecordsResponse, LastAction, RecordCount, ReturnedRecord, UpsertSummary } from '../types.js';
+import type {
+    CombinedFilterAction,
+    FormattedRecord,
+    FormattedRecordWithMetadata,
+    GetRecordsResponse,
+    LastAction,
+    RecordCount,
+    ReturnedRecord,
+    UpsertSummary
+} from '../types.js';
 import { decryptRecordData, encryptRecords } from '../utils/encryption.js';
 import { RECORDS_TABLE, RECORD_COUNTS_TABLE } from '../constants.js';
 import { removeDuplicateKey, getUniqueId } from '../helpers/uniqueKey.js';
@@ -53,7 +62,7 @@ export async function getRecords({
     model: string;
     modifiedAfter?: string | undefined;
     limit?: number | string | undefined;
-    filter?: LastAction | undefined;
+    filter?: CombinedFilterAction | LastAction | undefined;
     cursor?: string | undefined;
 }): Promise<Result<GetRecordsResponse>> {
     try {

--- a/packages/records/lib/types.ts
+++ b/packages/records/lib/types.ts
@@ -38,6 +38,7 @@ export type ReturnedRecord = {
 } & Record<string, RecordValue> & { id: string };
 
 export type LastAction = 'ADDED' | 'UPDATED' | 'DELETED' | 'added' | 'updated' | 'deleted';
+export type CombinedFilterAction = `${LastAction},${LastAction}`;
 
 interface RecordMetadata {
     first_seen_at: string;

--- a/packages/server/lib/controllers/records/getRecords.ts
+++ b/packages/server/lib/controllers/records/getRecords.ts
@@ -12,7 +12,12 @@ export const validationQuery = z
         delta: z.string().datetime().optional(),
         modified_after: z.string().datetime().optional(),
         limit: z.coerce.number().min(1).max(10000).default(100).optional(),
-        filter: z.enum(['added', 'updated', 'deleted']).optional(),
+        filter: z
+            .string()
+            .transform((value) => value.split(','))
+            .pipe(z.array(z.enum(['added', 'updated', 'deleted', 'ADDED', 'UPDATED', 'DELETED'])))
+            .transform<GetPublicRecords['Querystring']['filter']>((value) => value.join(',') as GetPublicRecords['Querystring']['filter'])
+            .optional(),
         cursor: z.string().min(1).max(1000).optional()
     })
     .strict();

--- a/packages/types/lib/record/api.ts
+++ b/packages/types/lib/record/api.ts
@@ -1,6 +1,7 @@
 import type { ApiError, Endpoint } from '../api';
 
 export type RecordLastAction = 'ADDED' | 'UPDATED' | 'DELETED' | 'added' | 'updated' | 'deleted';
+export type CombinedFilterAction = `${RecordLastAction},${RecordLastAction}`;
 
 export interface RecordMetadata {
     first_seen_at: string;
@@ -33,7 +34,7 @@ export type GetPublicRecords = Endpoint<{
         delta?: string | undefined;
         modified_after?: string | undefined;
         limit?: number | undefined;
-        filter?: 'added' | 'updated' | 'deleted' | undefined;
+        filter?: RecordLastAction | CombinedFilterAction | undefined;
         cursor?: string | undefined;
     };
     Success: {


### PR DESCRIPTION
## Changes

- `GET /records` filter param should accept uppercase and combined
I missed that when checking the openapi spec, it's not documented there but it's in the node-client. e.g: `ADDED,updated` 


```
curl --request GET \
  --url 'http://localhost:3003/records?model=LastSyncDate&limit=100&filter=UPDATED%2Cadded' \
  --header 'Authorization: ' \
  --header 'Connection-Id: 025d9a38-f31c-4a64-b034-57a425761a90' \
  --header 'Provider-Config-Key: unauthenticated' \
  --header 'content-type: application/json'
```