### PR TITLE
fix(api): accept empty scopes

### DIFF
--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
@@ -25,10 +25,7 @@ const validationBody = z
                         authType: z.enum(['OAUTH1', 'OAUTH2', 'TBA']),
                         clientId: z.string().min(1).max(255),
                         clientSecret: z.string().min(1),
-                        scopes: z
-                            .string()
-                            .regex(/^[0-9a-zA-Z:/_.-]+(,[0-9a-zA-Z:/_.-]+)*$/)
-                            .optional()
+                        scopes: z.union([z.string().regex(/^[0-9a-zA-Z:/_.-]+(,[0-9a-zA-Z:/_.-]+)*$/), z.string().max(0)])
                     })
                     .strict(),
                 z

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -66,10 +66,7 @@ export const integrationCredentialsSchema = z.discriminatedUnion(
                 type: z.enum(['OAUTH1', 'OAUTH2', 'TBA']),
                 client_id: z.string().min(1).max(255),
                 client_secret: z.string().min(1),
-                scopes: z
-                    .string()
-                    .regex(/^[0-9a-zA-Z:/*_. -]+(,[0-9a-zA-Z:/*_. -]+)*,?$/)
-                    .optional()
+                scopes: z.union([z.string().regex(/^[0-9a-zA-Z:/_.-]+(,[0-9a-zA-Z:/_.-]+)*$/), z.string().max(0)]).optional()
             })
             .strict(),
         z


### PR DESCRIPTION
## Changes

- Allow passing empty scopes for retro-compatibility 


<!-- Summary by @propel-code-bot -->

---

This PR modifies validation schemas to accept empty strings for authentication scopes, maintaining backward compatibility. The change affects two validation schemas by replacing multi-line regex validation with a simpler union type approach.

*This summary was automatically generated by @propel-code-bot*