### PR TITLE
feat: rename environments

### DIFF
--- a/packages/server/lib/controllers/v1/environment/patchEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/patchEnvironment.integration.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { environmentService, seeders } from '@nangohq/shared';
+
+import { isError, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+const endpoint = '/api/v1/environments';
+
+describe(`PATCH ${endpoint}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            // @ts-expect-error query params are required
+            query: { env: 'test' },
+            body: { name: 'new-name' }
+        });
+
+        shouldBeProtected(res);
+    });
+
+    it('should successfully rename an environment', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        const newName = 'renamed-env';
+
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            // @ts-expect-error query params are required
+            query: { env: env.name },
+            body: { name: newName },
+            token: env.secret_key
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            data: expect.objectContaining({
+                id: expect.any(Number),
+                name: newName,
+                account_id: expect.any(Number),
+                created_at: expect.any(String),
+                updated_at: expect.any(String)
+            })
+        });
+    });
+
+    it('should not allow renaming to an existing environment name', async () => {
+        const { env, account } = await seeders.seedAccountEnvAndUser();
+        await environmentService.createEnvironment(account.id, 'existing');
+
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            // @ts-expect-error query params are required
+            query: { env: env.name },
+            body: { name: 'existing' },
+            token: env.secret_key
+        });
+
+        expect(res.res.status).toBe(400);
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'conflict',
+                message: 'An environment with this name already exists'
+            }
+        });
+    });
+});

--- a/packages/server/lib/controllers/v1/environment/patchEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/patchEnvironment.integration.test.ts
@@ -64,7 +64,7 @@ describe(`PATCH ${endpoint}`, () => {
             token: env.secret_key
         });
 
-        expect(res.res.status).toBe(400);
+        expect(res.res.status).toBe(409);
         isError(res.json);
         expect(res.json).toStrictEqual<typeof res.json>({
             error: {

--- a/packages/server/lib/controllers/v1/environment/postEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/postEnvironment.integration.test.ts
@@ -1,5 +1,9 @@
-import { afterAll, beforeAll, describe, it } from 'vitest';
-import { runServer, shouldBeProtected } from '../../../utils/tests.js';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { environmentService, seeders, updatePlan } from '@nangohq/shared';
+
+import { isError, runServer, shouldBeProtected } from '../../../utils/tests.js';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 
@@ -20,6 +24,45 @@ describe(`POST ${endpoint}`, () => {
         });
 
         shouldBeProtected(res);
+    });
+
+    it('should not allow environment name to be the same as an existing environment', async () => {
+        const { env, plan } = await seeders.seedAccountEnvAndUser();
+        await updatePlan(db.knex, { id: plan.id, environments_max: 10 });
+        await environmentService.createEnvironment(env.account_id, 'existing');
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            body: { name: 'existing' },
+            token: env.secret_key
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'conflict',
+                message: 'Environment already exists'
+            }
+        });
+    });
+
+    it('should limit the number of environments based on environments_max flag', async () => {
+        const { env, plan } = await seeders.seedAccountEnvAndUser();
+        await updatePlan(db.knex, { id: plan.id, environments_max: 1 });
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            body: { name: 'dev' },
+            token: env.secret_key
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'resource_capped',
+                message: 'Maximum number of environments reached'
+            }
+        });
     });
 
     // Does not work because we only have env secret key for authentication but we actually want to create an env

--- a/packages/server/lib/controllers/v1/environment/postEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/postEnvironment.ts
@@ -30,7 +30,7 @@ export const postEnvironment = asyncWrapper<PostEnvironment>(async (req, res) =>
 
     const body: PostEnvironment['Body'] = valBody.data;
 
-    const accountId = res.locals.account.id;
+    const accountId = res.locals.user.account_id;
     const environments = await environmentService.getEnvironmentsByAccountId(accountId);
 
     if (flagHasPlan) {

--- a/packages/server/lib/controllers/v1/environment/postEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/postEnvironment.ts
@@ -30,7 +30,7 @@ export const postEnvironment = asyncWrapper<PostEnvironment>(async (req, res) =>
 
     const body: PostEnvironment['Body'] = valBody.data;
 
-    const accountId = res.locals.user.account_id;
+    const accountId = res.locals.account.id;
     const environments = await environmentService.getEnvironmentsByAccountId(accountId);
 
     if (flagHasPlan) {

--- a/packages/server/lib/controllers/v1/environment/postEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/postEnvironment.ts
@@ -30,7 +30,7 @@ export const postEnvironment = asyncWrapper<PostEnvironment>(async (req, res) =>
 
     const body: PostEnvironment['Body'] = valBody.data;
 
-    const accountId = res.locals.user.account_id;
+    const accountId = res.locals.account.id;
     const environments = await environmentService.getEnvironmentsByAccountId(accountId);
 
     if (flagHasPlan) {
@@ -45,7 +45,7 @@ export const postEnvironment = asyncWrapper<PostEnvironment>(async (req, res) =>
             res.status(400).send({
                 error: {
                     code: 'resource_capped',
-                    message: plan.name === 'free' ? 'Creating environment is only available for paying customer' : "Can't create more environments. "
+                    message: 'Maximum number of environments reached'
                 }
             });
             return;

--- a/packages/server/lib/controllers/v1/meta/getMeta.ts
+++ b/packages/server/lib/controllers/v1/meta/getMeta.ts
@@ -1,6 +1,9 @@
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
-import { baseUrl, NANGO_VERSION, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 import { environmentService, getOnboarding } from '@nangohq/shared';
+import { NANGO_VERSION, baseUrl, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { planToApi } from '../../../formatters/plan.js';
+import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+
 import type { GetMeta } from '@nangohq/types';
 
 export const getMeta = asyncWrapper<GetMeta>(async (req, res) => {
@@ -10,12 +13,13 @@ export const getMeta = asyncWrapper<GetMeta>(async (req, res) => {
         return;
     }
 
-    const sessionUser = res.locals['user'];
+    const { user: sessionUser, plan } = res.locals;
 
     const environments = await environmentService.getEnvironmentsByAccountId(sessionUser.account_id);
     const onboarding = await getOnboarding(sessionUser.id);
     res.status(200).send({
         data: {
+            plan: plan ? planToApi(plan) : null,
             environments,
             version: NANGO_VERSION,
             baseUrl,

--- a/packages/server/lib/controllers/v1/meta/getMeta.ts
+++ b/packages/server/lib/controllers/v1/meta/getMeta.ts
@@ -1,7 +1,6 @@
 import { environmentService, getOnboarding } from '@nangohq/shared';
 import { NANGO_VERSION, baseUrl, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { planToApi } from '../../../formatters/plan.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 
 import type { GetMeta } from '@nangohq/types';
@@ -13,13 +12,12 @@ export const getMeta = asyncWrapper<GetMeta>(async (req, res) => {
         return;
     }
 
-    const { user: sessionUser, plan } = res.locals;
+    const sessionUser = res.locals.user;
 
     const environments = await environmentService.getEnvironmentsByAccountId(sessionUser.account_id);
     const onboarding = await getOnboarding(sessionUser.id);
     res.status(200).send({
         data: {
-            plan: plan ? planToApi(plan) : null,
             environments: environments.map((env) => {
                 return { name: env.name };
             }),

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -536,7 +536,6 @@ async function fillLocalsFromSession(req: Request, res: Response<any, RequestLoc
 
         res.locals['account'] = result.account;
         res.locals['environment'] = result.environment;
-        res.locals['plan'] = plan;
         tagTraceUser({ ...result, plan });
         next();
     } catch (err) {

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -505,6 +505,17 @@ async function fillLocalsFromSession(req: Request, res: Response<any, RequestLoc
 
         res.locals['user'] = user;
 
+        let plan: DBPlan | null = null;
+        if (flagHasPlan) {
+            const planRes = await getPlan(db.knex, { accountId: user.account_id });
+            if (planRes.isErr()) {
+                res.status(401).send({ error: { code: 'plan_not_found' } });
+                return;
+            }
+            plan = planRes.value;
+        }
+        res.locals['plan'] = plan;
+
         const fullPath = path.join(req.baseUrl, req.route.path);
         if (ignoreEnvPaths.includes(fullPath)) {
             next();
@@ -521,16 +532,6 @@ async function fillLocalsFromSession(req: Request, res: Response<any, RequestLoc
         if (!result) {
             res.status(401).send({ error: { code: 'unknown_account_or_env' } });
             return;
-        }
-
-        let plan: DBPlan | null = null;
-        if (flagHasPlan) {
-            const planRes = await getPlan(db.knex, { accountId: result.account.id });
-            if (planRes.isErr()) {
-                res.status(401).send({ error: { code: 'plan_not_found' } });
-                return;
-            }
-            plan = planRes.value;
         }
 
         res.locals['account'] = result.account;

--- a/packages/shared/lib/constants.ts
+++ b/packages/shared/lib/constants.ts
@@ -1,0 +1,1 @@
+export const PROD_ENVIRONMENT_NAME = 'prod';

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -38,6 +38,8 @@ export * as oauth2Client from './clients/oauth2.client.js';
 
 export * from './models/index.js';
 
+export * from './constants.js';
+
 export * from './utils/utils.js';
 export * from './utils/error.js';
 

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -1,15 +1,19 @@
 import * as uuid from 'uuid';
+
 import db from '@nangohq/database';
-import encryptionManager, { pbkdf2 } from '../utils/encryption.manager.js';
-import type { DBTeam, DBEnvironmentVariable, DBEnvironment } from '@nangohq/types';
-import { LogActionEnum } from '../models/Telemetry.js';
-import errorManager, { ErrorSourceEnum } from '../utils/error.manager.js';
 import { isCloud } from '@nangohq/utils';
+
+import { PROD_ENVIRONMENT_NAME } from '../constants.js';
 import { externalWebhookService, getGlobalOAuthCallbackUrl } from '../index.js';
+import { LogActionEnum } from '../models/Telemetry.js';
+import encryptionManager, { pbkdf2 } from '../utils/encryption.manager.js';
+import errorManager, { ErrorSourceEnum } from '../utils/error.manager.js';
+
+import type { DBEnvironment, DBEnvironmentVariable, DBTeam } from '@nangohq/types';
 
 const TABLE = '_nango_environments';
 
-export const defaultEnvironments = ['prod', 'dev'];
+export const defaultEnvironments = [PROD_ENVIRONMENT_NAME, 'dev'];
 
 const hashLocalCache = new Map<string, string>();
 

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -1,4 +1,4 @@
-import type { ApiTimestamps, Endpoint } from '../../api';
+import type { ApiError, ApiTimestamps, Endpoint } from '../../api';
 import type { ApiPlan } from '../../plans/http.api';
 import type { DBEnvironment, DBExternalWebhook } from '../db';
 import type { ApiEnvironmentVariable } from '../variable/api';
@@ -40,6 +40,7 @@ export type PatchEnvironment = Endpoint<{
     Method: 'PATCH';
     Path: '/api/v1/environments';
     Body: {
+        name?: string | undefined;
         callback_url?: string | undefined;
         hmac_key?: string | undefined;
         hmac_enabled?: boolean | undefined;
@@ -50,4 +51,5 @@ export type PatchEnvironment = Endpoint<{
     Success: {
         data: ApiEnvironment;
     };
+    Error: ApiError<'conflict'>;
 }>;

--- a/packages/types/lib/meta/api.ts
+++ b/packages/types/lib/meta/api.ts
@@ -1,5 +1,6 @@
 import type { ApiError, Endpoint } from '../api';
 import type { DBEnvironment } from '../environment/db';
+import type { ApiPlan } from '../plans/http.api';
 
 export type GetMeta = Endpoint<{
     Method: 'GET';
@@ -8,6 +9,7 @@ export type GetMeta = Endpoint<{
     Error: ApiError<'user_not_found'>;
     Success: {
         data: {
+            plan: ApiPlan | null;
             environments: Pick<DBEnvironment, 'name'>[];
             version: string;
             baseUrl: string;

--- a/packages/types/lib/meta/api.ts
+++ b/packages/types/lib/meta/api.ts
@@ -1,6 +1,5 @@
 import type { ApiError, Endpoint } from '../api';
 import type { DBEnvironment } from '../environment/db';
-import type { ApiPlan } from '../plans/http.api';
 
 export type GetMeta = Endpoint<{
     Method: 'GET';
@@ -9,7 +8,6 @@ export type GetMeta = Endpoint<{
     Error: ApiError<'user_not_found'>;
     Success: {
         data: {
-            plan: ApiPlan | null;
             environments: Pick<DBEnvironment, 'name'>[];
             version: string;
             baseUrl: string;

--- a/packages/webapp/src/components/CreateEnvironmentButton.tsx
+++ b/packages/webapp/src/components/CreateEnvironmentButton.tsx
@@ -4,9 +4,10 @@ import { Link, useNavigate } from 'react-router-dom';
 
 import { SimpleTooltip } from './SimpleTooltip';
 import { Dialog, DialogClose, DialogContent, DialogFooter, DialogTitle, DialogTrigger } from './ui/Dialog';
-import { apiPostEnvironment } from '../hooks/useEnvironment';
+import { apiPostEnvironment, useEnvironment } from '../hooks/useEnvironment';
 import { useMeta } from '../hooks/useMeta';
 import { useToast } from '../hooks/useToast';
+import { useStore } from '../store';
 import { cn } from '../utils/utils';
 import { Button } from './ui/button/Button';
 import { Input } from './ui/input/Input';
@@ -14,7 +15,10 @@ import { Input } from './ui/input/Input';
 export const CreateEnvironmentButton: React.FC = () => {
     const navigate = useNavigate();
     const { toast } = useToast();
-    const { meta, mutate } = useMeta();
+    const { mutate: mutateMeta } = useMeta();
+    const env = useStore((state) => state.env);
+    const envs = useStore((state) => state.envs);
+    const environment = useEnvironment(env);
 
     const [openDialog, setOpenDialog] = useState(false);
     const [loading, setLoading] = useState(false);
@@ -39,19 +43,19 @@ export const CreateEnvironmentButton: React.FC = () => {
             setOpenDialog(false);
             setError(false);
             setName('');
-            void mutate();
+            void mutateMeta();
         }
 
         setLoading(false);
     };
 
-    const isMaxEnvironmentsReached = meta?.environments && meta?.plan && meta?.environments.length >= meta?.plan?.environments_max;
+    const isMaxEnvironmentsReached = envs && environment.plan && envs.length >= environment.plan.environments_max;
     let tooltipContent: React.ReactNode = null;
     if (isMaxEnvironmentsReached) {
         tooltipContent = (
             <span>
                 Max number of environments reached.{' '}
-                {meta?.plan?.name === 'scale' ? (
+                {environment?.plan?.name === 'scale' ? (
                     <>Contact Nango to add more</>
                 ) : (
                     <>

--- a/packages/webapp/src/components/CreateEnvironmentButton.tsx
+++ b/packages/webapp/src/components/CreateEnvironmentButton.tsx
@@ -1,0 +1,103 @@
+import { IconLock } from '@tabler/icons-react';
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+
+import { SimpleTooltip } from './SimpleTooltip';
+import { Dialog, DialogClose, DialogContent, DialogFooter, DialogTitle, DialogTrigger } from './ui/Dialog';
+import { apiPostEnvironment } from '../hooks/useEnvironment';
+import { useMeta } from '../hooks/useMeta';
+import { useToast } from '../hooks/useToast';
+import { cn } from '../utils/utils';
+import { Button } from './ui/button/Button';
+import { Input } from './ui/input/Input';
+
+export const CreateEnvironmentButton: React.FC = () => {
+    const navigate = useNavigate();
+    const { toast } = useToast();
+    const { meta, mutate } = useMeta();
+
+    const [openDialog, setOpenDialog] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(false);
+    const [name, setName] = useState('');
+
+    const onCreate = async () => {
+        setLoading(true);
+
+        const res = await apiPostEnvironment({ name });
+        if ('error' in res.json) {
+            const err = res.json.error;
+            if (err.code === 'invalid_body') {
+                setError(true);
+            } else if (['conflict', 'feature_disabled', 'resource_capped'].includes(err.code)) {
+                toast({ title: err.message, variant: 'error' });
+            } else {
+                toast({ title: 'Failed to create environment', variant: 'error' });
+            }
+        } else {
+            navigate(`/${res.json.data.name}`);
+            setOpenDialog(false);
+            setError(false);
+            setName('');
+            void mutate();
+        }
+
+        setLoading(false);
+    };
+
+    const isMaxEnvironmentsReached = meta?.environments && meta?.plan && meta?.environments.length >= meta?.plan?.environments_max;
+    let tooltipContent: React.ReactNode = null;
+    if (isMaxEnvironmentsReached) {
+        tooltipContent = (
+            <span>
+                Max number of environments reached.{' '}
+                {meta?.plan?.name === 'scale' ? (
+                    <>Contact Nango to add more</>
+                ) : (
+                    <>
+                        <Link to="https://app.withsurface.com/s/cm1zve3340001l503sm0xtvo1" className="underline">
+                            Upgrade
+                        </Link>{' '}
+                        to add more
+                    </>
+                )}
+            </span>
+        );
+    }
+
+    return (
+        <Dialog open={openDialog} onOpenChange={setOpenDialog}>
+            <SimpleTooltip tooltipContent={tooltipContent} delay={0} triggerClassName="w-full" className="text-gray-400" side="bottom">
+                <DialogTrigger className="w-full" asChild>
+                    <Button disabled={!!isMaxEnvironmentsReached} variant={'secondary'} className="w-full justify-center">
+                        {isMaxEnvironmentsReached && <IconLock size={18} stroke={1} />}
+                        Create environment
+                    </Button>
+                </DialogTrigger>
+            </SimpleTooltip>
+            <DialogContent className="w-[550px]">
+                <DialogTitle>Environment Name</DialogTitle>
+                <div>
+                    <Input
+                        placeholder="my-environment-name"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        variant={'black'}
+                        onKeyUp={(e) => e.code === 'Enter' && onCreate()}
+                    />
+                    <div className={cn('text-xs text-grayscale-500', error && 'text-alert-400')}>
+                        *Must be lowercase letters, numbers, underscores and dashes.
+                    </div>
+                </div>
+                <DialogFooter className="mt-4">
+                    <DialogClose asChild>
+                        <Button variant="zinc">Cancel</Button>
+                    </DialogClose>
+                    <Button variant="primary" onClick={onCreate} isLoading={loading} type="submit">
+                        Create environment
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};

--- a/packages/webapp/src/components/EnvironmentPicker.tsx
+++ b/packages/webapp/src/components/EnvironmentPicker.tsx
@@ -1,32 +1,22 @@
-import { Popover, PopoverContent, PopoverTrigger } from '../components/ui/Popover';
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '../components/ui/Command';
-import { useMeta } from '../hooks/useMeta';
-import { useNavigate } from 'react-router-dom';
-import { useState } from 'react';
 import { IconCheck, IconChevronDown } from '@tabler/icons-react';
-import { Button } from './ui/button/Button';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '../components/ui/Command';
+import { Popover, PopoverContent, PopoverTrigger } from '../components/ui/Popover';
+import { useMeta } from '../hooks/useMeta';
 import { useStore } from '../store';
+import { CreateEnvironmentButton } from './CreateEnvironmentButton';
 import { cn } from '../utils/utils';
-import { apiPostEnvironment } from '../hooks/useEnvironment';
-import { Dialog, DialogContent, DialogFooter, DialogTitle, DialogTrigger, DialogClose } from '../components/ui/Dialog';
-import { Input } from './ui/input/Input';
-import { Info } from './Info';
-import { useToast } from '../hooks/useToast';
+import { Button } from './ui/button/Button';
 
 export const EnvironmentPicker: React.FC = () => {
     const navigate = useNavigate();
-    const { toast } = useToast();
-
     const env = useStore((state) => state.env);
     const setEnv = useStore((state) => state.setEnv);
 
-    const { meta, mutate } = useMeta();
+    const { meta } = useMeta();
     const [open, setOpen] = useState(false);
-
-    const [openDialog, setOpenDialog] = useState(false);
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState(false);
-    const [name, setName] = useState('');
 
     const onSelect = (selected: string) => {
         if (selected === env) {
@@ -49,33 +39,6 @@ export const EnvironmentPicker: React.FC = () => {
         }
 
         navigate(newPath);
-    };
-
-    const onCreate = async () => {
-        setLoading(true);
-
-        const res = await apiPostEnvironment({ name });
-        if ('error' in res.json) {
-            const err = res.json.error;
-            if (err.code === 'conflict') {
-                toast({ title: 'Environment name already exists', variant: 'error' });
-            } else if (err.code === 'invalid_body') {
-                setError(true);
-            } else if (err.code === 'feature_disabled' || err.code === 'resource_capped') {
-                toast({ title: err.message, variant: 'error' });
-            } else {
-                toast({ title: 'Failed to create environment', variant: 'error' });
-            }
-        } else {
-            navigate(`/${res.json.data.name}`);
-            setOpen(false);
-            setOpenDialog(false);
-            setError(false);
-            setName('');
-            void mutate();
-        }
-
-        setLoading(false);
     };
 
     if (!meta) {
@@ -122,40 +85,7 @@ export const EnvironmentPicker: React.FC = () => {
                         </CommandGroup>
 
                         <div className="px-2.5 py-2.5">
-                            <Dialog open={openDialog} onOpenChange={setOpenDialog}>
-                                <DialogTrigger asChild>
-                                    <Button variant={'tertiary'} className="w-full justify-center">
-                                        Create environment
-                                    </Button>
-                                </DialogTrigger>
-                                <DialogContent className="w-[550px]">
-                                    <DialogTitle>Environment Name</DialogTitle>
-                                    <div>
-                                        <Input
-                                            placeholder="my-environment-name"
-                                            value={name}
-                                            onChange={(e) => setName(e.target.value)}
-                                            variant={'black'}
-                                            onKeyUp={(e) => e.code === 'Enter' && onCreate()}
-                                        />
-                                        <div className={cn('text-xs text-grayscale-500', error && 'text-alert-400')}>
-                                            *Must be lowercase letters, numbers, underscores and dashes.
-                                        </div>
-                                    </div>
-                                    <Info>
-                                        Only the Prod environment is billed. Other environments are free, with restrictions making them unsuitable for
-                                        production.
-                                    </Info>
-                                    <DialogFooter className="mt-4">
-                                        <DialogClose asChild>
-                                            <Button variant={'zinc'}>Cancel</Button>
-                                        </DialogClose>
-                                        <Button variant={'primary'} onClick={onCreate} isLoading={loading} type="submit">
-                                            Create environment
-                                        </Button>
-                                    </DialogFooter>
-                                </DialogContent>
-                            </Dialog>
+                            <CreateEnvironmentButton />
                         </div>
                     </CommandList>
                 </Command>

--- a/packages/webapp/src/components/PrivateRoute.tsx
+++ b/packages/webapp/src/components/PrivateRoute.tsx
@@ -1,11 +1,12 @@
-import { Outlet, Navigate } from 'react-router-dom';
-import { useMeta } from '../hooks/useMeta';
 import { useEffect, useState } from 'react';
-import { useStore } from '../store';
-import { useAnalyticsIdentify } from '../utils/analytics';
+import { Navigate, Outlet } from 'react-router-dom';
+
+import { useEnvironment } from '../hooks/useEnvironment';
+import { useMeta } from '../hooks/useMeta';
 import { useUser } from '../hooks/useUser';
 import PageNotFound from '../pages/PageNotFound';
-import { useEnvironment } from '../hooks/useEnvironment';
+import { useStore } from '../store';
+import { useAnalyticsIdentify } from '../utils/analytics';
 
 export const PrivateRoute: React.FC = () => {
     const { meta, error, loading: loadingMeta } = useMeta();

--- a/packages/webapp/src/components/SimpleTooltip.tsx
+++ b/packages/webapp/src/components/SimpleTooltip.tsx
@@ -1,10 +1,11 @@
-import type React from 'react';
-import { Tooltip, TooltipProvider, TooltipContent, TooltipTrigger } from './ui/Tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/Tooltip';
+
 import type { Content } from '@radix-ui/react-tooltip';
+import type React from 'react';
 
 export const SimpleTooltip: React.FC<
-    React.PropsWithChildren<{ tooltipContent: React.ReactNode; delay?: number } & React.ComponentPropsWithoutRef<typeof Content>>
-> = ({ tooltipContent, delay, children, ...rest }) => {
+    React.PropsWithChildren<{ tooltipContent: React.ReactNode; delay?: number; triggerClassName?: string } & React.ComponentPropsWithoutRef<typeof Content>>
+> = ({ tooltipContent, delay, children, triggerClassName, ...rest }) => {
     if (!tooltipContent) {
         return <>{children}</>;
     }
@@ -13,7 +14,9 @@ export const SimpleTooltip: React.FC<
         <TooltipProvider delayDuration={delay}>
             <Tooltip>
                 <TooltipContent {...rest}>{tooltipContent}</TooltipContent>
-                <TooltipTrigger>{children}</TooltipTrigger>
+                <TooltipTrigger className={triggerClassName} asChild>
+                    {children}
+                </TooltipTrigger>
             </Tooltip>
         </TooltipProvider>
     );

--- a/packages/webapp/src/constants.ts
+++ b/packages/webapp/src/constants.ts
@@ -1,0 +1,1 @@
+export const PROD_ENVIRONMENT_NAME = 'prod';

--- a/packages/webapp/src/pages/Environment/Settings/EditableInput.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/EditableInput.tsx
@@ -2,6 +2,7 @@ import { IconEdit, IconExternalLink } from '@tabler/icons-react';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
+import { SimpleTooltip } from '../../../components/SimpleTooltip';
 import { Button } from '../../../components/ui/button/Button';
 import { CopyButton } from '../../../components/ui/button/CopyButton';
 import { Input } from '../../../components/ui/input/Input';
@@ -12,19 +13,34 @@ import type { InputProps } from '../../../components/ui/input/Input';
 import type { ApiError } from '@nangohq/types';
 import type { ReactNode } from 'react';
 
-export const EditableInput: React.FC<
-    {
-        title: string;
-        subTitle?: boolean;
-        secret?: boolean;
-        name: string;
-        originalValue: string;
-        docs?: string;
-        editInfo?: ReactNode;
-        apiCall: (val: string) => Promise<{ json: ApiError<'invalid_body'> | Record<string, any> }>;
-        onSuccess: () => void;
-    } & InputProps
-> = ({ title, subTitle, secret, name, originalValue, docs, editInfo, apiCall, onSuccess, ...rest }) => {
+interface EditableInputProps extends InputProps {
+    title: string;
+    subTitle?: boolean;
+    secret?: boolean;
+    name: string;
+    originalValue: string;
+    docs?: string;
+    editInfo?: ReactNode;
+    blocked?: boolean;
+    blockedTooltip?: string;
+    apiCall: (val: string) => Promise<{ json: ApiError<'invalid_body'> | Record<string, any> }>;
+    onSuccess: (name: string) => void;
+}
+
+export const EditableInput: React.FC<EditableInputProps> = ({
+    title,
+    subTitle,
+    secret,
+    name,
+    originalValue,
+    docs,
+    editInfo,
+    apiCall,
+    onSuccess,
+    blocked,
+    blockedTooltip,
+    ...rest
+}) => {
     const { toast } = useToast();
 
     const [value, setValue] = useState<string>(() => originalValue);
@@ -50,7 +66,7 @@ export const EditableInput: React.FC<
         }
 
         toast({ title: `${title} updated successfully!`, variant: 'success' });
-        onSuccess();
+        onSuccess(value);
 
         setEdit(false);
         setError(null);
@@ -82,9 +98,17 @@ export const EditableInput: React.FC<
                     !edit && (
                         <div className="flex">
                             {secret && <CopyButton text={value} />}
-                            <Button variant={'icon'} size={'xs'} onClick={() => setEdit(true)}>
-                                <IconEdit stroke={1} size={18} />
-                            </Button>
+                            {blocked ? (
+                                <SimpleTooltip tooltipContent={blockedTooltip} side="top" delay={0}>
+                                    <Button variant={'icon'} size={'xs'} disabled>
+                                        <IconEdit stroke={1} size={18} />
+                                    </Button>
+                                </SimpleTooltip>
+                            ) : (
+                                <Button variant={'icon'} size={'xs'} onClick={() => setEdit(true)}>
+                                    <IconEdit stroke={1} size={18} />
+                                </Button>
+                            )}
                         </div>
                     )
                 }

--- a/packages/webapp/src/pages/Environment/Settings/Main.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Main.tsx
@@ -1,0 +1,43 @@
+import { IconSettings } from '@tabler/icons-react';
+import { Link, useNavigate } from 'react-router-dom';
+
+import { EditableInput } from './EditableInput';
+import { PROD_ENVIRONMENT_NAME } from '../../../constants';
+import { apiPatchEnvironment } from '../../../hooks/useEnvironment';
+import { useMeta } from '../../../hooks/useMeta';
+import { useStore } from '../../../store';
+
+export const MainSettings: React.FC = () => {
+    const navigate = useNavigate();
+
+    const env = useStore((state) => state.env);
+    const setEnv = useStore((state) => state.setEnv);
+    const { mutate: mutateMeta } = useMeta();
+
+    return (
+        <div className="text-grayscale-100 flex flex-col gap-10">
+            <Link className="flex gap-2 items-center rounded-md bg-grayscale-900 px-8 h-10" to="#main" id="main">
+                <div>
+                    <IconSettings stroke={1} size={18} />
+                </div>
+                <h3 className="uppercase text-sm">Main</h3>
+            </Link>
+            <div className="px-8 flex flex-col gap-10 w-3/5">
+                <EditableInput
+                    title="Environment Name"
+                    name="environmentName"
+                    originalValue={env}
+                    apiCall={(name) => apiPatchEnvironment(env, { name })}
+                    onSuccess={async (newName) => {
+                        // We have to start by changing the url, otherwise PrivateRoute will revert the env based on it.
+                        navigate(`/${newName}/environment-settings`);
+                        await mutateMeta();
+                        setEnv(newName);
+                    }}
+                    blocked={env === PROD_ENVIRONMENT_NAME}
+                    blockedTooltip={`You cannot rename the ${PROD_ENVIRONMENT_NAME} environment`}
+                />
+            </div>
+        </div>
+    );
+};

--- a/packages/webapp/src/pages/Environment/Settings/Show.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Show.tsx
@@ -1,19 +1,22 @@
+import { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
-import { LeftNavBarItems } from '../../../components/LeftNavBar';
-import DashboardLayout from '../../../layout/DashboardLayout';
+
 import { AuthorizationSettings } from './Authorization';
-import { VariablesSettings } from './Variables';
-import { NotificationSettings } from './Notification';
 import { BackendSettings } from './Backend';
 import { ExportSettings } from './Export';
+import { MainSettings } from './Main';
+import { NotificationSettings } from './Notification';
+import { VariablesSettings } from './Variables';
+import { LeftNavBarItems } from '../../../components/LeftNavBar';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '../../../components/ui/Accordion';
-import { useEnvironment } from '../../../hooks/useEnvironment';
-import { useStore } from '../../../store';
 import { Skeleton } from '../../../components/ui/Skeleton';
-import { useEffect, useState } from 'react';
+import { useEnvironment } from '../../../hooks/useEnvironment';
+import DashboardLayout from '../../../layout/DashboardLayout';
+import { useStore } from '../../../store';
 
 export const EnvironmentSettings: React.FC = () => {
     const env = useStore((state) => state.env);
+
     const { environmentAndAccount } = useEnvironment(env);
     const [scrolled, setScrolled] = useState(false);
 
@@ -63,7 +66,9 @@ export const EnvironmentSettings: React.FC = () => {
             <div className="flex justify-between mb-8 items-center">
                 <h2 className="flex text-left text-3xl font-semibold tracking-tight text-white">Environment Settings</h2>
             </div>
+
             <div className="flex flex-col gap-20 h-fit" key={env}>
+                <MainSettings />
                 <BackendSettings />
                 <NotificationSettings />
                 <VariablesSettings />

--- a/packages/webapp/src/store.ts
+++ b/packages/webapp/src/store.ts
@@ -1,4 +1,6 @@
 import { create } from 'zustand';
+
+import { PROD_ENVIRONMENT_NAME } from './constants';
 import storage, { LocalStorageKeys } from './utils/local-storage';
 
 interface Env {
@@ -7,8 +9,8 @@ interface Env {
 
 interface State {
     env: string;
-    baseUrl: string;
     envs: Env[];
+    baseUrl: string;
     showGettingStarted: boolean;
     debugMode: boolean;
     setEnv: (value: string) => void;
@@ -20,7 +22,7 @@ interface State {
 
 export const useStore = create<State>((set, get) => ({
     env: storage.getItem(LocalStorageKeys.LastEnvironment) || 'dev',
-    envs: [{ name: 'dev' }, { name: 'prod' }],
+    envs: [{ name: 'dev' }, { name: PROD_ENVIRONMENT_NAME }],
     baseUrl: 'https://api.nango.dev',
     showGettingStarted: true,
     debugMode: false,


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
### Description
This PR contains cherry-picked files (with tweaks) from #3849, excluding anything related to deleting environments.

- Added new `Main` section to environment settings with `EditableInput` for environment name.
<img width="952" alt="image" src="https://github.com/user-attachments/assets/04a06c7e-300c-4a66-b82b-acb46cd6c7cc" />

- Prod environment shouldn't be renamable with informative tooltip 
<img width="641" alt="image" src="https://github.com/user-attachments/assets/731e172d-b920-41fe-9a0e-cad15edd2f78" />

- Tweaked `Create Environment` button be blocked and show different tooltip based on plan, when maximum amount of environments is reached
<img width="419" alt="image" src="https://github.com/user-attachments/assets/9430bab5-9bd9-4ba1-b61f-1d209e9ecf69" />

- Removed message from create environment dialog that said only the prod environment is billed.


<!-- Issue ticket number and link (if applicable) -->
### Ticket
[NAN-2685](https://linear.app/nango/issue/NAN-2685/editdelete-environments-in-the-ui)

<!-- Testing instructions (skip if just adding/editing providers) -->
### Testing instructions
Checkout to branch and test mentioned changes in UI.

