### PR TITLE
feat(node-client): support sync_mode in triggerSync

### DIFF
--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -1,37 +1,10 @@
 import crypto from 'node:crypto';
-import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
-import axios from 'axios';
 import https from 'node:https';
 
-import type {
-    ApiKeyCredentials,
-    AppCredentials,
-    OAuth1Token,
-    AppStoreCredentials,
-    BasicApiCredentials,
-    CredentialsCommon,
-    CustomCredentials,
-    OAuth2ClientCredentials,
-    TbaCredentials,
-    TableauCredentials,
-    UnauthCredentials,
-    BillCredentials,
-    GetPublicProviders,
-    GetPublicProvider,
-    GetPublicListIntegrations,
-    GetPublicListIntegrationsLegacy,
-    GetPublicIntegration,
-    PostConnectSessions,
-    JwtCredentials,
-    TwoStepCredentials,
-    GetPublicConnections,
-    SignatureCredentials,
-    PostPublicConnectSessionsReconnect,
-    GetPublicConnection,
-    NangoRecord,
-    PostSyncVariant,
-    DeleteSyncVariant
-} from '@nangohq/types';
+import axios from 'axios';
+
+import { addQueryParams, getUserAgent, validateProxyConfiguration, validateSyncRecordConfiguration } from './utils.js';
+
 import type {
     CreateConnectionOAuth1,
     CreateConnectionOAuth2,
@@ -40,13 +13,43 @@ import type {
     ListRecordsRequestConfig,
     Metadata,
     MetadataChangeResponse,
-    StandardNangoConfig,
     NangoProps,
     ProxyConfiguration,
+    StandardNangoConfig,
     SyncStatusResponse,
     UpdateSyncFrequencyResponse
 } from './types.js';
-import { addQueryParams, getUserAgent, validateProxyConfiguration, validateSyncRecordConfiguration } from './utils.js';
+import type {
+    ApiKeyCredentials,
+    AppCredentials,
+    AppStoreCredentials,
+    BasicApiCredentials,
+    BillCredentials,
+    CredentialsCommon,
+    CustomCredentials,
+    DeleteSyncVariant,
+    GetPublicConnection,
+    GetPublicConnections,
+    GetPublicIntegration,
+    GetPublicListIntegrations,
+    GetPublicListIntegrationsLegacy,
+    GetPublicProvider,
+    GetPublicProviders,
+    JwtCredentials,
+    NangoRecord,
+    OAuth1Token,
+    OAuth2ClientCredentials,
+    PostConnectSessions,
+    PostPublicConnectSessionsReconnect,
+    PostPublicTrigger,
+    PostSyncVariant,
+    SignatureCredentials,
+    TableauCredentials,
+    TbaCredentials,
+    TwoStepCredentials,
+    UnauthCredentials
+} from '@nangohq/types';
+import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
 export const prodHost = 'https://api.nango.dev';
 
@@ -570,14 +573,14 @@ export class Nango {
      * @param providerConfigKey - The key identifying the provider configuration on Nango
      * @param syncs - An optional array of sync names or sync names/variants to trigger. If empty, all applicable syncs will be triggered
      * @param connectionId - An optional ID of the connection for which to trigger the syncs. If not provided, syncs will be triggered for all applicable connections
-     * @param fullResync - An optional flag indicating whether to perform a full resynchronization. Default is false
+     * @param syncMode - An optional flag indicating whether to perform an incremental or full resync. Defaults to 'incremental`
      * @returns A promise that resolves when the sync trigger request is sent
      */
     public async triggerSync(
         providerConfigKey: string,
         syncs?: (string | { name: string; variant: string })[],
         connectionId?: string,
-        fullResync?: boolean
+        syncMode?: PostPublicTrigger['Body']['sync_mode'] | boolean // boolean kept for backwards compatibility
     ): Promise<void> {
         const url = `${this.serverUrl}/sync/trigger`;
 
@@ -585,11 +588,17 @@ export class Nango {
             throw new Error('Syncs must be an array. If it is a single sync, please wrap it in an array.');
         }
 
+        if (typeof syncMode === 'boolean') {
+            syncMode = syncMode ? 'full_refresh' : 'incremental';
+        }
+
+        syncMode ??= 'incremental';
+
         const body = {
             syncs: syncs || [],
             provider_config_key: providerConfigKey,
             connection_id: connectionId,
-            full_resync: fullResync
+            sync_mode: syncMode
         };
 
         return this.http.post(url, body, { headers: this.enrichHeaders() });

--- a/packages/node-client/lib/index.unit.test.ts
+++ b/packages/node-client/lib/index.unit.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Nango } from './index.js';
+
+describe('triggerSync', () => {
+    const nango = new Nango({ secretKey: 'test' });
+    const mockHttp = {
+        post: vi.fn()
+    };
+    // @ts-expect-error - we're mocking the http instance
+    nango.http = mockHttp;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should handle sync_mode as a string', async () => {
+        await nango.triggerSync('test-provider', ['test-sync'], undefined, 'full_refresh');
+
+        expect(mockHttp.post).toHaveBeenCalledWith(
+            expect.any(String),
+            {
+                syncs: ['test-sync'],
+                provider_config_key: 'test-provider',
+                connection_id: undefined,
+                sync_mode: 'full_refresh'
+            },
+            expect.any(Object)
+        );
+    });
+
+    it('should handle sync_mode as a boolean (true)', async () => {
+        await nango.triggerSync('test-provider', ['test-sync'], undefined, true);
+
+        expect(mockHttp.post).toHaveBeenCalledWith(
+            expect.any(String),
+            {
+                syncs: ['test-sync'],
+                provider_config_key: 'test-provider',
+                connection_id: undefined,
+                sync_mode: 'full_refresh'
+            },
+            expect.any(Object)
+        );
+    });
+
+    it('should handle sync_mode as a boolean (false)', async () => {
+        await nango.triggerSync('test-provider', ['test-sync'], undefined, false);
+
+        expect(mockHttp.post).toHaveBeenCalledWith(
+            expect.any(String),
+            {
+                syncs: ['test-sync'],
+                provider_config_key: 'test-provider',
+                connection_id: undefined,
+                sync_mode: 'incremental'
+            },
+            expect.any(Object)
+        );
+    });
+
+    it('should default to incremental sync_mode when not provided', async () => {
+        await nango.triggerSync('test-provider', ['test-sync']);
+
+        expect(mockHttp.post).toHaveBeenCalledWith(
+            expect.any(String),
+            {
+                syncs: ['test-sync'],
+                provider_config_key: 'test-provider',
+                connection_id: undefined,
+                sync_mode: 'incremental'
+            },
+            expect.any(Object)
+        );
+    });
+});

--- a/packages/server/lib/controllers/sync/postTrigger.integration.test.ts
+++ b/packages/server/lib/controllers/sync/postTrigger.integration.test.ts
@@ -134,29 +134,6 @@ describe(`POST ${endpoint}`, () => {
                 }
             });
         });
-
-        it('should return 400 if connection_id is missing from body and headers', async () => {
-            const { env } = await seeders.seedAccountEnvAndUser();
-
-            const res = await api.fetch(endpoint, {
-                method: 'POST',
-                token: env.secret_key,
-                body: {
-                    syncs: ['sync1'],
-                    sync_mode: 'full_refresh',
-                    provider_config_key: 'test-key'
-                },
-                headers: {}
-            });
-
-            expect(res.res.status).toEqual(400);
-            expect(res.json).toStrictEqual({
-                error: {
-                    code: 'missing_connection_id',
-                    message: 'Missing connection_id. Provide it in the body or headers.'
-                }
-            });
-        });
     });
 
     it('should take provider_config_key and connection_id from headers', async () => {

--- a/packages/server/lib/controllers/sync/postTrigger.ts
+++ b/packages/server/lib/controllers/sync/postTrigger.ts
@@ -74,10 +74,6 @@ export const postPublicTrigger = asyncWrapper<PostPublicTrigger>(async (req, res
     }
 
     const connectionId: string | undefined = body.connection_id || headers['connection-id'];
-    if (!connectionId) {
-        res.status(400).send({ error: { code: 'missing_connection_id', message: 'Missing connection_id. Provide it in the body or headers.' } });
-        return;
-    }
 
     const { syncs, sync_mode, full_resync } = body;
 

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -1,19 +1,21 @@
-import { deleteSyncConfig, deleteSyncFilesForConfig, getSyncConfig, getSyncConfigByParams } from './config/config.service.js';
+import { getLogger, stringifyError } from '@nangohq/utils';
+
 import connectionService from '../connection.service.js';
+import { deleteSyncConfig, deleteSyncFilesForConfig, getSyncConfig, getSyncConfigByParams } from './config/config.service.js';
 import { getLatestSyncJob } from './job.service.js';
-import { createSync, getSyncsByConnectionId, getSyncsByProviderConfigKey, getSync, softDeleteSync, getSyncsBySyncConfigId } from './sync.service.js';
-import { errorNotificationService } from '../notification/error.service.js';
-import configService from '../config.service.js';
-import type { SyncWithConnectionId, ReportedSyncJobStatus, SyncCommand } from '../../models/Sync.js';
+import { createSync, getSync, getSyncsByConnectionId, getSyncsByProviderConfigKey, getSyncsBySyncConfigId, softDeleteSync } from './sync.service.js';
 import { SyncJobsType, SyncStatus } from '../../models/Sync.js';
 import { NangoError } from '../../utils/error.js';
-import type { Config as ProviderConfig } from '../../models/Provider.js';
-import type { ServiceResponse } from '../../models/Generic.js';
-import type { LogContext, LogContextGetter } from '@nangohq/logs';
-import { getLogger, stringifyError } from '@nangohq/utils';
+import configService from '../config.service.js';
 import environmentService from '../environment.service.js';
+import { errorNotificationService } from '../notification/error.service.js';
+
 import type { Orchestrator, RecordsServiceInterface } from '../../clients/orchestrator.js';
+import type { ServiceResponse } from '../../models/Generic.js';
 import type { NangoConfig, NangoIntegration, NangoIntegrationData } from '../../models/NangoConfig.js';
+import type { Config as ProviderConfig } from '../../models/Provider.js';
+import type { ReportedSyncJobStatus, SyncCommand, SyncWithConnectionId } from '../../models/Sync.js';
+import type { LogContext, LogContextGetter } from '@nangohq/logs';
 import type { CLIDeployFlowConfig, ConnectionInternal, DBConnection, DBConnectionDecrypted, DBEnvironment, SyncDeploymentResult } from '@nangohq/types';
 
 // Should be in "logs" package but impossible thanks to CLI
@@ -255,7 +257,7 @@ export class SyncManagerService {
         syncIdentifiers: { syncName: string; syncVariant: string }[];
         command: SyncCommand;
         logContextGetter: LogContextGetter;
-        connectionId?: string;
+        connectionId?: string | undefined;
         initiator: string;
         deleteRecords?: boolean;
     }): Promise<ServiceResponse<boolean>> {

--- a/packages/types/lib/sync/api.ts
+++ b/packages/types/lib/sync/api.ts
@@ -16,7 +16,7 @@ export type PostPublicTrigger = Endpoint<{
         'connection-id'?: string | undefined;
     };
     Success: { success: boolean };
-    Error: ApiError<'missing_provider_config_key' | 'missing_connection_id'>;
+    Error: ApiError<'missing_provider_config_key'>;
 }>;
 
 export type PostSyncVariant = Endpoint<{


### PR DESCRIPTION
<!-- Describe the problem and your solution -->
Replacing `full_resync` with `syncMode` in the node client while maintaining backwards compatibility.

<!-- Issue ticket number and link (if applicable) -->
[NAN-2964](https://linear.app/nango/issue/NAN-2964/triggers-sync-clear-cache-from-apisdk)

<!-- Testing instructions (skip if just adding/editing providers) -->

