### PR TITLE
fix: handle slack user token

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1042,10 +1042,18 @@ class ConnectionService {
     // Parses and arbitrary object (e.g. a server response or a user provided auth object) into AuthCredentials.
     // Throws if values are missing/missing the input is malformed.
     public parseRawCredentials(rawCredentials: object, authMode: AuthModeType, template?: ProviderOAuth2 | ProviderTwoStep): AuthCredentials {
-        const rawCreds = rawCredentials as Record<string, any>;
+        let rawCreds = rawCredentials as Record<string, any>;
 
         switch (authMode) {
             case 'OAUTH2': {
+                const isSlackUserToken = !rawCreds['access_token'] && !!rawCreds['authed_user'];
+                if (isSlackUserToken) {
+                    const userTokenData = rawCreds['authed_user'] as Record<string, string>;
+                    rawCreds = {
+                        ...userTokenData,
+                        ...rawCreds
+                    };
+                }
                 if (!rawCreds['access_token']) {
                     throw new NangoError(`incomplete_raw_credentials`);
                 }

--- a/packages/shared/lib/services/connection.service.unit.test.ts
+++ b/packages/shared/lib/services/connection.service.unit.test.ts
@@ -1,0 +1,30 @@
+import { expect, describe, it } from 'vitest';
+import connectionService from './connection.service'; // adjust path if necessary
+import type { OAuth2Credentials } from '../models';
+
+describe('Connection service tests', () => {
+    describe('parseRawCredentials', () => {
+        it('should extract access_token from authed_user for Slack authed_user', () => {
+            const rawCredentials = {
+                authed_user: {
+                    access_token: 'user_access_token',
+                    scope: 'channels:history,channels:read,channels:write,channels:write.topic,chat:write',
+                    token_type: 'user',
+                    id: 'user_id'
+                },
+                team: {
+                    id: 'team_id',
+                    name: 'Test'
+                },
+                ok: true,
+                app_id: 'app_id'
+            };
+
+            const credentials = connectionService.parseRawCredentials(rawCredentials, 'OAUTH2') as OAuth2Credentials;
+
+            expect(credentials).toBeDefined();
+            expect(credentials.type).toEqual('OAUTH2');
+            expect(credentials.access_token).toEqual('user_access_token');
+        });
+    });
+});

--- a/packages/shared/lib/services/connection.service.unit.test.ts
+++ b/packages/shared/lib/services/connection.service.unit.test.ts
@@ -4,7 +4,7 @@ import type { OAuth2Credentials } from '../models';
 
 describe('Connection service tests', () => {
     describe('parseRawCredentials', () => {
-        it('should extract access_token from authed_user for Slack authed_user', () => {
+        it('should extract access_token from authed_user for Slack user token authentication', () => {
             const rawCredentials = {
                 authed_user: {
                     access_token: 'user_access_token',


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

The solution is to flatten `authed_user` into the main object.

<!-- Issue ticket number and link (if applicable) -->

The problem is described in the issue https://github.com/NangoHQ/nango/issues/3560

<!-- Testing instructions (skip if just adding/editing providers) -->

