### PR TITLE
fix: remove usage of getEndUserByConnectionId

### DIFF
--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -11,7 +11,6 @@ import {
     errorManager,
     featureFlags,
     getApiUrl,
-    getEndUserByConnectionId,
     getSyncConfigRaw
 } from '@nangohq/shared';
 import { logContextGetter } from '@nangohq/logs';
@@ -19,14 +18,13 @@ import type { ConnectionJobs, DBEnvironment, DBSyncConfig, DBTeam, NangoProps } 
 import { startScript } from './operations/start.js';
 import { bigQueryClient, slackService } from '../clients.js';
 import { getRunnerFlags } from '../utils/flags.js';
-import db from '@nangohq/database';
 
 export async function startAction(task: TaskAction): Promise<Result<void>> {
     let account: DBTeam | undefined;
     let environment: DBEnvironment | undefined;
     let providerConfig: Config | undefined | null;
     let syncConfig: DBSyncConfig | null = null;
-    let endUser: NangoProps['endUser'] | null = null;
+    const endUser: NangoProps['endUser'] | null = null;
 
     try {
         const accountAndEnv = await environmentService.getAccountAndEnvironment({ environmentId: task.connection.environment_id });
@@ -50,11 +48,6 @@ export async function startAction(task: TaskAction): Promise<Result<void>> {
         });
         if (!syncConfig) {
             throw new Error(`Action config not found: ${task.id}`);
-        }
-
-        const getEndUser = await getEndUserByConnectionId(db.knex, { connectionId: task.connection.id });
-        if (getEndUser.isOk()) {
-            endUser = { id: getEndUser.value.id, endUserId: getEndUser.value.endUserId, orgId: getEndUser.value.organization?.organizationId || null };
         }
 
         const logCtx = await logContextGetter.get({ id: String(task.activityLogId) });

--- a/packages/jobs/lib/execution/onEvent.ts
+++ b/packages/jobs/lib/execution/onEvent.ts
@@ -2,12 +2,11 @@ import { Err, metrics, Ok, tagTraceUser } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
 import type { TaskOnEvent } from '@nangohq/nango-orchestrator';
 import type { Config } from '@nangohq/shared';
-import { configService, environmentService, featureFlags, getApiUrl, getEndUserByConnectionId, NangoError } from '@nangohq/shared';
+import { configService, environmentService, featureFlags, getApiUrl, NangoError } from '@nangohq/shared';
 import { logContextGetter } from '@nangohq/logs';
 import type { ConnectionJobs, DBEnvironment, DBSyncConfig, DBTeam, NangoProps } from '@nangohq/types';
 import { startScript } from './operations/start.js';
 import { bigQueryClient } from '../clients.js';
-import db from '@nangohq/database';
 import { getRunnerFlags } from '../utils/flags.js';
 
 export async function startOnEvent(task: TaskOnEvent): Promise<Result<void>> {
@@ -15,7 +14,7 @@ export async function startOnEvent(task: TaskOnEvent): Promise<Result<void>> {
     let environment: DBEnvironment | undefined;
     let providerConfig: Config | undefined | null;
     let syncConfig: DBSyncConfig | null = null;
-    let endUser: NangoProps['endUser'] | null = null;
+    const endUser: NangoProps['endUser'] | null = null;
 
     try {
         const accountAndEnv = await environmentService.getAccountAndEnvironment({ environmentId: task.connection.environment_id });
@@ -29,11 +28,6 @@ export async function startOnEvent(task: TaskOnEvent): Promise<Result<void>> {
         providerConfig = await configService.getProviderConfig(task.connection.provider_config_key, task.connection.environment_id);
         if (providerConfig === null) {
             throw new Error(`Provider config not found for connection: ${task.connection.connection_id}`);
-        }
-
-        const getEndUser = await getEndUserByConnectionId(db.knex, { connectionId: task.connection.id });
-        if (getEndUser.isOk()) {
-            endUser = { id: getEndUser.value.id, endUserId: getEndUser.value.endUserId, orgId: getEndUser.value.organization?.organizationId || null };
         }
 
         const logCtx = await logContextGetter.get({ id: String(task.activityLogId) });

--- a/packages/jobs/lib/execution/webhook.ts
+++ b/packages/jobs/lib/execution/webhook.ts
@@ -13,7 +13,6 @@ import {
     externalWebhookService,
     featureFlags,
     getApiUrl,
-    getEndUserByConnectionId,
     getSync,
     getSyncConfigRaw,
     updateSyncJobStatus
@@ -23,7 +22,6 @@ import { logContextGetter } from '@nangohq/logs';
 import type { ConnectionJobs, DBEnvironment, DBSyncConfig, DBTeam, NangoProps } from '@nangohq/types';
 import { startScript } from './operations/start.js';
 import { sendSync as sendSyncWebhook } from '@nangohq/webhooks';
-import db from '@nangohq/database';
 import { getRunnerFlags } from '../utils/flags.js';
 
 export async function startWebhook(task: TaskWebhook): Promise<Result<void>> {
@@ -33,7 +31,7 @@ export async function startWebhook(task: TaskWebhook): Promise<Result<void>> {
     let sync: Sync | undefined | null;
     let syncJob: Pick<Job, 'id'> | null = null;
     let syncConfig: DBSyncConfig | null = null;
-    let endUser: NangoProps['endUser'] | null = null;
+    const endUser: NangoProps['endUser'] | null = null;
 
     try {
         const accountAndEnv = await environmentService.getAccountAndEnvironment({ environmentId: task.connection.environment_id });
@@ -62,11 +60,6 @@ export async function startWebhook(task: TaskWebhook): Promise<Result<void>> {
         });
         if (!syncConfig) {
             throw new Error(`Webhook config not found: ${task.id}`);
-        }
-
-        const getEndUser = await getEndUserByConnectionId(db.knex, { connectionId: task.connection.id });
-        if (getEndUser.isOk()) {
-            endUser = { id: getEndUser.value.id, endUserId: getEndUser.value.endUserId, orgId: getEndUser.value.organization?.organizationId || null };
         }
 
         const logCtx = await logContextGetter.get({ id: String(task.activityLogId) });


### PR DESCRIPTION
Removing the usage of getEndUserByConnectionId query while we are investigating db connection errors. Impact is very low since the end user id is only used for Analyticss
