### PR TITLE
fix(connection): store metadata for refresh 

### DIFF
--- a/packages/database/lib/migrations/20250310134848_connection_add_meta_fields.cjs
+++ b/packages/database/lib/migrations/20250310134848_connection_add_meta_fields.cjs
@@ -1,0 +1,18 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE "_nango_connections"
+ADD COLUMN "credentials_expires_at" timestamptz,
+ADD COLUMN "last_refresh_success" timestamptz,
+ADD COLUMN "last_refresh_failure" timestamptz,
+ADD COLUMN "last_refresh_tries" int2,
+ADD COLUMN "refreshable" bool`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.raw(``);
+};

--- a/packages/database/lib/migrations/20250310134848_connection_add_meta_fields.cjs
+++ b/packages/database/lib/migrations/20250310134848_connection_add_meta_fields.cjs
@@ -6,8 +6,8 @@ exports.up = async function (knex) {
 ADD COLUMN "credentials_expires_at" timestamptz,
 ADD COLUMN "last_refresh_success" timestamptz,
 ADD COLUMN "last_refresh_failure" timestamptz,
-ADD COLUMN "last_refresh_tries" int2,
-ADD COLUMN "refreshable" bool`);
+ADD COLUMN "refresh_attempts" int2,
+ADD COLUMN "refresh_exhausted" bool`);
 };
 
 /**
@@ -18,6 +18,6 @@ exports.down = async function (knex) {
 DROP COLUMN "credentials_expires_at",
 DROP COLUMN "last_refresh_success",
 DROP COLUMN "last_refresh_failure",
-DROP COLUMN "last_refresh_tries",
-DROP COLUMN "refreshable"`);
+DROP COLUMN "refresh_attempts",
+DROP COLUMN "refresh_exhausted"`);
 };

--- a/packages/database/lib/migrations/20250310134848_connection_add_meta_fields.cjs
+++ b/packages/database/lib/migrations/20250310134848_connection_add_meta_fields.cjs
@@ -14,5 +14,10 @@ ADD COLUMN "refreshable" bool`);
  * @param {import('knex').Knex} knex
  */
 exports.down = async function (knex) {
-    await knex.raw(``);
+    await knex.raw(`ALTER TABLE "_nango_connections"
+DROP COLUMN "credentials_expires_at",
+DROP COLUMN "last_refresh_success",
+DROP COLUMN "last_refresh_failure",
+DROP COLUMN "last_refresh_tries",
+DROP COLUMN "refreshable"`);
 };


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-2852/store-more-metadata
Contributes to https://linear.app/nango/issue/NAN-2850/investigate-refresh-connections

- Store connection metadata for refresh