### PR TITLE
fix(api): GET /api/v1/integrations new format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6040,10 +6040,6 @@
             "resolved": "scripts",
             "link": true
         },
-        "node_modules/@nangohq/server": {
-            "resolved": "packages/server",
-            "link": true
-        },
         "node_modules/@nangohq/shared": {
             "resolved": "packages/shared",
             "link": true
@@ -39709,7 +39705,6 @@
                 "@mantine/core": "7.12.1",
                 "@mantine/prism": "5.10.5",
                 "@nangohq/frontend": "0.58.1",
-                "@nangohq/server": "file:../server",
                 "@nangohq/types": "file:../types",
                 "@radix-ui/react-accordion": "1.2.2",
                 "@radix-ui/react-avatar": "1.1.2",

--- a/packages/server/lib/controllers/config.controller.ts
+++ b/packages/server/lib/controllers/config.controller.ts
@@ -1,42 +1,26 @@
-import type { NextFunction, Request, Response } from 'express';
 import crypto from 'crypto';
-import type { Config as ProviderConfig, IntegrationWithCreds, Integration as ProviderIntegration } from '@nangohq/shared';
-import { isHosted } from '@nangohq/utils';
-import type { AuthModeType, NangoSyncConfig, ProviderTwoStep, StandardNangoConfig } from '@nangohq/types';
+
 import {
-    flowService,
-    errorManager,
+    AnalyticsTypes,
     NangoError,
     analytics,
-    AnalyticsTypes,
     configService,
     connectionService,
-    getUniqueSyncsByProviderConfig,
+    errorManager,
+    flowService,
     getActionsByProviderConfigKey,
-    getFlowConfigsByParams,
     getGlobalWebhookReceiveUrl,
-    getSyncConfigsAsStandardConfig,
     getProvider,
-    getProviders
+    getProviders,
+    getSyncConfigsAsStandardConfig,
+    getUniqueSyncsByProviderConfig
 } from '@nangohq/shared';
-import { parseConnectionConfigParamsFromTemplate, parseCredentialsParamsFromTemplate } from '../utils/utils.js';
+import { isHosted } from '@nangohq/utils';
+
 import type { RequestLocals } from '../utils/express.js';
-
-export interface Integration {
-    authMode: AuthModeType;
-    uniqueKey: string;
-    provider: string;
-    connection_count: number;
-    scripts: number;
-    creationDate: Date | undefined;
-    connectionConfigParams?: string[];
-    credentialParams?: string[];
-    missing_fields_count: number;
-}
-
-export interface ListIntegration {
-    integrations: Integration[];
-}
+import type { Config as ProviderConfig, Integration as ProviderIntegration, IntegrationWithCreds } from '@nangohq/shared';
+import type { NangoSyncConfig, StandardNangoConfig } from '@nangohq/types';
+import type { NextFunction, Request, Response } from 'express';
 
 interface FlowConfigs {
     enabledFlows: NangoSyncConfig[];
@@ -111,56 +95,6 @@ const getEnabledAndDisabledFlows = (publicFlows: StandardNangoConfig, allFlows: 
 };
 
 class ConfigController {
-    /**
-     * Webapp
-     */
-
-    async listProviderConfigsWeb(_: Request, res: Response<ListIntegration, Required<RequestLocals>>, next: NextFunction) {
-        try {
-            const { environment } = res.locals;
-
-            const configs = await configService.listIntegrationForApi(environment.id);
-
-            const integrations = await Promise.all(
-                configs.map(async (config) => {
-                    const provider = getProvider(config.provider);
-                    const activeFlows = await getFlowConfigsByParams(environment.id, config.unique_key);
-
-                    const integration: Integration = {
-                        authMode: provider?.auth_mode || 'APP',
-                        uniqueKey: config.unique_key,
-                        provider: config.provider,
-                        scripts: activeFlows.length,
-                        connection_count: Number(config.connection_count),
-                        creationDate: config.created_at,
-                        missing_fields_count: config.missing_fields.length
-                    };
-
-                    // Used by legacy connection create
-                    // TODO: remove this
-                    if (provider) {
-                        if (provider.auth_mode !== 'APP' && provider.auth_mode !== 'CUSTOM') {
-                            integration['connectionConfigParams'] = parseConnectionConfigParamsFromTemplate(provider);
-                        }
-
-                        // Check if provider is of type ProviderTwoStep
-                        if (provider.auth_mode === 'TWO_STEP') {
-                            integration['credentialParams'] = parseCredentialsParamsFromTemplate(provider as ProviderTwoStep);
-                        }
-                    }
-
-                    return integration;
-                })
-            );
-
-            res.status(200).send({
-                integrations: integrations
-            });
-        } catch (err) {
-            next(err);
-        }
-    }
-
     listProvidersFromYaml(_: Request, res: Response<any, Required<RequestLocals>>) {
         const providers = getProviders();
         if (!providers) {

--- a/packages/server/lib/controllers/v1/integrations/getIintegrations.ts
+++ b/packages/server/lib/controllers/v1/integrations/getIintegrations.ts
@@ -1,0 +1,57 @@
+import { configService, countSyncConfigByConfigId, getProvider } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { integrationToApi } from '../../../formatters/integration.js';
+import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { parseConnectionConfigParamsFromTemplate, parseCredentialsParamsFromTemplate } from '../../../utils/utils.js';
+
+import type { ApiIntegrationList, GetIntegrations, ProviderTwoStep } from '@nangohq/types';
+
+export const getIntegrations = asyncWrapper<GetIntegrations>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req, { withEnv: true });
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const { environment } = res.locals;
+
+    const configs = await configService.listIntegrationForApi(environment.id);
+
+    const integrations = await Promise.all(
+        configs.map(async (config) => {
+            const provider = getProvider(config.provider)!;
+            const activeFlows = await countSyncConfigByConfigId(environment.id, config.id!);
+
+            const integration: ApiIntegrationList = {
+                ...integrationToApi(config),
+                meta: {
+                    authMode: provider.auth_mode,
+                    scriptsCount: Number(activeFlows.count),
+                    connectionCount: Number(config.connection_count),
+                    creationDate: config.created_at.toISOString(),
+                    missingFieldsCount: config.missing_fields.length
+                }
+            };
+
+            // Used by legacy connection create
+            // TODO: remove this when we remove CreateLegacy.tsx
+            if (provider) {
+                if (provider.auth_mode !== 'APP' && provider.auth_mode !== 'CUSTOM') {
+                    integration.meta['connectionConfigParams'] = parseConnectionConfigParamsFromTemplate(provider);
+                }
+
+                // Check if provider is of type ProviderTwoStep
+                if (provider.auth_mode === 'TWO_STEP') {
+                    integration.meta['credentialParams'] = parseCredentialsParamsFromTemplate(provider as ProviderTwoStep);
+                }
+            }
+
+            return integration;
+        })
+    );
+
+    res.status(200).send({
+        data: integrations
+    });
+});

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/deleteIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/deleteIntegration.ts
@@ -1,10 +1,11 @@
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
-import type { DeleteIntegration } from '@nangohq/types';
 import { configService } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { getOrchestrator } from '../../../../utils/utils.js';
 import { validationParams } from './getIntegration.js';
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { getOrchestrator } from '../../../../utils/utils.js';
+
+import type { DeleteIntegration } from '@nangohq/types';
 
 const orchestrator = getOrchestrator();
 

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/flows/getFlows.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/flows/getFlows.ts
@@ -1,8 +1,10 @@
-import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
-import type { GetIntegration, GetIntegrationFlows, NangoSyncConfig } from '@nangohq/types';
 import { configService, flowService, getSyncConfigsAsStandardConfig } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
 import { validationParams } from '../getIntegration.js';
+
+import type { GetIntegration, GetIntegrationFlows, NangoSyncConfig } from '@nangohq/types';
 
 export const getIntegrationFlows = asyncWrapper<GetIntegrationFlows>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
@@ -1,11 +1,13 @@
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
-import type { PatchIntegration } from '@nangohq/types';
-import { configService, connectionService } from '@nangohq/shared';
 import { z } from 'zod';
 
-import { providerConfigKeySchema } from '../../../../helpers/validation.js';
+import { configService, connectionService } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
 import { validationParams } from './getIntegration.js';
+import { providerConfigKeySchema } from '../../../../helpers/validation.js';
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+
+import type { PatchIntegration } from '@nangohq/types';
 
 const privateKey = z.string().startsWith('-----BEGIN RSA PRIVATE KEY----').endsWith('-----END RSA PRIVATE KEY-----');
 const validationBody = z

--- a/packages/server/lib/index.ts
+++ b/packages/server/lib/index.ts
@@ -1,1 +1,0 @@
-export type { Integration, ListIntegration } from './controllers/config.controller.js';

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -43,6 +43,7 @@ import { patchFlowEnable } from './controllers/v1/flows/id/patchEnable.js';
 import { patchFlowFrequency } from './controllers/v1/flows/id/patchFrequency.js';
 import { postPreBuiltDeploy } from './controllers/v1/flows/preBuilt/postDeploy.js';
 import { putUpgradePreBuilt } from './controllers/v1/flows/preBuilt/putUpgrade.js';
+import { getIntegrations } from './controllers/v1/integrations/getIintegrations.js';
 import { postIntegration } from './controllers/v1/integrations/postIntegration.js';
 import { deleteIntegration } from './controllers/v1/integrations/providerConfigKey/deleteIntegration.js';
 import { getIntegrationFlows } from './controllers/v1/integrations/providerConfigKey/flows/getFlows.js';
@@ -150,7 +151,7 @@ web.route('/environment/admin-auth').get(webAuth, environmentController.getAdmin
 
 web.route('/connect/sessions').post(webAuth, postInternalConnectSessions);
 
-web.route('/integrations').get(webAuth, configController.listProviderConfigsWeb.bind(configController));
+web.route('/integrations').get(webAuth, getIntegrations);
 web.route('/integrations').post(webAuth, postIntegration);
 web.route('/integrations/:providerConfigKey').get(webAuth, getIntegration);
 web.route('/integrations/:providerConfigKey').patch(webAuth, patchIntegration);

--- a/packages/shared/lib/services/sync/config/config.service.ts
+++ b/packages/shared/lib/services/sync/config/config.service.ts
@@ -1,12 +1,15 @@
 import semver from 'semver';
-import db, { schema, dbNamespace } from '@nangohq/database';
+
+import db, { dbNamespace, schema } from '@nangohq/database';
+
+import { LogActionEnum } from '../../../models/Telemetry.js';
+import errorManager, { ErrorSourceEnum } from '../../../utils/error.manager.js';
 import configService from '../../config.service.js';
 import remoteFileService from '../../file/remote.service.js';
-import type { Action, SyncConfigWithProvider } from '../../../models/Sync.js';
-import { LogActionEnum } from '../../../models/Telemetry.js';
-import type { Config as ProviderConfig } from '../../../models/Provider.js';
+
 import type { NangoConfigV1 } from '../../../models/NangoConfig.js';
-import errorManager, { ErrorSourceEnum } from '../../../utils/error.manager.js';
+import type { Config as ProviderConfig } from '../../../models/Provider.js';
+import type { Action, SyncConfigWithProvider } from '../../../models/Sync.js';
 import type { DBConnection, DBSyncConfig, NangoSyncConfig, NangoSyncEndpointV2, SlimSync, StandardNangoConfig } from '@nangohq/types';
 
 const TABLE = dbNamespace + 'sync_configs';
@@ -160,16 +163,10 @@ export async function getSyncConfigsByConfigId(environment_id: number, nango_con
     return null;
 }
 
-export async function getFlowConfigsByParams(environment_id: number, providerConfigKey: string): Promise<DBSyncConfig[]> {
-    const config = await configService.getProviderConfig(providerConfigKey, environment_id);
-
-    if (!config) {
-        throw new Error('Provider config not found');
-    }
-
-    const result = await db.knex.from<DBSyncConfig>(TABLE).select<DBSyncConfig[]>('*').where({
-        environment_id,
-        nango_config_id: config.id!,
+export async function countSyncConfigByConfigId(environmentId: number, configId: number): Promise<{ count: string }> {
+    const result = await db.knex.from<DBSyncConfig>(TABLE).count<{ count: string }>('*').where({
+        environment_id: environmentId,
+        nango_config_id: configId,
         active: true,
         deleted: false
     });

--- a/packages/shared/lib/services/sync/config/config.service.ts
+++ b/packages/shared/lib/services/sync/config/config.service.ts
@@ -163,13 +163,16 @@ export async function getSyncConfigsByConfigId(environment_id: number, nango_con
     return null;
 }
 
-export async function countSyncConfigByConfigId(environmentId: number, configId: number): Promise<{ count: string }> {
-    const result = await db.knex.from<DBSyncConfig>(TABLE).count<{ count: string }>('*').where({
-        environment_id: environmentId,
-        nango_config_id: configId,
-        active: true,
-        deleted: false
-    });
+export async function countSyncConfigByConfigId(environmentId: number): Promise<{ nango_config_id: number; count: string }[]> {
+    const result = await db.knex
+        .from<DBSyncConfig>(TABLE)
+        .select<{ nango_config_id: number; count: string }[]>('nango_config_id', db.knex.raw('COUNT(1) as count'))
+        .where({
+            environment_id: environmentId,
+            active: true,
+            deleted: false
+        })
+        .groupBy('nango_config_id');
 
     return result;
 }

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -1,9 +1,9 @@
-import type { Merge } from 'type-fest';
 import type { ApiTimestamps, Endpoint } from '../api';
 import type { IntegrationConfig } from './db';
-import type { Provider } from '../providers/provider';
 import type { AuthModeType, AuthModes } from '../auth/api';
 import type { NangoSyncConfig } from '../flow';
+import type { Provider } from '../providers/provider';
+import type { Merge } from 'type-fest';
 
 export type ApiPublicIntegration = Merge<Pick<IntegrationConfig, 'created_at' | 'updated_at' | 'unique_key' | 'provider'>, ApiTimestamps> & {
     logo: string;
@@ -50,12 +50,23 @@ export type DeletePublicIntegration = Endpoint<{
 }>;
 
 export type ApiIntegration = Omit<Merge<IntegrationConfig, ApiTimestamps>, 'oauth_client_secret_iv' | 'oauth_client_secret_tag'>;
+export type ApiIntegrationList = ApiIntegration & {
+    meta: {
+        authMode: AuthModeType;
+        scriptsCount: number;
+        connectionCount: number;
+        creationDate: string;
+        missingFieldsCount: number;
+        connectionConfigParams?: string[];
+        credentialParams?: string[];
+    };
+};
 
 export type GetIntegrations = Endpoint<{
     Method: 'GET';
     Path: '/api/v1/integrations';
     Success: {
-        data: ApiIntegration[];
+        data: ApiIntegrationList[];
     };
 }>;
 

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -27,7 +27,6 @@
         "@mantine/core": "7.12.1",
         "@mantine/prism": "5.10.5",
         "@nangohq/frontend": "0.58.1",
-        "@nangohq/server": "file:../server",
         "@nangohq/types": "file:../types",
         "@radix-ui/react-accordion": "1.2.2",
         "@radix-ui/react-avatar": "1.1.2",

--- a/packages/webapp/src/hooks/useIntegration.tsx
+++ b/packages/webapp/src/hooks/useIntegration.tsx
@@ -1,23 +1,26 @@
-import type { Cache, useSWRConfig } from 'swr';
 import useSWR from 'swr';
-import type { ListIntegration } from '@nangohq/server';
-import type { SWRError } from '../utils/api';
+
 import { apiFetch, swrFetcher } from '../utils/api';
-import type { DeleteIntegration, GetIntegration, GetIntegrationFlows, PatchIntegration, PostIntegration } from '@nangohq/types';
+
+import type { SWRError } from '../utils/api';
+import type { DeleteIntegration, GetIntegration, GetIntegrationFlows, GetIntegrations, PatchIntegration, PostIntegration } from '@nangohq/types';
+import type { Cache, useSWRConfig } from 'swr';
 
 function integrationsPath(env: string) {
     return `/api/v1/integrations?env=${env}`;
 }
 
 export function useListIntegration(env: string) {
-    const { data, error, mutate } = useSWR<ListIntegration>(integrationsPath(env), swrFetcher, { refreshInterval: 15000 });
+    const { data, error, mutate } = useSWR<GetIntegrations['Success'], SWRError<GetIntegrations['Errors']>>(integrationsPath(env), swrFetcher, {
+        refreshInterval: 15000
+    });
 
     const loading = !data && !error;
 
     return {
         loading,
         error,
-        list: data,
+        list: data?.data,
         mutate
     };
 }

--- a/packages/webapp/src/pages/Connection/Create.tsx
+++ b/packages/webapp/src/pages/Connection/Create.tsx
@@ -29,7 +29,7 @@ import { globalEnv } from '../../utils/env';
 import { cn } from '../../utils/utils';
 
 import type { AuthResult, ConnectUI, OnConnectEvent } from '@nangohq/frontend';
-import type { Integration } from '@nangohq/server';
+import type { ApiIntegrationList } from '@nangohq/types';
 
 export const ConnectionCreate: React.FC = () => {
     const toast = useToast();
@@ -47,7 +47,7 @@ export const ConnectionCreate: React.FC = () => {
     const { list: listIntegration, mutate: listIntegrationMutate, loading } = useListIntegration(env);
 
     const [open, setOpen] = useState(false);
-    const [integration, setIntegration] = useState<Integration>();
+    const [integration, setIntegration] = useState<ApiIntegrationList>();
     const [testUserEmail, setTestUserEmail] = useState(user!.email);
     const [testUserId, setTestUserId] = useState(`test_${user!.name.toLocaleLowerCase().replaceAll(' ', '_')}`);
     const [testUserName, setTestUserName] = useState(user!.name);
@@ -66,7 +66,7 @@ export const ConnectionCreate: React.FC = () => {
                 void listIntegrationMutate();
                 if (hasConnected.current) {
                     toast.toast({ title: `Connected to ${hasConnected.current.providerConfigKey}`, variant: 'success' });
-                    navigate(`/${env}/connections/${integration?.uniqueKey}/${hasConnected.current.connectionId}`);
+                    navigate(`/${env}/connections/${integration?.unique_key}/${hasConnected.current.connectionId}`);
                 }
             } else if (event.type === 'connect') {
                 void listIntegrationMutate();
@@ -98,7 +98,7 @@ export const ConnectionCreate: React.FC = () => {
         //   instead of blocking the main loop and no visual clue for the end user
         setTimeout(async () => {
             const res = await apiConnectSessions(env, {
-                allowed_integrations: integration ? [integration.uniqueKey] : undefined,
+                allowed_integrations: integration ? [integration.unique_key] : undefined,
                 end_user: { id: testUserId, email: testUserEmail, display_name: testUserName },
                 organization: testOrgId ? { id: testOrgId, display_name: testOrgName } : undefined
             });
@@ -110,8 +110,8 @@ export const ConnectionCreate: React.FC = () => {
     };
 
     useEffect(() => {
-        if (paramIntegrationId && listIntegration?.integrations) {
-            const exists = listIntegration.integrations.find((v) => v.uniqueKey === paramIntegrationId);
+        if (paramIntegrationId && listIntegration) {
+            const exists = listIntegration.find((v) => v.unique_key === paramIntegrationId);
             if (exists) {
                 setIntegration(exists);
             }
@@ -161,7 +161,7 @@ export const ConnectionCreate: React.FC = () => {
                                         >
                                             {integration ? (
                                                 <div className="flex gap-3">
-                                                    <IntegrationLogo provider={integration.provider} /> {integration.uniqueKey}
+                                                    <IntegrationLogo provider={integration.provider} /> {integration.unique_key}
                                                 </div>
                                             ) : (
                                                 'Choose from the list'
@@ -183,17 +183,17 @@ export const ConnectionCreate: React.FC = () => {
                                             <CommandList className="max-h-[400px]">
                                                 <CommandEmpty>No integrations found.</CommandEmpty>
                                                 <CommandGroup className="px-0">
-                                                    {listIntegration?.integrations.map((item) => {
-                                                        const checked = integration && item.uniqueKey === integration.uniqueKey;
+                                                    {listIntegration?.map((item) => {
+                                                        const checked = integration && item.unique_key === integration.unique_key;
                                                         return (
                                                             <CommandItem
-                                                                key={item.uniqueKey}
-                                                                value={item.uniqueKey}
+                                                                key={item.unique_key}
+                                                                value={item.unique_key}
                                                                 onSelect={(curr) => {
                                                                     setIntegration(
-                                                                        integration && curr === integration.uniqueKey
+                                                                        integration && curr === integration.unique_key
                                                                             ? undefined
-                                                                            : listIntegration.integrations.find((v) => v.uniqueKey === curr)!
+                                                                            : listIntegration.find((v) => v.unique_key === curr)!
                                                                     );
                                                                     setOpen(false);
                                                                 }}
@@ -203,7 +203,7 @@ export const ConnectionCreate: React.FC = () => {
                                                                 )}
                                                             >
                                                                 <div className="flex gap-3">
-                                                                    <IntegrationLogo provider={item.provider} /> {item.uniqueKey}
+                                                                    <IntegrationLogo provider={item.provider} /> {item.unique_key}
                                                                 </div>
                                                                 <IconCheck className={cn('mr-2 h-4 w-4', checked ? 'opacity-100' : 'opacity-0')} />
                                                             </CommandItem>
@@ -409,7 +409,7 @@ export const ConnectionCreate: React.FC = () => {
                         )}
                         <div className="flex gap-4">
                             <ButtonLink
-                                to={`/${env}/connections/create-legacy?${integration ? `providerConfigKey=${integration.uniqueKey}` : ''}`}
+                                to={`/${env}/connections/create-legacy?${integration ? `providerConfigKey=${integration.unique_key}` : ''}`}
                                 onClick={onClickConnectUI}
                                 size="md"
                                 variant={'link'}

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -1,34 +1,34 @@
-import type React from 'react';
-import { useState, useMemo, useEffect } from 'react';
+import { MagnifyingGlassIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
+import { useEffect, useMemo, useState } from 'react';
+import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
-import * as Table from '../../components/ui/Table';
+import { useDebounce } from 'react-use';
 
-import { Input } from '../../components/ui/input/Input';
-import { useConnections, useConnectionsCount } from '../../hooks/useConnections';
-import { PlusIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
-import DashboardLayout from '../../layout/DashboardLayout';
+import { EndUserProfile } from './components/EndUserProfile';
+import { AvatarOrganization } from '../../components/AvatarCustom';
+import { CopyText } from '../../components/CopyText';
+import { ErrorCircle } from '../../components/ErrorCircle';
+import { ErrorPageComponent } from '../../components/ErrorComponent';
 import { LeftNavBarItems } from '../../components/LeftNavBar';
 import { MultiSelect } from '../../components/MultiSelect';
-
-import { useStore } from '../../store';
-import { Button, ButtonLink } from '../../components/ui/button/Button';
-import { formatDateToInternationalFormat } from '../../utils/utils';
-import { useDebounce } from 'react-use';
-import { useListIntegration } from '../../hooks/useIntegration';
-import { Skeleton } from '../../components/ui/Skeleton';
-import type { ColumnDef } from '@tanstack/react-table';
-import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
-import IntegrationLogo from '../../components/ui/IntegrationLogo';
-import { ErrorCircle } from '../../components/ErrorCircle';
-import Spinner from '../../components/ui/Spinner';
-import { AvatarOrganization } from '../../components/AvatarCustom';
-import type { ApiConnectionSimple } from '@nangohq/types';
-import { CopyText } from '../../components/CopyText';
 import { SimpleTooltip } from '../../components/SimpleTooltip';
-import { Helmet } from 'react-helmet';
-import { ErrorPageComponent } from '../../components/ErrorComponent';
-import { EndUserProfile } from './components/EndUserProfile';
+import IntegrationLogo from '../../components/ui/IntegrationLogo';
+import { Skeleton } from '../../components/ui/Skeleton';
+import Spinner from '../../components/ui/Spinner';
+import * as Table from '../../components/ui/Table';
+import { Button, ButtonLink } from '../../components/ui/button/Button';
+import { Input } from '../../components/ui/input/Input';
+import { useConnections, useConnectionsCount } from '../../hooks/useConnections';
+import { useListIntegration } from '../../hooks/useIntegration';
+import DashboardLayout from '../../layout/DashboardLayout';
+import { useStore } from '../../store';
 import { getConnectionDisplayName } from '../../utils/endUser';
+import { formatDateToInternationalFormat } from '../../utils/utils';
+
+import type { ApiConnectionSimple } from '@nangohq/types';
+import type { ColumnDef } from '@tanstack/react-table';
+import type React from 'react';
 
 const defaultFilter = ['all'];
 const filterErrors = [
@@ -160,10 +160,10 @@ export const ConnectionList: React.FC = () => {
         if (!listIntegration) {
             return [];
         }
-        return listIntegration.integrations.map((integration) => {
-            return { name: integration.uniqueKey, value: integration.uniqueKey };
+        return listIntegration.map((integration) => {
+            return { name: integration.unique_key, value: integration.unique_key };
         });
-    }, [listIntegration?.integrations]);
+    }, [listIntegration]);
 
     // --- Table Display
     useEffect(() => {

--- a/packages/webapp/src/pages/Integrations/List.tsx
+++ b/packages/webapp/src/pages/Integrations/List.tsx
@@ -1,30 +1,29 @@
-import { useNavigate, Link } from 'react-router-dom';
 import { Loading } from '@geist-ui/core';
 import { PlusIcon } from '@heroicons/react/24/outline';
-
-import DashboardLayout from '../../layout/DashboardLayout';
-import { LeftNavBarItems } from '../../components/LeftNavBar';
-import IntegrationLogo from '../../components/ui/IntegrationLogo';
-
-import { useStore } from '../../store';
-import { useListIntegration } from '../../hooks/useIntegration';
-import { ErrorCircle } from '../../components/ErrorCircle';
-import { SimpleTooltip } from '../../components/SimpleTooltip';
 import { Helmet } from 'react-helmet';
+import { Link, useNavigate } from 'react-router-dom';
+
+import { ErrorCircle } from '../../components/ErrorCircle';
 import { ErrorPageComponent } from '../../components/ErrorComponent';
+import { LeftNavBarItems } from '../../components/LeftNavBar';
+import { SimpleTooltip } from '../../components/SimpleTooltip';
+import IntegrationLogo from '../../components/ui/IntegrationLogo';
+import { useListIntegration } from '../../hooks/useIntegration';
+import DashboardLayout from '../../layout/DashboardLayout';
+import { useStore } from '../../store';
 
 export default function IntegrationList() {
     const navigate = useNavigate();
 
     const env = useStore((state) => state.env);
 
-    const { list: data, error } = useListIntegration(env);
+    const { list, error } = useListIntegration(env);
 
     if (error) {
-        return <ErrorPageComponent title="Integrations" error={error} page={LeftNavBarItems.Integrations} />;
+        return <ErrorPageComponent title="Integrations" error={error.json} page={LeftNavBarItems.Integrations} />;
     }
 
-    if (!data) {
+    if (!list) {
         return (
             <DashboardLayout selectedItem={LeftNavBarItems.Integrations}>
                 <Helmet>
@@ -35,8 +34,6 @@ export default function IntegrationList() {
         );
     }
 
-    const { integrations } = data;
-
     return (
         <DashboardLayout selectedItem={LeftNavBarItems.Integrations}>
             <Helmet>
@@ -44,7 +41,7 @@ export default function IntegrationList() {
             </Helmet>
             <div className="flex justify-between mb-8 items-center">
                 <h2 className="flex text-left text-3xl font-semibold tracking-tight text-white">Integrations</h2>
-                {integrations.length > 0 && (
+                {list.length > 0 && (
                     <Link
                         to={`/${env}/integrations/create`}
                         className="flex items-center mt-auto px-4 h-8 rounded-md text-sm text-black bg-white hover:bg-gray-300"
@@ -54,7 +51,7 @@ export default function IntegrationList() {
                     </Link>
                 )}
             </div>
-            {integrations?.length > 0 && (
+            {list.length > 0 && (
                 <>
                     <div className="h-fit rounded-md text-white text-sm">
                         <div className="w-full">
@@ -63,32 +60,32 @@ export default function IntegrationList() {
                                 <div className="w-1/3">Connections</div>
                                 <div className="w-24">Active Scripts</div>
                             </div>
-                            {integrations?.map(({ uniqueKey, provider, connection_count, scripts, missing_fields_count }) => (
+                            {list.map((integration) => (
                                 <div
-                                    key={`tr-${uniqueKey}`}
+                                    key={`tr-${integration.unique_key}`}
                                     className={`flex gap-4 ${
-                                        uniqueKey !== integrations.at(-1)?.uniqueKey ? 'border-b border-border-gray' : ''
+                                        integration.unique_key !== list.at(-1)?.unique_key ? 'border-b border-border-gray' : ''
                                     } min-h-[4em] px-2 justify-between items-center hover:bg-hover-gray cursor-pointer`}
                                     onClick={() => {
-                                        navigate(`/${env}/integrations/${uniqueKey}`);
+                                        navigate(`/${env}/integrations/${integration.unique_key}`);
                                     }}
                                 >
                                     <div className="flex items-center w-2/3 gap-2 py-2 truncate">
                                         <div className="w-10 shrink-0">
-                                            <IntegrationLogo provider={provider} height={7} width={7} />
+                                            <IntegrationLogo provider={integration.provider} height={7} width={7} />
                                         </div>
-                                        <p className="truncate">{uniqueKey}</p>
-                                        {missing_fields_count > 0 && (
+                                        <p className="truncate">{integration.unique_key}</p>
+                                        {integration.meta.missingFieldsCount > 0 && (
                                             <SimpleTooltip tooltipContent="Missing configuration">
                                                 <ErrorCircle icon="!" variant="warning" />
                                             </SimpleTooltip>
                                         )}
                                     </div>
                                     <div className="flex items-center w-1/3">
-                                        <p className="">{connection_count}</p>
+                                        <p className="">{integration.meta.connectionCount}</p>
                                     </div>
                                     <div className="flex items-center w-24">
-                                        <p className="">{scripts}</p>
+                                        <p className="">{integration.meta.scriptsCount}</p>
                                     </div>
                                 </div>
                             ))}
@@ -96,7 +93,7 @@ export default function IntegrationList() {
                     </div>
                 </>
             )}
-            {integrations?.length === 0 && (
+            {list.length === 0 && (
                 <div className="flex flex-col border border-border-gray rounded-md items-center text-white text-center p-10 py-20">
                     <h2 className="text-2xl text-center w-full">Configure a new integration</h2>
                     <div className="my-2 text-gray-400">Before exchanging data with an external API, you need to configure it on Nango.</div>

--- a/packages/webapp/src/utils/api.tsx
+++ b/packages/webapp/src/utils/api.tsx
@@ -108,30 +108,6 @@ export function useHostedSigninAPI() {
     };
 }
 
-export function useGetIntegrationListAPI(env: string) {
-    const signout = useSignout();
-
-    return async () => {
-        try {
-            const res = await apiFetch(`/api/v1/integrations?env=${env}`);
-
-            if (res.status === 401) {
-                await signout();
-                return;
-            }
-
-            if (res.status !== 200) {
-                serverErrorToast();
-                return;
-            }
-
-            return res;
-        } catch {
-            requestErrorToast();
-        }
-    };
-}
-
 export function useGetProvidersAPI(env: string) {
     const signout = useSignout();
 

--- a/packages/webapp/tsconfig.json
+++ b/packages/webapp/tsconfig.json
@@ -24,9 +24,6 @@
             "path": "../frontend"
         },
         {
-            "path": "../server"
-        },
-        {
             "path": "../types"
         }
     ],


### PR DESCRIPTION
## Changes

Contributes to https://linear.app/nango/issue/NAN-2109/finish-api-migrations-to-new-endpoint-format-and-validation

- GET /api/v1/integrations new format
Simplified the endpoint by pre-fetching active syncs per integration instead of doing N queries
Also changed a bit the output to avoid mixing the actual integration and additional metadata.
