### PR TITLE
chore: add accountId dimension to execution duration metrics

### DIFF
--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -436,7 +436,7 @@ export async function handleSyncSuccess({ taskId, nangoProps }: { taskId: string
             endUser: nangoProps.endUser
         });
 
-        metrics.duration(metrics.Types.SYNC_TRACK_RUNTIME, Date.now() - nangoProps.startedAt.getTime());
+        metrics.duration(metrics.Types.SYNC_TRACK_RUNTIME, Date.now() - nangoProps.startedAt.getTime(), { accountId: nangoProps.team?.id });
         metrics.increment(metrics.Types.SYNC_SUCCESS);
 
         await logCtx.success();

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -265,6 +265,7 @@ class SyncController {
             logCtx.attachSpan(new OtlpSpan(logCtx.operation));
 
             const actionResponse = await getOrchestrator().triggerAction({
+                accountId: account.id,
                 connection,
                 actionName: action_name,
                 input,

--- a/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
+++ b/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
@@ -71,7 +71,7 @@ export const postWebhook = asyncWrapper<PostPublicWebhook>(async (req, res) => {
             const endTime = Date.now();
             const totalRunTime = (endTime - startTime) / 1000;
 
-            metrics.duration(metrics.Types.WEBHOOK_TRACK_RUNTIME, totalRunTime);
+            metrics.duration(metrics.Types.WEBHOOK_TRACK_RUNTIME, totalRunTime, { accountId: account.id });
 
             if (!responsePayload) {
                 res.status(200).send();

--- a/packages/server/lib/hooks/connection/on/connection-created.ts
+++ b/packages/server/lib/hooks/connection/on/connection-created.ts
@@ -43,6 +43,7 @@ export async function postConnectionCreation(
         );
         logCtx.attachSpan(new OtlpSpan(logCtx.operation));
         const res = await getOrchestrator().triggerOnEventScript({
+            accountId: account.id,
             connection: createdConnection.connection,
             version,
             name,

--- a/packages/server/lib/hooks/connection/on/connection-deleted.ts
+++ b/packages/server/lib/hooks/connection/on/connection-deleted.ts
@@ -44,6 +44,7 @@ export async function preConnectionDeletion({
         );
 
         const res = await getOrchestrator().triggerOnEventScript({
+            accountId: team.id,
             connection,
             version,
             name,

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -99,11 +99,13 @@ export class Orchestrator {
     }
 
     async triggerAction<T = unknown>({
+        accountId,
         connection,
         actionName,
         input,
         logCtx
     }: {
+        accountId: number;
         connection: DBConnection | DBConnectionDecrypted;
         actionName: string;
         input: object;
@@ -210,7 +212,7 @@ export class Orchestrator {
         } finally {
             const endTime = Date.now();
             const totalRunTime = (endTime - startTime) / 1000;
-            metrics.duration(metrics.Types.ACTION_TRACK_RUNTIME, totalRunTime);
+            metrics.duration(metrics.Types.ACTION_TRACK_RUNTIME, totalRunTime, { accountId });
             span.finish();
         }
     }
@@ -346,12 +348,14 @@ export class Orchestrator {
     }
 
     async triggerOnEventScript<T = unknown>({
+        accountId,
         connection,
         version,
         name,
         fileLocation,
         logCtx
     }: {
+        accountId: number;
         connection: ConnectionJobs;
         version: string;
         name: string;
@@ -447,7 +451,7 @@ export class Orchestrator {
         } finally {
             const endTime = Date.now();
             const totalRunTime = (endTime - startTime) / 1000;
-            metrics.duration(metrics.Types.ON_EVENT_SCRIPT_RUNTIME, totalRunTime);
+            metrics.duration(metrics.Types.ON_EVENT_SCRIPT_RUNTIME, totalRunTime, { accountId });
             span.finish();
         }
     }

--- a/packages/shared/lib/services/notification/slack.service.ts
+++ b/packages/shared/lib/services/notification/slack.service.ts
@@ -209,6 +209,7 @@ export class SlackService {
 
         try {
             const actionResponse = await this.orchestrator.triggerAction<SlackActionResponse>({
+                accountId: adminEnvironment.account.id,
                 connection: slackConnection,
                 actionName: this.actionName,
                 input: payload,
@@ -345,6 +346,7 @@ export class SlackService {
 
         try {
             const actionResponse = await this.orchestrator.triggerAction<SlackActionResponse>({
+                accountId: adminEnvironment.account.id,
                 connection: slackConnection,
                 actionName: this.actionName,
                 input: payload,


### PR DESCRIPTION
So we can track total execution time per account

Tested in staging
