### PR TITLE
fix(orb): batch events

### DIFF
--- a/packages/billing/lib/billing.ts
+++ b/packages/billing/lib/billing.ts
@@ -33,7 +33,7 @@ export class Billing {
             ];
         });
 
-        return this.ingest(mapped);
+        return await this.ingest(mapped);
     }
 
     // Note: Events are sent immediately

--- a/packages/billing/lib/clients/orb.ts
+++ b/packages/billing/lib/clients/orb.ts
@@ -2,18 +2,24 @@ import Orb from 'orb-billing';
 
 import { envs } from '../envs.js';
 
-import type { BillingIngestEvent } from '../types.js';
+import type { BillingClient, BillingIngestEvent } from '../types.js';
 
 const orbSDK = new Orb({
     apiKey: envs.ORB_API_KEY || 'empty',
     maxRetries: 3
 });
 
-export const orb = {
-    ingest: async (events: BillingIngestEvent[]): Promise<void> => {
-        await orbSDK.events.ingest({
-            events: events.map(toOrbEvent)
-        });
+export const orb: BillingClient = {
+    ingest: async (events) => {
+        // Orb limit the number of events per batch to 500
+        const batchSize = 500;
+
+        for (let i = 0; i < events.length; i += batchSize) {
+            const batch = events.slice(i, i + batchSize);
+            await orbSDK.events.ingest({
+                events: batch.map(toOrbEvent)
+            });
+        }
     }
 };
 

--- a/packages/server/lib/crons/usage.ts
+++ b/packages/server/lib/crons/usage.ts
@@ -88,7 +88,10 @@ const billing = {
                     return { type: 'billable_connections', value: count, properties: { accountId, timestamp: now } };
                 });
 
-                await usageBilling.sendAll(events);
+                const sendRes = await usageBilling.sendAll(events);
+                if (sendRes.isErr()) {
+                    throw sendRes.error;
+                }
             } catch (err) {
                 span.setTag('error', err);
                 report(new Error('cron_failed_to_export_billable_connections', { cause: err }));


### PR DESCRIPTION
## Changes

- Fix orb accept at most 500 events per batch
When we changed events from paying to all customers, we went above the batching limit, and the error wasn't propagated correctly.


    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed event batching for Orb to ensure no more than 500 events are sent per batch, preventing errors when processing large numbers of events.

- **Bug Fixes**
  - Split events into batches of 500 before sending to Orb.
  - Improved error handling when sending usage events.

<!-- End of auto-generated description by mrge. -->

