### PR TITLE
fix: authenticate memory warning logs from runner to persist

### DIFF
--- a/packages/runner/lib/utils.ts
+++ b/packages/runner/lib/utils.ts
@@ -2,13 +2,24 @@ import { getLogger, stringifyError } from '@nangohq/utils';
 
 export const logger = getLogger('Runner');
 
-export async function httpFetch({ method, url, data = undefined }: { method: string; url: string; data?: string }): Promise<void> {
+export async function httpFetch({
+    method,
+    url,
+    headers = undefined,
+    data = undefined
+}: {
+    method: string;
+    url: string;
+    headers?: Record<string, string>;
+    data?: string;
+}): Promise<void> {
     try {
         const res = await fetch(url, {
             method: method,
             headers: {
                 Accept: 'application/json',
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                ...(headers ?? {})
             },
             ...(data && { body: data })
         });

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -56,6 +56,7 @@ export const ENVS = z.object({
     IDLE_MAX_DURATION_MS: z.coerce.number().default(0),
     RUNNER_NODE_ID: z.coerce.number().optional(),
     RUNNER_URL: z.string().url().optional(),
+    RUNNER_MEMORY_WARNING_THRESHOLD: z.coerce.number().optional().default(85),
 
     // FLEET
     FLEET_TIMEOUT_PENDING_MS: z.coerce


### PR DESCRIPTION
Making sure the correct authorization header is passed when making a call from runner to log memory usage warnings.

It was much easier to fix than I thought I wish I had looked into it earlier.

To test it locally you are gonna need to modify/remove the condition `if (memoryUsagePercentage > MEMORY_WARNING_PERCENTAGE_THRESHOLD)`