### PR TITLE
fix(orchestrator): fix dequeue long polling

### DIFF
--- a/packages/jobs/lib/processor/processor.ts
+++ b/packages/jobs/lib/processor/processor.ts
@@ -17,28 +17,28 @@ export class Processor {
         try {
             const syncWorker = new ProcessorWorker({
                 orchestratorUrl: this.orchestratorServiceUrl,
-                groupKey: 'sync*',
+                groupKey: 'sync',
                 maxConcurrency: 200
             });
             syncWorker.start();
 
             const actionWorker = new ProcessorWorker({
                 orchestratorUrl: this.orchestratorServiceUrl,
-                groupKey: 'action*',
+                groupKey: 'action',
                 maxConcurrency: 200
             });
             actionWorker.start();
 
             const webhookWorker = new ProcessorWorker({
                 orchestratorUrl: this.orchestratorServiceUrl,
-                groupKey: 'webhook*',
+                groupKey: 'webhook',
                 maxConcurrency: 50
             });
             webhookWorker.start();
 
             const onEventWorker = new ProcessorWorker({
                 orchestratorUrl: this.orchestratorServiceUrl,
-                groupKey: 'on-event*',
+                groupKey: 'on-event',
                 maxConcurrency: 50
             });
             onEventWorker.start();

--- a/packages/orchestrator/lib/events.ts
+++ b/packages/orchestrator/lib/events.ts
@@ -1,4 +1,5 @@
 import type { Scheduler, Task } from '@nangohq/scheduler';
+import { GROUP_PREFIX_SEPARATOR } from '@nangohq/scheduler';
 import EventEmitter from 'node:events';
 
 export class EventsHandler extends EventEmitter {
@@ -23,7 +24,8 @@ export class EventsHandler extends EventEmitter {
         this.onCallbacks = {
             CREATED: (scheduler: Scheduler, task: Task) => {
                 on.CREATED(scheduler, task);
-                this.emit(`task:created:${task.groupKey}`, task);
+                const groupKeyPrefix = task.groupKey.split(GROUP_PREFIX_SEPARATOR)[0]; // Emitting event on the group key prefix if any
+                this.emit(`task:created:${groupKeyPrefix}`, task);
             },
             STARTED: (scheduler: Scheduler, task: Task) => {
                 on.STARTED(scheduler, task);

--- a/packages/scheduler/lib/index.ts
+++ b/packages/scheduler/lib/index.ts
@@ -3,3 +3,4 @@ export * from './types.js';
 export * from './db/helpers.test.js';
 export * from './db/client.js';
 export * from './utils/format.js';
+export { GROUP_PREFIX_SEPARATOR } from './models/groups.js';

--- a/packages/scheduler/lib/models/groups.ts
+++ b/packages/scheduler/lib/models/groups.ts
@@ -4,6 +4,7 @@ import type { Result } from '@nangohq/utils';
 import type { Group } from '../types.js';
 
 export const GROUPS_TABLE = 'groups';
+export const GROUP_PREFIX_SEPARATOR = ':';
 
 export interface DbGroup {
     readonly key: string;


### PR DESCRIPTION
I introduced a bug when adding dequeuing tasks by group key prefix: The dequeue long polling logic for early return would listen on `task:created:action*` but the event is actually the real group key. ex: `task:created:action` It led to the long polling mechanism of dequeue to never be notified about created tasks while it was waiting.
The impact was very small in production because there is probably always tasks ready to be dequeued and long polling is less useful there but locally you would have had to wait for up to 10s (aka: next dequeue request) for a task to be processed

I fixed it by moving the group key pattern logic inside dequeue endpoint and emit event on the task's group key prefix. It is adding a constraint around how we name group key (ex: `prefix:rest`) but it is not a bad thing anyway to have some naming convention

As a TODO I want to rename the `groupKey` paramter that is passed around to `groupKeyPrefix` to make it clearer but it requires a 2 steps change so I will do that another time 😬 

<!-- Summary by @propel-code-bot -->

---

This PR fixes a bug in the long polling mechanism for task dequeuing. The issue was that the event emission and listening were mismatched - events were emitted with the actual group key but the code was listening for wildcarded group keys, causing tasks to remain unprocessed until the polling timeout (10s). The fix properly aligns event emission and listening patterns by using group key prefixes consistently.

**Key Changes:**
• Changed processor worker initialization to use simple prefixes without asterisks
• Added group key prefix handling in event emission
• Modified dequeue endpoint to apply the wildcard pattern internally


**Affected Areas:**
• Task processing mechanism
• Event handling system
• Dequeue API endpoint


*This summary was automatically generated by @propel-code-bot*