### PR TITLE
fix(scheduler): allow skipping group update if locked

### DIFF
--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -184,11 +184,15 @@ export class Scheduler {
                 };
 
                 if (props.groupUpdateFlag) {
-                    const group = await groups.upsert(trx, {
-                        key: props.groupKey,
-                        maxConcurrency: props.groupKeyMaxConcurrency,
-                        lastTaskAddedAt: now
-                    });
+                    const group = await groups.upsert(
+                        trx,
+                        {
+                            key: props.groupKey,
+                            maxConcurrency: props.groupKeyMaxConcurrency,
+                            lastTaskAddedAt: now
+                        },
+                        { skipLocked: true }
+                    );
                     if (group.isErr()) {
                         return Err(group.error);
                     }


### PR DESCRIPTION
Adding an option to groups.upsert to allow skipping the update if the group is being modified by another transaction. When triggering action, the upsert is mostly used to set the last_task_added_at. Because it is happenning a lot in production this query is waiting on other transaction. This commit allow to skip the update since the last_task_added_at doesn't have to be 100% accurate. It is currently only used to cleanup unused groups

<!-- Summary by @propel-code-bot -->

---

This PR adds a skipLocked option to the groups.upsert function to prevent transactions from waiting when another transaction is modifying the same group. The immediate scheduler now uses this option when updating last_task_added_at timestamps, avoiding unnecessary blocks since this value only needs to be approximate for group cleanup purposes.

*This summary was automatically generated by @propel-code-bot*