### PR TITLE
fix(es): prepare fields for duration and context

### DIFF
--- a/packages/logs/lib/es/__snapshots__/index.integration.test.ts.snap
+++ b/packages/logs/lib/es/__snapshots__/index.integration.test.ts.snap
@@ -23,8 +23,20 @@ exports[`mapping > should create one index automatically on log 1`] = `
         },
         "type": "text",
       },
+      "context": {
+        "type": "keyword",
+      },
       "createdAt": {
         "type": "date",
+      },
+      "durationMs": {
+        "type": "integer",
+      },
+      "endUserId": {
+        "type": "keyword",
+      },
+      "endUserName": {
+        "type": "keyword",
       },
       "endedAt": {
         "type": "date",

--- a/packages/logs/lib/es/schema.ts
+++ b/packages/logs/lib/es/schema.ts
@@ -64,6 +64,7 @@ const props: Record<keyof MessageRow | keyof OperationRow, estypes.MappingProper
     type: { type: 'keyword' },
     level: { type: 'keyword' },
     state: { type: 'keyword' },
+    context: { type: 'keyword' },
 
     source: { type: 'keyword' },
 
@@ -96,7 +97,8 @@ const props: Record<keyof MessageRow | keyof OperationRow, estypes.MappingProper
     updatedAt: { type: 'date' },
     startedAt: { type: 'date' },
     expiresAt: { type: 'date' },
-    endedAt: { type: 'date' }
+    endedAt: { type: 'date' },
+    durationMs: { type: 'integer' }
 };
 
 export function getDailyIndexPipeline(name: string): estypes.IngestPutPipelineRequest {

--- a/packages/logs/lib/es/schema.ts
+++ b/packages/logs/lib/es/schema.ts
@@ -37,6 +37,8 @@ const props: Record<keyof MessageRow | keyof OperationRow, estypes.MappingProper
             }
         }
     },
+    endUserId: { type: 'keyword' },
+    endUserName: { type: 'keyword' },
 
     syncConfigId: { type: 'keyword' },
     syncConfigName: {

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -132,6 +132,7 @@ export interface OperationRow {
     message: string;
     operation: OperationList;
     state: OperationState;
+    context?: 'script' | 'proxy';
 
     // Ids
     accountId: number;
@@ -175,6 +176,7 @@ export interface OperationRow {
     startedAt: string | null;
     endedAt: string | null;
     expiresAt: string | null;
+    durationMs?: number | undefined;
 }
 
 /**

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -107,6 +107,8 @@ export interface MessageRow {
     level: LogLevel;
     type: MessageType;
     message: string;
+    context?: 'script' | 'proxy' | 'webhook';
+
     // Operation row id
     parentId: string;
 
@@ -120,6 +122,7 @@ export interface MessageRow {
     // Dates
     createdAt: string;
     endedAt?: string | undefined;
+    durationMs?: number | undefined;
 }
 
 export interface OperationRow {
@@ -132,7 +135,6 @@ export interface OperationRow {
     message: string;
     operation: OperationList;
     state: OperationState;
-    context?: 'script' | 'proxy' | 'webhook';
 
     // Ids
     accountId: number;
@@ -156,6 +158,8 @@ export interface OperationRow {
 
     connectionId?: number | undefined;
     connectionName?: string | undefined;
+    endUserId?: string | undefined;
+    endUserName?: string | undefined;
 
     syncConfigId?: number | undefined;
     syncConfigName?: string | undefined;

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -132,7 +132,7 @@ export interface OperationRow {
     message: string;
     operation: OperationList;
     state: OperationState;
-    context?: 'script' | 'proxy';
+    context?: 'script' | 'proxy' | 'webhook';
 
     // Ids
     accountId: number;


### PR DESCRIPTION
## Changes

Contributes to https://linear.app/nango/issue/NAN-2778/http-logs-add-duration
Contributes to https://linear.app/nango/issue/NAN-2751/tag-http-calls-with-call-context

- Prepare fields for duration and context, endUser
Duration will help display the duration in the UI and compute graph
Context will help filtering HTTP calls depending on the context
