### PR TITLE
fix: decrypt provider config in refreshConnections

### DIFF
--- a/packages/server/lib/refreshConnections.ts
+++ b/packages/server/lib/refreshConnections.ts
@@ -65,14 +65,25 @@ export async function exec(): Promise<void> {
                     }
 
                     const { connection, account, environment, integration } = staleConnection;
-                    const decrypted = encryptionManager.decryptConnection(connection);
-                    logger.info(`${cronName} refreshing connection '${connection.connection_id}' for accountId '${account.id}'`);
+
+                    const decryptedConnection = encryptionManager.decryptConnection(connection);
+                    if (!decryptedConnection) {
+                        logger.error(`${cronName} failed to decrypt stale connection '${connection.id}'`);
+                        continue;
+                    }
+
+                    const decryptedIntegration = encryptionManager.decryptProviderConfig(integration);
+                    if (!decryptedIntegration) {
+                        logger.error(`${cronName} failed to decrypt integration '${integration.id} for stale connection '${connection.id}'`);
+                        continue;
+                    }
+
                     try {
                         const credentialResponse = await connectionService.refreshOrTestCredentials({
                             account,
                             environment,
-                            integration,
-                            connection: decrypted!,
+                            integration: decryptedIntegration,
+                            connection: decryptedConnection,
                             logContextGetter,
                             instantRefresh: false,
                             onRefreshSuccess: connectionRefreshSuccessHook,


### PR DESCRIPTION
We were passing the encrypted oauth client secret to refreshOrTestCredentials because unlike the other method in config.service the getStaleConnections function doesn't decrypt the oauth client secret :(

Ideally we should have different types for encrypted/decrypted entities to prevent passing the wrong one 

