### PR TITLE
fix(pagination): add support for dot notation in the body

### DIFF
--- a/packages/runner-sdk/lib/paginate.service.ts
+++ b/packages/runner-sdk/lib/paginate.service.ts
@@ -1,6 +1,7 @@
 import type { AxiosResponse } from 'axios';
 import parseLinksHeader from 'parse-link-header';
 import get from 'lodash-es/get.js';
+import set from 'lodash-es/set.js';
 import type { CursorPagination, LinkPagination, OffsetCalculationMethod, OffsetPagination, Pagination, UserProvidedProxyConfiguration } from '@nangohq/types';
 
 function isValidURL(str: string): boolean {
@@ -169,9 +170,19 @@ class PaginationService {
         }
     }
 
+    /*
+     * Update the config object with the updated body or params based on the pagination type
+     * @desc if a pagination type requires the pagination params to be passed in the body,
+     * then the updatedBodyOrParams will be passed in the body of the config object,
+     * with handling for . notation in the keys
+     */
     private updateConfigBodyOrParams(passPaginationParamsInBody: boolean, config: UserProvidedProxyConfiguration, updatedBodyOrParams: Record<string, string>) {
         if (passPaginationParamsInBody) {
-            config.data = updatedBodyOrParams;
+            const expandedParams = Object.keys(updatedBodyOrParams).reduce((acc, key) => {
+                set(acc, key, updatedBodyOrParams[key]);
+                return acc;
+            }, {});
+            config.data = expandedParams;
         } else {
             config.params = updatedBodyOrParams;
         }

--- a/packages/runner-sdk/lib/paginate.service.unit.test.ts
+++ b/packages/runner-sdk/lib/paginate.service.unit.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Unit tests for the PaginationService class, specifically focusing on . notation in cursor pagination.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { UserProvidedProxyConfiguration, CursorPagination } from '@nangohq/types';
+import PaginationService from './paginate.service';
+import type { AxiosResponse } from 'axios';
+
+describe('PaginationService', () => {
+    describe('cursor pagination', () => {
+        let config: UserProvidedProxyConfiguration;
+        let paginationConfig: CursorPagination;
+        let proxy: (config: UserProvidedProxyConfiguration) => Promise<AxiosResponse>;
+
+        beforeEach(() => {
+            config = {
+                endpoint: '/test',
+                method: 'POST',
+                providerConfigKey: 'test-provider-key',
+                connectionId: 'test-connection-id'
+            };
+
+            paginationConfig = {
+                type: 'cursor',
+                cursor_name_in_request: 'pagination.starting_after',
+                cursor_path_in_response: 'pages.next.starting_after',
+                limit: 150,
+                limit_name_in_request: 'pagination.per_page',
+                response_path: 'data'
+            };
+
+            proxy = vi.fn().mockResolvedValue({
+                data: {
+                    data: [{ id: 1 }],
+                    pages: {
+                        next: { starting_after: 'next-cursor' }
+                    }
+                }
+            });
+        });
+
+        describe('dot notation handling', () => {
+            it('should expand dot notation in body parameters', async () => {
+                const generator = PaginationService.cursor(
+                    config,
+                    paginationConfig,
+                    { 'pagination.per_page': 150 },
+                    true, // passPaginationParamsInBody = true
+                    proxy
+                );
+
+                await generator.next();
+
+                expect(proxy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        data: {
+                            pagination: {
+                                per_page: 150
+                            }
+                        }
+                    })
+                );
+            });
+
+            it('should handle multiple levels of dot notation', async () => {
+                const generator = PaginationService.cursor(
+                    config,
+                    paginationConfig,
+                    {
+                        'pagination.per_page': 150,
+                        'pagination.cursor.value': 'test-cursor'
+                    },
+                    true,
+                    proxy
+                );
+
+                await generator.next();
+
+                expect(proxy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        data: {
+                            pagination: {
+                                per_page: 150,
+                                cursor: {
+                                    value: 'test-cursor'
+                                }
+                            }
+                        }
+                    })
+                );
+            });
+
+            it('should not expand parameters when passing in query params', async () => {
+                const generator = PaginationService.cursor(
+                    config,
+                    paginationConfig,
+                    { 'pagination.per_page': 150 },
+                    false, // passPaginationParamsInBody = false
+                    proxy
+                );
+
+                await generator.next();
+
+                expect(proxy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        params: {
+                            'pagination.per_page': 150
+                        }
+                    })
+                );
+            });
+
+            it('should handle mixed dot notation and regular keys', async () => {
+                const generator = PaginationService.cursor(
+                    config,
+                    paginationConfig,
+                    {
+                        'pagination.per_page': 150,
+                        obj_key: 'value',
+                        'nested.key.with.dots': 'nested-value'
+                    },
+                    true,
+                    proxy
+                );
+
+                await generator.next();
+
+                expect(proxy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        data: {
+                            pagination: {
+                                per_page: 150
+                            },
+                            obj_key: 'value',
+                            nested: {
+                                key: {
+                                    with: {
+                                        dots: 'nested-value'
+                                    }
+                                }
+                            }
+                        }
+                    })
+                );
+            });
+
+            it('should handle updates to cursor with dot notation', async () => {
+                proxy
+                    .mockResolvedValueOnce({
+                        data: {
+                            data: [{ id: 1 }],
+                            pages: {
+                                next: { starting_after: 'next-cursor' }
+                            }
+                        }
+                    })
+                    .mockResolvedValueOnce({
+                        data: {
+                            data: [{ id: 2 }],
+                            pages: {
+                                next: null
+                            }
+                        }
+                    });
+
+                const generator = PaginationService.cursor(config, paginationConfig, { 'pagination.per_page': 150 }, true, proxy);
+
+                await generator.next(); // First page
+                await generator.next(); // Second page
+
+                expect(proxy).toHaveBeenNthCalledWith(
+                    2,
+                    expect.objectContaining({
+                        data: {
+                            pagination: {
+                                per_page: 150,
+                                starting_after: 'next-cursor'
+                            }
+                        }
+                    })
+                );
+            });
+        });
+
+        describe('response handling', () => {
+            it('should stop pagination when no next cursor', async () => {
+                proxy.mockResolvedValueOnce({
+                    data: {
+                        data: [{ id: 1 }],
+                        pages: { next: null }
+                    }
+                });
+
+                const generator = PaginationService.cursor(config, paginationConfig, { 'pagination.per_page': 150 }, true, proxy);
+
+                const first = await generator.next();
+                expect(first.value).toEqual([{ id: 1 }]);
+
+                const second = await generator.next();
+                expect(second.done).toBe(true);
+            });
+        });
+
+        describe('error handling', () => {
+            it('should handle undefined response data', async () => {
+                proxy.mockResolvedValueOnce({
+                    data: {
+                        pages: { next: null }
+                    }
+                });
+
+                const generator = PaginationService.cursor(config, paginationConfig, { 'pagination.per_page': 150 }, true, proxy);
+
+                const result = await generator.next();
+                expect(result.done).toBe(true);
+            });
+
+            it('should handle invalid cursor values', async () => {
+                proxy.mockResolvedValueOnce({
+                    data: {
+                        data: [{ id: 1 }],
+                        pages: {
+                            next: { starting_after: '   ' } // Empty string with spaces
+                        }
+                    }
+                });
+
+                const generator = PaginationService.cursor(config, paginationConfig, { 'pagination.per_page': 150 }, true, proxy);
+
+                const first = await generator.next();
+                expect(first.value).toEqual([{ id: 1 }]);
+
+                const second = await generator.next();
+                expect(second.done).toBe(true);
+            });
+        });
+    });
+});

--- a/packages/runner-sdk/lib/paginate.service.unit.test.ts
+++ b/packages/runner-sdk/lib/paginate.service.unit.test.ts
@@ -4,13 +4,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { UserProvidedProxyConfiguration, CursorPagination } from '@nangohq/types';
 import PaginationService from './paginate.service';
-import type { AxiosResponse } from 'axios';
 
 describe('PaginationService', () => {
     describe('cursor pagination', () => {
         let config: UserProvidedProxyConfiguration;
         let paginationConfig: CursorPagination;
-        let proxy: (config: UserProvidedProxyConfiguration) => Promise<AxiosResponse>;
+        let proxy: ReturnType<typeof vi.fn>; // Use ReturnType for type inference
 
         beforeEach(() => {
             config = {
@@ -164,7 +163,6 @@ describe('PaginationService', () => {
                     });
 
                 const generator = PaginationService.cursor(config, paginationConfig, { 'pagination.per_page': 150 }, true, proxy);
-
                 await generator.next(); // First page
                 await generator.next(); // Second page
 

--- a/packages/shared/lib/services/paginate.service.ts
+++ b/packages/shared/lib/services/paginate.service.ts
@@ -1,6 +1,7 @@
 import type { AxiosResponse } from 'axios';
 import parseLinksHeader from 'parse-link-header';
 import get from 'lodash-es/get.js';
+import set from 'lodash-es/set.js';
 import type {
     Pagination,
     UserProvidedProxyConfiguration,
@@ -169,9 +170,19 @@ class PaginationService {
         }
     }
 
+    /*
+     * Update the config object with the updated body or params based on the pagination type
+     * @desc if a pagination type requires the pagination params to be passed in the body,
+     * then the updatedBodyOrParams will be passed in the body of the config object,
+     * with handling for . notation in the keys
+     */
     private updateConfigBodyOrParams(passPaginationParamsInBody: boolean, config: UserProvidedProxyConfiguration, updatedBodyOrParams: Record<string, string>) {
         if (passPaginationParamsInBody) {
-            config.data = updatedBodyOrParams;
+            const expandedParams = Object.keys(updatedBodyOrParams).reduce((acc, key) => {
+                set(acc, key, updatedBodyOrParams[key]);
+                return acc;
+            }, {});
+            config.data = expandedParams;
         } else {
             config.params = updatedBodyOrParams;
         }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
This type of configuration didn't work properly

```
consit config: ProxyConfiguration = {
      endpoint: `${endpoint}/search`,
      method: 'POST',
      data: {
        query: {
          operator: 'AND',
          value: [
            {
              field: 'updated_at',
              operator: '>',
              value: lastSyncPoint,
            },
          ],
        },
      },
      paginate: {
        limit_name_in_request: 'pagination.per_page',
        cursor_name_in_request: 'pagination.starting_after',
      },
    }
}
```
as the resulting request would just be 
```
  "data": {
    "query": {
      "operator": "AND",
      "value": [
        {
          "field": "updated_at",
          "operator": ">",
          "value": 1704067200
        }
      ]
    },
    "pagination.per_page": 150,
    "pagination.starting_after": "WzE3Mzk4NTk0ODAwMDAsIjY2MDIyMjcyZmNmNGI0ZTc3MjQ5Y2M5OSIsMl0="
  }
```

With this update it renders as expected:
```
  "data": {
    "query": {
      "operator": "AND",
      "value": [
        {
          "field": "updated_at",
          "operator": ">",
          "value": 1704067200
        }
      ]
    },
    "pagination": {
      "per_page": 150,
      "starting_after": "WzE3Mzk4NDAwNTMwMDAsIjY2ZjM5ZThiOGFiMTQwZWU5ZWI1ZmRhYiIsMl0="
   
```

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

