### PR TITLE
fix: shouldRefreshCredentials to return false if credentials_expires_at is set

### DIFF
--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -430,7 +430,8 @@ export async function shouldRefreshCredentials({
             return { should: false, reason: 'fresh_introspected_token' };
         }
 
-        if (credentials.expires_at && !isTokenExpired(credentials.expires_at, provider.token_expiration_buffer || REFRESH_MARGIN_S)) {
+        const expires_at = credentials.expires_at || connection.credentials_expires_at;
+        if (expires_at && !isTokenExpired(expires_at, provider.token_expiration_buffer || REFRESH_MARGIN_S)) {
             return { should: false, reason: 'fresh' };
         }
     }

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -430,8 +430,9 @@ export async function shouldRefreshCredentials({
             return { should: false, reason: 'fresh_introspected_token' };
         }
 
-        const expires_at = credentials.expires_at || connection.credentials_expires_at;
-        if (expires_at && !isTokenExpired(expires_at, provider.token_expiration_buffer || REFRESH_MARGIN_S)) {
+        if (!credentials.expires_at) {
+            return { should: false, reason: 'no_expires_at' };
+        } else if (!isTokenExpired(credentials.expires_at, provider.token_expiration_buffer || REFRESH_MARGIN_S)) {
             return { should: false, reason: 'fresh' };
         }
     }

--- a/packages/shared/lib/services/connections/credentials/refresh.unit.test.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.unit.test.ts
@@ -11,7 +11,7 @@ describe('shouldRefreshCredentials', () => {
             const connection = getTestConnection();
             const res = await shouldRefreshCredentials({
                 connection,
-                credentials: { type: 'OAUTH2', access_token: '', raw: {} },
+                credentials: { type: 'OAUTH2', access_token: '', raw: {}, expires_at: new Date(Date.now() + 10000) },
                 instantRefresh: true,
                 provider: { auth_mode: 'OAUTH2' } as ProviderOAuth2,
                 providerConfig: { provider: 'facebook' } as Config
@@ -24,7 +24,7 @@ describe('shouldRefreshCredentials', () => {
             const connection = getTestConnection();
             const res = await shouldRefreshCredentials({
                 connection,
-                credentials: { type: 'OAUTH2', access_token: '', raw: {} },
+                credentials: { type: 'OAUTH2', access_token: '', raw: {}, expires_at: new Date(Date.now() + 10000) },
                 instantRefresh: false,
                 provider: { auth_mode: 'OAUTH2' } as ProviderOAuth2,
                 providerConfig: { provider: 'facebook' } as Config
@@ -135,6 +135,19 @@ describe('shouldRefreshCredentials', () => {
             });
 
             expect(res).toStrictEqual({ should: false, reason: 'fresh' });
+        });
+
+        it('should return false if no credentials.expires_at', async () => {
+            const connection = getTestConnection();
+            const res = await shouldRefreshCredentials({
+                connection,
+                credentials: { type: 'OAUTH2', access_token: '', refresh_token: 'token', raw: {} },
+                instantRefresh: false,
+                provider: { auth_mode: 'OAUTH2' } as ProviderOAuth2,
+                providerConfig: { provider: 'brightcrowd' } as Config
+            });
+
+            expect(res).toStrictEqual({ should: false, reason: 'no_expires_at' });
         });
     });
 });


### PR DESCRIPTION
in case of credentials without `expires_at` (ex: stripe) we fallback to the `credentials_expires_at` connection attribute to determine if a connection requires to be refreshed
