### PR TITLE
feat(webapp, api): allow updating sync frequency for a specific conne…

### DIFF
--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -175,6 +175,7 @@ web.route('/user/password').put(webAuth, userController.editPassword.bind(userCo
 
 web.route('/sync').get(webAuth, syncController.getSyncsByParams.bind(syncController));
 web.route('/sync/command').post(webAuth, syncController.syncCommand.bind(syncController));
+web.route('/sync/update-connection-frequency').put(webAuth, syncController.updateFrequencyForConnection.bind(syncController));
 web.route('/syncs').get(webAuth, syncController.getSyncs.bind(syncController));
 web.route('/flows').get(webAuth, flowController.getFlows.bind(syncController));
 web.route('/flows/pre-built/deploy').post(webAuth, postPreBuiltDeploy);

--- a/packages/types/lib/sync/api.ts
+++ b/packages/types/lib/sync/api.ts
@@ -36,6 +36,21 @@ export type PostSyncVariant = Endpoint<{
     Success: { id: string; name: string; variant: string };
 }>;
 
+export type UpdateSyncConnectionFrequency = Endpoint<{
+    Method: 'PUT';
+    Path: '/api/v1/sync/update-connection-frequency';
+    Querystring: { env: string };
+    Body: {
+        connection_id: string;
+        provider_config_key: string;
+        name: string;
+        variant: string;
+        frequency: string | null;
+    };
+    Error: ApiError<'unknown_provider_config'> | ApiError<'unknown_connection'>;
+    Success: { data: { frequency: string } };
+}>;
+
 export type DeleteSyncVariant = Endpoint<{
     Method: 'DELETE';
     Path: '/sync/:name/variant/:variant';

--- a/packages/types/lib/sync/api.ts
+++ b/packages/types/lib/sync/api.ts
@@ -36,7 +36,7 @@ export type PostSyncVariant = Endpoint<{
     Success: { id: string; name: string; variant: string };
 }>;
 
-export type UpdateSyncConnectionFrequency = Endpoint<{
+export type UpdateConnectionFrequency = Endpoint<{
     Method: 'PUT';
     Path: '/api/v1/sync/update-connection-frequency';
     Querystring: { env: string };

--- a/packages/webapp/src/hooks/useConnections.tsx
+++ b/packages/webapp/src/hooks/useConnections.tsx
@@ -3,7 +3,14 @@ import useSWR from 'swr';
 import useSWRInfinite from 'swr/infinite';
 import type { SWRError } from '../utils/api';
 import { apiFetch, swrFetcher } from '../utils/api';
-import type { GetConnections, DeleteConnection, GetConnectionsCount, GetConnection, PostConnectionRefresh } from '@nangohq/types';
+import type {
+    GetConnections,
+    DeleteConnection,
+    GetConnectionsCount,
+    GetConnection,
+    PostConnectionRefresh,
+    UpdateSyncConnectionFrequency
+} from '@nangohq/types';
 import { useMemo } from 'react';
 
 export function useConnections(queries: GetConnections['Querystring']) {
@@ -79,6 +86,21 @@ export async function apiRefreshConnection(params: PostConnectionRefresh['Params
     return {
         res,
         json: (await res.json()) as PostConnectionRefresh['Reply']
+    };
+}
+
+export async function apiUpdateSyncConnectionFrequency(env: string, { name: sync_name, ...body }: UpdateSyncConnectionFrequency['Body']) {
+    const method: UpdateSyncConnectionFrequency['Method'] = 'PUT';
+    const path: UpdateSyncConnectionFrequency['Path'] = '/api/v1/sync/update-connection-frequency';
+
+    const res = await apiFetch(`${path}?env=${env}`, {
+        method,
+        body: JSON.stringify({ ...body, sync_name })
+    });
+
+    return {
+        res,
+        json: (await res.json()) as UpdateSyncConnectionFrequency['Reply']
     };
 }
 

--- a/packages/webapp/src/hooks/useConnections.tsx
+++ b/packages/webapp/src/hooks/useConnections.tsx
@@ -3,14 +3,7 @@ import useSWR from 'swr';
 import useSWRInfinite from 'swr/infinite';
 import type { SWRError } from '../utils/api';
 import { apiFetch, swrFetcher } from '../utils/api';
-import type {
-    GetConnections,
-    DeleteConnection,
-    GetConnectionsCount,
-    GetConnection,
-    PostConnectionRefresh,
-    UpdateSyncConnectionFrequency
-} from '@nangohq/types';
+import type { GetConnections, DeleteConnection, GetConnectionsCount, GetConnection, PostConnectionRefresh, UpdateConnectionFrequency } from '@nangohq/types';
 import { useMemo } from 'react';
 
 export function useConnections(queries: GetConnections['Querystring']) {
@@ -89,9 +82,9 @@ export async function apiRefreshConnection(params: PostConnectionRefresh['Params
     };
 }
 
-export async function apiUpdateSyncConnectionFrequency(env: string, { name: sync_name, ...body }: UpdateSyncConnectionFrequency['Body']) {
-    const method: UpdateSyncConnectionFrequency['Method'] = 'PUT';
-    const path: UpdateSyncConnectionFrequency['Path'] = '/api/v1/sync/update-connection-frequency';
+export async function apiUpdateSyncConnectionFrequency(env: string, { name: sync_name, ...body }: UpdateConnectionFrequency['Body']) {
+    const method: UpdateConnectionFrequency['Method'] = 'PUT';
+    const path: UpdateConnectionFrequency['Path'] = '/api/v1/sync/update-connection-frequency';
 
     const res = await apiFetch(`${path}?env=${env}`, {
         method,
@@ -100,7 +93,7 @@ export async function apiUpdateSyncConnectionFrequency(env: string, { name: sync
 
     return {
         res,
-        json: (await res.json()) as UpdateSyncConnectionFrequency['Reply']
+        json: (await res.json()) as UpdateConnectionFrequency['Reply']
     };
 }
 

--- a/packages/webapp/src/pages/Connection/components/SyncRow.tsx
+++ b/packages/webapp/src/pages/Connection/components/SyncRow.tsx
@@ -22,12 +22,15 @@ import { Button, ButtonLink } from '../../../components/ui/button/Button';
 import { Popover, PopoverTrigger } from '../../../components/ui/Popover';
 import { PopoverContent } from '@radix-ui/react-popover';
 import { SimpleTooltip } from '../../../components/SimpleTooltip';
-import { IconClockPause, IconClockPlay, IconRefresh, IconX } from '@tabler/icons-react';
+import { IconClockPause, IconClockPlay, IconRefresh, IconX, IconPencil } from '@tabler/icons-react';
 import { useToast } from '../../../hooks/useToast';
 import { mutate } from 'swr';
 import { Select, SelectItem, SelectContent, SelectTrigger, SelectValue } from '../../../components/ui/Select';
 import { Checkbox } from '../../../components/ui/Checkbox';
 import { apiRunSyncCommand } from '../../../hooks/useSyncs';
+import { Input } from '../../../components/ui/input/Input';
+import { frequencyRegex } from '../../../utils/validation';
+import { apiUpdateSyncConnectionFrequency } from '../../../hooks/useConnections';
 
 export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFull; provider: string | null; showSyncVariant: boolean }> = ({
     sync,
@@ -47,6 +50,13 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
     const [deleteRecords, setDeleteRecords] = useState(false);
     const [modalSpinner, setModalShowSpinner] = useState(false);
     const [openConfirm, setOpenConfirm] = useState(false);
+
+    // Frequency
+    const [openFrequency, setOpenFrequency] = useState(false);
+    const [selectedFrequency, setSelectedFrequency] = useState(sync.frequency);
+    const [isSavingFrequency, setIsSavingFrequency] = useState(false);
+    const [frequencyError, setFrequencyError] = useState<string | null>(null);
+    const isSaveFrequencyDisabled = frequencyError !== null || selectedFrequency === sync.frequency;
 
     const confirmTrigger = async () => {
         if (!sync || !provider) {
@@ -124,6 +134,52 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
         resetLoaders();
     };
 
+    const onFrequencyChange = (value: string) => {
+        setSelectedFrequency(value);
+
+        const reg = value.match(frequencyRegex);
+        if (!reg || !reg.groups) {
+            setFrequencyError('Format should be "every (number) (unit)", e.g: "every 1 hour", "every 20 days"');
+            return;
+        }
+
+        const unit = reg.groups['unit'];
+        const amount = parseInt(reg.groups['amount'], 10);
+
+        if (unit.startsWith('s') && (amount < 30 || !amount)) {
+            setFrequencyError('The minimum frequency is 30 seconds');
+            return;
+        }
+
+        setFrequencyError(null);
+    };
+
+    const saveFrequency = async () => {
+        if (isSaveFrequencyDisabled) {
+            return;
+        }
+
+        setIsSavingFrequency(true);
+
+        const response = await apiUpdateSyncConnectionFrequency(env, {
+            connection_id: connection.connection_id,
+            provider_config_key: connection.provider_config_key,
+            name: sync.name,
+            variant: sync.variant,
+            frequency: selectedFrequency
+        });
+
+        if ('error' in response.json) {
+            toast({ title: response.json.error?.message || 'An unexpected error occurred', variant: 'error' });
+        } else {
+            toast({ title: 'Updated successfully', variant: 'success' });
+            await mutate((key) => typeof key === 'string' && key.startsWith(`/api/v1/sync`));
+        }
+
+        setIsSavingFrequency(false);
+        setOpenFrequency(false);
+    };
+
     return (
         <Table.Row className="text-white">
             <Table.Cell bordered>
@@ -156,7 +212,52 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
                 )}
                 {!sync.latest_sync && <Tag variant={'gray'}>NEVER RUN</Tag>}
             </Table.Cell>
-            <Table.Cell bordered>{formatFrequency(sync.frequency)}</Table.Cell>
+            <Table.Cell bordered>
+                <div className="flex items-center justify-end gap-2">
+                    <div className="capitalize">{formatFrequency(sync.frequency)}</div>
+                    <Dialog
+                        open={openFrequency}
+                        onOpenChange={(v) => {
+                            if (v) {
+                                onFrequencyChange(sync.frequency);
+                                setFrequencyError(null);
+                            }
+                            setOpenFrequency(v);
+                        }}
+                    >
+                        <DialogTrigger asChild>
+                            <Button variant="icon" size="xs">
+                                <IconPencil stroke={1} size={18} />
+                            </Button>
+                        </DialogTrigger>
+                        <DialogContent className="pointer-events-auto">
+                            <DialogTitle>Edit sync frequency</DialogTitle>
+                            <DialogDescription>
+                                This change only affects this connection. Increasing the sync frequency may increase API usage and billing.
+                            </DialogDescription>
+                            <div className="flex flex-col gap-2">
+                                <Input
+                                    variant="black"
+                                    value={selectedFrequency}
+                                    autoFocus
+                                    onChange={(e) => onFrequencyChange(e.target.value)}
+                                    onKeyDown={(e) => e.key === 'Enter' && saveFrequency()}
+                                />
+                                {frequencyError && <div className="text-sm text-red-base">{frequencyError}</div>}
+                            </div>
+                            <DialogFooter>
+                                <DialogClose asChild>
+                                    <Button variant="secondary">Cancel</Button>
+                                </DialogClose>
+                                <Button variant="primary" isLoading={isSavingFrequency} disabled={isSaveFrequencyDisabled} onClick={saveFrequency}>
+                                    Save
+                                </Button>
+                            </DialogFooter>
+                        </DialogContent>
+                    </Dialog>
+                </div>
+            </Table.Cell>
+
             <Table.Cell bordered>
                 <SimpleTooltip tooltipContent={JSON.stringify(sync.record_count, null, 2)}>
                     {formatQuantity(Object.entries(sync.record_count).reduce((acc, [, count]) => acc + count, 0))}

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Endpoints/components/ScriptSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Endpoints/components/ScriptSettings.tsx
@@ -14,10 +14,7 @@ import { mutate } from 'swr';
 import { Link } from 'react-router-dom';
 import { SimpleTooltip } from '../../../../../components/SimpleTooltip';
 import { IconCircleCheck, IconHelpCircle, IconPencil } from '@tabler/icons-react';
-
-// To sync with patchFrequency
-const frequencyRegex =
-    /^(?<every>every )?((?<amount>[0-9]+)?\s?(?<unit>(s|secs?|seconds?|m|mins?|minutes?|h|hrs?|hours?|d|days?))|(?<unit2>(month|week|half day|half hour|quarter hour)))$/;
+import { frequencyRegex } from '../../../../../utils/validation';
 
 export const ScriptSettings: React.FC<{
     integration: GetIntegration['Success']['data'];

--- a/packages/webapp/src/utils/validation.ts
+++ b/packages/webapp/src/utils/validation.ts
@@ -1,0 +1,3 @@
+// To sync with patchFrequency
+export const frequencyRegex =
+    /^(?<every>every )?((?<amount>[0-9]+)?\s?(?<unit>(s|secs?|seconds?|m|mins?|minutes?|h|hrs?|hours?|d|days?))|(?<unit2>(month|week|half day|half hour|quarter hour)))$/;

--- a/packages/webapp/src/utils/validation.ts
+++ b/packages/webapp/src/utils/validation.ts
@@ -1,3 +1,3 @@
 // To sync with patchFrequency
 export const frequencyRegex =
-    /^(?<every>every )?((?<amount>[0-9]+)?\s?(?<unit>(s|secs?|seconds?|m|mins?|minutes?|h|hrs?|hours?|d|days?))|(?<unit2>(month|week|half day|half hour|quarter hour)))$/;
+    /^every ((?<amount>[0-9]+)?\s?(?<unit>(s|secs?|seconds?|m|mins?|minutes?|h|hrs?|hours?|d|days?))|(?<unit2>(month|week|half day|half hour|quarter hour)))$/;


### PR DESCRIPTION

## Issue

Currently, there's no way for users to edit the sync frequency of a connection directly from the dashboard UI. The only available methods are via the public API or Node SDK, which adds unnecessary friction compared to making the change directly in the interface. This limitation was highlighted in [Slack](https://nango-community.slack.com/archives/C04ABR352H0/p1744242419038669) by a user trying to modify the frequency for a Salesforce connection.

## Fix

Adds support for editing the sync frequency of individual connections directly from the dashboard UI. Users can now click a pencil icon next to the frequency cell to open a dialog, enter a new frequency, validate it, and update it via the API.

Implements the `syncController.updateFrequencyForConnection` controller under the hood.

Includes:
- Frequency edit UI with validation, enter key handler, and dynamic button state
- Integration with new `syncController.updateFrequencyForConnection` controller
- SWR refresh with proper loading & error handling

## Testing

1. Create an integration (if you don’t have one already).
2. Create a connection tied to that integration.
3. Navigate to the **Connections** page.
4. In the **Frequency** column, you should see a ✏️ pencil icon.
5. Clicking the icon opens a modal with an input for the new frequency.
6. Input is validated using a regex (`every <number> <unit>` format).
7. The **Save** button is disabled unless the frequency is valid _and_ different from the current one.
8. Hitting **Enter** inside the input or clicking **Save** should update the frequency and close the modal.

## Preview

<img width="1440" alt="Screenshot 2025-04-10 at 11 13 05 PM" src="https://github.com/user-attachments/assets/a4bc04e3-b95e-4186-86a7-4301138c9d5b" />
<img width="1440" alt="Screenshot 2025-04-10 at 11 12 35 PM" src="https://github.com/user-attachments/assets/d826f815-72ac-4682-b8ae-d38736a1ea83" />

<!-- Summary by @propel-code-bot -->

---

This PR introduces the ability for users to update the sync frequency for specific connections directly from the dashboard UI, addressing feedback that previously only allowed this via API or SDK. The update includes front-end modal interactions, validation logic, and back-end endpoint additions to securely support frequency changes on a per-connection basis without editing all connection frequencies at once.

**Key Changes:**
• Adds a pencil/edit icon to the sync frequency column on the Connections dashboard, which opens a modal for frequency input.
• Implements front-end validation for frequency input with a shared regex and improved user feedback (error handling, disabled save if invalid).
• Introduces apiUpdateSyncConnectionFrequency in webapp, and a unified frequencyRegex utility for input validation.
• Extends the /api/v1/sync/update-connection-frequency API with controller, route, and types for updating frequency on a per-connection basis.
• Ensures SWR cache invalidation for sync data after successful update.
• Refactors related UI and moves frequency regex to a utils/validation file for DRY validation across components.


**Affected Areas:**
• Dashboard UI (SyncRow in Connection page)
• API routes and type declarations (server/routes.private, types/lib/sync/api.ts)
• Custom hooks for connection management (useConnections.tsx)
• Validation utility (utils/validation.ts)


*This summary was automatically generated by @propel-code-bot*