### PR TITLE
fix: pause schedules when disabling integration

### DIFF
--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -645,6 +645,31 @@ export class Orchestrator {
         }
         return res;
     }
+    async pauseSync({ syncId, environmentId }: { syncId: string; environmentId: number }): Promise<Result<void>> {
+        const res = await this.client.pauseSync({ scheduleName: `environment:${environmentId}:sync:${syncId}` });
+        if (res.isErr()) {
+            errorManager.report(res.error, {
+                source: ErrorSourceEnum.PLATFORM,
+                operation: LogActionEnum.SYNC,
+                environmentId,
+                metadata: { syncId, environmentId }
+            });
+        }
+        return res;
+    }
+
+    async unpauseSync({ syncId, environmentId }: { syncId: string; environmentId: number }): Promise<Result<void>> {
+        const res = await this.client.unpauseSync({ scheduleName: `environment:${environmentId}:sync:${syncId}` });
+        if (res.isErr()) {
+            errorManager.report(res.error, {
+                source: ErrorSourceEnum.PLATFORM,
+                operation: LogActionEnum.SYNC,
+                environmentId,
+                metadata: { syncId, environmentId }
+            });
+        }
+        return res;
+    }
 
     async scheduleSync({
         nangoConnection,

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -57,12 +57,6 @@ export const getById = async (id: string): Promise<Sync | null> => {
 };
 
 export const createSync = async (nangoConnectionId: number, syncConfig: DBSyncConfig): Promise<Sync | null> => {
-    const existingSync = await getSyncByIdAndName(nangoConnectionId, syncConfig.sync_name);
-
-    if (existingSync || !syncConfig.id) {
-        return null;
-    }
-
     const sync: Omit<Sync, 'created_at' | 'updated_at'> = {
         id: uuidv4(),
         nango_connection_id: nangoConnectionId,


### PR DESCRIPTION
when disabling an integration we currently only disable the sync config but we don't pause the schedules, which means we have schedules in STARTED state which are linked to disabled configs. The orchestrator is scheduling tasks for this schedules, even though the tasks fails quickly because the sync config is disable. 
Once this fix is merged, I will go over the existing schedules and paused every one of them that is associated to a disabled sync config. 

How to test:
1. Disable/enable integrations endpoints
2. check in db that the schedules state changes to PAUSED/STARTED

