### PR TITLE
feat(connect): store operation_id in DB

### DIFF
--- a/packages/database/lib/migrations/20250311125431_connect_sessions_operation_id.cjs
+++ b/packages/database/lib/migrations/20250311125431_connect_sessions_operation_id.cjs
@@ -1,0 +1,13 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE "connect_sessions" ADD COLUMN "operation_id" varchar(255)`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.raw(`ALTER TABLE "connect_sessions" DROP COLUMN "operation_id"`);
+};

--- a/packages/server/lib/services/connectSession.service.ts
+++ b/packages/server/lib/services/connectSession.service.ts
@@ -14,12 +14,13 @@ interface DBConnectSession {
     readonly account_id: number;
     readonly environment_id: number;
     readonly connection_id: number | null;
+    readonly operation_id: string | null;
     readonly created_at: Date;
     readonly updated_at: Date | null;
     readonly allowed_integrations: string[] | null;
     readonly integrations_config_defaults: Record<string, { connectionConfig: Record<string, unknown> }> | null;
 }
-type DbInsertConnectSession = Omit<DBConnectSession, 'id' | 'created_at' | 'updated_at'>;
+type DbInsertConnectSession = Omit<DBConnectSession, 'id' | 'created_at' | 'updated_at' | 'operation_id'>;
 
 const ConnectSessionMapper = {
     to: (session: ConnectSession): DBConnectSession => {
@@ -29,6 +30,7 @@ const ConnectSessionMapper = {
             account_id: session.accountId,
             environment_id: session.environmentId,
             connection_id: session.connectionId,
+            operation_id: session.operationId || null,
             created_at: session.createdAt,
             updated_at: session.updatedAt,
             allowed_integrations: session.allowedIntegrations || null,
@@ -42,6 +44,7 @@ const ConnectSessionMapper = {
             accountId: dbSession.account_id,
             environmentId: dbSession.environment_id,
             connectionId: dbSession.connection_id,
+            operationId: dbSession.operation_id || null,
             createdAt: dbSession.created_at,
             updatedAt: dbSession.updated_at,
             allowedIntegrations: dbSession.allowed_integrations || null,

--- a/packages/types/lib/connect/session.ts
+++ b/packages/types/lib/connect/session.ts
@@ -4,6 +4,7 @@ export interface ConnectSession {
     readonly accountId: number;
     readonly environmentId: number;
     readonly connectionId: number | null;
+    readonly operationId: string | null;
     readonly allowedIntegrations: string[] | null;
     readonly integrationsConfigDefaults: Record<
         string,


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-2889/store-operation-id-in-db

We want to log events before we actually save a connection's credentials. To do that, we will create a new public endpoint that receives events from the Connect UI. We need to either pre-create an operation or create the operation at the first event.

- Prepare connect_sessions table to receive an operation_id
