### PR TITLE
fix(connection): incorrect connection id

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -186,7 +186,7 @@ class ConnectionService {
         environment: DBEnvironment;
         account: DBTeam;
     }): Promise<ConnectionUpsertResponse[]> {
-        const encryptedConnection = encryptionManager.encryptConnection({
+        const { id, ...encryptedConnection } = encryptionManager.encryptConnection({
             connection_id: connectionId,
             provider_config_key: providerConfigKey,
             config_id: config.id as number,


### PR DESCRIPTION
## Changes

- Fix incorrect connection id
I add to fake a connection id to encrypt correctly, I did at two place and forgot to remove the -1 in the second one.