### PR TITLE
fix(jira-basic): update verification endpoint

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -5061,7 +5061,7 @@ jira-basic:
         verification:
             method: GET
             endpoints:
-                - /rest/api/2/applicationrole
+                - /rest/api/3/myself
     docs: https://docs.nango.dev/integrations/all/jira-basic
     connection_config:
         subdomain:


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Based on feedback from a customer: the former verification endpoint requires an admin while `myself` doesn't require admin permissions

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Changed the Jira Basic Auth verification endpoint to use /rest/api/3/myself, which does not require admin permissions.

<!-- End of auto-generated description by mrge. -->

