### PR TITLE
feat(ui, api): auto-add missing scopes on flow enable

### DIFF
--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
@@ -13,7 +13,8 @@ const privateKey = z.string().startsWith('-----BEGIN RSA PRIVATE KEY----').endsW
 const validationBody = z
     .object({
         integrationId: providerConfigKeySchema.optional(),
-        webhookSecret: z.string().min(0).max(255).optional()
+        webhookSecret: z.string().min(0).max(255).optional(),
+        scopes: z.string().optional()
     })
     .strict()
     .or(
@@ -102,12 +103,16 @@ export const patchIntegration = asyncWrapper<PatchIntegration>(async (req, res) 
         integration.unique_key = body.integrationId;
     }
 
+    // Scopes
+    if ('scopes' in body) {
+        integration.oauth_scopes = body.scopes;
+    }
+
     // Credentials
     if ('authType' in body) {
         if (body.authType === 'OAUTH1' || body.authType === 'OAUTH2' || body.authType === 'TBA') {
             integration.oauth_client_id = body.clientId;
             integration.oauth_client_secret = body.clientSecret;
-            integration.oauth_scopes = body.scopes || '';
         } else if (body.authType === 'APP') {
             integration.oauth_client_id = body.appId;
             // This is a legacy thing

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -104,7 +104,7 @@ export type PatchIntegration = Endpoint<{
     Querystring: { env: string };
     Params: { providerConfigKey: string };
     Body:
-        | { integrationId?: string | undefined; webhookSecret?: string | undefined }
+        | { integrationId?: string | undefined; webhookSecret?: string | undefined; scopes?: string | undefined }
         | {
               authType: Extract<AuthModeType, 'OAUTH1' | 'OAUTH2' | 'TBA'>;
               clientId: string;


### PR DESCRIPTION
## 🐞 Issue

In the [Quickstart](https://docs.nango.dev/getting-started/quickstart#run-the-sample-app), the required scopes are only mentioned when setting up the Slack OAuth app, but **not** when creating the integration or enabling endpoints.

As a result, if you follow the Quickstart exactly as written, you’ll run into the following error when trying to create a new connection with that integration:

```
Invalid permissions requested  
No scopes requested
```

## 🛠️ Fix 

Instead of mentioning the scopes in the docs when setting up the integration or enabling endpoints, have the endpoints automatically add their corresponding scopes to the integration.

Since scopes are required when adding a connection, and the necessary scopes are already known based on the enabled endpoints, it would make sense to automatically include them when setting up the integration. This would reduce manual configuration and make the process more intuitive.

When enabling, any missing required scopes should be added to the integration.
When disabling, scopes should not be removed, since the user might have added them manually for other endpoints that require the same scopes.

### 🧪  Testing Instructions

1. **Start with an integration** that does **not** have any scopes, or remove them manually.
2. Go to the **Endpoints** page and **enable an endpoint** that requires a specific scope.
   - ✅ The required scope should automatically be added to the integration's scopes.
3. Now, **disable the same endpoint**.
   - ✅ The scope should **not** be removed from the integration.
4. Re-enable the same endpoint.
   - ✅ The scope should **not** be added again since it already exists once.

