### PR TITLE
fix(zod-validation): return the parsed zod

### DIFF
--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -44,7 +44,7 @@ exports[`buildModelTs > should return empty (with sdk) 1`] = `
 import type { Nango } from '@nangohq/node';
 import type { AxiosInstance, AxiosInterceptorManager, AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
 import type { ApiEndUser, DBSyncConfig, DBTeam, GetPublicIntegration, HTTP_METHOD, RunnerFlags } from '@nangohq/types';
-import { ZodSchema } from 'zod';
+import type { ZodSchema, SafeParseSuccess } from 'zod';
 
 export declare const oldLevelToNewLevel: {
     readonly debug: 'debug';
@@ -387,7 +387,7 @@ export declare class NangoAction {
     getFlowAttributes<A = object>(): A | null;
     paginate<T = any>(config: ProxyConfiguration): AsyncGenerator<T[], undefined, void>;
     triggerAction<In = unknown, Out = object>(providerConfigKey: string, connectionId: string, actionName: string, input?: In): Promise<Out>;
-    zodValidateInput<T = any, Z = any>({ zodSchema, input }: { zodSchema: ZodSchema<Z>; input: T }): Promise<void>;
+    zodValidateInput<T = any, Z = any>({ zodSchema, input }: { zodSchema: ZodSchema<Z>; input: T }): Promise<SafeParseSuccess<Z>>;
     triggerSync(providerConfigKey: string, connectionId: string, syncName: string, fullResync?: boolean): Promise<void | string>;
     /**
      * Uncontrolled fetch is a regular fetch without retry or credentials injection.

--- a/packages/runner-sdk/lib/action.ts
+++ b/packages/runner-sdk/lib/action.ts
@@ -2,7 +2,7 @@
 import type { Nango } from '@nangohq/node';
 import paginateService from './paginate.service.js';
 import type { AxiosResponse } from 'axios';
-import type { ZodSchema } from 'zod';
+import type { ZodSchema, SafeParseSuccess } from 'zod';
 import type {
     ApiKeyCredentials,
     ApiPublicConnectionFull,
@@ -338,7 +338,7 @@ export abstract class NangoActionBase {
         return await this.nango.triggerAction(providerConfigKey, connectionId, actionName, input);
     }
 
-    public async zodValidateInput<T = any, Z = any>({ zodSchema, input }: { zodSchema: ZodSchema<Z>; input: T }): Promise<void> {
+    public async zodValidateInput<T = any, Z = any>({ zodSchema, input }: { zodSchema: ZodSchema<Z>; input: T }): Promise<SafeParseSuccess<Z>> {
         const parsedInput = zodSchema.safeParse(input);
         if (!parsedInput.success) {
             for (const error of parsedInput.error.errors) {
@@ -348,6 +348,8 @@ export abstract class NangoActionBase {
                 message: 'Invalid input provided'
             });
         }
+
+        return parsedInput;
     }
 
     public abstract triggerSync(

--- a/packages/runner-sdk/models.d.ts
+++ b/packages/runner-sdk/models.d.ts
@@ -1,7 +1,7 @@
 import type { Nango } from '@nangohq/node';
 import type { AxiosInstance, AxiosInterceptorManager, AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
 import type { ApiEndUser, DBSyncConfig, DBTeam, GetPublicIntegration, HTTP_METHOD, RunnerFlags } from '@nangohq/types';
-import { ZodSchema } from 'zod';
+import type { ZodSchema, SafeParseSuccess } from 'zod';
 
 export declare const oldLevelToNewLevel: {
     readonly debug: 'debug';
@@ -344,7 +344,7 @@ export declare class NangoAction {
     getFlowAttributes<A = object>(): A | null;
     paginate<T = any>(config: ProxyConfiguration): AsyncGenerator<T[], undefined, void>;
     triggerAction<In = unknown, Out = object>(providerConfigKey: string, connectionId: string, actionName: string, input?: In): Promise<Out>;
-    zodValidateInput<T = any, Z = any>({ zodSchema, input }: { zodSchema: ZodSchema<Z>; input: T }): Promise<void>;
+    zodValidateInput<T = any, Z = any>({ zodSchema, input }: { zodSchema: ZodSchema<Z>; input: T }): Promise<SafeParseSuccess<Z>>;
     triggerSync(providerConfigKey: string, connectionId: string, syncName: string, fullResync?: boolean): Promise<void | string>;
     /**
      * Uncontrolled fetch is a regular fetch without retry or credentials injection.


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
In some cases zod validatoin does a `refine` in which case we want the parsedData to use it later.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

