### PR TITLE
fix: update nango-runner package to utilize soap package 1.1.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24901,12 +24901,12 @@
             "dev": true
         },
         "node_modules/soap": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/soap/-/soap-1.1.8.tgz",
-            "integrity": "sha512-fDNGyGsPkQP3bZX/366Ud5Kpjo9mCMh7ZKYIc3uipBEPPM2ZqCNkv1Z2/w0qpzpYFLL7do8WWwVUAjAwuUe1AQ==",
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/soap/-/soap-1.1.10.tgz",
+            "integrity": "sha512-dqfX9qHhXup3ZLWsI5of6xJIJKeBCPnn3tTu9sKtASm2A53Zk6/u3drygLiUy+H1mmjRBptXfVkjY6pt8nhOjA==",
             "dependencies": {
-                "axios": "^1.7.9",
-                "axios-ntlm": "^1.4.2",
+                "axios": "^1.8.3",
+                "axios-ntlm": "^1.4.3",
                 "debug": "^4.4.0",
                 "formidable": "^3.5.2",
                 "get-stream": "^6.0.1",
@@ -24914,10 +24914,20 @@
                 "sax": "^1.4.1",
                 "strip-bom": "^3.0.0",
                 "whatwg-mimetype": "4.0.0",
-                "xml-crypto": "^6.0.0"
+                "xml-crypto": "^6.0.1"
             },
             "engines": {
                 "node": ">=14.17.0"
+            }
+        },
+        "node_modules/soap/node_modules/axios": {
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+            "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+            "dependencies": {
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/soap/node_modules/debug": {
@@ -28738,9 +28748,9 @@
             }
         },
         "node_modules/xml-crypto": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.0.0.tgz",
-            "integrity": "sha512-L3RgnkaDrHaYcCnoENv4Idzt1ZRj5U1z1BDH98QdDTQfssScx8adgxhd9qwyYo+E3fXbQZjEQH7aiXHLVgxGvw==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.0.1.tgz",
+            "integrity": "sha512-v05aU7NS03z4jlZ0iZGRFeZsuKO1UfEbbYiaeRMiATBFs6Jq9+wqKquEMTn4UTrYZ9iGD8yz3KT4L9o2iF682w==",
             "dependencies": {
                 "@xmldom/is-dom-node": "^1.0.1",
                 "@xmldom/xmldom": "^0.8.10",
@@ -30191,7 +30201,7 @@
                 "connect-timeout": "1.9.0",
                 "dd-trace": "5.21.0",
                 "express": "^4.20.0",
-                "soap": "1.1.8",
+                "soap": "1.1.10",
                 "superjson": "2.2.1",
                 "undici": "6.21.1",
                 "unzipper": "^0.12.3",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -30,7 +30,7 @@
         "connect-timeout": "1.9.0",
         "dd-trace": "5.21.0",
         "express": "^4.20.0",
-        "soap": "1.1.8",
+        "soap": "1.1.10",
         "superjson": "2.2.1",
         "undici": "6.21.1",
         "unzipper": "^0.12.3",


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

# Problem

This resolves a (reported) vulnerability in the "xml-crypto" library (https://nvd.nist.gov/vuln/detail/CVE-2025-29775). This vulnerability is not believed to be exploitable within the nango software but we do have a particular company we work with that would want to see this particular vulnerability patched.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

