### PR TITLE
docs: Standardize providers.yaml display names

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -146,7 +146,7 @@ affinity:
             doc_section: '#step-1-finding-your-api-key'
 
 aircall:
-    display_name: Aircall
+    display_name: Aircall (OAuth)
     categories:
         - support
     auth_mode: OAUTH2
@@ -169,7 +169,7 @@ aircall:
 
 aircall-basic:
     alias: aircall
-    display_name: Aircall (basic auth)
+    display_name: Aircall (Basic Auth)
     auth_mode: BASIC
     proxy:
         base_url: https://api.aircall.io
@@ -370,7 +370,7 @@ apaleo:
     docs: https://docs.nango.dev/integrations/all/apaleo
 
 apollo:
-    display_name: Apollo
+    display_name: Apollo (API Key)
     categories:
         - marketing
     auth_mode: API_KEY
@@ -608,7 +608,7 @@ avalara:
             doc_section: '#step-2-generating-an-avalara-client'
 
 avalara-sandbox:
-    display_name: Avalara (sandbox)
+    display_name: Avalara (Sandbox)
     categories:
         - legal
     auth_mode: BASIC
@@ -723,7 +723,7 @@ aws-iam:
             doc_section: '#step-2-finding-your-region-host'
 
 bamboohr:
-    display_name: BambooHR
+    display_name: BambooHR (OAuth)
     categories:
         - hr
     auth_mode: OAUTH2
@@ -750,7 +750,7 @@ bamboohr:
             order: 1
 
 bamboohr-basic:
-    display_name: BambooHR (basic auth)
+    display_name: BambooHR (Basic Auth)
     categories:
         - hr
     auth_mode: BASIC
@@ -917,7 +917,7 @@ bigcommerce:
             example: 123e4567-e89b-12d3-a456-426614174000
 
 bill-sandbox:
-    display_name: Bill (Connect API sandbox)
+    display_name: Bill (Connect API Sandbox)
     categories:
         - payment
     auth_mode: BILL
@@ -1096,7 +1096,7 @@ braintree:
     docs: https://docs.nango.dev/integrations/all/braintree
 
 braintree-sandbox:
-    display_name: Braintree (sandbox)
+    display_name: Braintree (Sandbox)
     auth_mode: OAUTH2
     authorization_url: https://api.sandbox.braintreegateway.com/oauth/connect
     token_url: https://api.sandbox.braintreegateway.com/oauth/access_tokens
@@ -1142,7 +1142,7 @@ braze:
             doc_section: '#step-2-finding-your-api-key'
 
 brevo-api-key:
-    display_name: Brevo (api key)
+    display_name: Brevo
     categories:
         - marketing
     auth_mode: API_KEY
@@ -1158,7 +1158,7 @@ brevo-api-key:
             description: The API key for your Brevo account
 
 brex:
-    display_name: Brex
+    display_name: Brex (OAuth)
     categories:
         - banking
     auth_mode: OAUTH2
@@ -1172,7 +1172,7 @@ brex:
     docs: https://docs.nango.dev/integrations/all/brex
 
 brex-api-key:
-    display_name: Brex (api key)
+    display_name: Brex (API Key)
     auth_mode: API_KEY
     proxy:
         headers:
@@ -1190,7 +1190,7 @@ brex-api-key:
             doc_section: '#step-1-finding-your-api-token'
 
 brex-staging:
-    display_name: Brex (staging)
+    display_name: Brex (Staging OAuth)
     auth_mode: OAUTH2
     authorization_url: https://accounts-api.staging.brexapps.com/oauth2/default/v1/authorize
     token_url: https://accounts-api.staging.brexapps.com/oauth2/default/v1/token
@@ -1217,7 +1217,7 @@ brightcrowd:
     docs_connect: https://docs.nango.dev/integrations/all/brightcrowd/connect
 
 builder-io-private:
-    display_name: Builder.io (private)
+    display_name: Builder.io (Private)
     categories:
         - dev-tools
         - design
@@ -1248,7 +1248,7 @@ builder-io-private:
             doc_section: '#step-2-finding-your-api-key'
 
 builder-io-public:
-    display_name: Builder.io (public)
+    display_name: Builder.io (Public)
     categories:
         - dev-tools
         - design
@@ -1574,7 +1574,7 @@ checkr-partner:
             description: The client ID of your Checkr Partner account
 
 checkr-partner-staging:
-    display_name: Checkr Partner (staging)
+    display_name: Checkr Partner (Staging)
     categories:
         - legal
     auth_mode: OAUTH2
@@ -1615,7 +1615,7 @@ checkout-com:
     docs: https://docs.nango.dev/integrations/all/checkout-com
 
 checkout-com-sandbox:
-    display_name: Checkout.com (sandbox)
+    display_name: Checkout.com (Sandbox)
     categories:
         - payment
     auth_mode: OAUTH2_CC
@@ -1825,7 +1825,7 @@ commercetools:
             doc_section: '#step-3-identify-your-region-and-cloud-provider'
 
 copper:
-    display_name: Copper
+    display_name: Copper (OAuth)
     categories:
         - crm
     auth_mode: OAUTH2
@@ -1844,7 +1844,7 @@ copper:
     docs: https://docs.nango.dev/integrations/all/copper
 
 copper-api-key:
-    display_name: Copper (api key)
+    display_name: Copper (API Key)
     categories:
         - crm
     auth_mode: API_KEY
@@ -1905,7 +1905,7 @@ connectwise-psa:
             description: The Client ID assigned to your integration
 
 connectwise-psa-staging:
-    display_name: ConnectWise PSA (staging)
+    display_name: ConnectWise PSA (Staging)
     categories:
         - support
         - ticketing
@@ -2018,7 +2018,7 @@ coros:
     docs: https://docs.nango.dev/integrations/all/coros
 
 coros-sandbox:
-    display_name: Coros (sandbox)
+    display_name: Coros (Sandbox)
     auth_mode: OAUTH2
     authorization_url: https://opentest.coros.com/oauth2/authorize
     token_url: https://opentest.coros.com/oauth2/accesstoken
@@ -2180,7 +2180,7 @@ deel:
     docs: https://docs.nango.dev/integrations/all/deel
 
 deel-sandbox:
-    display_name: Deel (sandbox)
+    display_name: Deel (Sandbox)
     auth_mode: OAUTH2
     authorization_url: https://demo.deel.com/oauth2/authorize
     token_url: https://demo.deel.com/oauth2/tokens
@@ -2213,7 +2213,7 @@ dialpad:
     docs: https://docs.nango.dev/integrations/all/dialpad
 
 dialpad-sandbox:
-    display_name: Dialpad (sandbox)
+    display_name: Dialpad (Sandbox)
     categories:
         - communication
     auth_mode: OAUTH2
@@ -2352,7 +2352,7 @@ docusign:
     docs: https://docs.nango.dev/integrations/all/docusign
 
 docusign-sandbox:
-    display_name: DocuSign (sandbox)
+    display_name: DocuSign (Sandbox)
     auth_mode: OAUTH2
     authorization_url: https://account-d.docusign.com/oauth/auth
     token_url: https://account-d.docusign.com/oauth/token
@@ -2502,7 +2502,7 @@ ebay:
     docs: https://docs.nango.dev/integrations/all/ebay
 
 ebay-sandbox:
-    display_name: eBay (sandbox)
+    display_name: eBay (Sandbox)
     categories:
         - e-commerce
     auth_mode: OAUTH2
@@ -2889,7 +2889,7 @@ fireflies:
             description: The API key for your Fireflies account
 
 fiserv:
-    display_name: Fiserv
+    display_name: Fiserv (OAuth)
     categories:
         - banking
         - payment
@@ -2911,7 +2911,7 @@ fiserv:
             prefix: https://
 
 fiserv-api-key:
-    display_name: Fiserv (api key)
+    display_name: Fiserv (API Key)
     categories:
         - banking
         - payment
@@ -3265,7 +3265,7 @@ guru:
             doc_section: '#step-2-generating-your-user-collection-token'
 
 github:
-    display_name: GitHub
+    display_name: GitHub (User OAuth)
     categories:
         - dev-tools
         - support
@@ -3286,7 +3286,7 @@ github:
     docs: https://docs.nango.dev/integrations/all/github
 
 github-app:
-    display_name: GitHub App
+    display_name: GitHub (App)
     categories:
         - dev-tools
         - ticketing
@@ -3312,7 +3312,7 @@ github-app:
             automated: true
 
 github-app-oauth:
-    display_name: GitHub App (oauth)
+    display_name: GitHub (App OAuth)
     categories:
         - dev-tools
         - ticketing
@@ -3428,7 +3428,7 @@ ghost-content:
             example: a1b2c3d4e5f6g7h8i9j0k1l2m3
 
 gong:
-    display_name: Gong
+    display_name: Gong (Basic Auth)
     categories:
         - productivity
     auth_mode: BASIC
@@ -3453,7 +3453,7 @@ gong:
             doc_section: '#step-1-finding-gong-api-key-and-api-key-secret'
 
 gong-oauth:
-    display_name: Gong (oauth)
+    display_name: Gong (Oauth)
     auth_mode: OAUTH2
     categories:
         - productivity
@@ -3659,7 +3659,7 @@ grafana:
             doc_section: '#step-2-generating-your-service-account-token'
 
 grain:
-    display_name: Grain
+    display_name: Grain (OAuth)
     categories:
         - video
         - communication
@@ -3676,7 +3676,7 @@ grain:
     docs: https://docs.nango.dev/integrations/all/grain
 
 grain-api-key:
-    display_name: Grain (api key)
+    display_name: Grain (API Key)
     categories:
         - video
         - communication
@@ -3697,7 +3697,7 @@ grain-api-key:
             description: The personal access token to your Grain account
 
 greenhouse:
-    display_name: Greenhouse
+    display_name: Greenhouse (OAuth)
     categories:
         - ats
     auth_mode: OAUTH2
@@ -3723,7 +3723,7 @@ greenhouse:
             prefix: https://
 
 greenhouse-basic:
-    display_name: Greenhouse (basic auth)
+    display_name: Greenhouse (Basic Auth)
     categories:
         - ats
     auth_mode: BASIC
@@ -3928,7 +3928,7 @@ gusto:
     docs: https://docs.nango.dev/integrations/all/gusto
 
 gusto-demo:
-    display_name: Gusto (demo)
+    display_name: Gusto (Demo)
     auth_mode: OAUTH2
     authorization_url: https://api.gusto-demo.com/oauth/authorize
     token_url: https://api.gusto-demo.com/oauth/token
@@ -4055,7 +4055,7 @@ highlevel:
     docs: https://docs.nango.dev/integrations/all/highlevel
 
 highlevel-white-label:
-    display_name: HighLevel (white label)
+    display_name: HighLevel (White Label)
     categories:
         - marketing
     auth_mode: OAUTH2
@@ -4204,7 +4204,7 @@ intuit:
     docs: https://docs.nango.dev/integrations/all/intuit
 
 jira:
-    display_name: Jira
+    display_name: Jira (OAuth)
     categories:
         - productivity
         - ticketing
@@ -4230,7 +4230,7 @@ jira:
     docs: https://docs.nango.dev/integrations/all/jira
 
 jira-basic:
-    display_name: Jira (basic auth)
+    display_name: Jira (Basic Auth)
     categories:
         - productivity
         - ticketing
@@ -4366,7 +4366,7 @@ keap:
     docs: https://docs.nango.dev/integrations/all/keap
 
 keeper-scim:
-    display_name: Keeper(SCIM)
+    display_name: Keeper (SCIM)
     categories:
         - productivity
     auth_mode: API_KEY
@@ -4417,7 +4417,7 @@ klipfolio:
             description: The API key for your Klipfolio account
 
 klaviyo:
-    display_name: Klaviyo
+    display_name: Klaviyo (API Key)
     categories:
         - marketing
     auth_mode: API_KEY
@@ -4440,7 +4440,7 @@ klaviyo:
             doc_section: '#step-1-finding-klaviyo-api-key'
 
 klaviyo-oauth:
-    display_name: Klaviyo (oauth)
+    display_name: Klaviyo (OAuth)
     categories:
         - marketing
     auth_mode: OAUTH2
@@ -4573,7 +4573,7 @@ lessonly:
             secret: true
 
 lever:
-    display_name: Lever
+    display_name: Lever (OAuth)
     categories:
         - ats
     auth_mode: OAUTH2
@@ -4588,7 +4588,7 @@ lever:
     docs: https://docs.nango.dev/integrations/all/lever
 
 lever-basic:
-    display_name: Lever (basic auth)
+    display_name: Lever (Basic Auth)
     auth_mode: BASIC
     proxy:
         base_url: https://api.lever.co
@@ -4608,7 +4608,7 @@ lever-basic:
             hidden: true
 
 lever-sandbox:
-    display_name: Lever (sandbox)
+    display_name: Lever (OAuth Sandbox)
     auth_mode: OAUTH2
     authorization_url: https://sandbox-lever.auth0.com/authorize
     token_url: https://sandbox-lever.auth0.com/oauth/token
@@ -4621,7 +4621,7 @@ lever-sandbox:
     docs: https://docs.nango.dev/integrations/all/lever-sandbox
 
 lever-basic-sandbox:
-    display_name: Lever (basic auth) (sandbox)
+    display_name: Lever (Basic Auth Sandbox))
     auth_mode: BASIC
     proxy:
         base_url: https://api.sandbox.lever.co
@@ -4707,7 +4707,7 @@ loops-so:
             example: d2d561f5ff80136f69b4b5a31b9fb3c9
 
 lucid-scim:
-    display_name: Lucid(SCIM)
+    display_name: Lucid (SCIM)
     categories:
         - productivity
     auth_mode: API_KEY
@@ -5035,7 +5035,7 @@ microsoft-teams:
     docs: https://docs.nango.dev/integrations/all/microsoft-teams
 
 microsoft-tenant-specific:
-    display_name: Microsoft (tenant)
+    display_name: Microsoft (Tenant)
     categories:
         - erp
     auth_mode: OAUTH2
@@ -5123,7 +5123,7 @@ microsoft-power-bi:
     docs: https://docs.nango.dev/integrations/all/microsoft-power-bi
 
 mindbody:
-    display_name: Mindbody (api key)
+    display_name: Mindbody
     categories:
         - productivity
     auth_mode: API_KEY
@@ -5306,7 +5306,7 @@ nationbuilder:
             description: The account ID of your NationBuilder account
 
 netsuite:
-    display_name: NetSuite
+    display_name: NetSuite (OAuth)
     categories:
         - accounting
         - erp
@@ -5332,7 +5332,7 @@ netsuite:
 
 netsuite-tba:
     alias: netsuite
-    display_name: NetSuite (tba)
+    display_name: NetSuite (TBA)
     auth_mode: TBA
     docs: https://docs.nango.dev/integrations/all/netsuite-tba
 
@@ -5404,7 +5404,7 @@ notion-scim:
             doc_section: '#step-1-finding-your-scim-api-key-token'
 
 odoo:
-    display_name: Odoo
+    display_name: Odoo (OAuth)
     categories:
         - erp
     auth_mode: OAUTH2
@@ -5702,7 +5702,7 @@ paypal:
     docs: https://docs.nango.dev/integrations/all/paypal
 
 paypal-sandbox:
-    display_name: Paypal (sandbox)
+    display_name: Paypal (Sandbox)
     auth_mode: OAUTH2
     authorization_url: https://www.sandbox.paypal.com/signin/authorize
     token_url: https://api-m.sandbox.paypal.com/v1/oauth2/token
@@ -5834,7 +5834,7 @@ perimeter81:
             secret: true
 
 personio:
-    display_name: Personio
+    display_name: Personio (v1)
     categories:
         - hr
     auth_mode: OAUTH2_CC
@@ -6162,7 +6162,7 @@ quickbooks:
 
 quickbooks-sandbox:
     alias: quickbooks
-    display_name: Quickbooks (sandbox)
+    display_name: Quickbooks (Sandbox)
     proxy:
         connection_config:
             realmId: ${connectionConfig.realmId}
@@ -6213,7 +6213,7 @@ ramp:
     docs: https://docs.nango.dev/integrations/all/ramp
 
 ramp-sandbox:
-    display_name: Ramp (sandbox)
+    display_name: Ramp (Sandbox)
     auth_mode: OAUTH2
     authorization_url: https://demo.ramp.com/v1/authorize
     token_url: https://demo-api.ramp.com/developer/v1/token
@@ -6360,7 +6360,7 @@ ring-central:
     docs: https://docs.nango.dev/integrations/all/ring-central
 
 ring-central-sandbox:
-    display_name: RingCentral (sandbox)
+    display_name: RingCentral (Sandbox)
     auth_mode: OAUTH2
     authorization_url: https://platform.devtest.ringcentral.com/restapi/oauth/authorize
     token_url: https://platform.devtest.ringcentral.com/restapi/oauth/token
@@ -6494,7 +6494,7 @@ salesforce:
             automated: true
 
 salesforce-sandbox:
-    display_name: Salesforce (sandbox)
+    display_name: Salesforce (Sandbox)
     auth_mode: OAUTH2
     authorization_url: https://test.salesforce.com/services/oauth2/authorize
     token_url: https://test.salesforce.com/services/oauth2/token
@@ -6677,7 +6677,7 @@ sendgrid:
             doc_section: '#step-1-generating-your-sendgrid-api-key'
 
 sedna:
-    display_name: Sedna (Oauth2)
+    display_name: Sedna (OAuth)
     auth_mode: OAUTH2_CC
     categories:
         - communication
@@ -6746,7 +6746,7 @@ signnow:
     docs: https://docs.nango.dev/integrations/all/signnow
 
 signnow-sandbox:
-    display_name: SignNow (sandbox)
+    display_name: SignNow (Sandbox)
     categories:
         - legal
     auth_mode: OAUTH2
@@ -6884,7 +6884,7 @@ shipstation:
             doc_section: '#step-1-finding-shipstation-api-key-and-api-secret'
 
 shopify:
-    display_name: Shopify
+    display_name: Shopify (OAuth)
     categories:
         - e-commerce
     auth_mode: OAUTH2
@@ -6908,7 +6908,7 @@ shopify:
             doc_section: '#step-1-finding-your-shopify-domain'
 
 shopify-api-key:
-    display_name: Shopify (api key)
+    display_name: Shopify (API Key)
     categories:
         - e-commerce
     auth_mode: API_KEY
@@ -7009,7 +7009,7 @@ slack:
     docs: https://docs.nango.dev/integrations/all/slack
 
 smartrecruiters-api-key:
-    display_name: Smartrecruiters (api key)
+    display_name: Smartrecruiters
     auth_mode: API_KEY
     proxy:
         base_url: https://api.smartrecruiters.com
@@ -7088,7 +7088,7 @@ splitwise:
     docs: https://docs.nango.dev/integrations/all/splitwise
 
 spotify:
-    display_name: Spotify
+    display_name: Spotify (OAuth)
     categories:
         - other
     auth_mode: OAUTH2
@@ -7104,7 +7104,7 @@ spotify:
         base_url: https://api.spotify.com
     docs: https://docs.nango.dev/integrations/all/spotify
 spotify-oauth2-cc:
-    display_name: Spotify (custom)
+    display_name: Spotify (Client Credentials)
     categories:
         - other
     auth_mode: OAUTH2_CC
@@ -7165,7 +7165,7 @@ squareup:
     docs: https://docs.nango.dev/integrations/all/squareup
 
 squareup-sandbox:
-    display_name: Squareup (sandbox)
+    display_name: Squareup (Sandbox)
     auth_mode: OAUTH2
     authorization_url: https://connect.squareupsandbox.com/oauth2/authorize
     token_url: https://connect.squareupsandbox.com/oauth2/token
@@ -7196,7 +7196,7 @@ stackexchange:
     docs: https://docs.nango.dev/integrations/all/stackexchange
 
 strava:
-    display_name: Strava (mobile)
+    display_name: Strava (Mobile)
     categories:
         - social
         - sports
@@ -7216,7 +7216,7 @@ strava:
     docs: https://docs.nango.dev/integrations/all/strava
 
 strava-web:
-    display_name: Strava (web)
+    display_name: Strava (Web)
     categories:
         - social
         - sports
@@ -7274,7 +7274,7 @@ stripe-app:
     docs: https://docs.nango.dev/integrations/all/stripe-app
 
 stripe-app-sandbox:
-    display_name: Stripe App (sandbox)
+    display_name: Stripe App (Sandbox)
     auth_mode: OAUTH2
     authorization_url: https://marketplace.stripe.com/oauth/v2/${connectionConfig.appDomain}/authorize
     token_url: https://api.stripe.com/v1/oauth/token
@@ -7470,7 +7470,7 @@ thrivecart-oauth:
     docs: https://docs.nango.dev/integrations/all/thrivecart-oauth
 
 thrivecart-api-key:
-    display_name: ThriveCart (api key)
+    display_name: ThriveCart (API Key)
     categories:
         - e-commerce
         - payment
@@ -7510,7 +7510,7 @@ tremendous:
     docs: https://docs.nango.dev/integrations/all/tremendous
 
 tremendous-sandbox:
-    display_name: Tremendous (sandbox)
+    display_name: Tremendous (Sandbox)
     categories:
         - payment
     auth_mode: OAUTH2
@@ -7673,7 +7673,7 @@ twitter-v2:
         base_url: https://api.twitter.com
     docs: https://docs.nango.dev/integrations/all/twitter-v2
 twitter-oauth2-cc:
-    display_name: Twitter (custom)
+    display_name: Twitter (Client Credentials)
     categories:
         - marketing
         - social
@@ -7938,7 +7938,7 @@ unipile:
             example: '13113'
 
 vimeo:
-    display_name: Vimeo
+    display_name: Vimeo (OAuth)
     categories:
         - video
     auth_mode: OAUTH2
@@ -7955,7 +7955,7 @@ vimeo:
     docs: https://docs.nango.dev/integrations/all/vimeo
 
 vimeo-basic:
-    display_name: Vimeo (basic auth)
+    display_name: Vimeo (Basic Auth)
     categories:
         - video
     auth_mode: BASIC
@@ -8137,7 +8137,7 @@ woocommerce:
             doc_section: '#step-2-finding-your-woocommerce-consumer-secret'
 
 workable:
-    display_name: Workable
+    display_name: Workable (API Key)
     categories:
         - ats
     auth_mode: API_KEY

--- a/packages/server/lib/controllers/config/getListIntegrations.integration.test.ts
+++ b/packages/server/lib/controllers/config/getListIntegrations.integration.test.ts
@@ -64,7 +64,7 @@ describe(`GET ${endpoint}`, () => {
                 {
                     provider: 'github',
                     unique_key: 'github',
-                    display_name: 'GitHub',
+                    display_name: 'GitHub (User OAuth)',
                     logo: 'http://localhost:3003/images/template-logos/github.svg',
                     created_at: expect.toBeIsoDate(),
                     updated_at: expect.toBeIsoDate()

--- a/packages/server/lib/controllers/integrations/getListIntegrations.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/getListIntegrations.integration.test.ts
@@ -78,7 +78,7 @@ describe(`GET ${endpoint}`, () => {
                 {
                     provider: 'github',
                     unique_key: 'github',
-                    display_name: 'GitHub',
+                    display_name: 'GitHub (User OAuth)',
                     logo: 'http://localhost:3003/images/template-logos/github.svg',
                     created_at: expect.toBeIsoDate(),
                     updated_at: expect.toBeIsoDate()

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.integration.test.ts
@@ -71,7 +71,7 @@ describe(`GET ${endpoint}`, () => {
             data: {
                 provider: 'github',
                 unique_key: 'github',
-                display_name: 'GitHub',
+                display_name: 'GitHub (User OAuth)',
                 logo: 'http://localhost:3003/images/template-logos/github.svg',
                 created_at: expect.toBeIsoDate(),
                 updated_at: expect.toBeIsoDate()


### PR DESCRIPTION
Guidelines I used: 
- Only specify auth type when there are multiple auth types for a given API
- Capitalize auth type
- Uppercase for acronyms

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

