### PR TITLE
feat(logs): search in global field, index batchSave

### DIFF
--- a/packages/logs/lib/client.ts
+++ b/packages/logs/lib/client.ts
@@ -46,9 +46,9 @@ export class LogContextStateless {
         );
     }
 
-    async info(message: string, meta?: MessageMeta): Promise<boolean> {
+    async info(message: string, meta?: MessageMeta, rest?: Partial<MessageRowInsert>): Promise<boolean> {
         return await this.transport.log(
-            { type: 'log', level: 'info', message, meta, source: 'internal', createdAt: new Date().toISOString() },
+            { type: 'log', level: 'info', message, meta, source: 'internal', createdAt: new Date().toISOString(), ...rest },
             { dryRun: this.dryRun, logToConsole: this.logToConsole, operationId: this.id, accountId: this.accountId }
         );
     }

--- a/packages/logs/lib/models/helpers.ts
+++ b/packages/logs/lib/models/helpers.ts
@@ -81,7 +81,7 @@ export function getFormattedMessage(data: SetRequired<Partial<MessageRow>, 'pare
         response: data.response,
         retry: data.retry,
         meta: data.meta,
-        batchSave: data.batchSave,
+        persistResults: data.persistResults,
 
         createdAt: data.createdAt || now.toISOString(),
         endedAt: data.endedAt,

--- a/packages/logs/lib/models/helpers.ts
+++ b/packages/logs/lib/models/helpers.ts
@@ -81,6 +81,7 @@ export function getFormattedMessage(data: SetRequired<Partial<MessageRow>, 'pare
         response: data.response,
         retry: data.retry,
         meta: data.meta,
+        batchSave: data.batchSave,
 
         createdAt: data.createdAt || now.toISOString(),
         endedAt: data.endedAt,

--- a/packages/logs/lib/models/messages.ts
+++ b/packages/logs/lib/models/messages.ts
@@ -1,4 +1,12 @@
+import { errors } from '@elastic/elasticsearch';
+
+import { isTest } from '@nangohq/utils';
+
+import { createCursor, getFullIndexName, parseCursor } from './helpers.js';
 import { client } from '../es/client.js';
+import { indexMessages } from '../es/schema.js';
+
+import type { estypes } from '@elastic/elasticsearch';
 import type {
     MessageRow,
     OperationRow,
@@ -9,12 +17,7 @@ import type {
     SearchOperationsSync,
     SearchOperationsType
 } from '@nangohq/types';
-import { indexMessages } from '../es/schema.js';
-import type { estypes } from '@elastic/elasticsearch';
-import { errors } from '@elastic/elasticsearch';
 import type { SetRequired } from 'type-fest';
-import { getFullIndexName, createCursor, parseCursor } from './helpers.js';
-import { isTest } from '@nangohq/utils';
 
 export interface ListOperations {
     count: number;
@@ -286,7 +289,7 @@ export async function listMessages(opts: {
     }
     if (opts.search) {
         (query.bool!.must as estypes.QueryDslQueryContainer[]).push({
-            match_phrase_prefix: { message: { query: opts.search } }
+            match_phrase_prefix: { meta_search: { query: opts.search } }
         });
     }
 

--- a/packages/persist/lib/records.ts
+++ b/packages/persist/lib/records.ts
@@ -127,7 +127,7 @@ export async function persistRecords({
             `Successfully batched ${allModifiedKeys.size} record${allModifiedKeys.size > 1 ? 's' : ''} for model ${baseModel}`,
             { persistType },
             {
-                batchSave: {
+                persistResults: {
                     model: baseModel,
                     added: summary.addedKeys.length,
                     updated: summary.updatedKeys.length,

--- a/packages/persist/lib/records.ts
+++ b/packages/persist/lib/records.ts
@@ -123,19 +123,22 @@ export async function persistRecords({
 
         const allModifiedKeys = new Set([...summary.addedKeys, ...summary.updatedKeys, ...(summary.deletedKeys || [])]);
 
-        void logCtx.info(`Successfully batched ${allModifiedKeys.size} record${allModifiedKeys.size > 1 ? 's' : ''} for model ${baseModel}`, {
-            persistType,
-            // Please note this object is indexed in Elasticsearch, be careful when changing the shape
-            updatedResults: {
-                model: baseModel,
-                added: summary.addedKeys.length,
-                //addedKeys: summary.addedKeys,
-                updated: summary.updatedKeys.length,
-                //updatedKeys: summary.updatedKeys,
-                deleted: summary.deletedKeys?.length || 0
-                //deleteKeys: summary.deletedKeys || []
+        void logCtx.info(
+            `Successfully batched ${allModifiedKeys.size} record${allModifiedKeys.size > 1 ? 's' : ''} for model ${baseModel}`,
+            { persistType },
+            {
+                batchSave: {
+                    model: baseModel,
+                    added: summary.addedKeys.length,
+                    updated: summary.updatedKeys.length,
+                    deleted: summary.deletedKeys?.length || 0,
+
+                    addedKeys: summary.addedKeys,
+                    updatedKeys: summary.updatedKeys,
+                    deleteKeys: summary.deletedKeys || []
+                }
             }
-        });
+        );
 
         const recordsSizeInBytes = Buffer.byteLength(JSON.stringify(records), 'utf8');
         const modifiedRecordsSizeInBytes = recordsData.reduce((acc, record) => {

--- a/packages/runner/lib/sdk/locks.unit.test.ts
+++ b/packages/runner/lib/sdk/locks.unit.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { Locks } from './locks.js';
 
 describe('Locks', () => {
@@ -140,7 +141,7 @@ describe('Locks', () => {
 
         it('should return false if the locks is expired', async () => {
             await locks.tryAcquireLock({ owner: 'owner1', key: 'resource1', ttlMs: 1 });
-            await new Promise((resolve) => setTimeout(resolve, 2)); // Wait for the lock to expire
+            await new Promise((resolve) => setTimeout(resolve, 10)); // Wait for the lock to expire
 
             const res = await locks.hasLock({ owner: 'owner1', key: 'resource1' });
             expect(res.unwrap()).toBe(false);

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -117,15 +117,17 @@ export interface MessageRow {
     request?: MessageHTTPRequest | undefined;
     response?: MessageHTTPResponse | undefined;
     meta?: MessageMeta | null | undefined;
-    batchSave?: {
-        model: string;
-        added: number;
-        addedKeys: string[];
-        updated: number;
-        updatedKeys: string[];
-        deleted: number;
-        deleteKeys: string[];
-    };
+    batchSave?:
+        | {
+              model: string;
+              added: number;
+              addedKeys: string[];
+              updated: number;
+              updatedKeys: string[];
+              deleted: number;
+              deleteKeys: string[];
+          }
+        | undefined;
     retry?: MessageHTTPRetry | undefined;
 
     // Dates

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -117,7 +117,7 @@ export interface MessageRow {
     request?: MessageHTTPRequest | undefined;
     response?: MessageHTTPResponse | undefined;
     meta?: MessageMeta | null | undefined;
-    batchSave?:
+    persistResults?:
         | {
               model: string;
               added: number;

--- a/packages/webapp/src/pages/Logs/ShowMessage.tsx
+++ b/packages/webapp/src/pages/Logs/ShowMessage.tsx
@@ -1,10 +1,12 @@
-import type { MessageRow } from '@nangohq/types';
-import { useMemo } from 'react';
-import { formatDateToLogFormat } from '../../utils/utils';
 import { Prism } from '@mantine/prism';
+import { CalendarIcon } from '@radix-ui/react-icons';
+import { useMemo } from 'react';
+
 import { LevelTag } from './components/LevelTag';
 import { Tag } from '../../components/ui/label/Tag';
-import { CalendarIcon } from '@radix-ui/react-icons';
+import { formatDateToLogFormat } from '../../utils/utils';
+
+import type { MessageRow } from '@nangohq/types';
 
 export const ShowMessage: React.FC<{ message: MessageRow }> = ({ message }) => {
     const createdAt = useMemo(() => {
@@ -25,6 +27,9 @@ export const ShowMessage: React.FC<{ message: MessageRow }> = ({ message }) => {
         }
         if (message.retry) {
             pl.retry = message.retry;
+        }
+        if (message.batchSave) {
+            pl.batchSave = message.batchSave;
         }
         if (message.error) {
             pl.error = { message: message.error.message };

--- a/packages/webapp/src/pages/Logs/ShowMessage.tsx
+++ b/packages/webapp/src/pages/Logs/ShowMessage.tsx
@@ -28,8 +28,8 @@ export const ShowMessage: React.FC<{ message: MessageRow }> = ({ message }) => {
         if (message.retry) {
             pl.retry = message.retry;
         }
-        if (message.batchSave) {
-            pl.batchSave = message.batchSave;
+        if (message.persistResults) {
+            pl.persistResults = message.persistResults;
         }
         if (message.error) {
             pl.error = { message: message.error.message };


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-2698/full-text-search-includes-payloads
Fixes https://linear.app/nango/issue/NAN-2699/search-logs-by-record-id

- Search in global field
It's still not searching everything but a selected number of fields, however, it's already better since we now have error messages, status codes and such. And we can add more.

- Index `batchSave`
Index this payload outside meta so we can store records id in the global field. This will probably log a lot of data in prod.

## 🧪 Tests

- Do that

https://github.com/user-attachments/assets/d6526b6e-4666-46d7-a782-4a1d2d7a06b9

