### PR TITLE
feat: nango locks in scripts

### DIFF
--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -401,6 +401,9 @@ export declare class NangoAction {
      * Only use that method when you want to access resources that are unrelated to the current connection/provider.
      */
     uncontrolledFetch(options: { url: URL; method?: HTTP_METHOD; headers?: Record<string, string> | undefined; body?: string | null }): Promise<Response>;
+    tryAcquireLock(props: { key: string; ttlMs: number }): Promise<boolean>;
+    releaseLock(props: { key: string }): Promise<boolean>;
+    releaseAllLocks(): Promise<void>;
     private sendLogToPersist;
     private logAPICall;
 }

--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -403,7 +403,6 @@ export declare class NangoAction {
     uncontrolledFetch(options: { url: URL; method?: HTTP_METHOD; headers?: Record<string, string> | undefined; body?: string | null }): Promise<Response>;
     tryAcquireLock(props: { key: string; ttlMs: number }): Promise<boolean>;
     releaseLock(props: { key: string }): Promise<boolean>;
-    releaseAllLocks(): Promise<void>;
     private sendLogToPersist;
     private logAPICall;
 }

--- a/packages/cli/lib/services/sdk.ts
+++ b/packages/cli/lib/services/sdk.ts
@@ -96,6 +96,23 @@ export class NangoActionCLI extends NangoActionBase {
         this.log(`This has no effect but on a remote Nango instance would start a schedule`);
         return Promise.resolve();
     }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public override async tryAcquireLock(_props: { key: string; ttlMs: number }): Promise<boolean> {
+        // Not applicable to CLI
+        return true;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public override async releaseLock(_props: { key: string }): Promise<boolean> {
+        // Not applicable to CLI
+        return true;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public override async releaseAllLocks(): Promise<void> {
+        // Not applicable to CLI
+    }
 }
 
 export class NangoSyncCLI extends NangoSyncBase {
@@ -287,6 +304,23 @@ export class NangoSyncCLI extends NangoSyncBase {
     public override async setMergingStrategy(_merging: { strategy: 'ignore_if_modified_after' | 'override' }, _model: string) {
         // Not applicable to CLI
         return Promise.resolve();
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public override async tryAcquireLock(_props: { key: string; ttlMs: number }): Promise<boolean> {
+        // Not applicable to CLI
+        return true;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public override async releaseLock(_props: { key: string }): Promise<boolean> {
+        // Not applicable to CLI
+        return true;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public override async releaseAllLocks(): Promise<void> {
+        // Not applicable to CLI
     }
 }
 

--- a/packages/cli/lib/services/sdk.ts
+++ b/packages/cli/lib/services/sdk.ts
@@ -146,6 +146,9 @@ export class NangoSyncCLI extends NangoSyncBase {
     log = NangoActionCLI['prototype']['log'];
     triggerSync = NangoActionCLI['prototype']['triggerSync'];
     startSync = NangoActionCLI['prototype']['startSync'];
+    tryAcquireLock = NangoActionCLI['prototype']['tryAcquireLock'];
+    releaseLock = NangoActionCLI['prototype']['releaseLock'];
+    releaseAllLocks = NangoActionCLI['prototype']['releaseAllLocks'];
 
     public batchSave<T extends object>(results: T[], model: string) {
         if (!results || results.length === 0) {
@@ -304,23 +307,6 @@ export class NangoSyncCLI extends NangoSyncBase {
     public override async setMergingStrategy(_merging: { strategy: 'ignore_if_modified_after' | 'override' }, _model: string) {
         // Not applicable to CLI
         return Promise.resolve();
-    }
-
-    // eslint-disable-next-line @typescript-eslint/require-await
-    public override async tryAcquireLock(_props: { key: string; ttlMs: number }): Promise<boolean> {
-        // Not applicable to CLI
-        return true;
-    }
-
-    // eslint-disable-next-line @typescript-eslint/require-await
-    public override async releaseLock(_props: { key: string }): Promise<boolean> {
-        // Not applicable to CLI
-        return true;
-    }
-
-    // eslint-disable-next-line @typescript-eslint/require-await
-    public override async releaseAllLocks(): Promise<void> {
-        // Not applicable to CLI
     }
 }
 

--- a/packages/runner-sdk/lib/action.ts
+++ b/packages/runner-sdk/lib/action.ts
@@ -48,7 +48,7 @@ export type ProxyConfiguration = Omit<UserProvidedProxyConfiguration, 'files' | 
 export abstract class NangoActionBase {
     abstract nango: Nango;
     private attributes = {};
-    activityLogId?: string | undefined;
+    activityLogId: string;
     syncId?: string;
     nangoConnectionId?: number;
     environmentId: number;
@@ -72,10 +72,7 @@ export abstract class NangoActionBase {
         this.environmentId = config.environmentId;
         this.providerConfigKey = config.providerConfigKey;
         this.runnerFlags = config.runnerFlags;
-
-        if (config.activityLogId) {
-            this.activityLogId = config.activityLogId;
-        }
+        this.activityLogId = config.activityLogId;
 
         if (config.syncId) {
             this.syncId = config.syncId;
@@ -385,4 +382,19 @@ export abstract class NangoActionBase {
 
         return await fetch(options.url, props);
     }
+
+    /**
+     * Try to acquire a lock for a given key.
+     * The lock is acquired if the key does not exist or if it exists but is expired.
+     * The lock is valid for the entire execution of the script and will be released automatically when the script ends.
+     */
+    public abstract tryAcquireLock({ key, ttlMs }: { key: string; ttlMs: number }): Promise<boolean>;
+    /**
+     * Release the lock for a given key.
+     */
+    public abstract releaseLock({ key }: { key: string }): Promise<boolean>;
+    /**
+     * Release all locks acquired during the execution of a script.
+     */
+    public abstract releaseAllLocks(): Promise<void>;
 }

--- a/packages/runner-sdk/lib/action.ts
+++ b/packages/runner-sdk/lib/action.ts
@@ -386,7 +386,7 @@ export abstract class NangoActionBase {
     /**
      * Try to acquire a lock for a given key.
      * The lock is acquired if the key does not exist or if it exists but is expired.
-     * The lock is valid for the entire execution of the script and will be released automatically when the script ends.
+     * The lock is valid for the entire execution of the script and will be released automatically when the script ends (or when releaseLock is called).
      */
     public abstract tryAcquireLock({ key, ttlMs }: { key: string; ttlMs: number }): Promise<boolean>;
     /**

--- a/packages/runner-sdk/models.d.ts
+++ b/packages/runner-sdk/models.d.ts
@@ -358,6 +358,9 @@ export declare class NangoAction {
      * Only use that method when you want to access resources that are unrelated to the current connection/provider.
      */
     uncontrolledFetch(options: { url: URL; method?: HTTP_METHOD; headers?: Record<string, string> | undefined; body?: string | null }): Promise<Response>;
+    tryAcquireLock(props: { key: string; ttlMs: number }): Promise<boolean>;
+    releaseLock(props: { key: string }): Promise<boolean>;
+    releaseAllLocks(): Promise<void>;
     private sendLogToPersist;
     private logAPICall;
 }

--- a/packages/runner-sdk/models.d.ts
+++ b/packages/runner-sdk/models.d.ts
@@ -360,7 +360,6 @@ export declare class NangoAction {
     uncontrolledFetch(options: { url: URL; method?: HTTP_METHOD; headers?: Record<string, string> | undefined; body?: string | null }): Promise<Response>;
     tryAcquireLock(props: { key: string; ttlMs: number }): Promise<boolean>;
     releaseLock(props: { key: string }): Promise<boolean>;
-    releaseAllLocks(): Promise<void>;
     private sendLogToPersist;
     private logAPICall;
 }

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -285,7 +285,11 @@ export async function exec({
                 };
             }
         } finally {
-            await nango.releaseAllLocks().catch((err: unknown) => logger.warning('Failed to release all locks', { reason: err }));
+            try {
+                await nango.releaseAllLocks();
+            } catch (err) {
+                logger.warning('Failed to release all locks', { reason: err });
+            }
             span.finish();
         }
     });

--- a/packages/runner/lib/sdk/locks.ts
+++ b/packages/runner/lib/sdk/locks.ts
@@ -69,7 +69,7 @@ export class Locks {
     public async releaseAllLocks({ owner }: { owner: string }): Promise<Result<void>> {
         for (const [key, lock] of this.store.entries()) {
             if (lock.owner === owner) {
-                this.releaseLock({ owner, key });
+                void this.releaseLock({ owner, key });
             }
         }
         return Ok(undefined);

--- a/packages/runner/lib/sdk/locks.ts
+++ b/packages/runner/lib/sdk/locks.ts
@@ -1,0 +1,85 @@
+/* eslint-disable @typescript-eslint/require-await */
+import type { Result } from '@nangohq/utils';
+import { Err, Ok } from '@nangohq/utils';
+
+interface Lock {
+    key: string;
+    owner: string;
+    expiresAt: Date;
+}
+
+export class Locks {
+    private store = new Map<string, Lock>();
+    private mutex = new Map<string, boolean>();
+
+    public async tryAcquireLock({ owner, key, ttlMs }: { owner: string; key: string; ttlMs: number }): Promise<Result<boolean>> {
+        if (!owner || owner.length === 0 || owner.length > 255) {
+            return Err('Invalid lock owner (must be between 1 and 255 characters)');
+        }
+        if (!key || key.length === 0 || key.length > 255) {
+            return Err('Invalid lock key (must be between 1 and 255 characters)');
+        }
+        if (ttlMs <= 0) {
+            return Err('Invalid lock TTL (must be greater than 0)');
+        }
+
+        // If mutex is already held, fail immediately
+        if (this.mutex.get(key)) {
+            return Ok(false);
+        }
+
+        try {
+            this.mutex.set(key, true);
+
+            const now = new Date();
+
+            // If the lock is already held by the same owner, or if it has expired, we can acquire it
+            const existing = this.store.get(key);
+            if (existing && existing.expiresAt > now && existing.owner !== owner) {
+                return Ok(false);
+            }
+            this.store.set(key, { key, owner, expiresAt: new Date(now.getTime() + ttlMs) });
+
+            return Ok(true);
+        } finally {
+            this.mutex.delete(key);
+        }
+    }
+
+    public async releaseLock({ owner, key }: { owner: string; key: string }): Promise<Result<boolean>> {
+        // If mutex is already held, fail immediately
+        if (this.mutex.get(key)) {
+            return Ok(false);
+        }
+        try {
+            this.mutex.set(key, true);
+
+            // If the lock is held by the same owner, release it
+            const lock = this.store.get(key);
+            if (lock && lock.owner === owner) {
+                this.store.delete(key);
+                return Ok(true);
+            }
+            return Ok(false);
+        } finally {
+            this.mutex.delete(key);
+        }
+    }
+
+    public async releaseAllLocks({ owner }: { owner: string }): Promise<Result<void>> {
+        for (const [key, lock] of this.store.entries()) {
+            if (lock.owner === owner) {
+                this.releaseLock({ owner, key });
+            }
+        }
+        return Ok(undefined);
+    }
+
+    public async hasLock({ owner, key }: { owner: string; key: string }): Promise<Result<boolean>> {
+        const lock = this.store.get(key);
+        if (lock && lock.owner === owner && lock.expiresAt >= new Date()) {
+            return Ok(true);
+        }
+        return Ok(false);
+    }
+}

--- a/packages/runner/lib/sdk/locks.unit.test.ts
+++ b/packages/runner/lib/sdk/locks.unit.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Locks } from './locks.js';
+
+describe('Locks', () => {
+    let locks: Locks;
+
+    beforeEach(() => {
+        locks = new Locks();
+    });
+    describe('tryAcquireLock input validation', () => {
+        it('should fail to acquire a lock with an empty key', async () => {
+            const res = await locks.tryAcquireLock({ owner: 'owner1', key: '', ttlMs: 1000 });
+            if (res.isOk()) {
+                throw new Error('Expected an error: empty key');
+            }
+        });
+        it('should fail to acquire a lock with a key longer than 255 characters', async () => {
+            const longKey = 'a'.repeat(256);
+            const res = await locks.tryAcquireLock({ owner: 'owner1', key: longKey, ttlMs: 1000 });
+            if (res.isOk()) {
+                throw new Error('Expected an error: key too long');
+            }
+        });
+        it('should fail to acquire a lock with an empty owner', async () => {
+            const res = await locks.tryAcquireLock({ owner: '', key: 'resource1', ttlMs: 1000 });
+            if (res.isOk()) {
+                throw new Error('Expected an error: empty owner');
+            }
+        });
+        it('should fail to acquire a lock with an owner longer than 255 characters', async () => {
+            const longOwner = 'a'.repeat(256);
+            const res = await locks.tryAcquireLock({ owner: longOwner, key: 'resource1', ttlMs: 1000 });
+            if (res.isOk()) {
+                throw new Error('Expected an error: owner too long');
+            }
+        });
+        it('should fail to acquire a lock with a TTL less than or equal to 0', async () => {
+            const res = await locks.tryAcquireLock({ owner: 'owner', key: 'resource1', ttlMs: 0 });
+            if (res.isOk()) {
+                throw new Error('Expected an error: ttl = 0');
+            }
+        });
+    });
+
+    describe('tryAcquireLock', () => {
+        it('should successfully acquire a lock when none exists', async () => {
+            const res = await locks.tryAcquireLock({ owner: 'owner1', key: 'resource1', ttlMs: 1000 });
+            expect(res.unwrap()).toBe(true);
+        });
+
+        it('should fail to acquire a lock that is already held and not expired', async () => {
+            await locks.tryAcquireLock({ owner: 'owner1', key: 'resource1', ttlMs: 1000 });
+
+            const res = await locks.tryAcquireLock({ owner: 'owner2', key: 'resource1', ttlMs: 1000 });
+            expect(res.unwrap()).toBe(false);
+        });
+
+        it('should successfully acquire a lock that is own by the same owner, regardless of the expiration', async () => {
+            const owner = 'owner1';
+            await locks.tryAcquireLock({ owner, key: 'resource1', ttlMs: 1000 });
+            const res = await locks.tryAcquireLock({ owner, key: 'resource1', ttlMs: 1000 });
+            expect(res.unwrap()).toBe(true);
+        });
+
+        it('should successfully acquire an expired lock', async () => {
+            await locks.tryAcquireLock({ owner: 'owner1', key: 'resource1', ttlMs: 1 });
+            await new Promise((resolve) => setTimeout(resolve, 2)); // Wait for the lock to expire
+
+            const res = await locks.tryAcquireLock({ owner: 'owner2', key: 'resource1', ttlMs: 1000 });
+            expect(res.unwrap()).toBe(true);
+        });
+
+        it('should ensure only one owner acquires the lock when called concurrently', async () => {
+            const concurrency = 100_000;
+            const attempts = Array.from({ length: concurrency }, (_, i) =>
+                locks.tryAcquireLock({ owner: `owner${i}`, key: 'concurrent-resource', ttlMs: 10000 })
+            );
+
+            const res = await Promise.all(attempts);
+            const successCount = res.filter((acquired) => acquired.unwrap()).length;
+            expect(successCount).toBe(1);
+        });
+    });
+
+    describe('releaseLock', () => {
+        it('should successfully release a lock owned by the requester', async () => {
+            await locks.tryAcquireLock({ owner: 'owner1', key: 'resource1', ttlMs: 1000 });
+            const res = await locks.releaseLock({ owner: 'owner1', key: 'resource1' });
+            expect(res.unwrap()).toBe(true);
+        });
+
+        it('should not release a lock owned by someone else', async () => {
+            await locks.tryAcquireLock({ owner: 'owner1', key: 'resource1', ttlMs: 1000 });
+            const res = await locks.releaseLock({ owner: 'owner2', key: 'resource1' });
+            expect(res.unwrap()).toBe(false);
+        });
+
+        it('should not release a non-existent lock', async () => {
+            const res = await locks.releaseLock({ owner: 'owner1', key: 'nonExisting' });
+            expect(res.unwrap()).toBe(false);
+        });
+    });
+
+    describe('releaseAllLocks', () => {
+        it('should release all locks owned by the requester', async () => {
+            await locks.tryAcquireLock({ owner: 'owner1', key: 'resource1', ttlMs: 1000 });
+            await locks.tryAcquireLock({ owner: 'owner1', key: 'resource2', ttlMs: 1000 });
+            await locks.tryAcquireLock({ owner: 'owner2', key: 'resource3', ttlMs: 1000 });
+
+            await locks.releaseAllLocks({ owner: 'owner1' });
+
+            const res1 = await locks.hasLock({ owner: 'owner1', key: 'resource1' });
+            expect(res1.unwrap()).toBe(false); // released
+
+            const res2 = await locks.hasLock({ owner: 'owner1', key: 'resource2' });
+            expect(res2.unwrap()).toBe(false); // released
+
+            const res3 = await locks.hasLock({ owner: 'owner2', key: 'resource3' });
+            expect(res3.unwrap()).toBe(true); // still owned by owner2
+        });
+    });
+
+    describe('hasLock', () => {
+        it('should return true if the lock is held by the specified owner', async () => {
+            await locks.tryAcquireLock({ owner: 'owner1', key: 'resource1', ttlMs: 1000 });
+            const res = await locks.hasLock({ owner: 'owner1', key: 'resource1' });
+            expect(res.unwrap()).toBe(true);
+        });
+
+        it('should return false if the lock is held by a different owner', async () => {
+            await locks.tryAcquireLock({ owner: 'owner1', key: 'resource1', ttlMs: 1000 });
+            const res = await locks.hasLock({ owner: 'owner2', key: 'resource1' });
+            expect(res.unwrap()).toBe(false);
+        });
+
+        it('should return false if the lock does not exist', async () => {
+            const res = await locks.hasLock({ owner: 'owner1', key: 'nonExisting' });
+            expect(res.unwrap()).toBe(false);
+        });
+
+        it('should return false if the locks is expired', async () => {
+            await locks.tryAcquireLock({ owner: 'owner1', key: 'resource1', ttlMs: 1 });
+            await new Promise((resolve) => setTimeout(resolve, 2)); // Wait for the lock to expire
+
+            const res = await locks.hasLock({ owner: 'owner1', key: 'resource1' });
+            expect(res.unwrap()).toBe(false);
+        });
+    });
+});

--- a/packages/runner/lib/sdk/sdk.integration.test.ts
+++ b/packages/runner/lib/sdk/sdk.integration.test.ts
@@ -3,9 +3,11 @@ import { multipleMigrations } from '@nangohq/database';
 import { connectionService, environmentService, seeders } from '@nangohq/shared';
 import type { DBEnvironment, DBSyncConfig, NangoProps } from '@nangohq/types';
 import { NangoActionRunner } from './sdk.js';
+import { Locks } from './locks.js';
 
 describe('Connection service integration tests', () => {
     let env: DBEnvironment;
+    const locks = new Locks();
     beforeAll(async () => {
         await multipleMigrations();
         env = await seeders.createEnvironmentSeed();
@@ -54,7 +56,7 @@ describe('Connection service integration tests', () => {
                 endUser: null
             };
 
-            const nango = new NangoActionRunner(nangoProps);
+            const nango = new NangoActionRunner(nangoProps, { locks });
 
             nango.nango.getConnection = async (providerConfigKey: string, connectionId: string) => {
                 const { response } = await connectionService.getConnection(connectionId, providerConfigKey, environment.id);

--- a/packages/runner/lib/server.ts
+++ b/packages/runner/lib/server.ts
@@ -12,6 +12,7 @@ import { envs, heartbeatIntervalMs } from './env.js';
 import type { NangoProps } from '@nangohq/types';
 import { jobsClient } from './clients/jobs.js';
 import { logger } from './logger.js';
+import { Locks } from './sdk/locks.js';
 
 export const t = initTRPC.create({
     transformer: superjson
@@ -43,6 +44,7 @@ function healthProcedure() {
 }
 
 const usage = new RunnerMonitor({ runnerId: envs.RUNNER_NODE_ID });
+const locks = new Locks();
 
 function startProcedure() {
     return publicProcedure
@@ -69,7 +71,7 @@ function startProcedure() {
                     const abortController = new AbortController();
                     abortControllers.set(taskId, abortController);
 
-                    const { error, response: output } = await exec(nangoProps, code, codeParams, abortController);
+                    const { error, response: output } = await exec({ nangoProps, code, codeParams, abortController, locks });
 
                     await jobsClient.putTask({
                         taskId,


### PR DESCRIPTION
Adding functions to the nango runner-sdk to manage locks.
```
await nango.tryAcquireLock({ key: "abc", ttlMs: 60_000 })
```
It makes it possible for customers to handle custom locking logic in their script, like skipping a webhook execution if one is already running.
I decided to make the locking a runner-sdk implementation details and be ok with a bit more duplication of code rather than having the implementation as part of the runner-sdk abstract class (and then have the state not fully self-contained). Locks state is imho at the runner-level and not script-level.

Caveat: for now the locks are stored in memory (by the runner). During deployment of runners, there might be 2 runners up at the same time and potentially the same lock could be acquired twice. In a second steps we will store the locks in a shared datastore to ensure 100% unique locks

# How to test
You can have 2 syncs that both tries to acquire the same lock and wait to ensure overlap
```
    const lock = await nango.tryAcquireLock({
        key: 'MY_KEY',
        ttlMs: 60_000,
    });
    if (!lock) {
        await nango.log('could not acquire lock. skipping...');
        return
    }
    await nango.log('acquired lock');

    const waitSecs = 10;
    for (let i = 0; i < waitSecs; i += 1) {
        await new Promise((resolve) => setTimeout(resolve, 1000));
        await nango.log(`waiting for ${waitSecs - i} seconds`);
    }
```

