### PR TITLE
fix(microsoft): remove prompt=consent

### DIFF
--- a/docs-v2/integrations/all/microsoft-ads.mdx
+++ b/docs-v2/integrations/all/microsoft-ads.mdx
@@ -6,6 +6,7 @@ sidebarTitle: Microsoft Ads
 import Overview from "/snippets/overview.mdx"
 import PreBuiltTooling from "/snippets/generated/microsoft-ads/PreBuiltTooling.mdx"
 import PreBuiltUseCases from "/snippets/generated/microsoft-ads/PreBuiltUseCases.mdx"
+import APIGotchas from "/snippets/microsoft-api-gotchas.mdx"
 
 <Overview />
 <PreBuiltTooling />
@@ -40,32 +41,7 @@ _No setup guide yet._
 
 -   The Microsoft Advertising API doesn't offer a REST API, which means certain Nango functionalities won't be accessible, including syncs, workflows, and proxy requests.
     To engage with the Microsoft Advertising API, developers must initially retrieve the access token utilizing the [backend API](https://docs.nango.dev/reference/api/connection/get). This token should then be utilized with [official client libraries](https://learn.microsoft.com/en-us/advertising/guides/client-libraries?view=bingads-13) or a [SOAP Client](https://learn.microsoft.com/en-us/advertising/guides/authentication-oauth-quick-start?view=bingads-13) for further interaction.
--   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
--   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
-
-```typescript
-const { data } = await nango.createConnectSession({
-  end_user: {
-    id: '<END-USER-ID>',
-    email: '<END-USER-EMAIL>',
-    display_name: '<END-USER-NAME>'
-  },
-  organization: {
-    id: '<ORGANIZATION-ID>',
-    display_name: '<ORGANIZATION-NAME>'
-  },
-  allowed_integrations: ['microsoft-ads'],
-  integrations_config_defaults: {
-    "microsoft-ads": {
-      authorization_params: {
-        "prompt": "consent"
-      }
-    }
-  }
-});
-```
-
-If this is not done, the app will [show a consent screen prompting the user to grant permissions](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#example-1-the-user-or-tenant-admin-has-granted-permissions) which the user will be unable to do without admin access.
+<APIGotchas />
 
 <Note>
     Add Getting Started links and Gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft-ads.mdx)

--- a/docs-v2/integrations/all/microsoft-ads.mdx
+++ b/docs-v2/integrations/all/microsoft-ads.mdx
@@ -40,10 +40,8 @@ _No setup guide yet._
 
 -   The Microsoft Advertising API doesn't offer a REST API, which means certain Nango functionalities won't be accessible, including syncs, workflows, and proxy requests.
     To engage with the Microsoft Advertising API, developers must initially retrieve the access token utilizing the [backend API](https://docs.nango.dev/reference/api/connection/get). This token should then be utilized with [official client libraries](https://learn.microsoft.com/en-us/advertising/guides/client-libraries?view=bingads-13) or a [SOAP Client](https://learn.microsoft.com/en-us/advertising/guides/authentication-oauth-quick-start?view=bingads-13) for further interaction.
--   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
-    - Override `authorization_params` by setting only `scope: '.default'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
-    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
-    - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
 
 ```typescript
 const { data } = await nango.createConnectSession({
@@ -60,8 +58,7 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "microsoft-ads": {
       authorization_params: {
-        scope: '.default offline_access',
-        "prompt": ""
+        "prompt": "consent"
       }
     }
   }

--- a/docs-v2/integrations/all/microsoft-business-central.mdx
+++ b/docs-v2/integrations/all/microsoft-business-central.mdx
@@ -40,10 +40,8 @@ _No setup guide yet._
 
 ## API gotchas
 
--   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
-    - Override `authorization_params` by setting only `scope: '.default'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
-    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
-    - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
 
 ```typescript
 const { data } = await nango.createConnectSession({
@@ -51,8 +49,7 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "microsoft-business-central": {
       authorization_params: {
-        scope: '.default offline_access',
-        "prompt": ""
+        "prompt": "consent"
       }
     }
   }

--- a/docs-v2/integrations/all/microsoft-business-central.mdx
+++ b/docs-v2/integrations/all/microsoft-business-central.mdx
@@ -6,6 +6,7 @@ sidebarTitle: Microsoft Business Central
 import Overview from "/snippets/overview.mdx"
 import PreBuiltTooling from "/snippets/generated/microsoft-business-central/PreBuiltTooling.mdx"
 import PreBuiltUseCases from "/snippets/generated/microsoft-business-central/PreBuiltUseCases.mdx"
+import APIGotchas from "/snippets/microsoft-api-gotchas.mdx"
 
 <Overview />
 <PreBuiltTooling />
@@ -39,24 +40,7 @@ _No setup guide yet._
 <Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft-business-central.mdx)</Note>
 
 ## API gotchas
-
--   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
--   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
-
-```typescript
-const { data } = await nango.createConnectSession({
-  [...],
-  integrations_config_defaults: {
-    "microsoft-business-central": {
-      authorization_params: {
-        "prompt": "consent"
-      }
-    }
-  }
-});
-```
-
-If this is not done, the app will [show a consent screen prompting the user to grant permissions](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#example-1-the-user-or-tenant-admin-has-granted-permissions) which the user will be unable to do without admin access.
+<APIGotchas />
 
 <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft-business-central.mdx)</Note>
 

--- a/docs-v2/integrations/all/microsoft-entra-id.mdx
+++ b/docs-v2/integrations/all/microsoft-entra-id.mdx
@@ -6,6 +6,7 @@ sidebarTitle: Microsoft Entra ID
 import Overview from "/snippets/overview.mdx"
 import PreBuiltTooling from "/snippets/generated/microsoft-entra-id/PreBuiltTooling.mdx"
 import PreBuiltUseCases from "/snippets/generated/microsoft-entra-id/PreBuiltUseCases.mdx"
+import APIGotchas from "/snippets/microsoft-api-gotchas.mdx"
 
 <Overview />
 <PreBuiltTooling />
@@ -39,23 +40,6 @@ _No setup guide yet._
 <Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft-entra-id.mdx)</Note>
 
 ## API gotchas
-
--   To get refresh token, you will need to add **`offline_access`** to the list of your scopes.
--   You can find permissions required for each API call in their corresponding API methods section.
--   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
--   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
-
-```typescript
-const { data } = await nango.createConnectSession({
-  [...],
-  integrations_config_defaults: {
-    "microsoft-entra-id": {
-      authorization_params: {
-        "prompt": "consent"
-      }
-    }
-  }
-});
-```
+<APIGotchas />
 
 <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft-entra-id.mdx)</Note>

--- a/docs-v2/integrations/all/microsoft-entra-id.mdx
+++ b/docs-v2/integrations/all/microsoft-entra-id.mdx
@@ -42,10 +42,8 @@ _No setup guide yet._
 
 -   To get refresh token, you will need to add **`offline_access`** to the list of your scopes.
 -   You can find permissions required for each API call in their corresponding API methods section.
--   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
-    - Override `authorization_params` by setting only `scope: '.default'` and `"prompt": ""` to remove the consent screen.
-    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen.
-    - See the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#the-default-scope) to ensure the permissions remain the same as those granted at the organization level.
+-   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
 
 ```typescript
 const { data } = await nango.createConnectSession({
@@ -53,14 +51,11 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "microsoft-entra-id": {
       authorization_params: {
-        scope: '.default offline_access',
-        "prompt": ""
+        "prompt": "consent"
       }
     }
   }
 });
 ```
-
-If this is not done, the app will [show a consent screen prompting the user to grant permissions](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#example-1-the-user-or-tenant-admin-has-granted-permissions) which the user will be unable to do without admin access.
 
 <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft-entra-id.mdx)</Note>

--- a/docs-v2/integrations/all/microsoft-oauth2-cc.mdx
+++ b/docs-v2/integrations/all/microsoft-oauth2-cc.mdx
@@ -6,6 +6,7 @@ sidebarTitle: Microsoft (Client Credentials)
 import Overview from "/snippets/overview.mdx"
 import PreBuiltTooling from "/snippets/generated/microsoft-oauth2-cc/PreBuiltTooling.mdx"
 import PreBuiltUseCases from "/snippets/generated/microsoft-oauth2-cc/PreBuiltUseCases.mdx"
+import APIGotchas from "/snippets/microsoft-api-gotchas.mdx"
 
 <Overview />
 <PreBuiltTooling />
@@ -40,25 +41,7 @@ _No setup guide yet._
 <Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft-oauth2-cc.mdx)</Note>
 
 ## API gotchas
-
--   Microsoft has a unified OAuth system for their various APIs. This provider should work for most of them (e.g. Microsoft EntraID, OneNote, Onedrive, Outlook, Sharepoint Online, Microsoft Teams etc.).
--   Microsoft offers a tool that allows you to construct and perform Graph API queries and see their response for any apps on which you have an admin, developer, or tester role. For more information you can check [Microsoft Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer).
--   Please be aware that the Microsoft Graph API implements throttling to manage the volume of requests. For more information on handling throttling, refer to the [Microsoft Graph Throttling Guidance](https://learn.microsoft.com/en-us/graph/throttling).
--   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
--   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
-
-```typescript
-const { data } = await nango.createConnectSession({
-  [...],
-  integrations_config_defaults: {
-    "microsoft-oauth2-cc": {
-      authorization_params: {
-        "prompt": "consent"
-      }
-    }
-  }
-});
-```
+<APIGotchas />
 
 <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft-oauth2-cc.mdx)</Note>
 

--- a/docs-v2/integrations/all/microsoft-oauth2-cc.mdx
+++ b/docs-v2/integrations/all/microsoft-oauth2-cc.mdx
@@ -44,10 +44,8 @@ _No setup guide yet._
 -   Microsoft has a unified OAuth system for their various APIs. This provider should work for most of them (e.g. Microsoft EntraID, OneNote, Onedrive, Outlook, Sharepoint Online, Microsoft Teams etc.).
 -   Microsoft offers a tool that allows you to construct and perform Graph API queries and see their response for any apps on which you have an admin, developer, or tester role. For more information you can check [Microsoft Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer).
 -   Please be aware that the Microsoft Graph API implements throttling to manage the volume of requests. For more information on handling throttling, refer to the [Microsoft Graph Throttling Guidance](https://learn.microsoft.com/en-us/graph/throttling).
--   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
-    - Override `authorization_params` by setting only `scope: '.default'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
-    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
-    - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
 
 ```typescript
 const { data } = await nango.createConnectSession({
@@ -55,15 +53,12 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "microsoft-oauth2-cc": {
       authorization_params: {
-        scope: '.default offline_access',
-        "prompt": ""
+        "prompt": "consent"
       }
     }
   }
 });
 ```
-
-If this is not done, the app will [show a consent screen prompting the user to grant permissions](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#example-1-the-user-or-tenant-admin-has-granted-permissions) which the user will be unable to do without admin access.
 
 <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft-oauth2-cc.mdx)</Note>
 

--- a/docs-v2/integrations/all/microsoft-power-bi.mdx
+++ b/docs-v2/integrations/all/microsoft-power-bi.mdx
@@ -6,6 +6,7 @@ sidebarTitle: Microsoft Power Bi
 import Overview from "/snippets/overview.mdx"
 import PreBuiltTooling from "/snippets/generated/microsoft-power-bi/PreBuiltTooling.mdx"
 import PreBuiltUseCases from "/snippets/generated/microsoft-power-bi/PreBuiltUseCases.mdx"
+import APIGotchas from "/snippets/microsoft-api-gotchas.mdx"
 
 <Overview />
 <PreBuiltTooling />
@@ -40,23 +41,6 @@ _No setup guide yet._
 <Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft-power-bi.mdx)</Note>
 
 ## API gotchas
-
--   You can find scopes required for each API call in their corresponding API calls section. For example, to retrieve a list of datasets from My workspace, you can refer to the Required scope section of the [Get Datasets](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/get-datasets#required-scope) documentation. You also need to prepend the hostname to the scope, which in the get datasets example would be `https://analysis.windows.net/powerbi/api/Dataset.ReadWrite.All`. For more details, check [this resource out](https://community.fabric.microsoft.com/t5/Service/Azure-AD-App-Authentication-scope-doesn-t-exist-on-app-with/m-p/3074525/highlight/true#M188140).
--   Please be aware that the Microsoft Power Bi implements throttling to manage the volume of requests. For more information on handling throttling, refer to the [Microsoft Power Bi Throttling Guidance](https://learn.microsoft.com/en-us/rest/api/power-bi/#throttling).
--   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
--   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
-
-```typescript
-const { data } = await nango.createConnectSession({
-  [...],
-  integrations_config_defaults: {
-    "microsoft-power-bi": {
-      authorization_params: {
-        "prompt": "consent"
-      }
-    }
-  }
-});
-```
+<APIGotchas />
 
 <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft-power-bi.mdx)</Note>

--- a/docs-v2/integrations/all/microsoft-power-bi.mdx
+++ b/docs-v2/integrations/all/microsoft-power-bi.mdx
@@ -43,10 +43,8 @@ _No setup guide yet._
 
 -   You can find scopes required for each API call in their corresponding API calls section. For example, to retrieve a list of datasets from My workspace, you can refer to the Required scope section of the [Get Datasets](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/get-datasets#required-scope) documentation. You also need to prepend the hostname to the scope, which in the get datasets example would be `https://analysis.windows.net/powerbi/api/Dataset.ReadWrite.All`. For more details, check [this resource out](https://community.fabric.microsoft.com/t5/Service/Azure-AD-App-Authentication-scope-doesn-t-exist-on-app-with/m-p/3074525/highlight/true#M188140).
 -   Please be aware that the Microsoft Power Bi implements throttling to manage the volume of requests. For more information on handling throttling, refer to the [Microsoft Power Bi Throttling Guidance](https://learn.microsoft.com/en-us/rest/api/power-bi/#throttling).
--   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
-    - Override `authorization_params` by setting only `scope: '.default'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
-    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
-    - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
 
 ```typescript
 const { data } = await nango.createConnectSession({
@@ -54,14 +52,11 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "microsoft-power-bi": {
       authorization_params: {
-        scope: '.default offline_access',
-        "prompt": ""
+        "prompt": "consent"
       }
     }
   }
 });
 ```
-
-If this is not done, the app will [show a consent screen prompting the user to grant permissions](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#example-1-the-user-or-tenant-admin-has-granted-permissions) which the user will be unable to do without admin access.
 
 <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft-power-bi.mdx)</Note>

--- a/docs-v2/integrations/all/microsoft-teams.mdx
+++ b/docs-v2/integrations/all/microsoft-teams.mdx
@@ -6,6 +6,7 @@ sidebarTitle: Microsoft Teams
 import Overview from "/snippets/overview.mdx"
 import PreBuiltTooling from "/snippets/generated/microsoft-teams/PreBuiltTooling.mdx"
 import PreBuiltUseCases from "/snippets/generated/microsoft-teams/PreBuiltUseCases.mdx"
+import APIGotchas from "/snippets/microsoft-api-gotchas.mdx"
 
 <Overview />
 <PreBuiltTooling />
@@ -47,8 +48,7 @@ This endpoint supports all Microsoft APIs available via the [Graph API](https://
 
 
 ## API gotchas
-
-* Make sure you request the `offline_access` scope to get a refresh token and keep access with your integration.
+<APIGotchas />
 
 
 <Note>

--- a/docs-v2/integrations/all/microsoft-tenant-specific.mdx
+++ b/docs-v2/integrations/all/microsoft-tenant-specific.mdx
@@ -6,6 +6,7 @@ sidebarTitle: Microsoft Tenant Specific
 import Overview from "/snippets/overview.mdx"
 import PreBuiltTooling from "/snippets/generated/microsoft-tenant-specific/PreBuiltTooling.mdx"
 import PreBuiltUseCases from "/snippets/generated/microsoft-tenant-specific/PreBuiltUseCases.mdx"
+import APIGotchas from "/snippets/microsoft-api-gotchas.mdx"
 
 <Overview />
 <PreBuiltTooling />
@@ -48,24 +49,9 @@ This endpoint supports services authorized using an Azure App Registration in an
 
 <Tip>You _can_ use this provider for general Microsoft Graph access (and the major Microsoft SaaS services like Teams, OneDrive, other Office 365 services, etc.) by setting the `tenant` to `common` but we recommend using the [Microsoft Teams provider](/integrations/all/microsoft-teams) instead which includes sync capability.</Tip>
 
-
 ## API gotchas
+<APIGotchas />
 
--   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
--   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
-
-```typescript
-const { data } = await nango.createConnectSession({
-  [...],
-  integrations_config_defaults: {
-    "microsoft-tenant-specific": {
-      authorization_params: {
-        "prompt": "consent"
-      }
-    }
-  }
-});
-```
 <Note>
     Add Getting Started links and Gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft-tenant-specific.mdx)
 </Note>

--- a/docs-v2/integrations/all/microsoft-tenant-specific.mdx
+++ b/docs-v2/integrations/all/microsoft-tenant-specific.mdx
@@ -51,10 +51,8 @@ This endpoint supports services authorized using an Azure App Registration in an
 
 ## API gotchas
 
--   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
-    - Override `authorization_params` by setting only `scope: '.default'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
-    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
-    - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
 
 ```typescript
 const { data } = await nango.createConnectSession({
@@ -62,16 +60,12 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "microsoft-tenant-specific": {
       authorization_params: {
-        scope: '.default offline_access',
-        "prompt": ""
+        "prompt": "consent"
       }
     }
   }
 });
 ```
-
-If this is not done, the app will [show a consent screen prompting the user to grant permissions](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#example-1-the-user-or-tenant-admin-has-granted-permissions) which the user will be unable to do without admin access.
-
 <Note>
     Add Getting Started links and Gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft-tenant-specific.mdx)
 </Note>

--- a/docs-v2/integrations/all/microsoft.mdx
+++ b/docs-v2/integrations/all/microsoft.mdx
@@ -45,9 +45,8 @@ _No setup guide yet._
 -   Microsoft offers a tool that allows you to construct and perform Graph API queries and see their response for any apps on which you have an admin, developer, or tester role. For more information you can check [Microsoft Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer).
 -   You can find permissions required for each API call in their corresponding API methods section, i.e, to retrieve a list of notebook objects from Onenote, you can have a look at [List Notebooks permissions](https://learn.microsoft.com/en-us/graph/api/onenote-list-notebooks?view=graph-rest-1.0&tabs=http#permissions).
 -   Please be aware that the Microsoft Graph API implements throttling to manage the volume of requests. For more information on handling throttling, refer to the [Microsoft Graph Throttling Guidance](https://learn.microsoft.com/en-us/graph/throttling).
--   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
-    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
-    - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
 
 ```typescript
 const { data } = await nango.createConnectSession({
@@ -55,8 +54,7 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "microsoft": {
       authorization_params: {
-        scope: '.default offline_access',
-        "prompt": ""
+        "prompt": "consent"
       }
     }
   }

--- a/docs-v2/integrations/all/microsoft.mdx
+++ b/docs-v2/integrations/all/microsoft.mdx
@@ -6,6 +6,7 @@ sidebarTitle: Microsoft
 import Overview from "/snippets/overview.mdx"
 import PreBuiltTooling from "/snippets/generated/microsoft/PreBuiltTooling.mdx"
 import PreBuiltUseCases from "/snippets/generated/microsoft/PreBuiltUseCases.mdx"
+import APIGotchas from "/snippets/microsoft-api-gotchas.mdx"
 
 <Overview />
 <PreBuiltTooling />
@@ -37,30 +38,10 @@ _No setup guide yet._
 -   [OAuth related docs](https://learn.microsoft.com/en-us/graph/auth-v2-user?tabs=http)
 -   [Microsoft permissions](https://learn.microsoft.com/en-us/graph/permissions-overview?tabs=http)
 
+## API gotchas
+<APIGotchas />
+
 <Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft.mdx)</Note>
 
-## API gotchas
-
--   Microsoft has a unified OAuth system for their various APIs. This provider should work for most of them (e.g. Microsoft EntraID, OneNote, Onedrive, Outlook, Sharepoint Online, Microsoft Teams etc.).
--   Microsoft offers a tool that allows you to construct and perform Graph API queries and see their response for any apps on which you have an admin, developer, or tester role. For more information you can check [Microsoft Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer).
--   You can find permissions required for each API call in their corresponding API methods section, i.e, to retrieve a list of notebook objects from Onenote, you can have a look at [List Notebooks permissions](https://learn.microsoft.com/en-us/graph/api/onenote-list-notebooks?view=graph-rest-1.0&tabs=http#permissions).
--   Please be aware that the Microsoft Graph API implements throttling to manage the volume of requests. For more information on handling throttling, refer to the [Microsoft Graph Throttling Guidance](https://learn.microsoft.com/en-us/graph/throttling).
--   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
--   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
-
-```typescript
-const { data } = await nango.createConnectSession({
-  [...],
-  integrations_config_defaults: {
-    "microsoft": {
-      authorization_params: {
-        "prompt": "consent"
-      }
-    }
-  }
-});
-```
-
-If this is not done, the app will [show a consent screen prompting the user to grant permissions](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#example-1-the-user-or-tenant-admin-has-granted-permissions) which the user will be unable to do without admin access.
 
 <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/microsoft.mdx)</Note>

--- a/docs-v2/integrations/all/one-drive.mdx
+++ b/docs-v2/integrations/all/one-drive.mdx
@@ -6,6 +6,7 @@ sidebarTitle: OneDrive
 import Overview from "/snippets/overview.mdx"
 import PreBuiltTooling from "/snippets/generated/one-drive/PreBuiltTooling.mdx"
 import PreBuiltUseCases from "/snippets/generated/one-drive/PreBuiltUseCases.mdx"
+import APIGotchas from "/snippets/microsoft-api-gotchas.mdx"
 
 <Overview />
 <PreBuiltTooling />
@@ -40,7 +41,6 @@ _No setup guide yet._
 <Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/one-drive.mdx)</Note>
 
 ## API gotchas
-
--   To get refresh token, you will need to add **`offline_access`** to the list of your scopes.
+<APIGotchas />
 
 <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/one-drive.mdx)</Note>

--- a/docs-v2/integrations/all/one-note.mdx
+++ b/docs-v2/integrations/all/one-note.mdx
@@ -6,6 +6,7 @@ sidebarTitle: OneNote
 import Overview from "/snippets/overview.mdx"
 import PreBuiltTooling from "/snippets/generated/one-note/PreBuiltTooling.mdx"
 import PreBuiltUseCases from "/snippets/generated/one-note/PreBuiltUseCases.mdx"
+import APIGotchas from "/snippets/microsoft-api-gotchas.mdx"
 
 <Overview />
 <PreBuiltTooling />
@@ -39,8 +40,6 @@ _No setup guide yet._
 <Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/one-note.mdx)</Note>
 
 ## API gotchas
-
--   To get refresh token, you will need to add **`offline_access`** to the list of your scopes.
--   You can find permissions required for each API call in their corresponding API methods section.
+<APIGotchas />
 
 <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/one-note.mdx)</Note>

--- a/docs-v2/integrations/all/outlook.mdx
+++ b/docs-v2/integrations/all/outlook.mdx
@@ -42,9 +42,8 @@ _No setup guide yet._
 
 -   To get refresh token, you will need to add **`offline_access`** to the list of your scopes.
 -   You can find permissions required for each API call in their corresponding API methods section.
--   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
-    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
-    - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
 
 ```typescript
 const { data } = await nango.createConnectSession({
@@ -52,14 +51,11 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "outlook": {
       authorization_params: {
-        scope: '.default offline_access',
-        "prompt": ""
+        "prompt": "consent"
       }
     }
   }
 });
 ```
-
-If this is not done, the app will [show a consent screen prompting the user to grant permissions](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#example-1-the-user-or-tenant-admin-has-granted-permissions) which the user will be unable to do without admin access.
 
 <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/outlook.mdx)</Note>

--- a/docs-v2/integrations/all/sharepoint-online-oauth2-cc.mdx
+++ b/docs-v2/integrations/all/sharepoint-online-oauth2-cc.mdx
@@ -43,21 +43,6 @@ _No setup guide yet._
 
 -   Nango supports both SharePoint Online v1 and v2, providing flexibility for integrations depending on your requirements. SharePoint v1 refers to the older REST API, which uses legacy authentication methods like SharePoint Online (SPO) or older OAuth implementations. Its endpoints follow the pattern `https://<your-tenant>.sharepoint.com/_api/`, and it supports basic SharePoint operations. However, v1 lacks modern features such as delta queries for incremental sync and deep integration with Microsoft 365.
 -   Sharepoint Online v2, on the other hand, is a modernized version aligned with the Microsoft Graph API. It uses OAuth 2.0 with the Microsoft Identity Platform (formerly Azure AD) for secure and scalable authentication. Endpoints for v2 are primarily accessed through `https://graph.microsoft.com/v1.0/sites/...`, and it offers advanced capabilities like delta queries for incremental sync, enhanced performance, and seamless integration with Microsoft 365 services.
--   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
--   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
-
-```typescript
-const { data } = await nango.createConnectSession({
-  [...],
-  integrations_config_defaults: {
-    "sharepoint-online-oauth2-cc": {
-      authorization_params: {
-        "prompt": "consent"
-      }
-    }
-  }
-});
-```
 
 <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/sharepoint-online-oauth2-cc.mdx)</Note>
 

--- a/docs-v2/integrations/all/sharepoint-online-oauth2-cc.mdx
+++ b/docs-v2/integrations/all/sharepoint-online-oauth2-cc.mdx
@@ -43,9 +43,8 @@ _No setup guide yet._
 
 -   Nango supports both SharePoint Online v1 and v2, providing flexibility for integrations depending on your requirements. SharePoint v1 refers to the older REST API, which uses legacy authentication methods like SharePoint Online (SPO) or older OAuth implementations. Its endpoints follow the pattern `https://<your-tenant>.sharepoint.com/_api/`, and it supports basic SharePoint operations. However, v1 lacks modern features such as delta queries for incremental sync and deep integration with Microsoft 365.
 -   Sharepoint Online v2, on the other hand, is a modernized version aligned with the Microsoft Graph API. It uses OAuth 2.0 with the Microsoft Identity Platform (formerly Azure AD) for secure and scalable authentication. Endpoints for v2 are primarily accessed through `https://graph.microsoft.com/v1.0/sites/...`, and it offers advanced capabilities like delta queries for incremental sync, enhanced performance, and seamless integration with Microsoft 365 services.
--   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
-    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
-    - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
 
 ```typescript
 const { data } = await nango.createConnectSession({
@@ -53,15 +52,12 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "sharepoint-online-oauth2-cc": {
       authorization_params: {
-        scope: '.default offline_access',
-        "prompt": ""
+        "prompt": "consent"
       }
     }
   }
 });
 ```
-
-If this is not done, the app will [show a consent screen prompting the user to grant permissions](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#example-1-the-user-or-tenant-admin-has-granted-permissions) which the user will be unable to do without admin access.
 
 <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/sharepoint-online-oauth2-cc.mdx)</Note>
 

--- a/docs-v2/integrations/all/sharepoint-online.mdx
+++ b/docs-v2/integrations/all/sharepoint-online.mdx
@@ -6,6 +6,7 @@ sidebarTitle: SharePoint Online (v2)
 import Overview from "/snippets/overview.mdx"
 import PreBuiltTooling from "/snippets/generated/sharepoint-online/PreBuiltTooling.mdx"
 import PreBuiltUseCases from "/snippets/generated/sharepoint-online/PreBuiltUseCases.mdx"
+import APIGotchas from "/snippets/microsoft-api-gotchas.mdx"
 
 <Overview />
 <PreBuiltTooling />
@@ -45,20 +46,6 @@ _No setup guide yet._
 
 -   Nango supports both SharePoint Online v1 and v2, providing flexibility for integrations depending on your requirements. SharePoint v1 refers to the older REST API, which uses legacy authentication methods like SharePoint Online (SPO) or older OAuth implementations. Its endpoints follow the pattern `https://<your-tenant>.sharepoint.com/_api/`, and it supports basic SharePoint operations. However, v1 lacks modern features such as delta queries for incremental sync and deep integration with Microsoft 365.
 -   Sharepoint Online v2, on the other hand, is a modernized version aligned with the Microsoft Graph API. It uses OAuth 2.0 with the Microsoft Identity Platform (formerly Azure AD) for secure and scalable authentication. Endpoints for v2 are primarily accessed through `https://graph.microsoft.com/v1.0/sites/...`, and it offers advanced capabilities like delta queries for incremental sync, enhanced performance, and seamless integration with Microsoft 365 services.
--   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
--   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
-
-```typescript
-const { data } = await nango.createConnectSession({
-  [...],
-  integrations_config_defaults: {
-    "sharepoint-online": {
-      authorization_params: {
-        "prompt": "consent"
-      }
-    }
-  }
-});
-```
+<APIGotchas />
 
 <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/sharepoint-online.mdx)</Note>

--- a/docs-v2/integrations/all/sharepoint-online.mdx
+++ b/docs-v2/integrations/all/sharepoint-online.mdx
@@ -45,9 +45,8 @@ _No setup guide yet._
 
 -   Nango supports both SharePoint Online v1 and v2, providing flexibility for integrations depending on your requirements. SharePoint v1 refers to the older REST API, which uses legacy authentication methods like SharePoint Online (SPO) or older OAuth implementations. Its endpoints follow the pattern `https://<your-tenant>.sharepoint.com/_api/`, and it supports basic SharePoint operations. However, v1 lacks modern features such as delta queries for incremental sync and deep integration with Microsoft 365.
 -   Sharepoint Online v2, on the other hand, is a modernized version aligned with the Microsoft Graph API. It uses OAuth 2.0 with the Microsoft Identity Platform (formerly Azure AD) for secure and scalable authentication. Endpoints for v2 are primarily accessed through `https://graph.microsoft.com/v1.0/sites/...`, and it offers advanced capabilities like delta queries for incremental sync, enhanced performance, and seamless integration with Microsoft 365 services.
--   If you are developing an app for users within your own organization and the app has already been granted adequate permissions at the organization level with user consent turned off, you must override the integration config when calling the create connect session method:
-    - Override `authorization_params` by setting only `scope: '.default offline_access'` and `"prompt": ""` to remove the consent screen. Note that if consent is required it will prompt the user for consent due to the ".default" scope.
-    - Set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
 
 ```typescript
 const { data } = await nango.createConnectSession({
@@ -55,14 +54,11 @@ const { data } = await nango.createConnectSession({
   integrations_config_defaults: {
     "sharepoint-online": {
       authorization_params: {
-        scope: '.default offline_access',
-        "prompt": ""
+        "prompt": "consent"
       }
     }
   }
 });
 ```
-
-If this is not done, the app will [show a consent screen prompting the user to grant permissions](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#example-1-the-user-or-tenant-admin-has-granted-permissions) which the user will be unable to do without admin access.
 
 <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/sharepoint-online.mdx)</Note>

--- a/docs-v2/snippets/microsoft-api-gotchas.mdx
+++ b/docs-v2/snippets/microsoft-api-gotchas.mdx
@@ -1,0 +1,24 @@
+-   Make sure you request the `offline_access` scope to get a refresh token and keep access with your integration.
+-   Microsoft has a unified OAuth system for their various APIs. This provider should work for most of them (e.g. Microsoft EntraID, OneNote, Onedrive, Outlook, Sharepoint Online, Microsoft Teams etc.).
+-   Microsoft offers a tool that allows you to construct and perform Graph API queries and see their response for any apps on which you have an admin, developer, or tester role. For more information you can check [Microsoft Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer).
+-   You can find permissions required for each API call in their corresponding API methods section, i.e, to retrieve a list of notebook objects from Onenote, you can have a look at [List Notebooks permissions](https://learn.microsoft.com/en-us/graph/api/onenote-list-notebooks?view=graph-rest-1.0&tabs=http#permissions).
+-   Please be aware that the Microsoft Graph API implements throttling to manage the volume of requests. For more information on handling throttling, refer to the [Microsoft Graph Throttling Guidance](https://learn.microsoft.com/en-us/graph/throttling).
+-   You can set the [`.default` scope documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) to ensure the permissions remain the same as those granted at the organization level.
+-   The `.default` scope can't be combined with the scopes registered in the Azure portal. So either just use the `.default` scope or remove it to list out explicit parameters that are required. If you attempt to combine them you'll receive the following error
+```
+.default scope can't be combined with resource-specific scopes
+```
+-   If you require a user to reauthenticate and force them to accept scopes that have been updated or changed you can force a prompt via the `authorization_params`:
+
+```typescript
+const { data } = await nango.createConnectSession({
+  [...],
+  integrations_config_defaults: {
+    "<provider-name>": {
+      authorization_params: {
+        "prompt": "consent"
+      }
+    }
+  }
+});
+```

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -6339,10 +6339,10 @@ microsoft:
     disable_pkce: true
     default_scopes:
         - offline_access
+        - .default
     authorization_params:
         response_type: code
         response_mode: query
-        prompt: consent
     token_params:
         grant_type: authorization_code
     refresh_params:


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Remove prompt for microsoft as it isn't required since permission will be prompted if consent hasn't been previously granted. [ref1](https://learn.microsoft.com/en-us/entra/identity-platform/application-consent-experience), [ref2](https://learn.microsoft.com/en-us/entra/identity-platform/howto-convert-app-to-be-multi-tenant)

## Background
This parameter was added with https://github.com/NangoHQ/nango/pull/952 which was due to #951, however in that scenario we should recommend our users to explicitly pass `authorization_params: { prompt: 'consent'}` like we recommended [here](https://github.com/NangoHQ/nango/issues/1040)

There is also a related #1371 and fix in #1374 however, upon testing Microsoft does allow you to select an account if there are multiple without the prompt param.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR removes the default `prompt=consent` parameter from Microsoft OAuth providers and adds `.default` to the default scopes. Microsoft's OAuth flow automatically prompts for permission when needed, making the explicit consent prompt unnecessary by default. Users can still force consent when needed by explicitly setting the parameter.

**Key Changes:**
• Removed `prompt=consent` from default authorization parameters in providers.yaml
• Added `.default` to the default scopes
• Created a shared Microsoft API gotchas snippet to centralize documentation
• Updated docs to show how to explicitly force consent when needed

**Affected Areas:**
• Microsoft OAuth provider configurations
• Documentation for multiple Microsoft integration providers

*This summary was automatically generated by @propel-code-bot*