### PR TITLE
fix(api): make sync_mode optional in /sync/trigger

### DIFF
--- a/packages/server/lib/controllers/sync/postTrigger.integration.test.ts
+++ b/packages/server/lib/controllers/sync/postTrigger.integration.test.ts
@@ -164,7 +164,6 @@ describe(`POST ${endpoint}`, () => {
             token: env.secret_key,
             body: {
                 syncs: ['sync1', 'sync2'],
-                sync_mode: 'full_refresh',
                 provider_config_key: 'test-key',
                 connection_id: '123'
             },
@@ -174,7 +173,7 @@ describe(`POST ${endpoint}`, () => {
         expect(res.res.status).toEqual(200);
         expect(mockRunSyncCommand).toHaveBeenCalledWith(
             expect.objectContaining({
-                command: 'RUN_FULL',
+                command: 'RUN',
                 syncIdentifiers: [
                     { syncName: 'sync1', syncVariant: 'base' },
                     { syncName: 'sync2', syncVariant: 'base' }
@@ -194,7 +193,6 @@ describe(`POST ${endpoint}`, () => {
                     { name: 'sync1', variant: 'v1' },
                     { name: 'sync2', variant: 'v2' }
                 ],
-                sync_mode: 'full_refresh',
                 provider_config_key: 'test-key',
                 connection_id: '123'
             },
@@ -204,7 +202,7 @@ describe(`POST ${endpoint}`, () => {
         expect(res.res.status).toEqual(200);
         expect(mockRunSyncCommand).toHaveBeenCalledWith(
             expect.objectContaining({
-                command: 'RUN_FULL',
+                command: 'RUN',
                 syncIdentifiers: [
                     { syncName: 'sync1', syncVariant: 'v1' },
                     { syncName: 'sync2', syncVariant: 'v2' }

--- a/packages/server/lib/controllers/sync/postTrigger.integration.test.ts
+++ b/packages/server/lib/controllers/sync/postTrigger.integration.test.ts
@@ -83,35 +83,6 @@ describe(`POST ${endpoint}`, () => {
             });
         });
 
-        it('should return 400 if sync_mode and full_resync are missing', async () => {
-            const { env } = await seeders.seedAccountEnvAndUser();
-
-            const res = await api.fetch(endpoint, {
-                method: 'POST',
-                token: env.secret_key,
-                body: {
-                    syncs: ['sync1'],
-                    connection_id: '123',
-                    provider_config_key: 'test-key'
-                },
-                headers: {}
-            });
-
-            expect(res.res.status).toEqual(400);
-            expect(res.json).toStrictEqual({
-                error: {
-                    code: 'invalid_body',
-                    errors: [
-                        {
-                            code: 'custom',
-                            message: 'sync_mode is required',
-                            path: []
-                        }
-                    ]
-                }
-            });
-        });
-
         it('should return 400 if provider_config_key is missing from body and headers', async () => {
             const { env } = await seeders.seedAccountEnvAndUser();
 
@@ -144,7 +115,6 @@ describe(`POST ${endpoint}`, () => {
             token: env.secret_key,
             body: {
                 syncs: ['sync1'],
-                sync_mode: 'full_refresh',
                 connection_id: '123'
             },
             headers: {

--- a/packages/server/lib/controllers/sync/postTrigger.ts
+++ b/packages/server/lib/controllers/sync/postTrigger.ts
@@ -23,17 +23,7 @@ const bodyValidation = z
         connection_id: z.string().optional(),
         provider_config_key: z.string().optional()
     })
-    .strict()
-    // Either sync_mode or full_resync is required. Error message incentive to use sync_mode.
-    .refine(
-        (input) => {
-            if (input.sync_mode === undefined && input.full_resync === undefined) {
-                return false;
-            }
-            return true;
-        },
-        { message: 'sync_mode is required' }
-    );
+    .strict();
 
 const headersValidation = z.object({
     'provider-config-key': z.string().optional(),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
I failed to realize that `full_resync` was actually optional before. The refine to make one of them required is unnecessary and causing a breaking change.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

