### PR TITLE
fix: unrecognized key 'async' when triggering on-events script

### DIFF
--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -249,8 +249,8 @@ export class OrchestratorClient {
     }
 
     public async executeOnEvent(props: ExecuteOnEventProps & { async: boolean }): Promise<VoidReturn> {
-        const { args, ...rest } = props;
-        const schedulingProps = {
+        const { args, async, ...rest } = props;
+        const schedulingProps: ImmediateProps = {
             retry: { count: 0, max: 0 },
             timeoutSettingsInSecs: {
                 createdToStarted: 30,
@@ -264,7 +264,7 @@ export class OrchestratorClient {
             }
         };
 
-        const res: Result<any, ClientError> = props.async ? await this.immediate(schedulingProps) : await this.immediateAndWait(schedulingProps);
+        const res: Result<any, ClientError> = async ? await this.immediate(schedulingProps) : await this.immediateAndWait(schedulingProps);
         if (res.isErr()) {
             return Err(res.error);
         }


### PR DESCRIPTION
Sending `async` key make the `POST /immediate` validation in orchestrator fail. 
Not sure why `z.strict` didn't catch it earlier maybe the recent addition of `z.preprocess` is the root cause. Anyway this commit ensures `async` is not sent to the orchestrator

<!-- Summary by @propel-code-bot -->

---

This PR fixes a validation error that occurs when triggering on-events scripts. The 'async' parameter was being included in the request to the orchestrator's /immediate endpoint, causing validation to fail. The fix properly destructures and excludes the 'async' parameter from the request.

*This summary was automatically generated by @propel-code-bot*