### PR TITLE
feat(persist): Add support for activityLogId to get records endpoint

### DIFF
--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getRecords.ts
@@ -15,7 +15,7 @@ type GetRecords = Endpoint<{
     Querystring: {
         model: string;
         externalIds: string[];
-        cursor: string;
+        cursor: string | undefined;
         limit: number;
         activityLogId: string | undefined;
     };

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getRecords.ts
@@ -2,7 +2,7 @@ import type { ApiError, Endpoint, GetRecordsSuccess } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, RouteHandler, Route } from '@nangohq/utils';
 import { records } from '@nangohq/records';
 import { validateGetRecords } from './validate.js';
-import type { LogContext } from '@nangohq/logs';
+import type { LogContextStateless } from '@nangohq/logs';
 import { logContextGetter } from '@nangohq/logs';
 
 type GetRecords = Endpoint<{
@@ -34,7 +34,7 @@ const handler = async (req: EndpointRequest<GetRecords>, res: EndpointResponse<G
         query: { model, externalIds, cursor, limit, activityLogId }
     } = req;
 
-    const logCtx: LogContext | undefined = undefined;
+    let logCtx: LogContextStateless | undefined = undefined;
     if (activityLogId) {
         logCtx = logContextGetter.getStateLess({ id: String(activityLogId) });
     }

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getRecords.ts
@@ -17,7 +17,7 @@ type GetRecords = Endpoint<{
         externalIds: string[];
         cursor: string;
         limit: number;
-        activityLogId: string;
+        activityLogId: string | undefined;
     };
     Error: ApiError<'get_records_failed'>;
     Success: GetRecordsSuccess;

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/validate.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/validate.ts
@@ -30,7 +30,7 @@ export const validateGetRecords = <E extends Endpoint<any>>() =>
                     model: z.string(),
                     cursor: z.string().optional(),
                     limit: z.coerce.number().int().positive().default(100),
-                    activityLogId: z.string(),
+                    activityLogId: z.string().optional(),
                     externalIds: z
                         .union([
                             z.string().min(1).max(256), // There is no diff between a normal query param and an array with one item

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/validate.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/validate.ts
@@ -30,6 +30,7 @@ export const validateGetRecords = <E extends Endpoint<any>>() =>
                     model: z.string(),
                     cursor: z.string().optional(),
                     limit: z.coerce.number().int().positive().default(100),
+                    activityLogId: z.string(),
                     externalIds: z
                         .union([
                             z.string().min(1).max(256), // There is no diff between a normal query param and an array with one item


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Realized it's ideal to be able to log from persist consistent with what we do on the other endpoints for saving records.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

