### PR TITLE
feat: add API endpoints and functions to create/delete sync variants

### DIFF
--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -398,6 +398,7 @@ export declare class NangoAction {
     private logAPICall;
 }
 export declare class NangoSync extends NangoAction {
+    variant: string;
     lastSyncDate?: Date;
     track_deletes: boolean;
     logMessages?:

--- a/packages/database/lib/migrations/20250227180909_sync_variant_unique.cjs
+++ b/packages/database/lib/migrations/20250227180909_sync_variant_unique.cjs
@@ -1,0 +1,20 @@
+exports.config = { transaction: false };
+
+const TABLE = '_nango_syncs';
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.schema.raw(`ALTER TABLE "${TABLE}" DROP CONSTRAINT IF EXISTS "_nango_syncs_name_nango_connection_id_deleted_at_unique";`);
+    await knex.schema.raw(`DROP INDEX CONCURRENTLY IF EXISTS "_nango_syncs_variant_name_nango_connection_id_deleted_at_unique"`);
+    await knex.schema.raw(`
+        CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "_nango_syncs_variant_name_nango_connection"
+        ON "${TABLE}" ("variant", "name", "nango_connection_id")
+        WHERE deleted_at IS NULL;
+    `);
+};
+
+exports.down = function () {
+    // do nothing
+};

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -762,6 +762,7 @@ export class Nango {
         const response = await this.http.post(url, body, { headers: this.enrichHeaders() });
         return response.data;
     }
+
     /**
      *
      * Delete an existing sync variant
@@ -778,7 +779,7 @@ export class Nango {
             },
             headers: this.enrichHeaders()
         });
-        return response.data as DeleteSyncVariant['Success'];
+        return response.data;
     }
 
     /**

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -28,7 +28,9 @@ import type {
     SignatureCredentials,
     PostPublicConnectSessionsReconnect,
     GetPublicConnection,
-    NangoRecord
+    NangoRecord,
+    PostSyncVariant,
+    DeleteSyncVariant
 } from '@nangohq/types';
 import type {
     CreateConnectionOAuth1,
@@ -744,6 +746,39 @@ export class Nango {
         const response = await this.http.put(url, body, { headers: this.enrichHeaders() });
 
         return response.data;
+    }
+
+    /**
+     * Creates a new sync variant
+     * @param props - The properties for the new variant (provider_config_key, connection_id, name, variant)
+     * @returns A promise that resolves with the new sync variant (id, name, variant)
+     */
+    public async createSyncVariant(props: PostSyncVariant['Body'] & PostSyncVariant['Params']): Promise<PostSyncVariant['Success']> {
+        const url = `${this.serverUrl}/sync/${props.name}/variant/${props.variant}`;
+        const body = {
+            provider_config_key: props.provider_config_key,
+            connection_id: props.connection_id
+        };
+        const response = await this.http.post(url, body, { headers: this.enrichHeaders() });
+        return response.data;
+    }
+    /**
+     *
+     * Delete an existing sync variant
+     * @param props - The properties of the variant to delete (provider_config_key, connection_id, name, variant)
+     * @returns A promise that resolves with void when the sync variant is deleted
+     */
+    public async deleteSyncVariant(props: DeleteSyncVariant['Body'] & DeleteSyncVariant['Params']): Promise<DeleteSyncVariant['Success']> {
+        const url = `${this.serverUrl}/sync/${props.name}/variant/${props.variant}`;
+
+        const response = await this.http.delete(url, {
+            data: {
+                provider_config_key: props.provider_config_key,
+                connection_id: props.connection_id
+            },
+            headers: this.enrichHeaders()
+        });
+        return response.data as DeleteSyncVariant['Success'];
     }
 
     /**

--- a/packages/runner-sdk/models.d.ts
+++ b/packages/runner-sdk/models.d.ts
@@ -355,6 +355,7 @@ export declare class NangoAction {
     private logAPICall;
 }
 export declare class NangoSync extends NangoAction {
+    variant: string;
     lastSyncDate?: Date;
     track_deletes: boolean;
     logMessages?:

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -6,7 +6,6 @@ import {
     connectionService,
     getSyncs,
     verifyOwnership,
-    isSyncValid,
     getSyncsByProviderConfigKey,
     getSyncConfigsWithConnectionsByEnvironmentId,
     getProviderConfigBySyncAndAccount,
@@ -611,47 +610,6 @@ class SyncController {
             const attributes = await getAttributes(provider_config_key as string, sync_name as string);
 
             res.status(200).send(attributes);
-        } catch (err) {
-            next(err);
-        }
-    }
-
-    public async deleteSync(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
-        try {
-            const syncId = req.params['syncId'];
-            const { connection_id, provider_config_key } = req.query;
-
-            if (!provider_config_key) {
-                res.status(400).send({ message: 'Missing provider config key' });
-
-                return;
-            }
-
-            if (!syncId) {
-                res.status(400).send({ message: 'Missing sync id' });
-
-                return;
-            }
-
-            if (!connection_id) {
-                res.status(400).send({ message: 'Missing connection id' });
-
-                return;
-            }
-
-            const environmentId = res.locals['environment'].id;
-
-            const isValid = await isSyncValid(connection_id as string, provider_config_key as string, environmentId, syncId);
-
-            if (!isValid) {
-                res.status(400).send({ message: 'Invalid sync id' });
-
-                return;
-            }
-
-            await syncManager.softDeleteSync(syncId, environmentId, orchestrator);
-
-            res.sendStatus(204);
         } catch (err) {
             next(err);
         }

--- a/packages/server/lib/controllers/sync/deleteSyncVariant.ts
+++ b/packages/server/lib/controllers/sync/deleteSyncVariant.ts
@@ -67,5 +67,5 @@ export const deleteSyncVariant = asyncWrapper<DeleteSyncVariant>(async (req, res
         res.status(500).send({ error: { code: 'failed_sync_variant_deletion' } });
         return;
     }
-    res.status(204).send();
+    res.status(200).send({ success: true });
 });

--- a/packages/server/lib/controllers/sync/deleteSyncVariant.ts
+++ b/packages/server/lib/controllers/sync/deleteSyncVariant.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+import { zodErrorToHTTP, requireEmptyQuery } from '@nangohq/utils';
+import type { DeleteSyncVariant } from '@nangohq/types';
+import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { connectionService, getSync, syncManager } from '@nangohq/shared';
+import { variantSchema, connectionIdSchema, syncNameSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { getOrchestrator } from '../../utils/utils.js';
+
+const orchestrator = getOrchestrator();
+
+const bodyValidation = z
+    .object({
+        provider_config_key: providerConfigKeySchema,
+        connection_id: connectionIdSchema
+    })
+    .strict();
+
+const paramsValidation = z
+    .object({
+        name: syncNameSchema,
+        variant: variantSchema
+    })
+    .strict();
+
+export const deleteSyncVariant = asyncWrapper<DeleteSyncVariant>(async (req, res) => {
+    const parsedBody = bodyValidation.safeParse(req.body);
+    if (!parsedBody.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(parsedBody.error) } });
+        return;
+    }
+
+    const parsedParams = paramsValidation.safeParse(req.params);
+    if (!parsedParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(parsedParams.error) } });
+        return;
+    }
+
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const body: DeleteSyncVariant['Body'] = parsedBody.data;
+    const params: DeleteSyncVariant['Params'] = parsedParams.data;
+    const { environment } = res.locals;
+
+    if (params.variant.toLowerCase() === 'base') {
+        res.status(400).send({ error: { code: 'invalid_variant', message: `Cannot delete protected variant "${params.variant}".` } });
+        return;
+    }
+    const { response: connection, error } = await connectionService.getConnection(body.connection_id, body.provider_config_key, environment.id);
+    if (error || !connection) {
+        res.status(400).send({ error: { code: 'unknown_connection' } });
+        return;
+    }
+
+    const sync = await getSync({ connectionId: connection.id, name: params.name, variant: params.variant });
+    if (!sync) {
+        res.status(404).send({ error: { code: 'not_found' } });
+        return;
+    }
+
+    try {
+        await syncManager.softDeleteSync(sync.id, environment.id, orchestrator);
+    } catch {
+        res.status(500).send({ error: { code: 'failed_sync_variant_deletion' } });
+        return;
+    }
+    res.status(204).send();
+});

--- a/packages/server/lib/controllers/sync/postSyncVariant.ts
+++ b/packages/server/lib/controllers/sync/postSyncVariant.ts
@@ -1,0 +1,132 @@
+import { z } from 'zod';
+import { zodErrorToHTTP, requireEmptyQuery } from '@nangohq/utils';
+import type { DBConnection, PostSyncVariant } from '@nangohq/types';
+import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { connectionService, getSyncConfigByParams, getSyncsByConnectionId, createSync, getSyncConfig, configService } from '@nangohq/shared';
+import { variantSchema, connectionIdSchema, syncNameSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { getOrchestrator } from '../../utils/utils.js';
+import { logContextGetter } from '@nangohq/logs';
+
+const orchestrator = getOrchestrator();
+
+const bodyValidation = z
+    .object({
+        provider_config_key: providerConfigKeySchema,
+        connection_id: connectionIdSchema
+    })
+    .strict();
+
+const paramsValidation = z
+    .object({
+        name: syncNameSchema,
+        variant: variantSchema
+    })
+    .strict();
+
+export const postSyncVariant = asyncWrapper<PostSyncVariant>(async (req, res) => {
+    const parsedBody = bodyValidation.safeParse(req.body);
+    if (!parsedBody.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(parsedBody.error) } });
+        return;
+    }
+
+    const parsedParams = paramsValidation.safeParse(req.params);
+    if (!parsedParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(parsedParams.error) } });
+        return;
+    }
+
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+    const body: PostSyncVariant['Body'] = parsedBody.data;
+    const params: PostSyncVariant['Params'] = parsedParams.data;
+    const { environment, account } = res.locals;
+
+    if (account?.is_capped) {
+        res.status(400).send({ error: { code: 'feature_disabled', message: 'Creating sync variant is only available for paying customer' } });
+        return;
+    }
+
+    if (params.variant.toLowerCase() === 'base') {
+        res.status(400).send({ error: { code: 'invalid_variant', message: `Variant name "${params.variant}" is protected.` } });
+        return;
+    }
+    const { response: connection, error } = await connectionService.getConnection(body.connection_id, body.provider_config_key, environment.id);
+    if (error || !connection) {
+        res.status(400).send({ error: { code: 'unknown_connection' } });
+        return;
+    }
+
+    const syncs = await getSyncsByConnectionId({ connectionId: connection.id });
+    if (!syncs) {
+        res.status(500).send({ error: { code: 'failed_sync_variant_creation' } });
+        return;
+    }
+
+    const maxSyncsPerConnection = 100; // arbitrary limit to prevent abuse/mistakes
+    if (syncs.length > maxSyncsPerConnection) {
+        res.status(400).send({ error: { code: 'resource_capped', message: `Maximum number of syncs per connection (${maxSyncsPerConnection}) reached` } });
+        return;
+    }
+
+    const existingSync = syncs.find((s) => s.name === params.name && s.variant === params.variant) || null;
+
+    if (existingSync) {
+        res.status(400).send({ error: { code: 'sync_variant_already_exists' } });
+        return;
+    }
+
+    const providerConfig = await configService.getProviderConfig(body.provider_config_key, environment.id);
+    if (!providerConfig) {
+        res.status(400).send({ error: { code: 'unknown_provider_config' } });
+        return;
+    }
+
+    const syncConfig = await getSyncConfigByParams(environment.id, params.name, body.provider_config_key);
+    if (!syncConfig) {
+        res.status(400).send({ error: { code: 'unknown_sync' } });
+        return;
+    }
+
+    const nangoConfig = await getSyncConfig({ nangoConnection: connection as DBConnection, syncName: params.name });
+    if (!nangoConfig) {
+        res.status(500).send({ error: { code: 'failed_sync_variant_creation' } });
+        return;
+    }
+
+    const syncData = nangoConfig.integrations[body.provider_config_key]?.[params.name];
+    if (!syncData) {
+        res.status(500).send({ error: { code: 'failed_sync_variant_creation' } });
+        return;
+    }
+
+    const sync = await createSync({
+        syncConfig: syncConfig,
+        connectionId: connection.id,
+        variant: params.variant
+    });
+
+    if (!sync) {
+        res.status(500).send({ error: { code: 'failed_sync_variant_creation' } });
+        return;
+    }
+
+    await orchestrator.scheduleSync({
+        nangoConnection: connection,
+        sync,
+        providerConfig,
+        syncName: sync.name,
+        syncVariant: sync.variant,
+        syncData,
+        logContextGetter
+    });
+
+    res.status(200).send({
+        id: sync.id,
+        name: sync.name,
+        variant: sync.variant
+    });
+});

--- a/packages/server/lib/controllers/sync/postSyncVariant.ts
+++ b/packages/server/lib/controllers/sync/postSyncVariant.ts
@@ -6,6 +6,7 @@ import { connectionService, getSyncConfigByParams, getSyncsByConnectionId, creat
 import { variantSchema, connectionIdSchema, syncNameSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { getOrchestrator } from '../../utils/utils.js';
 import { logContextGetter } from '@nangohq/logs';
+import { envs } from '../../env.js';
 
 const orchestrator = getOrchestrator();
 
@@ -66,7 +67,7 @@ export const postSyncVariant = asyncWrapper<PostSyncVariant>(async (req, res) =>
         return;
     }
 
-    const maxSyncsPerConnection = 100; // arbitrary limit to prevent abuse/mistakes
+    const maxSyncsPerConnection = envs.MAX_SYNCS_PER_CONNECTION;
     if (syncs.length > maxSyncsPerConnection) {
         res.status(400).send({ error: { code: 'resource_capped', message: `Maximum number of syncs per connection (${maxSyncsPerConnection}) reached` } });
         return;

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -30,6 +30,10 @@ export const modelSchema = z
     .string()
     .regex(/^[A-Z][a-zA-Z0-9_-]+$/)
     .max(255);
+export const syncNameSchema = z
+    .string()
+    .regex(/^[a-zA-Z0-9_-]+$/)
+    .max(255);
 export const variantSchema = z
     .string()
     .regex(/^[a-zA-Z0-9_-]+$/)

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -111,6 +111,8 @@ import { patchWebhook } from './controllers/v1/environment/webhook/patchWebhook.
 import { patchEnvironment } from './controllers/v1/environment/patchEnvironment.js';
 import { postEnvironmentVariables } from './controllers/v1/environment/variables/postVariables.js';
 import { getPublicRecords } from './controllers/records/getRecords.js';
+import { postSyncVariant } from './controllers/sync/postSyncVariant.js';
+import { deleteSyncVariant } from './controllers/sync/deleteSyncVariant.js';
 
 export const router = express.Router();
 
@@ -266,7 +268,8 @@ publicAPI.route('/sync/pause').post(apiAuth, syncController.pause.bind(syncContr
 publicAPI.route('/sync/start').post(apiAuth, syncController.start.bind(syncController));
 publicAPI.route('/sync/provider').get(apiAuth, syncController.getSyncProvider.bind(syncController));
 publicAPI.route('/sync/status').get(apiAuth, syncController.getSyncStatus.bind(syncController));
-publicAPI.route('/sync/:syncId').delete(apiAuth, syncController.deleteSync.bind(syncController));
+publicAPI.route('/sync/:name/variant/:variant').post(apiAuth, postSyncVariant);
+publicAPI.route('/sync/:name/variant/:variant').delete(apiAuth, deleteSyncVariant);
 
 publicAPI.use('/flow', jsonContentTypeMiddleware);
 publicAPI.route('/flow/attributes').get(apiAuth, syncController.getFlowAttributes.bind(syncController));

--- a/packages/shared/lib/models/Sync.ts
+++ b/packages/shared/lib/models/Sync.ts
@@ -62,6 +62,7 @@ export interface ReportedSyncJobStatus {
     id?: string;
     type: SyncJobsType | 'INITIAL';
     name?: string;
+    variant?: string;
     connection_id?: string;
     status: SyncStatus;
     latestResult?: SyncResultByModel | undefined;

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -527,6 +527,7 @@ export class SyncManagerService {
             finishedAt: latestJob?.updated_at,
             nextScheduledSyncAt: schedule.nextDueDate,
             name: sync.name,
+            variant: sync.variant,
             status: this.classifySyncStatus(latestJob?.status as SyncStatus, schedule.state),
             frequency,
             latestResult: latestJob?.result,

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -326,27 +326,6 @@ export const verifyOwnership = async (nangoConnectionId: number, environment_id:
     return true;
 };
 
-export const isSyncValid = async (connection_id: string, provider_config_key: string, environment_id: number, sync_id: string): Promise<boolean> => {
-    const result = await schema()
-        .select('*')
-        .from<Sync>(TABLE)
-        .join('_nango_connections', '_nango_connections.id', `${TABLE}.nango_connection_id`)
-        .where({
-            environment_id,
-            [`${TABLE}.id`]: sync_id,
-            connection_id,
-            provider_config_key,
-            [`_nango_connections.deleted`]: false,
-            [`${TABLE}.deleted`]: false
-        });
-
-    if (result.length === 0) {
-        return false;
-    }
-
-    return true;
-};
-
 export const softDeleteSync = async (syncId: string): Promise<string> => {
     await schema().from<Sync>(TABLE).where({ id: syncId, deleted: false }).update({ deleted: true, deleted_at: new Date() });
     return syncId;

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -31,6 +31,7 @@ export type * from './scripts/syncs/api.js';
 export type * from './slackNotifications/db.js';
 export type * from './notification/active-logs/db.js';
 export type * from './connection/api/get.js';
+export type * from './sync/api.js';
 export type * from './integration/api.js';
 export type * from './integration/db.js';
 export type * from './providers/provider.js';

--- a/packages/types/lib/sync/api.ts
+++ b/packages/types/lib/sync/api.ts
@@ -1,0 +1,33 @@
+import type { ApiError, Endpoint } from '../api.js';
+
+export type PostSyncVariant = Endpoint<{
+    Method: 'POST';
+    Path: '/sync/:name/variant/:variant';
+    Body: {
+        provider_config_key: string;
+        connection_id: string;
+    };
+    Params: {
+        name: string;
+        variant: string;
+    };
+    Error: ApiError<
+        'invalid_variant' | 'unknown_connection' | 'unknown_provider_config' | 'unknown_sync' | 'sync_variant_already_exists' | 'failed_sync_variant_creation'
+    >;
+    Success: { id: string; name: string; variant: string };
+}>;
+
+export type DeleteSyncVariant = Endpoint<{
+    Method: 'DELETE';
+    Path: '/sync/:name/variant/:variant';
+    Body: {
+        provider_config_key: string;
+        connection_id: string;
+    };
+    Params: {
+        name: string;
+        variant: string;
+    };
+    Error: ApiError<'invalid_variant' | 'unknown_connection' | 'failed_sync_variant_deletion'>;
+    Success: never;
+}>;

--- a/packages/types/lib/sync/api.ts
+++ b/packages/types/lib/sync/api.ts
@@ -29,5 +29,5 @@ export type DeleteSyncVariant = Endpoint<{
         variant: string;
     };
     Error: ApiError<'invalid_variant' | 'unknown_connection' | 'failed_sync_variant_deletion'>;
-    Success: never;
+    Success: { success: boolean };
 }>;

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -183,6 +183,9 @@ export const ENVS = z.object({
     // Internal API
     NANGO_INTERNAL_API_KEY: z.string().optional(),
 
+    // LIMITS
+    MAX_SYNCS_PER_CONNECTION: z.coerce.number().optional().default(100),
+
     // ----- Others
     SERVER_RUN_MODE: z.enum(['DOCKERIZED', '']).optional(),
     NANGO_CLOUD: bool,

--- a/packages/webapp/src/components/ui/label/Tag.tsx
+++ b/packages/webapp/src/components/ui/label/Tag.tsx
@@ -15,7 +15,7 @@ const variantStyles = cva('', {
         },
         size: {
             md: 'px-2 pt-[1px] leading-[17px]',
-            sm: 'px-1 pt-[1px] leading-[13px]'
+            sm: 'px-1 pb-[1px] leading-[13px]'
         }
     },
     defaultVariants: {

--- a/packages/webapp/src/pages/Connection/components/SyncRow.tsx
+++ b/packages/webapp/src/pages/Connection/components/SyncRow.tsx
@@ -132,7 +132,7 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
                         {sync.name}
                         {showSyncVariant && (
                             <SimpleTooltip tooltipContent={sync.variant}>
-                                <Tag variant="gray1" textCase="lowercase" size="sm">
+                                <Tag variant="gray1" textCase="normal" size="sm">
                                     {truncateMiddle(sync.variant)}
                                 </Tag>
                             </SimpleTooltip>


### PR DESCRIPTION
Create API endpoints and node client functions to create and delete a sync variant

How to test:
```
// creation
curl --request POST --header 'Authorization: SECRET' \                                            
  --url http://localhost:3003/sync/SYNC_NAME/variant/NEW_VARIANT \
  --header 'Content-Type: application/json' \
  --data '{
  "provider_config_key": "PROVIDER_CONFIG_KEY",
  "connection_id": "CONNECTION_ID"
}'

// deletion
curl --request DELETE --header 'Authorization: YOUR_SECRET' \                                            
  --url http://localhost:3003/sync/SYNC_NAME/variant/VARIANT \
  --header 'Content-Type: application/json' \
  --data '{
  "provider_config_key": "PROVIDER_CONFIG_KEY",
  "connection_id": "CONNECTION_ID"
}'
```