### PR TITLE
fix: clearing cache of variant syncs deletes records of the base sync

### DIFF
--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -77,11 +77,15 @@ class SyncController {
 
     private async addRecordCount(syncs: (Sync & { models: string[] })[], connectionId: number, environmentId: number) {
         const byModel = await recordsService.getRecordCountsByModel({ connectionId, environmentId });
-
         if (byModel.isOk()) {
             return syncs.map((sync) => ({
                 ...sync,
-                record_count: Object.fromEntries(sync.models.map((model) => [model, byModel.value[model]?.count ?? 0]))
+                record_count: Object.fromEntries(
+                    sync.models.map((model) => {
+                        const modelFullName = sync.variant === 'base' ? model : `${model}::${sync.variant}`;
+                        return [model, byModel.value[modelFullName]?.count ?? 0];
+                    })
+                )
             }));
         } else {
             return syncs.map((sync) => ({ ...sync, record_count: null }));

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -430,7 +430,7 @@ class SyncController {
         try {
             const { account, environment } = res.locals;
 
-            const { schedule_id, command, nango_connection_id, sync_id, sync_name, provider, delete_records } = req.body;
+            const { schedule_id, command, nango_connection_id, sync_id, sync_name, sync_variant, provider, delete_records } = req.body;
             const connection = await connectionService.getConnectionById(nango_connection_id);
             if (!connection) {
                 res.status(404).json({ error: { code: 'not_found' } });
@@ -471,6 +471,7 @@ class SyncController {
             const result = await orchestrator.runSyncCommand({
                 connectionId: connection.id,
                 syncId: sync_id,
+                syncVariant: sync_variant,
                 command,
                 environmentId: environment.id,
                 logCtx,

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -510,6 +510,7 @@ export class Orchestrator {
     async runSyncCommand({
         connectionId,
         syncId,
+        syncVariant,
         command,
         environmentId,
         logCtx,
@@ -519,6 +520,7 @@ export class Orchestrator {
     }: {
         connectionId: number;
         syncId: string;
+        syncVariant: string;
         command: SyncCommand;
         environmentId: number;
         logCtx: LogContext;
@@ -559,7 +561,10 @@ export class Orchestrator {
                     await clearLastSyncDate(syncId);
                     if (delete_records) {
                         const syncConfig = await getSyncConfigBySyncId(syncId);
-                        for (const model of syncConfig?.models || []) {
+                        for (let model of syncConfig?.models || []) {
+                            if (syncVariant !== 'base') {
+                                model = `${model}::${syncVariant}`;
+                            }
                             const del = await recordsService.deleteRecordsBySyncId({ syncId, connectionId, environmentId, model });
                             void logCtx.info(`Records for model ${model} were deleted successfully`, del);
                         }

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -295,6 +295,7 @@ export class SyncManagerService {
                 await orchestrator.runSyncCommand({
                     connectionId: connection.id,
                     syncId: sync.id,
+                    syncVariant: sync.variant,
                     command,
                     environmentId: environment.id,
                     logCtx,
@@ -321,6 +322,7 @@ export class SyncManagerService {
                 await orchestrator.runSyncCommand({
                     connectionId: connection.id,
                     syncId: sync.id,
+                    syncVariant: sync.variant,
                     command,
                     environmentId: environment.id,
                     logCtx,

--- a/packages/webapp/src/hooks/useSyncs.tsx
+++ b/packages/webapp/src/hooks/useSyncs.tsx
@@ -21,6 +21,7 @@ export async function apiRunSyncCommand(
         nango_connection_id: number;
         sync_id: string;
         sync_name: string;
+        sync_variant: string;
         provider: string;
         delete_records?: boolean;
     }

--- a/packages/webapp/src/pages/Connection/components/SyncRow.tsx
+++ b/packages/webapp/src/pages/Connection/components/SyncRow.tsx
@@ -63,6 +63,7 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
                       nango_connection_id: sync.nango_connection_id,
                       sync_id: sync.id,
                       sync_name: sync.name,
+                      sync_variant: sync.variant,
                       provider
                   })
                 : await apiRunSyncCommand(env, {
@@ -71,6 +72,7 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
                       nango_connection_id: sync.nango_connection_id,
                       sync_id: sync.id,
                       sync_name: sync.name,
+                      sync_variant: sync.variant,
                       provider,
                       delete_records: deleteRecords
                   });
@@ -103,13 +105,28 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
         setShowInterruptLoader(false);
     };
 
-    const syncCommand = async (command: RunSyncCommand, nango_connection_id: number, scheduleId: string, syncId: string, syncName: string) => {
+    const syncCommand = async (
+        command: RunSyncCommand,
+        nango_connection_id: number,
+        scheduleId: string,
+        syncId: string,
+        syncName: string,
+        syncVariant: string
+    ) => {
         if (syncCommandButtonsDisabled || !provider) {
             return;
         }
 
         setSyncCommandButtonsDisabled(true);
-        const res = await apiRunSyncCommand(env, { command, schedule_id: scheduleId, nango_connection_id, sync_id: syncId, sync_name: syncName, provider });
+        const res = await apiRunSyncCommand(env, {
+            command,
+            schedule_id: scheduleId,
+            nango_connection_id,
+            sync_id: syncId,
+            sync_name: syncName,
+            sync_variant: syncVariant,
+            provider
+        });
 
         if (res.res.status === 200) {
             await mutate((key) => typeof key === 'string' && key.startsWith(`/api/v1/sync`));
@@ -206,7 +223,8 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
                                             sync.nango_connection_id,
                                             sync.schedule_id,
                                             sync.id,
-                                            sync.name
+                                            sync.name,
+                                            sync.variant
                                         );
                                     }}
                                     isLoading={showPauseStartLoader}
@@ -229,7 +247,7 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
                                         disabled={syncCommandButtonsDisabled}
                                         onClick={() => {
                                             setShowInterruptLoader(true);
-                                            void syncCommand('CANCEL', sync.nango_connection_id, sync.schedule_id, sync.id, sync.name);
+                                            void syncCommand('CANCEL', sync.nango_connection_id, sync.schedule_id, sync.id, sync.name, sync.variant);
                                         }}
                                         isLoading={showInterruptLoader}
                                     >


### PR DESCRIPTION
- [fix: clearing cache of variant sync deletes records of the base sync](https://github.com/NangoHQ/nango/commit/b34204b76f58f63015a5d3f26fb3a97b47a2fa73) and therefore not clearing the cache for the variant sync.
- [fix: all rows of variant syncs shows records count of base sync](https://github.com/NangoHQ/nango/commit/dbf55c494893410ac807e99d4150f3a6f96fdced)

# How to test
1. create variant syncs that are saving records
2. Trigger full sync with cache clearing
3. Check the number of deleted records is correct in the logs and that sync is saving again the correct amount of records