### PR TITLE
refactor(scheduler): restart worker when exiting

### DIFF
--- a/packages/scheduler/lib/workers/cleanup/cleanup.worker.ts
+++ b/packages/scheduler/lib/workers/cleanup/cleanup.worker.ts
@@ -1,97 +1,32 @@
-import * as fs from 'fs';
 import type { MessagePort } from 'node:worker_threads';
-import { Worker, isMainThread } from 'node:worker_threads';
-import { stringifyError } from '@nangohq/utils';
 import * as tasks from '../../models/tasks.js';
 import * as schedules from '../../models/schedules.js';
-import { setTimeout } from 'node:timers/promises';
 import type knex from 'knex';
 import { logger } from '../../utils/logger.js';
+import { SchedulerWorker, SchedulerWorkerChild } from '../worker.js';
 
-interface ExpiredTasksMessage {
-    ids: string[];
-}
-
-export class CleanupWorker {
-    private worker: Worker | null;
+export class CleanupWorker extends SchedulerWorker {
     constructor({ databaseUrl, databaseSchema }: { databaseUrl: string; databaseSchema: string }) {
-        if (isMainThread) {
-            const url = new URL('../../../dist/workers/cleanup/cleanup.worker.boot.js', import.meta.url);
-            if (!fs.existsSync(url)) {
-                throw new Error(`Cleanup script not found at ${url.href}`);
-            }
-
-            this.worker = new Worker(url, { workerData: { url: databaseUrl, schema: databaseSchema } });
-            // Throw error if cleanup exits with error
-            this.worker.on('error', (err) => {
-                throw new Error(`Cleanup exited with error: ${stringifyError(err)}`);
-            });
-            // Throw error if cleanup exits with non-zero exit code
-            this.worker.on('exit', (code) => {
-                if (code !== 0) {
-                    throw new Error(`Cleanup exited with exit code: ${code}`);
-                }
-            });
-        } else {
-            throw new Error('CleanupWorker should be instantiated in the main thread');
-        }
-    }
-
-    start(): void {
-        this.worker?.postMessage('start');
-    }
-
-    stop(): void {
-        if (this.worker) {
-            this.worker.postMessage('stop');
-            this.worker = null;
-        }
-    }
-
-    on(callback: (message: ExpiredTasksMessage) => void): void {
-        this.worker?.on('message', callback);
+        super({
+            workerUrl: new URL('../../../dist/workers/cleanup/cleanup.worker.boot.js', import.meta.url),
+            name: 'Cleanup',
+            databaseUrl: databaseUrl,
+            databaseSchema
+        });
     }
 }
 
-export class CleanupChild {
-    private db: knex.Knex;
-    private parent: MessagePort;
-    private cancelled: boolean = false;
-    private tickIntervalMs = 10_000;
-
+export class CleanupChild extends SchedulerWorkerChild {
     constructor(parent: MessagePort, db: knex.Knex) {
-        if (isMainThread) {
-            throw new Error('Cleanup should not be instantiated in the main thread');
-        }
-        this.db = db;
-        this.parent = parent;
-        this.parent.on('message', async (msg: 'start' | 'stop') => {
-            switch (msg) {
-                case 'start':
-                    await this.start();
-                    break;
-                case 'stop':
-                    this.stop();
-                    break;
-            }
+        super({
+            name: 'Cleanup',
+            parent,
+            db,
+            tickIntervalMs: 10_000
         });
     }
 
-    async start(): Promise<void> {
-        logger.info('Starting cleanup...');
-
-        while (!this.cancelled) {
-            await this.clean();
-            await setTimeout(this.tickIntervalMs);
-        }
-    }
-
-    stop(): void {
-        logger.info('Stopping cleanup...');
-        this.cancelled = true;
-    }
-
-    async clean(): Promise<void> {
+    async run(): Promise<void> {
         await this.db.transaction(async (trx) => {
             // hard delete schedules where deletedAt is older than 10 days
             const deletedSchedules = await schedules.hardDeleteOlderThanNDays(trx, 10);

--- a/packages/scheduler/lib/workers/monitor/monitor.worker.ts
+++ b/packages/scheduler/lib/workers/monitor/monitor.worker.ts
@@ -1,96 +1,32 @@
-import * as fs from 'fs';
 import type { MessagePort } from 'node:worker_threads';
-import { Worker, isMainThread } from 'node:worker_threads';
 import { stringifyError } from '@nangohq/utils';
 import * as tasks from '../../models/tasks.js';
-import { setTimeout } from 'node:timers/promises';
 import type knex from 'knex';
 import { logger } from '../../utils/logger.js';
+import { SchedulerWorker, SchedulerWorkerChild } from '../worker.js';
 
-interface ExpiredTasksMessage {
-    ids: string[];
-}
-
-export class MonitorWorker {
-    private worker: Worker | null;
+export class MonitorWorker extends SchedulerWorker {
     constructor({ databaseUrl, databaseSchema }: { databaseUrl: string; databaseSchema: string }) {
-        if (isMainThread) {
-            const url = new URL('../../../dist/workers/monitor/monitor.worker.boot.js', import.meta.url);
-            if (!fs.existsSync(url)) {
-                throw new Error(`Monitor script not found at ${url.href}`);
-            }
-
-            this.worker = new Worker(url, { workerData: { url: databaseUrl, schema: databaseSchema } });
-            // Throw error if monitor exits with error
-            this.worker.on('error', (err) => {
-                throw new Error(`Monitor exited with error: ${stringifyError(err)}`);
-            });
-            // Throw error if monitor exits with non-zero exit code
-            this.worker.on('exit', (code) => {
-                if (code !== 0) {
-                    throw new Error(`Monitor exited with exit code: ${code}`);
-                }
-            });
-        } else {
-            throw new Error('MonitorWorker should be instantiated in the main thread');
-        }
-    }
-
-    start(): void {
-        this.worker?.postMessage('start');
-    }
-
-    stop(): void {
-        if (this.worker) {
-            this.worker.postMessage('stop');
-            this.worker = null;
-        }
-    }
-
-    on(callback: (message: ExpiredTasksMessage) => void): void {
-        this.worker?.on('message', callback);
+        super({
+            workerUrl: new URL('../../../dist/workers/monitor/monitor.worker.boot.js', import.meta.url),
+            name: 'Monitor',
+            databaseUrl: databaseUrl,
+            databaseSchema
+        });
     }
 }
 
-export class MonitorChild {
-    private db: knex.Knex;
-    private parent: MessagePort;
-    private cancelled: boolean = false;
-    private tickIntervalMs = 100;
-
+export class MonitorChild extends SchedulerWorkerChild {
     constructor(parent: MessagePort, db: knex.Knex) {
-        if (isMainThread) {
-            throw new Error('Monitor should not be instantiated in the main thread');
-        }
-        this.db = db;
-        this.parent = parent;
-        this.parent.on('message', async (msg: 'start' | 'stop') => {
-            switch (msg) {
-                case 'start':
-                    await this.start();
-                    break;
-                case 'stop':
-                    this.stop();
-                    break;
-            }
+        super({
+            name: 'Monitor',
+            parent,
+            db,
+            tickIntervalMs: 100
         });
     }
 
-    async start(): Promise<void> {
-        logger.info('Starting monitor...');
-
-        while (!this.cancelled) {
-            await this.expires();
-            await setTimeout(this.tickIntervalMs);
-        }
-    }
-
-    stop(): void {
-        logger.info('Stopping monitor...');
-        this.cancelled = true;
-    }
-
-    async expires(): Promise<void> {
+    async run(): Promise<void> {
         const expired = await tasks.expiresIfTimeout(this.db);
         if (expired.isErr()) {
             logger.error(`Error expiring tasks: ${stringifyError(expired.error)}`);
@@ -100,7 +36,7 @@ export class MonitorChild {
                 if (taskIds.length > 0 && !this.cancelled) {
                     this.parent.postMessage({ ids: taskIds }); // Notifying parent that tasks have expired
                 }
-                logger.info(`Expired tasks: ${JSON.stringify(expired.value.map((t) => t.id))} `);
+                logger.info(`Expired tasks: ${JSON.stringify(expired.value.map((t) => t.id))}`);
             }
         }
     }

--- a/packages/scheduler/lib/workers/scheduling/scheduling.worker.ts
+++ b/packages/scheduler/lib/workers/scheduling/scheduling.worker.ts
@@ -1,6 +1,4 @@
-import * as fs from 'fs';
 import type { MessagePort } from 'node:worker_threads';
-import { Worker, isMainThread } from 'node:worker_threads';
 import type { Result } from '@nangohq/utils';
 import { Err, Ok, stringifyError } from '@nangohq/utils';
 import { setTimeout } from 'node:timers/promises';
@@ -9,96 +7,34 @@ import { logger } from '../../utils/logger.js';
 import { dueSchedules } from './scheduling.js';
 import * as tasks from '../../models/tasks.js';
 import * as schedules from '../../models/schedules.js';
+import { SchedulerWorker, SchedulerWorkerChild } from '../worker.js';
 import tracer from 'dd-trace';
 
-interface CreatedTasksMessage {
-    ids: string[];
-}
-
-export class SchedulingWorker {
-    private worker: Worker | null;
+export class SchedulingWorker extends SchedulerWorker {
     constructor({ databaseUrl, databaseSchema }: { databaseUrl: string; databaseSchema: string }) {
-        if (isMainThread) {
-            const url = new URL('../../../dist/workers/scheduling/scheduling.worker.boot.js', import.meta.url);
-            if (!fs.existsSync(url)) {
-                throw new Error(`Scheduling script not found at ${url.href}`);
-            }
-
-            this.worker = new Worker(url, { workerData: { url: databaseUrl, schema: databaseSchema } });
-            // Throw error if worker exits with error
-            this.worker.on('error', (err) => {
-                throw new Error(`Scheduling exited with error: ${stringifyError(err)}`);
-            });
-            // Throw error if worker exits with non-zero exit code
-            this.worker.on('exit', (code) => {
-                if (code !== 0) {
-                    throw new Error(`Scheduling exited with exit code: ${code}`);
-                }
-            });
-        } else {
-            throw new Error('SchedulingWorker should be instantiated in the main thread');
-        }
-    }
-
-    start(): void {
-        this.worker?.postMessage('start');
-    }
-
-    stop(): void {
-        if (this.worker) {
-            this.worker.postMessage('stop');
-            this.worker = null;
-        }
-    }
-
-    on(callback: (message: CreatedTasksMessage) => void): void {
-        this.worker?.on('message', callback);
+        super({
+            workerUrl: new URL('../../../dist/workers/scheduling/scheduling.worker.boot.js', import.meta.url),
+            name: 'Scheduling',
+            databaseUrl: databaseUrl,
+            databaseSchema
+        });
     }
 }
 
-export class SchedulingChild {
-    private db: knex.Knex;
-    private parent: MessagePort;
-    private cancelled: boolean = false;
-    private tickIntervalMs = 100;
-
+export class SchedulingChild extends SchedulerWorkerChild {
     constructor(parent: MessagePort, db: knex.Knex) {
-        if (isMainThread) {
-            throw new Error('Scheduling should not be instantiated in the main thread');
-        }
-        this.db = db;
-        this.parent = parent;
-        this.parent.on('message', async (msg: 'start' | 'stop') => {
-            switch (msg) {
-                case 'start':
-                    await this.start();
-                    break;
-                case 'stop':
-                    this.stop();
-                    break;
-            }
+        super({
+            name: 'Scheduling',
+            parent,
+            db,
+            tickIntervalMs: 100
         });
     }
 
-    async start(): Promise<void> {
-        logger.info('Starting scheduling...');
-
-        while (!this.cancelled) {
-            await this.schedule();
-            await setTimeout(this.tickIntervalMs);
-        }
-    }
-
-    stop(): void {
-        logger.info('Stopping scheduling...');
-        this.cancelled = true;
-    }
-
-    async schedule(): Promise<void> {
+    async run(): Promise<void> {
         const res = await this.db.transaction(async (trx): Promise<Result<string[]>> => {
             const taskIds: string[] = [];
             const span = tracer.startSpan('scheduler.scheduling.schedule');
-
             try {
                 // Try to acquire a lock to prevent multiple instances from scheduling at the same time
                 const lockSpan = tracer.startSpan('scheduler.scheduling.acquire_lock', { childOf: span });

--- a/packages/scheduler/lib/workers/worker.ts
+++ b/packages/scheduler/lib/workers/worker.ts
@@ -1,0 +1,104 @@
+import * as fs from 'fs';
+import type { MessagePort } from 'node:worker_threads';
+import { Worker, isMainThread } from 'node:worker_threads';
+import { stringifyError } from '@nangohq/utils';
+import { logger } from '../utils/logger.js';
+import { setTimeout } from 'node:timers/promises';
+import type knex from 'knex';
+
+interface ExpiredTasksMessage {
+    ids: string[];
+}
+
+export abstract class SchedulerWorker {
+    protected workerUrl: URL;
+    protected name: string;
+    private worker: Worker | null = null;
+    constructor({ name, workerUrl, databaseUrl, databaseSchema }: { name: string; workerUrl: URL; databaseUrl: string; databaseSchema: string }) {
+        if (isMainThread) {
+            this.name = name;
+            this.workerUrl = workerUrl;
+            if (!fs.existsSync(workerUrl)) {
+                throw new Error(`Code for ${name} worker not found at ${workerUrl.href}`);
+            }
+
+            const createWorker = () => {
+                this.worker = new Worker(workerUrl, { workerData: { url: databaseUrl, schema: databaseSchema } });
+
+                this.worker.on('error', (err) => {
+                    logger.error(`${name} worker error: ${stringifyError(err)}`);
+                });
+
+                this.worker.on('exit', (code) => {
+                    logger.error(`${name} worker exited with code: ${code}. Restarting...`);
+                    this.worker = null;
+                    createWorker();
+                    this.start();
+                });
+            };
+            createWorker();
+        } else {
+            throw new Error(`${name} worker should be instantiated in the main thread`);
+        }
+    }
+
+    start(): void {
+        this.worker?.postMessage('start');
+    }
+
+    stop(): void {
+        if (this.worker) {
+            this.worker.postMessage('stop');
+            this.worker = null;
+        }
+    }
+
+    on(callback: (message: ExpiredTasksMessage) => void): void {
+        this.worker?.on('message', callback);
+    }
+}
+
+export abstract class SchedulerWorkerChild {
+    private name: string;
+    private tickIntervalMs: number;
+
+    protected db: knex.Knex;
+    protected parent: MessagePort;
+    protected cancelled: boolean = false;
+
+    constructor({ name, parent, db, tickIntervalMs }: { name: string; parent: MessagePort; db: knex.Knex; tickIntervalMs: number }) {
+        if (isMainThread) {
+            throw new Error(`${name} should not be instantiated in the main thread`);
+        }
+        this.name = name;
+        this.tickIntervalMs = tickIntervalMs;
+        this.db = db;
+        this.parent = parent;
+        this.parent.on('message', async (msg: 'start' | 'stop') => {
+            switch (msg) {
+                case 'start':
+                    await this.start();
+                    break;
+                case 'stop':
+                    this.stop();
+                    break;
+            }
+        });
+    }
+
+    async start(): Promise<void> {
+        logger.info(`Starting ${this.name}...`);
+
+        while (!this.cancelled) {
+            await this.run();
+            await setTimeout(this.tickIntervalMs);
+        }
+    }
+
+    stop(): void {
+        logger.info(`Stopping ${this.name}...`);
+        this.cancelled = true;
+    }
+
+    abstract run(): Promise<void>;
+}

--- a/packages/scheduler/lib/workers/worker.ts
+++ b/packages/scheduler/lib/workers/worker.ts
@@ -31,6 +31,7 @@ export abstract class SchedulerWorker {
 
                 this.worker.on('exit', (code) => {
                     report(`${name} worker exited with code: ${code}. Restarting...`);
+                    this.worker?.removeAllListeners();
                     this.worker = null;
                     createWorker();
                     this.start();

--- a/packages/scheduler/lib/workers/worker.ts
+++ b/packages/scheduler/lib/workers/worker.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import type { MessagePort } from 'node:worker_threads';
 import { Worker, isMainThread } from 'node:worker_threads';
-import { stringifyError } from '@nangohq/utils';
+import { report, stringifyError } from '@nangohq/utils';
 import { logger } from '../utils/logger.js';
 import { setTimeout } from 'node:timers/promises';
 import type knex from 'knex';
@@ -26,11 +26,11 @@ export abstract class SchedulerWorker {
                 this.worker = new Worker(workerUrl, { workerData: { url: databaseUrl, schema: databaseSchema } });
 
                 this.worker.on('error', (err) => {
-                    logger.error(`${name} worker error: ${stringifyError(err)}`);
+                    report(`${name} worker error: ${stringifyError(err)}`);
                 });
 
                 this.worker.on('exit', (code) => {
-                    logger.error(`${name} worker exited with code: ${code}. Restarting...`);
+                    report(`${name} worker exited with code: ${code}. Restarting...`);
                     this.worker = null;
                     createWorker();
                     this.start();


### PR DESCRIPTION
This commit contains 2 changes:
- create worker and worker child abstract classes to consolidate the worker and worker child logic in one single place
- on worker exit, the worker is restarted instead of throwing an error

