### PR TITLE
fix(verification): not all providers have a valid method or script

### DIFF
--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -111,15 +111,7 @@ export async function testConnectionCredentials({
             });
             return result;
         }
-
-        logs.push({
-            type: 'log',
-            level: 'error',
-            message: 'No verification script or provider verification method found.',
-            createdAt: new Date().toISOString()
-        });
-
-        return Err(new NangoError('no_verification_script_or_verification_method', { logs }));
+        return Ok({ logs: [], tested: false });
     } catch (err) {
         logs.push({
             type: 'log',

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -294,11 +294,6 @@ export class NangoError extends Error {
                 this.message = `The given credentials were found to be invalid${status ? ` and received a ${status} on a test API call` : ''}. Please check the credentials and try again.`;
                 break;
 
-            case 'no_verification_script_or_verification_method':
-                this.status = status || 400;
-                this.message = 'No verification script or provider verification method found.';
-                break;
-
             case 'invalid_auth_mode':
                 this.status = 400;
                 this.message = 'Invalid auth mode. The provider does not support this auth mode.';


### PR DESCRIPTION
## Describe the problem and your solution

- Not all providers have a valid `proxy.verification` method or `verification` script.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

