### PR TITLE
chore: sync total active time

### DIFF
--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -26,6 +26,7 @@ export * from './services/sync/job.service.js';
 export * from './services/sync/config/config.service.js';
 export * from './services/sync/config/endpoint.service.js';
 export * from './services/sync/config/deploy.service.js';
+export * from './services/sync/utils.js';
 export * from './services/endUser.service.js';
 export * from './services/onboarding.service.js';
 export * from './services/invitations.js';

--- a/packages/shared/lib/services/sync/utils.ts
+++ b/packages/shared/lib/services/sync/utils.ts
@@ -1,0 +1,31 @@
+import type { Result } from '@nangohq/utils';
+import { Err, Ok } from '@nangohq/utils';
+import ms from 'ms';
+import type { StringValue } from 'ms';
+import { NangoError } from '../../utils/error.js';
+
+export function getFrequencyMs(runs: string): Result<number> {
+    const runsMap = new Map([
+        ['every half day', '12h'],
+        ['every half hour', '30m'],
+        ['every quarter hour', '15m'],
+        ['every hour', '1h'],
+        ['every day', '1d'],
+        ['every month', '30d'],
+        ['every week', '7d']
+    ]);
+    const interval = runsMap.get(runs) || runs.replace('every ', '');
+
+    const intervalMs = ms(interval as StringValue);
+    if (!intervalMs) {
+        const error = new NangoError('sync_interval_invalid');
+        return Err(error);
+    }
+
+    if (intervalMs < ms('30s')) {
+        const error = new NangoError('sync_interval_too_short');
+        return Err(error);
+    }
+
+    return Ok(intervalMs);
+}

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -48,6 +48,8 @@ export enum Types {
     RUNNER_INVALID_ACTION_OUTPUT = 'nango.runner.invalidActionOutput',
     RUNNER_INVALID_SYNCS_RECORDS = 'nango.runner.invalidSyncsRecords',
 
+    SYNC_LOW_FREQUENCY_MS = 'nango.jobs.sync.lowFrequencyMs',
+    SYNC_HIGH_FREQUENCY_MS = 'nango.jobs.sync.highFrequencyMs',
     SYNC_EXECUTION = 'nango.jobs.syncExecution',
     SYNC_TRACK_RUNTIME = 'sync_script_track_runtime',
     SYNC_SUCCESS = 'nango.orch.sync.success',


### PR DESCRIPTION
for more context: https://linear.app/nango/issue/NAN-2958/metric-sync-schedule-active-time

We want to track how long syncs are being active (aka: started) 
In order to get an approximation, we are pushing a metric per account for every sync being started. 
The value is equal to the frequency of the sync. By summing up this metric we should then be able to know the total active sync time for an account

