### PR TITLE
fix(persist): express error handler didn't use correct error response schema

### DIFF
--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -90,7 +90,7 @@ describe('Persist API', () => {
             }
         });
         expect(response.status).toEqual(400);
-        expect(await response.json()).toStrictEqual({ error: 'Entity too large' });
+        expect(await response.json()).toStrictEqual({ error: { code: 'request_too_large', message: 'Entity too large' } });
     });
 
     describe('save records', () => {

--- a/packages/persist/lib/server.ts
+++ b/packages/persist/lib/server.ts
@@ -10,6 +10,7 @@ import { routeHandler as deleteRecordsHandler } from './routes/environment/envir
 import { routeHandler as getCursorHandler, path as cursorPath } from './routes/environment/environmentId/connection/connectionId/getCursor.js';
 import { routeHandler as getRecordsHandler, path as getRecordsPath } from './routes/environment/environmentId/connection/connectionId/getRecords.js';
 import { recordsPath } from './records.js';
+import type { ApiError } from '@nangohq/types';
 
 const logger = getLogger('Persist');
 const maxSizeJsonLog = '100kb';
@@ -41,15 +42,15 @@ server.use((_req: Request, res: Response, next: NextFunction) => {
     next();
 });
 
-server.use((err: unknown, _req: Request, res: Response, next: NextFunction) => {
+server.use((err: unknown, _req: Request, res: Response<ApiError<'request_too_large' | 'server_error'>>, next: NextFunction) => {
     if (err instanceof Error) {
         if (err.message === 'request entity too large') {
-            res.status(400).json({ error: 'Entity too large' });
+            res.status(400).json({ error: { code: 'request_too_large', message: 'Entity too large' } });
             return;
         }
-        res.status(500).json({ error: err.message });
+        res.status(500).json({ error: { code: 'server_error', message: err.message } });
     } else if (err) {
-        res.status(500).json({ error: 'uncaught error' });
+        res.status(500).json({ error: { code: 'server_error' } });
     } else {
         next();
     }


### PR DESCRIPTION
Wrong error response schema was used when running into a request too large error

