### PR TITLE
fix(refresh): missing last_fetched_at

### DIFF
--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -293,6 +293,7 @@ async function testCredentials(
 
         const connection = await connectionService.updateConnection({
             ...oldConnection,
+            last_fetched_at: new Date(),
             credentials_expires_at: getExpiresAtFromCredentials(oldConnection.credentials),
             last_refresh_failure: null,
             last_refresh_success: new Date(),
@@ -406,6 +407,7 @@ async function refreshCredentialsIfNeeded({
         connectionToRefresh.credentials = newCredentials;
         connectionToRefresh = await connectionService.updateConnection({
             ...connectionToRefresh,
+            last_fetched_at: new Date(),
             credentials_expires_at: getExpiresAtFromCredentials(newCredentials),
             last_refresh_failure: null,
             last_refresh_success: new Date(),


### PR DESCRIPTION
## Changes

- Missing last_fetched_at when we backfill data
Causing some connections to be refreshed over and over