### PR TITLE
fix(webhooks): Remove webhook response body from webhook logging

### DIFF
--- a/packages/logs/lib/es/__snapshots__/index.integration.test.ts.snap
+++ b/packages/logs/lib/es/__snapshots__/index.integration.test.ts.snap
@@ -106,11 +106,6 @@ exports[`mapping > should create one index automatically on log 1`] = `
       },
       "response": {
         "properties": {
-          "body": {
-            "doc_values": false,
-            "index": false,
-            "type": "keyword",
-          },
           "code": {
             "type": "integer",
           },

--- a/packages/logs/lib/es/schema.ts
+++ b/packages/logs/lib/es/schema.ts
@@ -84,8 +84,7 @@ const props: Record<keyof MessageRow, estypes.MappingProperty> = {
     response: {
         properties: {
             code: { type: 'integer' },
-            headers: { type: 'object', enabled: false },
-            body: { type: 'keyword', index: false, doc_values: false }
+            headers: { type: 'object', enabled: false }
         }
     },
 

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -136,7 +136,6 @@ export interface MessageRow {
     response: {
         code: number;
         headers: Record<string, string>;
-        body?: unknown;
     } | null;
     meta: MessageMeta | null;
 

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -29,8 +29,7 @@ export const NON_FORWARDABLE_HEADERS = [
 function formatLogResponse(response: AxiosResponse): MessageRow['response'] {
     return {
         code: response.status,
-        headers: response.headers ? redactHeaders({ headers: response.headers }) : {},
-        body: response.data
+        headers: response.headers ? redactHeaders({ headers: response.headers }) : {}
     };
 }
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
We were seeing errors come back from logging the response body on webhooks, and it's not very useful anyway.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

## How I tested it
- trigger a webhook
- review the response in logs

