### PR TITLE
fix(db): use read-only for getProviderConfig

### DIFF
--- a/packages/shared/lib/services/config.service.ts
+++ b/packages/shared/lib/services/config.service.ts
@@ -32,7 +32,7 @@ class ConfigService {
     }
 
     async getProviderConfig(providerConfigKey: string, environment_id: number): Promise<ProviderConfig | null> {
-        const result = await db.knex
+        const result = await db.readOnly
             .select('*')
             .from<ProviderConfig>(`_nango_configs`)
             .where({ unique_key: providerConfigKey, environment_id, deleted: false })


### PR DESCRIPTION
## Changes

- use read-only for getProviderConfig
It's the third most hit query in the system