### PR TITLE
fix(auth): github app custom token, copy buttons

### DIFF
--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -19,9 +19,9 @@ import {
     interpolateObjectValues,
     interpolateStringFromObject,
     linkConnection,
+    makeUrl,
     oauth2Client,
-    providerClientManager,
-    makeUrl
+    providerClientManager
 } from '@nangohq/shared';
 import { errorToObject, metrics, stringifyError } from '@nangohq/utils';
 
@@ -45,7 +45,7 @@ import type { ConnectSessionAndEndUser } from '../services/connectSession.servic
 import type { RequestLocals } from '../utils/express.js';
 import type { LogContext } from '@nangohq/logs';
 import type { Config as ProviderConfig, ConnectionUpsertResponse, OAuth1RequestTokenResult, OAuth2Credentials, OAuthSession } from '@nangohq/shared';
-import type { ConnectionConfig, DBEnvironment, DBTeam, Provider, ProviderGithubApp, ProviderOAuth2 } from '@nangohq/types';
+import type { ConnectionConfig, DBEnvironment, DBTeam, Provider, ProviderCustom, ProviderGithubApp, ProviderOAuth2 } from '@nangohq/types';
 import type { NextFunction, Request, Response } from 'express';
 
 class OAuthController {
@@ -873,7 +873,7 @@ class OAuthController {
     }
 
     private async oauth2Callback(
-        provider: ProviderOAuth2,
+        provider: ProviderOAuth2 | ProviderCustom,
         config: ProviderConfig,
         session: OAuthSession,
         req: Request,

--- a/packages/shared/lib/auth/githubApp.ts
+++ b/packages/shared/lib/auth/githubApp.ts
@@ -4,7 +4,7 @@ import * as jwtClient from './jwt.js';
 import { AuthCredentialsError } from '../utils/error.js';
 import { interpolateStringFromObject } from '../utils/utils.js';
 
-import type { AppCredentials, ConnectionConfig, IntegrationConfig, ProviderGithubApp } from '@nangohq/types';
+import type { AppCredentials, ConnectionConfig, IntegrationConfig, ProviderCustom, ProviderGithubApp } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 /**
@@ -15,12 +15,13 @@ export async function createCredentials({
     integration,
     connectionConfig
 }: {
-    provider: ProviderGithubApp;
+    provider: ProviderGithubApp | ProviderCustom;
     integration: IntegrationConfig;
     connectionConfig: ConnectionConfig;
 }): Promise<Result<AppCredentials, AuthCredentialsError>> {
     try {
-        const tokenUrl = interpolateStringFromObject(provider.token_url, { connectionConfig });
+        const templateTokenUrl = typeof provider.token_url === 'string' ? provider.token_url : provider.token_url.APP;
+        const tokenUrl = interpolateStringFromObject(templateTokenUrl, { connectionConfig });
         const privateKeyBase64 = integration.custom ? integration.custom['private_key'] : integration.oauth_client_secret;
 
         const privateKey = Buffer.from(privateKeyBase64 as string, 'base64').toString('utf8');

--- a/packages/types/lib/providers/provider.ts
+++ b/packages/types/lib/providers/provider.ts
@@ -89,7 +89,7 @@ export interface BaseProvider {
 }
 
 export interface ProviderOAuth2 extends BaseProvider {
-    auth_mode: 'OAUTH2' | 'CUSTOM';
+    auth_mode: 'OAUTH2';
 
     disable_pkce?: boolean; // Defaults to false (=PKCE used) if not provided
 
@@ -118,6 +118,15 @@ export interface ProviderOAuth1 extends BaseProvider {
     token_http_method?: 'GET' | 'PUT' | 'POST'; // Defaults to POST if not provided
 
     signature_method: 'HMAC-SHA1' | 'RSA-SHA1' | 'PLAINTEXT';
+}
+
+// Github APP Oauth
+export interface ProviderCustom extends Omit<ProviderOAuth2, 'auth_mode'> {
+    auth_mode: 'CUSTOM';
+    token_url: {
+        OAUTH2: string;
+        APP: string;
+    };
 }
 
 export interface ProviderJwt extends BaseProvider {
@@ -204,7 +213,8 @@ export type Provider =
     | ProviderTableau
     | ProviderBill
     | ProviderGithubApp
-    | ProviderAppleAppStore;
+    | ProviderAppleAppStore
+    | ProviderCustom;
 
 export type RefreshableProvider = ProviderTwoStep | ProviderJwt | ProviderSignature | ProviderOAuth2; // TODO: fix this type
 export type TestableProvider = ProviderApiKey; // TODO: fix this type

--- a/packages/webapp/src/components/ui/button/CopyButton.tsx
+++ b/packages/webapp/src/components/ui/button/CopyButton.tsx
@@ -1,9 +1,11 @@
-import { useState, useEffect, useRef } from 'react';
 import { CopyIcon, Link2Icon } from '@radix-ui/react-icons';
-import type { ClassValue } from 'clsx';
-import { cn } from '../../../utils/utils';
+import { useEffect, useRef, useState } from 'react';
+
 import { Button } from './Button';
+import { cn } from '../../../utils/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../Tooltip';
+
+import type { ClassValue } from 'clsx';
 
 interface ClipboardButtonProps {
     text: string;

--- a/packages/webapp/src/components/ui/input/SecretTextArea.tsx
+++ b/packages/webapp/src/components/ui/input/SecretTextArea.tsx
@@ -1,36 +1,25 @@
-import type { ChangeEvent, TextareaHTMLAttributes } from 'react';
-import { forwardRef, useCallback, useState } from 'react';
-import { CopyButton } from '../button/CopyButton';
-import { cn } from '../../../utils/utils';
 import { EyeNoneIcon, EyeOpenIcon } from '@radix-ui/react-icons';
-import { Button } from '../button/Button';
+import { forwardRef, useCallback, useState } from 'react';
+
 import { Input } from './Input';
+import { cn } from '../../../utils/utils';
+import { Button } from '../button/Button';
+import { CopyButton } from '../button/CopyButton';
+
+import type { TextareaHTMLAttributes } from 'react';
 
 interface SecretTextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
     copy?: boolean;
-    optionalValue?: string;
-    setOptionalValue?: (value: string) => void;
-    additionalClass?: string;
+    onUpdate: (value: string) => void;
 }
 
-const SecretTextarea = forwardRef<HTMLTextAreaElement, SecretTextareaProps>(function SecretTextarea(
-    { className, copy, optionalValue, setOptionalValue, additionalClass, defaultValue, ...rest },
-    ref
-) {
+export const SecretTextArea = forwardRef<HTMLTextAreaElement, SecretTextareaProps>(function SecretTextArea({ className, copy, value, onUpdate, ...rest }, ref) {
     const [isSecretVisible, setIsSecretVisible] = useState(false);
-    const [changedValue, setChangedValue] = useState(defaultValue);
-
-    const value = optionalValue || changedValue;
-    const updateValue = setOptionalValue || setChangedValue;
 
     const toggleSecretVisibility = useCallback(() => setIsSecretVisible(!isSecretVisible), [isSecretVisible]);
 
-    const handleTextareaChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-        updateValue(e.currentTarget.value);
-    };
-
     return (
-        <div className={cn('relative flex', additionalClass)}>
+        <div className={cn('relative flex w-full')}>
             {isSecretVisible ? (
                 <textarea
                     ref={ref}
@@ -40,7 +29,7 @@ const SecretTextarea = forwardRef<HTMLTextAreaElement, SecretTextareaProps>(func
                         'h-48'
                     )}
                     value={value}
-                    onChange={handleTextareaChange}
+                    onChange={(e) => onUpdate(e.currentTarget.value)}
                     {...rest}
                 />
             ) : (
@@ -49,7 +38,7 @@ const SecretTextarea = forwardRef<HTMLTextAreaElement, SecretTextareaProps>(func
                     variant={'flat'}
                     value={value}
                     // @ts-expect-error we are mixing input and textarea props
-                    onChange={(e) => updateValue(e.currentTarget.value)}
+                    onChange={(e) => onUpdate(e.currentTarget.value)}
                     {...rest}
                 />
             )}
@@ -62,5 +51,3 @@ const SecretTextarea = forwardRef<HTMLTextAreaElement, SecretTextareaProps>(func
         </div>
     );
 });
-
-export default SecretTextarea;

--- a/packages/webapp/src/pages/Connection/CreateLegacy.tsx
+++ b/packages/webapp/src/pages/Connection/CreateLegacy.tsx
@@ -12,7 +12,7 @@ import Nango, { AuthError } from '@nangohq/frontend';
 
 import { LeftNavBarItems } from '../../components/LeftNavBar';
 import SecretInput from '../../components/ui/input/SecretInput';
-import SecretTextArea from '../../components/ui/input/SecretTextArea';
+import { SecretTextArea } from '../../components/ui/input/SecretTextArea';
 import TagsInput from '../../components/ui/input/TagsInput';
 import { useEnvironment } from '../../hooks/useEnvironment';
 import { useListIntegration } from '../../hooks/useIntegration';
@@ -1066,7 +1066,7 @@ nango.${integration.meta.authMode === 'NONE' ? 'create' : 'auth'}('${integration
                                             defaultValue="{ }"
                                             className={`${authorizationParamsError ? 'border-red-700' : 'border-border-gray'}  ${
                                                 authorizationParamsError ? 'text-red-700' : 'text-text-light-gray'
-                                            } focus:ring-white bg-active-gray block focus:border-white focus:ring-white block w-full appearance-none rounded-md border px-3 py-1 text-sm placeholder-gray-400 shadow-sm focus:outline-none`}
+                                            } focus:ring-white bg-active-gray block focus:border-white w-full appearance-none rounded-md border px-3 py-1 text-sm placeholder-gray-400 shadow-sm focus:outline-none`}
                                             onChange={handleAuthorizationParamsChange}
                                         />
                                     </div>
@@ -1156,8 +1156,8 @@ nango.${integration.meta.authMode === 'NONE' ? 'create' : 'auth'}('${integration
                                             copy={true}
                                             id="private_key"
                                             name="private_key"
-                                            optionalValue={privateKey}
-                                            setOptionalValue={(value) => setPrivateKey(value)}
+                                            value={privateKey}
+                                            onUpdate={(value) => setPrivateKey(value)}
                                             required
                                         />
                                     </div>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/App.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/App.tsx
@@ -6,7 +6,7 @@ import { InfoBloc } from '../../../../../components/InfoBloc';
 import { Button } from '../../../../../components/ui/button/Button';
 import { CopyButton } from '../../../../../components/ui/button/CopyButton';
 import { Input } from '../../../../../components/ui/input/Input';
-import SecretTextarea from '../../../../../components/ui/input/SecretTextArea';
+import { SecretTextArea } from '../../../../../components/ui/input/SecretTextArea';
 import { apiPatchIntegration } from '../../../../../hooks/useIntegration';
 import { useToast } from '../../../../../hooks/useToast';
 import { useStore } from '../../../../../store';
@@ -83,15 +83,7 @@ export const SettingsApp: React.FC<{ data: GetIntegration['Success']['data']; en
                 title="App Private Key"
                 help={<p>Obtain the app private key from the app page by downloading the private key and pasting the entirety of its contents here</p>}
             >
-                <SecretTextarea
-                    copy={true}
-                    id="private_key"
-                    name="private_key"
-                    value={privateKey}
-                    onChange={(e) => setPrivateKey(e.target.value)}
-                    additionalClass={`w-full`}
-                    required
-                />
+                <SecretTextArea copy={true} id="private_key" name="private_key" value={privateKey} onUpdate={(value) => setPrivateKey(value)} required />
             </InfoBloc>
 
             <div className="flex justify-between">

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/Custom.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/Custom.tsx
@@ -7,7 +7,7 @@ import { Button } from '../../../../../components/ui/button/Button';
 import { CopyButton } from '../../../../../components/ui/button/CopyButton';
 import { Input } from '../../../../../components/ui/input/Input';
 import SecretInput from '../../../../../components/ui/input/SecretInput';
-import SecretTextarea from '../../../../../components/ui/input/SecretTextArea';
+import { SecretTextArea } from '../../../../../components/ui/input/SecretTextArea';
 import { apiPatchIntegration } from '../../../../../hooks/useIntegration';
 import { useToast } from '../../../../../hooks/useToast';
 import { useStore } from '../../../../../store';
@@ -61,7 +61,7 @@ export const SettingsCustom: React.FC<{ data: GetIntegration['Success']['data'];
                             required
                             minLength={1}
                             variant={'flat'}
-                            after={<CopyButton text={integration.oauth_client_id || ''} />}
+                            after={<CopyButton text={appId} />}
                         />
                     </InfoBloc>
                     <InfoBloc title="App Public Link">
@@ -75,7 +75,7 @@ export const SettingsCustom: React.FC<{ data: GetIntegration['Success']['data'];
                             required
                             minLength={1}
                             variant={'flat'}
-                            after={<CopyButton text={integration.app_link || ''} />}
+                            after={<CopyButton text={appLink} />}
                         />
                     </InfoBloc>
                 </div>
@@ -92,7 +92,7 @@ export const SettingsCustom: React.FC<{ data: GetIntegration['Success']['data'];
                         required
                         minLength={1}
                         variant={'flat'}
-                        after={<CopyButton text={integration.oauth_client_id || ''} />}
+                        after={<CopyButton text={clientId} />}
                     />
                 </InfoBloc>
 
@@ -113,13 +113,13 @@ export const SettingsCustom: React.FC<{ data: GetIntegration['Success']['data'];
                     title="App Private Key"
                     help={<p>Obtain the app private key from the app page by downloading the private key and pasting the entirety of its contents here</p>}
                 >
-                    <SecretTextarea
+                    <SecretTextArea
                         copy={true}
                         id="private_key"
                         name="private_key"
                         value={privateKey}
-                        onChange={(e) => setPrivateKey(e.target.value)}
-                        additionalClass={`w-full`}
+                        onUpdate={(value) => setPrivateKey(value)}
+                        className={`w-full`}
                         required
                     />
                 </InfoBloc>


### PR DESCRIPTION
## Changes

- Github app custom token
Thought it was legacy stuff, but turns out `token_url` can also be an object especially in the github app case.

- Fix UI copy buttons
While trying to get this app working locally, I noticed a lot of copy buttons were not working properly

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed support for GitHub App custom token URLs and repaired broken copy buttons in the UI.

- **Bug Fixes**
  - Handled GitHub App providers where `token_url` is an object, not just a string.
  - Fixed copy buttons in several UI components so they now work as expected.

<!-- End of auto-generated description by mrge. -->

