### PR TITLE
fix(connect): wrong condition on preconfigured field

### DIFF
--- a/packages/connect-ui/src/views/Go.tsx
+++ b/packages/connect-ui/src/views/Go.tsx
@@ -352,7 +352,7 @@ export const Go: React.FC = () => {
                                         <FormField
                                             key={name}
                                             control={form.control}
-                                            defaultValue={isPreconfigured ?? definition?.default_value ?? ''}
+                                            defaultValue={isPreconfigured ? preconfigured[key] : (definition?.default_value ?? '')}
                                             // disabled={Boolean(definition?.hidden)} DO NOT disable it breaks the form
                                             name={name}
                                             render={({ field }) => {


### PR DESCRIPTION
## Changes

- Wrong condition on preconfigured field
It was showing a boolean instead of the string when undefined
<!-- Summary by @propel-code-bot -->

---

Fixes a bug in the connect UI where preconfigured field values were showing a boolean instead of the actual string value when the field was preconfigured.

*This summary was automatically generated by @propel-code-bot*