### PR TITLE
fix(cron): automatic refresh token was not passing decrypted connection

### DIFF
--- a/packages/server/lib/refreshConnections.ts
+++ b/packages/server/lib/refreshConnections.ts
@@ -1,6 +1,6 @@
 import * as cron from 'node-cron';
 import type { Lock } from '@nangohq/shared';
-import { errorManager, ErrorSourceEnum, connectionService, locking } from '@nangohq/shared';
+import { errorManager, ErrorSourceEnum, connectionService, locking, encryptionManager } from '@nangohq/shared';
 import { stringifyError, getLogger, metrics } from '@nangohq/utils';
 import { logContextGetter } from '@nangohq/logs';
 import {
@@ -65,13 +65,14 @@ export async function exec(): Promise<void> {
                     }
 
                     const { connection, account, environment, integration } = staleConnection;
+                    const decrypted = encryptionManager.decryptConnection(connection);
                     logger.info(`${cronName} refreshing connection '${connection.connection_id}' for accountId '${account.id}'`);
                     try {
                         const credentialResponse = await connectionService.refreshOrTestCredentials({
                             account,
                             environment,
                             integration,
-                            connection,
+                            connection: decrypted!,
                             logContextGetter,
                             instantRefresh: false,
                             onRefreshSuccess: connectionRefreshSuccessHook,

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -861,6 +861,10 @@ class ConnectionService {
 
         const copy = { ...connection };
 
+        if (!connection.credentials || 'encrypted_credentials' in connection.credentials) {
+            return Err(new NangoError('invalid_crypted_connection'));
+        }
+
         if (
             connection?.credentials?.type === 'OAUTH2' ||
             connection?.credentials?.type === 'APP' ||


### PR DESCRIPTION
## Changes 

Noticed something weird while improving the type for Connection in #3470 

- Automatic refresh token was not passing decrypted connection


When doing this refactor https://github.com/NangoHQ/nango/pull/2870 I split the refresh and the getConnection because it was inefficient. I forgot to decrypt the connection, and due to bad typing, there was no difference between Connection and (decrypted)Connection. The really permissive code completely allowed this to pass, and still mark connection has refreshed while not being refreshed.

NB: this was not impacting the regular refresh on fetch