### PR TITLE
feat: add support for variant when fetching records

### DIFF
--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -520,9 +520,12 @@ export class Nango {
     public async listRecords<T extends Record<string, any> = Record<string, any>>(
         config: ListRecordsRequestConfig
     ): Promise<{ records: NangoRecord<T>[]; next_cursor: string | null }> {
-        const { connectionId, providerConfigKey, model, delta, modifiedAfter, limit, filter, cursor } = config;
+        const { connectionId, providerConfigKey, model, variant, delta, modifiedAfter, limit, filter, cursor } = config;
         validateSyncRecordConfiguration(config);
         const usp = new URLSearchParams({ model });
+        if (variant) {
+            usp.set('variant', variant);
+        }
         if (modifiedAfter || delta) {
             usp.set('modified_after', `${modifiedAfter || delta}`);
         }

--- a/packages/node-client/lib/types.ts
+++ b/packages/node-client/lib/types.ts
@@ -127,6 +127,7 @@ export interface ListRecordsRequestConfig {
     providerConfigKey: string;
     connectionId: string;
     model: string;
+    variant?: string;
     /**
      * @deprecated use modifiedAfter
      */

--- a/packages/server/lib/controllers/records/getRecords.ts
+++ b/packages/server/lib/controllers/records/getRecords.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 import { zodErrorToHTTP } from '@nangohq/utils';
-import { connectionIdSchema, modelSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { connectionIdSchema, modelSchema, variantSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import type { GetPublicRecords } from '@nangohq/types';
 import { connectionService, trackFetch } from '@nangohq/shared';
 import { records } from '@nangohq/records';
@@ -9,6 +9,7 @@ import { records } from '@nangohq/records';
 export const validationQuery = z
     .object({
         model: modelSchema,
+        variant: variantSchema.optional(),
         delta: z.string().datetime().optional(),
         modified_after: z.string().datetime().optional(),
         limit: z.coerce.number().min(1).max(10000).default(100).optional(),
@@ -65,7 +66,7 @@ export const getPublicRecords = asyncWrapper<GetPublicRecords>(async (req, res) 
 
     const result = await records.getRecords({
         connectionId: connection.id,
-        model: query.model,
+        model: query.variant && query.variant !== 'base' ? `${query.model}::${query.variant}` : query.model,
         modifiedAfter: query.delta || query.modified_after,
         limit: query.limit,
         filter: query.filter,

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -30,6 +30,10 @@ export const modelSchema = z
     .string()
     .regex(/^[A-Z][a-zA-Z0-9_-]+$/)
     .max(255);
+export const variantSchema = z
+    .string()
+    .regex(/^[a-zA-Z0-9_-]+$/)
+    .max(255);
 
 export const connectionCredential = z.union([
     z.object({ public_key: z.string().uuid(), hmac: z.string().optional() }),

--- a/packages/types/lib/record/api.ts
+++ b/packages/types/lib/record/api.ts
@@ -31,6 +31,7 @@ export type GetPublicRecords = Endpoint<{
     Error: ApiError<'unknown_connection'>;
     Querystring: {
         model: string;
+        variant?: string | undefined;
         delta?: string | undefined;
         modified_after?: string | undefined;
         limit?: number | undefined;


### PR DESCRIPTION
part of https://linear.app/nango/issue/NAN-2418/sync-and-model-variants

One can now specify a `variant=VARIANT` query parameter when fetching records via the API. 
Also accepting variant parameter in node-client `listRecords`

Note: not yet useful/testable since it is not possible to save records for a variant model. You can test that current behavior (without variant) is not affected though
