### PR TITLE
fix(integrations): use correct Vercel verifcation endpoint

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -10115,7 +10115,7 @@ vercel:
         verification:
             method: GET
             endpoints:
-                - /v1/sessions
+                - /v2/user
     docs: https://docs.nango.dev/integrations/all/vercel
     docs_connect: https://docs.nango.dev/integrations/all/vercel
     credentials:


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
This PR fixes an issue with the `Vercel` verification endpoint

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->
1. Connect to vercel using the  API key.
2. See that the verification returns a 200 response


    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed the Vercel verification endpoint to use /v2/user instead of /v1/sessions, ensuring correct verification responses.

<!-- End of auto-generated description by mrge. -->

