### PR TITLE
fix(npm): put types pkg as prod dependency

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -14,7 +14,7 @@
     },
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "scripts": {},
-    "devDependencies": {
+    "dependencies": {
         "@nangohq/types": "0.52.5"
     },
     "files": [

--- a/packages/node-client/package.json
+++ b/packages/node-client/package.json
@@ -25,6 +25,7 @@
     },
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
+        "@nangohq/types": "0.52.5",
         "axios": "^1.7.9"
     },
     "engines": {
@@ -36,7 +37,6 @@
         "README.md"
     ],
     "devDependencies": {
-        "@nangohq/types": "0.52.5",
         "tsup": "^8.2.4",
         "vitest": "2.1.9"
     }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -11,11 +11,13 @@
         "url": "git+https://github.com/NangoHQ/nango.git",
         "directory": "packages/utils"
     },
-    "devDependencies": {
-        "@types/json-schema": "7.0.15",
+    "dependencies": {
         "axios": "^1.7.9",
         "json-schema": "0.4.0",
         "type-fest": "4.32.0"
+    },
+    "devDependencies": {
+        "@types/json-schema": "7.0.15"
     },
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "files": [


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-2666/types-are-not-installed-with-node-client

While doing a fresh install to test some stuff, I realized typescript is complaining that `@nangohq/types` was not installed. Because it's set as devDependencies it's not installed automatically along `@nangohq/node` which makes it mandatory for any user to install it (+ `type-fest` `json-schema`) 

- Put types pkg as prod dependency