### PR TITLE
fix: do not block request if rate limit cannot be computed

### DIFF
--- a/packages/server/lib/middleware/ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/ratelimit.middleware.ts
@@ -62,7 +62,8 @@ export const rateLimiterMiddleware = (req: Request, res: Response, next: NextFun
             }
 
             logger.error('Failed to compute rate limit', { error: err });
-            res.status(500).send({ error: { code: 'server_error', message: 'Failed to compute rate limit' } });
+            // If we can't get the rate limit (ex: redis is unreachable), we should not block the request
+            next();
         });
 };
 


### PR DESCRIPTION
As experienced recently, a redis outage would cause all requests made to Nango api and web to fail.
This commit changes the behavior to not block requests if rate limit cannot be computed, which will allow requests to dashboard and api to continue to be served even if redis isn't reachable 
Caveat: if Redis is down we don't have any rate-limit protection but it is better imho than to be fully down. wdyt?

