### PR TITLE
feat: track nango.proxy() egress/ingress

### DIFF
--- a/packages/jobs/lib/routes/tasks/putTask.ts
+++ b/packages/jobs/lib/routes/tasks/putTask.ts
@@ -89,10 +89,12 @@ const validate = validateRequest<PutTask>({
                 output: jsonSchema.default(null),
                 stats: z
                     .object({
-                        proxy_egress_bytes: z.number().default(0),
-                        proxy_ingress_bytes: z.number().default(0)
+                        proxy_success_egress_bytes: z.number().default(0),
+                        proxy_success_ingress_bytes: z.number().default(0),
+                        proxy_failure_egress_bytes: z.number().default(0),
+                        proxy_failure_ingress_bytes: z.number().default(0)
                     })
-                    .default({ proxy_egress_bytes: 0, proxy_ingress_bytes: 0 })
+                    .default({ proxy_success_egress_bytes: 0, proxy_success_ingress_bytes: 0, proxy_failure_egress_bytes: 0, proxy_failure_ingress_bytes: 0 })
             })
             .parse(data),
     parseParams: (data) => z.object({ taskId: z.string().uuid() }).strict().parse(data)

--- a/packages/runner-sdk/lib/action.ts
+++ b/packages/runner-sdk/lib/action.ts
@@ -25,6 +25,7 @@ import type {
     OAuth2ClientCredentials,
     Pagination,
     PostPublicTrigger,
+    RunnerStats,
     SetMetadata,
     SignatureCredentials,
     TableauCredentials,
@@ -58,6 +59,7 @@ export abstract class NangoActionBase {
     abortSignal?: NangoProps['abortSignal'];
     syncConfig?: NangoProps['syncConfig'];
     runnerFlags: NangoProps['runnerFlags'];
+    public runnerStats: RunnerStats;
 
     public connectionId: string;
     public providerConfigKey: string;
@@ -74,6 +76,10 @@ export abstract class NangoActionBase {
         this.providerConfigKey = config.providerConfigKey;
         this.runnerFlags = config.runnerFlags;
         this.activityLogId = config.activityLogId;
+        this.runnerStats = {
+            proxy_egress_bytes: 0,
+            proxy_ingress_bytes: 0
+        };
 
         if (config.syncId) {
             this.syncId = config.syncId;

--- a/packages/runner-sdk/lib/action.ts
+++ b/packages/runner-sdk/lib/action.ts
@@ -77,8 +77,10 @@ export abstract class NangoActionBase {
         this.runnerFlags = config.runnerFlags;
         this.activityLogId = config.activityLogId;
         this.runnerStats = {
-            proxy_egress_bytes: 0,
-            proxy_ingress_bytes: 0
+            proxy_success_egress_bytes: 0,
+            proxy_success_ingress_bytes: 0,
+            proxy_failure_egress_bytes: 0,
+            proxy_failure_ingress_bytes: 0
         };
 
         if (config.syncId) {

--- a/packages/runner/lib/clients/jobs.ts
+++ b/packages/runner/lib/clients/jobs.ts
@@ -27,7 +27,7 @@ class JobsClient {
         return Ok(undefined as PostHeartbeat['Success']);
     }
 
-    async putTask({ taskId, nangoProps, error, output }: PutTask['Body'] & PutTask['Params']): Promise<Result<PutTask['Success']>> {
+    async putTask({ taskId, nangoProps, error, output, stats }: PutTask['Body'] & PutTask['Params']): Promise<Result<PutTask['Success']>> {
         const res = await retryWithBackoff(async () => {
             const resp = await httpFetch(`${this.baseUrl}/tasks/${taskId}`, {
                 method: 'PUT',
@@ -35,7 +35,8 @@ class JobsClient {
                     'Content-Type': 'application/json'
                 },
                 body: JSON.stringify({
-                    nangoProps: nangoProps,
+                    nangoProps,
+                    stats,
                     ...(error ? { error } : { output })
                 })
             });

--- a/packages/runner/lib/exec.unit.test.ts
+++ b/packages/runner/lib/exec.unit.test.ts
@@ -48,6 +48,7 @@ describe('Exec', () => {
         const res = await exec({ nangoProps, code });
         expect(res.error).toEqual(null);
         expect(res.success).toEqual(true);
+        expect(res.stats).toEqual({ proxy_egress_bytes: 0, proxy_ingress_bytes: 0 });
     });
 
     it('should return a formatted error when receiving an Error', async () => {

--- a/packages/runner/lib/exec.unit.test.ts
+++ b/packages/runner/lib/exec.unit.test.ts
@@ -48,7 +48,12 @@ describe('Exec', () => {
         const res = await exec({ nangoProps, code });
         expect(res.error).toEqual(null);
         expect(res.success).toEqual(true);
-        expect(res.stats).toEqual({ proxy_egress_bytes: 0, proxy_ingress_bytes: 0 });
+        expect(res.stats).toEqual({
+            proxy_success_egress_bytes: 0,
+            proxy_success_ingress_bytes: 0,
+            proxy_failure_egress_bytes: 0,
+            proxy_failure_ingress_bytes: 0
+        });
     });
 
     it('should return a formatted error when receiving an Error', async () => {

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -94,11 +94,12 @@ export class NangoActionRunner extends NangoActionBase {
 
         const res = await proxy.request();
 
-        this.runnerStats.proxy_egress_bytes += sizeInBytes(proxy.config.data);
         if (res.isOk()) {
-            this.runnerStats.proxy_ingress_bytes += Number(res.value.headers['content-length']) || sizeInBytes(res.value.data);
+            this.runnerStats.proxy_success_egress_bytes += sizeInBytes(proxy.config.data);
+            this.runnerStats.proxy_success_ingress_bytes += Number(res.value.headers['content-length']) || sizeInBytes(res.value.data);
         } else if (isAxiosError(res.error)) {
-            this.runnerStats.proxy_ingress_bytes += Number(res.error.response?.headers['content-length']) || sizeInBytes(res.error.response?.data);
+            this.runnerStats.proxy_failure_egress_bytes += sizeInBytes(proxy.config.data);
+            this.runnerStats.proxy_failure_ingress_bytes += Number(res.error.response?.headers['content-length']) || sizeInBytes(res.error.response?.data);
         }
 
         return res.unwrap();

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -96,10 +96,10 @@ export class NangoActionRunner extends NangoActionBase {
 
         if (res.isOk()) {
             this.runnerStats.proxy_success_egress_bytes += sizeInBytes(proxy.config.data);
-            this.runnerStats.proxy_success_ingress_bytes += Number(res.value.headers['content-length']) || sizeInBytes(res.value.data);
+            this.runnerStats.proxy_success_ingress_bytes += Number(res.value.headers?.['content-length']) || sizeInBytes(res.value.data);
         } else if (isAxiosError(res.error)) {
             this.runnerStats.proxy_failure_egress_bytes += sizeInBytes(proxy.config.data);
-            this.runnerStats.proxy_failure_ingress_bytes += Number(res.error.response?.headers['content-length']) || sizeInBytes(res.error.response?.data);
+            this.runnerStats.proxy_failure_ingress_bytes += Number(res.error.response?.headers?.['content-length']) || sizeInBytes(res.error.response?.data);
         }
 
         return res.unwrap();

--- a/packages/runner/lib/server.ts
+++ b/packages/runner/lib/server.ts
@@ -71,12 +71,13 @@ function startProcedure() {
                     const abortController = new AbortController();
                     abortControllers.set(taskId, abortController);
 
-                    const { error, response: output } = await exec({ nangoProps, code, codeParams, abortController, locks });
+                    const { error, response, stats } = await exec({ nangoProps, code, codeParams, abortController, locks });
 
                     await jobsClient.putTask({
                         taskId,
                         nangoProps,
-                        ...(error ? { error } : { output: output as any })
+                        stats,
+                        ...(error ? { error } : { output: response as any })
                     });
                 } finally {
                     clearInterval(heartbeat);

--- a/packages/types/lib/jobs/api.ts
+++ b/packages/types/lib/jobs/api.ts
@@ -1,6 +1,6 @@
 import type { JsonValue } from 'type-fest';
 import type { ApiError, Endpoint } from '../api';
-import type { RunnerOutputError } from '../runner';
+import type { RunnerOutputError, RunnerStats } from '../runner';
 import type { NangoProps } from '../runner/sdk';
 
 export type PostHeartbeat = Endpoint<{
@@ -24,6 +24,7 @@ export type PutTask = Endpoint<{
         nangoProps?: NangoProps | undefined;
         error?: RunnerOutputError | undefined;
         output?: JsonValue | undefined;
+        stats?: RunnerStats | undefined;
     };
     Error: ApiError<'put_task_failed'>;
     Success: never;

--- a/packages/types/lib/runner/index.ts
+++ b/packages/types/lib/runner/index.ts
@@ -9,6 +9,7 @@ export interface RunnerOutput {
     success: boolean;
     error: RunnerOutputError | null;
     response?: unknown; // TODO: define response type
+    stats: RunnerStats;
 }
 
 export interface RunnerFlags {
@@ -16,4 +17,9 @@ export interface RunnerFlags {
     validateActionOutput: boolean;
     validateSyncRecords: boolean;
     validateSyncMetadata: boolean;
+}
+
+export interface RunnerStats {
+    proxy_egress_bytes: number;
+    proxy_ingress_bytes: number;
 }

--- a/packages/types/lib/runner/index.ts
+++ b/packages/types/lib/runner/index.ts
@@ -20,6 +20,8 @@ export interface RunnerFlags {
 }
 
 export interface RunnerStats {
-    proxy_egress_bytes: number;
-    proxy_ingress_bytes: number;
+    proxy_success_egress_bytes: number;
+    proxy_success_ingress_bytes: number;
+    proxy_failure_egress_bytes: number;
+    proxy_failure_ingress_bytes: number;
 }

--- a/packages/utils/lib/json.ts
+++ b/packages/utils/lib/json.ts
@@ -63,3 +63,7 @@ export function truncateJson<TObject extends Record<string, any>>(value: TObject
 export function truncateJsonString(value: string, maxSize: number = MAX_LOG_PAYLOAD): string {
     return truncateJsonPkg(value, maxSize).jsonString;
 }
+
+export function sizeInBytes(value: any): number {
+    return value ? Buffer.byteLength(stringifyObject(value), 'utf8') : 0;
+}


### PR DESCRIPTION
We now keep track of the total size of requests/responses data made in scripts to 3rd party provider via nango.proxy. The 2 stats, `proxy_egress_bytes` and `proxy_ingress_bytes`, are then sent back alongside the script output/error. This commit only logs the stats for now, next step will be exporting them to our billing platform

How to test:
 - run any script that is making a use of `nango.proxy()` or related method.
 - check the stats numbers in the logs

