### PR TITLE
fix(db): parametrize pool size 

### DIFF
--- a/packages/fleet/lib/db/client.ts
+++ b/packages/fleet/lib/db/client.ts
@@ -3,6 +3,7 @@ import knex from 'knex';
 import { fileURLToPath } from 'node:url';
 import { logger } from '../utils/logger.js';
 import { isTest } from '@nangohq/utils';
+import { envs } from '../env.js';
 
 const runningMigrationOnly = process.argv.some((v) => v === 'migrate:latest');
 const isJS = !runningMigrationOnly;
@@ -13,7 +14,7 @@ export class DatabaseClient {
     public url: string;
     private config: knex.Knex.Config;
 
-    constructor({ url, schema, poolMax = 15 }: { url: string; schema: string; poolMax?: number }) {
+    constructor({ url, schema, poolMax = envs.FLEET_DB_POOL_MAX }: { url: string; schema: string; poolMax?: number }) {
         this.url = url;
         this.schema = schema;
         this.config = {
@@ -23,7 +24,7 @@ export class DatabaseClient {
                 statement_timeout: 60000
             },
             searchPath: schema,
-            pool: { min: 2, max: poolMax },
+            pool: { min: 0, max: poolMax },
             migrations: {
                 extension: isJS ? 'js' : 'ts',
                 directory: 'migrations',

--- a/packages/fleet/lib/db/client.ts
+++ b/packages/fleet/lib/db/client.ts
@@ -24,7 +24,7 @@ export class DatabaseClient {
                 statement_timeout: 60000
             },
             searchPath: schema,
-            pool: { min: 0, max: poolMax },
+            pool: { min: 0, max: poolMax, idleTimeoutMillis: 5000 },
             migrations: {
                 extension: isJS ? 'js' : 'ts',
                 directory: 'migrations',

--- a/packages/scheduler/lib/db/client.ts
+++ b/packages/scheduler/lib/db/client.ts
@@ -3,6 +3,7 @@ import knex from 'knex';
 import { fileURLToPath } from 'node:url';
 import { logger } from '../utils/logger.js';
 import { isTest } from '@nangohq/utils';
+import { envs } from '../env.js';
 
 const runningMigrationOnly = process.argv.some((v) => v === 'migrate:latest');
 const isJS = !runningMigrationOnly;
@@ -13,7 +14,7 @@ export class DatabaseClient {
     public url: string;
     private config: knex.Knex.Config;
 
-    constructor({ url, schema, poolMax = 50 }: { url: string; schema: string; poolMax?: number }) {
+    constructor({ url, schema, poolMax = envs.ORCHESTRATOR_DB_POOL_MAX }: { url: string; schema: string; poolMax?: number }) {
         this.url = url;
         this.schema = schema;
         this.config = {

--- a/packages/scheduler/lib/env.ts
+++ b/packages/scheduler/lib/env.ts
@@ -1,0 +1,3 @@
+import { ENVS, parseEnvs } from '@nangohq/utils';
+
+export const envs = parseEnvs(ENVS);

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -41,6 +41,7 @@ export const ENVS = z.object({
     NANGO_ORCHESTRATOR_PORT: z.coerce.number().optional().default(3008),
     ORCHESTRATOR_DATABASE_URL: z.string().url().optional(),
     ORCHESTRATOR_DATABASE_SCHEMA: z.string().optional().default('nango_scheduler'),
+    ORCHESTRATOR_DB_POOL_MAX: z.coerce.number().optional().default(50),
 
     // Jobs
     JOBS_SERVICE_URL: z.string().url().optional().default('http://localhost:3005'),
@@ -105,6 +106,7 @@ export const ENVS = z.object({
         .number()
         .optional()
         .default(2 * 60 * 1000), // 2 minutes
+    FLEET_DB_POOL_MAX: z.coerce.number().optional().default(5),
 
     // --- Third parties
     // AWS


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-2818/parametrize-pool-size

- Parametrize fleet and orchestrator pool max size
- Set fleet to 5max and 0 default
So it consumes less but also release unused connections sooner