### PR TITLE
fix(refresh-token): add offline_access scope

### DIFF
--- a/docs-v2/integrations/all/microsoft-ads.mdx
+++ b/docs-v2/integrations/all/microsoft-ads.mdx
@@ -42,6 +42,7 @@ _No setup guide yet._
     To engage with the Microsoft Advertising API, developers must initially retrieve the access token utilizing the [backend API](https://docs.nango.dev/reference/api/connection/get). This token should then be utilized with [official client libraries](https://learn.microsoft.com/en-us/advertising/guides/client-libraries?view=bingads-13) or a [SOAP Client](https://learn.microsoft.com/en-us/advertising/guides/authentication-oauth-quick-start?view=bingads-13) for further interaction.
 -   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
     - Override `authorization_params` by setting only `scope: '.default'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
+    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
     - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
 
 ```typescript
@@ -59,7 +60,7 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "microsoft-ads": {
       authorization_params: {
-        scope: '.default',
+        scope: '.default offline_access',
         "prompt": ""
       }
     }

--- a/docs-v2/integrations/all/microsoft-business-central.mdx
+++ b/docs-v2/integrations/all/microsoft-business-central.mdx
@@ -42,6 +42,7 @@ _No setup guide yet._
 
 -   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
     - Override `authorization_params` by setting only `scope: '.default'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
+    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
     - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
 
 ```typescript
@@ -50,7 +51,7 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "microsoft-business-central": {
       authorization_params: {
-        scope: '.default',
+        scope: '.default offline_access',
         "prompt": ""
       }
     }

--- a/docs-v2/integrations/all/microsoft-entra-id.mdx
+++ b/docs-v2/integrations/all/microsoft-entra-id.mdx
@@ -44,6 +44,7 @@ _No setup guide yet._
 -   You can find permissions required for each API call in their corresponding API methods section.
 -   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
     - Override `authorization_params` by setting only `scope: '.default'` and `"prompt": ""` to remove the consent screen.
+    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen.
     - See the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#the-default-scope) to ensure the permissions remain the same as those granted at the organization level.
 
 ```typescript
@@ -52,7 +53,7 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "microsoft-entra-id": {
       authorization_params: {
-        scope: '.default',
+        scope: '.default offline_access',
         "prompt": ""
       }
     }

--- a/docs-v2/integrations/all/microsoft-oauth2-cc.mdx
+++ b/docs-v2/integrations/all/microsoft-oauth2-cc.mdx
@@ -46,6 +46,7 @@ _No setup guide yet._
 -   Please be aware that the Microsoft Graph API implements throttling to manage the volume of requests. For more information on handling throttling, refer to the [Microsoft Graph Throttling Guidance](https://learn.microsoft.com/en-us/graph/throttling).
 -   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
     - Override `authorization_params` by setting only `scope: '.default'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
+    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
     - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
 
 ```typescript
@@ -54,7 +55,7 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "microsoft-oauth2-cc": {
       authorization_params: {
-        scope: '.default',
+        scope: '.default offline_access',
         "prompt": ""
       }
     }

--- a/docs-v2/integrations/all/microsoft-power-bi.mdx
+++ b/docs-v2/integrations/all/microsoft-power-bi.mdx
@@ -45,6 +45,7 @@ _No setup guide yet._
 -   Please be aware that the Microsoft Power Bi implements throttling to manage the volume of requests. For more information on handling throttling, refer to the [Microsoft Power Bi Throttling Guidance](https://learn.microsoft.com/en-us/rest/api/power-bi/#throttling).
 -   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
     - Override `authorization_params` by setting only `scope: '.default'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
+    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
     - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
 
 ```typescript
@@ -53,7 +54,7 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "microsoft-power-bi": {
       authorization_params: {
-        scope: '.default',
+        scope: '.default offline_access',
         "prompt": ""
       }
     }

--- a/docs-v2/integrations/all/microsoft-tenant-specific.mdx
+++ b/docs-v2/integrations/all/microsoft-tenant-specific.mdx
@@ -53,6 +53,7 @@ This endpoint supports services authorized using an Azure App Registration in an
 
 -   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
     - Override `authorization_params` by setting only `scope: '.default'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
+    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
     - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
 
 ```typescript
@@ -61,7 +62,7 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "microsoft-tenant-specific": {
       authorization_params: {
-        scope: '.default',
+        scope: '.default offline_access',
         "prompt": ""
       }
     }

--- a/docs-v2/integrations/all/microsoft.mdx
+++ b/docs-v2/integrations/all/microsoft.mdx
@@ -46,8 +46,8 @@ _No setup guide yet._
 -   You can find permissions required for each API call in their corresponding API methods section, i.e, to retrieve a list of notebook objects from Onenote, you can have a look at [List Notebooks permissions](https://learn.microsoft.com/en-us/graph/api/onenote-list-notebooks?view=graph-rest-1.0&tabs=http#permissions).
 -   Please be aware that the Microsoft Graph API implements throttling to manage the volume of requests. For more information on handling throttling, refer to the [Microsoft Graph Throttling Guidance](https://learn.microsoft.com/en-us/graph/throttling).
 -   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
-    - Override `authorization_params` by setting only `scope: '.default'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
-    - See the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
+    - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
 
 ```typescript
 const { data } = await nango.createConnectSession({
@@ -55,7 +55,7 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "microsoft": {
       authorization_params: {
-        scope: '.default',
+        scope: '.default offline_access',
         "prompt": ""
       }
     }

--- a/docs-v2/integrations/all/outlook.mdx
+++ b/docs-v2/integrations/all/outlook.mdx
@@ -43,7 +43,7 @@ _No setup guide yet._
 -   To get refresh token, you will need to add **`offline_access`** to the list of your scopes.
 -   You can find permissions required for each API call in their corresponding API methods section.
 -   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
-    - Override `authorization_params` by setting only `scope: '.default'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
+    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
     - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
 
 ```typescript
@@ -52,7 +52,7 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "outlook": {
       authorization_params: {
-        scope: '.default',
+        scope: '.default offline_access',
         "prompt": ""
       }
     }

--- a/docs-v2/integrations/all/sharepoint-online-oauth2-cc.mdx
+++ b/docs-v2/integrations/all/sharepoint-online-oauth2-cc.mdx
@@ -44,7 +44,7 @@ _No setup guide yet._
 -   Nango supports both SharePoint Online v1 and v2, providing flexibility for integrations depending on your requirements. SharePoint v1 refers to the older REST API, which uses legacy authentication methods like SharePoint Online (SPO) or older OAuth implementations. Its endpoints follow the pattern `https://<your-tenant>.sharepoint.com/_api/`, and it supports basic SharePoint operations. However, v1 lacks modern features such as delta queries for incremental sync and deep integration with Microsoft 365.
 -   Sharepoint Online v2, on the other hand, is a modernized version aligned with the Microsoft Graph API. It uses OAuth 2.0 with the Microsoft Identity Platform (formerly Azure AD) for secure and scalable authentication. Endpoints for v2 are primarily accessed through `https://graph.microsoft.com/v1.0/sites/...`, and it offers advanced capabilities like delta queries for incremental sync, enhanced performance, and seamless integration with Microsoft 365 services.
 -   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
-    - Override `authorization_params` by setting only `scope: '.default'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
+    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
     - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
 
 ```typescript
@@ -53,7 +53,7 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "sharepoint-online-oauth2-cc": {
       authorization_params: {
-        scope: '.default',
+        scope: '.default offline_access',
         "prompt": ""
       }
     }

--- a/docs-v2/integrations/all/sharepoint-online.mdx
+++ b/docs-v2/integrations/all/sharepoint-online.mdx
@@ -46,7 +46,7 @@ _No setup guide yet._
 -   Nango supports both SharePoint Online v1 and v2, providing flexibility for integrations depending on your requirements. SharePoint v1 refers to the older REST API, which uses legacy authentication methods like SharePoint Online (SPO) or older OAuth implementations. Its endpoints follow the pattern `https://<your-tenant>.sharepoint.com/_api/`, and it supports basic SharePoint operations. However, v1 lacks modern features such as delta queries for incremental sync and deep integration with Microsoft 365.
 -   Sharepoint Online v2, on the other hand, is a modernized version aligned with the Microsoft Graph API. It uses OAuth 2.0 with the Microsoft Identity Platform (formerly Azure AD) for secure and scalable authentication. Endpoints for v2 are primarily accessed through `https://graph.microsoft.com/v1.0/sites/...`, and it offers advanced capabilities like delta queries for incremental sync, enhanced performance, and seamless integration with Microsoft 365 services.
 -   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
-    - Override `authorization_params` by setting only `scope: '.default'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
+    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
     - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
 
 ```typescript
@@ -55,7 +55,7 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "sharepoint-online": {
       authorization_params: {
-        scope: '.default',
+        scope: '.default offline_access',
         "prompt": ""
       }
     }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Update documentation to include `offline_access` to ensure a refresh token is issued

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the documentation for several Microsoft-related integration providers to include the 'offline_access' scope, which is necessary to ensure refresh tokens are issued. Without this scope, connections may not receive refresh tokens, leading to expiration issues when access tokens expire.

**Key Changes:**
• Added 'offline_access' to the scope parameter in authorization_params for all Microsoft-related integrations
• Updated code examples in documentation to reflect the correct scope requirements


**Affected Areas:**
• Microsoft documentation
• Outlook documentation
• SharePoint documentation
• Other Microsoft service documentation files (Power BI, Business Central, etc.)


*This summary was automatically generated by @propel-code-bot*