### PR TITLE
fix(github-app-oauth): don't exit early on an update setup_action

### DIFF
--- a/docs-v2/integrations/all/github-app.mdx
+++ b/docs-v2/integrations/all/github-app.mdx
@@ -52,7 +52,6 @@ _No setup guide yet._
     - The App ID is made of numbers (e.g. 401953)
     - The App Public Link is the URL to your Github App public page (e.g. https://github.com/apps/nango-github-app)
     - The App Private Key needs to be generated in your GitHub App settings and starts with `-----BEGIN RSA PRIVATE KEY-----` (not to be confused with the Client Secrets)
-    - Ensure you checked the "Request user authorization (OAuth) during installation" checkbox and entered in the callback URL to Nango (https://api.nango.dev/oauth/callback)
     - The "Callback URL" needs to be filled in with the callback URL which unless customized will be https://api.nango.dev/oauth/callback and the checkbox "Request user authorization (OAuth) during installation" should be checked
     - The checkbox "Redirect on update" under "Post installation" should NOT be checked and the "Setup URL (optional)" should not be accessible
 -   There are certain API methods that only work with an OAuth App that will not work with an App. Please check the Github documentation and look for a "Works with Github Apps" header under the endpoint.

--- a/docs-v2/integrations/all/github-app.mdx
+++ b/docs-v2/integrations/all/github-app.mdx
@@ -52,6 +52,7 @@ _No setup guide yet._
     - The App ID is made of numbers (e.g. 401953)
     - The App Public Link is the URL to your Github App public page (e.g. https://github.com/apps/nango-github-app)
     - The App Private Key needs to be generated in your GitHub App settings and starts with `-----BEGIN RSA PRIVATE KEY-----` (not to be confused with the Client Secrets)
+    - Ensure you checked the "Request user authorization (OAuth) during installation" checkbox and entered in the callback URL to Nango (https://api.nango.dev/oauth/callback)
     - The "Callback URL" needs to be filled in with the callback URL which unless customized will be https://api.nango.dev/oauth/callback and the checkbox "Request user authorization (OAuth) during installation" should be checked
     - The checkbox "Redirect on update" under "Post installation" should NOT be checked and the "Setup URL (optional)" should not be accessible
 -   There are certain API methods that only work with an OAuth App that will not work with an App. Please check the Github documentation and look for a "Works with Github Apps" header under the endpoint.

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -920,7 +920,6 @@ class OAuthController {
             return publisher.notifyErr(res, channel, providerConfigKey, connectionId, error);
         }
 
-        // no need to do anything here until the request is approved
         if (session.authMode === 'CUSTOM' && req.query['setup_action'] === 'update' && installationId) {
             // this means the update request was performed from the provider itself
             if (!req.query['state']) {
@@ -929,11 +928,8 @@ class OAuthController {
                 return;
             }
 
-            void logCtx.info('Update request has been made', { provider: session.provider, providerConfigKey, connectionId });
-            await logCtx.success();
-
-            await publisher.notifySuccess(res, channel, providerConfigKey, connectionId);
-            return;
+            // this could be a new connection that is actually using updated permissions
+            // so we continue to upsert the connection to be sure
         }
 
         // check for oauth overrides in the connection config


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
If a user is attempting to create a new connection using an Github app that is already installed, allow the connection to be created. Previously we just exited the flow once we saw it was an update action for the `github-app-oauth`.

It is worth noting that updating the repositories an github-app-oauth connects to for a user updates for all instances of that app for a user. So if a user has connection `ABC` and connection `DEF` and updates the repositories an app has access to for `ABC` it'll also update `DEF`

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR modifies the GitHub App OAuth flow to allow creation of new connections using already installed GitHub apps by removing code that was exiting early when detecting an 'update' setup action. The change ensures users can create multiple connections using the same GitHub app installation.

*This summary was automatically generated by @propel-code-bot*