### PR TITLE
fix(fleet): do not fetch next page if no more nodes

### DIFF
--- a/packages/fleet/lib/models/nodes.ts
+++ b/packages/fleet/lib/models/nodes.ts
@@ -177,7 +177,8 @@ export async function search(
         }
 
         const nextCursor = nodes[nodes.length - 1]?.id;
-        if (!nextCursor) {
+        const hasMore = nodes.length === pageSize;
+        if (!nextCursor || !hasMore) {
             return nodesMap;
         }
 


### PR DESCRIPTION
We were doing an unnecessary query to fetch nodes next page even when there were no more

