### PR TITLE
fix(proxy): refresh connection between retries (again)

### DIFF
--- a/packages/node-client/lib/types.ts
+++ b/packages/node-client/lib/types.ts
@@ -115,7 +115,7 @@ export interface CreateConnectionOAuth2 extends OAuth2Credentials {
     type: AuthModes['OAuth2'];
 }
 
-export type ProxyConfiguration = Omit<UserProvidedProxyConfiguration, 'files' | 'providerConfigKey' | 'connectionId'> & {
+export type ProxyConfiguration = Omit<UserProvidedProxyConfiguration, 'files' | 'providerConfigKey'> & {
     providerConfigKey?: string;
     connectionId?: string;
 };

--- a/packages/runner-sdk/lib/action.ts
+++ b/packages/runner-sdk/lib/action.ts
@@ -113,7 +113,6 @@ export abstract class NangoActionBase {
             method: 'GET',
             ...config,
             providerConfigKey: config.providerConfigKey || this.providerConfigKey,
-            connectionId: config.connectionId || this.connectionId,
             headers: {
                 ...(config.headers || {}),
                 'user-agent': this.nango.userAgent

--- a/packages/runner-sdk/lib/paginate.service.ts
+++ b/packages/runner-sdk/lib/paginate.service.ts
@@ -66,7 +66,7 @@ class PaginationService {
 
             this.updateConfigBodyOrParams(passPaginationParamsInBody, config, updatedBodyOrParams);
 
-            const response: AxiosResponse = await proxy(config);
+            const response = await proxy(config);
 
             const responseData: T[] = cursorPagination.response_path ? get(response.data, cursorPagination.response_path) : response.data;
 
@@ -100,7 +100,7 @@ class PaginationService {
         this.updateConfigBodyOrParams(passPaginationParamsInBody, config, updatedBodyOrParams);
 
         while (true) {
-            const response: AxiosResponse = await proxy(config);
+            const response = await proxy(config);
 
             const responseData: T[] = paginationConfig.response_path ? get(response.data, paginationConfig.response_path) : response.data;
             if (!responseData.length) {
@@ -144,7 +144,7 @@ class PaginationService {
 
             this.updateConfigBodyOrParams(passPaginationParamsInBody, config, updatedBodyOrParams);
 
-            const response: AxiosResponse = await proxy(config);
+            const response = await proxy(config);
 
             const responseData: T[] = paginationConfig.response_path ? get(response.data, paginationConfig.response_path) : response.data;
             if (!responseData || !responseData.length) {

--- a/packages/runner-sdk/lib/paginate.service.unit.test.ts
+++ b/packages/runner-sdk/lib/paginate.service.unit.test.ts
@@ -15,8 +15,7 @@ describe('PaginationService', () => {
             config = {
                 endpoint: '/test',
                 method: 'POST',
-                providerConfigKey: 'test-provider-key',
-                connectionId: 'test-connection-id'
+                providerConfigKey: 'test-provider-key'
             };
 
             paginationConfig = {

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -38,38 +38,38 @@ export class NangoActionRunner extends NangoActionBase {
             }
         );
 
-        if (!this.activityLogId) throw new Error('Parameter activityLogId is required when not in dryRun');
-        if (!this.environmentId) throw new Error('Parameter environmentId is required when not in dryRun');
-        if (!this.nangoConnectionId) throw new Error('Parameter nangoConnectionId is required when not in dryRun');
-        if (!this.syncConfig) throw new Error('Parameter syncConfig is required when not in dryRun');
+        if (!this.activityLogId) throw new Error('Parameter activityLogId is required');
+        if (!this.environmentId) throw new Error('Parameter environmentId is required');
+        if (!this.nangoConnectionId) throw new Error('Parameter nangoConnectionId is required');
+        if (!this.syncConfig) throw new Error('Parameter syncConfig is required');
     }
 
     public override async proxy<T = any>(config: ProxyConfiguration): Promise<AxiosResponse<T>> {
         this.throwIfAborted();
-        if (!config.method) {
-            config.method = 'GET';
-        }
 
         const { connectionId, providerConfigKey } = config;
-        const connection = await this.getConnection(providerConfigKey, connectionId);
-        if (!connection) {
-            throw new Error(`Connection not found using the provider config key ${this.providerConfigKey} and connection id ${this.connectionId}`);
-        }
 
-        const computedConfig = getProxyConfiguration({
-            externalConfig: this.getProxyConfig(config),
-            internalConfig: {
-                connection,
-                providerName: this.provider!
-            }
-        }).unwrap();
         const proxy = new ProxyRequest({
+            proxyConfig: getProxyConfiguration({
+                externalConfig: this.getProxyConfig(config),
+                internalConfig: {
+                    providerName: this.provider!
+                }
+            }).unwrap(),
             logger: async (log) => {
                 await this.sendLogToPersist(log);
             },
-            proxyConfig: computedConfig
+            getConnection: async () => {
+                // We try to refresh connection at each iteration so we have fresh credentials even after waiting minutes between calls
+                const connection = await this.getConnection(providerConfigKey, connectionId);
+                if (!connection) {
+                    throw new Error(`Connection not found using the provider config key ${this.providerConfigKey} and connection id ${this.connectionId}`);
+                }
+
+                return connection;
+            }
         });
-        const response = (await proxy.call()).unwrap();
+        const response = (await proxy.request()).unwrap();
 
         return response;
     }
@@ -201,8 +201,8 @@ export class NangoSyncRunner extends NangoSyncBase {
             }
         );
 
-        if (!this.syncId) throw new Error('Parameter syncId is required when not in dryRun');
-        if (!this.syncJobId) throw new Error('Parameter syncJobId is required when not in dryRun');
+        if (!this.syncId) throw new Error('Parameter syncId is required');
+        if (!this.syncJobId) throw new Error('Parameter syncJobId is required');
     }
 
     // Can't double extends

--- a/packages/runner/nodemon.json
+++ b/packages/runner/nodemon.json
@@ -1,5 +1,5 @@
 {
-    "watch": ["dist", "../shared/dist", "../utils/dist", "../../.env"],
+    "watch": ["dist", "../shared/dist", "../utils/dist", "../../.env", "../runner-sdk/dist"],
     "ext": "js,ts,json",
     "ignore": ["lib/**/*.test.ts"],
     "exec": "tsx -r dotenv/config lib/app.ts dotenv_config_path=./../../.env"

--- a/packages/server/lib/controllers/proxy.controller.ts
+++ b/packages/server/lib/controllers/proxy.controller.ts
@@ -6,7 +6,8 @@ import { Readable, Transform, PassThrough } from 'stream';
 import type { UrlWithParsedQuery } from 'url';
 import url from 'url';
 import querystring from 'querystring';
-import type { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { isAxiosError } from 'axios';
+import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 import {
     LogActionEnum,
     errorManager,
@@ -14,27 +15,22 @@ import {
     connectionService,
     configService,
     featureFlags,
-    buildProxyURL,
     getProxyConfiguration,
-    buildProxyHeaders,
-    ProxyRequest
+    ProxyRequest,
+    ProxyError
 } from '@nangohq/shared';
 import { metrics, getLogger, getHeaders, redactHeaders } from '@nangohq/utils';
 import { logContextGetter } from '@nangohq/logs';
 import { connectionRefreshFailed as connectionRefreshFailedHook, connectionRefreshSuccess as connectionRefreshSuccessHook } from '../hooks/hooks.js';
 import type { LogContext } from '@nangohq/logs';
 import type { RequestLocals } from '../utils/express.js';
-import type {
-    ApplicationConstructedProxyConfiguration,
-    HTTP_METHOD,
-    InternalProxyConfiguration,
-    ProxyFile,
-    UserProvidedProxyConfiguration
-} from '@nangohq/types';
+import type { HTTP_METHOD, InternalProxyConfiguration, ProxyFile } from '@nangohq/types';
 
 type ForwardedHeaders = Record<string, string>;
 
 const logger = getLogger('Proxy.Controller');
+
+const MEMOIZED_CONNECTION_TTL = 60000;
 
 class ProxyController {
     /**
@@ -49,9 +45,9 @@ class ProxyController {
         const { environment, account } = res.locals;
 
         let logCtx: LogContext | undefined;
+        const connectionId = req.get('Connection-Id') || '';
+        const providerConfigKey = req.get('Provider-Config-Key') || '';
         try {
-            const connectionId = req.get('Connection-Id') || '';
-            const providerConfigKey = req.get('Provider-Config-Key') || '';
             const retries = req.get('Retries') as string;
             const baseUrlOverride = req.get('Base-Url-Override') as string;
             const decompress = req.get('Decompress') as string;
@@ -84,20 +80,6 @@ class ProxyController {
                 files = req.files as ProxyFile[];
             }
 
-            const externalConfig: UserProvidedProxyConfiguration = {
-                endpoint,
-                providerConfigKey,
-                connectionId,
-                retries: retries ? Number(retries) : 0,
-                data,
-                files,
-                headers,
-                baseUrlOverride,
-                decompress: decompress === 'true' ? true : false,
-                method: method.toUpperCase() as HTTP_METHOD,
-                retryOn
-            };
-
             const integration = await configService.getProviderConfig(providerConfigKey, environment.id);
             if (!integration) {
                 await logCtx.error('Provider configuration not found');
@@ -117,7 +99,9 @@ class ProxyController {
             if (connectionRes.error || !connectionRes.response) {
                 await logCtx.error('Failed to get connection', { error: connectionRes.error });
                 await logCtx.failed();
-                errorManager.errResFromNangoErr(res, connectionRes.error);
+                res.status(400).send({
+                    error: { code: 'server_error', message: `Failed to get connection` }
+                });
                 return;
             }
 
@@ -131,7 +115,6 @@ class ProxyController {
                 onRefreshSuccess: connectionRefreshSuccessHook,
                 onRefreshFailed: connectionRefreshFailedHook
             });
-
             if (credentialResponse.isErr()) {
                 await logCtx.error('Failed to get connection credentials', { error: credentialResponse.error });
                 await logCtx.failed();
@@ -153,25 +136,65 @@ class ProxyController {
             });
 
             const internalConfig: InternalProxyConfiguration = {
-                existingActivityLogId: logCtx.id,
-                connection,
                 providerName: integration.provider
             };
 
-            const proxyConfig = getProxyConfiguration({ externalConfig, internalConfig });
-            if (proxyConfig.isErr()) {
-                await logCtx.error('failed to configure proxy', { error: proxyConfig.error });
+            let lastConnectionRefresh = Date.now();
+            let freshConnection = connection;
+            const proxy = new ProxyRequest({
+                proxyConfig: getProxyConfiguration({
+                    externalConfig: {
+                        endpoint,
+                        providerConfigKey,
+                        retries: retries ? Number(retries) : 0,
+                        data,
+                        files,
+                        headers,
+                        baseUrlOverride,
+                        decompress: decompress === 'true' ? true : false,
+                        method: method.toUpperCase() as HTTP_METHOD,
+                        retryOn,
+                        responseType: 'stream'
+                    },
+                    internalConfig
+                }).unwrap(),
+                logger: async (msg) => {
+                    await logCtx?.log(msg);
+                },
+                getConnection: async () => {
+                    if (Date.now() - lastConnectionRefresh < MEMOIZED_CONNECTION_TTL) {
+                        return freshConnection;
+                    }
+
+                    lastConnectionRefresh = Date.now();
+                    const credentialResponse = await connectionService.refreshOrTestCredentials({
+                        account,
+                        environment,
+                        connection,
+                        integration,
+                        logContextGetter,
+                        instantRefresh: false,
+                        onRefreshSuccess: connectionRefreshSuccessHook,
+                        onRefreshFailed: connectionRefreshFailedHook
+                    });
+                    if (credentialResponse.isErr()) {
+                        throw new ProxyError('failed_to_get_connection', 'Failed to get connection credentials', connectionRes.error);
+                    }
+
+                    freshConnection = credentialResponse.value;
+                    return freshConnection;
+                }
+            });
+
+            try {
+                const responseStream = (await proxy.request()).unwrap();
+                await this.handleResponse({ res, responseStream, logCtx });
+            } catch (err) {
+                await this.handleErrorResponse({ res, error: err, requestConfig: proxy.axiosConfig, logCtx });
                 await logCtx.failed();
                 metrics.increment(metrics.Types.PROXY_FAILURE);
-                res.status(400).send({ error: { code: 'server_error', message: 'failed to configure proxy' } });
-                return;
             }
-
-            await this.sendToHttpMethod({ res, method: method as HTTP_METHOD, configBody: proxyConfig.value, logCtx });
         } catch (err) {
-            const connectionId = req.get('Connection-Id') as string;
-            const providerConfigKey = req.get('Provider-Config-Key') as string;
-
             errorManager.report(err, {
                 source: ErrorSourceEnum.PLATFORM,
                 operation: LogActionEnum.PROXY,
@@ -201,38 +224,6 @@ class ProxyController {
                 }
             });
         }
-    }
-
-    /**
-     * Send to http method
-     */
-    private sendToHttpMethod({
-        res,
-        method,
-        configBody,
-        logCtx
-    }: {
-        res: Response;
-        method: HTTP_METHOD;
-        configBody: ApplicationConstructedProxyConfiguration;
-        logCtx: LogContext;
-    }) {
-        const url = buildProxyURL(configBody);
-        let decompress = false;
-
-        if (configBody.decompress === true || configBody.provider.proxy?.decompress === true) {
-            decompress = true;
-        }
-
-        return this.request({
-            res,
-            method,
-            url,
-            config: configBody,
-            decompress,
-            data: configBody.data,
-            logCtx
-        });
     }
 
     private async handleResponse({ res, responseStream, logCtx }: { res: Response; responseStream: AxiosResponse; logCtx: LogContext }) {
@@ -302,8 +293,30 @@ class ProxyController {
         });
     }
 
-    private async handleErrorResponse({ res, e, requestConfig, logCtx }: { res: Response; e: unknown; requestConfig: AxiosRequestConfig; logCtx: LogContext }) {
-        const error = e as AxiosError;
+    private async handleErrorResponse({
+        res,
+        error,
+        requestConfig,
+        logCtx
+    }: {
+        res: Response;
+        error: unknown;
+        requestConfig?: AxiosRequestConfig | undefined;
+        logCtx: LogContext;
+    }) {
+        if (!isAxiosError(error)) {
+            if (error instanceof ProxyError) {
+                await logCtx.error('Unknown error', { error });
+                res.status(400).send({
+                    error: { code: error.code, message: error.message }
+                });
+                return;
+            }
+
+            await logCtx.error('Unknown error', { error });
+            res.status(500).send();
+            return;
+        }
 
         if (!error.response?.data && error.toJSON) {
             const {
@@ -314,7 +327,7 @@ class ProxyController {
                 status
             } = error.toJSON() as any;
 
-            const errorObject = { message, stack, code, status, url: requestConfig.url, method };
+            const errorObject = { message, stack, code, status, url: requestConfig?.url, method };
 
             const responseStatus = error.response?.status || 500;
             const responseHeaders = error.response?.headers || {};
@@ -357,57 +370,6 @@ class ProxyController {
                 }
                 void logCtx.error('Failed with this body', { body: errorData });
             });
-        } else {
-            await logCtx.error('Unknown error', { error });
-            await logCtx.failed();
-            res.status(500).send();
-        }
-    }
-
-    private async request({
-        res,
-        method,
-        url,
-        config,
-        decompress,
-        data,
-        logCtx
-    }: {
-        res: Response;
-        method: HTTP_METHOD;
-        url: string;
-        config: ApplicationConstructedProxyConfiguration;
-        decompress: boolean;
-        data?: unknown;
-        logCtx: LogContext;
-    }) {
-        const headers = buildProxyHeaders(config, url);
-
-        const axiosConfig: AxiosRequestConfig = {
-            method,
-            url,
-            responseType: 'stream',
-            headers,
-            decompress
-        };
-        try {
-            if (data && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
-                axiosConfig.data = data;
-            }
-            const proxy = new ProxyRequest({
-                logger: async (msg) => {
-                    await logCtx.log(msg);
-                },
-                proxyConfig: config
-            });
-
-            const responseStream = (await proxy.request({ axiosConfig })).unwrap();
-
-            await this.handleResponse({ res, responseStream, logCtx });
-        } catch (err) {
-            await this.handleErrorResponse({ res, e: err, requestConfig: axiosConfig, logCtx });
-            await logCtx.failed();
-            metrics.increment(metrics.Types.PROXY_FAILURE);
         }
     }
 }

--- a/packages/server/lib/hooks/connection/basecamp-post-connection.ts
+++ b/packages/server/lib/hooks/connection/basecamp-post-connection.ts
@@ -8,7 +8,6 @@ export default async function execute(nango: Nango) {
     const response = await nango.proxy<BasecampAuthorizationResponse>({
         baseUrlOverride: 'https://launchpad.37signals.com',
         endpoint: '/authorization.json',
-        connectionId: connection.connection_id,
         providerConfigKey: connection.provider_config_key
     });
 

--- a/packages/server/lib/hooks/connection/calendly-post-connection.ts
+++ b/packages/server/lib/hooks/connection/calendly-post-connection.ts
@@ -7,7 +7,6 @@ export default async function execute(nango: Nango) {
 
     const response = await nango.proxy<CalendlyUser>({
         endpoint: '/users/me',
-        connectionId: connection.connection_id,
         providerConfigKey: connection.provider_config_key
     });
 

--- a/packages/server/lib/hooks/connection/checkr-post-connection.ts
+++ b/packages/server/lib/hooks/connection/checkr-post-connection.ts
@@ -19,7 +19,6 @@ export default async function execute(nango: Nango) {
         headers: {
             Authorization: 'Basic ' + Buffer.from(access_token + ':').toString('base64')
         },
-        connectionId: connection.connection_id,
         providerConfigKey: connection.provider_config_key
     });
 

--- a/packages/server/lib/hooks/connection/docusign-post-connection.ts
+++ b/packages/server/lib/hooks/connection/docusign-post-connection.ts
@@ -10,7 +10,6 @@ export default async function execute(nango: Nango) {
     const response = await nango.proxy<UserInfoResponse>({
         baseUrlOverride: `https://${rootUrl}`,
         endpoint: '/oauth/userinfo',
-        connectionId: connection.connection_id,
         providerConfigKey: connection.provider_config_key
     });
 

--- a/packages/server/lib/hooks/connection/github-app-oauth-post-connection.ts
+++ b/packages/server/lib/hooks/connection/github-app-oauth-post-connection.ts
@@ -6,7 +6,6 @@ export default async function execute(nango: Nango) {
     const connection = await nango.getConnection();
     const response = await nango.proxy({
         endpoint: `/user`,
-        connectionId: connection.connection_id,
         providerConfigKey: connection.provider_config_key
     });
 

--- a/packages/server/lib/hooks/connection/gusto-post-connection.ts
+++ b/packages/server/lib/hooks/connection/gusto-post-connection.ts
@@ -9,7 +9,6 @@ export default async function execute(nango: Nango) {
     const response = await nango.proxy<GustoTokenInfoResponse>({
         baseUrlOverride: `https://${rootUrl}`,
         endpoint: '/v1/token_info',
-        connectionId: connection.connection_id,
         providerConfigKey: connection.provider_config_key
     });
 

--- a/packages/server/lib/hooks/connection/hubspot-post-connection.ts
+++ b/packages/server/lib/hooks/connection/hubspot-post-connection.ts
@@ -5,7 +5,6 @@ export default async function execute(nango: Nango) {
     const connection = await nango.getConnection();
     const response = await nango.proxy({
         endpoint: '/account-info/v3/details',
-        connectionId: connection.connection_id,
         providerConfigKey: connection.provider_config_key
     });
 

--- a/packages/server/lib/hooks/connection/jira-post-connection.ts
+++ b/packages/server/lib/hooks/connection/jira-post-connection.ts
@@ -5,7 +5,6 @@ export default async function execute(nango: Nango) {
     const connection = await nango.getConnection();
     const response = await nango.proxy({
         endpoint: `oauth/token/accessible-resources`,
-        connectionId: connection.connection_id,
         providerConfigKey: connection.provider_config_key
     });
 
@@ -18,7 +17,6 @@ export default async function execute(nango: Nango) {
 
     const accountResponse = await nango.proxy({
         endpoint: `ex/jira/${cloudId}/rest/api/3/myself`,
-        connectionId: connection.connection_id,
         providerConfigKey: connection.provider_config_key
     });
 

--- a/packages/server/lib/hooks/connection/linear-post-connection.ts
+++ b/packages/server/lib/hooks/connection/linear-post-connection.ts
@@ -14,7 +14,6 @@ export default async function execute(nango: Nango) {
         endpoint: '/graphql',
         data: { query },
         method: 'POST',
-        connectionId: connection.connection_id,
         providerConfigKey: connection.provider_config_key
     });
 

--- a/packages/server/lib/hooks/connection/microsoft-teams-post-connection.ts
+++ b/packages/server/lib/hooks/connection/microsoft-teams-post-connection.ts
@@ -6,7 +6,6 @@ export default async function execute(nango: Nango) {
     const response = await nango.proxy({
         endpoint: '/v1.0/organization',
         method: 'GET',
-        connectionId: connection.connection_id,
         providerConfigKey: connection.provider_config_key
     });
 

--- a/packages/server/lib/hooks/connection/workable-post-connection.ts
+++ b/packages/server/lib/hooks/connection/workable-post-connection.ts
@@ -14,7 +14,6 @@ export default async function execute(nango: Nango) {
         baseUrlOverride: 'https://workable.com',
         endpoint: '/spi/v3/accounts',
         method: 'GET',
-        connectionId: connection.connection_id,
         providerConfigKey: connection.provider_config_key
     });
 

--- a/packages/server/lib/hooks/connection/xero-post-connection.ts
+++ b/packages/server/lib/hooks/connection/xero-post-connection.ts
@@ -40,7 +40,6 @@ export default async function execute(nango: Nango) {
 
     const response = await nango.proxy({
         endpoint: 'connections',
-        connectionId: connection.connection_id,
         providerConfigKey: connection.provider_config_key
     });
 

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -257,11 +257,10 @@ export async function connectionTest({
         provider,
         providerName: config.provider,
         providerConfigKey: config.unique_key,
-        connectionId,
         headers: {
             'Content-Type': 'application/json'
         },
-        connection
+        decompress: false
     };
 
     if (headers) {
@@ -273,8 +272,7 @@ export async function connectionTest({
     }
 
     const internalConfig: InternalProxyConfiguration = {
-        providerName: config.provider,
-        connection
+        providerName: config.provider
     };
 
     const logs: MessageRowInsert[] = [
@@ -286,9 +284,12 @@ export async function connectionTest({
             logger: (msg) => {
                 logs.push(msg);
             },
-            proxyConfig
+            proxyConfig,
+            getConnection: () => {
+                return connection;
+            }
         });
-        const response = (await proxy.call()).unwrap();
+        const response = (await proxy.request()).unwrap();
 
         if (response.status && (response?.status < 200 || response?.status > 300)) {
             const error = new NangoError('connection_test_failed', { response, logs });

--- a/packages/shared/lib/services/proxy/request.ts
+++ b/packages/shared/lib/services/proxy/request.ts
@@ -3,9 +3,16 @@ import type { AxiosResponse, AxiosRequestConfig } from 'axios';
 import type { Result, RetryAttemptArgument } from '@nangohq/utils';
 import { axiosInstance as axios, Err, Ok, redactHeaders, redactURL, retryFlexible } from '@nangohq/utils';
 
-import type { ApplicationConstructedProxyConfiguration, MaybePromise, MessageRowInsert } from '@nangohq/types';
-import { buildProxyHeaders, buildProxyURL, ProxyError } from './utils.js';
+import type { ApplicationConstructedProxyConfiguration, ConnectionForProxy, MaybePromise, MessageRowInsert } from '@nangohq/types';
+import { getAxiosConfiguration, ProxyError } from './utils.js';
 import { getProxyRetryFromErr } from './retry.js';
+
+interface Props {
+    proxyConfig: ApplicationConstructedProxyConfiguration;
+    logger: (msg: MessageRowInsert) => MaybePromise<void>;
+    onError?: (args: { err: unknown; max: number; attempt: number }) => { retry: boolean; reason: string; wait?: number };
+    getConnection: () => MaybePromise<ConnectionForProxy>;
+}
 
 /**
  * This simple class is responsible to execute a call to a third-party
@@ -14,61 +21,69 @@ import { getProxyRetryFromErr } from './retry.js';
  * It's the same code for the SDK and for the Proxy API.
  */
 export class ProxyRequest {
-    logger: (msg: MessageRowInsert) => MaybePromise<void>;
-    config: ApplicationConstructedProxyConfiguration;
+    logger: Props['logger'];
 
-    constructor({ logger, proxyConfig }: { logger: (msg: MessageRowInsert) => MaybePromise<void>; proxyConfig: ApplicationConstructedProxyConfiguration }) {
-        this.logger = logger;
-        this.config = proxyConfig;
-    }
+    config: Props['proxyConfig'];
 
     /**
-     * Prepare the request and execute.
-     * Most code should use this method.
+     * Called before each tries to re-build proxy config
      */
-    public async call(): Promise<Result<AxiosResponse>> {
-        const options: AxiosRequestConfig = {};
+    getConnection: Props['getConnection'];
 
-        if (this.config.responseType) {
-            options.responseType = this.config.responseType;
-        }
+    /**
+     * Called on error, gives the ability to control the retry and wait time
+     */
+    onError?: Props['onError'];
 
-        if (this.config.data) {
-            options.data = this.config.data;
-        }
+    /**
+     * Build at each iteration
+     */
+    axiosConfig?: AxiosRequestConfig;
 
-        const { method } = this.config;
+    /**
+     * Build at each iteration
+     */
+    connection?: ConnectionForProxy;
 
-        options.url = buildProxyURL(this.config);
-        options.method = method;
-
-        options.headers = buildProxyHeaders(this.config, options.url);
-
-        return await this.request({ axiosConfig: options });
+    constructor(props: Props) {
+        this.config = props.proxyConfig;
+        this.logger = props.logger;
+        this.onError = props.onError;
+        this.getConnection = props.getConnection;
     }
 
     /**
      * Send a request to the third-party with retry.
-     * Only use this if you want a different axiosConfig than the one created in call()
      */
-    public async request({ axiosConfig }: { axiosConfig: AxiosRequestConfig }): Promise<Result<AxiosResponse>> {
+    public async request(): Promise<Result<AxiosResponse>> {
         try {
             const response = await retryFlexible<Promise<AxiosResponse>>(
                 async (retryAttempt) => {
+                    // Dynamically re-build proxy and axios config
+                    // Useful for example to refresh connection's credentials
+                    this.connection = await this.getConnection();
+                    this.axiosConfig = getAxiosConfiguration({ proxyConfig: this.config, connection: this.connection });
+
                     const start = new Date();
                     try {
-                        const res = await axios.request(axiosConfig);
-                        await this.logResponse({ response: res, axiosConfig, retryAttempt, start });
+                        const res = await this.httpCall(this.axiosConfig);
+                        await this.logResponse({ response: res, retryAttempt, start });
                         return res;
                     } catch (err) {
-                        await this.logErrorResponse({ error: err, axiosConfig, retryAttempt, start });
+                        await this.logErrorResponse({ error: err, retryAttempt, start });
                         throw err;
                     }
                 },
                 {
                     max: this.config.retries || 0,
                     onError: async ({ err, nextWait, max, attempt }) => {
-                        const retry = getProxyRetryFromErr({ err, proxyConfig: this.config });
+                        let retry = getProxyRetryFromErr({ err, proxyConfig: this.config });
+
+                        // Only call onError if it's an actionable error
+                        if (retry.reason !== 'unknown_error' && this.onError) {
+                            retry = this.onError({ err, max, attempt });
+                        }
+
                         if (retry.retry) {
                             await this.logger({
                                 type: 'log',
@@ -97,22 +112,20 @@ export class ProxyRequest {
         }
     }
 
-    private async logErrorResponse({
-        error,
-        axiosConfig,
-        retryAttempt,
-        start
-    }: {
-        error: unknown;
-        axiosConfig: AxiosRequestConfig;
-        retryAttempt: RetryAttemptArgument;
-        start: Date;
-    }): Promise<void> {
-        const valuesToFilter = Object.values(this.config.connection.credentials);
-        const redactedURL = redactURL({ url: axiosConfig.url!, valuesToFilter });
+    /**
+     * For testing purpose only
+     * @private
+     */
+    public async httpCall(axiosConfig: AxiosRequestConfig): Promise<AxiosResponse> {
+        return await axios.request(axiosConfig);
+    }
+
+    private async logErrorResponse({ error, retryAttempt, start }: { error: unknown; retryAttempt: RetryAttemptArgument; start: Date }): Promise<void> {
+        const valuesToFilter = this.connection ? Object.values(this.connection.credentials) : [];
+        const redactedURL = redactURL({ url: this.axiosConfig?.url || '', valuesToFilter });
 
         if (isAxiosError(error)) {
-            const safeHeaders = redactHeaders({ headers: axiosConfig.headers, valuesToFilter });
+            const safeHeaders = redactHeaders({ headers: this.axiosConfig?.headers, valuesToFilter });
             await this.logger({
                 type: 'http',
                 level: 'error',
@@ -153,20 +166,11 @@ export class ProxyRequest {
         }
     }
 
-    private async logResponse({
-        response,
-        axiosConfig,
-        retryAttempt,
-        start
-    }: {
-        response: AxiosResponse;
-        axiosConfig: AxiosRequestConfig;
-        retryAttempt: RetryAttemptArgument;
-        start: Date;
-    }): Promise<void> {
-        const valuesToFilter = Object.values(this.config.connection.credentials);
-        const safeHeaders = redactHeaders({ headers: axiosConfig.headers, valuesToFilter });
-        const redactedURL = redactURL({ url: axiosConfig.url!, valuesToFilter });
+    private async logResponse({ response, retryAttempt, start }: { response: AxiosResponse; retryAttempt: RetryAttemptArgument; start: Date }): Promise<void> {
+        const valuesToFilter = this.connection ? Object.values(this.connection.credentials) : [];
+        const safeHeaders = redactHeaders({ headers: this.axiosConfig?.headers, valuesToFilter });
+        const redactedURL = redactURL({ url: this.axiosConfig?.url || '', valuesToFilter });
+
         await this.logger({
             type: 'http',
             level: 'info',

--- a/packages/shared/lib/services/proxy/retry.ts
+++ b/packages/shared/lib/services/proxy/retry.ts
@@ -8,13 +8,16 @@ const networkError = ['ECONNRESET', 'ETIMEDOUT', 'ECONNABORTED'];
  * Determine if we can retry or not based on the error we are receiving
  * The strategy has been laid out carefully, be careful on modifying anything here.
  */
-export function getProxyRetryFromErr({ err, proxyConfig }: { err: unknown; proxyConfig: ApplicationConstructedProxyConfiguration }): {
+export function getProxyRetryFromErr({ err, proxyConfig }: { err: unknown; proxyConfig?: ApplicationConstructedProxyConfiguration | undefined }): {
     retry: boolean;
     reason: string;
     wait?: number;
 } {
     if (!isAxiosError(err)) {
         return { retry: false, reason: 'unknown_error' };
+    }
+    if (!proxyConfig) {
+        return { retry: false, reason: 'empty_proxy_config' };
     }
 
     if (err.code && networkError.includes(err.code)) {

--- a/packages/shared/lib/services/proxy/utils.test.ts
+++ b/packages/shared/lib/services/proxy/utils.test.ts
@@ -1,6 +1,6 @@
 import type { ApplicationConstructedProxyConfiguration, DBConnectionDecrypted, Provider } from '@nangohq/types';
 
-export function getDefaultConnection(): DBConnectionDecrypted {
+export function getDefaultConnection(override?: Partial<DBConnectionDecrypted>): DBConnectionDecrypted {
     return {
         connection_id: 'a',
         created_at: new Date(),
@@ -17,23 +17,23 @@ export function getDefaultConnection(): DBConnectionDecrypted {
         deleted_at: null,
         id: -1,
         last_fetched_at: null,
-        metadata: null
+        metadata: null,
+        ...override
     };
 }
 
 export function getDefaultProxy(
     override: Omit<Partial<ApplicationConstructedProxyConfiguration>, 'connection' | 'provider'> &
         Partial<{
-            connection: Partial<ApplicationConstructedProxyConfiguration['connection']>;
             provider: Partial<ApplicationConstructedProxyConfiguration['provider']>;
         }>
 ): ApplicationConstructedProxyConfiguration {
     return {
-        connectionId: 'a',
         endpoint: '/api/test',
         method: 'GET',
         providerConfigKey: 'freshteam',
         providerName: 'freshteam',
+        decompress: false,
         ...override,
         provider: {
             auth_mode: 'API_KEY',
@@ -45,7 +45,6 @@ export function getDefaultProxy(
                 }
             },
             ...override.provider
-        } as Provider,
-        connection: { ...getDefaultConnection(), ...override.connection }
+        } as Provider
     };
 }

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -6,17 +6,24 @@ import FormData from 'form-data';
 
 import { interpolateIfNeeded, connectionCopyWithParsedConnectionConfig, mapProxyBaseUrlInterpolationFormat } from '../../utils/utils.js';
 import { getProvider } from '../providers.js';
-import type { ApplicationConstructedProxyConfiguration, HTTP_METHOD, InternalProxyConfiguration, UserProvidedProxyConfiguration } from '@nangohq/types';
+import type {
+    ApplicationConstructedProxyConfiguration,
+    ConnectionForProxy,
+    HTTP_METHOD,
+    InternalProxyConfiguration,
+    UserProvidedProxyConfiguration
+} from '@nangohq/types';
+import type { AxiosRequestConfig } from 'axios';
 
 type ProxyErrorCode =
     | 'missing_api_url'
-    | 'missing_connection_id'
     | 'missing_provider'
     | 'unsupported_auth'
     | 'unknown_provider'
     | 'unsupported_provider'
     | 'invalid_query_params'
-    | 'unknown_error';
+    | 'unknown_error'
+    | 'failed_to_get_connection';
 
 export class ProxyError extends Error {
     code: ProxyErrorCode;
@@ -26,6 +33,37 @@ export class ProxyError extends Error {
     }
 }
 
+const methodDataAllowed = ['POST', 'PUT', 'PATCH', 'DELETE'];
+
+export function getAxiosConfiguration({
+    proxyConfig,
+    connection
+}: {
+    proxyConfig: ApplicationConstructedProxyConfiguration;
+    connection: ConnectionForProxy;
+}): AxiosRequestConfig {
+    const url = buildProxyURL({ config: proxyConfig, connection });
+    const axiosConfig: AxiosRequestConfig = {
+        method: proxyConfig.method,
+        url,
+        headers: buildProxyHeaders({ config: proxyConfig, url, connection })
+    };
+
+    if (proxyConfig.responseType) {
+        axiosConfig.responseType = proxyConfig.responseType;
+    }
+
+    if (proxyConfig.data && methodDataAllowed.includes(proxyConfig.method)) {
+        axiosConfig.data = proxyConfig.data;
+    }
+
+    if (proxyConfig.decompress || proxyConfig.provider.proxy?.decompress === true) {
+        axiosConfig.decompress = true;
+    }
+
+    return axiosConfig;
+}
+
 export function getProxyConfiguration({
     externalConfig,
     internalConfig
@@ -33,15 +71,12 @@ export function getProxyConfiguration({
     externalConfig: ApplicationConstructedProxyConfiguration | UserProvidedProxyConfiguration;
     internalConfig: InternalProxyConfiguration;
 }): Result<ApplicationConstructedProxyConfiguration, ProxyError> {
-    const { endpoint: passedEndpoint, providerConfigKey, connectionId, method, retries, headers, baseUrlOverride, retryOn } = externalConfig;
-    const { connection, providerName } = internalConfig;
+    const { endpoint: passedEndpoint, providerConfigKey, method, retries, headers, baseUrlOverride, retryOn } = externalConfig;
+    const { providerName } = internalConfig;
     let data = externalConfig.data;
 
     if (!passedEndpoint && !baseUrlOverride) {
         return Err(new ProxyError('missing_api_url'));
-    }
-    if (!connectionId) {
-        return Err(new ProxyError('missing_connection_id'));
     }
     if (!providerConfigKey) {
         return Err(new ProxyError('missing_provider'));
@@ -87,11 +122,10 @@ export function getProxyConfiguration({
 
     const configBody: ApplicationConstructedProxyConfiguration = {
         endpoint,
-        method: method?.toUpperCase() as HTTP_METHOD,
+        method: method ? (method.toUpperCase() as HTTP_METHOD) : 'GET',
         provider,
         providerName,
         providerConfigKey,
-        connectionId,
         headers: headersCleaned,
         data,
         retries: retries || 0,
@@ -100,7 +134,6 @@ export function getProxyConfiguration({
         // Coming from a flow it is not a proxy call since the worker
         // makes the request so we don't allow an override in that case
         decompress: externalConfig.decompress === 'true' || externalConfig.decompress === true,
-        connection,
         params: externalConfig.params as Record<string, string>, // TODO: fix this
         responseType: externalConfig.responseType,
         retryOn: retryOn && Array.isArray(retryOn) ? retryOn.map(Number) : null
@@ -112,8 +145,7 @@ export function getProxyConfiguration({
 /**
  * Construct URL
  */
-export function buildProxyURL(config: ApplicationConstructedProxyConfiguration) {
-    const { connection } = config;
+export function buildProxyURL({ config, connection }: { config: ApplicationConstructedProxyConfiguration; connection: ConnectionForProxy }) {
     const { provider: { proxy: { base_url: templateApiBase } = {} } = {}, endpoint: apiEndpoint } = config;
 
     let apiBase = config.baseUrlOverride || templateApiBase;
@@ -149,9 +181,9 @@ export function buildProxyURL(config: ApplicationConstructedProxyConfiguration) 
         }
     }
 
-    if (config.connection.credentials.type === 'API_KEY' && 'proxy' in config.provider && 'query' in config.provider.proxy) {
+    if (connection.credentials.type === 'API_KEY' && 'proxy' in config.provider && 'query' in config.provider.proxy) {
         const apiKeyProp = Object.keys(config.provider.proxy.query)[0];
-        url.searchParams.set(apiKeyProp!, config.connection.credentials.apiKey);
+        url.searchParams.set(apiKeyProp!, connection.credentials.apiKey);
     }
 
     return url.toString();
@@ -160,10 +192,17 @@ export function buildProxyURL(config: ApplicationConstructedProxyConfiguration) 
 /**
  * Build Headers for proxy
  */
-export function buildProxyHeaders(config: ApplicationConstructedProxyConfiguration, url: string): Record<string, string> {
+export function buildProxyHeaders({
+    config,
+    url,
+    connection
+}: {
+    config: ApplicationConstructedProxyConfiguration;
+    url: string;
+    connection: ConnectionForProxy;
+}): Record<string, string> {
     let headers: Record<Lowercase<string>, string> = {};
 
-    const { connection } = config;
     switch (connection.credentials.type) {
         case 'BASIC': {
             headers['authorization'] = `Basic ${Buffer.from(`${connection.credentials.username}:${connection.credentials.password ?? ''}`).toString('base64')}`;
@@ -192,8 +231,8 @@ export function buildProxyHeaders(config: ApplicationConstructedProxyConfigurati
         }
         case 'TBA': {
             const credentials = connection.credentials;
-            const consumerKey: string = credentials.config_override['client_id'] || config.connection.connection_config['oauth_client_id'];
-            const consumerSecret: string = credentials.config_override['client_secret'] || config.connection.connection_config['oauth_client_secret'];
+            const consumerKey: string = credentials.config_override['client_id'] || connection.connection_config['oauth_client_id'];
+            const consumerSecret: string = credentials.config_override['client_secret'] || connection.connection_config['oauth_client_secret'];
             const accessToken = credentials['token_id'];
             const accessTokenSecret = credentials['token_secret'];
 
@@ -218,7 +257,7 @@ export function buildProxyHeaders(config: ApplicationConstructedProxyConfigurati
             const authHeaders = oauth.toHeader(oauth.authorize(requestData, token));
 
             // splice in the realm into the header
-            let realm = config.connection.connection_config['accountId'];
+            let realm = connection.connection_config['accountId'];
             realm = realm.replace('-', '_').toUpperCase();
 
             headers['authorization'] = authHeaders.Authorization.replace('OAuth ', `OAuth realm="${realm}", `);

--- a/packages/shared/lib/services/proxy/utils.unit.test.ts
+++ b/packages/shared/lib/services/proxy/utils.unit.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, it } from 'vitest';
 import { buildProxyHeaders, buildProxyURL, getProxyConfiguration, ProxyError } from './utils.js';
-import type { UserProvidedProxyConfiguration, InternalProxyConfiguration, OAuth2Credentials } from '@nangohq/types';
+import type { UserProvidedProxyConfiguration, InternalProxyConfiguration } from '@nangohq/types';
 
 import { getDefaultConnection, getDefaultProxy } from './utils.test.js';
 
@@ -18,16 +18,19 @@ describe('buildProxyHeaders', () => {
                         'x-test': 'test'
                     }
                 }
-            },
-            connection: {
+            }
+        });
+
+        const headers = buildProxyHeaders({
+            config,
+            url: 'https://api.nangostarter.com',
+            connection: getDefaultConnection({
                 credentials: { type: 'API_KEY', apiKey: 'sweet-secret-token' },
                 connection_config: {
                     instance_url: 'bar'
                 }
-            }
+            })
         });
-
-        const headers = buildProxyHeaders(config, 'https://api.nangostarter.com');
 
         expect(headers).toEqual({
             'my-token': 'sweet-secret-token',
@@ -40,13 +43,16 @@ describe('buildProxyHeaders', () => {
             provider: {
                 auth_mode: 'BASIC',
                 proxy: { base_url: '' }
-            },
-            connection: {
-                credentials: { type: 'BASIC', username: 'testuser', password: 'testpassword' }
             }
         });
 
-        const result = buildProxyHeaders(config, 'https://api.nangostarter.com');
+        const result = buildProxyHeaders({
+            config,
+            url: 'https://api.nangostarter.com',
+            connection: getDefaultConnection({
+                credentials: { type: 'BASIC', username: 'testuser', password: 'testpassword' }
+            })
+        });
 
         expect(result).toEqual({
             authorization: 'Basic ' + Buffer.from('testuser:testpassword').toString('base64')
@@ -58,13 +64,16 @@ describe('buildProxyHeaders', () => {
             provider: {
                 auth_mode: 'BASIC',
                 proxy: { base_url: '' }
-            },
-            connection: {
-                credentials: { type: 'BASIC', username: 'testuser', password: '' }
             }
         });
 
-        const result = buildProxyHeaders(config, 'https://api.nangostarter.com');
+        const result = buildProxyHeaders({
+            config,
+            url: 'https://api.nangostarter.com',
+            connection: getDefaultConnection({
+                credentials: { type: 'BASIC', username: 'testuser', password: '' }
+            })
+        });
 
         expect(result).toEqual({
             authorization: 'Basic ' + Buffer.from('testuser:').toString('base64')
@@ -81,13 +90,16 @@ describe('buildProxyHeaders', () => {
                         'x-test': 'test'
                     }
                 }
-            },
-            connection: {
-                credentials: { type: 'BASIC', username: 'testuser', password: 'testpassword' }
             }
         });
 
-        const result = buildProxyHeaders(config, 'https://api.nangostarter.com');
+        const result = buildProxyHeaders({
+            config,
+            url: 'https://api.nangostarter.com',
+            connection: getDefaultConnection({
+                credentials: { type: 'BASIC', username: 'testuser', password: 'testpassword' }
+            })
+        });
 
         expect(result).toEqual({
             authorization: 'Basic ' + Buffer.from('testuser:testpassword').toString('base64'),
@@ -100,15 +112,18 @@ describe('buildProxyHeaders', () => {
             provider: {
                 auth_mode: 'BASIC'
             },
-            connection: {
-                credentials: { type: 'BASIC', username: 'testuser', password: 'testpassword' }
-            },
             headers: {
                 authorization: 'Bearer testtoken'
             }
         });
 
-        const result = buildProxyHeaders(config, 'https://api.nangostarter.com');
+        const result = buildProxyHeaders({
+            config,
+            url: 'https://api.nangostarter.com',
+            connection: getDefaultConnection({
+                credentials: { type: 'BASIC', username: 'testuser', password: 'testpassword' }
+            })
+        });
 
         expect(result).toEqual({
             authorization: 'Bearer testtoken'
@@ -125,13 +140,16 @@ describe('buildProxyHeaders', () => {
                         'x-access-token': '${accessToken}'
                     }
                 }
-            },
-            connection: {
-                credentials: { type: 'OAUTH2', access_token: 'some-oauth-access-token', raw: {} }
             }
         });
 
-        const result = buildProxyHeaders(config, 'https://api.nangostarter.com');
+        const result = buildProxyHeaders({
+            config,
+            url: 'https://api.nangostarter.com',
+            connection: getDefaultConnection({
+                credentials: { type: 'OAUTH2', access_token: 'some-oauth-access-token', raw: {} }
+            })
+        });
 
         expect(result).toEqual({
             authorization: 'Bearer some-oauth-access-token',
@@ -150,16 +168,19 @@ describe('buildProxyHeaders', () => {
                     }
                 }
             },
-            connection: {
-                credentials: { type: 'API_KEY', apiKey: 'some-abc-token' }
-            },
             headers: {
                 'x-custom-header': 'custom value',
                 'y-custom-header': 'custom values'
             }
         });
 
-        const result = buildProxyHeaders(config, 'https://api.nangostarter.com');
+        const result = buildProxyHeaders({
+            config,
+            url: 'https://api.nangostarter.com',
+            connection: getDefaultConnection({
+                credentials: { type: 'API_KEY', apiKey: 'some-abc-token' }
+            })
+        });
 
         expect(result).toEqual({
             'my-token': 'some-abc-token',
@@ -179,16 +200,19 @@ describe('buildProxyHeaders', () => {
                         'x-api-password': '${connectionConfig.API_PASSWORD}'
                     }
                 }
-            },
-            connection: {
+            }
+        });
+
+        const result = buildProxyHeaders({
+            config,
+            url: 'https://api.nangostarter.com',
+            connection: getDefaultConnection({
                 credentials: { type: 'API_KEY', apiKey: 'api-key-value' },
                 connection_config: {
                     API_PASSWORD: 'api-password-value'
                 }
-            }
+            })
         });
-
-        const result = buildProxyHeaders(config, 'https://api.nangostarter.com');
 
         expect(result).toEqual({
             'x-api-key': 'api-key-value',
@@ -206,13 +230,16 @@ describe('buildProxyHeaders', () => {
                         'x-wsse': '${accessToken}'
                     }
                 }
-            },
-            connection: {
-                credentials: { type: 'SIGNATURE', username: 't', password: 'some-oauth-access-token', token: 'some-oauth-access-token' }
             }
         });
 
-        const result = buildProxyHeaders(config, 'https://api.nangostarter.com');
+        const result = buildProxyHeaders({
+            config,
+            url: 'https://api.nangostarter.com',
+            connection: getDefaultConnection({
+                credentials: { type: 'SIGNATURE', username: 't', password: 'some-oauth-access-token', token: 'some-oauth-access-token' }
+            })
+        });
 
         expect(result).toEqual({
             authorization: 'Bearer some-oauth-access-token',
@@ -222,7 +249,6 @@ describe('buildProxyHeaders', () => {
 
     it('should correctly override headers with different casing', () => {
         const config: UserProvidedProxyConfiguration = {
-            connectionId: 'a',
             endpoint: '/top',
             method: 'GET',
             providerConfigKey: 'foobar',
@@ -234,8 +260,7 @@ describe('buildProxyHeaders', () => {
         };
 
         const internalConfig: InternalProxyConfiguration = {
-            providerName: 'workable',
-            connection: getDefaultConnection()
+            providerName: 'workable'
         };
 
         const result = getProxyConfiguration({ externalConfig: config, internalConfig });
@@ -245,7 +270,7 @@ describe('buildProxyHeaders', () => {
             foo: 'Bar'
         });
 
-        const merge = buildProxyHeaders(val, 'http://example.com');
+        const merge = buildProxyHeaders({ config: val, url: 'http://example.com', connection: getDefaultConnection() });
         expect(merge).toStrictEqual({
             authorization: 'my custom auth',
             foo: 'Bar'
@@ -264,7 +289,7 @@ describe('buildProxyURL', () => {
             endpoint: 'api/test'
         });
 
-        const result = buildProxyURL(config);
+        const result = buildProxyURL({ config, connection: getDefaultConnection() });
 
         expect(result).toBe('https://example.com/api/test');
     });
@@ -278,7 +303,7 @@ describe('buildProxyURL', () => {
             }
         });
 
-        const result = buildProxyURL(config);
+        const result = buildProxyURL({ config, connection: getDefaultConnection() });
 
         expect(result).toBe('https://example.com/api/test');
     });
@@ -294,7 +319,7 @@ describe('buildProxyURL', () => {
             baseUrlOverride: 'https://override.com'
         });
 
-        const result = buildProxyURL(config);
+        const result = buildProxyURL({ config, connection: getDefaultConnection() });
 
         // Assuming interpolateIfNeeded doesn't change the input
         expect(result).toBe('https://override.com/api/test');
@@ -310,7 +335,7 @@ describe('buildProxyURL', () => {
             baseUrlOverride: 'https://override.com'
         });
 
-        const result = buildProxyURL(config);
+        const result = buildProxyURL({ config, connection: getDefaultConnection() });
 
         // Assuming interpolateIfNeeded doesn't change the input
         expect(result).toBe('https://override.com/api/test');
@@ -327,13 +352,15 @@ describe('buildProxyURL', () => {
                     }
                 }
             },
-            connection: {
-                credentials: { type: 'API_KEY', apiKey: 'sweet-secret-token' }
-            },
             baseUrlOverride: 'https://override.com'
         });
 
-        const result = buildProxyURL(config);
+        const result = buildProxyURL({
+            config,
+            connection: getDefaultConnection({
+                credentials: { type: 'API_KEY', apiKey: 'sweet-secret-token' }
+            })
+        });
 
         // Assuming interpolateIfNeeded doesn't change the input
         expect(result).toBe('https://override.com/api/test?api_key=sweet-secret-token');
@@ -351,13 +378,15 @@ describe('buildProxyURL', () => {
                     }
                 }
             },
-            connection: {
-                credentials: { type: 'API_KEY', apiKey: 'sweet-secret-token' }
-            },
             baseUrlOverride: 'https://override.com'
         });
 
-        const result = buildProxyURL(config);
+        const result = buildProxyURL({
+            config,
+            connection: getDefaultConnection({
+                credentials: { type: 'API_KEY', apiKey: 'sweet-secret-token' }
+            })
+        });
 
         expect(result).toBe('https://override.com/api/test?key=sweet-secret-token');
     });
@@ -373,14 +402,16 @@ describe('buildProxyURL', () => {
                     }
                 }
             },
-            connection: {
-                credentials: { type: 'API_KEY', apiKey: 'sweet-secret-token' }
-            },
             endpoint: '/api/test?foo=bar',
             baseUrlOverride: 'https://override.com'
         });
 
-        const result = buildProxyURL(config);
+        const result = buildProxyURL({
+            config,
+            connection: getDefaultConnection({
+                credentials: { type: 'API_KEY', apiKey: 'sweet-secret-token' }
+            })
+        });
 
         expect(result).toBe('https://override.com/api/test?foo=bar&api_key=sweet-secret-token');
     });
@@ -401,17 +432,17 @@ describe('buildProxyURL', () => {
                     }
                 }
             },
-            connection: {
-                credentials: { type: 'API_KEY', apiKey: 'sweet-secret-token' }
-            },
             endpoint: '/api/test?foo=bar',
             baseUrlOverride: 'https://override.com'
         });
-        const url = buildProxyURL(config);
+        const connection = getDefaultConnection({
+            credentials: { type: 'API_KEY', apiKey: 'sweet-secret-token' }
+        });
+        const url = buildProxyURL({ config, connection });
 
         expect(url).toBe('https://override.com/api/test?foo=bar&api_key=sweet-secret-token');
 
-        const headers = buildProxyHeaders(config, 'https://override.com/api/test?foo=bar&api_key=sweet-secret-token');
+        const headers = buildProxyHeaders({ config, connection, url: 'https://override.com/api/test?foo=bar&api_key=sweet-secret-token' });
 
         expect(headers).toEqual({
             'x-custom-header': 'custom value',
@@ -427,14 +458,16 @@ describe('buildProxyURL', () => {
                 proxy: {
                     base_url: 'https://www.zohoapis.${connectionConfig.extension}'
                 }
-            },
-            connection: {
-                credentials: { type: 'API_KEY', apiKey: 'sweet-secret-token' },
-                connection_config: { extension: 'eu' }
             }
         });
 
-        const url = buildProxyURL(config);
+        const url = buildProxyURL({
+            config,
+            connection: getDefaultConnection({
+                credentials: { type: 'API_KEY', apiKey: 'sweet-secret-token' },
+                connection_config: { extension: 'eu' }
+            })
+        });
 
         expect(url).toBe('https://www.zohoapis.eu/api/test');
     });
@@ -446,14 +479,16 @@ describe('buildProxyURL', () => {
                 proxy: {
                     base_url: '${metadata.instance_url}'
                 }
-            },
-            connection: {
-                credentials: { type: 'API_KEY', apiKey: 'sweet-secret-token' },
-                metadata: { instance_url: 'https://myinstanceurl.com' }
             }
         });
 
-        const url = buildProxyURL(config);
+        const url = buildProxyURL({
+            config,
+            connection: getDefaultConnection({
+                credentials: { type: 'API_KEY', apiKey: 'sweet-secret-token' },
+                metadata: { instance_url: 'https://myinstanceurl.com' }
+            })
+        });
 
         expect(url).toBe('https://myinstanceurl.com/api/test');
     });
@@ -465,14 +500,16 @@ describe('buildProxyURL', () => {
                 proxy: {
                     base_url: '${connectionConfig.api_base_url_for_customer} || https://api.gong.io'
                 }
-            },
-            connection: {
-                credentials: { type: 'API_KEY', apiKey: 'sweet-secret-token' },
-                connection_config: { api_base_url_for_customer: 'https://company-17.api.gong.io' }
             }
         });
 
-        const url = buildProxyURL(config);
+        const url = buildProxyURL({
+            config,
+            connection: getDefaultConnection({
+                credentials: { type: 'API_KEY', apiKey: 'sweet-secret-token' },
+                connection_config: { api_base_url_for_customer: 'https://company-17.api.gong.io' }
+            })
+        });
 
         expect(url).toBe('https://company-17.api.gong.io/api/test');
     });
@@ -484,20 +521,22 @@ describe('buildProxyURL', () => {
                 proxy: {
                     base_url: '${connectionConfig.api_base_url_for_customer}||https://api.gong.io'
                 }
-            },
-            connection: {
-                credentials: { type: 'API_KEY', apiKey: 'sweet-secret-token' }
             }
         });
 
-        const url = buildProxyURL(config);
+        const url = buildProxyURL({
+            config,
+            connection: getDefaultConnection({
+                credentials: { type: 'API_KEY', apiKey: 'sweet-secret-token' }
+            })
+        });
 
         expect(url).toBe('https://api.gong.io/api/test');
     });
 
     it('should construct url with a string query params with ?', () => {
-        const url = buildProxyURL(
-            getDefaultProxy({
+        const url = buildProxyURL({
+            config: getDefaultProxy({
                 provider: {
                     auth_mode: 'OAUTH2',
                     proxy: {
@@ -505,15 +544,16 @@ describe('buildProxyURL', () => {
                     }
                 },
                 params: '?foo=bar'
-            })
-        );
+            }),
+            connection: getDefaultConnection()
+        });
 
         expect(url).toBe('https://example.com/api/test?foo=bar');
     });
 
     it('should construct url with a string query params without ?', () => {
-        const url = buildProxyURL(
-            getDefaultProxy({
+        const url = buildProxyURL({
+            config: getDefaultProxy({
                 provider: {
                     auth_mode: 'OAUTH2',
                     proxy: {
@@ -521,16 +561,17 @@ describe('buildProxyURL', () => {
                     }
                 },
                 params: 'foo=bar'
-            })
-        );
+            }),
+            connection: getDefaultConnection()
+        });
 
         expect(url).toBe('https://example.com/api/test?foo=bar');
     });
 
     it('should throw when setting query params in both endpoint and params', () => {
         expect(() => {
-            buildProxyURL(
-                getDefaultProxy({
+            buildProxyURL({
+                config: getDefaultProxy({
                     provider: {
                         auth_mode: 'OAUTH2',
                         proxy: {
@@ -539,8 +580,9 @@ describe('buildProxyURL', () => {
                     },
                     endpoint: 'https://example.com?bar=foo',
                     params: '?foo=bar'
-                })
-            );
+                }),
+                connection: getDefaultConnection()
+            });
         }).toThrow(new Error('Can not set query params in endpoint and in params'));
     });
 });
@@ -550,18 +592,10 @@ describe('getProxyConfiguration', () => {
         const externalConfig: UserProvidedProxyConfiguration = {
             method: 'GET',
             providerConfigKey: 'provider-config-key-1',
-            connectionId: 'connection-1',
             endpoint: ''
         };
         const internalConfig: InternalProxyConfiguration = {
-            providerName: 'provider-1',
-            connection: {
-                connection_id: 'connection-1',
-                credentials: {} as OAuth2Credentials,
-                connection_config: {},
-                metadata: null
-            },
-            existingActivityLogId: '1'
+            providerName: 'provider-1'
         };
 
         const res = getProxyConfiguration({ externalConfig, internalConfig });
@@ -574,50 +608,14 @@ describe('getProxyConfiguration', () => {
         expect(err).toStrictEqual(new ProxyError('missing_api_url'));
     });
 
-    it('should fail if no connectionId', () => {
-        const externalConfig: UserProvidedProxyConfiguration = {
-            method: 'GET',
-            providerConfigKey: 'provider-config-key-1',
-            connectionId: '',
-            endpoint: 'https://example.com'
-        };
-        const internalConfig: InternalProxyConfiguration = {
-            providerName: 'provider-1',
-            connection: {
-                connection_id: 'connection-1',
-                credentials: {} as OAuth2Credentials,
-                connection_config: {},
-                metadata: null
-            },
-            existingActivityLogId: '1'
-        };
-
-        const res = getProxyConfiguration({ externalConfig, internalConfig });
-        if (res.isOk()) {
-            expect(res.value).toBe(Error);
-            return;
-        }
-
-        const err = res.error;
-        expect(err).toStrictEqual(new ProxyError('missing_connection_id'));
-    });
-
     it('should fail if no providerConfigKey', () => {
         const externalConfig: UserProvidedProxyConfiguration = {
             method: 'GET',
             providerConfigKey: '',
-            connectionId: 'connection-1',
             endpoint: 'https://example.com'
         };
         const internalConfig: InternalProxyConfiguration = {
-            providerName: 'provider-1',
-            connection: {
-                connection_id: 'connection-1',
-                credentials: {} as OAuth2Credentials,
-                connection_config: {},
-                metadata: null
-            },
-            existingActivityLogId: '1'
+            providerName: 'provider-1'
         };
 
         const res = getProxyConfiguration({ externalConfig, internalConfig });
@@ -634,18 +632,10 @@ describe('getProxyConfiguration', () => {
         const externalConfig: UserProvidedProxyConfiguration = {
             method: 'GET',
             providerConfigKey: 'provider-config-key-1',
-            connectionId: 'connection-1',
             endpoint: 'https://example.com'
         };
         const internalConfig: InternalProxyConfiguration = {
-            providerName: 'unknown',
-            connection: {
-                connection_id: 'connection-1',
-                credentials: {} as OAuth2Credentials,
-                connection_config: {},
-                metadata: null
-            },
-            existingActivityLogId: '1'
+            providerName: 'unknown'
         };
 
         const res = getProxyConfiguration({ externalConfig, internalConfig });
@@ -662,7 +652,6 @@ describe('getProxyConfiguration', () => {
         const externalConfig: UserProvidedProxyConfiguration = {
             method: 'GET',
             providerConfigKey: 'provider-config-key-1',
-            connectionId: 'connection-1',
             endpoint: '/api/test',
             retries: 3,
             baseUrlOverride: 'https://api.github.com.override',
@@ -673,14 +662,7 @@ describe('getProxyConfiguration', () => {
             responseType: 'blob'
         };
         const internalConfig: InternalProxyConfiguration = {
-            providerName: 'github',
-            connection: {
-                connection_id: 'connection-1',
-                credentials: {} as OAuth2Credentials,
-                connection_config: {},
-                metadata: null
-            },
-            existingActivityLogId: '1'
+            providerName: 'github'
         };
 
         const res = getProxyConfiguration({ externalConfig, internalConfig });
@@ -703,18 +685,12 @@ describe('getProxyConfiguration', () => {
             },
             providerName: 'github',
             providerConfigKey: 'provider-config-key-1',
-            connectionId: 'connection-1',
             headers: {
                 'x-custom': 'custom-value'
             },
             retries: 3,
             baseUrlOverride: 'https://api.github.com.override',
             decompress: false,
-            connection: {
-                connection_id: 'connection-1',
-                credentials: {},
-                connection_config: {}
-            },
             params: { foo: 'bar' },
             responseType: 'blob'
         });

--- a/packages/types/lib/proxy/api.ts
+++ b/packages/types/lib/proxy/api.ts
@@ -16,7 +16,6 @@ export interface ProxyFile {
 
 export interface BaseProxyConfiguration {
     providerConfigKey: string;
-    connectionId: string;
     endpoint: string;
     retries?: number;
     data?: unknown;
@@ -35,20 +34,19 @@ export interface UserProvidedProxyConfiguration extends BaseProxyConfiguration {
     paginate?: Partial<CursorPagination> | Partial<LinkPagination> | Partial<OffsetPagination>;
 }
 
+export type ConnectionForProxy = Pick<DBConnectionDecrypted, 'connection_id' | 'connection_config' | 'credentials' | 'metadata'>;
+
 export interface ApplicationConstructedProxyConfiguration extends BaseProxyConfiguration {
-    decompress?: boolean;
+    decompress: boolean;
     method: HTTP_METHOD;
     providerName: string;
     provider: Provider;
-    connection: Pick<DBConnectionDecrypted, 'connection_id' | 'connection_config' | 'credentials' | 'metadata'>;
 }
 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
 
 export interface InternalProxyConfiguration {
     providerName: string;
-    connection: Pick<DBConnectionDecrypted, 'connection_id' | 'connection_config' | 'credentials' | 'metadata'>;
-    existingActivityLogId?: string | null | undefined;
 }
 
 export interface RetryHeaderConfig {


### PR DESCRIPTION
## Changes

See #3566 that was reverted 

- Fix missing `responseType` 

---

To compare easily  `git diff 85c998b4fe9998162c59bafacb114c500ff8d772..64f284dd55104516af9b2f2c31cbfa5989170256`

```diff
git diff 85c998b4fe9998162c59bafacb114c500ff8d772..64f284dd55104516af9b2f2c31cbfa5989170256
diff --git a/packages/server/lib/controllers/proxy.controller.ts b/packages/server/lib/controllers/proxy.controller.ts
index f578aab29..846955177 100644
--- a/packages/server/lib/controllers/proxy.controller.ts
+++ b/packages/server/lib/controllers/proxy.controller.ts
@@ -153,7 +153,8 @@ class ProxyController {
                         baseUrlOverride,
                         decompress: decompress === 'true' ? true : false,
                         method: method.toUpperCase() as HTTP_METHOD,
-                        retryOn
+                        retryOn,
+                        responseType: 'stream'
                     },
                     internalConfig
                 }).unwrap(),
```
