### PR TITLE
fix(ui): show correct message for credentials error

### DIFF
--- a/packages/server/lib/formatters/connection.ts
+++ b/packages/server/lib/formatters/connection.ts
@@ -1,3 +1,5 @@
+import { endUserToApi } from './endUser.js';
+
 import type {
     ApiConnectionFull,
     ApiConnectionSimple,
@@ -8,7 +10,6 @@ import type {
     DBConnectionDecrypted,
     DBEndUser
 } from '@nangohq/types';
-import { endUserToApi } from './endUser.js';
 
 export function connectionSimpleToApi({
     data,
@@ -34,9 +35,20 @@ export function connectionSimpleToApi({
 }
 export function connectionFullToApi(connection: DBConnectionDecrypted): ApiConnectionFull {
     return {
-        ...connection,
         id: connection.id,
         config_id: connection.config_id,
+        environment_id: connection.environment_id,
+        connection_id: connection.connection_id,
+        provider_config_key: connection.provider_config_key,
+        connection_config: connection.connection_config,
+        credentials: connection.credentials,
+        metadata: connection.metadata,
+        last_fetched_at: connection.last_fetched_at ? String(connection.last_fetched_at) : null,
+        credentials_expires_at: connection.credentials_expires_at ? String(connection.credentials_expires_at) : null,
+        last_refresh_failure: connection.last_refresh_failure ? String(connection.last_refresh_failure) : null,
+        last_refresh_success: connection.last_refresh_success ? String(connection.last_refresh_success) : null,
+        refresh_attempts: connection.refresh_attempts,
+        refresh_exhausted: connection.refresh_exhausted,
         created_at: String(connection.created_at),
         updated_at: String(connection.updated_at)
     };

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -1,43 +1,46 @@
-import type { Span } from 'dd-trace';
+import tracer from 'dd-trace';
+
 import {
+    AnalyticsTypes,
     CONNECTIONS_WITH_SCRIPTS_CAP_LIMIT,
     NangoError,
-    getSyncConfigsWithConnections,
+    ProxyRequest,
     analytics,
     errorNotificationService,
     externalWebhookService,
-    AnalyticsTypes,
-    syncManager,
     getProxyConfiguration,
-    ProxyRequest
+    getSyncConfigsWithConnections,
+    syncManager
 } from '@nangohq/shared';
-import type { ApiKeyCredentials, BasicApiCredentials, Config } from '@nangohq/shared';
-import { getLogger, Ok, Err, isHosted, stringifyError } from '@nangohq/utils';
-import { getOrchestrator } from '../utils/utils.js';
-import type {
-    TbaCredentials,
-    IntegrationConfig,
-    DBEnvironment,
-    Provider,
-    JwtCredentials,
-    SignatureCredentials,
-    MessageRowInsert,
-    RecentlyFailedConnection,
-    RecentlyCreatedConnection,
-    ConnectionConfig,
-    DBConnectionDecrypted,
-    DBTeam,
-    ApplicationConstructedProxyConfiguration,
-    InternalProxyConfiguration
-} from '@nangohq/types';
-import type { Result } from '@nangohq/utils';
-import type { LogContext, LogContextGetter } from '@nangohq/logs';
-import postConnection from './connection/post-connection.js';
-import { postConnectionCreation } from './connection/on/connection-created.js';
+import { Err, Ok, getLogger, isHosted } from '@nangohq/utils';
 import { sendAuth as sendAuthWebhook } from '@nangohq/webhooks';
-import tracer from 'dd-trace';
+
+import { getOrchestrator } from '../utils/utils.js';
 import executeVerificationScript from './connection/credentials-verification-script.js';
 import { slackService } from '../services/slack.js';
+import { postConnectionCreation } from './connection/on/connection-created.js';
+import postConnection from './connection/post-connection.js';
+
+import type { LogContext, LogContextGetter } from '@nangohq/logs';
+import type { ApiKeyCredentials, BasicApiCredentials, Config } from '@nangohq/shared';
+import type {
+    ApplicationConstructedProxyConfiguration,
+    ConnectionConfig,
+    DBConnectionDecrypted,
+    DBEnvironment,
+    DBTeam,
+    IntegrationConfig,
+    InternalProxyConfiguration,
+    JwtCredentials,
+    MessageRowInsert,
+    Provider,
+    RecentlyCreatedConnection,
+    RecentlyFailedConnection,
+    SignatureCredentials,
+    TbaCredentials
+} from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+import type { Span } from 'dd-trace';
 
 const logger = getLogger('hooks');
 const orchestrator = getOrchestrator();
@@ -353,15 +356,8 @@ export async function credentialsTest({
             if (response.status && response.status >= 200 && response.status < 300) {
                 return Ok({ logs, tested: true });
             }
-
-            logs.push({ type: 'log', level: 'error', message: `Failed verification for endpoint: ${endpoint}`, createdAt: new Date().toISOString() });
-        } catch (err) {
-            logs.push({
-                type: 'log',
-                level: 'error',
-                message: `Error testing endpoint: ${endpoint},  ${stringifyError(err)}`,
-                createdAt: new Date().toISOString()
-            });
+        } catch {
+            // Already covered
         }
     }
 

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -1,9 +1,10 @@
 import type { ApiError, ApiTimestamps, Endpoint } from '../../api.js';
-import type { DBConnection, DBConnectionDecrypted } from '../db.js';
-import type { ActiveLog } from '../../notification/active-logs/db.js';
-import type { Merge } from 'type-fest';
-import type { ApiEndUser } from '../../endUser/index.js';
 import type { AllAuthCredentials } from '../../auth/api.js';
+import type { ApiEndUser } from '../../endUser/index.js';
+import type { ActiveLog } from '../../notification/active-logs/db.js';
+import type { ReplaceInObject } from '../../utils.js';
+import type { DBConnection, DBConnectionDecrypted } from '../db.js';
+import type { Merge } from 'type-fest';
 
 export type ApiConnectionSimple = Pick<Merge<DBConnection, ApiTimestamps>, 'id' | 'connection_id' | 'provider_config_key' | 'created_at' | 'updated_at'> & {
     provider: string;
@@ -57,7 +58,10 @@ export type GetPublicConnections = Endpoint<{
     };
 }>;
 
-export type ApiConnectionFull = Merge<DBConnectionDecrypted, ApiTimestamps>;
+export type ApiConnectionFull = Omit<
+    ReplaceInObject<DBConnectionDecrypted, Date, string>,
+    'credentials_iv' | 'end_user_id' | 'credentials_tag' | 'deleted' | 'deleted_at'
+>;
 export type GetConnection = Endpoint<{
     Method: 'GET';
     Params: {

--- a/packages/webapp/src/pages/Connection/Authorization.tsx
+++ b/packages/webapp/src/pages/Connection/Authorization.tsx
@@ -1,20 +1,21 @@
 import { Prism } from '@mantine/prism';
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { mutate } from 'swr';
 
-import PrismPlus from '../../components/ui/prism/PrismPlus';
-import type { ActiveLog, ApiConnectionFull, ApiEndUser } from '@nangohq/types';
-import { formatDateToShortUSFormat } from '../../utils/utils';
+import { CopyText } from '../../components/CopyText';
+import { Info } from '../../components/Info';
 import SecretInput from '../../components/ui/input/SecretInput';
 import TagsInput from '../../components/ui/input/TagsInput';
-import type React from 'react';
+import PrismPlus from '../../components/ui/prism/PrismPlus';
 import { apiRefreshConnection } from '../../hooks/useConnections';
-import { useMemo, useState } from 'react';
-import { useStore } from '../../store';
 import { useToast } from '../../hooks/useToast';
-import { mutate } from 'swr';
+import { useStore } from '../../store';
 import { getLogsUrl } from '../../utils/logs';
-import { Info } from '../../components/Info';
-import { Link } from 'react-router-dom';
-import { CopyText } from '../../components/CopyText';
+import { formatDateToShortUSFormat } from '../../utils/utils';
+
+import type { ActiveLog, ApiConnectionFull, ApiEndUser } from '@nangohq/types';
+import type React from 'react';
 
 const JSON_DISPLAY_LIMIT = 250_000;
 
@@ -56,7 +57,9 @@ export const Authorization: React.FC<AuthorizationProps> = ({ connection, errorL
             {errorLog && (
                 <div className="flex my-4">
                     <Info variant={'destructive'}>
-                        There was an error refreshing the credentials
+                        {connection.credentials.type === 'BASIC' || connection.credentials.type === 'API_KEY'
+                            ? 'There was an error while testing credentials validity'
+                            : 'There was an error refreshing the credentials'}
                         <Link
                             to={getLogsUrl({ env, operationId: errorLog.log_id, connections: connection.connection_id, day: errorLog.created_at })}
                             className="ml-1 cursor-pointer underline"


### PR DESCRIPTION
## Changes 

Fixes https://linear.app/nango/issue/NAN-2949/stop-refreshing-credentials-that-are-repeatedly-failing-beyond-the#comment-4e0b3541

- show correct message for credentials error
Dissociate test vs refresh

- Do not "leak" credentials_iv in private API
Not critical at all but it's cleaner

- Fix testing credentials would log twice the error
