### PR TITLE
fix: abort all scripts when timing out

### DIFF
--- a/packages/jobs/lib/execution/operations/abort.ts
+++ b/packages/jobs/lib/execution/operations/abort.ts
@@ -1,8 +1,25 @@
 import type { Result } from '@nangohq/utils';
 import { Err, Ok } from '@nangohq/utils';
 import { getRunner } from '../../runner/runner.js';
+import { environmentService } from '@nangohq/shared';
+import { logger } from '../../logger.js';
+import type { TaskAbort } from '@nangohq/nango-orchestrator';
 
-export async function abortScript({ taskId, teamId }: { taskId: string; teamId: number }): Promise<Result<void>> {
+export async function abortTask(task: TaskAbort): Promise<Result<void>> {
+    const accountAndEnv = await environmentService.getAccountAndEnvironment({ environmentId: task.connection.environment_id });
+    if (!accountAndEnv) {
+        throw new Error(`Account and environment not found`);
+    }
+    const { account: team } = accountAndEnv;
+
+    const abortedScript = await abortTaskWithId({ taskId: task.abortedTask.id, teamId: team.id });
+    if (abortedScript.isErr()) {
+        logger.error(`failed to abort script for task ${task.abortedTask.id}`, abortedScript.error);
+    }
+    return abortedScript;
+}
+
+export async function abortTaskWithId({ taskId, teamId }: { taskId: string; teamId: number }): Promise<Result<void>> {
     const runner = await getRunner(teamId);
     if (runner.isErr()) {
         return Err(runner.error);

--- a/packages/jobs/lib/execution/operations/abort.ts
+++ b/packages/jobs/lib/execution/operations/abort.ts
@@ -8,7 +8,7 @@ import type { TaskAbort } from '@nangohq/nango-orchestrator';
 export async function abortTask(task: TaskAbort): Promise<Result<void>> {
     const accountAndEnv = await environmentService.getAccountAndEnvironment({ environmentId: task.connection.environment_id });
     if (!accountAndEnv) {
-        throw new Error(`Account and environment not found`);
+        return Err(`Account and environment not found`);
     }
     const { account: team } = accountAndEnv;
 

--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -3,7 +3,7 @@ import { multipleMigrations } from '@nangohq/database';
 import type { UnencryptedRecordData, ReturnedRecord } from '@nangohq/records';
 import { records as recordsService, format as recordsFormatter, migrate as migrateRecords, clearDbTestsOnly as clearRecordsDb } from '@nangohq/records';
 import { handleSyncSuccess, startSync } from './sync.js';
-import type { TaskAction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from '@nangohq/nango-orchestrator';
+import type { TaskAbort, TaskAction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from '@nangohq/nango-orchestrator';
 import type { Sync, SyncResult, Job as SyncJob } from '@nangohq/shared';
 import { isSyncJobRunning, seeders, getLatestSyncJob, updateSyncJobResult } from '@nangohq/shared';
 import { Ok, stringifyError } from '@nangohq/utils';
@@ -197,7 +197,8 @@ const runJob = async (
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
-        isSyncAbort: (): this is TaskSyncAbort => false
+        isSyncAbort: (): this is TaskSyncAbort => false,
+        isAbort: (): this is TaskAbort => false
     };
     const nangoProps = await startSync(task, mockStartScript);
     if (nangoProps.isErr()) {

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -29,7 +29,7 @@ import { sendSync as sendSyncWebhook } from '@nangohq/webhooks';
 
 import { bigQueryClient, orchestratorClient, slackService } from '../clients.js';
 import { logger } from '../logger.js';
-import { abortScript } from './operations/abort.js';
+import { abortTaskWithId } from './operations/abort.js';
 import { startScript } from './operations/start.js';
 import { getRunnerFlags } from '../utils/flags.js';
 import { setTaskFailed, setTaskSuccess } from './operations/state.js';
@@ -533,7 +533,7 @@ export async function abortSync(task: TaskSyncAbort): Promise<Result<void>> {
         }
         const { account: team, environment } = accountAndEnv;
 
-        const abortedScript = await abortScript({ taskId: task.abortedTask.id, teamId: team.id });
+        const abortedScript = await abortTaskWithId({ taskId: task.abortedTask.id, teamId: team.id });
         if (abortedScript.isErr()) {
             logger.error(`failed to abort script for task ${task.abortedTask.id}`, abortedScript.error);
         }

--- a/packages/jobs/lib/processor/handler.ts
+++ b/packages/jobs/lib/processor/handler.ts
@@ -6,6 +6,7 @@ import { startSync, abortSync } from '../execution/sync.js';
 import { startAction } from '../execution/action.js';
 import { startWebhook } from '../execution/webhook.js';
 import { startOnEvent } from '../execution/onEvent.js';
+import { abortTask } from '../execution/operations/abort.js';
 
 export async function handler(task: OrchestratorTask): Promise<Result<void>> {
     if (task.isSync()) {
@@ -44,6 +45,14 @@ export async function handler(task: OrchestratorTask): Promise<Result<void>> {
         const span = tracer.startSpan('jobs.handler.onEvent');
         return await tracer.scope().activate(span, async () => {
             const res = startOnEvent(task);
+            span.finish();
+            return res;
+        });
+    }
+    if (task.isAbort()) {
+        const span = tracer.startSpan('jobs.handler.abort');
+        return await tracer.scope().activate(span, async () => {
+            const res = await abortTask(task);
             span.finish();
             return res;
         });

--- a/packages/orchestrator/lib/abort.ts
+++ b/packages/orchestrator/lib/abort.ts
@@ -3,40 +3,43 @@ import { validateTask } from './clients/validate.js';
 import { Err, stringifyError } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
 import { logger } from './utils.js';
+import type { JsonValue } from 'type-fest';
 
 export async function scheduleAbortTask({ scheduler, task }: { scheduler: Scheduler; task: Task }): Promise<Result<Task>> {
     const aborted = validateTask(task);
     if (aborted.isErr()) {
         return Err(aborted.error);
     }
-    if (aborted.value.isSync()) {
-        const reason = aborted.value.state === 'EXPIRED' ? 'Expired execution' : 'Execution was cancelled';
-        const abortTask = await scheduler.immediate({
-            name: `abort:${aborted.value.name}`,
-            payload: {
-                type: 'abort',
-                abortedTask: {
-                    id: aborted.value.id,
-                    state: aborted.value.state
-                },
-                reason,
-                syncId: aborted.value.syncId,
-                syncName: aborted.value.syncName,
-                debug: aborted.value.debug,
-                connection: aborted.value.connection
-            },
-            groupKey: aborted.value.groupKey,
-            retryMax: 0,
-            retryCount: 0,
-            createdToStartedTimeoutSecs: 60,
-            startedToCompletedTimeoutSecs: 60,
-            heartbeatTimeoutSecs: 60
-        });
-        if (abortTask.isErr()) {
-            logger.error(`Failed to create abort task: ${stringifyError(abortTask.error)}`);
-            return Err(abortTask.error);
-        }
-        return abortTask;
+    const reason = aborted.value.state === 'EXPIRED' ? 'Expired execution' : 'Execution was cancelled';
+    const payload: JsonValue = {
+        type: 'abort',
+        abortedTask: {
+            id: aborted.value.id,
+            state: aborted.value.state
+        },
+        reason,
+        connection: aborted.value.connection
+    };
+    const abortTask = await scheduler.immediate({
+        name: `abort:${aborted.value.name}`,
+        payload: aborted.value.isSync()
+            ? {
+                  ...payload,
+                  syncId: aborted.value.syncId,
+                  syncName: aborted.value.syncName,
+                  debug: aborted.value.debug
+              }
+            : payload,
+        groupKey: aborted.value.groupKey,
+        retryMax: 0,
+        retryCount: 0,
+        createdToStartedTimeoutSecs: 60,
+        startedToCompletedTimeoutSecs: 60,
+        heartbeatTimeoutSecs: 60
+    });
+    if (abortTask.isErr()) {
+        logger.error(`Failed to create abort task: ${stringifyError(abortTask.error)}`);
+        return Err(abortTask.error);
     }
-    return Err(`Task ${aborted.value.id} is not a sync task`);
+    return abortTask;
 }

--- a/packages/orchestrator/lib/abort.ts
+++ b/packages/orchestrator/lib/abort.ts
@@ -1,6 +1,6 @@
 import type { Scheduler, Task } from '@nangohq/scheduler';
 import { validateTask } from './clients/validate.js';
-import { Err, stringifyError } from '@nangohq/utils';
+import { Err } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
 import { logger } from './utils.js';
 import type { JsonValue } from 'type-fest';
@@ -38,7 +38,7 @@ export async function scheduleAbortTask({ scheduler, task }: { scheduler: Schedu
         heartbeatTimeoutSecs: 60
     });
     if (abortTask.isErr()) {
-        logger.error(`Failed to create abort task: ${stringifyError(abortTask.error)}`);
+        logger.error(`Failed to create abort task`, abortTask.error);
         return Err(abortTask.error);
     }
     return abortTask;

--- a/packages/orchestrator/lib/abort.ts
+++ b/packages/orchestrator/lib/abort.ts
@@ -10,6 +10,12 @@ export async function scheduleAbortTask({ scheduler, task }: { scheduler: Schedu
     if (aborted.isErr()) {
         return Err(aborted.error);
     }
+
+    // we don't want to abort an abort task
+    if (aborted.value.isAbort() || aborted.value.isSyncAbort()) {
+        return Err(`Task is already an abort task`);
+    }
+
     const reason = aborted.value.state === 'EXPIRED' ? 'Expired execution' : 'Execution was cancelled';
     const payload: JsonValue = {
         type: 'abort',

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -22,6 +22,7 @@ interface AbortArgs {
         state: TaskState;
     };
     reason: string;
+    connection: ConnectionJobs;
 }
 interface ActionArgs {
     actionName: string;
@@ -61,7 +62,7 @@ export interface OrchestratorSchedule {
     nextDueDate: Date | null;
 }
 
-export type OrchestratorTask = TaskSync | TaskSyncAbort | TaskAction | TaskWebhook | TaskOnEvent;
+export type OrchestratorTask = TaskSync | TaskSyncAbort | TaskAction | TaskWebhook | TaskOnEvent | TaskAbort;
 
 interface TaskCommonFields {
     id: string;
@@ -76,6 +77,26 @@ interface TaskCommon extends TaskCommonFields {
     isAction(this: OrchestratorTask): this is TaskAction;
     isOnEvent(this: OrchestratorTask): this is TaskOnEvent;
     isSyncAbort(this: OrchestratorTask): this is TaskSyncAbort;
+    isAbort(this: OrchestratorTask): this is TaskAbort;
+}
+export interface TaskAbort extends TaskCommon, AbortArgs {}
+export function TaskAbort(props: TaskCommonFields & AbortArgs): TaskAbort {
+    return {
+        id: props.id,
+        abortedTask: props.abortedTask,
+        name: props.name,
+        state: props.state,
+        attempt: props.attempt,
+        connection: props.connection,
+        groupKey: props.groupKey,
+        reason: props.reason,
+        isSync: (): this is TaskSync => false,
+        isWebhook: (): this is TaskWebhook => false,
+        isAction: (): this is TaskAction => false,
+        isOnEvent: (): this is TaskOnEvent => false,
+        isSyncAbort: (): this is TaskSyncAbort => false,
+        isAbort: (): this is TaskAbort => true
+    };
 }
 
 export interface TaskSync extends TaskCommon, SyncArgs {}
@@ -95,7 +116,8 @@ export function TaskSync(props: TaskCommonFields & SyncArgs): TaskSync {
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
-        isSyncAbort: (): this is TaskSyncAbort => false
+        isSyncAbort: (): this is TaskSyncAbort => false,
+        isAbort: (): this is TaskAbort => false
     };
 }
 
@@ -118,7 +140,8 @@ export function TaskSyncAbort(props: TaskCommonFields & SyncArgs & AbortArgs): T
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
-        isSyncAbort: (): this is TaskSyncAbort => true
+        isSyncAbort: (): this is TaskSyncAbort => true,
+        isAbort: (): this is TaskAbort => false
     };
 }
 
@@ -138,7 +161,8 @@ export function TaskAction(props: TaskCommonFields & ActionArgs): TaskAction {
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => true,
         isOnEvent: (): this is TaskOnEvent => false,
-        isSyncAbort: (): this is TaskSyncAbort => false
+        isSyncAbort: (): this is TaskSyncAbort => false,
+        isAbort: (): this is TaskAbort => false
     };
 }
 
@@ -159,7 +183,8 @@ export function TaskWebhook(props: TaskCommonFields & WebhookArgs): TaskWebhook 
         isWebhook: (): this is TaskWebhook => true,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
-        isSyncAbort: (): this is TaskSyncAbort => false
+        isSyncAbort: (): this is TaskSyncAbort => false,
+        isAbort: (): this is TaskAbort => false
     };
 }
 
@@ -180,7 +205,8 @@ export function TaskOnEvent(props: TaskCommonFields & OnEventArgs): TaskOnEvent 
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => true,
-        isSyncAbort: (): this is TaskSyncAbort => false
+        isSyncAbort: (): this is TaskSyncAbort => false,
+        isAbort: (): this is TaskAbort => false
     };
 }
 

--- a/packages/runner/lib/server.ts
+++ b/packages/runner/lib/server.ts
@@ -67,9 +67,7 @@ function startProcedure() {
                 }, heartbeatIntervalMs);
                 try {
                     const abortController = new AbortController();
-                    if (nangoProps.scriptType == 'sync' && nangoProps.activityLogId) {
-                        abortControllers.set(taskId, abortController);
-                    }
+                    abortControllers.set(taskId, abortController);
 
                     const { error, response: output } = await exec(nangoProps, code, codeParams, abortController);
 

--- a/packages/runner/lib/state.ts
+++ b/packages/runner/lib/state.ts
@@ -1,2 +1,1 @@
-export const syncAbortControllers = new Map<string, AbortController>();
 export const abortControllers = new Map<string, AbortController>();


### PR DESCRIPTION
We currently only abort syncs when they timed out, which means that action, webhook or on-event scripts keep executing in the runner even though the task is timed out
This commit adds support for aborting any script

