### PR TITLE
feat(webhooks): webhook env var injected primary URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,3 +112,7 @@ NANGO_PUBLIC_CONNECT_URL=
 # Only relevant for self-hosted
 NANGO_CONNECT_UI_PORT=3009
 FLAG_SERVE_CONNECT_UI=true
+
+# Override webhook primary URL for a specific environment
+# NANGO_WEBHOOK_PRIMARY_URL_PROD=https://example_env_prod.com/webook_from_nango_prod
+# NANGO_WEBHOOK_PRIMARY_URL_DEV=https://example_env_dev.com/webook_from_nango_dev

--- a/packages/shared/lib/services/external-webhook.service.ts
+++ b/packages/shared/lib/services/external-webhook.service.ts
@@ -1,7 +1,7 @@
 import db from '@nangohq/database';
 import type { DBExternalWebhook, DBEnvironment } from '@nangohq/types';
 
-export async function get(id: number): Promise<Omit<DBExternalWebhook, 'id'> | null> {
+export async function get(id: number): Promise<DBExternalWebhook | null> {
     // First, get the environment information so we can check if there is a related env var by its name
     const environment = await db.knex.select('name').from<DBEnvironment>('_nango_environments').where({ id }).first();
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Problem:
We are self-hosting Nango and as part of the [public key deprecation](https://docs.nango.dev/guides/api-authorization/public-key-deprecation) we have set up webhooks but we do not want to have to [go into each customer instance to define the primary webhook URL](https://docs.nango.dev/guides/webhooks/webhooks-from-nango#configuring-nango-webhooks) and instead we would like to just configure it via environment variables (similar to how we can override the secret keys via env vars NANGO_SECRET_KEY_PROD and NANGO_PUBLIC_KEY_PROD).

Solution:
Within the existing external-webhook.service, obtain the environment from the database using the id, so we can use the name to, check if a related env var is defined for using as the primary url.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->
Testing:
Simply set env var for a named environment (e.g. NANGO_WEBHOOK_PRIMARY_URL_PROD=https://example_env_prod.com/webook_from_nango_prod) and then see if the UI display it and that any webhooks requests are sent to it accordingly. 
