### PR TITLE
fix: wait for 10 successes to consider a runner healthy

### DIFF
--- a/packages/fleet/lib/fleet.ts
+++ b/packages/fleet/lib/fleet.ts
@@ -14,7 +14,7 @@ import type { FleetId } from './instances.js';
 import { envs } from './env.js';
 import { withPgLock } from './utils/locking.js';
 import { noopNodeProvider } from './node-providers/noop.js';
-import { waithUntilHealthy } from './utils/url.js';
+import { waitUntilHealthy } from './utils/url.js';
 
 const defaultDbUrl =
     envs.NANGO_DATABASE_URL ||
@@ -140,7 +140,7 @@ export class Fleet {
         }
         // in Render, network configuration can take a long time to be applied and accessible to other services
         // we therefore wait until the health url is reachable
-        const healthy = await waithUntilHealthy({ url: `${url}/health`, timeoutMs: envs.FLEET_TIMEOUT_HEALTHY_MS });
+        const healthy = await waitUntilHealthy({ url: `${url}/health`, timeoutMs: envs.FLEET_TIMEOUT_HEALTHY_MS });
         if (healthy.isErr()) {
             return Err(healthy.error);
         }

--- a/packages/fleet/lib/utils/url.ts
+++ b/packages/fleet/lib/utils/url.ts
@@ -2,18 +2,25 @@ import type { Result } from '@nangohq/utils';
 import { Err, Ok } from '@nangohq/utils';
 import { setTimeout } from 'node:timers/promises';
 
-export async function waithUntilHealthy({ url, timeoutMs }: { url: string; timeoutMs: number }): Promise<Result<void>> {
+export async function waitUntilHealthy({ url, timeoutMs }: { url: string; timeoutMs: number }): Promise<Result<void>> {
     const startTime = Date.now();
     const waitMs = 1000;
+    const requiredSuccesses = 10;
+    let successCount = 0;
     while (Date.now() - startTime < timeoutMs) {
         try {
             const res = await fetch(url);
             if (res.ok) {
-                return Ok(undefined);
+                successCount++;
+                if (successCount >= requiredSuccesses) {
+                    return Ok(undefined);
+                }
             } else {
-                await setTimeout(waitMs);
+                successCount = 0;
             }
+            await setTimeout(waitMs);
         } catch {
+            successCount = 0;
             await setTimeout(waitMs);
         }
     }


### PR DESCRIPTION
when a runner goes live we had a few cases where the fleet supervisor would successfully reach the /health endpoint and mark it as running but then a script execution would fail trying to reach the runner. My hypothesis is that Render network config can take a bit of time to propagate and even if a runner can be reached from one jobs instance (the one running fleet supervisor) there is not guarantee it can also be reached immediately by all jobs instances.
This commit requires consecutive successes when making sure the runner is healthy before it can be registered. It is making the registration slower but it is a one-off thing


