### PR TITLE
fix(CLI): nango.proxy should throw if request fails

### DIFF
--- a/packages/cli/lib/services/sdk.ts
+++ b/packages/cli/lib/services/sdk.ts
@@ -31,12 +31,16 @@ export class NangoActionCLI extends NangoActionBase {
         this.nango = new Nango({ isSync: false, dryRun: true, ...props }, getAxiosSettings(props));
     }
 
-    public override proxy<T = any>(config: ProxyConfiguration): Promise<AxiosResponse<T>> {
+    public override async proxy<T = any>(config: ProxyConfiguration): Promise<AxiosResponse<T>> {
         if (!config.method) {
             config.method = 'GET';
         }
 
-        return this.nango.proxy(config);
+        const res = await this.nango.proxy(config);
+        if (isAxiosError(res)) {
+            throw res;
+        }
+        return res;
     }
 
     public override log(...args: [...any]): void {


### PR DESCRIPTION
A dry-run execution is currently continuing if nango.proxy fails which is not consistant with the behavior when run by the runner

This behavior might have changed when we refactored the runner-sdk at the end of January.
