### PR TITLE
chore: add GET /records metrics

### DIFF
--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -73,7 +73,10 @@ export enum Types {
     API_REQUEST_CONTENT_LENGTH = 'nango.api.request.content_length',
 
     AUTH_SUCCESS = 'nango.server.auth.success',
-    AUTH_FAILURE = 'nango.server.auth.failure'
+    AUTH_FAILURE = 'nango.server.auth.failure',
+
+    GET_RECORDS_COUNT = 'nango.server.getRecords.count',
+    GET_RECORDS_SIZE_IN_BYTES = 'nango.server.getRecords.sizeInBytes'
 }
 
 type Dimensions = Record<string, string | number> | undefined;


### PR DESCRIPTION
We want to be able to know how much records/data is being read for each account from the records db.
Adding metrics on GET /records endpoint:
- number of records fetched
- size of records fetched (in order to avoid calculating the size, we use the content-length of the response. It is not exactly the size of the records since the response contains some metadata like cursors but it is a good and stable approximation)

Those 2 metrics would be a good proxy for records db I/O 

