### PR TITLE
fix: fleet fallback db url

### DIFF
--- a/packages/fleet/lib/fleet.ts
+++ b/packages/fleet/lib/fleet.ts
@@ -18,6 +18,7 @@ import { waitUntilHealthy } from './utils/url.js';
 
 const defaultDbUrl =
     envs.RUNNERS_DATABASE_URL ||
+    envs.NANGO_DATABASE_URL ||
     `postgres://${encodeURIComponent(envs.NANGO_DB_USER)}:${encodeURIComponent(envs.NANGO_DB_PASSWORD)}@${envs.NANGO_DB_HOST}:${envs.NANGO_DB_PORT}/${envs.NANGO_DB_NAME}?application_name=${envs.NANGO_DB_APPLICATION_NAME}${envs.NANGO_DB_SSL ? '&sslmode=no-verify' : ''}`;
 
 export class Fleet {


### PR DESCRIPTION
avoiding issue in case an enterprise customer uses NANGO_DATABASE_URL instead of the multiple DB related env vars

