### PR TITLE
fix(connections): fill new refresh columns

### DIFF
--- a/packages/shared/lib/services/proxy/utils.test.ts
+++ b/packages/shared/lib/services/proxy/utils.test.ts
@@ -18,6 +18,11 @@ export function getDefaultConnection(override?: Partial<DBConnectionDecrypted>):
         id: -1,
         last_fetched_at: null,
         metadata: null,
+        credentials_expires_at: null,
+        last_refresh_failure: null,
+        last_refresh_success: null,
+        refresh_attempts: null,
+        refresh_exhausted: false,
         ...override
     };
 }

--- a/packages/types/lib/connection/db.ts
+++ b/packages/types/lib/connection/db.ts
@@ -25,6 +25,12 @@ export interface DBConnection extends TimestampsAndDeletedCorrect {
     credentials_iv: string | null;
     credentials_tag: string | null;
     last_fetched_at: Date | null;
+
+    credentials_expires_at: Date | null;
+    last_refresh_success: Date | null;
+    last_refresh_failure: Date | null;
+    refresh_attempts: number | null;
+    refresh_exhausted: boolean | null;
 }
 export type DBConnectionDecrypted = Merge<DBConnection, { credentials: AllAuthCredentials }>;
 


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-2854/store-credential-expires-at

- Fill new refresh columns
Set credentials_expires_at when available and set success or failure when applicable. Columns are still not used