### PR TITLE
chore: remove instance id in logger

### DIFF
--- a/packages/utils/lib/json.ts
+++ b/packages/utils/lib/json.ts
@@ -1,5 +1,6 @@
 import safeStringify from 'fast-safe-stringify';
 import truncateJsonPkg from 'truncate-json';
+
 import { truncateBytes } from './string.js';
 
 export const MAX_LOG_PAYLOAD = 99_000; // in  bytes

--- a/packages/utils/lib/logger.ts
+++ b/packages/utils/lib/logger.ts
@@ -1,8 +1,11 @@
 import { inspect } from 'node:util';
-import winston from 'winston';
-import type { Logform, Logger } from 'winston';
+
 import colors from '@colors/colors';
+import winston from 'winston';
+
 import { isCloud, isEnterprise, isTest } from './environment/detection.js';
+
+import type { Logform, Logger } from 'winston';
 
 const SPLAT = Symbol.for('splat');
 const level = process.env['LOG_LEVEL'] ? process.env['LOG_LEVEL'] : isTest ? 'error' : 'info';
@@ -41,16 +44,10 @@ if (!isCloud && !isEnterprise) {
         })
     ];
 } else {
-    let instanceId = '';
-    if (isCloud && process.env['RENDER_INSTANCE_ID']) {
-        const parts = process.env['RENDER_INSTANCE_ID'].split('-');
-        instanceId = parts[parts.length - 1] ? ` ${parts[parts.length - 1]}` : '';
-    }
-
     formatters = [
         winston.format.printf((info) => {
             const splat = info[SPLAT] && info[SPLAT].length > 0 ? JSON.stringify(info[SPLAT]) : '';
-            return `[${info.level.toUpperCase()}]${instanceId}${info['service'] ? ` [${info['service']}] ` : ''}${info.message} ${splat}`;
+            return `[${info.level.toUpperCase()}]${info['service'] ? ` [${info['service']}] ` : ''}${info.message} ${splat}`;
         })
     ];
 }


### PR DESCRIPTION
## Changes

- remove instance id in logger
It's now by default in render

<!-- Summary by @propel-code-bot -->

---

This PR removes the Render instance ID from the logger since it's now included by default in Render. The changes simply remove the custom code that extracted and formatted the instance ID from environment variables.

*This summary was automatically generated by @propel-code-bot*