### PR TITLE
fix(ui): use singular for operation type

### DIFF
--- a/packages/webapp/src/pages/Logs/constants.tsx
+++ b/packages/webapp/src/pages/Logs/constants.tsx
@@ -119,15 +119,15 @@ export const typesOptions = [
         childs: [
             { name: 'External webhook executed', value: 'webhook:incoming' },
             { name: 'External webhook forwarded', value: 'webhook:forward' },
-            { name: 'Connection creation webhooks', value: 'webhook:connection_create' },
-            { name: 'Sync completion webhooks', value: 'webhook:sync' },
-            { name: 'Token refresh webhooks', value: 'webhook:connection_refresh' }
+            { name: 'Connection creation webhook', value: 'webhook:connection_create' },
+            { name: 'Sync completion webhook', value: 'webhook:sync' },
+            { name: 'Token refresh webhook', value: 'webhook:connection_refresh' }
         ]
     },
-    { value: 'action', name: 'Actions' },
-    { value: 'events', name: 'Event-based executions' },
+    { value: 'action', name: 'Action' },
+    { value: 'events', name: 'Event-based execution' },
     { value: 'proxy', name: 'Proxy' },
-    { value: 'deploy', name: 'Deploys' }
+    { value: 'deploy', name: 'Deploy' }
 ];
 
 export const integrationsDefaultOptions: SearchOperationsIntegration[] = ['all'];


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-2762/ensure-consistency-in-singular-vs-plural-names-in-type-filter

- use singular for operation type