### PR TITLE
chore: pass accountId to log context to use it in metrics

### DIFF
--- a/packages/logs/lib/client.ts
+++ b/packages/logs/lib/client.ts
@@ -17,11 +17,13 @@ interface Options {
  */
 export class LogContextStateless {
     id: OperationRow['id'];
+    accountId: OperationRow['accountId'];
     dryRun: boolean;
     logToConsole: boolean;
 
-    constructor(data: { parentId: OperationRow['id'] }, options: Options = { dryRun: false, logToConsole: true }) {
+    constructor(data: { parentId: OperationRow['id']; accountId: OperationRow['accountId'] }, options: Options = { dryRun: false, logToConsole: true }) {
         this.id = data.parentId;
+        this.accountId = data.accountId;
         this.dryRun = isCli || !envs.NANGO_LOGS_ENABLED ? true : options.dryRun || false;
         this.logToConsole = options.logToConsole ?? true;
     }
@@ -49,7 +51,7 @@ export class LogContextStateless {
             report(new Error('failed_to_insert_in_es', { cause: err }));
             return false;
         } finally {
-            metrics.duration(metrics.Types.LOGS_LOG, Date.now() - start);
+            metrics.duration(metrics.Types.LOGS_LOG, Date.now() - start, { accountId: this.accountId });
         }
     }
 
@@ -127,7 +129,8 @@ export class LogContext extends LogContextStateless {
     span?: OtlpSpan;
 
     constructor(data: { parentId: string; operation: OperationRow }, options: Options = { dryRun: false, logToConsole: true }) {
-        super(data, options);
+        const { operation, ...rest } = data;
+        super({ ...rest, accountId: data.operation.accountId }, options);
         this.operation = data.operation;
     }
 

--- a/packages/logs/lib/models/logContextGetter.ts
+++ b/packages/logs/lib/models/logContextGetter.ts
@@ -62,7 +62,7 @@ export const logContextGetter = {
         return new LogContext({ parentId: id, operation: { id: nanoid(), createdAt: new Date().toISOString() } as OperationRow }, { ...options, dryRun: true });
     },
 
-    getStateLess({ id }: { id: OperationRow['id'] }, options?: Options): LogContextStateless {
-        return new LogContextStateless({ parentId: id }, options);
+    getStateLess({ id, accountId }: { id: OperationRow['id']; accountId: OperationRow['accountId'] }, options?: Options): LogContextStateless {
+        return new LogContextStateless({ parentId: id, accountId }, options);
     }
 };

--- a/packages/persist/lib/records.ts
+++ b/packages/persist/lib/records.ts
@@ -86,7 +86,7 @@ export async function persistRecords({
         syncJobId,
         softDelete
     });
-    const logCtx = logContextGetter.getStateLess({ id: String(activityLogId) });
+    const logCtx = logContextGetter.getStateLess({ id: String(activityLogId), accountId });
     if (formatting.isErr()) {
         void logCtx.error('There was an issue with the batch', { error: formatting.error, persistType });
         const err = new Error(`Failed to ${persistType} records ${activityLogId}`);

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getRecords.ts
@@ -38,8 +38,9 @@ const handler = async (req: EndpointRequest<GetRecords>, res: EndpointResponse<G
     } = req;
 
     let logCtx: LogContextStateless | undefined = undefined;
+    const { account } = res.locals;
     if (activityLogId) {
-        logCtx = logContextGetter.getStateLess({ id: String(activityLogId) });
+        logCtx = logContextGetter.getStateLess({ id: String(activityLogId), accountId: account.id });
     }
 
     const result = await records.getRecords({

--- a/packages/persist/lib/routes/environment/environmentId/postLog.ts
+++ b/packages/persist/lib/routes/environment/environmentId/postLog.ts
@@ -59,6 +59,7 @@ const validate = validateRequest<PostLog>({
 
 const handler = (req: EndpointRequest<PostLog>, res: EndpointResponse<PostLog, AuthLocals>) => {
     const { body } = req;
+    const { account } = res.locals;
 
     const truncate = (str: string) => (str.length > MAX_LOG_CHAR ? `${str.substring(0, MAX_LOG_CHAR)}... (truncated)` : str);
 
@@ -66,7 +67,7 @@ const handler = (req: EndpointRequest<PostLog>, res: EndpointResponse<PostLog, A
         ...body.log,
         message: truncate(body.log.message)
     };
-    const logCtx = logContextGetter.getStateLess({ id: String(body.activityLogId) }, { logToConsole: false });
+    const logCtx = logContextGetter.getStateLess({ id: String(body.activityLogId), accountId: account.id }, { logToConsole: false });
     void logCtx.log(log);
     res.status(204).send();
 

--- a/packages/server/lib/controllers/connect/postTelemetry.ts
+++ b/packages/server/lib/controllers/connect/postTelemetry.ts
@@ -62,10 +62,10 @@ export const postConnectTelemetry = asyncWrapper<PostPublicConnectTelemetry>(asy
         return;
     }
 
-    const { connectSession } = res.locals;
+    const { connectSession, account } = res.locals;
     const body: PostPublicConnectTelemetry['Body'] = val.data;
 
-    const logCtx = logContextGetter.getStateLess({ id: connectSession.operationId! });
+    const logCtx = logContextGetter.getStateLess({ id: connectSession.operationId!, accountId: account.id });
     switch (body.event) {
         case 'open': {
             const ua = UAParser(req.headers['user-agent']);


### PR DESCRIPTION
we could also eventually add accountId and/or environmentId to add to the payload to make filtering easier

Tested in staging
