### PR TITLE
feat(scheduler): max concurrency aware dequeue query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28403,6 +28403,7 @@
             "name": "@nangohq/nango-orchestrator",
             "version": "1.0.0",
             "dependencies": {
+                "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/scheduler": "file:../scheduler",
                 "@nangohq/utils": "file:../utils",
                 "dd-trace": "5.21.0",

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -339,17 +339,20 @@ export class OrchestratorClient {
     public async dequeue({
         groupKey,
         limit,
-        longPolling
+        longPolling,
+        flagDequeueLegacy = true
     }: {
         groupKey: string;
         limit: number;
         longPolling: boolean;
+        flagDequeueLegacy?: boolean;
     }): Promise<Result<OrchestratorTask[], ClientError>> {
         const res = await this.routeFetch(postDequeueRoute)({
             body: {
                 groupKey,
                 limit,
-                longPolling
+                longPolling,
+                flagDequeueLegacy
             }
         });
         if ('error' in res) {

--- a/packages/orchestrator/lib/clients/processor.ts
+++ b/packages/orchestrator/lib/clients/processor.ts
@@ -1,4 +1,5 @@
 import type { Result } from '@nangohq/utils';
+import { getFeatureFlagsClient } from '@nangohq/kvstore';
 import { stringifyError, getLogger } from '@nangohq/utils';
 import type { OrchestratorClient } from './client.js';
 import type { OrchestratorTask } from './types.js';
@@ -6,6 +7,7 @@ import PQueue from 'p-queue';
 import type { Tracer } from 'dd-trace';
 
 const logger = getLogger('orchestrator.clients.processor');
+const featureFlags = await getFeatureFlagsClient();
 
 export class OrchestratorProcessor {
     private handler: (task: OrchestratorTask) => Promise<Result<void>>;
@@ -47,11 +49,12 @@ export class OrchestratorProcessor {
 
     private async processingLoop(ctx: { tracer: Tracer }) {
         while (!this.stopped) {
+            const flagDequeueV2 = await featureFlags.isSet('scheduler:dequeueV2');
             // wait for the queue to have space before dequeuing more tasks
             await this.queue.onSizeLessThan(this.queue.concurrency);
             const available = this.queue.concurrency - this.queue.size;
             const limit = available + this.queue.concurrency; // fetching more than available to keep the queue full
-            const tasks = await this.orchestratorClient.dequeue({ groupKey: this.groupKey, limit, longPolling: true });
+            const tasks = await this.orchestratorClient.dequeue({ groupKey: this.groupKey, limit, longPolling: true, flagDequeueLegacy: !flagDequeueV2 });
             if (tasks.isErr()) {
                 logger.error(`failed to dequeue tasks: ${stringifyError(tasks.error)}`);
                 await new Promise((resolve) => setTimeout(resolve, 1000)); // wait for a bit before retrying to avoid hammering the server in case of repetitive errors

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -16,6 +16,7 @@
     "dependencies": {
         "@nangohq/scheduler": "file:../scheduler",
         "@nangohq/utils": "file:../utils",
+        "@nangohq/kvstore": "file:../kvstore",
         "dd-trace": "5.21.0",
         "express": "4.20.0",
         "get-port": "7.1.0",

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -1,5 +1,6 @@
 import { expect, describe, it, beforeEach, afterEach } from 'vitest';
 import * as tasks from './tasks.js';
+import * as groups from './groups.js';
 import { taskStates } from '../types.js';
 import type { TaskState, Task } from '../types.js';
 import { getTestDbClient } from '../db/helpers.test.js';
@@ -118,6 +119,62 @@ describe('Task', () => {
         const dequeued = (await tasks.dequeue(db, { groupKey: task.groupKey, limit: 1 })).unwrap();
         expect(dequeued).toHaveLength(0);
     });
+    it('should be dequeued according to group max concurrency ', async () => {
+        const groupKey = 'A';
+        const groupMaxConcurrency = 2;
+        const t0 = await createTask(db, { groupKey, groupMaxConcurrency });
+        const t1 = await createTask(db, { groupKey, groupMaxConcurrency });
+
+        let dequeued = (await tasks.dequeue(db, { groupKey, limit: 10 })).unwrap();
+        expect(dequeued).toHaveLength(2);
+        expect(dequeued[0]).toMatchObject({ id: t0.id, state: 'STARTED' });
+        expect(dequeued[1]).toMatchObject({ id: t1.id, state: 'STARTED' });
+
+        // group has reached its max concurrency, so no more tasks should be dequeued
+        const t2 = await createTask(db, { groupKey, groupMaxConcurrency });
+        dequeued = (await tasks.dequeue(db, { groupKey, limit: 10 })).unwrap();
+        expect(dequeued).toHaveLength(0);
+
+        // dequeuing tasks with different group key should not be affected
+        const t3 = await createTask(db, { groupKey: 'B', groupMaxConcurrency });
+        dequeued = (await tasks.dequeue(db, { groupKey: 'B', limit: 10 })).unwrap();
+        expect(dequeued).toHaveLength(1);
+        expect(dequeued[0]).toMatchObject({ id: t3.id, state: 'STARTED' });
+
+        // tasks now completes
+        await succeedTask(db, t0.id);
+        await succeedTask(db, t1.id);
+
+        // group should be able to dequeue again
+        dequeued = (await tasks.dequeue(db, { groupKey, limit: 10 })).unwrap();
+        expect(dequeued).toHaveLength(1);
+        expect(dequeued[0]).toMatchObject({ id: t2.id, state: 'STARTED' });
+    });
+    it('should respect group max concurrency with parallel dequeue calls', async () => {
+        const groupKey = 'A';
+        const groupMaxConcurrency = 2;
+
+        // creating and dequeing tasks in parallel in a tight loop
+        // to increase the chance of race conditions
+        const createdPromises: Promise<Task>[] = [];
+        const createInterval = setInterval(() => {
+            createdPromises.push(createTask(db, { groupKey, groupMaxConcurrency }));
+        }, 1);
+        const dequeuePromises: Promise<Task[]>[] = [];
+        const dequeueInterval = setInterval(() => {
+            dequeuePromises.push(tasks.dequeue(db, { groupKey, limit: 100 }).then((d) => d.unwrap()));
+        }, 1);
+
+        await new Promise((resolve) => void setTimeout(resolve, 2000));
+        clearInterval(createInterval);
+        clearInterval(dequeueInterval);
+
+        const created = await Promise.all(createdPromises);
+        const dequeued = (await Promise.all(dequeuePromises)).flat();
+
+        expect(created.length).toBeGreaterThan(groupMaxConcurrency);
+        expect(dequeued).toHaveLength(groupMaxConcurrency);
+    });
     it('should expires tasks if createdToStartedTimeoutSecs is reached', async () => {
         const timeout = 1;
         await createTask(db, { createdToStartedTimeoutSecs: timeout });
@@ -195,7 +252,13 @@ async function createTaskWithState(db: knex.Knex, state: TaskState): Promise<Tas
     }
 }
 
-async function createTask(db: knex.Knex, props?: Partial<tasks.TaskProps>): Promise<Task> {
+async function createTask(db: knex.Knex, props?: Partial<tasks.TaskProps> & { groupMaxConcurrency?: number | undefined }): Promise<Task> {
+    const now = new Date();
+    await groups.upsert(db, {
+        key: props?.groupKey || nanoid(),
+        maxConcurrency: props?.groupMaxConcurrency || 0,
+        lastTaskAddedAt: now
+    });
     return tasks
         .create(db, {
             name: props?.name || nanoid(),
@@ -203,7 +266,7 @@ async function createTask(db: knex.Knex, props?: Partial<tasks.TaskProps>): Prom
             groupKey: props?.groupKey || nanoid(),
             retryMax: props?.retryMax || 3,
             retryCount: props?.retryCount || 1,
-            startsAfter: props?.startsAfter || new Date(),
+            startsAfter: props?.startsAfter || now,
             createdToStartedTimeoutSecs: props?.createdToStartedTimeoutSecs || 10,
             startedToCompletedTimeoutSecs: props?.startedToCompletedTimeoutSecs || 20,
             heartbeatTimeoutSecs: props?.heartbeatTimeoutSecs || 5,
@@ -214,4 +277,8 @@ async function createTask(db: knex.Knex, props?: Partial<tasks.TaskProps>): Prom
 
 async function startTask(db: knex.Knex, props?: Partial<tasks.TaskProps>): Promise<Task> {
     return createTask(db, props).then(async (t) => (await tasks.transitionState(db, { taskId: t.id, newState: 'STARTED' })).unwrap());
+}
+
+async function succeedTask(db: knex.Knex, taskId: string): Promise<Task> {
+    return tasks.transitionState(db, { taskId, newState: 'SUCCEEDED', output: true }).then((t) => t.unwrap());
 }

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -125,19 +125,19 @@ describe('Task', () => {
         const t0 = await createTask(db, { groupKey, groupMaxConcurrency });
         const t1 = await createTask(db, { groupKey, groupMaxConcurrency });
 
-        let dequeued = (await tasks.dequeue(db, { groupKey, limit: 10 })).unwrap();
+        let dequeued = (await tasks.dequeue(db, { groupKey, limit: 10, flagDequeueLegacy: false })).unwrap();
         expect(dequeued).toHaveLength(2);
         expect(dequeued[0]).toMatchObject({ id: t0.id, state: 'STARTED' });
         expect(dequeued[1]).toMatchObject({ id: t1.id, state: 'STARTED' });
 
         // group has reached its max concurrency, so no more tasks should be dequeued
         const t2 = await createTask(db, { groupKey, groupMaxConcurrency });
-        dequeued = (await tasks.dequeue(db, { groupKey, limit: 10 })).unwrap();
+        dequeued = (await tasks.dequeue(db, { groupKey, limit: 10, flagDequeueLegacy: false })).unwrap();
         expect(dequeued).toHaveLength(0);
 
         // dequeuing tasks with different group key should not be affected
         const t3 = await createTask(db, { groupKey: 'B', groupMaxConcurrency });
-        dequeued = (await tasks.dequeue(db, { groupKey: 'B', limit: 10 })).unwrap();
+        dequeued = (await tasks.dequeue(db, { groupKey: 'B', limit: 10, flagDequeueLegacy: false })).unwrap();
         expect(dequeued).toHaveLength(1);
         expect(dequeued[0]).toMatchObject({ id: t3.id, state: 'STARTED' });
 
@@ -146,7 +146,7 @@ describe('Task', () => {
         await succeedTask(db, t1.id);
 
         // group should be able to dequeue again
-        dequeued = (await tasks.dequeue(db, { groupKey, limit: 10 })).unwrap();
+        dequeued = (await tasks.dequeue(db, { groupKey, limit: 10, flagDequeueLegacy: false })).unwrap();
         expect(dequeued).toHaveLength(1);
         expect(dequeued[0]).toMatchObject({ id: t2.id, state: 'STARTED' });
     });
@@ -162,7 +162,7 @@ describe('Task', () => {
         }, 1);
         const dequeuePromises: Promise<Task[]>[] = [];
         const dequeueInterval = setInterval(() => {
-            dequeuePromises.push(tasks.dequeue(db, { groupKey, limit: 100 }).then((d) => d.unwrap()));
+            dequeuePromises.push(tasks.dequeue(db, { groupKey, limit: 100, flagDequeueLegacy: false }).then((d) => d.unwrap()));
         }, 1);
 
         await new Promise((resolve) => void setTimeout(resolve, 2000));

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -6,6 +6,7 @@ import { taskStates } from '../types.js';
 import type { TaskState, Task, TaskTerminalState, TaskNonTerminalState } from '../types.js';
 import { uuidv7 } from 'uuidv7';
 import { SCHEDULES_TABLE } from './schedules.js';
+import { GROUPS_TABLE } from './groups.js';
 
 export const TASKS_TABLE = 'tasks';
 
@@ -233,31 +234,79 @@ export async function dequeue(db: knex.Knex, { groupKey, limit }: { groupKey: st
     try {
         const groupKeyPattern = groupKey.replace(/\*/g, '%');
         const tasks = await db
-            .update({
-                state: 'STARTED',
-                last_state_transition_at: new Date()
-            })
-            .from<DbTask>(TASKS_TABLE)
-            .whereIn(
-                'id',
-                db
-                    .select('id')
-                    .from<DbTask>(TASKS_TABLE)
-                    .where('state', 'CREATED')
+            // 1. select created tasks that are ready to be started alongside their group
+            // Note: tasks and groups are locked for update, preventing concurrent queries
+            // to dequeue the same tasks and/or groups
+            .with('candidates', (qb) => {
+                qb.select('t.id', 't.group_key', 't.created_at', 'g.max_concurrency')
+                    .from(`${TASKS_TABLE} as t`)
+                    .join(`${GROUPS_TABLE} as g`, 'g.key', 't.group_key')
+                    .where('t.state', 'CREATED')
                     .whereLike('group_key', groupKeyPattern)
-                    .where('starts_after', '<=', db.fn.now())
-                    .orderBy('id')
-                    .limit(limit)
+                    .where('t.starts_after', '<=', db.fn.now())
                     .forUpdate()
-                    .skipLocked()
+                    .skipLocked();
+            })
+            // 2. count the number of running tasks for each group
+            .with('running', (qb) => {
+                qb.select(db.raw('count(id) as running_count'), 'group_key')
+                    .from(TASKS_TABLE)
+                    .where('state', 'STARTED')
+                    .whereIn('group_key', function () {
+                        this.distinct('group_key').from('candidates');
+                    })
+                    .groupBy('group_key');
+            })
+            // 3. rank the candidate tasks by created_at for each group
+            .with('with_rank', (qb) => {
+                qb.select(
+                    'c.*',
+                    db.raw('ROW_NUMBER() OVER (PARTITION BY c.group_key ORDER BY c.created_at ASC) as rank'),
+                    db.raw('COALESCE(r.running_count, 0) as current_running')
+                )
+                    .from('candidates as c')
+                    .leftJoin('running as r', 'c.group_key', 'r.group_key');
+            })
+            // 4. select the tasks that can be started based on the max_concurrency
+            .with('to_start', (qb) => {
+                qb.select('id', 'group_key', 'created_at')
+                    .from('with_rank')
+                    .whereRaw('max_concurrency = 0 OR (rank + current_running <= max_concurrency)')
+
+                    .orderBy('created_at', 'asc')
+                    .limit(limit);
+            })
+            // 5. starts the tasks
+            .with(
+                'updated_tasks',
+                db
+                    .update({
+                        state: 'STARTED',
+                        last_state_transition_at: new Date()
+                    })
+                    .from(TASKS_TABLE)
+                    .whereIn('id', db.select('id').from('to_start'))
+                    .returning('*')
             )
-            .returning('*');
+            // 6. update the group last_task_added_at
+            .with(
+                'updated_groups',
+                db
+                    .update({
+                        last_task_added_at: new Date()
+                    })
+                    .from(GROUPS_TABLE)
+                    .whereIn('key', db.select('group_key').from('updated_tasks'))
+            )
+            // 7. return the updated tasks
+            .select('*')
+            .from<DbTask>('updated_tasks')
+            .orderBy('id');
+
         if (!tasks?.[0]) {
             return Ok([]);
         }
-        // Sort tasks by id (uuidv7) to ensure ordering by creation date
-        const sorted = tasks.sort((a, b) => a.id.localeCompare(b.id)).map(DbTask.from);
-        return Ok(sorted);
+        return Ok(tasks.map(DbTask.from));
     } catch (err) {
         return Err(new Error(`Error dequeuing tasks for group key '${groupKey}': ${stringifyError(err)}`));
     }

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -8,7 +8,6 @@ import { uuidv7 } from 'uuidv7';
 import { SCHEDULES_TABLE } from './schedules.js';
 
 export const TASKS_TABLE = 'tasks';
-export const GROUPS_TABLE = 'groups';
 
 export type TaskProps = Omit<Task, 'id' | 'createdAt' | 'state' | 'lastStateTransitionAt' | 'lastHeartbeatAt' | 'output' | 'terminated'>;
 

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -8,6 +8,7 @@ import { uuidv7 } from 'uuidv7';
 import { SCHEDULES_TABLE } from './schedules.js';
 
 export const TASKS_TABLE = 'tasks';
+export const GROUPS_TABLE = 'groups';
 
 export type TaskProps = Omit<Task, 'id' | 'createdAt' | 'state' | 'lastStateTransitionAt' | 'lastHeartbeatAt' | 'output' | 'terminated'>;
 

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -249,8 +249,16 @@ export class Scheduler {
      * @example
      * const dequeued = await scheduler.dequeue({ groupKey: 'test', limit: 1 });
      */
-    public async dequeue({ groupKey, limit }: { groupKey: string; limit: number }): Promise<Result<Task[]>> {
-        const dequeued = await tasks.dequeue(this.dbClient.db, { groupKey, limit });
+    public async dequeue({
+        groupKey,
+        limit,
+        flagDequeueLegacy = true
+    }: {
+        groupKey: string;
+        limit: number;
+        flagDequeueLegacy?: boolean;
+    }): Promise<Result<Task[]>> {
+        const dequeued = await tasks.dequeue(this.dbClient.db, { groupKey, limit, flagDequeueLegacy });
         if (dequeued.isOk()) {
             dequeued.value.forEach((task) => this.onCallbacks[task.state](this, task));
         }


### PR DESCRIPTION
Updating the `tasks.dequeue` query to ensure only `max_concurrency` tasks are running at the same time.

The query is more complicated obviously as shown by the query plans:

before:
```
Limit  (cost=9562.85..9567.85 rows=400 width=22)
  ->  LockRows  (cost=9562.85..9637.01 rows=5933 width=22)
        ->  Sort  (cost=9562.85..9577.68 rows=5933 width=22)
              Sort Key: id
              ->  Index Scan using idx_tasks_group_key_created on tasks  (cost=0.38..9276.77 rows=5933 width=22)
                    Filter: (((group_key)::text ~~ 'sync%'::text) AND (state = 'CREATED'::nango_scheduler.task_states) AND (starts_after <= CURRENT_TIMESTAMP))
```

after
```
Sort  (cost=21646.93..21647.93 rows=400 width=540)
  Sort Key: with_rank.id
  CTE candidates
    ->  LockRows  (cost=13.53..9365.29 rows=5933 width=45)
          ->  Hash Join  (cost=13.53..9305.96 rows=5933 width=45)
                Hash Cond: ((t.group_key)::text = (g.key)::text)
                ->  Index Scan using idx_tasks_group_key_created on tasks t  (cost=0.38..9276.77 rows=5933 width=35)
                      Filter: (((group_key)::text ~~ 'sync%'::text) AND (state = 'CREATED'::nango_scheduler.task_states) AND (starts_after <= CURRENT_TIMESTAMP))
                ->  Hash  (cost=11.40..11.40 rows=140 width=526)
                      ->  Seq Scan on groups g  (cost=0.00..11.40 rows=140 width=526)
  ->  Limit  (cost=12263.35..12264.35 rows=400 width=540)
        ->  Sort  (cost=12263.35..12268.35 rows=1997 width=540)
              Sort Key: with_rank.created_at
              ->  Subquery Scan on with_rank  (cost=11944.57..12167.06 rows=1997 width=540)
                    Filter: ((with_rank.max_concurrency = 0) OR ((with_rank.rank + with_rank.current_running) <= with_rank.max_concurrency))
                    ->  WindowAgg  (cost=11944.57..12063.23 rows=5933 width=560)
                          ->  Sort  (cost=11944.57..11959.41 rows=5933 width=552)
                                Sort Key: c.group_key, c.created_at
                                ->  Hash Left Join  (cost=11438.17..11572.74 rows=5933 width=552)
                                      Hash Cond: ((c.group_key)::text = (tasks.group_key)::text)
                                      ->  CTE Scan on candidates c  (cost=0.00..118.66 rows=5933 width=544)
                                      ->  Hash  (cost=11438.13..11438.13 rows=3 width=13)
                                            ->  HashAggregate  (cost=11438.10..11438.13 rows=3 width=13)
                                                  Group Key: tasks.group_key
                                                  ->  Hash Join  (cost=138.56..11405.09 rows=6602 width=21)
                                                        Hash Cond: ((tasks.group_key)::text = (candidates.group_key)::text)
                                                        ->  Index Scan using idx_tasks_state on tasks  (cost=0.56..11249.40 rows=6602 width=21)
                                                              Index Cond: (state = 'STARTED'::nango_scheduler.task_states)
                                                        ->  Hash  (cost=135.49..135.49 rows=200 width=516)
                                                              ->  HashAggregate  (cost=133.49..135.49 rows=200 width=516)
                                                                    Group Key: candidates.group_key
                                                                    ->  CTE Scan on candidates  (cost=0.00..118.66 rows=5933 width=516)
```

There is some room for improvements to tweak the indexes. I'll do it later if necessary

<!-- Summary by @propel-code-bot -->

---

This PR enhances the scheduler's dequeue mechanism to respect group-level max concurrency limits. The implementation uses Common Table Expressions (CTEs) to ensure that only a configured maximum number of tasks run concurrently within a group. The new query is more complex but prevents resource overutilization while maintaining proper task ordering. Implementation is behind a feature flag ('scheduler:dequeueV2') for safe rollout.

**Key Changes:**
• Redesigned the dequeue query to enforce max concurrency limits per task group
• Added integration tests verifying concurrency enforcement including parallel scenarios
• Implemented feature flag for controlled rollout
• Created required parameter plumbing throughout the system

**Affected Areas:**
• Task scheduler dequeue functionality
• Group concurrency management
• Task processing pipeline

*This summary was automatically generated by @propel-code-bot*