### PR TITLE
feat: set task ownerKey and retryKey

### DIFF
--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -193,6 +193,7 @@ const runJob = async (
             provider_config_key: connection.provider_config_key,
             connection_id: connection.connection_id
         },
+        ownerKey: null,
         isSync: (): this is TaskSync => true,
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,

--- a/packages/orchestrator/lib/abort.ts
+++ b/packages/orchestrator/lib/abort.ts
@@ -40,7 +40,8 @@ export async function scheduleAbortTask({ scheduler, task, reason }: { scheduler
         retryCount: 0,
         createdToStartedTimeoutSecs: 60,
         startedToCompletedTimeoutSecs: 60,
-        heartbeatTimeoutSecs: 60
+        heartbeatTimeoutSecs: 60,
+        ownerKey: aborted.value.ownerKey
     });
     if (abortTask.isErr()) {
         logger.error(`Failed to create abort task`, abortTask.error);

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -58,15 +58,7 @@ export class OrchestratorClient {
     }
 
     public async immediate(props: ImmediateProps): Promise<Result<{ taskId: string }, ClientError>> {
-        const res = await this.routeFetch(postImmediateRoute)({
-            body: {
-                name: props.name,
-                group: props.group,
-                retry: props.retry,
-                timeoutSettingsInSecs: props.timeoutSettingsInSecs,
-                args: props.args
-            }
-        });
+        const res = await this.routeFetch(postImmediateRoute)({ body: props });
         if ('error' in res) {
             return Err({
                 name: res.error.code,

--- a/packages/orchestrator/lib/clients/processor.integration.test.ts
+++ b/packages/orchestrator/lib/clients/processor.integration.test.ts
@@ -90,6 +90,7 @@ async function immediateTask({ groupKey }: { groupKey: string }) {
         name: nanoid(),
         retryMax: 0,
         retryCount: 0,
+        ownerKey: null,
         createdToStartedTimeoutSecs: 30,
         startedToCompletedTimeoutSecs: 30,
         heartbeatTimeoutSecs: 30,

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -70,6 +70,7 @@ interface TaskCommonFields {
     groupKey: string;
     state: TaskState;
     attempt: number;
+    ownerKey: string | null;
 }
 interface TaskCommon extends TaskCommonFields {
     isSync(this: OrchestratorTask): this is TaskSync;
@@ -90,6 +91,7 @@ export function TaskAbort(props: TaskCommonFields & AbortArgs): TaskAbort {
         connection: props.connection,
         groupKey: props.groupKey,
         reason: props.reason,
+        ownerKey: props.ownerKey,
         isSync: (): this is TaskSync => false,
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
@@ -112,6 +114,7 @@ export function TaskSync(props: TaskCommonFields & SyncArgs): TaskSync {
         debug: props.debug,
         connection: props.connection,
         groupKey: props.groupKey,
+        ownerKey: props.ownerKey,
         isSync: (): this is TaskSync => true,
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
@@ -136,6 +139,7 @@ export function TaskSyncAbort(props: TaskCommonFields & SyncArgs & AbortArgs): T
         connection: props.connection,
         groupKey: props.groupKey,
         reason: props.reason,
+        ownerKey: props.ownerKey,
         isSync: (): this is TaskSync => false,
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
@@ -157,6 +161,7 @@ export function TaskAction(props: TaskCommonFields & ActionArgs): TaskAction {
         activityLogId: props.activityLogId,
         input: props.input,
         groupKey: props.groupKey,
+        ownerKey: props.ownerKey,
         isSync: (): this is TaskSync => false,
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => true,
@@ -179,6 +184,7 @@ export function TaskWebhook(props: TaskCommonFields & WebhookArgs): TaskWebhook 
         activityLogId: props.activityLogId,
         input: props.input,
         groupKey: props.groupKey,
+        ownerKey: props.ownerKey,
         isSync: (): this is TaskSync => false,
         isWebhook: (): this is TaskWebhook => true,
         isAction: (): this is TaskAction => false,
@@ -201,6 +207,7 @@ export function TaskOnEvent(props: TaskCommonFields & OnEventArgs): TaskOnEvent 
         fileLocation: props.fileLocation,
         activityLogId: props.activityLogId,
         groupKey: props.groupKey,
+        ownerKey: props.ownerKey,
         isSync: (): this is TaskSync => false,
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -73,7 +73,8 @@ const commonSchemaFields = {
     name: z.string().min(1),
     groupKey: z.string().min(1),
     state: z.enum(taskStates),
-    retryCount: z.number().int()
+    retryCount: z.number().int(),
+    ownerKey: z.string().min(1).nullable()
 };
 const abortSchema = z.object({
     ...commonSchemaFields,
@@ -114,6 +115,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 syncVariant: sync.data.payload.syncVariant,
                 connection: sync.data.payload.connection,
                 groupKey: sync.data.groupKey,
+                ownerKey: sync.data.ownerKey,
                 debug: sync.data.payload.debug
             })
         );
@@ -132,6 +134,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 syncVariant: syncAbort.data.payload.syncVariant,
                 connection: syncAbort.data.payload.connection,
                 groupKey: syncAbort.data.groupKey,
+                ownerKey: syncAbort.data.ownerKey,
                 reason: syncAbort.data.payload.reason,
                 debug: syncAbort.data.payload.debug
             })
@@ -149,6 +152,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 connection: action.data.payload.connection,
                 activityLogId: action.data.payload.activityLogId,
                 groupKey: action.data.groupKey,
+                ownerKey: action.data.ownerKey,
                 input: action.data.payload.input
             })
         );
@@ -166,6 +170,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 connection: webhook.data.payload.connection,
                 activityLogId: webhook.data.payload.activityLogId,
                 groupKey: webhook.data.groupKey,
+                ownerKey: webhook.data.ownerKey,
                 input: webhook.data.payload.input
             })
         );
@@ -182,6 +187,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 version: onEvent.data.payload.version,
                 connection: onEvent.data.payload.connection,
                 groupKey: onEvent.data.groupKey,
+                ownerKey: onEvent.data.ownerKey,
                 fileLocation: onEvent.data.payload.fileLocation,
                 activityLogId: onEvent.data.payload.activityLogId
             })
@@ -198,6 +204,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 attempt: abort.data.retryCount + 1,
                 connection: abort.data.payload.connection,
                 groupKey: abort.data.groupKey,
+                ownerKey: abort.data.ownerKey,
                 reason: abort.data.payload.reason
             })
         );

--- a/packages/orchestrator/lib/routes/v1/postImmediate.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediate.ts
@@ -15,6 +15,7 @@ export type PostImmediate = Endpoint<{
     Path: typeof path;
     Body: {
         name: string;
+        ownerKey?: string;
         group: {
             key: string;
             maxConcurrency: number;
@@ -61,6 +62,7 @@ const validate = validateRequest<PostImmediate>({
         const schema = z
             .object({
                 name: z.string().min(1),
+                ownerKey: z.string().optional().default(''), // for backwards compatibility. TODO: replace with z.string() once all callers are updated
                 group: z.object({
                     key: z.string().min(1),
                     maxConcurrency: z.coerce.number()
@@ -99,6 +101,7 @@ const handler = (scheduler: Scheduler) => {
             groupKeyMaxConcurrency: req.body.group.maxConcurrency,
             retryMax: req.body.retry.max,
             retryCount: req.body.retry.count,
+            ownerKey: req.body.ownerKey || null,
             createdToStartedTimeoutSecs: req.body.timeoutSettingsInSecs.createdToStarted,
             startedToCompletedTimeoutSecs: req.body.timeoutSettingsInSecs.startedToCompleted,
             heartbeatTimeoutSecs: req.body.timeoutSettingsInSecs.heartbeat

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -19,37 +19,40 @@ describe('Task', () => {
     });
 
     it('should be successfully created', async () => {
-        const task = (
-            await tasks.create(db, {
-                name: 'Test Task',
-                payload: { foo: 'bar' },
-                groupKey: 'groupA',
-                retryMax: 3,
-                retryCount: 1,
-                startsAfter: new Date(),
-                createdToStartedTimeoutSecs: 10,
-                startedToCompletedTimeoutSecs: 20,
-                heartbeatTimeoutSecs: 5,
-                scheduleId: null
-            })
-        ).unwrap();
-        expect(task).toMatchObject({
-            id: expect.any(String),
+        const props = {
             name: 'Test Task',
             payload: { foo: 'bar' },
             groupKey: 'groupA',
             retryMax: 3,
             retryCount: 1,
-            startsAfter: expect.toBeIsoDateTimezone(),
-            createdAt: expect.toBeIsoDateTimezone(),
+            startsAfter: new Date(),
             createdToStartedTimeoutSecs: 10,
             startedToCompletedTimeoutSecs: 20,
+            heartbeatTimeoutSecs: 5,
+            scheduleId: null,
+            retryKey: '00000000-0000-0000-0000-000000000000',
+            ownerKey: 'ownerA'
+        };
+        const task = (await tasks.create(db, props)).unwrap();
+        expect(task).toMatchObject({
+            id: expect.any(String),
+            name: props.name,
+            payload: props.payload,
+            groupKey: props.groupKey,
+            retryMax: props.retryMax,
+            retryCount: props.retryCount,
+            startsAfter: expect.toBeIsoDateTimezone(),
+            createdAt: expect.toBeIsoDateTimezone(),
+            createdToStartedTimeoutSecs: props.createdToStartedTimeoutSecs,
+            startedToCompletedTimeoutSecs: props.startedToCompletedTimeoutSecs,
             state: 'CREATED',
             lastStateTransitionAt: expect.toBeIsoDateTimezone(),
             lastHeartbeatAt: expect.toBeIsoDateTimezone(),
             output: null,
             terminated: false,
-            scheduleId: null
+            scheduleId: props.scheduleId,
+            retryKey: props.retryKey,
+            ownerKey: props.ownerKey
         });
     });
     it('should have their heartbeat updated', async () => {
@@ -270,7 +273,9 @@ async function createTask(db: knex.Knex, props?: Partial<tasks.TaskProps> & { gr
             createdToStartedTimeoutSecs: props?.createdToStartedTimeoutSecs || 10,
             startedToCompletedTimeoutSecs: props?.startedToCompletedTimeoutSecs || 20,
             heartbeatTimeoutSecs: props?.heartbeatTimeoutSecs || 5,
-            scheduleId: props?.scheduleId || null
+            scheduleId: props?.scheduleId || null,
+            retryKey: props?.retryKey || null,
+            ownerKey: props?.ownerKey || null
         })
         .then((t) => t.unwrap());
 }

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -1,16 +1,19 @@
-import type { JsonValue } from 'type-fest';
+import type { JsonValue, SetOptional } from 'type-fest';
 import type knex from 'knex';
 import type { Result } from '@nangohq/utils';
 import { Ok, Err, stringifyError } from '@nangohq/utils';
 import { taskStates } from '../types.js';
 import type { TaskState, Task, TaskTerminalState, TaskNonTerminalState } from '../types.js';
-import { uuidv7 } from 'uuidv7';
+import { uuidv7, uuidv4 } from 'uuidv7';
 import { SCHEDULES_TABLE } from './schedules.js';
 import { GROUPS_TABLE } from './groups.js';
 
 export const TASKS_TABLE = 'tasks';
 
-export type TaskProps = Omit<Task, 'id' | 'createdAt' | 'state' | 'lastStateTransitionAt' | 'lastHeartbeatAt' | 'output' | 'terminated'>;
+export type TaskProps = SetOptional<
+    Omit<Task, 'id' | 'createdAt' | 'state' | 'lastStateTransitionAt' | 'lastHeartbeatAt' | 'output' | 'terminated'>,
+    'retryKey'
+>;
 
 interface TaskStateTransition {
     from: TaskState;
@@ -60,6 +63,8 @@ export interface DbTask {
     output: JsonValue | null;
     terminated: boolean;
     readonly schedule_id: string | null;
+    readonly retry_key: string | null;
+    readonly owner_key: string | null;
 }
 export const DbTask = {
     to: (task: Task): DbTask => {
@@ -80,7 +85,9 @@ export const DbTask = {
             last_heartbeat_at: task.lastHeartbeatAt,
             output: task.output,
             terminated: task.terminated,
-            schedule_id: task.scheduleId
+            schedule_id: task.scheduleId,
+            retry_key: task.retryKey,
+            owner_key: task.ownerKey
         };
     },
     from: (dbTask: DbTask): Task => {
@@ -101,7 +108,9 @@ export const DbTask = {
             lastHeartbeatAt: dbTask.last_heartbeat_at,
             output: dbTask.output,
             terminated: dbTask.terminated,
-            scheduleId: dbTask.schedule_id
+            scheduleId: dbTask.schedule_id,
+            retryKey: dbTask.retry_key,
+            ownerKey: dbTask.owner_key
         };
     }
 };
@@ -117,7 +126,8 @@ export async function create(db: knex.Knex, taskProps: TaskProps): Promise<Resul
         lastHeartbeatAt: now,
         terminated: false,
         output: null,
-        scheduleId: taskProps.scheduleId
+        scheduleId: taskProps.scheduleId,
+        retryKey: taskProps.retryKey || uuidv4()
     };
     try {
         const inserted = await db.from<DbTask>(TASKS_TABLE).insert(DbTask.to(newTask)).returning('*');

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -50,6 +50,7 @@ describe('Scheduler', () => {
         (await scheduler.fail({ taskId: task.id, error: { message: 'failure happened' } })).unwrap();
         const retried = (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
         expect(retried.length).toBe(1);
+        expect(retried[0]?.retryKey).toBe(task.retryKey);
     });
     it('should not retry failed task if reached max retries', async () => {
         const task = await immediate(scheduler, { taskProps: { retryMax: 2, retryCount: 2 } });
@@ -198,7 +199,9 @@ async function immediate(
             retryCount: props?.taskProps?.retryCount || 0,
             createdToStartedTimeoutSecs: props?.taskProps?.createdToStartedTimeoutSecs || 3600,
             startedToCompletedTimeoutSecs: props?.taskProps?.startedToCompletedTimeoutSecs || 3600,
-            heartbeatTimeoutSecs: props?.taskProps?.heartbeatTimeoutSecs || 600
+            heartbeatTimeoutSecs: props?.taskProps?.heartbeatTimeoutSecs || 600,
+            ownerKey: props?.taskProps?.ownerKey || null,
+            retryKey: props?.taskProps?.retryKey || null
         };
     }
     return (await scheduler.immediate(taskProps)).unwrap();

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -174,7 +174,8 @@ export class Scheduler {
                     startedToCompletedTimeoutSecs: schedule.startedToCompletedTimeoutSecs,
                     heartbeatTimeoutSecs: schedule.heartbeatTimeoutSecs,
                     startsAfter: now,
-                    scheduleId: schedule.id
+                    scheduleId: schedule.id,
+                    ownerKey: null
                 };
             } else {
                 taskProps = {
@@ -322,7 +323,9 @@ export class Scheduler {
                         retryCount: task.retryCount + 1,
                         createdToStartedTimeoutSecs: task.createdToStartedTimeoutSecs,
                         startedToCompletedTimeoutSecs: task.startedToCompletedTimeoutSecs,
-                        heartbeatTimeoutSecs: task.heartbeatTimeoutSecs
+                        heartbeatTimeoutSecs: task.heartbeatTimeoutSecs,
+                        ownerKey: task.ownerKey,
+                        retryKey: task.retryKey
                     };
                     const res = await this.immediate(taskProps);
                     if (res.isErr()) {

--- a/packages/scheduler/lib/types.ts
+++ b/packages/scheduler/lib/types.ts
@@ -1,4 +1,4 @@
-import type { JsonValue } from 'type-fest';
+import type { JsonValue, SetOptional } from 'type-fest';
 import type { TaskProps } from './models/tasks.js';
 
 export const taskStates = ['CREATED', 'STARTED', 'SUCCEEDED', 'FAILED', 'EXPIRED', 'CANCELLED'] as const;
@@ -24,12 +24,14 @@ export interface Task {
     readonly output: JsonValue | null;
     readonly terminated: boolean;
     readonly scheduleId: string | null;
+    readonly retryKey: string | null;
+    readonly ownerKey: string | null;
 }
 
 interface WithGroupKeyMaxConcurrency {
     groupKeyMaxConcurrency?: number | undefined;
 }
-export type ImmediateProps = Omit<TaskProps, 'startsAfter' | 'scheduleId'> & WithGroupKeyMaxConcurrency;
+export type ImmediateProps = SetOptional<Omit<TaskProps, 'startsAfter' | 'scheduleId'>, 'retryKey'> & WithGroupKeyMaxConcurrency;
 export type ScheduleProps = Omit<Schedule, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'> & WithGroupKeyMaxConcurrency;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/scheduler/lib/workers/scheduling/scheduling.integration.test.ts
+++ b/packages/scheduler/lib/workers/scheduling/scheduling.integration.test.ts
@@ -145,7 +145,9 @@ async function addTask(
         heartbeat_timeout_secs: 1,
         last_heartbeat_at: new Date(),
         output: {},
-        terminated: params?.state !== 'CREATED' && params?.state !== 'STARTED'
+        terminated: params?.state !== 'CREATED' && params?.state !== 'STARTED',
+        retry_key: null,
+        owner_key: null
     };
     const res = await db.from<DbTask>(TASKS_TABLE).insert(task).returning('*');
     const inserted = res[0];

--- a/packages/scheduler/lib/workers/scheduling/scheduling.worker.ts
+++ b/packages/scheduler/lib/workers/scheduling/scheduling.worker.ts
@@ -69,7 +69,8 @@ export class SchedulingChild extends SchedulerWorkerChild {
                                     retryMax: schedule.retryMax,
                                     createdToStartedTimeoutSecs: schedule.createdToStartedTimeoutSecs,
                                     startedToCompletedTimeoutSecs: schedule.startedToCompletedTimeoutSecs,
-                                    heartbeatTimeoutSecs: schedule.heartbeatTimeoutSecs
+                                    heartbeatTimeoutSecs: schedule.heartbeatTimeoutSecs,
+                                    ownerKey: null
                                 })
                             );
                             const res = await Promise.allSettled(createTasks);

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -154,6 +154,7 @@ export class Orchestrator {
             const actionResult = await this.client.executeAction({
                 name: executionId,
                 group: { key: groupKey, maxConcurrency: 0 },
+                ownerKey: `environment:${connection.environment_id}`,
                 args
             });
 


### PR DESCRIPTION
This commit:
- set task retryKey to random uuid or use previous attempt retryKey in case of retry
- pass ownerKey from server (actions only).

Note: There is no change in behavior. retryKey and ownerKey are not yet being used

<!-- Summary by @propel-code-bot -->

---

This PR adds two new properties to the Task model: `retryKey` (set to a random UUID or using the previous attempt's key for retries) and `ownerKey` (passed from the server for actions). These fields are added throughout the system but don't change current functionality as they're not yet being used in business logic.

**Key Changes:**
• Add retryKey and ownerKey fields to Task model
• Pass environment ID as ownerKey for actions
• Ensure retry tasks inherit retryKey from parent task

**Affected Areas:**
• Task model
• Scheduler
• Client interfaces
• Task validation
• Integration tests

*This summary was automatically generated by @propel-code-bot*