### PR TITLE
fix: connection is already deleted when executing pre-connection-deletion

### DIFF
--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -162,7 +162,7 @@ export class OrchestratorClient {
         }
     }
 
-    private async execute(props: ExecuteProps): Promise<ExecuteReturn> {
+    private async immediateAndWait(props: ExecuteProps): Promise<ExecuteReturn> {
         const scheduleProps = {
             retry: { count: 0, max: 0 },
             timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
@@ -235,7 +235,7 @@ export class OrchestratorClient {
                 type: 'action' as const
             }
         };
-        return this.execute(schedulingProps);
+        return this.immediateAndWait(schedulingProps);
     }
 
     public async executeWebhook(props: ExecuteWebhookProps): Promise<ExecuteReturn> {
@@ -252,10 +252,10 @@ export class OrchestratorClient {
                 type: 'webhook' as const
             }
         };
-        return this.execute(schedulingProps);
+        return this.immediateAndWait(schedulingProps);
     }
 
-    public async executeOnEvent(props: ExecuteOnEventProps): Promise<VoidReturn> {
+    public async executeOnEvent(props: ExecuteOnEventProps & { async: boolean }): Promise<VoidReturn> {
         const { args, ...rest } = props;
         const schedulingProps = {
             retry: { count: 0, max: 0 },
@@ -270,7 +270,8 @@ export class OrchestratorClient {
                 type: 'on-event' as const
             }
         };
-        const res = await this.immediate(schedulingProps);
+
+        const res: Result<any, ClientError> = props.async ? await this.immediate(schedulingProps) : await this.immediateAndWait(schedulingProps);
         if (res.isErr()) {
             return Err(res.error);
         }

--- a/packages/server/lib/hooks/connection/on/connection-created.ts
+++ b/packages/server/lib/hooks/connection/on/connection-created.ts
@@ -48,6 +48,7 @@ export async function postConnectionCreation(
             version,
             name,
             fileLocation,
+            async: true,
             logCtx
         });
         if (res.isErr()) {

--- a/packages/server/lib/hooks/connection/on/connection-deleted.ts
+++ b/packages/server/lib/hooks/connection/on/connection-deleted.ts
@@ -49,6 +49,7 @@ export async function preConnectionDeletion({
             version,
             name,
             fileLocation,
+            async: false,
             logCtx
         });
         if (res.isErr()) {

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -52,7 +52,7 @@ export interface OrchestratorClientInterface {
     recurring(props: RecurringProps): Promise<Result<{ scheduleId: string }>>;
     executeAction(props: ExecuteActionProps): Promise<ExecuteReturn>;
     executeWebhook(props: ExecuteWebhookProps): Promise<ExecuteReturn>;
-    executeOnEvent(props: ExecuteOnEventProps): Promise<VoidReturn>;
+    executeOnEvent(props: ExecuteOnEventProps & { async: boolean }): Promise<VoidReturn>;
     executeSync(props: ExecuteSyncProps): Promise<VoidReturn>;
     pauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn>;
     unpauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn>;
@@ -353,6 +353,7 @@ export class Orchestrator {
         version,
         name,
         fileLocation,
+        async,
         logCtx
     }: {
         accountId: number;
@@ -360,6 +361,7 @@ export class Orchestrator {
         version: string;
         name: string;
         fileLocation: string;
+        async: boolean;
         logCtx: LogContext;
     }): Promise<Result<T, NangoError>> {
         const activeSpan = tracer.scope().active();
@@ -393,7 +395,8 @@ export class Orchestrator {
             const result = await this.client.executeOnEvent({
                 name: executionId,
                 groupKey,
-                args
+                args,
+                async
             });
 
             const res = result.mapError((err) => {


### PR DESCRIPTION
we currently execute the pre-connection-deletion on-event script asynchronously which means the connection is likely already deleted when the script execute.

This commit adds a way to execute a on-event script either asynchronously (for post-connection-creation) or synchronously (for pre-connection-deletion)
The drawback of waiting for the script to finish executing is that when deleting via the dasbhoard UI or the API, the user must now wait

