### PR TITLE
docs: document credentials validation errors

### DIFF
--- a/docs-v2/reference/sdks/frontend.mdx
+++ b/docs-v2/reference/sdks/frontend.mdx
@@ -220,6 +220,38 @@ const result = nango.auth('<INTEGRATION-ID>', {
   </ResponseField>
 </Expandable>
 
+# Credentials Verification
+
+For some integrations using API Key or Basic authentication methods, Nango automatically verifies the provided credentials by making a test request to the integration's API. This verification ensures that the credentials are valid before creating the connection.
+
+If the credentials are invalid, Nango will throw an error with the following structure:
+
+```json
+{
+    "error": {
+        "code": "connection_test_failed",
+        "message": "The given credentials were found to be invalid. Please check the credentials and try again."
+    }
+}
+```
+
+You can handle this error in your code to provide appropriate feedback to your end users:
+
+```js
+import { AuthError } from '@nangohq/frontend';
+
+try {
+    const result = await nango.auth('<INTEGRATION-ID>', {
+        credentials: { apiKey: '<END-USER-API-KEY>' }
+    });
+} catch (error) {
+    if (error instanceof AuthError && error.type === 'connection_test_failed') {
+        // Handle invalid credentials
+        console.error('Invalid credentials provided');
+    }
+}
+```
+
 <Tip>
 **Questions, problems, feedback?** Please reach out in the [Slack community](https://nango.dev/slack).
 </Tip>


### PR DESCRIPTION
## Describe the problem and your solution

- Document credentials validation errors 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR adds documentation to the frontend SDK reference explaining how Nango handles credential verification for API Key and Basic authentication methods. It includes JSON error structure examples and code snippets demonstrating how to handle invalid credential errors in client applications.

*This summary was automatically generated by @propel-code-bot*