### PR TITLE
fix(connect): support empty string in default

### DIFF
--- a/packages/connect-ui/src/views/Go.tsx
+++ b/packages/connect-ui/src/views/Go.tsx
@@ -159,7 +159,7 @@ export const Go: React.FC = () => {
                 order += 1;
                 orderedFields[`params.${name}`] = order;
             }
-            if (typeof preconfigured[name] !== 'undefined' || schema.hidden) {
+            if (preconfigured[name] ?? schema.hidden) {
                 hiddenFields += 1;
             }
         }

--- a/packages/connect-ui/src/views/Go.tsx
+++ b/packages/connect-ui/src/views/Go.tsx
@@ -159,7 +159,7 @@ export const Go: React.FC = () => {
                 order += 1;
                 orderedFields[`params.${name}`] = order;
             }
-            if (preconfigured[name] || schema.hidden) {
+            if (typeof preconfigured[name] !== 'undefined' || schema.hidden) {
                 hiddenFields += 1;
             }
         }
@@ -345,7 +345,7 @@ export const Go: React.FC = () => {
                                     const definition = provider[type === 'credentials' ? 'credentials' : 'connection_config']?.[key];
                                     // Not all fields have a definition in providers.yaml so we fallback to default
                                     const base = name in defaultConfiguration ? defaultConfiguration[name] : undefined;
-                                    const isPreconfigured = preconfigured[key];
+                                    const isPreconfigured = typeof preconfigured[key] !== 'undefined';
                                     const isOptional = definition && 'optional' in definition && definition.optional === true;
 
                                     return (


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-3015/quickbooks-realmid-problem#comment-e9d34be0

- Support empty string in default
This allow customer to hide optional fields

<!-- Summary by @propel-code-bot -->

---

Fixes a bug where empty strings in default connection configuration were not properly detected, causing optional fields that should be hidden to remain visible. The PR changes boolean checks to properly detect empty strings as valid configuration values.

*This summary was automatically generated by @propel-code-bot*