### PR TITLE
fix(oauth2): fix authorization params miss interpolation logic

### DIFF
--- a/docs-v2/integrations/all/squareup.mdx
+++ b/docs-v2/integrations/all/squareup.mdx
@@ -43,5 +43,6 @@ _No setup guide yet._
 
 -   When creating an integration on the UI, please use **_squareup-sandbox_** for development and **_squareup_** for production.
 -   Please! It is important you follow this instruction [here](https://developer.squareup.com/docs/oauth-api/walkthrough) to create an app and an account that can be used for testing.
+-   When testing in the sandbox environment, you must first launch the seller test account from the Developer Console. For detailed instructions, please [visit squareup guide](https://developer.squareup.com/docs/oauth-api/walkthrough#3-set-up-a-seller-test-account-and-simulate-the-seller-authorization).
 
 <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/squareup.mdx)</Note>

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -7865,6 +7865,8 @@ squareup:
 
 squareup-sandbox:
     display_name: Squareup (Sandbox)
+    categories:
+        - payment
     auth_mode: OAUTH2
     authorization_url: https://connect.squareupsandbox.com/oauth2/authorize
     token_url: https://connect.squareupsandbox.com/oauth2/token

--- a/packages/server/lib/utils/utils.ts
+++ b/packages/server/lib/utils/utils.ts
@@ -62,8 +62,13 @@ export function missesInterpolationParam(str: string, replacers: Record<string, 
  * missesInterpolationParamInObject({ context: 'stores/${storeHash}', response_type: 'code' }, { storeHash: 'abc123' }) -> returns false
  * missesInterpolationParamInObject({ context: 'stores/${storeHash}', response_type: 'code' }, {}) -> returns true
  */
-export function missesInterpolationParamInObject(params: Record<string, string>, replacers: Record<string, any>) {
-    return Object.values(params).some((param) => missesInterpolationParam(param, replacers));
+export function missesInterpolationParamInObject(params: Record<string, any>, replacers: Record<string, any>) {
+    return Object.values(params).some((param) => {
+        if (typeof param === 'string') {
+            return missesInterpolationParam(param, replacers);
+        }
+        return false;
+    });
 }
 /**
  * A helper function to extract the additional authorization parameters from the frontend Auth request.


### PR DESCRIPTION
## Describe the problem and your solution

- Added a type check to ensure the function only processes string values, preventing runtime  errors when non-string values (e.g., booleans, numbers) are passed. This was throwing an error if we had boolean within `authorization_params`.


<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

