### PR TITLE
feat(scheduler): dequeue on group key pattern

### DIFF
--- a/packages/jobs/lib/processor/processor.ts
+++ b/packages/jobs/lib/processor/processor.ts
@@ -17,28 +17,28 @@ export class Processor {
         try {
             const syncWorker = new ProcessorWorker({
                 orchestratorUrl: this.orchestratorServiceUrl,
-                groupKey: 'sync',
+                groupKey: 'sync*',
                 maxConcurrency: 200
             });
             syncWorker.start();
 
             const actionWorker = new ProcessorWorker({
                 orchestratorUrl: this.orchestratorServiceUrl,
-                groupKey: 'action',
+                groupKey: 'action*',
                 maxConcurrency: 200
             });
             actionWorker.start();
 
             const webhookWorker = new ProcessorWorker({
                 orchestratorUrl: this.orchestratorServiceUrl,
-                groupKey: 'webhook',
+                groupKey: 'webhook*',
                 maxConcurrency: 50
             });
             webhookWorker.start();
 
             const onEventWorker = new ProcessorWorker({
                 orchestratorUrl: this.orchestratorServiceUrl,
-                groupKey: 'on-event',
+                groupKey: 'on-event*',
                 maxConcurrency: 50
             });
             onEventWorker.start();

--- a/packages/jobs/lib/processor/processor.worker.ts
+++ b/packages/jobs/lib/processor/processor.worker.ts
@@ -3,7 +3,6 @@ import type { MessagePort } from 'node:worker_threads';
 import { Worker, isMainThread } from 'node:worker_threads';
 import { getLogger, stringifyError } from '@nangohq/utils';
 import { OrchestratorClient, OrchestratorProcessor } from '@nangohq/nango-orchestrator';
-import type { TaskType } from '@nangohq/nango-orchestrator';
 import { handler } from './handler.js';
 import tracer from 'dd-trace';
 
@@ -11,7 +10,7 @@ const logger = getLogger('jobs.processor.worker');
 
 export class ProcessorWorker {
     private worker: Worker | null;
-    constructor({ orchestratorUrl, groupKey, maxConcurrency }: { orchestratorUrl: string; groupKey: TaskType; maxConcurrency: number }) {
+    constructor({ orchestratorUrl, groupKey, maxConcurrency }: { orchestratorUrl: string; groupKey: string; maxConcurrency: number }) {
         if (isMainThread) {
             const url = new URL('../../dist/processor/processor.worker.boot.js', import.meta.url);
             if (!fs.existsSync(url)) {

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -231,6 +231,7 @@ export async function transitionState(
 
 export async function dequeue(db: knex.Knex, { groupKey, limit }: { groupKey: string; limit: number }): Promise<Result<Task[]>> {
     try {
+        const groupKeyPattern = groupKey.replace(/\*/g, '%');
         const tasks = await db
             .update({
                 state: 'STARTED',
@@ -242,7 +243,8 @@ export async function dequeue(db: knex.Knex, { groupKey, limit }: { groupKey: st
                 db
                     .select('id')
                     .from<DbTask>(TASKS_TABLE)
-                    .where({ group_key: groupKey, state: 'CREATED' })
+                    .where('state', 'CREATED')
+                    .whereLike('group_key', groupKeyPattern)
                     .where('starts_after', '<=', db.fn.now())
                     .orderBy('id')
                     .limit(limit)

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -218,7 +218,7 @@ export class Scheduler {
 
     /**
      * Dequeue tasks
-     * @param groupKey - Group key
+     * @param groupKey - Group key or group key pattern (e.g. 'myGroupKey*')
      * @param limit - Limit
      * @returns Task[]
      * @example


### PR DESCRIPTION
In order to support script execution max concurrency, we are gonna need to have dynamic groups/queues in the scheduler.
This commit allows to dequeue tasks based on a group_key pattern. 
Keeping things simple for now and only allowing wildcard `*`

query plan in prod before:
```
Limit  (cost=2280.57..2285.57 rows=400 width=22) (actual time=0.466..0.479 rows=7 loops=1)
  ->  LockRows  (cost=2280.57..2298.02 rows=1396 width=22) (actual time=0.465..0.477 rows=7 loops=1)
        ->  Sort  (cost=2280.57..2284.06 rows=1396 width=22) (actual time=0.392..0.392 rows=7 loops=1)
              Sort Key: id
              Sort Method: quicksort  Memory: 25kB
              ->  Index Scan using idx_tasks_group_key_created on tasks  (cost=0.38..2213.26 rows=1396 width=22) (actual time=0.378..0.383 rows=7 loops=1)
                    Index Cond: ((group_key)::text = 'sync'::text)
                    Filter: ((state = 'CREATED'::nango_scheduler.task_states) AND (starts_after <= CURRENT_TIMESTAMP))
Planning Time: 0.492 ms
Execution Time: 0.512 ms
```

query plan in prod after:
```
Limit  (cost=2595.85..2600.85 rows=400 width=22) (actual time=0.776..0.777 rows=0 loops=1)
  ->  LockRows  (cost=2595.85..2613.30 rows=1396 width=22) (actual time=0.775..0.776 rows=0 loops=1)
        ->  Sort  (cost=2595.85..2599.34 rows=1396 width=22) (actual time=0.774..0.775 rows=0 loops=1)
              Sort Key: id
              Sort Method: quicksort  Memory: 25kB
              ->  Index Scan using idx_tasks_group_key_created on tasks  (cost=0.38..2528.53 rows=1396 width=22) (actual time=0.754..0.754 rows=0 loops=1)
                    Filter: (((group_key)::text ~~ 'sync%'::text) AND (state = 'CREATED'::nango_scheduler.task_states) AND (starts_after <= CURRENT_TIMESTAMP))
Planning Time: 0.181 ms
Execution Time: 0.804 ms
```

*How to test*
- *No behavior has been changed so just ensure all types of task are being processed.*


