### PR TITLE
fix(connection): decryption without a secret key would void credentials

### DIFF
--- a/packages/shared/lib/utils/encryption.manager.integration.test.ts
+++ b/packages/shared/lib/utils/encryption.manager.integration.test.ts
@@ -1,6 +1,8 @@
 import { beforeAll, describe, expect, it } from 'vitest';
-import encryptionManager, { EncryptionManager } from './encryption.manager';
+
 import db, { multipleMigrations } from '@nangohq/database';
+
+import encryptionManager, { EncryptionManager } from './encryption.manager';
 import { seedAccountEnvAndUser } from '../seeders/index.js';
 import environmentService from '../services/environment.service';
 

--- a/packages/shared/lib/utils/encryption.manager.ts
+++ b/packages/shared/lib/utils/encryption.manager.ts
@@ -87,7 +87,7 @@ export class EncryptionManager extends Encryption {
         const credentials =
             connection.credentials['encrypted_credentials'] && connection.credentials_iv && connection.credentials_tag
                 ? JSON.parse(this.decrypt(connection.credentials['encrypted_credentials'], connection.credentials_iv, connection.credentials_tag))
-                : {};
+                : connection.credentials;
         if (isConnectionJsonRow(connection)) {
             const parsed: DBConnectionDecrypted = {
                 ...connection,

--- a/packages/shared/lib/utils/encryption.manager.unit.test.ts
+++ b/packages/shared/lib/utils/encryption.manager.unit.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import encryptionManager from './encryption.manager';
+import { getTestConnection } from '../services/connections/utils.test';
+
+import type { DBConnection } from '@nangohq/types';
+
+describe('encryption', () => {
+    describe('decryption', () => {
+        it('should return connection', () => {
+            const res = encryptionManager.decryptConnection(getTestConnection() as DBConnection);
+            expect(res.credentials).toStrictEqual({
+                apiKey: 'random_token',
+                type: 'API_KEY'
+            });
+        });
+
+        it('should return proper connection if json', () => {
+            const test = getTestConnection();
+            const res = encryptionManager.decryptConnection(JSON.parse(JSON.stringify(test)) as DBConnection);
+            expect(res.created_at).toStrictEqual(new Date(test.created_at));
+        });
+    });
+});


### PR DESCRIPTION
## Changes

User reported an issue, but couldn't reproduce it. Turns out it was a bug with decryption when encryption_key is not set, which is quite rare since we are recommending NANGO_ENCRYPTION_KEY to be set for a while now (edit: we are not enforcing which might be a mistake)

- Fix decryption should return credentials even when encryption is not enabled
I had copied this code but before there was an early return that would prevent this code from being reached.
Added small unit test to prevent regression