### PR TITLE
chore(scheduler): add groups table

### DIFF
--- a/packages/scheduler/lib/db/migrations/20250501173800_create_groups_table.ts
+++ b/packages/scheduler/lib/db/migrations/20250501173800_create_groups_table.ts
@@ -1,0 +1,17 @@
+import type { Knex } from 'knex';
+import { GROUPS_TABLE } from '../../models/tasks.js';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`
+            CREATE TABLE IF NOT EXISTS ${GROUPS_TABLE} (
+                key varchar(255) PRIMARY KEY,
+                max_concurrency integer NOT NULL,
+                created_at timestamp with time zone NOT NULL,
+                last_modified_at timestamp with time zone NOT NULL,
+                deleted_at timestamp with time zone NULL,
+                last_task_added_at timestamp with time zone NULL
+            );
+        `);
+}
+
+export async function down(): Promise<void> {}

--- a/packages/scheduler/lib/db/migrations/20250501173800_create_groups_table.ts
+++ b/packages/scheduler/lib/db/migrations/20250501173800_create_groups_table.ts
@@ -1,17 +1,36 @@
 import type { Knex } from 'knex';
-import { GROUPS_TABLE } from '../../models/tasks.js';
+import { GROUPS_TABLE } from '../../models/groups.js';
 
 export async function up(knex: Knex): Promise<void> {
-    await knex.raw(`
+    await knex.transaction(async (trx) => {
+        await trx.raw(`
             CREATE TABLE IF NOT EXISTS ${GROUPS_TABLE} (
                 key varchar(255) PRIMARY KEY,
                 max_concurrency integer NOT NULL,
                 created_at timestamp with time zone NOT NULL,
-                last_modified_at timestamp with time zone NOT NULL,
+                updated_at timestamp with time zone NOT NULL,
                 deleted_at timestamp with time zone NULL,
                 last_task_added_at timestamp with time zone NULL
             );
         `);
+        await trx.raw(`
+            CREATE INDEX IF NOT EXISTS idx_groups_last_task_added_at ON ${GROUPS_TABLE} (last_task_added_at);
+        `);
+        await trx.raw(`
+            CREATE INDEX IF NOT EXISTS idx_groups_updated_at ON ${GROUPS_TABLE} (updated_at);
+        `);
+
+        // Insert existing groups (webhook, action, sync and on-event)
+        // with max_concurrency 0 (aka: unlimited)
+        await trx.raw(`
+            INSERT INTO ${GROUPS_TABLE} (key, max_concurrency, created_at, updated_at)
+            VALUES ('webhook', 0, NOW(), NOW()),
+                   ('action', 0, NOW(), NOW()),
+                   ('sync', 0, NOW(), NOW()),
+                   ('on-event', 0, NOW(), NOW())
+            ON CONFLICT (key) DO NOTHING
+        `);
+    });
 }
 
 export async function down(): Promise<void> {}

--- a/packages/scheduler/lib/models/groups.integration.test.ts
+++ b/packages/scheduler/lib/models/groups.integration.test.ts
@@ -1,0 +1,85 @@
+import { expect, describe, it, beforeEach, afterEach } from 'vitest';
+import * as groups from './groups.js';
+import { getTestDbClient } from '../db/helpers.test.js';
+import { setTimeout } from 'timers/promises';
+
+describe('Groups', () => {
+    const dbClient = getTestDbClient();
+    const db = dbClient.db;
+    beforeEach(async () => {
+        await dbClient.migrate();
+        await dbClient.db.raw('TRUNCATE TABLE groups CASCADE');
+    });
+    afterEach(async () => {
+        await dbClient.clearDatabase();
+    });
+
+    it('should be successfully created', async () => {
+        const group = (
+            await groups.upsert(db, {
+                key: 'test-group',
+                maxConcurrency: 10,
+                lastTaskAddedAt: null
+            })
+        ).unwrap();
+        expect(group).toMatchObject({
+            key: 'test-group',
+            maxConcurrency: 10,
+            createdAt: expect.toBeIsoDateTimezone(),
+            updatedAt: expect.toBeIsoDateTimezone(),
+            deletedAt: null,
+            lastTaskAddedAt: null
+        });
+    });
+    it('should be successfully updated', async () => {
+        await groups.upsert(db, {
+            key: 'original',
+            maxConcurrency: 1,
+            lastTaskAddedAt: null
+        });
+        const updated = (
+            await groups.upsert(db, {
+                key: 'new',
+                maxConcurrency: 2,
+                lastTaskAddedAt: new Date()
+            })
+        ).unwrap();
+        expect(updated).toMatchObject({
+            key: 'new',
+            maxConcurrency: 2,
+            createdAt: expect.toBeIsoDateTimezone(),
+            updatedAt: expect.toBeIsoDateTimezone(),
+            deletedAt: null,
+            lastTaskAddedAt: expect.toBeIsoDateTimezone()
+        });
+    });
+    it('should be deleted if not used for a while', async () => {
+        const intervalMs = 20;
+        const groupA = (
+            await groups.upsert(db, {
+                key: 'groupA',
+                maxConcurrency: 1,
+                lastTaskAddedAt: new Date()
+            })
+        ).unwrap();
+        const groupB = (
+            await groups.upsert(db, {
+                key: 'groupB',
+                maxConcurrency: 1,
+                lastTaskAddedAt: null
+            })
+        ).unwrap();
+
+        await setTimeout(intervalMs + 1);
+
+        await groups.upsert(db, {
+            key: 'groupC',
+            maxConcurrency: 1,
+            lastTaskAddedAt: new Date()
+        });
+
+        const deleted = (await groups.hardDeleteUnused(db, { ms: intervalMs })).unwrap();
+        expect(deleted.length).toBe(2);
+        expect(deleted.map((group) => group.key)).toEqual([groupA.key, groupB.key]);
+    });
+});

--- a/packages/scheduler/lib/models/groups.ts
+++ b/packages/scheduler/lib/models/groups.ts
@@ -1,0 +1,92 @@
+import type knex from 'knex';
+import { Err, Ok, stringifyError } from '@nangohq/utils';
+import type { Result } from '@nangohq/utils';
+import type { Group } from '../types.js';
+
+export const GROUPS_TABLE = 'groups';
+
+export interface DbGroup {
+    readonly key: string;
+    readonly max_concurrency: number;
+    readonly created_at: Date;
+    updated_at: Date;
+    last_task_added_at: Date | null;
+    deleted_at: Date | null;
+}
+
+export const DbGroup = {
+    to: (group: Group): DbGroup => ({
+        key: group.key,
+        max_concurrency: group.maxConcurrency,
+        created_at: group.createdAt,
+        updated_at: group.updatedAt,
+        last_task_added_at: group.lastTaskAddedAt,
+        deleted_at: group.deletedAt
+    }),
+    from: (dbGroup: DbGroup): Group => ({
+        key: dbGroup.key,
+        maxConcurrency: dbGroup.max_concurrency,
+        createdAt: dbGroup.created_at,
+        updatedAt: dbGroup.updated_at,
+        lastTaskAddedAt: dbGroup.last_task_added_at,
+        deletedAt: dbGroup.deleted_at
+    })
+};
+
+export async function upsert(db: knex.Knex, group: Omit<Group, 'createdAt' | 'updatedAt' | 'deletedAt'>): Promise<Result<Group>> {
+    const now = new Date();
+    try {
+        const toInsert: DbGroup = {
+            key: group.key,
+            max_concurrency: group.maxConcurrency,
+            created_at: now,
+            updated_at: now,
+            last_task_added_at: group.lastTaskAddedAt,
+            deleted_at: null
+        };
+        const [dbGroup] = await db
+            .from<DbGroup>(GROUPS_TABLE)
+            .insert(toInsert)
+            .onConflict('key')
+            .merge({
+                max_concurrency: group.maxConcurrency,
+                last_task_added_at: group.lastTaskAddedAt,
+                deleted_at: null
+            })
+            .returning('*');
+        if (!dbGroup) {
+            return Err(new Error(`Failed to upsert group '${group.key}'`));
+        }
+        return Ok(DbGroup.from(dbGroup));
+    } catch (err) {
+        return Err(new Error(`Error upserting group '${group.key}': ${stringifyError(err)}`));
+    }
+}
+
+export async function hardDeleteUnused(db: knex.Knex, props: { ms: number }): Promise<Result<Group[]>> {
+    try {
+        const deleted = await db
+            .from<Group>(GROUPS_TABLE)
+            .where(
+                'key',
+                '=',
+                db.raw(`ANY(ARRAY(
+                    SELECT "key"
+                    FROM ${GROUPS_TABLE}
+                    WHERE (
+                        "last_task_added_at" < NOW() - INTERVAL '${props.ms} milliseconds'
+                        OR (
+                            "last_task_added_at" IS NULL
+                            AND "updated_at" < NOW() - INTERVAL '${props.ms} milliseconds'
+                        )
+                    )
+                    LIMIT 100
+                  ))`)
+            )
+            .del()
+            .returning('*');
+        return Ok(deleted);
+    } catch (err) {
+        return Err(new Error(`Error hard deleting group unused in ${props.ms} ms: ${stringifyError(err)}`));
+    }
+}

--- a/packages/scheduler/lib/models/schedules.ts
+++ b/packages/scheduler/lib/models/schedules.ts
@@ -3,7 +3,7 @@ import { uuidv7 } from 'uuidv7';
 import type knex from 'knex';
 import { Err, Ok, stringifyError } from '@nangohq/utils';
 import type { Result } from '@nangohq/utils';
-import type { Schedule, ScheduleState } from '../types';
+import type { Schedule, ScheduleState } from '../types.js';
 
 export const SCHEDULES_TABLE = 'schedules';
 

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -8,7 +8,6 @@ import { uuidv7 } from 'uuidv7';
 import { SCHEDULES_TABLE } from './schedules.js';
 
 export const TASKS_TABLE = 'tasks';
-export const GROUPS_TABLE = 'groups';
 
 export type TaskProps = Omit<Task, 'id' | 'createdAt' | 'state' | 'lastStateTransitionAt' | 'lastHeartbeatAt' | 'output' | 'terminated'>;
 

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -8,6 +8,7 @@ import { uuidv7 } from 'uuidv7';
 import { SCHEDULES_TABLE } from './schedules.js';
 
 export const TASKS_TABLE = 'tasks';
+export const GROUPS_TABLE = 'groups';
 
 export type TaskProps = Omit<Task, 'id' | 'createdAt' | 'state' | 'lastStateTransitionAt' | 'lastHeartbeatAt' | 'output' | 'terminated'>;
 

--- a/packages/scheduler/lib/types.ts
+++ b/packages/scheduler/lib/types.ts
@@ -51,3 +51,12 @@ export interface Schedule {
     readonly deletedAt: Date | null;
     readonly lastScheduledTaskId: string | null;
 }
+
+export interface Group {
+    readonly key: string;
+    readonly maxConcurrency: number;
+    readonly createdAt: Date;
+    readonly updatedAt: Date;
+    readonly lastTaskAddedAt: Date | null;
+    readonly deletedAt: Date | null;
+}


### PR DESCRIPTION
Adding a groups table in scheduler in order to 
- store the max concurrency value for each group 
- ensure each group is only processed by one processor at a time. (since the algo is going to be 1. check how many slots are available for a group 2. select candidate tasks for this group limit slots, we are gonna have some locking at the group level)

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added a groups table to the scheduler to store max concurrency for each group and ensure only one processor handles a group at a time.

<!-- End of auto-generated description by mrge. -->

