### PR TITLE
fix(scheduler): decrease tasks table autovacuum factor settings

### DIFF
--- a/packages/scheduler/lib/db/migrations/20250509143200_tasks_autovacuum_settings.ts
+++ b/packages/scheduler/lib/db/migrations/20250509143200_tasks_autovacuum_settings.ts
@@ -1,0 +1,14 @@
+import type { Knex } from 'knex';
+import { TASKS_TABLE } from '../../models/tasks.js';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`
+            ALTER TABLE ${TASKS_TABLE} SET (
+                autovacuum_vacuum_scale_factor = 0.01,        -- reducing from 10% to 1%
+                autovacuum_analyze_scale_factor = 0.01,       -- reducing from 5% to 1%
+                autovacuum_vacuum_insert_scale_factor = 0.05  -- reducing from 20% to 5%
+            );
+        `);
+}
+
+export async function down(): Promise<void> {}


### PR DESCRIPTION
tl;dr: Squeeze more performance out of the orchestrator db

The tasks table update rate is very high (ex: frequent state and dates updates) and create table bloat,
causing the expireTasks query to slow down over time until vacuuming occurs and speed of the query is back to its baseline again.
This commit is an attempt at optimizing the autovacuum settings for the tasks table to trigger cleaning operations more frequently by reducing scale factors. (The pg default autovaccum settings are too high for the tasks table) 
By vacuuming at 1% modified rows rather than the default 10%, we'll maintain more consistent query performance while preventing excessive dead tuple accumulation I choose the new value somehow arbitrarily. I will keep monitoring the scheduler queries

example of the effect of vacuuming (vacuuming is in pink)
![Screenshot 2025-05-09 at 10 56 32](https://github.com/user-attachments/assets/ffadaf14-223a-44ee-98d5-55bfae0799ef)

<!-- Summary by @propel-code-bot -->

---

This PR introduces a database migration that reduces autovacuum scale factors for the tasks table to prevent performance degradation. By decreasing threshold values (vacuum: 10%→1%, analyze: 5%→1%, insert: 20%→5%), the database will perform cleanup operations more frequently, reducing table bloat caused by high update rates.

*This summary was automatically generated by @propel-code-bot*