### PR TITLE
chore: update the DryRunService to improve error messages 

### DIFF
--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -157,15 +157,30 @@ export class DryRunService {
             }
 
             // Priority for syncs and actions
+            let foundInProviderConfigKey: string | undefined;
             for (const script of [...integration.syncs, ...integration.actions]) {
                 if (script.name !== syncName) {
                     continue;
                 }
                 if (scriptInfo) {
-                    console.log(chalk.red(`Multiple integrations contain a script named "${syncName}". Please use "--integration-id"`));
+                    // TODO: Confirm: If exists another script with the same name in the same integration, it's a variant issue
+                    if (foundInProviderConfigKey === providerConfigKey) {
+                        console.log(
+                            chalk.red(
+                                `Multiple variants of script "${syncName}" found in integration "${providerConfigKey}". Please specify which variant to use with "--variant"`
+                            )
+                        );
+                    } else {
+                        console.log(
+                            chalk.red(
+                                `Script "${syncName}" exists in multiple integrations (${foundInProviderConfigKey}, ${providerConfigKey}). Please specify which integration to use with "--integration-id"`
+                            )
+                        );
+                    }
                     return;
                 }
                 scriptInfo = script;
+                foundInProviderConfigKey = providerConfigKey;
                 providerConfigKey = integration.providerConfigKey;
             }
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
- Added logic to differentiate between variants within the same integration and scripts across different integrations, prompting users to specify the correct variant or integration ID as needed.

<!-- Issue ticket number and link (if applicable) -->
[EXT-610](https://linear.app/nango/issue/EXT-610/improve-dryrun-error-messaging)
<!-- Testing instructions (skip if just adding/editing providers) -->
**Open Issues**
Will require validation and additional testing for variants
<!-- Summary by @propel-code-bot -->

---

This PR enhances error messaging in the CLI's DryRunService by differentiating between script variants within the same integration versus scripts across different integrations. When a script name conflict is detected, users now receive more specific guidance on whether to use '--variant' or '--integration-id' flags.

*This summary was automatically generated by @propel-code-bot*