### PR TITLE
fix(rateLimit): increase limit for providers.json

### DIFF
--- a/docs-v2/guides/resource-limits.mdx
+++ b/docs-v2/guides/resource-limits.mdx
@@ -13,7 +13,7 @@ description: 'Overview of resource limits on Nango Cloud.'
 ### Integration endpoints & scripts
 
 - This feature is gated behind a 14-day trial
-- Trials can be extended indefinitely via the Nango UI (14 days at a time) 
+- Trials can be extended indefinitely via the Nango UI (14 days at a time)
 - Integrations using integration endpoints/scripts are limited to 50 connections
 
 <Note>
@@ -26,13 +26,13 @@ Integration endpoints and scripts run in isolated virtual machines to ensure rel
 
 ### API rate-limit
 
-- 2,400 requests per minute across all usage (app and integration scripts).
+- Free tier: 200 requests per minute across all usage (app and integration scripts).
 - If the limit is exceeded, use the standard rate-limit headers to determine when to resume requests.
-- Higher limits are available for Scale customers.
+- Higher limits are available for paying customers.
 
 ### Integration scripts
 
-Integrations have the following limits: 
+Integrations have the following limits:
 
 | Script Type | Max execution time | Max enqueuing time |
 | - | - | - |

--- a/package-lock.json
+++ b/package-lock.json
@@ -26850,6 +26850,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "darwin"

--- a/packages/server/lib/middleware/ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/ratelimit.middleware.ts
@@ -19,8 +19,8 @@ const rateLimiterSize: Record<DBPlan['api_rate_limit_size'], number> = {
     m: defaultLimit,
     l: defaultLimit * 5,
     xl: defaultLimit * 10,
-    '2xl': defaultLimit * 50,
-    '3xl': defaultLimit * 100
+    '2xl': defaultLimit * 25,
+    '3xl': defaultLimit * 50
 };
 const limiters = new Map<DBPlan['api_rate_limit_size'], RateLimiterAbstract>();
 

--- a/packages/server/lib/middleware/ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/ratelimit.middleware.ts
@@ -20,7 +20,8 @@ const rateLimiterSize: Record<DBPlan['api_rate_limit_size'], number> = {
     l: defaultLimit * 5,
     xl: defaultLimit * 10,
     '2xl': defaultLimit * 25,
-    '3xl': defaultLimit * 50
+    '3xl': defaultLimit * 50,
+    '4xl': defaultLimit * 75
 };
 const limiters = new Map<DBPlan['api_rate_limit_size'], RateLimiterAbstract>();
 

--- a/packages/server/lib/middleware/ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/ratelimit.middleware.ts
@@ -119,6 +119,7 @@ function getPointsToConsume(req: Request, res: Response<any, RequestLocals>, max
         // limiting to 6 requests per period to avoid brute force attacks
         return Math.floor(maxPoints / 6);
     } else if (fullPath === '/providers.json') {
+        // Special case because it's hit by all runners with the same ip
         return 1;
     } else if (!res.locals.account || (flagHasPlan && !res.locals.plan)) {
         // Throttle api calls without valid credentials

--- a/packages/server/lib/middleware/ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/ratelimit.middleware.ts
@@ -117,6 +117,8 @@ function getPointsToConsume(req: Request, res: Response<any, RequestLocals>, max
     if (specialPaths.some((p) => fullPath.startsWith(p))) {
         // limiting to 6 requests per period to avoid brute force attacks
         return Math.floor(maxPoints / 6);
+    } else if (fullPath === '/providers.json') {
+        return 1;
     } else if (!res.locals.account || (flagHasPlan && !res.locals.plan)) {
         // Throttle api calls without valid credentials
         return 10;

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -49,5 +49,5 @@ export interface DBPlan extends Timestamps {
      * Change the applied rate limit for the public API
      * @default "m"
      */
-    api_rate_limit_size: 's' | 'm' | 'l' | 'xl' | '2xl' | '3xl';
+    api_rate_limit_size: 's' | 'm' | 'l' | 'xl' | '2xl' | '3xl' | '4xl';
 }


### PR DESCRIPTION
## Changs

- increase limit for providers.json
Since all runners hit this endpoint with just 2-4 ips, it spammed the API. It should be better like this, but ultimately it's not enough

- Add more granular increment for rate limit size
The jump was a bit too big