### PR TITLE
fix(ui): create connection missing integration

### DIFF
--- a/packages/webapp/src/pages/Connection/Create.tsx
+++ b/packages/webapp/src/pages/Connection/Create.tsx
@@ -66,7 +66,7 @@ export const ConnectionCreate: React.FC = () => {
                 void listIntegrationMutate();
                 if (hasConnected.current) {
                     toast.toast({ title: `Connected to ${hasConnected.current.providerConfigKey}`, variant: 'success' });
-                    navigate(`/${env}/connections/${integration?.unique_key}/${hasConnected.current.connectionId}`);
+                    navigate(`/${env}/connections/${integration?.unique_key || hasConnected.current.providerConfigKey}/${hasConnected.current.connectionId}`);
                 }
             } else if (event.type === 'connect') {
                 void listIntegrationMutate();


### PR DESCRIPTION
## Changes 

Fixes https://linear.app/nango/issue/NAN-3048/creating-a-test-connection-fails

- create connection missing integration when not selecting an integration first

