### PR TITLE
fix(records): wrong nextMerging cursor when last record was not updated

### DIFF
--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -299,6 +299,13 @@ export async function upsert({
                     });
                 };
 
+                interface UpsertResult {
+                    external_id: string;
+                    id: string;
+                    last_modified_at: string;
+                    status: 'inserted' | 'changed' | 'undeleted' | 'deleted' | 'unchanged';
+                }
+
                 // we need to know which records were updated, deleted, undeleted or unchanged
                 // we achieve this by comparing the records data_hash and deleted_at fields before and after the update
                 const externalIds = chunk.map((r) => r.external_id);
@@ -328,9 +335,7 @@ export async function upsert({
                             }
                         }
                     })
-                    .select<
-                        { external_id: string; id: string; last_modified_at: string; status: 'inserted' | 'changed' | 'undeleted' | 'deleted' | 'unchanged' }[]
-                    >(
+                    .select<UpsertResult[]>(
                         trx.raw(`
                             upsert.id as id,
                             upsert.external_id as external_id,
@@ -366,12 +371,23 @@ export async function upsert({
                     summary.updatedKeys.push(...updated);
                 }
 
-                const lastRecord = updatedRes[updatedRes.length - 1];
-                if (merging.strategy === 'ignore_if_modified_after_cursor' && lastRecord) {
-                    summary.nextMerging = {
-                        strategy: merging.strategy,
-                        cursor: Cursor.new(lastRecord)
+                if (merging.strategy === 'ignore_if_modified_after_cursor') {
+                    // Next cursor is the last MODIFIED record
+                    const getLastModifiedRecord = (records: UpsertResult[]): UpsertResult | undefined => {
+                        for (let i = records.length - 1; i >= 0; i--) {
+                            if (records[i]?.status !== 'unchanged') {
+                                return records[i];
+                            }
+                        }
+                        return undefined;
                     };
+                    const lastRecord = getLastModifiedRecord(updatedRes);
+                    if (lastRecord) {
+                        summary.nextMerging = {
+                            strategy: merging.strategy,
+                            cursor: Cursor.new(lastRecord)
+                        };
+                    }
                 }
             }
             const delta = summary.addedKeys.length - (summary.deletedKeys?.length ?? 0);


### PR DESCRIPTION
Next merging cursor was wrongly set to the last record returned by the query even when the last record was unchanged (aka: same values and therefore same old updated_at). 
In this case this old record will be used for subsequent batch operations as the cursor and prevent more recent records to be updated.
Coupled with `track_deletes=true` it could lead to records be wrongly discarded and therefore deleted at the end of the sync

added integration tests


