### PR TITLE
feat: nango to respond/forward webhook immediately

### DIFF
--- a/docs-v2/guides/webhooks/webhooks-from-apis/real-time-syncing-with-webhooks.mdx
+++ b/docs-v2/guides/webhooks/webhooks-from-apis/real-time-syncing-with-webhooks.mdx
@@ -19,7 +19,7 @@ When processed in a sync:
 - The script extracts data from the webhook and optionally fetches additional data from the external API
 - The modified data is stored in the Nango cache
 
-henever the cache is updated, Nango sends a [sync completion webhook](/guides/webhooks/webhooks-from-nango#sync-webhooks) to notify your application of new data. This entire process happens in real-time.
+Whenever the cache is updated, Nango sends a [sync completion webhook](/guides/webhooks/webhooks-from-nango#sync-webhooks) to notify your application of new data. This entire process happens in real-time.
 
 <Tip>
 **Webhooks and periodic polling:**

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -803,4 +803,5 @@ async function onFailure({
     }
 
     metrics.increment(metrics.Types.SYNC_FAILURE);
+    metrics.duration(metrics.Types.SYNC_TRACK_RUNTIME, Date.now() - startedAt.getTime(), team ? { accountId: team.id } : {});
 }

--- a/packages/jobs/lib/execution/webhook.ts
+++ b/packages/jobs/lib/execution/webhook.ts
@@ -160,7 +160,8 @@ export async function startWebhook(task: TaskWebhook): Promise<Result<void>> {
             runTime: 0,
             error,
             syncConfig,
-            endUser
+            endUser,
+            startedAt: new Date()
         });
         return Err(error);
     }
@@ -256,6 +257,9 @@ export async function handleWebhookSuccess({ taskId, nangoProps }: { taskId: str
             });
         }
     }
+
+    metrics.increment(metrics.Types.WEBHOOK_SUCCESS);
+    metrics.duration(metrics.Types.WEBHOOK_TRACK_RUNTIME, Date.now() - nangoProps.startedAt.getTime(), team ? { accountId: team.id } : {});
 }
 
 export async function handleWebhookError({ taskId, nangoProps, error }: { taskId: string; nangoProps: NangoProps; error: NangoError }): Promise<void> {
@@ -299,7 +303,8 @@ export async function handleWebhookError({ taskId, nangoProps, error }: { taskId
         runTime: (new Date().getTime() - nangoProps.startedAt.getTime()) / 1000,
         error,
         syncConfig: nangoProps.syncConfig,
-        endUser: nangoProps.endUser
+        endUser: nangoProps.endUser,
+        startedAt: nangoProps.startedAt
     });
 }
 
@@ -317,7 +322,8 @@ async function onFailure({
     models,
     runTime,
     error,
-    endUser
+    endUser,
+    startedAt
 }: {
     connection: ConnectionJobs;
     team: DBTeam | undefined;
@@ -334,6 +340,7 @@ async function onFailure({
     runTime: number;
     error: NangoError;
     endUser: NangoProps['endUser'];
+    startedAt: Date;
 }): Promise<void> {
     if (environment) {
         const webhookSettings = await externalWebhookService.get(environment.id);
@@ -403,4 +410,7 @@ async function onFailure({
             endUser
         });
     }
+
+    metrics.increment(metrics.Types.WEBHOOK_FAILURE);
+    metrics.duration(metrics.Types.WEBHOOK_TRACK_RUNTIME, Date.now() - startedAt.getTime(), team ? { accountId: team.id } : {});
 }

--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -249,14 +249,13 @@ describe('OrchestratorClient', async () => {
         });
     });
     describe('executeWebhook', () => {
-        it('should be successful when action task succeed', async () => {
+        it('should be successful', async () => {
             const groupKey = nanoid();
-            const output = { count: 9 };
 
             const processor = new MockProcessor({
                 groupKey,
                 process: async (task) => {
-                    await scheduler.succeed({ taskId: task.id, output });
+                    await scheduler.succeed({ taskId: task.id, output: null });
                 }
             });
             try {
@@ -276,42 +275,7 @@ describe('OrchestratorClient', async () => {
                         input: { foo: 'bar' }
                     }
                 });
-                expect(res.unwrap()).toEqual(output);
-            } finally {
-                processor.stop();
-            }
-        });
-        it('should return an error if action task fails', async () => {
-            const groupKey = nanoid();
-
-            const errorPayload = { message: 'something bad happened' };
-            const processor = new MockProcessor({
-                groupKey,
-                process: async (task) => {
-                    await scheduler.fail({ taskId: task.id, error: errorPayload });
-                }
-            });
-            try {
-                const res = await client.executeWebhook({
-                    name: nanoid(),
-                    groupKey: groupKey,
-                    args: {
-                        webhookName: 'W',
-                        parentSyncName: nanoid(),
-                        connection: {
-                            id: 1234,
-                            connection_id: 'C',
-                            provider_config_key: 'P',
-                            environment_id: 5678
-                        },
-                        activityLogId: '9876',
-                        input: { foo: 'bar' }
-                    }
-                });
-                expect(res.isOk()).toBe(false);
-                if (res.isErr()) {
-                    expect(res.error.payload).toBe(res.error.payload);
-                }
+                expect(res.isOk()).toBe(true);
             } finally {
                 processor.stop();
             }

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -242,6 +242,7 @@ export class OrchestratorClient {
         const { args, ...rest } = props;
         const schedulingProps = {
             ...rest,
+            retry: { count: 0, max: 0 },
             timeoutSettingsInSecs: {
                 createdToStarted: 30,
                 startedToCompleted: 15 * 60,

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -252,7 +252,7 @@ export class OrchestratorClient {
                 type: 'webhook' as const
             }
         };
-        return this.immediateAndWait(schedulingProps);
+        return this.immediate(schedulingProps);
     }
 
     public async executeOnEvent(props: ExecuteOnEventProps & { async: boolean }): Promise<VoidReturn> {

--- a/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
+++ b/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
@@ -66,19 +66,9 @@ export const postWebhook = asyncWrapper<PostPublicWebhook>(async (req, res) => {
 
             metrics.increment(metrics.Types.WEBHOOK_INCOMING_RECEIVED);
 
-            const startTime = Date.now();
-            const responsePayload = await routeWebhook({ environment, account, integration, headers, body: req.body, rawBody: req.rawBody!, logContextGetter });
-            const endTime = Date.now();
-            const totalRunTime = (endTime - startTime) / 1000;
+            await routeWebhook({ environment, account, integration, headers, body: req.body, rawBody: req.rawBody!, logContextGetter });
 
-            metrics.duration(metrics.Types.WEBHOOK_TRACK_RUNTIME, totalRunTime, { accountId: account.id });
-
-            if (!responsePayload) {
-                res.status(200).send();
-                return;
-            }
-
-            res.status(200).send(responsePayload);
+            res.status(200).send();
         } catch (err) {
             span.setTag('nango.error', err);
 

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -308,7 +308,6 @@ export class Orchestrator {
 
             await logCtx.success();
 
-            metrics.increment(metrics.Types.WEBHOOK_SUCCESS);
             return res as Result<T, NangoError>;
         } catch (err) {
             let formattedError: NangoError;
@@ -339,7 +338,6 @@ export class Orchestrator {
                 }
             });
 
-            metrics.increment(metrics.Types.WEBHOOK_FAILURE);
             span.setTag('error', formattedError);
             return Err(formattedError);
         } finally {


### PR DESCRIPTION
This commit is changing the behavior of 3rd party webhooks. 
Nango will responds to the `/webhook` request immediately and not wait for the webhook script to execute. The webhook is also forwarded immediately
