### PR TITLE
fix: make Slack notifications aware of sync variants

### DIFF
--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -407,7 +407,7 @@ export async function handleSyncSuccess({ taskId, nangoProps }: { taskId: string
 
         await slackService.removeFailingConnection({
             connection,
-            name: nangoProps.syncConfig.sync_name,
+            name: nangoProps.syncVariant === 'base' ? nangoProps.syncConfig.sync_name : `${nangoProps.syncConfig.sync_name}::${nangoProps.syncVariant}`,
             type: 'sync',
             originalActivityLogId: nangoProps.activityLogId,
             provider: nangoProps.provider
@@ -660,7 +660,7 @@ async function onFailure({
                     account: team,
                     environment,
                     connection,
-                    name: syncName,
+                    name: syncVariant === 'base' ? syncName : `${syncName}::${syncVariant}`,
                     type: 'sync',
                     originalActivityLogId: logCtx.id,
                     provider

--- a/packages/shared/lib/services/notification/slack.service.ts
+++ b/packages/shared/lib/services/notification/slack.service.ts
@@ -193,7 +193,7 @@ export class SlackService {
      *      2) Add an activity log entry for the notification to the admin account
      *
      */
-    async reportResolution(
+    private async reportResolution(
         connection: ConnectionJobs,
         name: string,
         type: string,
@@ -262,7 +262,7 @@ export class SlackService {
      * and environment id and if so return the necessary information to be able
      * to update the notification.
      */
-    async hasOpenNotification(
+    private async hasOpenNotification(
         nangoConnection: Pick<DBConnection, 'environment_id'>,
         name: string,
         type: string,
@@ -288,7 +288,7 @@ export class SlackService {
      * @desc create a new notification for the given name and environment id
      * and return the id of the created notification.
      */
-    async createNotification(
+    private async createNotification(
         nangoConnection: Pick<DBConnection, 'id' | 'environment_id'>,
         name: string,
         type: string,
@@ -317,7 +317,7 @@ export class SlackService {
      * @desc check if there is an open notification for the given name and environment id
      * and if so add the connection id to the connection list.
      */
-    async addFailingConnection(nangoConnection: ConnectionJobs, name: string, type: string): Promise<ServiceResponse<NotificationResponse>> {
+    private async addFailingConnection(nangoConnection: ConnectionJobs, name: string, type: string): Promise<ServiceResponse<NotificationResponse>> {
         return await db.knex.transaction(async (trx) => {
             const lockKey = stringToHash(`${nangoConnection.environment_id}-${name}-${type}-add`);
 


### PR DESCRIPTION
Slack notifications are currently not aware of sync variants, which means that all sync execution for the base sync and its variant fall into the same entry in the slack_notifications table. This could lead to bugs where one variant fails triggering the push of a 'Failed sync' notif followed by another variant that is successful, marking the initial Slack notifications as resolved even though it is a different variants.
Fixing the bug by appending the variant to the sync name if it is not the base one
