### PR TITLE
fix(auth): can't detect popup with security headers

### DIFF
--- a/packages/connect-ui/src/views/Go.tsx
+++ b/packages/connect-ui/src/views/Go.tsx
@@ -212,7 +212,7 @@ export const Go: React.FC = () => {
             }
 
             telemetry('click:connect');
-            setLoading(true);
+            setLoading(detectClosedAuthWindow);
             setError(null);
             // we don't care if it was already opened
             nango.clear();

--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -224,7 +224,7 @@ export default class Nango {
                     return;
                 }
 
-                if (this.win.modal.window && !this.win.modal.window.closed) {
+                if (this.win.modal.window && !this.win.modal.closed) {
                     return;
                 }
 
@@ -234,10 +234,12 @@ export default class Nango {
                     return;
                 }
 
-                clearInterval(this.tm as unknown as number);
-                this.win.close();
-
                 if (options?.detectClosedAuthWindow) {
+                    // Unfortunately some third party are blocking us from accessing the popup
+                    // So we can't reliably close the popup and websocket connection
+                    clearInterval(this.tm as unknown as number);
+                    this.win.close();
+
                     this.win = null;
                     reject(new AuthError('The authorization window was closed before the authorization flow was completed', 'windowClosed'));
                 }


### PR DESCRIPTION
## Changes

- Auth frontend: we cant' reliably detect popup
e.g: linear is using `Cross-Origin-Opener-Policy: same-origin`. I think it's a mistake on their end but it's breaking auth flow.

<!-- Summary by @propel-code-bot -->

---

This PR fixes an issue where the auth popup couldn't be reliably detected when third-party services use strict security headers like `Cross-Origin-Opener-Policy: same-origin`. The fix changes how the popup window's closed state is checked.

*This summary was automatically generated by @propel-code-bot*