### PR TITLE
feat: introduce sync variant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36967,6 +36967,7 @@
                 "@nangohq/database": "file:../database",
                 "@nangohq/types": "file:../types",
                 "@types/connect-timeout": "0.0.39",
+                "@types/unzipper": "^0.10.10",
                 "typescript": "5.7.3",
                 "vitest": "2.1.9"
             }

--- a/packages/database/lib/migrations/20250211192007_sync_variant.cjs
+++ b/packages/database/lib/migrations/20250211192007_sync_variant.cjs
@@ -1,0 +1,15 @@
+const TABLE = '_nango_syncs';
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.schema.raw(`
+        ALTER TABLE "${TABLE}"
+        ADD COLUMN IF NOT EXISTS "variant" varchar(255) NOT NULL DEFAULT 'base'
+    `);
+};
+
+exports.down = function () {
+    // do nothing
+};

--- a/packages/database/lib/migrations/20250211192007_sync_variant.cjs
+++ b/packages/database/lib/migrations/20250211192007_sync_variant.cjs
@@ -1,3 +1,5 @@
+exports.config = { transaction: false };
+
 const TABLE = '_nango_syncs';
 
 /**
@@ -7,6 +9,10 @@ exports.up = async function (knex) {
     await knex.schema.raw(`
         ALTER TABLE "${TABLE}"
         ADD COLUMN IF NOT EXISTS "variant" varchar(255) NOT NULL DEFAULT 'base'
+    `);
+    await knex.schema.raw(`
+        CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "_nango_syncs_variant_name_nango_connection_id_deleted_at_unique"
+        ON "${TABLE}" ("variant", "name", "nango_connection_id", "deleted_at")
     `);
 };
 

--- a/packages/jobs/lib/execution/webhook.ts
+++ b/packages/jobs/lib/execution/webhook.ts
@@ -14,7 +14,7 @@ import {
     featureFlags,
     getApiUrl,
     getEndUserByConnectionId,
-    getSyncByIdAndName,
+    getSync,
     getSyncConfigRaw,
     updateSyncJobStatus
 } from '@nangohq/shared';
@@ -49,7 +49,7 @@ export async function startWebhook(task: TaskWebhook): Promise<Result<void>> {
             throw new Error(`Provider config not found for connection: ${task.connection.connection_id}`);
         }
 
-        sync = await getSyncByIdAndName(task.connection.id, task.parentSyncName);
+        sync = await getSync({ connectionId: task.connection.id, name: task.parentSyncName, variant: 'base' }); // webhooks are always executed against the 'base' sync
         if (!sync) {
             throw new Error(`Sync not found for connection: ${task.connection.connection_id}`);
         }

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -469,7 +469,7 @@ const initDb = async () => {
     const connection = await connectionService.getConnectionById(connectionId);
     if (!connection) throw new Error('Connection not found');
 
-    const sync = await createSync(connectionId, syncConfig);
+    const sync = await createSync({ connectionId, syncConfig, variant: 'base' });
     if (!sync?.id) throw new Error('Sync not created');
 
     const syncJob = await createSyncJob({

--- a/packages/server/lib/controllers/flow.controller.ts
+++ b/packages/server/lib/controllers/flow.controller.ts
@@ -58,7 +58,12 @@ class FlowController {
                 return;
             }
 
-            await syncManager.triggerIfConnectionsExist(preBuiltResponse.result, environment.id, logContextGetter, orchestrator);
+            await syncManager.triggerIfConnectionsExist({
+                flows: preBuiltResponse.result,
+                environmentId: environment.id,
+                logContextGetter,
+                orchestrator
+            });
 
             res.sendStatus(200);
         } catch (err) {

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -716,6 +716,7 @@ class SyncController {
             }
             const connection = getConnection.response;
 
+            // TODO: handle variant
             const syncs = await findSyncByConnections([Number(connection.id)], sync_name);
             if (syncs.length <= 0) {
                 res.status(400).send({ message: 'Invalid sync_name' });

--- a/packages/server/lib/controllers/v1/flows/id/patchEnable.ts
+++ b/packages/server/lib/controllers/v1/flows/id/patchEnable.ts
@@ -56,12 +56,12 @@ export const patchFlowEnable = asyncWrapper<PatchFlowEnable>(async (req, res) =>
     const updated = await enableScriptConfig({ id: valParams.data.id, environmentId: environment.id });
 
     if (updated > 0) {
-        await syncManager.triggerIfConnectionsExist(
-            [{ ...syncConfig, name: syncConfig.sync_name, providerConfigKey: body.providerConfigKey }],
-            environment.id,
+        await syncManager.triggerIfConnectionsExist({
+            flows: [{ ...syncConfig, name: syncConfig.sync_name, providerConfigKey: body.providerConfigKey }],
+            environmentId: environment.id,
             logContextGetter,
             orchestrator
-        );
+        });
         res.status(200).send({ data: { success: true } });
     } else {
         res.status(400).send({ data: { success: false } });

--- a/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.ts
+++ b/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.ts
@@ -85,7 +85,7 @@ export const postPreBuiltDeploy = asyncWrapper<PostPreBuiltDeploy>(async (req, r
         return;
     }
 
-    await syncManager.triggerIfConnectionsExist(response.result, environmentId, logContextGetter, orchestrator);
+    await syncManager.triggerIfConnectionsExist({ flows: response.result, environmentId, logContextGetter, orchestrator });
 
     res.status(201).send({ data: { id: response.result[0]!.id! } });
 });

--- a/packages/shared/lib/models/Sync.ts
+++ b/packages/shared/lib/models/Sync.ts
@@ -31,6 +31,7 @@ export interface Sync extends TimestampsAndDeleted {
     id: string;
     nango_connection_id: number;
     name: string;
+    variant: string;
     last_sync_date: Date | null;
     futureActionTimes?: {
         seconds?: number;

--- a/packages/shared/lib/seeders/sync.seeder.ts
+++ b/packages/shared/lib/seeders/sync.seeder.ts
@@ -42,7 +42,7 @@ export async function createSyncSeeds({
         throw new Error('Sync config not created');
     }
 
-    const sync = await syncService.createSync(connectionId, syncConfig);
+    const sync = await syncService.createSync({ connectionId, syncConfig, variant: 'base' });
     if (!sync) {
         throw new Error('Sync not created');
     }

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -6,7 +6,7 @@ import {
     getSyncsByConnectionId,
     getSyncsByProviderConfigKey,
     getSyncsByProviderConfigAndSyncNames,
-    getSyncByIdAndName,
+    getSync,
     getSyncNamesByConnectionId,
     softDeleteSync,
     getSyncsBySyncConfigId
@@ -40,13 +40,14 @@ export interface CreateSyncArgs {
     environmentId: number;
     sync: IncomingFlowConfig;
     syncName: string;
+    variant: string;
 }
 
 const logger = getLogger('sync.manager');
 
 export class SyncManagerService {
-    public async createSyncForConnection(nangoConnectionId: number, logContextGetter: LogContextGetter, orchestrator: Orchestrator): Promise<void> {
-        const nangoConnection = (await connectionService.getConnectionById(nangoConnectionId))!;
+    public async createSyncForConnection(connectionId: number, logContextGetter: LogContextGetter, orchestrator: Orchestrator): Promise<void> {
+        const nangoConnection = (await connectionService.getConnectionById(connectionId))!;
         const nangoConfig = await getSyncConfig({ nangoConnection });
         if (!nangoConfig) {
             logger.error(
@@ -79,12 +80,12 @@ export class SyncManagerService {
                 continue;
             }
 
-            const existingSync = await getSyncByIdAndName(nangoConnectionId, syncConfig.sync_name);
+            const existingSync = await getSync({ connectionId, name: syncName, variant: 'base' });
             if (existingSync) {
                 await orchestrator.unpauseSync({ syncId: existingSync.id, environmentId: nangoConnection.environment_id });
                 continue;
             }
-            const sync = await createSync(nangoConnectionId, syncConfig);
+            const sync = await createSync({ connectionId, syncConfig, variant: 'base' });
             if (sync) {
                 await orchestrator.scheduleSync({
                     nangoConnection,
@@ -101,6 +102,7 @@ export class SyncManagerService {
     public async createSyncForConnections(
         connections: ConnectionInternal[],
         syncName: string,
+        variant: string,
         providerConfigKey: string,
         environmentId: number,
         flowConfig: IncomingFlowConfig,
@@ -114,20 +116,17 @@ export class SyncManagerService {
             if (!providerConfig) {
                 throw new Error(`Provider config not found for ${providerConfigKey} in environment ${environmentId}`);
             }
-            if (debug) {
-                await logCtx?.debug(`Beginning iteration of starting syncs for ${syncName} with ${connections.length} connections`);
-            }
             for (const connection of connections) {
                 const syncConfig = await getSyncConfigByParams(connection.environment_id, syncName, providerConfigKey);
                 if (!syncConfig) {
                     continue;
                 }
-                const existingSync = await getSyncByIdAndName(connection.id, syncConfig.sync_name);
+                const existingSync = await getSync({ connectionId: connection.id, name: syncName, variant });
                 if (existingSync) {
                     await orchestrator.unpauseSync({ syncId: existingSync.id, environmentId: connection.environment_id });
                     continue;
                 }
-                const sync = await createSync(connection.id, syncConfig);
+                const sync = await createSync({ connectionId: connection.id, syncConfig, variant });
                 if (sync) {
                     await orchestrator.scheduleSync({
                         nangoConnection: connection,
@@ -161,10 +160,11 @@ export class SyncManagerService {
     ): Promise<boolean> {
         let success = true;
         for (const syncToCreate of syncArgs) {
-            const { connections, providerConfigKey, environmentId, sync, syncName } = syncToCreate;
+            const { connections, providerConfigKey, environmentId, sync, syncName, variant } = syncToCreate;
             const result = await this.createSyncForConnections(
                 connections,
                 syncName,
+                variant,
                 providerConfigKey,
                 environmentId,
                 sync,
@@ -265,7 +265,7 @@ export class SyncManagerService {
             }
 
             for (const syncName of syncs) {
-                const sync = await getSyncByIdAndName(connection.id, syncName);
+                const sync = await getSync({ connectionId: connection.id, name: syncName, variant: 'base' }); //TODO: pass variant in addition to sync names and iterate over them all
                 if (!sync) {
                     throw new Error(`Sync "${syncName}" doesn't exists.`);
                 }
@@ -339,7 +339,7 @@ export class SyncManagerService {
 
         if (connection) {
             for (const syncName of syncNames) {
-                const sync = await getSyncByIdAndName(connection.id, syncName);
+                const sync = await getSync({ connectionId: connection.id, name: syncName, variant: 'base' }); //TODO: pass variant in addition to sync names and iterate over them all
                 if (!sync) {
                     continue;
                 }
@@ -402,12 +402,18 @@ export class SyncManagerService {
      * Trigger If Connections Exist
      * @desc for the recently deploy flows, create the sync and trigger it if there are connections
      */
-    public async triggerIfConnectionsExist(
-        flows: SyncDeploymentResult[],
-        environmentId: number,
-        logContextGetter: LogContextGetter,
-        orchestrator: Orchestrator
-    ) {
+    public async triggerIfConnectionsExist({
+        flows,
+        environmentId,
+        logContextGetter,
+        orchestrator
+    }: {
+        flows: SyncDeploymentResult[];
+        environmentId: number;
+        logContextGetter: LogContextGetter;
+        orchestrator: Orchestrator;
+    }) {
+        const variant = 'base';
         for (const flow of flows) {
             if (flow.type === 'action') {
                 continue;
@@ -425,6 +431,7 @@ export class SyncManagerService {
             await this.createSyncForConnections(
                 existingConnections,
                 name as string,
+                variant,
                 providerConfigKey,
                 environmentId,
                 flow as unknown as IncomingFlowConfig,
@@ -482,7 +489,7 @@ export class SyncManagerService {
             throw new Error(`Schedule for sync ${sync.id} and environment ${environmentId} not found`);
         }
 
-        const countRes = await recordsService.getRecordCountsByModel({ connectionId: sync.nango_connection_id, environmentId });
+        const countRes = await recordsService.getRecordCountsByModel({ connectionId: sync.nango_connection_id, environmentId }); // TODO: handle sync's variant
         if (countRes.isErr()) {
             throw new Error(`Failed to get records count for sync ${sync.id} in environment ${environmentId}: ${stringifyError(countRes.error)}`);
         }


### PR DESCRIPTION
Adding the 'variant' column to the syncs table with a default 'base'value and add variant parameters to sync related function so we can pass a different value later.
This commit doesn't change any behavior. There is still no way to create a variant and cardinality of sync_config:sync is still 1:1 

Next steps:
- modify existing public function/api (trigger, pause, status, ...) to accept a sync name + variant
- expose variant into the script
- modify runner-sdk to save variant records and modify getRecords to handle variants
- add new functions/api to be able to create a variant
- update docs
