### PR TITLE
feat(sync): logs unchanged in results

### DIFF
--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -245,7 +245,8 @@ export async function handleSyncSuccess({ nangoProps }: { nangoProps: NangoProps
                 [model]: {
                     added: 0,
                     updated: 0,
-                    deleted: deletedKeys.length
+                    deleted: deletedKeys.length,
+                    unchanged: 0
                 }
             };
 
@@ -277,20 +278,23 @@ export async function handleSyncSuccess({ nangoProps }: { nangoProps: NangoProps
             let added = 0;
             let updated = 0;
             let deleted = 0;
+            let unchanged = 0;
 
             if (result && result[model]) {
                 const modelResult = result[model] as SyncResult;
                 added = modelResult.added;
                 updated = modelResult.updated;
                 deleted = modelResult.deleted;
+                unchanged = modelResult.unchanged;
             } else {
                 // legacy json structure
                 added = (result?.['added'] as unknown as number) ?? 0;
                 updated = (result?.['updated'] as unknown as number) ?? 0;
                 deleted = (result?.['deleted'] as unknown as number) ?? 0;
+                unchanged = (result?.['unchanged'] as unknown as number) ?? 0;
             }
 
-            syncPayload.records[model] = { added, updated, deleted };
+            syncPayload.records[model] = { added, updated, deleted, unchanged };
 
             if (webhookSettings && environment) {
                 const span = tracer.startSpan('jobs.sync.webhook', {
@@ -320,7 +324,8 @@ export async function handleSyncSuccess({ nangoProps }: { nangoProps: NangoProps
                                 responseResults: {
                                     added,
                                     updated,
-                                    deleted
+                                    deleted,
+                                    unchanged
                                 },
                                 operation: lastSyncDate ? SyncJobsType.INCREMENTAL : SyncJobsType.FULL
                             });

--- a/packages/jobs/lib/execution/webhook.ts
+++ b/packages/jobs/lib/execution/webhook.ts
@@ -229,7 +229,7 @@ export async function handleWebhookSuccess({ nangoProps }: { nangoProps: NangoPr
                         model,
                         now: nangoProps.startedAt,
                         success: true,
-                        responseResults: syncJob.result?.[model] || { added: 0, updated: 0, deleted: 0 },
+                        responseResults: syncJob.result?.[model] || { added: 0, updated: 0, deleted: 0, unchanged: 0 },
                         operation: 'WEBHOOK'
                     });
 

--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -74,6 +74,7 @@ describe('Records service', () => {
             updatedKeys: [],
             deletedKeys: [],
             nonUniqueKeys: ['1'],
+            unchangedKeys: [],
             nextMerging: { strategy: 'override' }
         });
 
@@ -87,7 +88,7 @@ describe('Records service', () => {
             updatedKeys: ['2'],
             deletedKeys: [],
             nonUniqueKeys: [],
-
+            unchangedKeys: ['1'],
             nextMerging: { strategy: 'override' }
         });
 
@@ -98,7 +99,14 @@ describe('Records service', () => {
         expect(after.find((r) => r.external_id === '4')?.sync_job_id).toBe(1);
 
         const updated = await updateRecords({ records: [{ id: '1', name: 'Maurice Doe' }], connectionId, model, syncId, syncJobId: 3 });
-        expect(updated).toStrictEqual({ addedKeys: [], updatedKeys: ['1'], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
+        expect(updated).toStrictEqual({
+            addedKeys: [],
+            updatedKeys: ['1'],
+            deletedKeys: [],
+            nonUniqueKeys: [],
+            unchangedKeys: [],
+            nextMerging: { strategy: 'override' }
+        });
     });
 
     describe('upserting records', () => {
@@ -121,6 +129,7 @@ describe('Records service', () => {
                     updatedKeys: [],
                     deletedKeys: [],
                     nonUniqueKeys: ['1'],
+                    unchangedKeys: [],
                     nextMerging: { strategy: 'override' }
                 });
 
@@ -134,6 +143,7 @@ describe('Records service', () => {
                     updatedKeys: ['2'],
                     deletedKeys: [],
                     nonUniqueKeys: [],
+                    unchangedKeys: ['1'],
                     nextMerging: { strategy: 'override' }
                 });
 
@@ -171,6 +181,7 @@ describe('Records service', () => {
                     updatedKeys: [],
                     deletedKeys: [],
                     nonUniqueKeys: [],
+                    unchangedKeys: [],
                     nextMerging: {
                         strategy: 'ignore_if_modified_after_cursor',
                         cursor: (await Records.getCursor({ connectionId, model, offset: 'last' })).unwrap()
@@ -188,6 +199,7 @@ describe('Records service', () => {
                     updatedKeys: ['4'],
                     deletedKeys: [],
                     nonUniqueKeys: [],
+                    unchangedKeys: [],
                     nextMerging: { strategy: 'override' }
                 });
 
@@ -211,6 +223,7 @@ describe('Records service', () => {
                     updatedKeys: ['1'],
                     deletedKeys: [],
                     nonUniqueKeys: [],
+                    unchangedKeys: [],
                     nextMerging: {
                         strategy: 'ignore_if_modified_after_cursor',
                         cursor: (await Records.getCursor({ connectionId, model, offset: 'last' })).unwrap()
@@ -246,12 +259,20 @@ describe('Records service', () => {
                 return {
                     addedKeys: acc.addedKeys.concat(curr.addedKeys),
                     updatedKeys: acc.updatedKeys.concat(curr.updatedKeys),
+                    unchangedKeys: [],
                     deletedKeys: (acc.deletedKeys || []).concat(curr.deletedKeys || []),
                     nonUniqueKeys: acc.nonUniqueKeys.concat(curr.nonUniqueKeys),
                     nextMerging: curr.nextMerging
                 };
             });
-            expect(agg).toStrictEqual({ addedKeys: ['1'], updatedKeys: [], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
+            expect(agg).toStrictEqual({
+                addedKeys: ['1'],
+                updatedKeys: [],
+                deletedKeys: [],
+                nonUniqueKeys: [],
+                unchangedKeys: [],
+                nextMerging: { strategy: 'override' }
+            });
         });
     });
 
@@ -269,6 +290,7 @@ describe('Records service', () => {
                 updatedKeys: [],
                 deletedKeys: [],
                 nonUniqueKeys: [],
+                unchangedKeys: [],
                 nextMerging: {
                     strategy: 'override'
                 }
@@ -297,6 +319,7 @@ describe('Records service', () => {
                 updatedKeys: ['1'],
                 deletedKeys: [],
                 nonUniqueKeys: [],
+                unchangedKeys: [],
                 nextMerging: {
                     strategy: 'override'
                 }
@@ -335,12 +358,21 @@ describe('Records service', () => {
                     updatedKeys: [],
                     deletedKeys: [],
                     nonUniqueKeys: ['1'],
+                    unchangedKeys: [],
                     nextMerging: { strategy: 'override' }
                 });
 
                 const updated = await updateRecords({ records: [{ id: '1', name: 'Maurice Doe' }], connectionId, model, syncId, syncJobId: 2 });
-                expect(updated).toStrictEqual({ addedKeys: [], updatedKeys: ['1'], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
+                expect(updated).toStrictEqual({
+                    addedKeys: [],
+                    updatedKeys: ['1'],
+                    deletedKeys: [],
+                    nonUniqueKeys: [],
+                    unchangedKeys: [],
+                    nextMerging: { strategy: 'override' }
+                });
             });
+
             it('when strategy = ignore_if_modified_after_cursor', async () => {
                 const connectionId = rnd.number();
                 const environmentId = rnd.number();
@@ -368,6 +400,7 @@ describe('Records service', () => {
                     updatedKeys: [],
                     deletedKeys: [],
                     nonUniqueKeys: [],
+                    unchangedKeys: [],
                     nextMerging: {
                         strategy: 'ignore_if_modified_after_cursor',
                         cursor: (await Records.getCursor({ connectionId, model, offset: 'last' })).unwrap()
@@ -382,7 +415,14 @@ describe('Records service', () => {
                     syncId,
                     syncJobId: 2
                 });
-                expect(updated).toStrictEqual({ addedKeys: [], updatedKeys: ['4'], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
+                expect(updated).toStrictEqual({
+                    addedKeys: [],
+                    updatedKeys: ['4'],
+                    deletedKeys: [],
+                    nonUniqueKeys: [],
+                    unchangedKeys: [],
+                    nextMerging: { strategy: 'override' }
+                });
 
                 // update records with merging strategy 'ignore_if_modified_after_cursor'
                 const upserted = await updateRecords({
@@ -403,6 +443,7 @@ describe('Records service', () => {
                     updatedKeys: ['1'],
                     deletedKeys: [],
                     nonUniqueKeys: [],
+                    unchangedKeys: [],
                     nextMerging: { strategy: 'ignore_if_modified_after_cursor', cursor: nextCursor }
                 });
             });
@@ -457,13 +498,21 @@ describe('Records service', () => {
             updatedKeys: [],
             deletedKeys: expect.arrayContaining(['1', '2']),
             nonUniqueKeys: [],
+            unchangedKeys: [],
             nextMerging: { strategy: 'override' }
         });
 
         // Try to delete the same records again
         // Should not have any effect
         const res2 = await upsertRecords({ records: toDelete, connectionId, environmentId, model, syncId, softDelete: true });
-        expect(res2).toStrictEqual({ addedKeys: [], updatedKeys: [], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
+        expect(res2).toStrictEqual({
+            addedKeys: [],
+            updatedKeys: [],
+            deletedKeys: [],
+            nonUniqueKeys: [],
+            unchangedKeys: expect.arrayContaining(['1', '2']),
+            nextMerging: { strategy: 'override' }
+        });
     });
 
     describe('getRecords', () => {

--- a/packages/records/lib/types.ts
+++ b/packages/records/lib/types.ts
@@ -57,6 +57,7 @@ export interface UpsertSummary {
     addedKeys: string[];
     updatedKeys: string[];
     deletedKeys?: string[];
+    unchangedKeys: string[];
     nonUniqueKeys: string[];
     nextMerging: MergingStrategy;
 }

--- a/packages/shared/lib/models/Sync.ts
+++ b/packages/shared/lib/models/Sync.ts
@@ -21,6 +21,7 @@ export interface SyncResult {
     added: number;
     updated: number;
     deleted: number;
+    unchanged: number;
 }
 
 export type SyncResultByModel = Record<string, SyncResult>;

--- a/packages/shared/lib/services/sync/job.service.ts
+++ b/packages/shared/lib/services/sync/job.service.ts
@@ -130,14 +130,15 @@ export const updateSyncJobResult = async (id: number, result: SyncResultByModel,
 
             return updatedRow as SyncJob;
         } else {
-            const { added, updated, deleted } = existingResult[model] || { added: 0, updated: 0, deleted: 0 };
+            const { added, updated, deleted, unchanged } = existingResult[model] || { added: 0, updated: 0, deleted: 0 };
 
             const incomingResult = result[model];
             const finalResult = {
                 ...existingResult,
                 [model]: {
                     added: Number(added) + Number(incomingResult?.added),
-                    updated: Number(updated) + Number(incomingResult?.updated)
+                    updated: Number(updated) + Number(incomingResult?.updated),
+                    unchanged: Number(unchanged) + Number(incomingResult?.unchanged)
                 }
             };
 

--- a/packages/types/lib/scripts/syncs/api.ts
+++ b/packages/types/lib/scripts/syncs/api.ts
@@ -2,6 +2,7 @@ export interface SyncResult {
     added: number;
     updated: number;
     deleted: number;
+    unchanged: number;
 }
 
 export type SyncOperationType = 'INCREMENTAL' | 'FULL' | 'WEBHOOK';

--- a/packages/webhooks/lib/sync.ts
+++ b/packages/webhooks/lib/sync.ts
@@ -98,15 +98,13 @@ export const sendSync = async ({
             responseResults: {
                 added: responseResults.added,
                 updated: responseResults.updated,
-                deleted: 0
+                deleted: responseResults.deleted,
+                unchanged: responseResults.unchanged
             },
             modifiedAfter: dayjs(now).toDate().toISOString(),
             queryTimeStamp: now as unknown as string // Deprecated
         };
 
-        if (responseResults.deleted && responseResults.deleted > 0) {
-            finalBody.responseResults.deleted = responseResults.deleted;
-        }
         endingMessage = noChanges ? 'with no data changes as per your environment settings.' : 'with data changes.';
     } else {
         finalBody = {

--- a/packages/webhooks/lib/sync.unit.test.ts
+++ b/packages/webhooks/lib/sync.unit.test.ts
@@ -80,7 +80,7 @@ describe('Webhooks: sync notification tests', () => {
     });
 
     it('Should not send a sync webhook if the webhook url is not present', async () => {
-        const responseResults = { added: 10, updated: 0, deleted: 0 };
+        const responseResults = { added: 10, updated: 0, deleted: 0, unchanged: 0 };
 
         await sendSync({
             account,
@@ -104,7 +104,7 @@ describe('Webhooks: sync notification tests', () => {
     });
 
     it('Should not send a sync webhook if the webhook url is not present even if always send is checked', async () => {
-        const responseResults = { added: 10, updated: 0, deleted: 0 };
+        const responseResults = { added: 10, updated: 0, deleted: 0, unchanged: 0 };
         await sendSync({
             account,
             connection,
@@ -127,7 +127,7 @@ describe('Webhooks: sync notification tests', () => {
     });
 
     it('Should not send a sync webhook if the webhook url is present but if always send is not checked and there were no sync changes', async () => {
-        const responseResults = { added: 0, updated: 0, deleted: 0 };
+        const responseResults = { added: 0, updated: 0, deleted: 0, unchanged: 0 };
         await sendSync({
             account,
             connection,
@@ -149,7 +149,7 @@ describe('Webhooks: sync notification tests', () => {
     });
 
     it('Should send a sync webhook if the webhook url is present and if always send is not checked and there were sync changes', async () => {
-        const responseResults = { added: 10, updated: 0, deleted: 0 };
+        const responseResults = { added: 10, updated: 0, deleted: 0, unchanged: 0 };
         await sendSync({
             account,
             connection,
@@ -171,7 +171,7 @@ describe('Webhooks: sync notification tests', () => {
     });
 
     it('Should send a sync webhook if the webhook url is present and if always send is checked and there were sync changes', async () => {
-        const responseResults = { added: 10, updated: 0, deleted: 0 };
+        const responseResults = { added: 10, updated: 0, deleted: 0, unchanged: 0 };
         await sendSync({
             account,
             connection,
@@ -193,7 +193,7 @@ describe('Webhooks: sync notification tests', () => {
     });
 
     it('Should send an sync webhook if the webhook url is present and if always send is checked and there were no sync changes', async () => {
-        const responseResults = { added: 0, updated: 0, deleted: 0 };
+        const responseResults = { added: 0, updated: 0, deleted: 0, unchanged: 0 };
         await sendSync({
             account,
             connection,
@@ -215,7 +215,7 @@ describe('Webhooks: sync notification tests', () => {
     });
 
     it('Should send an sync webhook twice if the webhook url and secondary are present and if always send is checked and there were no sync changes', async () => {
-        const responseResults = { added: 0, updated: 0, deleted: 0 };
+        const responseResults = { added: 0, updated: 0, deleted: 0, unchanged: 0 };
         await sendSync({
             account,
             connection,
@@ -238,7 +238,7 @@ describe('Webhooks: sync notification tests', () => {
     it('Should send a webhook with the correct body on sync success', async () => {
         const now = new Date();
 
-        const responseResults = { added: 10, updated: 0, deleted: 0 };
+        const responseResults = { added: 10, updated: 0, deleted: 0, unchanged: 0 };
         await sendSync({
             account,
             connection,


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-2916/log-unchanged-records

> [!NOTE]
> This is a proposal: it's hard to debug how many records have been sent and the logs only say "0 saved" which adds to the confusion. Same for the webhook. 

- Logs unchanged in results and webhook
If this PR is accepted, we will need to announce a breaking change in the webhook shape just in case, because people might be using strict struct to parse the json.
