### PR TITLE
chore: send metric with accountId as value and accountName dimension

### DIFF
--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -107,6 +107,10 @@ class AccountService {
     async editCustomer(is_capped: boolean, accountId: number): Promise<void> {
         await db.knex.update({ is_capped }).from<DBTeam>(`_nango_accounts`).where({ id: accountId });
     }
+
+    async getAll(): Promise<DBTeam[]> {
+        return db.knex.select('*').from<DBTeam>(`_nango_accounts`);
+    }
 }
 
 export default new AccountService();

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -83,7 +83,9 @@ export enum Types {
     CONNECTIONS_WITH_SYNCS_COUNT = 'nango.connections.withSyncs.count',
     CONNECTIONS_WITH_WEBHOOKS_COUNT = 'nango.connections.withWebhooks.count',
 
-    RECORDS_TOTAL_COUNT = 'nango.records.total.count'
+    RECORDS_TOTAL_COUNT = 'nango.records.total.count',
+
+    ACCOUNT_NAME = 'nango.account.name'
 }
 
 type Dimensions = Record<string, string | number> | undefined;


### PR DESCRIPTION
A little trick to be able to show a list in the usage dashboard linking the account id and the name. 
This metrics doesn't represent anything, it will just have a constant value that is the account id

Tested in staging
<img width="447" alt="Screenshot 2025-03-14 at 16 28 31" src="https://github.com/user-attachments/assets/3f7904c0-4584-4437-8f47-166a25f6aea9" />