### PR TITLE
fix(providers.yaml): retry for 403 for google cal and hibob connect UI

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -4092,6 +4092,8 @@ google-calendar:
             limit_name_in_request: maxSize
             cursor_name_in_request: pageToken
             response_path: items
+        retry:
+            error_code: 403
     docs: https://docs.nango.dev/integrations/all/google-calendar
 
 google-docs:

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -4645,15 +4645,15 @@ hibob-service-user:
     credentials:
         username:
             type: string
-            title: User name
+            title: Hibob ID
             description: Your Hibob ID
             doc_section: '#step-1-finding-your-hibob-service-user-id'
         password:
             type: string
-            title: Password
+            title: Hibob Token
             description: Your Hibob Token
             default_value: ''
-            hidden: true
+            secret: true
             doc_section: '#step-2-finding-your-hibob-token'
     docs: https://docs.nango.dev/integrations/all/hibob-service-user
     docs_connect: https://docs.nango.dev/integrations/all/hibob-service-user/connect


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
- Google cal: they issue a 403 for rate limit exceeded: https://developers.google.com/calendar/api/guides/errors#403_usage_limits_exceeded
- Hibob: fix field names and fix for them to show the password (token) field

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

