### PR TITLE
fix(env): missing NANGO_PUBLIC_SERVER_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,7 @@ WORKER_PORT=3004
 # - Configure server full URL (current value is the default for running Nango locally).
 #
 NANGO_SERVER_URL=http://localhost:3003
+NANGO_PUBLIC_SERVER_URL=http://localhost:3000
 CSP_REPORT_ONLY=false
 # FLAG_AUTH_ENABLED=false
 #

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,6 +32,7 @@ services:
             - SERVER_PORT
             - CSP_REPORT_ONLY=true
             - NANGO_SERVER_URL=${NANGO_SERVER_URL:-http://localhost:3003}
+            - NANGO_PUBLIC_SERVER_URL=${NANGO_PUBLIC_SERVER_URL:-http://localhost:3000}
             - FLAG_AUTH_ENABLED
             - NANGO_DASHBOARD_USERNAME
             - NANGO_DASHBOARD_PASSWORD


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-3003/add-missing-nango-public-to-envexample

- missing NANGO_PUBLIC_SERVER_URL
Required to provide accurate CORS