### PR TITLE
fix(github-app-oauth): refresh user credentials when refreshing github app oauth connection

### DIFF
--- a/packages/shared/lib/clients/oauth2.client.ts
+++ b/packages/shared/lib/clients/oauth2.client.ts
@@ -12,7 +12,7 @@ import { makeUrl } from '../utils/utils.js';
 import type { ServiceResponse } from '../models/Generic.js';
 import type { Config as ProviderConfig, OAuth2Credentials } from '../models/index.js';
 import type { LogContextStateless } from '@nangohq/logs';
-import type { DBConnectionDecrypted, Provider, ProviderOAuth2 } from '@nangohq/types';
+import type { DBConnectionDecrypted, Provider, ProviderOAuth2, ProviderCustom } from '@nangohq/types';
 import type { AccessToken, ModuleOptions, WreckHttpOptions } from 'simple-oauth2';
 import type { Merge } from 'type-fest';
 
@@ -76,7 +76,7 @@ export async function getFreshOAuth2Credentials({
 }: {
     connection: DBConnectionDecrypted;
     config: ProviderConfig;
-    provider: ProviderOAuth2;
+    provider: ProviderOAuth2 | ProviderCustom;
     logCtx: LogContextStateless;
 }): Promise<ServiceResponse<OAuth2Credentials>> {
     const credentials = connection.credentials as OAuth2Credentials;
@@ -96,10 +96,11 @@ export async function getFreshOAuth2Credentials({
         simpleOAuth2ClientConfig.http.headers = headers;
     }
     const client = new AuthorizationCode(simpleOAuth2ClientConfig);
+    const tokenSource = provider.auth_mode === 'CUSTOM' ? connection.connection_config['userCredentials'] : credentials;
     const oldAccessToken = client.createToken({
-        access_token: credentials.access_token,
-        expires_at: credentials.expires_at,
-        refresh_token: credentials.refresh_token
+        access_token: tokenSource.access_token,
+        expires_at: tokenSource.expires_at,
+        refresh_token: tokenSource.refresh_token
     });
 
     let additionalParams = {};

--- a/packages/shared/lib/models/Auth.ts
+++ b/packages/shared/lib/models/Auth.ts
@@ -100,11 +100,6 @@ export interface OAuth2Credentials extends CredentialsCommon {
         client_secret?: string;
     };
 }
-export interface CombinedOauth2AppCredentials extends CredentialsCommon {
-    type: 'CUSTOM';
-    app: AppCredentials;
-    user: OAuth2Credentials | null;
-}
 export interface OAuth2ClientCredentials extends CredentialsCommon {
     type: 'OAUTH2_CC';
     token: string;

--- a/packages/shared/lib/models/Auth.ts
+++ b/packages/shared/lib/models/Auth.ts
@@ -100,7 +100,11 @@ export interface OAuth2Credentials extends CredentialsCommon {
         client_secret?: string;
     };
 }
-
+export interface CombinedOauth2AppCredentials extends CredentialsCommon {
+    type: 'CUSTOM';
+    app: AppCredentials;
+    user: OAuth2Credentials | null;
+}
 export interface OAuth2ClientCredentials extends CredentialsCommon {
     type: 'OAUTH2_CC';
     token: string;

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -40,7 +40,8 @@ import type {
     BasicApiCredentials,
     ConnectionUpsertResponse,
     OAuth2ClientCredentials,
-    OAuth2Credentials
+    OAuth2Credentials,
+    CombinedOauth2AppCredentials
 } from '../models/Auth.js';
 import type { ServiceResponse } from '../models/Generic.js';
 import type { AuthCredentials, Config as ProviderConfig, OAuth1Credentials } from '../models/index.js';
@@ -988,6 +989,50 @@ class ConnectionService {
         return Ok(undefined);
     }
 
+    public async refreshAppCredentials(
+        provider: Provider,
+        config: ProviderConfig,
+        connection: DBConnectionDecrypted,
+        logCtx: LogContextStateless
+    ): Promise<Result<CombinedOauth2AppCredentials | AppCredentials, AuthCredentialsError>> {
+        const [userResult, appResult] = await Promise.all([
+            getFreshOAuth2Credentials({
+                connection,
+                config,
+                provider: provider as ProviderOAuth2,
+                logCtx
+            }),
+            githubAppClient.createCredentials({
+                integration: config,
+                provider: provider as ProviderGithubApp,
+                connectionConfig: connection.connection_config
+            })
+        ]);
+
+        if (!appResult.isOk()) {
+            return Err(new NangoError('github_app_token_fetch_error'));
+        }
+
+        if (!userResult.success || !userResult.response) {
+            const credentials: CombinedOauth2AppCredentials = {
+                type: 'CUSTOM',
+                user: null,
+                app: appResult.value,
+                raw: appResult.value
+            };
+            return Ok(credentials);
+        }
+
+        const credentials: CombinedOauth2AppCredentials = {
+            type: 'CUSTOM',
+            user: userResult.response,
+            app: appResult.value,
+            raw: appResult.value
+        };
+
+        return Ok(credentials);
+    }
+
     public async getOauthClientCredentials({
         provider,
         client_id,
@@ -1284,6 +1329,7 @@ class ConnectionService {
             | BillCredentials
             | TwoStepCredentials
             | SignatureCredentials
+            | CombinedOauth2AppCredentials
         >
     > {
         if (providerClient.shouldUseProviderClient(providerConfig.provider)) {
@@ -1338,11 +1384,7 @@ class ConnectionService {
 
             return { success: true, error: null, response: create.value };
         } else if (provider.auth_mode === 'APP' || (provider.auth_mode === 'CUSTOM' && connection.credentials.type !== 'OAUTH2')) {
-            const create = await githubAppClient.createCredentials({
-                integration: providerConfig,
-                provider: provider as ProviderGithubApp,
-                connectionConfig: connection.connection_config
-            });
+            const create = await this.refreshAppCredentials(provider, providerConfig, connection, logCtx);
             if (create.isErr()) {
                 return { success: false, error: create.error, response: null };
             }

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -40,8 +40,7 @@ import type {
     BasicApiCredentials,
     ConnectionUpsertResponse,
     OAuth2ClientCredentials,
-    OAuth2Credentials,
-    CombinedOauth2AppCredentials
+    OAuth2Credentials
 } from '../models/Auth.js';
 import type { ServiceResponse } from '../models/Generic.js';
 import type { AuthCredentials, Config as ProviderConfig, OAuth1Credentials } from '../models/index.js';
@@ -77,7 +76,8 @@ import type {
     SignatureCredentials,
     TableauCredentials,
     TbaCredentials,
-    TwoStepCredentials
+    TwoStepCredentials,
+    CombinedOauth2AppCredentials
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
@@ -1009,7 +1009,7 @@ class ConnectionService {
             })
         ]);
 
-        if (!appResult.isOk()) {
+        if (appResult.isErr()) {
             return Err(new NangoError('github_app_token_fetch_error'));
         }
 

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -425,7 +425,7 @@ async function refreshCredentialsIfNeeded({
         return Ok({
             connection: connectionToRefresh,
             refreshed: true,
-            credentials: newCredentials as unknown as RefreshableCredentials
+            credentials: newCredentials as RefreshableCredentials
         });
     } catch (err) {
         const error = new NangoError('refresh_token_external_error', { message: err instanceof Error ? err.message : 'unknown error' });

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -404,7 +404,13 @@ async function refreshCredentialsIfNeeded({
             return Err(error!);
         }
 
-        connectionToRefresh.credentials = newCredentials;
+        if ('user' in newCredentials && newCredentials.user) {
+            connectionToRefresh.connection_config['userCredentials'] = newCredentials.user;
+        }
+        if ('app' in newCredentials && newCredentials.app) {
+            connectionToRefresh.credentials = newCredentials.app;
+        }
+
         connectionToRefresh = await connectionService.updateConnection({
             ...connectionToRefresh,
             last_fetched_at: new Date(),
@@ -416,7 +422,11 @@ async function refreshCredentialsIfNeeded({
             updated_at: new Date()
         });
 
-        return Ok({ connection: connectionToRefresh, refreshed: true, credentials: newCredentials });
+        return Ok({
+            connection: connectionToRefresh,
+            refreshed: true,
+            credentials: newCredentials as unknown as RefreshableCredentials
+        });
     } catch (err) {
         const error = new NangoError('refresh_token_external_error', { message: err instanceof Error ? err.message : 'unknown error' });
 

--- a/packages/shared/lib/services/connections/utils.ts
+++ b/packages/shared/lib/services/connections/utils.ts
@@ -9,11 +9,25 @@ export const MAX_CONSECUTIVE_DAYS_FAILED_REFRESH = 4;
 export const REFRESH_MARGIN_S = ms('15minutes') / 1000;
 
 export function getExpiresAtFromCredentials(credentials: AllAuthCredentials): Date | null {
+    if (credentials.type === 'CUSTOM' && 'app' in credentials) {
+        const appExpiresAt = credentials.app?.expires_at ? new Date(credentials.app.expires_at) : null;
+
+        const userExpiresAt = credentials.user?.expires_at ? new Date(credentials.user.expires_at) : null;
+        console.log('this is the app expirationa', appExpiresAt);
+        console.log('this is the user expirations', userExpiresAt);
+
+        if (appExpiresAt && userExpiresAt) {
+            return appExpiresAt < userExpiresAt ? appExpiresAt : userExpiresAt;
+        }
+
+        return appExpiresAt || userExpiresAt || new Date(Date.now() + DEFAULT_EXPIRES_AT_MS);
+    }
+
     if ('expires_at' in credentials && credentials['expires_at']) {
         return credentials['expires_at'];
     }
 
-    if (credentials.type === 'CUSTOM' || credentials.type === 'OAUTH1' || credentials.type === 'APP_STORE' || !credentials.type) {
+    if (credentials.type === 'OAUTH1' || credentials.type === 'APP_STORE' || !credentials.type) {
         return new Date(Date.now() + DEFAULT_INFINITE_EXPIRES_AT_MS);
     }
 

--- a/packages/shared/lib/services/connections/utils.ts
+++ b/packages/shared/lib/services/connections/utils.ts
@@ -13,9 +13,6 @@ export function getExpiresAtFromCredentials(credentials: AllAuthCredentials): Da
         const appExpiresAt = credentials.app?.expires_at ? new Date(credentials.app.expires_at) : null;
 
         const userExpiresAt = credentials.user?.expires_at ? new Date(credentials.user.expires_at) : null;
-        console.log('this is the app expirationa', appExpiresAt);
-        console.log('this is the user expirations', userExpiresAt);
-
         if (appExpiresAt && userExpiresAt) {
             return appExpiresAt < userExpiresAt ? appExpiresAt : userExpiresAt;
         }

--- a/packages/types/lib/auth/api.ts
+++ b/packages/types/lib/auth/api.ts
@@ -189,7 +189,7 @@ export interface AuthorizationTokenResponse extends Omit<OAuth2Credentials, 'typ
 }
 
 export interface CombinedOauth2AppCredentials extends CredentialsCommon {
-    type: 'CUSTOM';
+    type: AuthModes['Custom'];
     app: AppCredentials;
     user: OAuth2Credentials | null;
 }

--- a/packages/types/lib/auth/api.ts
+++ b/packages/types/lib/auth/api.ts
@@ -188,6 +188,12 @@ export interface AuthorizationTokenResponse extends Omit<OAuth2Credentials, 'typ
     expires_in?: number;
 }
 
+export interface CombinedOauth2AppCredentials extends CredentialsCommon {
+    type: 'CUSTOM';
+    app: AppCredentials;
+    user: OAuth2Credentials | null;
+}
+
 export type TestableCredentials = ApiKeyCredentials | BasicApiCredentials | TbaCredentials | JwtCredentials | SignatureCredentials;
 export type RefreshableCredentials =
     | OAuth2Credentials
@@ -215,4 +221,5 @@ export type AllAuthCredentials =
     | JwtCredentials
     | BillCredentials
     | TwoStepCredentials
+    | CombinedOauth2AppCredentials
     | SignatureCredentials;


### PR DESCRIPTION
## Describe the problem and your solution

- Allow for refreshing of user credentials when refreshing github app oauth connection

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Updated the GitHub App OAuth flow to refresh user credentials when refreshing the app connection. This ensures both app and user tokens stay up to date.

- **Bug Fixes**
  - Refreshed user credentials are now saved alongside app credentials during OAuth refresh.
  - Updated credential handling to support combined app and user tokens.

<!-- End of auto-generated description by mrge. -->

