### PR TITLE
fix(connect-ui): show unique_key instead of display_name

### DIFF
--- a/packages/connect-ui/src/views/IntegrationsList.tsx
+++ b/packages/connect-ui/src/views/IntegrationsList.tsx
@@ -158,7 +158,7 @@ const Integration: React.FC<{ integration: ApiPublicIntegration }> = ({ integrat
                 <div className="w-[50px] h-[50px] bg-white transition-colors rounded-xl shadow-card p-2.5 group-hover:bg-dark-100">
                     <img src={integration.logo} />
                 </div>
-                <div className="text-zinc-900">{integration.display_name}</div>
+                <div className="text-zinc-900">{integration.unique_key}</div>
                 {error && (
                     <div className="border border-red-base bg-red-base-35 text-red-base flex items-center py-1 px-4 rounded gap-2">
                         <IconExclamationCircle size={17} stroke={1} /> {error}


### PR DESCRIPTION
## Issue

In Slack, a user reported that when having multiple integrations for the same provider (e.g., multiple Wildix PBXs), it's unclear which one to select from the Connect UI.
Only the provider name is shown, making it impossible to distinguish between them visually [Slack thread](https://nango-community.slack.com/archives/C04ABR352H0/p1743696112486929).


## Fix (Option 1 — this PR)

This version **replaces** the `display_name` entirely with the `unique_key` for _all_ integrations, not just duplicates.

## Alternative (Option 2 — separate PR)

There is a second PR available: 
- When a `display_name` appears more than once, the UI appends the `unique_key` in parentheses after a dash. 
	- Example: `Dropbox - (dropbox-tmwr)`
- Non-duplicate integrations are left unchanged for visual cleanliness

Feel free to choose whichever behaviour you prefer. Happy to adapt based on your preference!