### PR TITLE
chore: add billed records metrics

### DIFF
--- a/packages/persist/lib/records.ts
+++ b/packages/persist/lib/records.ts
@@ -133,6 +133,7 @@ export async function persistRecords({
             return acc;
         }, 0);
 
+        metrics.increment(metrics.Types.BILLED_RECORDS_COUNT, new Set(summary.billedKeys).size, { accountId });
         metrics.increment(metrics.Types.PERSIST_RECORDS_COUNT, records.length, { accountId });
         metrics.increment(metrics.Types.PERSIST_RECORDS_SIZE_IN_BYTES, recordsSizeInBytes, { accountId });
         metrics.increment(metrics.Types.PERSIST_RECORDS_MODIFIED_COUNT, allModifiedKeys.size, { accountId });

--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -73,6 +73,7 @@ describe('Records service', () => {
             addedKeys: expect.arrayContaining(['1', '2', '3', '4']),
             updatedKeys: [],
             deletedKeys: [],
+            billedKeys: expect.arrayContaining(['1', '2', '3', '4']),
             nonUniqueKeys: ['1'],
             nextMerging: { strategy: 'override' }
         });
@@ -85,9 +86,9 @@ describe('Records service', () => {
         expect(upserted).toStrictEqual({
             addedKeys: [],
             updatedKeys: ['2'],
+            billedKeys: [],
             deletedKeys: [],
             nonUniqueKeys: [],
-
             nextMerging: { strategy: 'override' }
         });
 
@@ -98,7 +99,14 @@ describe('Records service', () => {
         expect(after.find((r) => r.external_id === '4')?.sync_job_id).toBe(1);
 
         const updated = await updateRecords({ records: [{ id: '1', name: 'Maurice Doe' }], connectionId, model, syncId, syncJobId: 3 });
-        expect(updated).toStrictEqual({ addedKeys: [], updatedKeys: ['1'], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
+        expect(updated).toStrictEqual({
+            addedKeys: [],
+            updatedKeys: ['1'],
+            deletedKeys: [],
+            billedKeys: [],
+            nonUniqueKeys: [],
+            nextMerging: { strategy: 'override' }
+        });
     });
 
     describe('upserting records', () => {
@@ -120,6 +128,7 @@ describe('Records service', () => {
                     addedKeys: expect.arrayContaining(['1', '2', '3', '4']),
                     updatedKeys: [],
                     deletedKeys: [],
+                    billedKeys: expect.arrayContaining(['1', '2', '3', '4']),
                     nonUniqueKeys: ['1'],
                     nextMerging: { strategy: 'override' }
                 });
@@ -133,6 +142,7 @@ describe('Records service', () => {
                     addedKeys: [],
                     updatedKeys: ['2'],
                     deletedKeys: [],
+                    billedKeys: [],
                     nonUniqueKeys: [],
                     nextMerging: { strategy: 'override' }
                 });
@@ -170,6 +180,7 @@ describe('Records service', () => {
                     addedKeys: expect.arrayContaining(['1', '2', '3', '4']),
                     updatedKeys: [],
                     deletedKeys: [],
+                    billedKeys: expect.arrayContaining(['1', '2', '3', '4']),
                     nonUniqueKeys: [],
                     nextMerging: {
                         strategy: 'ignore_if_modified_after_cursor',
@@ -186,6 +197,7 @@ describe('Records service', () => {
                 expect(added).toStrictEqual({
                     addedKeys: ['5'],
                     updatedKeys: ['4'],
+                    billedKeys: ['5'],
                     deletedKeys: [],
                     nonUniqueKeys: [],
                     nextMerging: { strategy: 'override' }
@@ -210,6 +222,7 @@ describe('Records service', () => {
                     addedKeys: [],
                     updatedKeys: ['1'],
                     deletedKeys: [],
+                    billedKeys: [],
                     nonUniqueKeys: [],
                     nextMerging: {
                         strategy: 'ignore_if_modified_after_cursor',
@@ -259,6 +272,7 @@ describe('Records service', () => {
                     addedKeys: [],
                     updatedKeys: [],
                     deletedKeys: [],
+                    billedKeys: [],
                     nonUniqueKeys: [],
                     nextMerging: {
                         strategy: 'ignore_if_modified_after_cursor',
@@ -284,6 +298,7 @@ describe('Records service', () => {
                     addedKeys: [],
                     updatedKeys: ['3'],
                     deletedKeys: [],
+                    billedKeys: [],
                     nonUniqueKeys: [],
                     nextMerging: {
                         strategy: 'ignore_if_modified_after_cursor',
@@ -322,10 +337,18 @@ describe('Records service', () => {
                     updatedKeys: acc.updatedKeys.concat(curr.updatedKeys),
                     deletedKeys: (acc.deletedKeys || []).concat(curr.deletedKeys || []),
                     nonUniqueKeys: acc.nonUniqueKeys.concat(curr.nonUniqueKeys),
+                    billedKeys: acc.billedKeys.concat(curr.billedKeys),
                     nextMerging: curr.nextMerging
                 };
             });
-            expect(agg).toStrictEqual({ addedKeys: ['1'], updatedKeys: [], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
+            expect(agg).toStrictEqual({
+                addedKeys: ['1'],
+                updatedKeys: [],
+                deletedKeys: [],
+                billedKeys: ['1'],
+                nonUniqueKeys: [],
+                nextMerging: { strategy: 'override' }
+            });
         });
     });
 
@@ -342,6 +365,7 @@ describe('Records service', () => {
                 addedKeys: ['1'],
                 updatedKeys: [],
                 deletedKeys: [],
+                billedKeys: ['1'],
                 nonUniqueKeys: [],
                 nextMerging: {
                     strategy: 'override'
@@ -370,6 +394,7 @@ describe('Records service', () => {
                 addedKeys: [],
                 updatedKeys: ['1'],
                 deletedKeys: [],
+                billedKeys: [],
                 nonUniqueKeys: [],
                 nextMerging: {
                     strategy: 'override'
@@ -408,12 +433,20 @@ describe('Records service', () => {
                     addedKeys: expect.arrayContaining(['1', '2', '3', '4']),
                     updatedKeys: [],
                     deletedKeys: [],
+                    billedKeys: expect.arrayContaining(['1', '2', '3', '4']),
                     nonUniqueKeys: ['1'],
                     nextMerging: { strategy: 'override' }
                 });
 
                 const updated = await updateRecords({ records: [{ id: '1', name: 'Maurice Doe' }], connectionId, model, syncId, syncJobId: 2 });
-                expect(updated).toStrictEqual({ addedKeys: [], updatedKeys: ['1'], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
+                expect(updated).toStrictEqual({
+                    addedKeys: [],
+                    updatedKeys: ['1'],
+                    deletedKeys: [],
+                    billedKeys: [],
+                    nonUniqueKeys: [],
+                    nextMerging: { strategy: 'override' }
+                });
             });
             it('when strategy = ignore_if_modified_after_cursor', async () => {
                 const connectionId = rnd.number();
@@ -441,6 +474,7 @@ describe('Records service', () => {
                     addedKeys: expect.arrayContaining(['1', '2', '3', '4']),
                     updatedKeys: [],
                     deletedKeys: [],
+                    billedKeys: expect.arrayContaining(['1', '2', '3', '4']),
                     nonUniqueKeys: [],
                     nextMerging: {
                         strategy: 'ignore_if_modified_after_cursor',
@@ -456,7 +490,14 @@ describe('Records service', () => {
                     syncId,
                     syncJobId: 2
                 });
-                expect(updated).toStrictEqual({ addedKeys: [], updatedKeys: ['4'], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
+                expect(updated).toStrictEqual({
+                    addedKeys: [],
+                    updatedKeys: ['4'],
+                    deletedKeys: [],
+                    billedKeys: [],
+                    nonUniqueKeys: [],
+                    nextMerging: { strategy: 'override' }
+                });
 
                 // update records with merging strategy 'ignore_if_modified_after_cursor'
                 const upserted = await updateRecords({
@@ -476,6 +517,7 @@ describe('Records service', () => {
                     addedKeys: [],
                     updatedKeys: ['1'],
                     deletedKeys: [],
+                    billedKeys: [],
                     nonUniqueKeys: [],
                     nextMerging: { strategy: 'ignore_if_modified_after_cursor', cursor: nextCursor }
                 });
@@ -530,6 +572,7 @@ describe('Records service', () => {
             addedKeys: [],
             updatedKeys: [],
             deletedKeys: expect.arrayContaining(['1', '2']),
+            billedKeys: [],
             nonUniqueKeys: [],
             nextMerging: { strategy: 'override' }
         });
@@ -537,7 +580,14 @@ describe('Records service', () => {
         // Try to delete the same records again
         // Should not have any effect
         const res2 = await upsertRecords({ records: toDelete, connectionId, environmentId, model, syncId, softDelete: true });
-        expect(res2).toStrictEqual({ addedKeys: [], updatedKeys: [], deletedKeys: [], nonUniqueKeys: [], nextMerging: { strategy: 'override' } });
+        expect(res2).toStrictEqual({
+            addedKeys: [],
+            updatedKeys: [],
+            deletedKeys: [],
+            billedKeys: [],
+            nonUniqueKeys: [],
+            nextMerging: { strategy: 'override' }
+        });
     });
 
     describe('getRecords', () => {

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -405,13 +405,12 @@ export async function upsert({
                 // A record is billed only once per month. ie:
                 // - If a record is inserted, it is billed
                 // - If a record is updated, it is billed if it has not been billed yet during the current month
-                // - If a record is undeleted, it is billed if it has not been billed yet during the current month
-                // - If a record is deleted, it is billed if it has not been billed yet during the current month
+                // - If a record is undeleted, it is not billed
+                // - If a record is deleted, it is not billed
 
                 if (softDelete) {
                     const deleted = res.filter((r) => r.status === 'deleted');
                     summary.deletedKeys?.push(...deleted.map((r) => r.external_id));
-                    summary.billedKeys.push(...billable(deleted).map((r) => r.external_id));
                 } else {
                     const undeletedRes = res.filter((r) => r.status === 'undeleted');
                     const changedRes = res.filter((r) => r.status === 'changed');
@@ -420,7 +419,7 @@ export async function upsert({
                     const undeletedKeys = undeletedRes.map((r) => r.external_id);
                     const addedKeys = insertedKeys.concat(undeletedKeys);
                     const updatedKeys = changedRes.map((r) => r.external_id);
-                    const billableKeys = [...insertedKeys, ...billable([...changedRes, ...undeletedRes]).map((r) => r.external_id)];
+                    const billableKeys = [...insertedKeys, ...billable(changedRes).map((r) => r.external_id)];
 
                     summary.addedKeys.push(...addedKeys);
                     summary.updatedKeys.push(...updatedKeys);

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -26,6 +26,25 @@ dayjs.extend(utc);
 
 const BATCH_SIZE = 1000;
 
+interface UpsertResult {
+    external_id: string;
+    id: string;
+    last_modified_at: string;
+    previous_last_modified_at: string | null;
+    status: 'inserted' | 'changed' | 'undeleted' | 'deleted' | 'unchanged';
+}
+
+function billable(records: UpsertResult[]): UpsertResult[] {
+    return records.filter((r) => {
+        if (!r.previous_last_modified_at) {
+            return true;
+        }
+        const firstDayOfMonth = dayjs().utc().startOf('month');
+        const previousLastModifiedAt = dayjs(r.previous_last_modified_at).utc();
+        return previousLastModifiedAt.isBefore(firstDayOfMonth);
+    });
+}
+
 export async function getRecordCountsByModel({
     connectionId,
     environmentId
@@ -295,7 +314,7 @@ export async function upsert({
         );
     }
 
-    const summary: UpsertSummary = { addedKeys: [], updatedKeys: [], deletedKeys: [], nonUniqueKeys, nextMerging: merging };
+    const summary: UpsertSummary = { addedKeys: [], updatedKeys: [], deletedKeys: [], nonUniqueKeys, nextMerging: merging, billedKeys: [] };
     try {
         await db.transaction(async (trx) => {
             // Lock to prevent concurrent upserts
@@ -320,19 +339,12 @@ export async function upsert({
                     });
                 };
 
-                interface UpsertResult {
-                    external_id: string;
-                    id: string;
-                    last_modified_at: string;
-                    status: 'inserted' | 'changed' | 'undeleted' | 'deleted' | 'unchanged';
-                }
-
                 // we need to know which records were updated, deleted, undeleted or unchanged
                 // we achieve this by comparing the records data_hash and deleted_at fields before and after the update
                 const externalIds = chunk.map((r) => r.external_id);
                 const query = trx
                     .with('existing', (qb) => {
-                        qb.select('external_id', 'data_hash', 'deleted_at')
+                        qb.select('external_id', 'data_hash', 'deleted_at', 'updated_at')
                             .from(RECORDS_TABLE)
                             .where({
                                 connection_id: connectionId,
@@ -362,6 +374,10 @@ export async function upsert({
                             upsert.external_id as external_id,
                             to_json(upsert.updated_at) as last_modified_at,
                             CASE
+                              WHEN existing.updated_at IS NULL THEN NULL
+                              ELSE to_json(existing.updated_at)
+                            END as previous_last_modified_at,
+                            CASE
                                 WHEN existing.external_id IS NULL THEN 'inserted'
                                 ELSE
                                     CASE
@@ -375,21 +391,36 @@ export async function upsert({
                     .from('upsert')
                     .leftJoin('existing', 'upsert.external_id', 'existing.external_id')
                     .orderBy([
-                        { column: 'updated_at', order: 'asc' },
-                        { column: 'id', order: 'asc' }
+                        { column: 'upsert.updated_at', order: 'asc' },
+                        { column: 'upsert.id', order: 'asc' }
                     ]);
-                const updatedRes = await withRetry(query);
 
-                const inserted = updatedRes.filter((r) => r.status === 'inserted').map((r) => r.external_id);
-                const undeleted = updatedRes.filter((r) => r.status === 'undeleted').map((r) => r.external_id);
-                const deleted = updatedRes.filter((r) => r.status === 'deleted').map((r) => r.external_id);
-                const updated = updatedRes.filter((r) => r.status === 'changed').map((r) => r.external_id);
+                const res = await withRetry(query);
+
+                // Billing:
+                // A record is billed only once per month. ie:
+                // - If a record is inserted, it is billed
+                // - If a record is updated, it is billed if it has not been billed yet during the current month
+                // - If a record is undeleted, it is billed if it has not been billed yet during the current month
+                // - If a record is deleted, it is billed if it has not been billed yet during the current month
 
                 if (softDelete) {
-                    summary.deletedKeys?.push(...deleted);
+                    const deleted = res.filter((r) => r.status === 'deleted');
+                    summary.deletedKeys?.push(...deleted.map((r) => r.external_id));
+                    summary.billedKeys.push(...billable(deleted).map((r) => r.external_id));
                 } else {
-                    summary.addedKeys.push(...inserted.concat(undeleted));
-                    summary.updatedKeys.push(...updated);
+                    const undeletedRes = res.filter((r) => r.status === 'undeleted');
+                    const changedRes = res.filter((r) => r.status === 'changed');
+
+                    const insertedKeys = res.filter((r) => r.status === 'inserted').map((r) => r.external_id);
+                    const undeletedKeys = undeletedRes.map((r) => r.external_id);
+                    const addedKeys = insertedKeys.concat(undeletedKeys);
+                    const updatedKeys = changedRes.map((r) => r.external_id);
+                    const billableKeys = [...insertedKeys, ...billable([...changedRes, ...undeletedRes]).map((r) => r.external_id)];
+
+                    summary.addedKeys.push(...addedKeys);
+                    summary.updatedKeys.push(...updatedKeys);
+                    summary.billedKeys.push(...billableKeys);
                 }
 
                 if (merging.strategy === 'ignore_if_modified_after_cursor') {
@@ -402,7 +433,7 @@ export async function upsert({
                         }
                         return undefined;
                     };
-                    const lastRecord = getLastModifiedRecord(updatedRes);
+                    const lastRecord = getLastModifiedRecord(res);
                     if (lastRecord) {
                         summary.nextMerging = {
                             strategy: merging.strategy,
@@ -476,6 +507,7 @@ export async function update({
 
     try {
         const updatedKeys: string[] = [];
+        const billedKeys: string[] = [];
         await db.transaction(async (trx) => {
             // Lock to prevent concurrent updates
             await trx.raw(`SELECT pg_advisory_xact_lock(?) as lock_records_update`, [newLockId(connectionId, model)]);
@@ -545,6 +577,17 @@ export async function update({
                     const updated = await query;
                     updatedKeys.push(...updated.map((record) => record.external_id));
 
+                    const firstUpdateThisMonth = updated.filter((r) => {
+                        const firstDayOfMonth = dayjs().startOf('month').toDate();
+                        const oldRecord = oldRecords.find((old) => old.external_id === r.external_id);
+                        if (!oldRecord) {
+                            return false;
+                        }
+                        const previousLastModifiedAt = dayjs(oldRecord.updated_at);
+                        return previousLastModifiedAt.isBefore(firstDayOfMonth);
+                    });
+                    billedKeys.push(...firstUpdateThisMonth.map((r) => r.external_id));
+
                     const lastRecord = updated[updated.length - 1];
                     if (merging.strategy === 'ignore_if_modified_after_cursor' && lastRecord) {
                         nextMerging = {
@@ -559,6 +602,7 @@ export async function update({
             addedKeys: [],
             updatedKeys,
             deletedKeys: [],
+            billedKeys,
             nonUniqueKeys,
             nextMerging
         });

--- a/packages/records/lib/types.ts
+++ b/packages/records/lib/types.ts
@@ -57,6 +57,7 @@ export interface UpsertSummary {
     addedKeys: string[];
     updatedKeys: string[];
     deletedKeys?: string[];
+    billedKeys: string[];
     nonUniqueKeys: string[];
     nextMerging: MergingStrategy;
 }

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -20,6 +20,7 @@ export enum Types {
     JOBS_DELETE_OLD_DATA = 'nango.jobs.cron.deleteOldData',
 
     LOGS_LOG = 'nango.logs.log',
+    BILLED_RECORDS_COUNT = 'nango.billed.records.count',
     PERSIST_RECORDS_COUNT = 'nango.persist.records.count',
     PERSIST_RECORDS_SIZE_IN_BYTES = 'nango.persist.records.sizeInBytes',
     PERSIST_RECORDS_MODIFIED_COUNT = 'nango.persist.records.modified.count',


### PR DESCRIPTION
Latest iteration of the records billing is as follow: The same record is accounted for billing only once during a calendar month, which means:
- inserted records are billed
- updated records are billed if they were not inserted/updated in the same calendar month
- deleted records are billed if they were not inserted/updated in the same calendar month
- undeleted records are billed if they were not inserted/updated in the same calendar month

