### PR TITLE
chore(scheduler): decrease frequency of monitor worker

### DIFF
--- a/packages/scheduler/lib/workers/cleanup/cleanup.worker.ts
+++ b/packages/scheduler/lib/workers/cleanup/cleanup.worker.ts
@@ -5,6 +5,7 @@ import * as schedules from '../../models/schedules.js';
 import type knex from 'knex';
 import { logger } from '../../utils/logger.js';
 import { SchedulerWorker, SchedulerWorkerChild } from '../worker.js';
+import { envs } from '../../env.js';
 
 export class CleanupWorker extends SchedulerWorker {
     constructor({ databaseUrl, databaseSchema }: { databaseUrl: string; databaseSchema: string }) {
@@ -23,7 +24,7 @@ export class CleanupChild extends SchedulerWorkerChild {
             name: 'Cleanup',
             parent,
             db,
-            tickIntervalMs: 10_000
+            tickIntervalMs: envs.ORCHESTRATOR_CLEANUP_TICK_INTERVAL_MS
         });
     }
 

--- a/packages/scheduler/lib/workers/monitor/monitor.worker.ts
+++ b/packages/scheduler/lib/workers/monitor/monitor.worker.ts
@@ -4,6 +4,7 @@ import * as tasks from '../../models/tasks.js';
 import type knex from 'knex';
 import { logger } from '../../utils/logger.js';
 import { SchedulerWorker, SchedulerWorkerChild } from '../worker.js';
+import { envs } from '../../env.js';
 
 export class MonitorWorker extends SchedulerWorker {
     constructor({ databaseUrl, databaseSchema }: { databaseUrl: string; databaseSchema: string }) {
@@ -22,7 +23,7 @@ export class MonitorChild extends SchedulerWorkerChild {
             name: 'Monitor',
             parent,
             db,
-            tickIntervalMs: 100
+            tickIntervalMs: envs.ORCHESTRATOR_MONITOR_TICK_INTERVAL_MS
         });
     }
 

--- a/packages/scheduler/lib/workers/scheduling/scheduling.worker.ts
+++ b/packages/scheduler/lib/workers/scheduling/scheduling.worker.ts
@@ -9,6 +9,7 @@ import * as tasks from '../../models/tasks.js';
 import * as schedules from '../../models/schedules.js';
 import { SchedulerWorker, SchedulerWorkerChild } from '../worker.js';
 import tracer from 'dd-trace';
+import { envs } from '../../env.js';
 
 export class SchedulingWorker extends SchedulerWorker {
     constructor({ databaseUrl, databaseSchema }: { databaseUrl: string; databaseSchema: string }) {
@@ -27,7 +28,7 @@ export class SchedulingChild extends SchedulerWorkerChild {
             name: 'Scheduling',
             parent,
             db,
-            tickIntervalMs: 100
+            tickIntervalMs: envs.ORCHESTRATOR_SCHEDULING_TICK_INTERVAL_MS
         });
     }
 

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -62,6 +62,9 @@ export const ENVS = z.object({
     ORCHESTRATOR_DATABASE_URL: z.string().url().optional(),
     ORCHESTRATOR_DATABASE_SCHEMA: z.string().optional().default('nango_scheduler'),
     ORCHESTRATOR_DB_POOL_MAX: z.coerce.number().optional().default(50),
+    ORCHESTRATOR_MONITOR_TICK_INTERVAL_MS: z.coerce.number().optional().default(1000),
+    ORCHESTRATOR_CLEANUP_TICK_INTERVAL_MS: z.coerce.number().optional().default(10000),
+    ORCHESTRATOR_SCHEDULING_TICK_INTERVAL_MS: z.coerce.number().optional().default(100),
 
     // Jobs
     JOBS_SERVICE_URL: z.string().url().optional().default('http://localhost:3005'),


### PR DESCRIPTION
Expiring tasks isn't time critical. ie: it is ok if a task is not considered expired for an extra second.
Since expiring tasks is the most expensive SQL query, we are lowering its frequency to lower the pressure on the orchestrator db 
This commit also adds env vars for all the scheduler worker tick intervals so we can tweak the without having to make a code change

<!-- Summary by @propel-code-bot -->

---

This PR reduces the scheduler's monitor worker frequency from 100ms to 1000ms (1s) to lower database pressure. The monitor worker handles task expiration checks which involves expensive SQL queries but isn't time-critical. The PR also adds environment variables for all scheduler worker tick intervals to enable runtime adjustments without code changes.

**Key Changes:**
• Decreased monitor worker frequency from 100ms to 1000ms
• Added environment variables for scheduler worker tick intervals
• Updated tests to account for the new timing configuration

**Affected Areas:**
• Scheduler monitoring system
• Task expiration checks
• Worker configuration

*This summary was automatically generated by @propel-code-bot*