### PR TITLE
fix(runner): do not exit on unhandledRejection

### DIFF
--- a/packages/runner/lib/app.ts
+++ b/packages/runner/lib/app.ts
@@ -40,9 +40,8 @@ try {
     });
 
     process.on('unhandledRejection', (reason) => {
-        logger.error(`${id} Received unhandledRejection...`, reason);
-        process.exitCode = 1;
-        close();
+        logger.error(`${id} Received uncaughtException...`, reason);
+        // not closing on purpose
     });
 
     process.on('uncaughtException', (e) => {


### PR DESCRIPTION
we don't exit on uncaughtException but we do on unhandledRejection 
Making it consistant by only logging and not exiting the runner because one script throwing an exception/rejection should not crash the entire runner
