### PR TITLE
feat(ui): show sync variant on connections page

### DIFF
--- a/packages/webapp/src/components/ui/label/Tag.tsx
+++ b/packages/webapp/src/components/ui/label/Tag.tsx
@@ -2,7 +2,7 @@ import { cn } from '../../../utils/utils';
 import type { VariantProps } from 'class-variance-authority';
 import { cva } from 'class-variance-authority';
 
-const variants = cva('', {
+const variantStyles = cva('', {
     variants: {
         variant: {
             success: 'bg-success-400 border-success-400 text-success-400',
@@ -10,22 +10,56 @@ const variants = cva('', {
             info: 'bg-info-400 border-info-400 text-info-400',
             warning: 'bg-warning-400 border-warning-400 text-warning-400',
             gray: 'bg-grayscale-500 border-grayscale-500 text-grayscale-500',
+            gray1: 'bg-grayscale-500 border-grayscale-700 text-white',
             neutral: 'bg-grayscale-900 border-grayscale-700 text-grayscale-100'
+        },
+        size: {
+            default: 'px-2 pt-[1px]',
+            small: 'px-1 pt-[1px]'
         }
     },
     defaultVariants: {
-        variant: 'neutral'
+        variant: 'neutral',
+        size: 'default'
+    }
+});
+
+const textCaseStyles = cva('', {
+    variants: {
+        textCase: {
+            uppercase: 'uppercase',
+            lowercase: 'lowercase',
+            capitalize: 'capitalize',
+            normal: 'normal-case'
+        }
+    },
+    defaultVariants: {
+        textCase: 'uppercase'
+    }
+});
+
+const sizeTextStyles = cva('text-[11px]', {
+    variants: {
+        size: {
+            default: 'leading-[17px]',
+            small: 'leading-[14px]'
+        }
+    },
+    defaultVariants: {
+        size: 'default'
     }
 });
 
 export const Tag: React.FC<
     {
         children: React.ReactNode;
-    } & VariantProps<typeof variants>
-> = ({ children, variant }) => {
+        textCase?: 'uppercase' | 'lowercase' | 'capitalize' | 'normal';
+        size?: 'default' | 'small';
+    } & VariantProps<typeof variantStyles>
+> = ({ children, variant, textCase, size }) => {
     return (
-        <div className={cn('inline-flex px-2 pt-[1px] border-[0.5px] bg-opacity-30 rounded', variants({ variant }))}>
-            <div className={cn('uppercase text-[11px] leading-[17px]')}>{children}</div>
+        <div className={cn('inline-flex border-[0.5px] bg-opacity-30 rounded', variantStyles({ variant, size }))}>
+            <div className={cn(sizeTextStyles({ size }), textCaseStyles({ textCase }))}>{children}</div>
         </div>
     );
 };

--- a/packages/webapp/src/components/ui/label/Tag.tsx
+++ b/packages/webapp/src/components/ui/label/Tag.tsx
@@ -14,13 +14,13 @@ const variantStyles = cva('', {
             neutral: 'bg-grayscale-900 border-grayscale-700 text-grayscale-100'
         },
         size: {
-            default: 'px-2 pt-[1px]',
-            small: 'px-1 pt-[1px]'
+            md: 'px-2 pt-[1px] leading-[17px]',
+            sm: 'px-1 pt-[1px] leading-[13px]'
         }
     },
     defaultVariants: {
         variant: 'neutral',
-        size: 'default'
+        size: 'md'
     }
 });
 
@@ -38,28 +38,16 @@ const textCaseStyles = cva('', {
     }
 });
 
-const sizeTextStyles = cva('text-[11px]', {
-    variants: {
-        size: {
-            default: 'leading-[17px]',
-            small: 'leading-[14px]'
-        }
-    },
-    defaultVariants: {
-        size: 'default'
-    }
-});
-
 export const Tag: React.FC<
     {
         children: React.ReactNode;
         textCase?: 'uppercase' | 'lowercase' | 'capitalize' | 'normal';
-        size?: 'default' | 'small';
+        size?: 'md' | 'sm';
     } & VariantProps<typeof variantStyles>
 > = ({ children, variant, textCase, size }) => {
     return (
         <div className={cn('inline-flex border-[0.5px] bg-opacity-30 rounded', variantStyles({ variant, size }))}>
-            <div className={cn(sizeTextStyles({ size }), textCaseStyles({ textCase }))}>{children}</div>
+            <div className={cn(textCaseStyles({ textCase }))}>{children}</div>
         </div>
     );
 };

--- a/packages/webapp/src/pages/Connection/Syncs.tsx
+++ b/packages/webapp/src/pages/Connection/Syncs.tsx
@@ -23,6 +23,8 @@ export const Syncs: React.FC<SyncsProps> = ({ connection, provider }) => {
 
     const { data: syncs, loading, mutate } = useSyncs({ env, provider_config_key: connection.provider_config_key, connection_id: connection.connection_id });
 
+    const showSyncVariant = (target: SyncResponse): boolean => (syncs?.filter((sync) => sync.name === target.name) || []).length > 1;
+
     useInterval(async () => {
         await mutate();
     }, 5000);
@@ -104,7 +106,7 @@ export const Syncs: React.FC<SyncsProps> = ({ connection, provider }) => {
                     </Table.Header>
                     <Table.Body>
                         {syncs.map((sync) => (
-                            <SyncRow key={sync.id} sync={sync} connection={connection} provider={provider} />
+                            <SyncRow key={sync.id} sync={sync} connection={connection} provider={provider} showSyncVariant={showSyncVariant(sync)} />
                         ))}
                     </Table.Body>
                 </Table.Table>

--- a/packages/webapp/src/pages/Connection/components/SyncRow.tsx
+++ b/packages/webapp/src/pages/Connection/components/SyncRow.tsx
@@ -3,7 +3,15 @@ import * as Table from '../../../components/ui/Table';
 import { Tag } from '../../../components/ui/label/Tag';
 import { Link } from 'react-router-dom';
 import { EllipsisHorizontalIcon, QueueListIcon } from '@heroicons/react/24/outline';
-import { formatFrequency, getRunTime, parseLatestSyncResult, formatDateToUSFormat, interpretNextRun, formatQuantity } from '../../../utils/utils';
+import {
+    formatFrequency,
+    getRunTime,
+    parseLatestSyncResult,
+    formatDateToUSFormat,
+    interpretNextRun,
+    formatQuantity,
+    truncateMiddle
+} from '../../../utils/utils';
 import { getLogsUrl } from '../../../utils/logs';
 import { UserFacingSyncCommand } from '../../../types';
 import type { RunSyncCommand, SyncResponse } from '../../../types';
@@ -21,7 +29,12 @@ import { Select, SelectItem, SelectContent, SelectTrigger, SelectValue } from '.
 import { Checkbox } from '../../../components/ui/Checkbox';
 import { apiRunSyncCommand } from '../../../hooks/useSyncs';
 
-export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFull; provider: string | null }> = ({ sync, connection, provider }) => {
+export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFull; provider: string | null; showSyncVariant: boolean }> = ({
+    sync,
+    connection,
+    provider,
+    showSyncVariant
+}) => {
     const { toast } = useToast();
 
     const env = useStore((state) => state.env);
@@ -114,7 +127,17 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
     return (
         <Table.Row className="text-white">
             <Table.Cell bordered>
-                <div className="w-36 max-w-3xl truncate">{sync.name}</div>
+                <div className="w-36 max-w-3xl truncate">
+                    {sync.name}
+                    {showSyncVariant && ' '}
+                    {showSyncVariant && (
+                        <SimpleTooltip tooltipContent={sync.variant}>
+                            <Tag variant="gray1" textCase="lowercase" size="small">
+                                {truncateMiddle(sync.variant)}
+                            </Tag>
+                        </SimpleTooltip>
+                    )}
+                </div>
             </Table.Cell>
             <Table.Cell bordered>
                 <div className="w-36 max-w-3xl truncate">{Array.isArray(sync.models) ? sync.models.join(', ') : sync.models}</div>

--- a/packages/webapp/src/pages/Connection/components/SyncRow.tsx
+++ b/packages/webapp/src/pages/Connection/components/SyncRow.tsx
@@ -128,15 +128,16 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
         <Table.Row className="text-white">
             <Table.Cell bordered>
                 <div className="w-36 max-w-3xl truncate">
-                    {sync.name}
-                    {showSyncVariant && ' '}
-                    {showSyncVariant && (
-                        <SimpleTooltip tooltipContent={sync.variant}>
-                            <Tag variant="gray1" textCase="lowercase" size="small">
-                                {truncateMiddle(sync.variant)}
-                            </Tag>
-                        </SimpleTooltip>
-                    )}
+                    <div className="flex gap-2">
+                        {sync.name}
+                        {showSyncVariant && (
+                            <SimpleTooltip tooltipContent={sync.variant}>
+                                <Tag variant="gray1" textCase="lowercase" size="sm">
+                                    {truncateMiddle(sync.variant)}
+                                </Tag>
+                            </SimpleTooltip>
+                        )}
+                    </div>
                 </div>
             </Table.Cell>
             <Table.Cell bordered>

--- a/packages/webapp/src/types.ts
+++ b/packages/webapp/src/types.ts
@@ -13,6 +13,7 @@ export interface SyncResponse {
     created_at: string;
     nango_connection_id: number;
     name: string;
+    variant: string;
     frequency: string;
     frequency_override: string | null;
     futureActionTimes: number[];

--- a/packages/webapp/src/utils/utils.tsx
+++ b/packages/webapp/src/utils/utils.tsx
@@ -253,3 +253,12 @@ export function stringArrayEqual(prev: string[], next: string[]) {
     }
     return true;
 }
+
+export function truncateMiddle(str: string, maxLength: number = 14, ellipsis: string = '...'): string {
+    if (str.length <= maxLength) return str;
+    if (maxLength <= ellipsis.length) return ellipsis.substring(0, maxLength);
+    const charsToShow = maxLength - ellipsis.length;
+    const frontChars = Math.ceil(charsToShow / 2);
+    const backChars = Math.floor(charsToShow / 2);
+    return str.substring(0, frontChars) + ellipsis + str.substring(str.length - backChars);
+}


### PR DESCRIPTION
https://linear.app/nango/issue/NAN-2726/[design]-sync-variant-feature-quick-one 

Show sync variant in a grey bubble next to the sync name 
Only show variant bubble if there is more than the base variant 
Long variant names are truncated. Full name can be seen in a tooltip


<img width="1048" alt="Screenshot 2025-02-26 at 15 13 38" src="https://github.com/user-attachments/assets/0ac34ec5-13f0-4f29-8c40-60a24369ff82" />


