### PR TITLE
fix(runner-sdk): catch void this.log

### DIFF
--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -177,7 +177,11 @@ export class NangoActionRunner extends NangoActionBase {
                 }
             },
             { level: res.status > 299 ? 'error' : 'info' }
-        );
+        ).catch(() => {
+            // this.log can throw when the script is aborted
+            // since it is not awaited, the exception might not be caught
+            // we therefore swallow the exception here to avoid an unhandledRejection error
+        });
         return res;
     }
 }


### PR DESCRIPTION
not awaiting this.log could lead to an unhandledException and a runner crash when the script is aborted. 
This commit ensures exception are caught when calling this.log without awaiting

#How to test:
1. Create a sync where you call a nango function in a loop. Be careful a lot of methods memoized and don't call the API more than once. Ex:
```
...
    const waitSecs = 30;
    const now = new Date();
    await nango.log(`waiting for ${waitSecs} seconds`);
    while (new Date().getTime() - now.getTime() < waitSecs * 1000) {
        await nango.getEnvironmentVariables();
    }
...
```
2. Cancel the sync while in the loop
3. Notice the crash of the runner when not on this branch.
4. Checkout this branch and confirm that cancelling doesn't crash the runner and successfully abort the script

