### PR TITLE
fix: webhook response

### DIFF
--- a/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
+++ b/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
@@ -66,9 +66,13 @@ export const postWebhook = asyncWrapper<PostPublicWebhook>(async (req, res) => {
 
             metrics.increment(metrics.Types.WEBHOOK_INCOMING_RECEIVED);
 
-            await routeWebhook({ environment, account, integration, headers, body: req.body, rawBody: req.rawBody!, logContextGetter });
+            const response = await routeWebhook({ environment, account, integration, headers, body: req.body, rawBody: req.rawBody!, logContextGetter });
 
-            res.status(200).send();
+            if (!response) {
+                res.status(200).send();
+                return;
+            }
+            res.status(200).send(response);
         } catch (err) {
             span.setTag('nango.error', err);
 


### PR DESCRIPTION
In some cases the webhook must responds with some data. For example the Slack verification challenge https://github.com/NangoHQ/nango/blob/6f5fd8970e82673a708055a47e436541a813159d/packages/server/lib/webhook/slack-webhook-routing.ts#L19

It was recently broken by this commit https://github.com/NangoHQ/nango/commit/3d0e82cb7d46bdf728a416d9c1ac4e6ec08e4734#diff-321ff59880f5539a1ef95b82922f6d17faf82eb08c9998bd7aec141aea56c2ed
