### PR TITLE
fix: 10 successful reqs to runner /healthy for cloud only

### DIFF
--- a/packages/fleet/lib/utils/url.ts
+++ b/packages/fleet/lib/utils/url.ts
@@ -1,11 +1,11 @@
 import type { Result } from '@nangohq/utils';
-import { Err, Ok } from '@nangohq/utils';
+import { Err, Ok, isCloud } from '@nangohq/utils';
 import { setTimeout } from 'node:timers/promises';
 
 export async function waitUntilHealthy({ url, timeoutMs }: { url: string; timeoutMs: number }): Promise<Result<void>> {
     const startTime = Date.now();
     const waitMs = 1000;
-    const requiredSuccesses = 10;
+    const requiredSuccesses = isCloud ? 10 : 1;
     let successCount = 0;
     while (Date.now() - startTime < timeoutMs) {
         try {


### PR DESCRIPTION
when running locally we don't need to wait for 10 consecutives successful requests to runner /health to consider it healthy

