### PR TITLE
fix: add scheduler indexes for expired tasks query

### DIFF
--- a/packages/scheduler/lib/db/migrations/20250508210600_monitor_tasks_indexes.ts
+++ b/packages/scheduler/lib/db/migrations/20250508210600_monitor_tasks_indexes.ts
@@ -1,0 +1,21 @@
+import type { Knex } from 'knex';
+import { TASKS_TABLE } from '../../models/tasks.js';
+
+export const config = {
+    transaction: false
+};
+
+export async function up(knex: Knex): Promise<void> {
+    // Specific indexes to improve performance of the query monitoring for expired tasks
+    await knex.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_tasks_created_starts_after" ON ${TASKS_TABLE} USING BTREE (starts_after) WHERE state = 'CREATED';`
+    );
+    await knex.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_tasks_started_last_heartbeat" ON ${TASKS_TABLE} USING BTREE (last_heartbeat_at) WHERE state = 'STARTED';`
+    );
+    await knex.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_tasks_started_last_state_transition" ON ${TASKS_TABLE} USING BTREE (last_state_transition_at) WHERE state = 'STARTED';`
+    );
+}
+
+export async function down(): Promise<void> {}


### PR DESCRIPTION
The query expiring tasks is by far the most expensive. 
This commits adds specific indexes to help the filtering of the expired tasks

The query in question is here: https://github.com/NangoHQ/nango/blob/ae92cd34357709cf8379de13150c7f501daba30a/packages/scheduler/lib/models/tasks.ts#L353-L383

As you can see the in the query plan the indexes used for the filtering are not optimal:
```
...
                Filter: ...
                ->  BitmapOr  (cost=42.86..42.86 rows=4511 width=0)
                      ->  Bitmap Index Scan on idx_tasks_group_key_created  (cost=0.00..4.38 rows=2255 width=0)
                      ->  Bitmap Index Scan on idx_tasks_state  (cost=0.00..37.48 rows=2255 width=0)
                            Index Cond: (state = 'STARTED'::nango_scheduler.task_states)
...
```

I have already created the indexes in prod. Here are the AWS DBLoadCPU metric graph
<img width="1367" alt="Screenshot 2025-05-08 at 16 24 24" src="https://github.com/user-attachments/assets/99afa8ee-4bbb-4f79-a4f8-829ae316c770" />

and the Load By Wait before:
<img width="1289" alt="Screenshot 2025-05-08 at 16 26 07" src="https://github.com/user-attachments/assets/1b1d7758-09e9-4eab-9fab-4ebed4f24ce6" />

and after
<img width="1284" alt="Screenshot 2025-05-08 at 16 25 54" src="https://github.com/user-attachments/assets/cdbb1a79-712c-4481-b01a-c86bd9f0c28d" />
<!-- Summary by @propel-code-bot -->

---

This PR adds three specific database indexes to optimize the expensive query that identifies expired tasks in the scheduler. The indexes are created concurrently and target specific columns with state-based conditions to improve query performance.

*This summary was automatically generated by @propel-code-bot*