### PR TITLE
feat: add support for sync variant in runner-sdk/cli

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -117,6 +117,7 @@ program
         '-l, --lastSyncDate [lastSyncDate]',
         'Optional (for syncs only): last sync date to retrieve records greater than this date. The format is any string that can be successfully parsed by `new Date()` in JavaScript'
     )
+    .option('--variant [variant]', 'Optional: The variant of the sync to run for the dryrun. If not provided, the base variant will be used.')
     .option(
         '-i, --input [input]',
         'Optional (for actions only): input to pass to the action script. The `input` can be supplied in either JSON format or as a plain string. For example --input \'{"foo": "bar"}\'  --input \'foobar\'. ' +

--- a/packages/cli/lib/services/response-saver.service.ts
+++ b/packages/cli/lib/services/response-saver.service.ts
@@ -64,12 +64,14 @@ export function onAxiosRequestFulfilled({
     response,
     providerConfigKey,
     connectionId,
-    syncName
+    syncName,
+    syncVariant
 }: {
     response: AxiosResponse;
     providerConfigKey: string | undefined;
     connectionId: string;
     syncName: string;
+    syncVariant: string;
 }): AxiosResponse {
     if (!providerConfigKey) {
         return response;
@@ -97,6 +99,7 @@ export function onAxiosRequestFulfilled({
 
     const requestIdentity = computeConfigIdentity(response.config);
 
+    const syncSubDir = syncVariant ? `${syncName}/${syncVariant}` : syncName;
     saveResponse<CachedRequest>({
         directoryName,
         data: {
@@ -105,7 +108,7 @@ export function onAxiosRequestFulfilled({
             status: response.status,
             headers: response.headers as Record<string, string>
         },
-        customFilePath: `mocks/nango/${requestIdentity.method}/proxy/${requestIdentity.endpoint}/${syncName}/${requestIdentity.requestIdentityHash}.json`
+        customFilePath: `mocks/nango/${requestIdentity.method}/proxy/${requestIdentity.endpoint}/${syncSubDir}/${requestIdentity.requestIdentityHash}.json`
     });
 
     return response;
@@ -114,18 +117,21 @@ export function onAxiosRequestFulfilled({
 export function onAxiosRequestRejected({
     error,
     providerConfigKey,
-    syncName
+    syncName,
+    syncVariant
 }: {
     error: unknown;
     providerConfigKey: string | undefined;
     connectionId: string;
     syncName: string;
+    syncVariant: string;
 }) {
     const directoryName = `${process.env['NANGO_MOCKS_RESPONSE_DIRECTORY'] ?? ''}${providerConfigKey}`;
 
     const response: AxiosResponse | undefined = (error as AxiosError).response;
     if (response) {
         const requestIdentity = computeConfigIdentity(response.config);
+        const syncSubDir = syncVariant ? `${syncName}/${syncVariant}` : syncName;
         saveResponse<CachedRequest>({
             directoryName,
             data: {
@@ -134,7 +140,7 @@ export function onAxiosRequestRejected({
                 status: response.status,
                 headers: response.headers as Record<string, string>
             },
-            customFilePath: `mocks/nango/${requestIdentity.method}/proxy/${requestIdentity.endpoint}/${syncName}/${requestIdentity.requestIdentityHash}.json`
+            customFilePath: `mocks/nango/${requestIdentity.method}/proxy/${requestIdentity.endpoint}/${syncSubDir}/${requestIdentity.requestIdentityHash}.json`
         });
     }
 

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -111,6 +111,7 @@ export async function startSync(task: TaskSync, startScriptFn = startScript): Pr
 
         await logCtx.info(`Starting sync '${task.syncName}'`, {
             syncName: task.syncName,
+            syncVariant: task.syncVariant,
             syncType,
             connection: task.connection.connection_id,
             integration: task.connection.provider_config_key,

--- a/packages/runner-sdk/lib/action.ts
+++ b/packages/runner-sdk/lib/action.ts
@@ -350,7 +350,12 @@ export abstract class NangoActionBase {
         }
     }
 
-    public abstract triggerSync(providerConfigKey: string, connectionId: string, syncName: string, fullResync?: boolean): Promise<void | string>;
+    public abstract triggerSync(
+        providerConfigKey: string,
+        connectionId: string,
+        sync: string | { name: string; variant: string },
+        fullResync?: boolean
+    ): Promise<void | string>;
 
     /**
      * Uncontrolled fetch is a regular fetch without retry or credentials injection.

--- a/packages/runner-sdk/lib/sync.ts
+++ b/packages/runner-sdk/lib/sync.ts
@@ -3,7 +3,11 @@ import { validateData } from './dataValidation.js';
 import type { ValidateDataError } from './dataValidation.js';
 import { NangoActionBase } from './action.js';
 
+export const BASE_VARIANT = 'base';
+
 export abstract class NangoSyncBase extends NangoActionBase {
+    public variant = BASE_VARIANT;
+
     lastSyncDate?: Date;
     track_deletes = false;
 
@@ -17,6 +21,17 @@ export abstract class NangoSyncBase extends NangoActionBase {
         if (config.track_deletes) {
             this.track_deletes = config.track_deletes;
         }
+
+        if (config.syncVariant) {
+            this.variant = config.syncVariant;
+        }
+    }
+
+    public modelFullName(model: string) {
+        if (this.variant === BASE_VARIANT) {
+            return model;
+        }
+        return `${model}::${this.variant}`;
     }
 
     /**
@@ -33,6 +48,8 @@ export abstract class NangoSyncBase extends NangoActionBase {
     public abstract batchUpdate<T extends object>(results: T[], model: string): MaybePromise<boolean>;
 
     public abstract getRecordsByIds<K = string | number, T = any>(ids: K[], model: string): MaybePromise<Map<K, T>>;
+
+    public abstract setMergingStrategy(merging: { strategy: 'ignore_if_modified_after' | 'override' }, model: string): Promise<void>;
 
     protected validateRecords(model: string, records: unknown[]): { data: any; validation: ValidateDataError[] }[] {
         // Validate records

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -107,9 +107,14 @@ export class NangoActionRunner extends NangoActionBase {
         });
     }
 
-    public triggerSync(providerConfigKey: string, connectionId: string, syncName: string, fullResync?: boolean): Promise<void | string> {
+    public triggerSync(
+        providerConfigKey: string,
+        connectionId: string,
+        sync: string | { name: string; variant: string },
+        fullResync?: boolean
+    ): Promise<void | string> {
         this.throwIfAborted();
-        return this.nango.triggerSync(providerConfigKey, [syncName], connectionId, fullResync);
+        return this.nango.triggerSync(providerConfigKey, [sync], connectionId, fullResync);
     }
 
     private async sendLogToPersist(log: MessageRowInsert) {
@@ -214,7 +219,8 @@ export class NangoSyncRunner extends NangoSyncBase {
 
     public async setMergingStrategy(merging: { strategy: 'ignore_if_modified_after' | 'override' }, model: string): Promise<void> {
         const now = new Date();
-        if (this.mergingByModel.has(model)) {
+        const modelFullName = this.modelFullName(model);
+        if (this.mergingByModel.has(modelFullName)) {
             await this.sendLogToPersist({
                 type: 'log',
                 level: 'warn',
@@ -237,11 +243,11 @@ export class NangoSyncRunner extends NangoSyncBase {
                 if (res.isErr()) {
                     throw res.error;
                 }
-                this.mergingByModel.set(model, { strategy: 'ignore_if_modified_after_cursor', ...(res.value ? { cursor: res.value.cursor } : {}) });
+                this.mergingByModel.set(modelFullName, { strategy: 'ignore_if_modified_after_cursor', ...(res.value ? { cursor: res.value.cursor } : {}) });
                 break;
             }
             case 'override':
-                this.mergingByModel.set(model, { strategy: 'override' });
+                this.mergingByModel.set(modelFullName, { strategy: 'override' });
                 break;
             default:
                 throw new Error(`Unsupported merging strategy: ${merging.strategy}`);
@@ -257,11 +263,11 @@ export class NangoSyncRunner extends NangoSyncBase {
     }
 
     private getMergingStrategy(model: string): MergingStrategy {
-        return this.mergingByModel.get(model) || { strategy: 'override' };
+        return this.mergingByModel.get(this.modelFullName(model)) || { strategy: 'override' };
     }
 
     private setMergingStrategyByModel(model: string, merging: MergingStrategy): void {
-        this.mergingByModel.set(model, merging);
+        this.mergingByModel.set(this.modelFullName(model), merging);
     }
 
     public async batchSave<T extends object>(results: T[], model: string) {
@@ -305,10 +311,11 @@ export class NangoSyncRunner extends NangoSyncBase {
             );
         }
 
+        const modelFullName = this.modelFullName(model);
         for (let i = 0; i < resultsWithoutMetadata.length; i += this.batchSize) {
             const batch = resultsWithoutMetadata.slice(i, i + this.batchSize);
             const res = await this.persistClient.saveRecords({
-                model,
+                model: modelFullName,
                 records: batch,
                 environmentId: this.environmentId,
                 providerConfigKey: this.providerConfigKey,
@@ -317,12 +324,12 @@ export class NangoSyncRunner extends NangoSyncBase {
                 syncId: this.syncId!,
                 syncJobId: this.syncJobId!,
                 activityLogId: this.activityLogId!,
-                merging: this.getMergingStrategy(model)
+                merging: this.getMergingStrategy(modelFullName)
             });
             if (res.isErr()) {
                 throw res.error;
             }
-            this.setMergingStrategyByModel(model, res.value.nextMerging);
+            this.setMergingStrategyByModel(modelFullName, res.value.nextMerging);
         }
         return true;
     }
@@ -335,10 +342,11 @@ export class NangoSyncRunner extends NangoSyncBase {
 
         const resultsWithoutMetadata = this.removeMetadata(results);
 
+        const modelFullName = this.modelFullName(model);
         for (let i = 0; i < resultsWithoutMetadata.length; i += this.batchSize) {
             const batch = resultsWithoutMetadata.slice(i, i + this.batchSize);
             const res = await this.persistClient.deleteRecords({
-                model,
+                model: modelFullName,
                 records: batch,
                 environmentId: this.environmentId,
                 providerConfigKey: this.providerConfigKey,
@@ -347,12 +355,12 @@ export class NangoSyncRunner extends NangoSyncBase {
                 syncId: this.syncId!,
                 syncJobId: this.syncJobId!,
                 activityLogId: this.activityLogId!,
-                merging: this.getMergingStrategy(model)
+                merging: this.getMergingStrategy(modelFullName)
             });
             if (res.isErr()) {
                 throw res.error;
             }
-            this.setMergingStrategyByModel(model, res.value.nextMerging);
+            this.setMergingStrategyByModel(modelFullName, res.value.nextMerging);
         }
 
         return true;
@@ -366,10 +374,11 @@ export class NangoSyncRunner extends NangoSyncBase {
 
         const resultsWithoutMetadata = this.removeMetadata(results);
 
+        const modelFullName = this.modelFullName(model);
         for (let i = 0; i < resultsWithoutMetadata.length; i += this.batchSize) {
             const batch = resultsWithoutMetadata.slice(i, i + this.batchSize);
             const res = await this.persistClient.updateRecords({
-                model,
+                model: modelFullName,
                 records: batch,
                 environmentId: this.environmentId,
                 providerConfigKey: this.providerConfigKey,
@@ -378,12 +387,12 @@ export class NangoSyncRunner extends NangoSyncBase {
                 syncId: this.syncId!,
                 syncJobId: this.syncJobId!,
                 activityLogId: this.activityLogId!,
-                merging: this.getMergingStrategy(model)
+                merging: this.getMergingStrategy(modelFullName)
             });
             if (res.isErr()) {
                 throw res.error;
             }
-            this.setMergingStrategyByModel(model, res.value.nextMerging);
+            this.setMergingStrategyByModel(modelFullName, res.value.nextMerging);
         }
         return true;
     }


### PR DESCRIPTION
Making runner-sdk and CLI sync variant aware.

You can't test variant yet unless you modify your test database (sync and schedule payload) but you can check that current behavior is not impacted.
Next PR: expose variant in Nango webhook payload