### PR TITLE
fix(integrations): missing retry header for Slack

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -8368,6 +8368,8 @@ slack:
         - team.id
     proxy:
         base_url: https://slack.com/api
+        retry:
+            after: 'retry-after'
         paginate:
             type: cursor
             cursor_path_in_response: response_metadata.next_cursor

--- a/packages/shared/lib/services/proxy/request.ts
+++ b/packages/shared/lib/services/proxy/request.ts
@@ -1,11 +1,13 @@
 import { isAxiosError } from 'axios';
-import type { AxiosResponse, AxiosRequestConfig } from 'axios';
-import type { Result, RetryAttemptArgument } from '@nangohq/utils';
-import { axiosInstance as axios, Err, Ok, redactHeaders, redactURL, retryFlexible } from '@nangohq/utils';
+
+import { Err, Ok, axiosInstance as axios, redactHeaders, redactURL, retryFlexible } from '@nangohq/utils';
+
+import { getProxyRetryFromErr } from './retry.js';
+import { ProxyError, getAxiosConfiguration } from './utils.js';
 
 import type { ApplicationConstructedProxyConfiguration, ConnectionForProxy, MaybePromise, MessageRowInsert } from '@nangohq/types';
-import { getAxiosConfiguration, ProxyError } from './utils.js';
-import { getProxyRetryFromErr } from './retry.js';
+import type { Result, RetryAttemptArgument } from '@nangohq/utils';
+import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 
 interface Props {
     proxyConfig: ApplicationConstructedProxyConfiguration;

--- a/packages/shared/lib/services/proxy/retry.ts
+++ b/packages/shared/lib/services/proxy/retry.ts
@@ -1,7 +1,9 @@
-import type { ApplicationConstructedProxyConfiguration } from '@nangohq/types';
-import { networkError } from '@nangohq/utils';
-import type { AxiosError } from 'axios';
 import { isAxiosError } from 'axios';
+
+import { networkError } from '@nangohq/utils';
+
+import type { ApplicationConstructedProxyConfiguration } from '@nangohq/types';
+import type { AxiosError } from 'axios';
 
 /**
  * Determine if we can retry or not based on the error we are receiving
@@ -116,7 +118,7 @@ export function getRetryFromHeader({
             return { found: false, reason: 'after:no_header' };
         }
 
-        // TODO: handle non-seconds header
+        // TODO: handle non-seconds header (e.g: linear)
         const retryAfter = Number(retryHeaderVal);
 
         return { found: true, reason: 'after', wait: retryAfter * 1000 };


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-3059/investigate-slack-retry-after

- missing retry header for Slack