### PR TITLE
fix(refresh): incorrect condition for stale connections, missing expires_at for api_key

### DIFF
--- a/packages/shared/lib/services/connections/utils.ts
+++ b/packages/shared/lib/services/connections/utils.ts
@@ -1,4 +1,5 @@
 import ms from 'ms';
+
 import type { AllAuthCredentials, DBConnection, DBConnectionAsJSONRow } from '@nangohq/types';
 
 export const DEFAULT_EXPIRES_AT_MS = ms('1day');


### PR DESCRIPTION
## Changes

- Fix incorrect condition for stale connections
It was missing `or NULL` otherwise it would only refresh connections that were queried at least once.

- Missing updating `credentials_expires_at` when testing a connection (api_key and such)

