### PR TITLE
chore(persist): add accountId dimension to records metrics

### DIFF
--- a/packages/persist/lib/middleware/auth.middleware.ts
+++ b/packages/persist/lib/middleware/auth.middleware.ts
@@ -1,8 +1,14 @@
 import type { Request, Response, NextFunction } from 'express';
 import { environmentService } from '@nangohq/shared';
 import { stringifyError, tagTraceUser } from '@nangohq/utils';
+import type { DBEnvironment, DBTeam } from '@nangohq/types';
 
-export const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
+export interface AuthLocals {
+    account: DBTeam;
+    environment: DBEnvironment;
+}
+
+export const authMiddleware = (req: Request, res: Response<any, AuthLocals>, next: NextFunction) => {
     const authorizationHeader = req.get('authorization');
 
     if (!authorizationHeader) {
@@ -28,6 +34,8 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
             if (!result || result.environment.id !== environmentId) {
                 throw new Error('Cannot find matching environment');
             }
+            res.locals['account'] = result.account;
+            res.locals['environment'] = result.environment;
             tagTraceUser(result);
             next();
         })

--- a/packages/persist/lib/records.ts
+++ b/packages/persist/lib/records.ts
@@ -13,6 +13,7 @@ export const recordsPath = '/environment/:environmentId/connection/:nangoConnect
 
 export async function persistRecords({
     persistType,
+    accountId,
     environmentId,
     connectionId,
     providerConfigKey,
@@ -25,6 +26,7 @@ export async function persistRecords({
     merging = { strategy: 'override' }
 }: {
     persistType: PersistType;
+    accountId: number;
     environmentId: number;
     connectionId: string;
     providerConfigKey: string;
@@ -124,8 +126,8 @@ export async function persistRecords({
         });
         await updateSyncJobResult(syncJobId, updatedResults, baseModel);
 
-        metrics.increment(metrics.Types.PERSIST_RECORDS_COUNT, records.length);
-        metrics.increment(metrics.Types.PERSIST_RECORDS_SIZE_IN_BYTES, recordsSizeInBytes);
+        metrics.increment(metrics.Types.PERSIST_RECORDS_COUNT, records.length, { accountId });
+        metrics.increment(metrics.Types.PERSIST_RECORDS_SIZE_IN_BYTES, recordsSizeInBytes, { accountId });
 
         span.finish();
         return Ok(persistResult.value.nextMerging);

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getCursor.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getCursor.ts
@@ -3,6 +3,7 @@ import { validateRequest } from '@nangohq/utils';
 import type { EndpointRequest, EndpointResponse, RouteHandler, Route } from '@nangohq/utils';
 import { records } from '@nangohq/records';
 import { getCursorRequestParser } from './validate.js';
+import type { AuthLocals } from '../../../../../middleware/auth.middleware.js';
 
 type GetCursor = Endpoint<{
     Method: typeof method;
@@ -24,7 +25,7 @@ const method = 'GET';
 
 const validate = validateRequest<GetCursor>(getCursorRequestParser);
 
-const handler = async (req: EndpointRequest<GetCursor>, res: EndpointResponse<GetCursor>) => {
+const handler = async (req: EndpointRequest<GetCursor>, res: EndpointResponse<GetCursor, AuthLocals>) => {
     const {
         params: { nangoConnectionId },
         query: { model, offset }
@@ -44,7 +45,7 @@ const handler = async (req: EndpointRequest<GetCursor>, res: EndpointResponse<Ge
 
 export const route: Route<GetCursor> = { path, method };
 
-export const routeHandler: RouteHandler<GetCursor> = {
+export const routeHandler: RouteHandler<GetCursor, AuthLocals> = {
     method,
     path,
     validate,

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getRecords.ts
@@ -5,6 +5,7 @@ import { records } from '@nangohq/records';
 import { getRecordsRequestParser } from './validate.js';
 import type { LogContextStateless } from '@nangohq/logs';
 import { logContextGetter } from '@nangohq/logs';
+import type { AuthLocals } from '../../../../../middleware/auth.middleware.js';
 
 type GetRecords = Endpoint<{
     Method: typeof method;
@@ -30,7 +31,7 @@ const method = 'GET';
 
 const validate = validateRequest<GetRecords>(getRecordsRequestParser);
 
-const handler = async (req: EndpointRequest<GetRecords>, res: EndpointResponse<GetRecords>) => {
+const handler = async (req: EndpointRequest<GetRecords>, res: EndpointResponse<GetRecords, AuthLocals>) => {
     const {
         params: { nangoConnectionId },
         query: { model, externalIds, cursor, limit, activityLogId }
@@ -64,7 +65,7 @@ const handler = async (req: EndpointRequest<GetRecords>, res: EndpointResponse<G
 
 export const route: Route<GetRecords> = { path, method };
 
-export const routeHandler: RouteHandler<GetRecords> = {
+export const routeHandler: RouteHandler<GetRecords, AuthLocals> = {
     method,
     path,
     validate,

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteRecords.ts
@@ -3,6 +3,7 @@ import { validateRequest } from '@nangohq/utils';
 import type { EndpointRequest, EndpointResponse, RouteHandler, Route } from '@nangohq/utils';
 import { persistRecords, recordsPath } from '../../../../../../../../../records.js';
 import { recordsRequestParser } from './validate.js';
+import type { AuthLocals } from '../../../../../../../../../middleware/auth.middleware.js';
 
 type DeleteRecords = Endpoint<{
     Method: typeof method;
@@ -30,12 +31,14 @@ const method = 'DELETE';
 
 const validate = validateRequest<DeleteRecords>(recordsRequestParser);
 
-const handler = async (req: EndpointRequest<DeleteRecords>, res: EndpointResponse<DeleteRecords>) => {
+const handler = async (req: EndpointRequest<DeleteRecords>, res: EndpointResponse<DeleteRecords, AuthLocals>) => {
     const { environmentId, nangoConnectionId, syncId, syncJobId }: DeleteRecords['Params'] = req.params;
     const { model, records, providerConfigKey, connectionId, activityLogId, merging }: DeleteRecords['Body'] = req.body;
+    const { account } = res.locals;
     const result = await persistRecords({
         persistType: 'delete',
         environmentId,
+        accountId: account.id,
         connectionId,
         providerConfigKey,
         nangoConnectionId,
@@ -56,7 +59,7 @@ const handler = async (req: EndpointRequest<DeleteRecords>, res: EndpointRespons
 
 export const route: Route<DeleteRecords> = { path, method };
 
-export const routeHandler: RouteHandler<DeleteRecords> = {
+export const routeHandler: RouteHandler<DeleteRecords, AuthLocals> = {
     method,
     path,
     validate,

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/postRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/postRecords.ts
@@ -3,6 +3,7 @@ import { validateRequest } from '@nangohq/utils';
 import type { EndpointRequest, EndpointResponse, RouteHandler } from '@nangohq/utils';
 import { persistRecords, recordsPath } from '../../../../../../../../../records.js';
 import { recordsRequestParser } from './validate.js';
+import type { AuthLocals } from '../../../../../../../../../middleware/auth.middleware.js';
 
 type PostRecords = Endpoint<{
     Method: typeof method;
@@ -30,11 +31,13 @@ const method = 'POST';
 
 const validate = validateRequest<PostRecords>(recordsRequestParser);
 
-const handler = async (req: EndpointRequest<PostRecords>, res: EndpointResponse<PostRecords>) => {
+const handler = async (req: EndpointRequest<PostRecords>, res: EndpointResponse<PostRecords, AuthLocals>) => {
     const { environmentId, nangoConnectionId, syncId, syncJobId }: PostRecords['Params'] = req.params;
     const { model, records, providerConfigKey, connectionId, activityLogId, merging }: PostRecords['Body'] = req.body;
+    const { account } = res.locals;
     const result = await persistRecords({
         persistType: 'save',
+        accountId: account.id,
         environmentId,
         connectionId,
         providerConfigKey,
@@ -54,7 +57,7 @@ const handler = async (req: EndpointRequest<PostRecords>, res: EndpointResponse<
     return;
 };
 
-export const routeHandler: RouteHandler<PostRecords> = {
+export const routeHandler: RouteHandler<PostRecords, AuthLocals> = {
     method,
     path,
     validate,

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/putRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/putRecords.ts
@@ -3,6 +3,7 @@ import { validateRequest } from '@nangohq/utils';
 import type { EndpointRequest, EndpointResponse, RouteHandler } from '@nangohq/utils';
 import { persistRecords, recordsPath } from '../../../../../../../../../records.js';
 import { recordsRequestParser } from './validate.js';
+import type { AuthLocals } from '../../../../../../../../../middleware/auth.middleware.js';
 
 type PutRecords = Endpoint<{
     Method: typeof method;
@@ -30,11 +31,13 @@ const method = 'PUT';
 
 const validate = validateRequest<PutRecords>(recordsRequestParser);
 
-const handler = async (req: EndpointRequest<PutRecords>, res: EndpointResponse<PutRecords>) => {
+const handler = async (req: EndpointRequest<PutRecords>, res: EndpointResponse<PutRecords, AuthLocals>) => {
     const { environmentId, nangoConnectionId, syncId, syncJobId }: PutRecords['Params'] = req.params;
     const { model, records, providerConfigKey, connectionId, activityLogId, merging }: PutRecords['Body'] = req.body;
+    const { account } = res.locals;
     const result = await persistRecords({
         persistType: 'update',
+        accountId: account.id,
         environmentId,
         connectionId,
         providerConfigKey,
@@ -54,7 +57,7 @@ const handler = async (req: EndpointRequest<PutRecords>, res: EndpointResponse<P
     return;
 };
 
-export const routeHandler: RouteHandler<PutRecords> = {
+export const routeHandler: RouteHandler<PutRecords, AuthLocals> = {
     method,
     path,
     validate,

--- a/packages/persist/lib/routes/environment/environmentId/postLog.ts
+++ b/packages/persist/lib/routes/environment/environmentId/postLog.ts
@@ -3,6 +3,7 @@ import type { MessageRowInsert, PostLog } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, RouteHandler, Route } from '@nangohq/utils';
 import { validateRequest } from '@nangohq/utils';
 import { logContextGetter } from '@nangohq/logs';
+import type { AuthLocals } from '../../../middleware/auth.middleware';
 
 const MAX_LOG_CHAR = 10000;
 
@@ -54,7 +55,7 @@ const validate = validateRequest<PostLog>({
             .parse(data)
 });
 
-const handler = (req: EndpointRequest<PostLog>, res: EndpointResponse<PostLog>) => {
+const handler = (req: EndpointRequest<PostLog>, res: EndpointResponse<PostLog, AuthLocals>) => {
     const { body } = req;
 
     const truncate = (str: string) => (str.length > MAX_LOG_CHAR ? `${str.substring(0, MAX_LOG_CHAR)}... (truncated)` : str);
@@ -72,7 +73,7 @@ const handler = (req: EndpointRequest<PostLog>, res: EndpointResponse<PostLog>) 
 
 export const route: Route<PostLog> = { method: 'POST', path: '/environment/:environmentId/log' };
 
-export const routeHandler: RouteHandler<PostLog> = {
+export const routeHandler: RouteHandler<PostLog, AuthLocals> = {
     ...route,
     validate,
     handler

--- a/packages/persist/lib/routes/getHealth.ts
+++ b/packages/persist/lib/routes/getHealth.ts
@@ -1,5 +1,6 @@
 import type { Endpoint } from '@nangohq/types';
 import type { RouteHandler } from '@nangohq/utils';
+import type { AuthLocals } from '../middleware/auth.middleware';
 
 type Health = Endpoint<{
     Method: typeof method;
@@ -10,7 +11,7 @@ type Health = Endpoint<{
 const path = '/health';
 const method = 'GET';
 
-export const routeHandler: RouteHandler<Health> = {
+export const routeHandler: RouteHandler<Health, AuthLocals> = {
     path,
     method,
     validate: (_req, _res, next) => next(),

--- a/packages/utils/lib/express/route.ts
+++ b/packages/utils/lib/express/route.ts
@@ -4,20 +4,20 @@ import type { Endpoint } from '@nangohq/types';
 import * as metrics from '../telemetry/metrics.js';
 
 export type EndpointRequest<E extends Endpoint<any>> = Request<E['Params'], E['Reply'], E['Body'], E['Querystring']>;
-export type EndpointResponse<E extends Endpoint<any>> = Response<E['Reply']>;
+export type EndpointResponse<E extends Endpoint<any>, Locals extends Record<string, any> = Record<string, never>> = Response<E['Reply'], Locals>;
 
 export interface Route<E extends Endpoint<any>> {
     path: E['Path'];
     method: E['Method'];
 }
 
-export interface RouteHandler<E extends Endpoint<any>> extends Route<E> {
-    validate: (req: EndpointRequest<E>, res: EndpointResponse<E>, next: NextFunction) => void;
-    handler: (req: EndpointRequest<E>, res: EndpointResponse<E>, next: NextFunction) => void | Promise<void>;
+export interface RouteHandler<E extends Endpoint<any>, Locals extends Record<string, any> = Record<string, never>> extends Route<E> {
+    validate: (req: EndpointRequest<E>, res: EndpointResponse<E, Locals>, next: NextFunction) => void;
+    handler: (req: EndpointRequest<E>, res: EndpointResponse<E, Locals>, next: NextFunction) => void | Promise<void>;
 }
 
-export const createRoute = <E extends Endpoint<any>>(server: Express, rh: RouteHandler<E>): void => {
-    const safeHandler = (req: EndpointRequest<E>, res: EndpointResponse<E>, next: NextFunction): void => {
+export const createRoute = <E extends Endpoint<any>, Locals extends Record<string, any>>(server: Express, rh: RouteHandler<E, Locals>): void => {
+    const safeHandler = (req: EndpointRequest<E>, res: EndpointResponse<E, Locals>, next: NextFunction): void => {
         const active = tracer.scope().active();
         if (active) {
             active?.setTag('http.route', req.route?.path || req.originalUrl);

--- a/packages/utils/lib/express/validate.ts
+++ b/packages/utils/lib/express/validate.ts
@@ -11,7 +11,7 @@ interface RequestParser<E extends Endpoint<any>> {
 
 export const validateRequest =
     <E extends Endpoint<any>>(parser: RequestParser<E>) =>
-    (req: EndpointRequest<E>, res: EndpointResponse<E>, next: NextFunction) => {
+    (req: EndpointRequest<E>, res: EndpointResponse<E, any>, next: NextFunction) => {
         try {
             if (parser.parseBody) {
                 req.body = parser.parseBody(req.body);


### PR DESCRIPTION
Adding accountId dimension so we can drill down those metrics per account.

Adding support for `Locals` in the express route types to make the account available in the endpoint handlers