### PR TITLE
fix: show model in sync webhook log operation

### DIFF
--- a/packages/webhooks/lib/sync.ts
+++ b/packages/webhooks/lib/sync.ts
@@ -65,7 +65,7 @@ export const sendSync = async ({
             integration: { id: providerConfig.id!, name: providerConfig.unique_key, provider: providerConfig.provider },
             connection: { id: connection.id, name: connection.connection_id },
             syncConfig: { id: syncConfig.id, name: syncConfig.sync_name },
-            meta: { scriptVersion: syncConfig.version, syncVariant }
+            meta: { scriptVersion: syncConfig.version, syncVariant, model }
         }
     );
 


### PR DESCRIPTION
![Screenshot 2025-03-07 at 09 06 03](https://github.com/user-attachments/assets/b549fec6-478d-4722-b821-c2e270dcfa96)

It helps differentiate multiple webhook operations when sync are multi-model