### PR TITLE
fix: use knex Transaction for all queries within a transaction

### DIFF
--- a/packages/fleet/lib/models/deployments.ts
+++ b/packages/fleet/lib/models/deployments.ts
@@ -36,7 +36,7 @@ export async function create(db: knex.Knex, image: string): Promise<Result<Deplo
     try {
         return await db.transaction(async (trx) => {
             // do nothing if already active deployment
-            const active = await getActive(db);
+            const active = await getActive(trx);
             if (active.isErr()) {
                 return Err(active.error);
             }

--- a/packages/server/lib/controllers/connect/postSessions.ts
+++ b/packages/server/lib/controllers/connect/postSessions.ts
@@ -74,7 +74,7 @@ export const postConnectSessions = asyncWrapper<PostConnectSessions>(async (req,
         }
 
         if (body.allowed_integrations || body.integrations_config_defaults) {
-            const integrations = await configService.listProviderConfigs(environment.id);
+            const integrations = await configService.listProviderConfigs(environment.id, trx);
 
             // Enforce that integrations exists in `allowed_integrations`
             if (body.allowed_integrations && body.allowed_integrations.length > 0) {

--- a/packages/shared/lib/services/config.service.ts
+++ b/packages/shared/lib/services/config.service.ts
@@ -31,8 +31,8 @@ class ConfigService {
         return result.id;
     }
 
-    async getProviderConfig(providerConfigKey: string, environment_id: number): Promise<ProviderConfig | null> {
-        const result = await db.readOnly
+    async getProviderConfig(providerConfigKey: string, environment_id: number, trx = db.readOnly): Promise<ProviderConfig | null> {
+        const result = await trx
             .select('*')
             .from<ProviderConfig>(`_nango_configs`)
             .where({ unique_key: providerConfigKey, environment_id, deleted: false })
@@ -45,9 +45,9 @@ class ConfigService {
         return encryptionManager.decryptProviderConfig(result);
     }
 
-    async listProviderConfigs(environment_id: number): Promise<ProviderConfig[]> {
+    async listProviderConfigs(environment_id: number, trx = db.knex): Promise<ProviderConfig[]> {
         return (
-            await db.knex
+            await trx
                 .select('*')
                 .from<ProviderConfig>(`_nango_configs`)
                 .where({ environment_id, deleted: false })

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -268,8 +268,8 @@ class EnvironmentService {
         return result.map((env) => encryptionManager.decryptEnvironment(env));
     }
 
-    async getSlackNotificationsEnabled(environmentId: number): Promise<boolean | null> {
-        const result = await db.knex.select('slack_notifications').from<DBEnvironment>(TABLE).where({ id: environmentId });
+    async getSlackNotificationsEnabled(environmentId: number, trx = db.knex): Promise<boolean | null> {
+        const result = await trx.select('slack_notifications').from<DBEnvironment>(TABLE).where({ id: environmentId });
 
         if (result == null || result.length == 0 || result[0] == null) {
             return null;

--- a/packages/shared/lib/services/notification/slack.service.ts
+++ b/packages/shared/lib/services/notification/slack.service.ts
@@ -532,7 +532,7 @@ export class SlackService {
         provider: string;
     }): Promise<void> {
         const update = await db.knex.transaction(async (trx) => {
-            const slackNotificationsEnabled = await environmentService.getSlackNotificationsEnabled(nangoConnection.environment_id);
+            const slackNotificationsEnabled = await environmentService.getSlackNotificationsEnabled(nangoConnection.environment_id, trx);
             if (!slackNotificationsEnabled) {
                 return;
             }

--- a/packages/shared/lib/services/on-event-scripts.service.ts
+++ b/packages/shared/lib/services/on-event-scripts.service.ts
@@ -85,7 +85,7 @@ export const onEventScriptService = {
             for (const onEventScriptByProvider of onEventScriptsByProvider) {
                 const { providerConfigKey, scripts } = onEventScriptByProvider;
 
-                const config = await configService.getProviderConfig(providerConfigKey, environment.id);
+                const config = await configService.getProviderConfig(providerConfigKey, environment.id, trx);
                 if (!config || !config.id) {
                     continue;
                 }


### PR DESCRIPTION
We are not always using the Knex Transaction when making queries within a transaction, using more connections that necessary and potentially causing exhaustion of the db connections pool

