### PR TITLE
fix(compile-error): remove unneeded conditions

### DIFF
--- a/packages/cli/lib/services/compile.service.ts
+++ b/packages/cli/lib/services/compile.service.ts
@@ -64,9 +64,7 @@ export async function compileAllFiles({
         try {
             const completed = await compile({ fullPath, file, parsed, compiler, debug });
             if (completed === false) {
-                if (scriptName && file.inputPath.includes(scriptName)) {
-                    success = false;
-                }
+                return false;
             }
         } catch (err) {
             console.log(chalk.red(`Error compiling "${file.inputPath}":`));


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Script name isn't always going to be provided but we should still show the compile as failed if a compilation fails

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

