### PR TITLE
feat: limit valid characters in sync names

### DIFF
--- a/packages/nango-yaml/lib/errors.ts
+++ b/packages/nango-yaml/lib/errors.ts
@@ -10,6 +10,16 @@ export class ParserError {
     }
 }
 
+export class ParserErrorInvalidSyncName extends ParserError {
+    constructor(options: { name: string; path: string[] }) {
+        super({
+            code: 'invalid_sync_name',
+            message: `Sync "${options.name}" contains invalid characters`,
+            path: options.path
+        });
+    }
+}
+
 export class ParserErrorInvalidModelName extends ParserError {
     constructor(options: { model: string; path: string[] }) {
         super({

--- a/packages/nango-yaml/lib/parser.ts
+++ b/packages/nango-yaml/lib/parser.ts
@@ -3,6 +3,7 @@ import { ModelsParser, getRecursiveModelNames } from './modelsParser.js';
 import {
     ParserErrorDuplicateEndpoint,
     ParserErrorDuplicateModel,
+    ParserErrorInvalidSyncName,
     ParserErrorMissingId,
     ParserErrorModelIsLiteral,
     ParserErrorModelNotFound
@@ -77,6 +78,11 @@ export abstract class NangoYamlParser {
 
             // --- Validate syncs
             for (const sync of integration.syncs) {
+                const syncNameRegex = /^[a-zA-Z0-9-_]+$/;
+                if (!syncNameRegex.test(sync.name)) {
+                    this.errors.push(new ParserErrorInvalidSyncName({ name: sync.name, path: [integrationName, 'syncs', sync.name] }));
+                    continue;
+                }
                 const usedModelsSync = new Set<string>();
                 if (sync.output) {
                     for (const output of sync.output) {


### PR DESCRIPTION
I wanted to prevent using "::" in sync name in order to avoid conflict with sync name format `name::variant` and after checking the prod db with the following sql query:
```
WITH characters AS (
  SELECT DISTINCT unnest(string_to_array(name, NULL)) AS character
  FROM nango._nango_syncs
  WHERE deleted = FALSE
)
SELECT character
FROM characters
ORDER BY character;
```
I confirmed that nothing but alphanumeric + underscore + dash characters are being used in sync names.
Therfore I've decided to restrict sync name in the nango.yaml to only be characters in `a-zA-Z0-9-_`

How to test:
- add invalid character(s) in your test nango.yaml
- run `nango compile`
- check compilation error

