### PR TITLE
fix(plans): store definitions, fix trial api path 

### DIFF
--- a/packages/server/lib/controllers/v1/getEnvJs.ts
+++ b/packages/server/lib/controllers/v1/getEnvJs.ts
@@ -1,5 +1,5 @@
 import { envs } from '@nangohq/logs';
-import { basePublicUrl, baseUrl, connectUrl, flagHasAuth, flagHasManagedAuth, flagHasScripts, flagHasSlack, isCloud } from '@nangohq/utils';
+import { basePublicUrl, baseUrl, connectUrl, flagHasAuth, flagHasManagedAuth, flagHasPlan, flagHasScripts, flagHasSlack, isCloud } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 
@@ -24,7 +24,8 @@ export const getEnvJs = asyncWrapper<any, any>((_, res) => {
             auth: flagHasAuth,
             managedAuth: flagHasManagedAuth,
             gettingStarted: true,
-            slack: flagHasSlack
+            slack: flagHasSlack,
+            plan: flagHasPlan
         }
     };
     res.setHeader('content-type', 'text/javascript');

--- a/packages/server/lib/controllers/v1/plans/trial/postPlanExtendTrial.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/trial/postPlanExtendTrial.integration.test.ts
@@ -3,9 +3,9 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import db from '@nangohq/database';
 import { TRIAL_DURATION, getPlan, seeders, updatePlan } from '@nangohq/shared';
 
-import { isSuccess, runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../utils/tests.js';
+import { isSuccess, runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../../utils/tests.js';
 
-const route = '/api/v1/plan/trial/extension';
+const route = '/api/v1/plans/trial/extension';
 let api: Awaited<ReturnType<typeof runServer>>;
 describe(`POST ${route}`, () => {
     beforeAll(async () => {

--- a/packages/server/lib/controllers/v1/plans/trial/postPlanExtendTrial.ts
+++ b/packages/server/lib/controllers/v1/plans/trial/postPlanExtendTrial.ts
@@ -2,7 +2,7 @@ import db from '@nangohq/database';
 import { productTracking, startTrial } from '@nangohq/shared';
 import { flagHasPlan, requireEmptyBody, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 
 import type { PostPlanExtendTrial } from '@nangohq/types';
 

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -62,7 +62,7 @@ import { searchMessages } from './controllers/v1/logs/searchMessages.js';
 import { searchOperations } from './controllers/v1/logs/searchOperations.js';
 import { getMeta } from './controllers/v1/meta/getMeta.js';
 import { patchOnboarding } from './controllers/v1/onboarding/patchOnboarding.js';
-import { postPlanExtendTrial } from './controllers/v1/plan/postPlanExtendTrial.js';
+import { postPlanExtendTrial } from './controllers/v1/plans/trial/postPlanExtendTrial.js';
 import { getTeam } from './controllers/v1/team/getTeam.js';
 import { putTeam } from './controllers/v1/team/putTeam.js';
 import { deleteTeamUser } from './controllers/v1/team/users/deleteTeamUser.js';
@@ -138,7 +138,7 @@ web.route('/invite/:id').get(rateLimiterMiddleware, getInvite);
 web.route('/invite/:id').post(webAuth, acceptInvite);
 web.route('/invite/:id').delete(webAuth, declineInvite);
 web.route('/account/admin/switch').post(webAuth, accountController.switchAccount.bind(accountController));
-web.route('/plan/trial/extension').post(webAuth, postPlanExtendTrial);
+web.route('/plans/trial/extension').post(webAuth, postPlanExtendTrial);
 
 web.route('/environments').post(webAuth, postEnvironment);
 web.route('/environments/').patch(webAuth, patchEnvironment);

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -4,6 +4,7 @@ import { flagHasPlan, report } from '@nangohq/utils';
 import environmentService from './environment.service.js';
 import { LogActionEnum } from '../models/Telemetry.js';
 import errorManager, { ErrorSourceEnum } from '../utils/error.manager.js';
+import { plansList } from './plans/definitions.js';
 import { createPlan } from './plans/plans.js';
 
 import type { DBEnvironment, DBTeam } from '@nangohq/types';
@@ -89,7 +90,8 @@ class AccountService {
 
         await environmentService.createDefaultEnvironments(result[0].id);
         if (flagHasPlan) {
-            const res = await createPlan(db.knex, { account_id: result[0].id, name: 'free' });
+            const freePlan = plansList.find((plan) => plan.code === 'free');
+            const res = await createPlan(db.knex, { account_id: result[0].id, name: 'free', ...freePlan?.flags });
             if (res.isErr()) {
                 report(res.error);
             }

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -41,7 +41,6 @@ export const plansList: PlanDefinition[] = [
         description: 'Pay-as-you-go integrations.',
         canUpgrade: true,
         canDowngrade: false,
-        stripLookupKey: 'growth_2025_04_monthly',
         flags: {
             api_rate_limit_size: 'l',
             connection_with_scripts_max: null,
@@ -65,7 +64,7 @@ export const plansList: PlanDefinition[] = [
             environments_max: 10,
             has_otel: true,
             has_sync_variants: true,
-            name: 'free',
+            name: 'enterprise',
             sync_frequency_secs_min: 30
         }
     },
@@ -84,7 +83,7 @@ export const plansList: PlanDefinition[] = [
             environments_max: 3,
             has_otel: false,
             has_sync_variants: true,
-            name: 'growth',
+            name: 'starter',
             sync_frequency_secs_min: 30
         }
     },
@@ -101,7 +100,7 @@ export const plansList: PlanDefinition[] = [
             environments_max: 3,
             has_otel: false,
             has_sync_variants: true,
-            name: 'growth',
+            name: 'scale',
             sync_frequency_secs_min: 30
         }
     }

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -1,0 +1,108 @@
+import type { PlanDefinition } from '@nangohq/types';
+
+export const plansList: PlanDefinition[] = [
+    {
+        code: 'free',
+        title: 'Free',
+        description: 'API authorization only.',
+        canUpgrade: true,
+        canDowngrade: false,
+        flags: {
+            api_rate_limit_size: 'm',
+            connection_with_scripts_max: 50,
+            environments_max: 2,
+            has_otel: false,
+            has_sync_variants: false,
+            name: 'free',
+            sync_frequency_secs_min: 3600
+        }
+    },
+    {
+        code: 'yc',
+        title: 'YC Plan',
+        description: 'For our friends at YC.',
+        canUpgrade: true,
+        canDowngrade: false,
+        cta: 'Contact Us',
+        hidden: true,
+        flags: {
+            api_rate_limit_size: 'l',
+            connection_with_scripts_max: null,
+            environments_max: 3,
+            has_otel: false,
+            has_sync_variants: true,
+            name: 'yc',
+            sync_frequency_secs_min: 30
+        }
+    },
+    {
+        code: 'growth',
+        title: 'Growth',
+        description: 'Pay-as-you-go integrations.',
+        canUpgrade: true,
+        canDowngrade: false,
+        stripLookupKey: 'growth_2025_04_monthly',
+        flags: {
+            api_rate_limit_size: 'l',
+            connection_with_scripts_max: null,
+            environments_max: 3,
+            has_otel: false,
+            has_sync_variants: true,
+            name: 'growth',
+            sync_frequency_secs_min: 30
+        }
+    },
+    {
+        code: 'enterprise',
+        title: 'Enterprise',
+        description: 'Tailored to your scale.',
+        canUpgrade: false,
+        canDowngrade: false,
+        cta: 'Contact Us',
+        flags: {
+            api_rate_limit_size: '2xl',
+            connection_with_scripts_max: null,
+            environments_max: 10,
+            has_otel: true,
+            has_sync_variants: true,
+            name: 'free',
+            sync_frequency_secs_min: 30
+        }
+    },
+
+    // Old plans
+    {
+        code: 'starter',
+        title: 'Starter',
+        description: '',
+        canUpgrade: false,
+        canDowngrade: false,
+        hidden: true,
+        flags: {
+            api_rate_limit_size: 'l',
+            connection_with_scripts_max: null,
+            environments_max: 3,
+            has_otel: false,
+            has_sync_variants: true,
+            name: 'growth',
+            sync_frequency_secs_min: 30
+        }
+    },
+    {
+        code: 'scale',
+        title: 'Scale',
+        description: '',
+        canUpgrade: false,
+        canDowngrade: false,
+        hidden: true,
+        flags: {
+            api_rate_limit_size: 'l',
+            connection_with_scripts_max: null,
+            environments_max: 3,
+            has_otel: false,
+            has_sync_variants: true,
+            name: 'growth',
+            sync_frequency_secs_min: 30
+        }
+    }
+];

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -25,9 +25,6 @@ export async function createPlan(
         const res = await db
             .from<DBPlan>('plans')
             .insert({
-                connection_with_scripts_max: 50,
-                has_sync_variants: true,
-                sync_frequency_secs_min: 30,
                 ...rest,
                 created_at: new Date(),
                 updated_at: new Date(),

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -6,9 +6,31 @@ export type ApiPlan = ReplaceInObject<DBPlan, Date, string>;
 
 export type PostPlanExtendTrial = Endpoint<{
     Method: 'POST';
-    Path: '/api/v1/plan/trial/extension';
+    Path: '/api/v1/plans/trial/extension';
     Querystring: { env: string };
     Success: {
         data: { success: boolean };
+    };
+}>;
+
+export interface PlanDefinition {
+    code: string;
+    title: string;
+    description: string;
+    canUpgrade: boolean;
+    canDowngrade: false;
+    cta?: string;
+    hidden?: boolean;
+    // We use the lookup id instead of price_id, so it's unique across prod and staging env
+    stripLookupKey?: string;
+    flags: Omit<Partial<DBPlan>, 'id' | 'account_id'>;
+}
+
+export type GetPlans = Endpoint<{
+    Method: 'GET';
+    Path: '/api/v1/plans';
+    Querystring: { env: string };
+    Success: {
+        data: PlanDefinition[];
     };
 }>;

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -25,12 +25,3 @@ export interface PlanDefinition {
     stripLookupKey?: string;
     flags: Omit<Partial<DBPlan>, 'id' | 'account_id'>;
 }
-
-export type GetPlans = Endpoint<{
-    Method: 'GET';
-    Path: '/api/v1/plans';
-    Querystring: { env: string };
-    Success: {
-        data: PlanDefinition[];
-    };
-}>;

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -21,7 +21,5 @@ export interface PlanDefinition {
     canDowngrade: false;
     cta?: string;
     hidden?: boolean;
-    // We use the lookup id instead of price_id, so it's unique across prod and staging env
-    stripLookupKey?: string;
     flags: Omit<Partial<DBPlan>, 'id' | 'account_id'>;
 }

--- a/packages/types/lib/web/env.ts
+++ b/packages/types/lib/web/env.ts
@@ -17,5 +17,6 @@ export interface WindowEnv {
         managedAuth: boolean;
         gettingStarted: boolean;
         slack: boolean;
+        plan: boolean;
     };
 }

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -5,7 +5,7 @@ import { apiFetch } from '../utils/api';
 import type { ApiPlan, PostPlanExtendTrial } from '@nangohq/types';
 
 export async function apiPostPlanExtendTrial(env: string) {
-    const res = await apiFetch(`/api/v1/plan/trial/extension?env=${env}`, {
+    const res = await apiFetch(`/api/v1/plans/trial/extension?env=${env}`, {
         method: 'POST'
     });
 


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-3133/disable-sync-partitioning-by-default-for-new-accounts
Fixes https://linear.app/nango/issue/NAN-3146/store-definitions

- Store plan definitions
- Fix trial api path
Should have been plans in plural to prepare for future listing endpoint, and in the subfolder trial

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added plan definitions for easier management and updated the trial API path to use the correct plural form.

- **Refactors**
  - Moved plan definitions to a shared file for future use.
  - Changed trial extension API route from `/plan/trial/extension` to `/plans/trial/extension`.

<!-- End of auto-generated description by mrge. -->

