### PR TITLE
chore: Removing scheduler flags

### DIFF
--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -339,20 +339,17 @@ export class OrchestratorClient {
     public async dequeue({
         groupKey,
         limit,
-        longPolling,
-        flagDequeueLegacy = true
+        longPolling
     }: {
         groupKey: string;
         limit: number;
         longPolling: boolean;
-        flagDequeueLegacy?: boolean;
     }): Promise<Result<OrchestratorTask[], ClientError>> {
         const res = await this.routeFetch(postDequeueRoute)({
             body: {
                 groupKey,
                 limit,
-                longPolling,
-                flagDequeueLegacy
+                longPolling
             }
         });
         if ('error' in res) {

--- a/packages/orchestrator/lib/clients/processor.ts
+++ b/packages/orchestrator/lib/clients/processor.ts
@@ -1,5 +1,4 @@
 import type { Result } from '@nangohq/utils';
-import { getFeatureFlagsClient } from '@nangohq/kvstore';
 import { stringifyError, getLogger } from '@nangohq/utils';
 import type { OrchestratorClient } from './client.js';
 import type { OrchestratorTask } from './types.js';
@@ -7,7 +6,6 @@ import PQueue from 'p-queue';
 import type { Tracer } from 'dd-trace';
 
 const logger = getLogger('orchestrator.clients.processor');
-const featureFlags = await getFeatureFlagsClient();
 
 export class OrchestratorProcessor {
     private handler: (task: OrchestratorTask) => Promise<Result<void>>;
@@ -49,12 +47,11 @@ export class OrchestratorProcessor {
 
     private async processingLoop(ctx: { tracer: Tracer }) {
         while (!this.stopped) {
-            const flagDequeueV2 = await featureFlags.isSet('scheduler:dequeueV2');
             // wait for the queue to have space before dequeuing more tasks
             await this.queue.onSizeLessThan(this.queue.concurrency);
             const available = this.queue.concurrency - this.queue.size;
             const limit = available + this.queue.concurrency; // fetching more than available to keep the queue full
-            const tasks = await this.orchestratorClient.dequeue({ groupKey: this.groupKey, limit, longPolling: true, flagDequeueLegacy: !flagDequeueV2 });
+            const tasks = await this.orchestratorClient.dequeue({ groupKey: this.groupKey, limit, longPolling: true });
             if (tasks.isErr()) {
                 logger.error(`failed to dequeue tasks: ${stringifyError(tasks.error)}`);
                 await new Promise((resolve) => setTimeout(resolve, 1000)); // wait for a bit before retrying to avoid hammering the server in case of repetitive errors

--- a/packages/orchestrator/lib/routes/v1/postDequeue.ts
+++ b/packages/orchestrator/lib/routes/v1/postDequeue.ts
@@ -15,7 +15,6 @@ type PostDequeue = Endpoint<{
         groupKey: string;
         limit: number;
         longPolling: boolean;
-        flagDequeueLegacy?: boolean;
     };
     Error: ApiError<'dequeue_failed'>;
     Success: Task[];
@@ -27,8 +26,7 @@ const validate = validateRequest<PostDequeue>({
             .object({
                 groupKey: z.string().min(1),
                 limit: z.coerce.number().positive(),
-                longPolling: z.coerce.boolean(),
-                flagDequeueLegacy: z.coerce.boolean().default(true)
+                longPolling: z.coerce.boolean()
             })
             .strict()
             .parse(data)
@@ -46,7 +44,7 @@ export const routeHandler = (scheduler: Scheduler, eventEmitter: EventEmitter): 
 
 const handler = (scheduler: Scheduler, eventEmitter: EventEmitter) => {
     return async (req: EndpointRequest<PostDequeue>, res: EndpointResponse<PostDequeue>) => {
-        const { groupKey, limit, longPolling, flagDequeueLegacy } = req.body;
+        const { groupKey, limit, longPolling } = req.body;
         const longPollingTimeoutMs = 10_000;
         const eventId = `task:created:${groupKey}`;
         const groupKeyPrefix = `${groupKey}*`; // Dequeuing all tasks with the same group key prefix
@@ -63,7 +61,7 @@ const handler = (scheduler: Scheduler, eventEmitter: EventEmitter) => {
         };
         const onTaskStarted = (_t: Task) => {
             cleanupAndRespond(async (res) => {
-                const getTasks = await scheduler.dequeue({ groupKey: groupKeyPrefix, limit, flagDequeueLegacy: flagDequeueLegacy ?? true });
+                const getTasks = await scheduler.dequeue({ groupKey: groupKeyPrefix, limit });
                 if (getTasks.isErr()) {
                     res.status(500).json({ error: { code: 'dequeue_failed', message: getTasks.error.message } });
                 } else {
@@ -75,7 +73,7 @@ const handler = (scheduler: Scheduler, eventEmitter: EventEmitter) => {
             cleanupAndRespond((res) => res.status(200).send([]));
         }, longPollingTimeoutMs);
 
-        const getTasks = await scheduler.dequeue({ groupKey: groupKeyPrefix, limit, flagDequeueLegacy: flagDequeueLegacy ?? true });
+        const getTasks = await scheduler.dequeue({ groupKey: groupKeyPrefix, limit });
         if (getTasks.isErr()) {
             cleanupAndRespond((res) => res.status(500).json({ error: { code: 'dequeue_failed', message: getTasks.error.message } }));
             return;

--- a/packages/orchestrator/lib/routes/v1/postImmediate.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediate.ts
@@ -18,7 +18,6 @@ export type PostImmediate = Endpoint<{
         group: {
             key: string;
             maxConcurrency: number;
-            updateFlag?: boolean;
         };
         retry: {
             count: number;
@@ -64,8 +63,7 @@ const validate = validateRequest<PostImmediate>({
                 name: z.string().min(1),
                 group: z.object({
                     key: z.string().min(1),
-                    maxConcurrency: z.coerce.number(),
-                    updateFlag: z.boolean().default(false)
+                    maxConcurrency: z.coerce.number()
                 }),
                 retry: z.object({
                     count: z.number().int(),
@@ -99,7 +97,6 @@ const handler = (scheduler: Scheduler) => {
             payload: req.body.args,
             groupKey: req.body.group.key,
             groupKeyMaxConcurrency: req.body.group.maxConcurrency,
-            groupUpdateFlag: req.body.group.updateFlag,
             retryMax: req.body.retry.max,
             retryCount: req.body.retry.count,
             createdToStartedTimeoutSecs: req.body.timeoutSettingsInSecs.createdToStarted,

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -125,19 +125,19 @@ describe('Task', () => {
         const t0 = await createTask(db, { groupKey, groupMaxConcurrency });
         const t1 = await createTask(db, { groupKey, groupMaxConcurrency });
 
-        let dequeued = (await tasks.dequeue(db, { groupKey, limit: 10, flagDequeueLegacy: false })).unwrap();
+        let dequeued = (await tasks.dequeue(db, { groupKey, limit: 10 })).unwrap();
         expect(dequeued).toHaveLength(2);
         expect(dequeued[0]).toMatchObject({ id: t0.id, state: 'STARTED' });
         expect(dequeued[1]).toMatchObject({ id: t1.id, state: 'STARTED' });
 
         // group has reached its max concurrency, so no more tasks should be dequeued
         const t2 = await createTask(db, { groupKey, groupMaxConcurrency });
-        dequeued = (await tasks.dequeue(db, { groupKey, limit: 10, flagDequeueLegacy: false })).unwrap();
+        dequeued = (await tasks.dequeue(db, { groupKey, limit: 10 })).unwrap();
         expect(dequeued).toHaveLength(0);
 
         // dequeuing tasks with different group key should not be affected
         const t3 = await createTask(db, { groupKey: 'B', groupMaxConcurrency });
-        dequeued = (await tasks.dequeue(db, { groupKey: 'B', limit: 10, flagDequeueLegacy: false })).unwrap();
+        dequeued = (await tasks.dequeue(db, { groupKey: 'B', limit: 10 })).unwrap();
         expect(dequeued).toHaveLength(1);
         expect(dequeued[0]).toMatchObject({ id: t3.id, state: 'STARTED' });
 
@@ -146,7 +146,7 @@ describe('Task', () => {
         await succeedTask(db, t1.id);
 
         // group should be able to dequeue again
-        dequeued = (await tasks.dequeue(db, { groupKey, limit: 10, flagDequeueLegacy: false })).unwrap();
+        dequeued = (await tasks.dequeue(db, { groupKey, limit: 10 })).unwrap();
         expect(dequeued).toHaveLength(1);
         expect(dequeued[0]).toMatchObject({ id: t2.id, state: 'STARTED' });
     });
@@ -162,7 +162,7 @@ describe('Task', () => {
         }, 1);
         const dequeuePromises: Promise<Task[]>[] = [];
         const dequeueInterval = setInterval(() => {
-            dequeuePromises.push(tasks.dequeue(db, { groupKey, limit: 100, flagDequeueLegacy: false }).then((d) => d.unwrap()));
+            dequeuePromises.push(tasks.dequeue(db, { groupKey, limit: 100 }).then((d) => d.unwrap()));
         }, 1);
 
         await new Promise((resolve) => void setTimeout(resolve, 2000));

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -230,42 +230,9 @@ export async function transitionState(
     return Ok(DbTask.from(updated[0]));
 }
 
-export async function dequeue(
-    db: knex.Knex,
-    { groupKey, limit, flagDequeueLegacy = true }: { groupKey: string; limit: number; flagDequeueLegacy?: boolean }
-): Promise<Result<Task[]>> {
+export async function dequeue(db: knex.Knex, { groupKey, limit }: { groupKey: string; limit: number }): Promise<Result<Task[]>> {
     try {
         const groupKeyPattern = groupKey.replace(/\*/g, '%');
-
-        if (flagDequeueLegacy) {
-            const tasks = await db
-                .update({
-                    state: 'STARTED',
-                    last_state_transition_at: new Date()
-                })
-                .from<DbTask>(TASKS_TABLE)
-                .whereIn(
-                    'id',
-                    db
-                        .select('id')
-                        .from<DbTask>(TASKS_TABLE)
-                        .where('state', 'CREATED')
-                        .whereLike('group_key', groupKeyPattern)
-                        .where('starts_after', '<=', db.fn.now())
-                        .orderBy('id')
-                        .limit(limit)
-                        .forUpdate()
-                        .skipLocked()
-                )
-                .returning('*');
-            if (!tasks?.[0]) {
-                return Ok([]);
-            }
-
-            // Sort tasks by id (uuidv7) to ensure ordering by creation date
-            const sorted = tasks.sort((a, b) => a.id.localeCompare(b.id)).map(DbTask.from);
-            return Ok(sorted);
-        }
 
         const tasks = await db
             // 1. select created tasks that are ready to be started alongside their group

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -253,16 +253,8 @@ export class Scheduler {
      * @example
      * const dequeued = await scheduler.dequeue({ groupKey: 'test', limit: 1 });
      */
-    public async dequeue({
-        groupKey,
-        limit,
-        flagDequeueLegacy = true
-    }: {
-        groupKey: string;
-        limit: number;
-        flagDequeueLegacy?: boolean;
-    }): Promise<Result<Task[]>> {
-        const dequeued = await tasks.dequeue(this.dbClient.db, { groupKey, limit, flagDequeueLegacy });
+    public async dequeue({ groupKey, limit }: { groupKey: string; limit: number }): Promise<Result<Task[]>> {
+        const dequeued = await tasks.dequeue(this.dbClient.db, { groupKey, limit });
         if (dequeued.isOk()) {
             dequeued.value.forEach((task) => this.onCallbacks[task.state](this, task));
         }

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -183,19 +183,17 @@ export class Scheduler {
                     scheduleId: null
                 };
 
-                if (props.groupUpdateFlag) {
-                    const group = await groups.upsert(
-                        trx,
-                        {
-                            key: props.groupKey,
-                            maxConcurrency: props.groupKeyMaxConcurrency,
-                            lastTaskAddedAt: now
-                        },
-                        { skipLocked: true }
-                    );
-                    if (group.isErr()) {
-                        return Err(group.error);
-                    }
+                const group = await groups.upsert(
+                    trx,
+                    {
+                        key: props.groupKey,
+                        maxConcurrency: props.groupKeyMaxConcurrency,
+                        lastTaskAddedAt: now
+                    },
+                    { skipLocked: true }
+                );
+                if (group.isErr()) {
+                    return Err(group.error);
                 }
             }
 

--- a/packages/scheduler/lib/types.ts
+++ b/packages/scheduler/lib/types.ts
@@ -28,7 +28,6 @@ export interface Task {
 
 interface WithGroupKeyMaxConcurrency {
     groupKeyMaxConcurrency?: number | undefined;
-    groupUpdateFlag?: boolean | undefined;
 }
 export type ImmediateProps = Omit<TaskProps, 'startsAfter' | 'scheduleId'> & WithGroupKeyMaxConcurrency;
 export type ScheduleProps = Omit<Schedule, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'> & WithGroupKeyMaxConcurrency;

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -23,7 +23,7 @@ import {
 } from '@nangohq/shared';
 import { Err, Ok, getHeaders, isHosted, redactHeaders, truncateJson } from '@nangohq/utils';
 
-import { featureFlags, getOrchestrator } from '../utils/utils.js';
+import { getOrchestrator } from '../utils/utils.js';
 import { getPublicRecords } from './records/getRecords.js';
 
 import type { RequestLocals } from '../utils/express.js';
@@ -218,14 +218,12 @@ class SyncController {
             );
             logCtx.attachSpan(new OtlpSpan(logCtx.operation));
 
-            const groupUpdateFlag = await featureFlags.isSet('scheduler:groupUpdate');
             const actionResponse = await getOrchestrator().triggerAction({
                 accountId: account.id,
                 connection,
                 actionName: action_name,
                 input,
-                logCtx,
-                groupUpdateFlag
+                logCtx
             });
 
             if (actionResponse.isOk()) {

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -106,15 +106,13 @@ export class Orchestrator {
         connection,
         actionName,
         input,
-        logCtx,
-        groupUpdateFlag = false
+        logCtx
     }: {
         accountId: number;
         connection: DBConnection | DBConnectionDecrypted;
         actionName: string;
         input: object;
         logCtx: LogContext;
-        groupUpdateFlag?: boolean;
     }): Promise<Result<T, NangoError>> {
         const activeSpan = tracer.scope().active();
         const spanTags = {
@@ -155,7 +153,7 @@ export class Orchestrator {
             };
             const actionResult = await this.client.executeAction({
                 name: executionId,
-                group: { key: groupKey, maxConcurrency: 0, updateFlag: groupUpdateFlag },
+                group: { key: groupKey, maxConcurrency: 0 },
                 args
             });
 


### PR DESCRIPTION
I used the flags to release the scheduler groups update change and the new dequeue query.
Metrics for those queries looks ok: https://291213480759-my474j3e.us-west-2.console.aws.amazon.com/rds/home?region=us-west-2#performance-insights-v20206:/resourceId/db-VIAT2BFLGYLIR5E6SWBER5OX3Y/resourceName/orchestrator-instance-1/presetUnit/seconds/presetAmount/3600/timeZone/UTC

<!-- Summary by @propel-code-bot -->

---

This PR removes two feature flags (`flagDequeueLegacy` and `groupUpdateFlag`) that were used to control the rollout of scheduler group updates and dequeue query improvements. With metrics confirming proper functioning of these features, the flags are no longer needed and the code is being simplified by making the new implementations the default.

**Key Changes:**
• Removed `flagDequeueLegacy` parameter from the dequeue method
• Removed `groupUpdateFlag` from the scheduler's immediate method
• Updated all client and service references to match the new parameter signatures

**Affected Areas:**
• Scheduler library
• Orchestrator client
• Task models
• API routes (postDequeue, postImmediate)

*This summary was automatically generated by @propel-code-bot*