### PR TITLE
fix: set missing application_name in knex connection config

### DIFF
--- a/packages/fleet/lib/db/client.ts
+++ b/packages/fleet/lib/db/client.ts
@@ -21,7 +21,8 @@ export class DatabaseClient {
             client: 'postgres',
             connection: {
                 connectionString: url,
-                statement_timeout: 60000
+                statement_timeout: 60000,
+                application_name: process.env['NANGO_DB_APPLICATION_NAME'] || '[unknown]'
             },
             searchPath: schema,
             pool: { min: 0, max: poolMax, idleTimeoutMillis: 5000 },

--- a/packages/records/lib/db/config.ts
+++ b/packages/records/lib/db/config.ts
@@ -13,7 +13,8 @@ const config: Knex.Config = {
     client: 'postgres',
     connection: {
         connectionString: databaseUrl,
-        statement_timeout: 60000
+        statement_timeout: 60000,
+        application_name: process.env['NANGO_DB_APPLICATION_NAME'] || '[unknown]'
     },
     searchPath: schema,
     pool: { min: 2, max: 50 },
@@ -32,7 +33,8 @@ const configRead: Knex.Config | undefined = envs.RECORDS_DATABASE_READ_URL
           ...config,
           connection: {
               connectionString: envs.RECORDS_DATABASE_READ_URL,
-              statement_timeout: 60000
+              statement_timeout: 60000,
+              application_name: process.env['NANGO_DB_APPLICATION_NAME'] || '[unknown]'
           }
       }
     : undefined;

--- a/packages/scheduler/lib/db/client.ts
+++ b/packages/scheduler/lib/db/client.ts
@@ -21,7 +21,8 @@ export class DatabaseClient {
             client: 'postgres',
             connection: {
                 connectionString: url,
-                statement_timeout: 60000
+                statement_timeout: 60000,
+                application_name: process.env['NANGO_DB_APPLICATION_NAME'] || '[unknown]'
             },
             searchPath: schema,
             pool: { min: 2, max: poolMax },


### PR DESCRIPTION
`application_name` was not set in fleet, records and scheduler knex configs
