### PR TITLE
fix: check record is not null in removeMetadata

### DIFF
--- a/packages/runner-sdk/lib/sync.ts
+++ b/packages/runner-sdk/lib/sync.ts
@@ -77,7 +77,7 @@ export abstract class NangoSyncBase extends NangoActionBase {
 
     protected removeMetadata<T extends object>(results: T[]) {
         return results.map((result) => {
-            if ('_nango_metadata' in result) {
+            if (result && '_nango_metadata' in result) {
                 delete result._nango_metadata;
             }
 

--- a/packages/runner-sdk/lib/sync.ts
+++ b/packages/runner-sdk/lib/sync.ts
@@ -76,6 +76,9 @@ export abstract class NangoSyncBase extends NangoActionBase {
     }
 
     protected removeMetadata<T extends object>(results: T[]) {
+        if (!Array.isArray(results)) {
+            return results;
+        }
         return results.map((result) => {
             if (result && '_nango_metadata' in result) {
                 delete result._nango_metadata;


### PR DESCRIPTION
One can possibly pass a null record to batchSave. (I need to come up with a 'ts types are lies meme')

It currently fails with a `cannot access _nango_metadata in null`. This commit make sure result is defined first.

Passing a null record will fail later anyway but the error message is going to be a bit more comprehensible (ie: `invalid_type: Expected object, received null`)


