### PR TITLE
fix(persist): fix lock id generation

### DIFF
--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -732,6 +732,10 @@ async function getRecordsToUpdate({
 }
 
 function newLockId(connectionId: number, model: string): bigint {
-    const modelHash = stringToHash(model);
+    // convert modelHash to unsigned 32-bit integer to ensure
+    // negative hash values don't cause sign extension problems
+    // when combined with connectionId in the bitwise OR operation
+    const modelHash = stringToHash(model) >>> 0;
+
     return (BigInt(connectionId) << 32n) | BigInt(modelHash);
 }


### PR DESCRIPTION
if the model hash results in a negative number, combining it with the connectionId with the bitwise OR operator will lead to the same lock id to be generated for every connection causing a contention for every execution of the same sync by different connections.

The fix is simple, making sure the model hash is an unsigned int


