### PR TITLE
feat(webapp): jump to specific time in logs

### DIFF
--- a/packages/webapp/src/pages/Logs/components/DatePicker.tsx
+++ b/packages/webapp/src/pages/Logs/components/DatePicker.tsx
@@ -1,4 +1,3 @@
-import { CalendarIcon } from '@radix-ui/react-icons';
 import { IconCalendar, IconCheck } from '@tabler/icons-react';
 import { format, subDays } from 'date-fns';
 import { useEffect, useMemo, useState } from 'react';
@@ -115,7 +114,7 @@ export const DatePicker: React.FC<{
                     size={'sm'}
                     className={cn('flex-grow truncate text-text-light-gray', period && selectedPreset?.name !== 'last24h' && 'text-white')}
                 >
-                    <CalendarIcon />
+                    <IconCalendar size={18} />
                     {display} {isLive && '(live)'}
                 </Button>
             </PopoverTrigger>
@@ -131,7 +130,7 @@ export const DatePicker: React.FC<{
                             )}
                         >
                             <div className="w-12 flex-shrink-0 flex justify-center items-center h-full p-1 bg-grayscale-5 rounded-md font-medium">
-                                <IconCalendar className="w-[18px] h-[18px]" />
+                                <IconCalendar size={18} />
                             </div>
                             <form onSubmit={onSubmitCustomRange} className="w-full">
                                 <input

--- a/packages/webapp/src/pages/Logs/components/DatePicker.tsx
+++ b/packages/webapp/src/pages/Logs/components/DatePicker.tsx
@@ -119,9 +119,10 @@ export const DatePicker: React.FC<{
                     {display} {isLive && '(live)'}
                 </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-fit p-4 rounded-md text-sm text-grayscale-11 bg-grayscale-1" align="end">
+            <PopoverContent className="w-fit p-4 pt-0 rounded-md text-sm text-grayscale-11 bg-grayscale-1" align="end">
                 <div className="flex flex-col gap-4 w-80">
                     <div className="flex flex-col gap-1">
+                        <span className="text-xs text-grayscale-8 self-end">UTC{format(new Date(), 'XXX')}</span>
                         <div
                             className={cn(
                                 'h-10 flex items-center bg-grayscale-3 rounded-md',

--- a/packages/webapp/src/pages/Logs/components/DatePicker.tsx
+++ b/packages/webapp/src/pages/Logs/components/DatePicker.tsx
@@ -22,7 +22,7 @@ export const DatePicker: React.FC<{
     const [open, setOpen] = useState<boolean>(false);
 
     const [synced, setSynced] = useState<boolean>(false);
-    const [date, setDate] = useState<DateRange | undefined>();
+    const [date, setDate] = useState<DateRange>(period);
 
     const [customRangeInputValue, setCustomRangeInputValue] = useState<string>('');
     const [rangeInputErrorMessage, setRangeInputErrorMessage] = useState<string>('');
@@ -104,7 +104,7 @@ export const DatePicker: React.FC<{
                 setOpen(open);
 
                 if (open) {
-                    setCustomRangeInputValue(`${format(period.from, dateTimeFormat)} - ${format(new Date(), dateTimeFormat)}`);
+                    setCustomRangeInputValue(`${format(date?.from, dateTimeFormat)} - ${format(date?.to || new Date(), dateTimeFormat)}`);
                     setRangeInputErrorMessage('');
                 }
             }}

--- a/packages/webapp/src/pages/Logs/components/DatePicker.tsx
+++ b/packages/webapp/src/pages/Logs/components/DatePicker.tsx
@@ -62,7 +62,7 @@ export const DatePicker: React.FC<{
             return;
         }
 
-        const { dateRange, error } = parseDateRange(inputValue, dateTimeFormat);
+        const { dateRange, error } = parseDateRange(inputValue, dateTimeFormat, rangeInputExample);
         if (error || !dateRange) {
             setRangeInputErrorMessage(error || 'Invalid date');
             return;

--- a/packages/webapp/src/pages/Logs/components/DatePicker.tsx
+++ b/packages/webapp/src/pages/Logs/components/DatePicker.tsx
@@ -1,13 +1,16 @@
-import { useEffect, useMemo, useState } from 'react';
 import { CalendarIcon } from '@radix-ui/react-icons';
-import { addDays, addMonths, format } from 'date-fns';
-import type { DateRange } from 'react-day-picker';
+import { IconCalendar, IconCheck } from '@tabler/icons-react';
+import { format, subDays } from 'date-fns';
+import { useEffect, useMemo, useState } from 'react';
+
 import { Popover, PopoverContent, PopoverTrigger } from '../../../components/ui/Popover';
-import { cn } from '../../../utils/utils';
 import { Button } from '../../../components/ui/button/Button';
-import { Calendar } from '../../../components/ui/Calendar';
-import type { Preset } from '../../../utils/logs';
-import { getPresetRange, matchPresetFromRange, presets } from '../../../utils/logs';
+import { getPresetRange, matchPresetFromRange, parseDateRange, presets } from '../../../utils/logs';
+import { cn } from '../../../utils/utils';
+
+import type { DateRange, Preset } from '../../../utils/logs';
+
+const dateTimeFormat = 'LLL dd, HH:mm';
 
 export const DatePicker: React.FC<{
     isLive: boolean;
@@ -16,21 +19,16 @@ export const DatePicker: React.FC<{
 }> = ({ isLive, period, onChange }) => {
     const [selectedPreset, setSelectedPreset] = useState<Preset | null>(null);
 
+    const [open, setOpen] = useState<boolean>(false);
+
     const [synced, setSynced] = useState<boolean>(false);
     const [date, setDate] = useState<DateRange | undefined>();
-    const [tmpDate, setTmpDate] = useState<DateRange | undefined>();
 
-    const defaultMonth = useMemo(() => {
-        const today = new Date();
-        return today.getDate() > 15 ? today : addMonths(today, -1);
-    }, []);
+    const [customRangeInputValue, setCustomRangeInputValue] = useState<string>('');
+    const [rangeInputErrorMessage, setRangeInputErrorMessage] = useState<string>('');
 
-    const disabledBefore = useMemo(() => {
-        return addDays(new Date(), -14);
-    }, []);
-
-    const disabledAfter = useMemo(() => {
-        return new Date();
+    const rangeInputExample = useMemo(() => {
+        return `${format(subDays(new Date(), 1), dateTimeFormat)} - ${format(new Date(), dateTimeFormat)}`;
     }, []);
 
     const display = useMemo(() => {
@@ -41,39 +39,38 @@ export const DatePicker: React.FC<{
             return 'Last 24 hours';
         }
         if (date.from && date.to) {
-            return `${format(date.from, 'LLL dd, HH:mm')} - ${format(date.to, 'LLL dd, HH:mm')}`;
+            return `${format(date.from, dateTimeFormat)} - ${format(date.to, dateTimeFormat)}`;
         }
-        return format(date.from, 'LLL dd, HH:mm');
+        return format(date.from, dateTimeFormat);
     }, [date, selectedPreset]);
 
     const onClickPreset = (preset: Preset) => {
         const range = getPresetRange(preset.name);
         setSelectedPreset(preset);
-        setTmpDate(range);
+        setCustomRangeInputValue(`${format(range.from, dateTimeFormat)} - ${format(new Date(), dateTimeFormat)}`);
         onChange(range, true);
+        setOpen(false);
     };
 
-    const onClickCalendar = (e?: DateRange) => {
-        if (e?.from) {
-            e.from.setHours(0, 0, 0);
-        }
-        if (e?.to) {
-            e.to.setHours(23, 59, 59);
+    const onSubmitCustomRange = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        setRangeInputErrorMessage('');
+
+        const inputValue = e.currentTarget.querySelector('input')?.value;
+        if (!inputValue) {
+            setRangeInputErrorMessage('Set custom range');
+            return;
         }
 
-        setTmpDate(e);
-
-        if (e?.from && e?.to) {
-            // Commit change only on full range
-            onChange(e, e.to.toISOString().split('T')[0] === new Date().toISOString().split('T')[0]);
+        const { dateRange, error } = parseDateRange(inputValue, dateTimeFormat);
+        if (error || !dateRange) {
+            setRangeInputErrorMessage(error || 'Invalid date');
+            return;
         }
 
-        if (!e?.from && !e?.to) {
-            // Unselected everything should fallback to default preset
-            onClickPreset({ label: 'Last 24 hours', name: 'last24h' });
-        } else {
-            setSelectedPreset(null);
-        }
+        setSelectedPreset(null);
+        onChange(dateRange, false);
+        setOpen(false);
     };
 
     useEffect(
@@ -84,7 +81,6 @@ export const DatePicker: React.FC<{
 
             setSynced(true);
             setDate(period);
-            setTmpDate(period);
             setSelectedPreset(matchPresetFromRange(period));
         },
         [period]
@@ -102,7 +98,17 @@ export const DatePicker: React.FC<{
     );
 
     return (
-        <Popover>
+        <Popover
+            open={open}
+            onOpenChange={(open) => {
+                setOpen(open);
+
+                if (open) {
+                    setCustomRangeInputValue(`${format(period.from, dateTimeFormat)} - ${format(new Date(), dateTimeFormat)}`);
+                    setRangeInputErrorMessage('');
+                }
+            }}
+        >
             <PopoverTrigger asChild>
                 <Button
                     variant="zombieGray"
@@ -113,30 +119,50 @@ export const DatePicker: React.FC<{
                     {display} {isLive && '(live)'}
                 </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-auto p-0 text-white bg-active-gray" align="end">
-                <div className="flex gap-6">
-                    <Calendar
-                        mode="range"
-                        defaultMonth={defaultMonth}
-                        selected={tmpDate}
-                        onSelect={onClickCalendar}
-                        initialFocus
-                        numberOfMonths={2}
-                        disabled={{ before: disabledBefore, after: disabledAfter }}
-                        weekStartsOn={1}
-                        showOutsideDays={false}
-                    />
-                    <div className="flex flex-col mt-6">
+            <PopoverContent className="w-fit p-4 rounded-md text-sm text-grayscale-11 bg-grayscale-1" align="end">
+                <div className="flex flex-col gap-4 w-80">
+                    <div className="flex flex-col gap-1">
+                        <div
+                            className={cn(
+                                'h-10 flex items-center bg-grayscale-3 rounded-md',
+                                !selectedPreset && 'border border-grayscale-8',
+                                rangeInputErrorMessage && 'border border-alert-red'
+                            )}
+                        >
+                            <div className="w-12 flex-shrink-0 flex justify-center items-center h-full p-1 bg-grayscale-5 rounded-md font-medium">
+                                <IconCalendar className="w-[18px] h-[18px]" />
+                            </div>
+                            <form onSubmit={onSubmitCustomRange} className="w-full">
+                                <input
+                                    type="text"
+                                    placeholder={rangeInputExample}
+                                    className="w-full bg-transparent text-sm text-grayscale-13 placeholder:text-grayscale-10 focus:outline-none focus:ring-0 border-none"
+                                    value={customRangeInputValue}
+                                    onChange={(e) => setCustomRangeInputValue(e.target.value)}
+                                />
+                            </form>
+                        </div>
+                        {rangeInputErrorMessage && <span className="text-alert-red text-sm">{rangeInputErrorMessage}</span>}
+                    </div>
+                    <div className="flex flex-col gap-2 w-80">
                         {presets.map((preset) => {
                             return (
-                                <Button
+                                <div
                                     key={preset.name}
-                                    variant={'zombieGray'}
-                                    className={cn('justify-end', selectedPreset?.name === preset.name && 'bg-pure-black')}
+                                    className={cn(
+                                        'flex items-center gap-2 cursor-pointer hover:bg-grayscale-3 rounded-md',
+                                        selectedPreset?.name === preset.name && 'bg-grayscale-3 text-grayscale-13'
+                                    )}
                                     onClick={() => onClickPreset(preset)}
                                 >
-                                    {preset.label}
-                                </Button>
+                                    <div className="flex-grow flex items-center gap-2">
+                                        <div className="w-12 flex-shrink-0 flex justify-center items-center p-1 bg-grayscale-5 rounded-md font-medium">
+                                            {preset.shortLabel}
+                                        </div>
+                                        <span>{preset.label}</span>
+                                    </div>
+                                    {selectedPreset?.name === preset.name && <IconCheck className="w-4 h-4 mr-2" />}
+                                </div>
                             );
                         })}
                     </div>
@@ -145,7 +171,3 @@ export const DatePicker: React.FC<{
         </Popover>
     );
 };
-
-{
-    /*  */
-}

--- a/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
+++ b/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
@@ -23,9 +23,9 @@ import { getPresetRange, slidePeriod } from '../../../utils/logs';
 import { calculateTableSizing } from '../../../utils/table';
 import { formatQuantity } from '../../../utils/utils';
 
+import type { DateRange } from '../../../utils/logs';
 import type { OperationRow as OperationRowType, SearchOperations, SearchOperationsData } from '@nangohq/types';
 import type { Table as ReactTable } from '@tanstack/react-table';
-import type { DateRange } from 'react-day-picker';
 
 interface Props {
     onSelectOperation: (open: boolean, operationId: string) => void;
@@ -99,7 +99,7 @@ export const SearchAllOperations: React.FC<Props> = ({ onSelectOperation }) => {
             // We do it only at query time so the URL stays the same
             if (isLive) {
                 const tmp = slidePeriod({ from: period[0], to: period[1] });
-                periodCopy = { from: tmp.from!.toISOString(), to: tmp.to!.toISOString() };
+                periodCopy = { from: tmp.from.toISOString(), to: tmp.to!.toISOString() };
             } else {
                 periodCopy = { from: new Date(period[0]).toISOString(), to: new Date(period[1]).toISOString() };
             }

--- a/packages/webapp/src/utils/logs.tsx
+++ b/packages/webapp/src/utils/logs.tsx
@@ -1,6 +1,11 @@
+import { addMilliseconds, parse } from 'date-fns';
+
 import type { SearchOperations, SearchOperationsPeriod } from '@nangohq/types';
-import { addMilliseconds } from 'date-fns';
-import type { DateRange } from 'react-day-picker';
+
+export interface DateRange {
+    from: Date;
+    to?: Date;
+}
 
 export function getLogsUrl(
     options: Omit<
@@ -34,7 +39,7 @@ export function getLogsUrl(
 
 export function slidePeriod(period: DateRange | SearchOperationsPeriod): DateRange {
     const now = new Date();
-    let from = new Date(period.from!);
+    let from = new Date(period.from);
     let to = new Date(period.to!);
     const sliding = now.getTime() - to.getTime();
     to = addMilliseconds(to, sliding);
@@ -45,12 +50,12 @@ export function slidePeriod(period: DateRange | SearchOperationsPeriod): DateRan
 
 // Define presets
 export const presets = [
-    { name: 'last5m', label: 'Last 5 minutes' },
-    { name: 'last1h', label: 'Last hour' },
-    { name: 'last24h', label: 'Last 24 hours' },
-    { name: 'last3d', label: 'Last 3 days' },
-    { name: 'last7d', label: 'Last 7 days' },
-    { name: 'last14d', label: 'Last 14 days' }
+    { name: 'last5m', label: 'Last 5 minutes', shortLabel: '5m' },
+    { name: 'last1h', label: 'Last hour', shortLabel: '1h' },
+    { name: 'last24h', label: 'Last 24 hours', shortLabel: '24h' },
+    { name: 'last3d', label: 'Last 3 days', shortLabel: '3d' },
+    { name: 'last7d', label: 'Last 7 days', shortLabel: '1w' },
+    { name: 'last14d', label: 'Last 14 days', shortLabel: '2w' }
 ] as const;
 export type PresetNames = (typeof presets)[number]['name'];
 export type Preset = (typeof presets)[number];
@@ -90,14 +95,39 @@ export function getPresetRange(preset: PresetNames): DateRange {
 }
 
 export function matchPresetFromRange(range: DateRange): Preset | null {
-    const minutes = (range.to!.getTime() - range.from!.getTime()) / 1000 / 60;
+    const minutes = (range.to!.getTime() - range.from.getTime()) / 1000 / 60;
     for (const preset of presets) {
         const tmp = getPresetRange(preset.name);
-        const tmpMinutes = (tmp.to!.getTime() - tmp.from!.getTime()) / 1000 / 60;
+        const tmpMinutes = (tmp.to!.getTime() - tmp.from.getTime()) / 1000 / 60;
         if (tmpMinutes === minutes) {
             return preset;
         }
     }
 
     return null;
+}
+
+export function parseDateRange(input: string, dateTimeFormat: string): { dateRange: DateRange | null; error: string | null } {
+    // Validate input format
+    const dateFormatRegex = /^[A-Z][a-z]{2} \d{1,2}, \d{1,2}:\d{2} - [A-Z][a-z]{2} \d{1,2}, \d{1,2}:\d{2}$/;
+    if (!dateFormatRegex.test(input)) {
+        return { dateRange: null, error: 'Invalid format' };
+    }
+
+    const [from, to] = input.split('-').map((d) => d.trim());
+
+    const range = {
+        from: parse(from, dateTimeFormat, new Date()),
+        to: parse(to, dateTimeFormat, new Date())
+    };
+
+    if (isNaN(range.from.getTime()) || isNaN(range.to.getTime())) {
+        return { dateRange: null, error: 'Invalid date' };
+    }
+
+    if (range.from > range.to) {
+        return { dateRange: null, error: 'From date must be before to date' };
+    }
+
+    return { dateRange: range, error: null };
 }

--- a/packages/webapp/src/utils/logs.tsx
+++ b/packages/webapp/src/utils/logs.tsx
@@ -107,11 +107,11 @@ export function matchPresetFromRange(range: DateRange): Preset | null {
     return null;
 }
 
-export function parseDateRange(input: string, dateTimeFormat: string): { dateRange: DateRange | null; error: string | null } {
+export function parseDateRange(input: string, dateTimeFormat: string, example: string): { dateRange: DateRange | null; error: string | null } {
     // Validate input format
     const dateFormatRegex = /^[A-Z][a-z]{2} \d{1,2}, \d{1,2}:\d{2} - [A-Z][a-z]{2} \d{1,2}, \d{1,2}:\d{2}$/;
     if (!dateFormatRegex.test(input)) {
-        return { dateRange: null, error: 'Invalid format' };
+        return { dateRange: null, error: `Invalid format. Example: ${example}` };
     }
 
     const [from, to] = input.split('-').map((d) => d.trim());
@@ -122,7 +122,7 @@ export function parseDateRange(input: string, dateTimeFormat: string): { dateRan
     };
 
     if (isNaN(range.from.getTime()) || isNaN(range.to.getTime())) {
-        return { dateRange: null, error: 'Invalid date' };
+        return { dateRange: null, error: `Invalid date. Example: ${example}` };
     }
 
     if (range.from > range.to) {

--- a/packages/webapp/src/utils/logs.tsx
+++ b/packages/webapp/src/utils/logs.tsx
@@ -126,7 +126,7 @@ export function parseDateRange(input: string, dateTimeFormat: string): { dateRan
     }
 
     if (range.from > range.to) {
-        return { dateRange: null, error: 'From date must be before to date' };
+        return { dateRange: null, error: "'from' date must be before 'to' date" };
     }
 
     return { dateRange: range, error: null };

--- a/packages/webapp/tailwind.config.js
+++ b/packages/webapp/tailwind.config.js
@@ -68,6 +68,22 @@ export default {
                 // -----
                 // Design system v2
                 //
+                'grayscale-1': '#0D0D0D',
+                'grayscale-2': '#161616',
+                'grayscale-3': '#1C1C1C',
+                'grayscale-4': '#2A2A2A',
+                'grayscale-5': '#333333',
+                'grayscale-6': '#444444',
+                'grayscale-7': '#555555',
+                'grayscale-8': '#666666',
+                'grayscale-9': '#888888',
+                'grayscale-10': '#9FA2A9',
+                'grayscale-11': '#B3B7BF',
+                'grayscale-12': '#C7CCD5',
+                'grayscale-13': '#E4E9F2',
+                'grayscale-14': '#F8FAFE',
+
+                // Design system v2 - Outdated colors. Created separate ones above in order to not break existing styles. Delete after migration.
                 'grayscale-100': '#fafafa',
                 'grayscale-200': '#ececec',
                 'grayscale-300': '#d0d1d0',


### PR DESCRIPTION
<!-- Describe the problem and your solution -->
### Description
In the log filters, we currently allow selecting custom date ranges but we give no control over specific TIME ranges. This PR reworks the DatePicker (maybe not the best name anymore?) to allow for custom inputs, with heavy inspiration on DataDog. See [Figma design](https://www.figma.com/design/a4t7gaUATMqUcWedowFPFd/Design-Sytem---Nango?node-id=4516-34222&p=f&t=pPuIjoDVaG3A0M37-0).

I took some liberties over the design and functionality. The custom input always comes pre-filled with the current time range based on the selected preset. This way serves as both an example and a starting point for editing:
<img width="359" alt="image" src="https://github.com/user-attachments/assets/ef9961f8-da1e-49d9-b781-f84f85ed730b" />

I've also free-styled errors:
<img width="361" alt="image" src="https://github.com/user-attachments/assets/fafbd766-dcef-410c-8629-e046498eda4c" />



<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->
### Testing
Please checkout to this branch and try to break it. Any feedback is welcome.

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added support for jumping to a specific time range in logs by allowing custom date and time input in the DatePicker.

- **New Features**
  - Users can now enter a custom date and time range to filter logs.
  - Improved error handling and input validation for custom ranges.
  - Updated UI to show preset time ranges with short labels.

<!-- End of auto-generated description by mrge. -->

