### PR TITLE
fix: expose reason a task was expired

### DIFF
--- a/packages/orchestrator/lib/abort.ts
+++ b/packages/orchestrator/lib/abort.ts
@@ -5,7 +5,7 @@ import type { Result } from '@nangohq/utils';
 import { logger } from './utils.js';
 import type { JsonValue } from 'type-fest';
 
-export async function scheduleAbortTask({ scheduler, task }: { scheduler: Scheduler; task: Task }): Promise<Result<Task>> {
+export async function scheduleAbortTask({ scheduler, task, reason }: { scheduler: Scheduler; task: Task; reason: string }): Promise<Result<Task>> {
     const aborted = validateTask(task);
     if (aborted.isErr()) {
         return Err(aborted.error);
@@ -16,7 +16,6 @@ export async function scheduleAbortTask({ scheduler, task }: { scheduler: Schedu
         return Err(`Task is already an abort task`);
     }
 
-    const reason = aborted.value.state === 'EXPIRED' ? 'Expired execution' : 'Execution was cancelled';
     const payload: JsonValue = {
         type: 'abort',
         abortedTask: {

--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -53,12 +53,13 @@ try {
         EXPIRED: async (scheduler: Scheduler, task: Task) => {
             logger.error(`Task expired: ${stringifyTask(task)}`);
             metrics.increment(metrics.Types.ORCH_TASKS_EXPIRED);
-            await scheduleAbortTask({ scheduler, task });
+            const { reason } = task.output as unknown as { reason?: string };
+            await scheduleAbortTask({ scheduler, task, reason: `Execution expired: ${reason || 'unknown reason'}` });
         },
         CANCELLED: async (scheduler: Scheduler, task: Task) => {
             logger.info(`Task cancelled: ${stringifyTask(task)}`);
             metrics.increment(metrics.Types.ORCH_TASKS_CANCELLED);
-            await scheduleAbortTask({ scheduler, task });
+            await scheduleAbortTask({ scheduler, task, reason: `Execution was cancelled` });
         }
     });
 


### PR DESCRIPTION
When a task currently expires the message is simply `Execution expired` without any information about  why.
This exposing is exposing the reason (for example: `heartbeatTimeoutSecs_exceeded` or `startedToCompletedTimeoutSecs_exceeded`
