### PR TITLE
fix(cli): reup validation error message

### DIFF
--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -412,10 +412,10 @@ export class DryRunService {
             if (results.error) {
                 const err = results.error;
                 console.error(chalk.red('An error occurred during execution'));
-                if (err instanceof SDKError) {
+                if (err instanceof SDKError || err.type === 'invalid_sync_record') {
                     console.error(chalk.red(err.message), chalk.gray(`(${err.code})`));
-                    if (err.code === 'invalid_action_output' || err.code === 'invalid_action_input' || err.code === 'invalid_sync_record') {
-                        displayValidationError(err.payload as any);
+                    if (err.code === 'invalid_action_output' || err.code === 'invalid_action_input' || err.type === 'invalid_sync_record') {
+                        displayValidationError(err.payload);
                         return;
                     }
 
@@ -652,6 +652,16 @@ export class DryRunService {
                         error: {
                             type: err.type,
                             payload: err.payload || {},
+                            status: 500
+                        },
+                        response: null
+                    };
+                } else if (err instanceof SDKError) {
+                    return {
+                        success: false,
+                        error: {
+                            type: err.code,
+                            payload: err.payload,
                             status: 500
                         },
                         response: null

--- a/packages/cli/lib/services/sdk.ts
+++ b/packages/cli/lib/services/sdk.ts
@@ -1,12 +1,14 @@
-import { Nango } from '@nangohq/node';
-import type { ProxyConfiguration } from '@nangohq/runner-sdk';
-import { InvalidRecordSDKError, NangoActionBase, NangoSyncBase, BASE_VARIANT } from '@nangohq/runner-sdk';
-import type { AdminAxiosProps, ListRecordsRequestConfig } from '@nangohq/node';
-import type { Metadata, NangoProps, UserLogParameters, GetPublicConnection } from '@nangohq/types';
 import { isAxiosError } from 'axios';
-import type { AxiosError, AxiosResponse } from 'axios';
-import type { DryRunService } from './dryrun.service';
 import chalk from 'chalk';
+
+import { Nango } from '@nangohq/node';
+import { BASE_VARIANT, InvalidRecordSDKError, NangoActionBase, NangoSyncBase } from '@nangohq/runner-sdk';
+
+import type { DryRunService } from './dryrun.service';
+import type { AdminAxiosProps, ListRecordsRequestConfig } from '@nangohq/node';
+import type { ProxyConfiguration } from '@nangohq/runner-sdk';
+import type { GetPublicConnection, Metadata, NangoProps, UserLogParameters } from '@nangohq/types';
+import type { AxiosError, AxiosResponse } from 'axios';
 
 const logLevelToLogger = {
     info: 'info',
@@ -16,6 +18,12 @@ const logLevelToLogger = {
     http: 'info',
     verbose: 'debug',
     silly: 'debug'
+} as const;
+const logLevelToColor = {
+    info: 'white',
+    debug: 'gray',
+    error: 'red',
+    warn: 'yellow'
 } as const;
 
 export class NangoActionCLI extends NangoActionBase {
@@ -65,7 +73,7 @@ export class NangoActionCLI extends NangoActionBase {
         if (args.length > 1 && 'type' in args[1] && args[1].type === 'http') {
             console[logLevel](args[0], { status: args[1]?.response?.code || 'xxx' });
         } else {
-            console[logLevel](...args);
+            console[logLevel](chalk[logLevelToColor[logLevel]](...args));
         }
     }
 

--- a/packages/runner-sdk/lib/sync.ts
+++ b/packages/runner-sdk/lib/sync.ts
@@ -1,7 +1,8 @@
-import type { MaybePromise, NangoProps } from '@nangohq/types';
-import { validateData } from './dataValidation.js';
-import type { ValidateDataError } from './dataValidation.js';
 import { NangoActionBase } from './action.js';
+import { validateData } from './dataValidation.js';
+
+import type { ValidateDataError } from './dataValidation.js';
+import type { MaybePromise, NangoProps } from '@nangohq/types';
 
 export const BASE_VARIANT = 'base';
 
@@ -80,7 +81,7 @@ export abstract class NangoSyncBase extends NangoActionBase {
             return results;
         }
         return results.map((result) => {
-            if (result && '_nango_metadata' in result) {
+            if (result && typeof result === 'object' && '_nango_metadata' in result) {
                 delete result._nango_metadata;
             }
 


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-2987/validation-fails-without-showing-specific-error-reasons

- Reup validation error message for syncs
Error was not properly handled since we had changed the constructor name. Plus I think it never worked for syncs since we are throwing anyway.

- Fix remove metadata not checking if record is an actual object
- Fix add color to log 
Used to be the case when we using logger in shared
