### PR TITLE
chore: add metric for records total count per account

### DIFF
--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -50,6 +50,22 @@ export async function getRecordCountsByModel({
     }
 }
 
+export async function countMetric(): Promise<Result<{ environment_id: number; count: string }[]>> {
+    // Note: count is a string because pg returns bigint as string
+    try {
+        const res = await db
+            .from(RECORD_COUNTS_TABLE)
+            .sum('count as count')
+            .groupBy('environment_id')
+            .select<{ environment_id: number; count: string }[]>('environment_id');
+
+        return Ok(res);
+    } catch {
+        const e = new Error(`Failed to count records`);
+        return Err(e);
+    }
+}
+
 /**
  * Get Records is using the read replicas (when possible)
  */

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -50,14 +50,14 @@ export async function getRecordCountsByModel({
     }
 }
 
-export async function countMetric(): Promise<Result<{ environment_id: number; count: string }[]>> {
+export async function countMetric(): Promise<Result<{ environmentId: number; count: string }[]>> {
     // Note: count is a string because pg returns bigint as string
     try {
         const res = await db
             .from(RECORD_COUNTS_TABLE)
             .sum('count as count')
             .groupBy('environment_id')
-            .select<{ environment_id: number; count: string }[]>('environment_id');
+            .select<{ environmentId: number; count: string }[]>('environment_id as environmentId');
 
         return Ok(res);
     } catch {

--- a/packages/server/lib/crons/exportMetrics.ts
+++ b/packages/server/lib/crons/exportMetrics.ts
@@ -1,8 +1,9 @@
 import * as cron from 'node-cron';
-import { errorManager, ErrorSourceEnum, connectionService } from '@nangohq/shared';
+import { errorManager, ErrorSourceEnum, connectionService, environmentService } from '@nangohq/shared';
 import { stringifyError, getLogger, metrics } from '@nangohq/utils';
 import tracer from 'dd-trace';
 import { envs } from '../env.js';
+import { records } from '@nangohq/records';
 
 const logger = getLogger('Server.exportUsageMetrics');
 const cronMinutes = envs.CRON_EXPORT_USAGE_METRICS_MINUTES;
@@ -22,27 +23,69 @@ export function exportUsageMetricsCron(): void {
 }
 
 export async function exec(): Promise<void> {
-    await tracer.trace<Promise<void>>('nango.server.cron.exportUsageMetrics', async (span) => {
-        try {
-            logger.info(`Starting`);
+    await tracer.trace<Promise<void>>('nango.cron.exportUsageMetrics', async () => {
+        logger.info(`Starting`);
+        await exportConnectionsMetrics();
+        await exportRecordsMetrics();
+        logger.info(`✅ done`);
+    });
+}
 
-            // CONNECTIONS COUNT
-            const res = await connectionService.countMetric();
-            if (res.isErr()) {
-                throw res.error;
+async function exportConnectionsMetrics(): Promise<void> {
+    await tracer.trace<Promise<void>>('nango.cron.exportUsageMetrics.connections', async (span) => {
+        try {
+            const connRes = await connectionService.countMetric();
+            if (connRes.isErr()) {
+                throw connRes.error;
             }
-            for (const { account_id, count, with_actions, with_syncs, with_webhooks } of res.value) {
+            for (const { account_id, count, with_actions, with_syncs, with_webhooks } of connRes.value) {
                 metrics.gauge(metrics.Types.CONNECTIONS_COUNT, count, { accountId: account_id });
                 metrics.gauge(metrics.Types.CONNECTIONS_WITH_ACTIONS_COUNT, with_actions, { accountId: account_id });
                 metrics.gauge(metrics.Types.CONNECTIONS_WITH_SYNCS_COUNT, with_syncs, { accountId: account_id });
                 metrics.gauge(metrics.Types.CONNECTIONS_WITH_WEBHOOKS_COUNT, with_webhooks, { accountId: account_id });
             }
-
-            logger.info(`✅ done`);
         } catch (err) {
             span.setTag('error', err);
             logger.error(`failed: ${stringifyError(err)}`);
-            const e = new Error('failed_to_export_metrics', {
+            const e = new Error('failed_to_export_connections_metrics', {
+                cause: err instanceof Error ? err.message : String(err)
+            });
+            errorManager.report(e, { source: ErrorSourceEnum.PLATFORM });
+        }
+    });
+}
+
+async function exportRecordsMetrics(): Promise<void> {
+    await tracer.trace<Promise<void>>('nango.cron.exportUsageMetrics.records', async (span) => {
+        try {
+            // Records count
+            // Records db doesn't store account so we first get records count per environment
+            // and then we aggregate environments per account
+            const recordsRes = await records.countMetric();
+            if (recordsRes.isErr()) {
+                throw recordsRes.error;
+            }
+            const envs = await environmentService.getAll();
+            if (envs.length <= 0) {
+                throw new Error('no_environments');
+            }
+            const countByAccount = recordsRes.value.reduce((acc, { environment_id, count }) => {
+                const env = envs.find((e) => e.id === environment_id);
+                if (!env) {
+                    return acc;
+                }
+                const prev = acc.get(env.account_id) || 0;
+                acc.set(env.account_id, prev + Number(count));
+                return acc;
+            }, new Map<number, number>());
+
+            for (const [accountId, count] of countByAccount) {
+                metrics.gauge(metrics.Types.RECORDS_TOTAL_COUNT, count, { accountId });
+            }
+        } catch (err) {
+            span.setTag('error', err);
+            logger.error(`failed: ${stringifyError(err)}`);
+            const e = new Error('failed_to_export_records_metrics', {
                 cause: err instanceof Error ? err.message : String(err)
             });
             errorManager.report(e, { source: ErrorSourceEnum.PLATFORM });

--- a/packages/server/lib/crons/exportMetrics.ts
+++ b/packages/server/lib/crons/exportMetrics.ts
@@ -38,11 +38,11 @@ async function exportConnectionsMetrics(): Promise<void> {
             if (connRes.isErr()) {
                 throw connRes.error;
             }
-            for (const { account_id, count, with_actions, with_syncs, with_webhooks } of connRes.value) {
-                metrics.gauge(metrics.Types.CONNECTIONS_COUNT, count, { accountId: account_id });
-                metrics.gauge(metrics.Types.CONNECTIONS_WITH_ACTIONS_COUNT, with_actions, { accountId: account_id });
-                metrics.gauge(metrics.Types.CONNECTIONS_WITH_SYNCS_COUNT, with_syncs, { accountId: account_id });
-                metrics.gauge(metrics.Types.CONNECTIONS_WITH_WEBHOOKS_COUNT, with_webhooks, { accountId: account_id });
+            for (const { accountId, count, withActions, withSyncs, withWebhooks } of connRes.value) {
+                metrics.gauge(metrics.Types.CONNECTIONS_COUNT, count, { accountId: accountId });
+                metrics.gauge(metrics.Types.CONNECTIONS_WITH_ACTIONS_COUNT, withActions, { accountId });
+                metrics.gauge(metrics.Types.CONNECTIONS_WITH_SYNCS_COUNT, withSyncs, { accountId });
+                metrics.gauge(metrics.Types.CONNECTIONS_WITH_WEBHOOKS_COUNT, withWebhooks, { accountId });
             }
         } catch (err) {
             span.setTag('error', err);
@@ -69,13 +69,13 @@ async function exportRecordsMetrics(): Promise<void> {
             if (envs.length <= 0) {
                 throw new Error('no_environments');
             }
-            const countByAccount = recordsRes.value.reduce((acc, { environment_id, count }) => {
-                const env = envs.find((e) => e.id === environment_id);
+            const countByAccount = recordsRes.value.reduce((acc, { environmentId, count }) => {
+                const env = envs.find((e) => e.environmentId === environmentId);
                 if (!env) {
                     return acc;
                 }
-                const prev = acc.get(env.account_id) || 0;
-                acc.set(env.account_id, prev + Number(count));
+                const prev = acc.get(env.accountId) || 0;
+                acc.set(env.accountId, prev + Number(count));
                 return acc;
             }, new Map<number, number>());
 

--- a/packages/server/lib/crons/exportMetrics.ts
+++ b/packages/server/lib/crons/exportMetrics.ts
@@ -26,16 +26,18 @@ export async function exec(): Promise<void> {
         try {
             logger.info(`Starting`);
 
+            // CONNECTIONS COUNT
             const res = await connectionService.countMetric();
             if (res.isErr()) {
                 throw res.error;
             }
-            for (const { accountId, count, with_actions, with_syncs, with_webhooks } of res.value) {
-                metrics.gauge(metrics.Types.CONNECTIONS_COUNT, count, { accountId });
-                metrics.gauge(metrics.Types.CONNECTIONS_WITH_ACTIONS_COUNT, with_actions, { accountId });
-                metrics.gauge(metrics.Types.CONNECTIONS_WITH_SYNCS_COUNT, with_syncs, { accountId });
-                metrics.gauge(metrics.Types.CONNECTIONS_WITH_WEBHOOKS_COUNT, with_webhooks, { accountId });
+            for (const { account_id, count, with_actions, with_syncs, with_webhooks } of res.value) {
+                metrics.gauge(metrics.Types.CONNECTIONS_COUNT, count, { accountId: account_id });
+                metrics.gauge(metrics.Types.CONNECTIONS_WITH_ACTIONS_COUNT, with_actions, { accountId: account_id });
+                metrics.gauge(metrics.Types.CONNECTIONS_WITH_SYNCS_COUNT, with_syncs, { accountId: account_id });
+                metrics.gauge(metrics.Types.CONNECTIONS_WITH_WEBHOOKS_COUNT, with_webhooks, { accountId: account_id });
             }
+
             logger.info(`✅ done`);
         } catch (err) {
             span.setTag('error', err);

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -2054,7 +2054,7 @@ class ConnectionService {
     async countMetric(): Promise<
         Result<
             {
-                accountId: number;
+                account_id: number;
                 count: number;
                 with_actions: number;
                 with_syncs: number;
@@ -2076,14 +2076,14 @@ class ConnectionService {
             .leftJoin('_nango_sync_configs', '_nango_sync_configs.nango_config_id', '_nango_configs.id')
             .select<
                 {
-                    accountId: number;
+                    account_id: number;
                     count: number;
                     with_actions: number;
                     with_syncs: number;
                     with_webhooks: number;
                 }[]
             >(
-                db.knex.raw(`_nango_environments.account_id as accountId`),
+                db.knex.raw(`_nango_environments.account_id as account_id`),
                 db.knex.raw(`count(DISTINCT _nango_connections.id) AS count`),
                 db.knex.raw(`count(DISTINCT CASE WHEN _nango_sync_configs.type = 'action' THEN _nango_connections.id ELSE NULL END) as with_actions`),
                 db.knex.raw(`count(DISTINCT CASE WHEN _nango_sync_configs.type = 'sync' THEN _nango_connections.id ELSE NULL END) as with_syncs`),

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -2054,11 +2054,11 @@ class ConnectionService {
     async countMetric(): Promise<
         Result<
             {
-                account_id: number;
+                accountId: number;
                 count: number;
-                with_actions: number;
-                with_syncs: number;
-                with_webhooks: number;
+                withActions: number;
+                withSyncs: number;
+                withWebhooks: number;
             }[],
             NangoError
         >
@@ -2076,19 +2076,19 @@ class ConnectionService {
             .leftJoin('_nango_sync_configs', '_nango_sync_configs.nango_config_id', '_nango_configs.id')
             .select<
                 {
-                    account_id: number;
+                    accountId: number;
                     count: number;
-                    with_actions: number;
-                    with_syncs: number;
-                    with_webhooks: number;
+                    withActions: number;
+                    withSyncs: number;
+                    withWebhooks: number;
                 }[]
             >(
-                db.knex.raw(`_nango_environments.account_id as account_id`),
-                db.knex.raw(`count(DISTINCT _nango_connections.id) AS count`),
-                db.knex.raw(`count(DISTINCT CASE WHEN _nango_sync_configs.type = 'action' THEN _nango_connections.id ELSE NULL END) as with_actions`),
-                db.knex.raw(`count(DISTINCT CASE WHEN _nango_sync_configs.type = 'sync' THEN _nango_connections.id ELSE NULL END) as with_syncs`),
+                db.knex.raw(`_nango_environments.account_id as "accountId"`),
+                db.knex.raw(`count(DISTINCT _nango_connections.id) AS "count"`),
+                db.knex.raw(`count(DISTINCT CASE WHEN _nango_sync_configs.type = 'action' THEN _nango_connections.id ELSE NULL END) as "withActions"`),
+                db.knex.raw(`count(DISTINCT CASE WHEN _nango_sync_configs.type = 'sync' THEN _nango_connections.id ELSE NULL END) as "withSyncs"`),
                 db.knex.raw(
-                    `count(DISTINCT CASE WHEN _nango_sync_configs.webhook_subscriptions IS NOT NULL AND array_length(_nango_sync_configs.webhook_subscriptions, 1) > 0 THEN _nango_connections.id ELSE NULL END) as with_webhooks`
+                    `count(DISTINCT CASE WHEN _nango_sync_configs.webhook_subscriptions IS NOT NULL AND array_length(_nango_sync_configs.webhook_subscriptions, 1) > 0 THEN _nango_connections.id ELSE NULL END) as "withWebhooks"`
                 )
             )
             .whereNull('_nango_connections.deleted_at')

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -224,9 +224,8 @@ class EnvironmentService {
         return encryptionManager.decryptEnvironment(result[0]);
     }
 
-    async getAll(): Promise<DBEnvironment[]> {
-        const result = await db.knex.select('*').from<DBEnvironment>(TABLE);
-        // NOTE: we are not decrypting the environments
+    async getAll(): Promise<{ environmentId: number; accountId: number }[]> {
+        const result = await db.knex.select('id as environmentId', 'account_id as accountId').from<{ environmentId: number; accountId: number }[]>(TABLE);
         return result || [];
     }
 

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -224,6 +224,12 @@ class EnvironmentService {
         return encryptionManager.decryptEnvironment(result[0]);
     }
 
+    async getAll(): Promise<DBEnvironment[]> {
+        const result = await db.knex.select('*').from<DBEnvironment>(TABLE);
+        // NOTE: we are not decrypting the environments
+        return result || [];
+    }
+
     async createEnvironment(accountId: number, name: string): Promise<DBEnvironment | null> {
         const [environment] = await db.knex.from<DBEnvironment>(TABLE).insert({ account_id: accountId, name }).returning('*');
 

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -81,7 +81,9 @@ export enum Types {
     CONNECTIONS_COUNT = 'nango.connections.count',
     CONNECTIONS_WITH_ACTIONS_COUNT = 'nango.connections.withActions.count',
     CONNECTIONS_WITH_SYNCS_COUNT = 'nango.connections.withSyncs.count',
-    CONNECTIONS_WITH_WEBHOOKS_COUNT = 'nango.connections.withWebhooks.count'
+    CONNECTIONS_WITH_WEBHOOKS_COUNT = 'nango.connections.withWebhooks.count',
+
+    RECORDS_TOTAL_COUNT = 'nango.records.total.count'
 }
 
 type Dimensions = Record<string, string | number> | undefined;


### PR DESCRIPTION
Using the `records_count` table to aggregate the total number of records per account and sending the metric in the same cron job as the connection count.
I went for a single cron that submit the different metrics sequentially. wdyt?
