### PR TITLE
feat: adding GET /action/:id endpoint

### DIFF
--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -5,7 +5,9 @@ import { getServer } from '../server.js';
 import { OrchestratorClient } from './client.js';
 import getPort from 'get-port';
 import { EventsHandler } from '../events.js';
+import type { Result } from '@nangohq/utils';
 import { nanoid } from '@nangohq/utils';
+import type { PostImmediate } from '../routes/v1/postImmediate.js';
 
 const dbClient = getTestDbClient();
 const eventsHandler = new EventsHandler({
@@ -153,24 +155,7 @@ describe('OrchestratorClient', async () => {
 
     describe('heartbeat', () => {
         it('should be successful', async () => {
-            const scheduledTask = await client.immediate({
-                name: nanoid(),
-                group: { key: nanoid(), maxConcurrency: 0 },
-                retry: { count: 0, max: 0 },
-                timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
-                args: {
-                    type: 'action',
-                    actionName: nanoid(),
-                    connection: {
-                        id: 123,
-                        connection_id: 'C',
-                        provider_config_key: 'P',
-                        environment_id: 456
-                    },
-                    activityLogId: '789',
-                    input: { foo: 'bar' }
-                }
-            });
+            const scheduledTask = await immediateAction(client, { groupKey: nanoid() });
             const taskId = scheduledTask.unwrap().taskId;
             const beforeTask = await scheduler.get({ taskId });
             const res = await client.heartbeat({ taskId });
@@ -284,24 +269,7 @@ describe('OrchestratorClient', async () => {
     describe('succeed', () => {
         it('should support big output', async () => {
             const groupKey = nanoid();
-            const actionA = await client.immediate({
-                name: nanoid(),
-                group: { key: groupKey, maxConcurrency: 0 },
-                retry: { count: 0, max: 0 },
-                timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
-                args: {
-                    type: 'action',
-                    actionName: `A`,
-                    connection: {
-                        id: 123,
-                        connection_id: 'C',
-                        provider_config_key: 'P',
-                        environment_id: 456
-                    },
-                    activityLogId: '789',
-                    input: { foo: 'bar' }
-                }
-            });
+            const actionA = await immediateAction(client, { groupKey });
             await client.dequeue({ groupKey, limit: 1, longPolling: false });
             const res = await client.succeed({ taskId: actionA.unwrap().taskId, output: { a: 'a'.repeat(10_000_000) } });
             expect(res.isOk()).toBe(true);
@@ -309,42 +277,9 @@ describe('OrchestratorClient', async () => {
     });
     describe('search', () => {
         it('should returns task by ids', async () => {
-            const actionA = await client.immediate({
-                name: nanoid(),
-                group: { key: nanoid(), maxConcurrency: 0 },
-                retry: { count: 0, max: 0 },
-                timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
-                args: {
-                    type: 'action',
-                    actionName: `A`,
-                    connection: {
-                        id: 123,
-                        connection_id: 'C',
-                        provider_config_key: 'P',
-                        environment_id: 456
-                    },
-                    activityLogId: '789',
-                    input: { foo: 'bar' }
-                }
-            });
-            const actionB = await client.immediate({
-                name: nanoid(),
-                group: { key: nanoid(), maxConcurrency: 0 },
-                retry: { count: 0, max: 0 },
-                timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
-                args: {
-                    type: 'action',
-                    actionName: `A`,
-                    connection: {
-                        id: 123,
-                        connection_id: 'C',
-                        provider_config_key: 'P',
-                        environment_id: 456
-                    },
-                    activityLogId: '789',
-                    input: { foo: 'bar' }
-                }
-            });
+            const groupKey = nanoid();
+            const actionA = await immediateAction(client, { groupKey });
+            const actionB = await immediateAction(client, { groupKey });
             const ids = [actionA.unwrap().taskId, actionB.unwrap().taskId];
             const res = await client.searchTasks({ ids });
             expect(res.unwrap().length).toBe(2);
@@ -358,24 +293,7 @@ describe('OrchestratorClient', async () => {
         });
         it('should return scheduled tasks', async () => {
             const groupKey = nanoid();
-            const scheduledAction = await client.immediate({
-                name: nanoid(),
-                group: { key: groupKey, maxConcurrency: 0 },
-                retry: { count: 0, max: 0 },
-                timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
-                args: {
-                    type: 'action',
-                    actionName: `A`,
-                    connection: {
-                        id: 123,
-                        connection_id: 'C',
-                        provider_config_key: 'P',
-                        environment_id: 456
-                    },
-                    activityLogId: '789',
-                    input: { foo: 'bar' }
-                }
-            });
+            const scheduledAction = await immediateAction(client, { groupKey });
             const scheduledWebhook = await client.immediate({
                 name: nanoid(),
                 group: { key: groupKey, maxConcurrency: 0 },
@@ -402,7 +320,197 @@ describe('OrchestratorClient', async () => {
             expect(res.unwrap().map((task) => task.id)).toEqual([scheduledAction.unwrap().taskId, scheduledWebhook.unwrap().taskId]);
         });
     });
+    describe('getRetryOutput', () => {
+        it('should return null if retryKey does not exist', async () => {
+            const res = (
+                await client.getOutput({
+                    retryKey: '00000000-0000-0000-0000-000000000000',
+                    ownerKey: 'does-not-exist'
+                })
+            ).unwrap();
+            expect(res).toBe(null);
+        });
+        it('should return null if owner key does not match', async () => {
+            const groupKey = nanoid();
+            const ownerKey = nanoid();
+            const expectedOutput = { count: 9 };
+            let processed = false;
+
+            const processor = new MockProcessor({
+                groupKey,
+                process: async (task) => {
+                    await scheduler.succeed({ taskId: task.id, output: expectedOutput });
+                    processed = true;
+                }
+            });
+            try {
+                const task = await immediateAction(client, { groupKey, ownerKey });
+                const retryKey = task.unwrap().retryKey as string;
+                expect(retryKey).not.toBeNull();
+
+                while (!processed) {
+                    await new Promise((resolve) => setTimeout(resolve, 10));
+                }
+
+                const output = (await client.getOutput({ retryKey, ownerKey: 'another-owner' })).unwrap();
+                expect(output).toEqual(null);
+            } finally {
+                processor.stop();
+            }
+        });
+        it('should return the output of successful task (no retry)', async () => {
+            const groupKey = nanoid();
+            const ownerKey = nanoid();
+            const expectedOutput = { count: 9 };
+            let processed = false;
+
+            const processor = new MockProcessor({
+                groupKey,
+                process: async (task) => {
+                    await scheduler.succeed({ taskId: task.id, output: expectedOutput });
+                    processed = true;
+                }
+            });
+            try {
+                const task = await immediateAction(client, { groupKey, ownerKey });
+                const retryKey = task.unwrap().retryKey as string;
+                expect(retryKey).not.toBeNull();
+
+                while (!processed) {
+                    await new Promise((resolve) => setTimeout(resolve, 10));
+                }
+
+                const output = (await client.getOutput({ retryKey, ownerKey })).unwrap();
+                expect(output).toEqual(expectedOutput);
+            } finally {
+                processor.stop();
+            }
+        });
+        it('should return the output of successful retry', async () => {
+            const groupKey = nanoid();
+            const ownerKey = nanoid();
+            const expectedOutput = { count: 9 };
+            let processed = false;
+            const retryMax = 3;
+
+            const processor = new MockProcessor({
+                groupKey,
+                process: async (task) => {
+                    if (task.retryCount === retryMax) {
+                        await scheduler.succeed({ taskId: task.id, output: expectedOutput });
+                        processed = true;
+                    } else {
+                        await scheduler.fail({ taskId: task.id, error: { message: 'it failed' } });
+                    }
+                }
+            });
+            try {
+                const task = await immediateAction(client, { groupKey, ownerKey, retryMax });
+                const retryKey = task.unwrap().retryKey as string;
+                expect(retryKey).not.toBeNull();
+
+                while (!processed) {
+                    await new Promise((resolve) => setTimeout(resolve, 10));
+                }
+
+                const output = (await client.getOutput({ retryKey, ownerKey })).unwrap();
+                expect(output).toEqual(expectedOutput);
+            } finally {
+                processor.stop();
+            }
+        });
+        it('should return error when task fails', async () => {
+            const groupKey = nanoid();
+            const ownerKey = nanoid();
+            const expectedError = { message: 'it failed' };
+            let processed = false;
+
+            const processor = new MockProcessor({
+                groupKey,
+                process: async (task) => {
+                    await scheduler.fail({ taskId: task.id, error: expectedError });
+                    processed = true;
+                }
+            });
+            try {
+                const task = await immediateAction(client, { groupKey, ownerKey });
+                const retryKey = task.unwrap().retryKey as string;
+                expect(retryKey).not.toBeNull();
+
+                while (!processed) {
+                    await new Promise((resolve) => setTimeout(resolve, 10));
+                }
+
+                const res = await client.getOutput({ retryKey, ownerKey });
+                expect(res.isErr()).toBe(true);
+                if (res.isErr()) {
+                    expect(res.error.payload).toEqual(expectedError);
+                }
+            } finally {
+                processor.stop();
+            }
+        });
+        it('should return error when all attempts failed', async () => {
+            const groupKey = nanoid();
+            const ownerKey = nanoid();
+            const expectedError = { message: 'it failed' };
+            const retryMax = 3;
+            let processed = false;
+
+            const processor = new MockProcessor({
+                groupKey,
+                process: async (task) => {
+                    await scheduler.fail({ taskId: task.id, error: expectedError });
+                    if (task.retryCount === retryMax) {
+                        processed = true;
+                    }
+                }
+            });
+            try {
+                const task = await immediateAction(client, { groupKey, ownerKey, retryMax });
+                const retryKey = task.unwrap().retryKey as string;
+                expect(retryKey).not.toBeNull();
+
+                while (!processed) {
+                    await new Promise((resolve) => setTimeout(resolve, 10));
+                }
+
+                const res = await client.getOutput({ retryKey, ownerKey });
+                expect(res.isErr()).toBe(true);
+                if (res.isErr()) {
+                    expect(res.error.payload).toEqual(expectedError);
+                }
+            } finally {
+                processor.stop();
+            }
+        });
+    });
 });
+
+async function immediateAction(
+    client: OrchestratorClient,
+    props: { groupKey: string; retryMax?: number; ownerKey?: string | undefined }
+): Promise<Result<PostImmediate['Success']>> {
+    return client.immediate({
+        name: nanoid(),
+        group: { key: props.groupKey, maxConcurrency: 0 },
+        retry: { count: 0, max: props.retryMax || 0 },
+        ...(props.ownerKey ? { ownerKey: props.ownerKey } : {}),
+        timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
+        args: {
+            type: 'action',
+            actionName: nanoid(),
+            connection: {
+                id: 123,
+                connection_id: 'C',
+                provider_config_key: 'P',
+                environment_id: 456
+            },
+            activityLogId: '789',
+            input: { foo: 'bar' }
+        }
+    });
+}
 
 class MockProcessor {
     private interval;

--- a/packages/orchestrator/lib/routes/v1/postImmediate.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediate.ts
@@ -32,7 +32,7 @@ export type PostImmediate = Endpoint<{
         args: JsonValue & { type: TaskType };
     };
     Error: ApiError<'immediate_failed'>;
-    Success: { taskId: string };
+    Success: { taskId: string; retryKey: string | null };
 }>;
 
 const validate = validateRequest<PostImmediate>({
@@ -110,7 +110,7 @@ const handler = (scheduler: Scheduler) => {
             res.status(500).json({ error: { code: 'immediate_failed', message: task.error.message } });
             return;
         }
-        res.status(200).json({ taskId: task.value.id });
+        res.status(200).json({ taskId: task.value.id, retryKey: task.value.retryKey });
         return;
     };
 };

--- a/packages/orchestrator/lib/routes/v1/retries/retryKey/getOutput.ts
+++ b/packages/orchestrator/lib/routes/v1/retries/retryKey/getOutput.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+import type { JsonValue } from 'type-fest';
+import type { Scheduler, TaskState } from '@nangohq/scheduler';
+import type { Endpoint } from '@nangohq/types';
+import type { EndpointRequest, EndpointResponse, RouteHandler, Route } from '@nangohq/utils';
+import { validateRequest } from '@nangohq/utils';
+
+type GetRetryOutput = Endpoint<{
+    Method: typeof method;
+    Path: typeof path;
+    Params: {
+        retryKey: string;
+    };
+    Querystring: {
+        ownerKey: string;
+    };
+    Success: { state: TaskState; output: JsonValue } | { state: 'no_tasks' } | { state: 'in_progress' };
+}>;
+
+const path = '/v1/retries/:retryKey/output';
+const method = 'GET';
+
+const validate = validateRequest<GetRetryOutput>({
+    parseQuery: (data) =>
+        z
+            .object({ ownerKey: z.string().min(1) })
+            .strict()
+            .parse(data),
+    parseParams: (data) => z.object({ retryKey: z.string().uuid() }).strict().parse(data)
+});
+
+const handler = (scheduler: Scheduler) => {
+    return async (req: EndpointRequest<GetRetryOutput>, res: EndpointResponse<GetRetryOutput>) => {
+        const tasks = await scheduler.searchTasks({ retryKey: req.params.retryKey, ownerKey: req.query.ownerKey });
+        if (tasks.isErr()) {
+            res.status(500).send({ error: { code: 'server_error', message: 'Failed to fetch tasks' } });
+            return;
+        }
+        if (tasks.value.length === 0) {
+            res.status(200).send({ state: 'no_tasks' });
+            return;
+        }
+        for (const task of tasks.value) {
+            if (!task.terminated) {
+                continue;
+            }
+            if (task.retryCount === task.retryMax || task.state === 'SUCCEEDED') {
+                res.send({
+                    state: task.state,
+                    output: task.output
+                });
+                return;
+            }
+        }
+        res.status(200).send({ state: 'in_progress' });
+        return;
+    };
+};
+
+export const route: Route<GetRetryOutput> = { path, method };
+
+export const routeHandler = (scheduler: Scheduler): RouteHandler<GetRetryOutput> => {
+    return {
+        ...route,
+        validate,
+        handler: handler(scheduler)
+    };
+};

--- a/packages/orchestrator/lib/server.ts
+++ b/packages/orchestrator/lib/server.ts
@@ -11,6 +11,7 @@ import { routeHandler as putTaskHandler } from './routes/v1/tasks/putTaskId.js';
 import { routeHandler as getHealthHandler } from './routes/getHealth.js';
 import { routeHandler as getOutputHandler } from './routes/v1/tasks/taskId/getOutput.js';
 import { routeHandler as postHeartbeatHandler } from './routes/v1/tasks/taskId/postHeartbeat.js';
+import { routeHandler as getRetryOutputHandler } from './routes/v1/retries/retryKey/getOutput.js';
 import { getLogger, createRoute, requestLoggerMiddleware } from '@nangohq/utils';
 import type { Scheduler } from '@nangohq/scheduler';
 import type { ApiError } from '@nangohq/types';
@@ -42,6 +43,7 @@ export const getServer = (scheduler: Scheduler, eventEmmiter: EventEmitter): Exp
     createRoute(server, getOutputHandler(scheduler, eventEmmiter));
     createRoute(server, postHeartbeatHandler(scheduler));
     createRoute(server, postDequeueHandler(scheduler, eventEmmiter));
+    createRoute(server, getRetryOutputHandler(scheduler));
 
     server.use((err: any, _req: Request, res: Response<ApiError<'invalid_json' | 'internal_error' | 'payload_too_big'>>, _next: NextFunction) => {
         if (err instanceof SyntaxError && 'body' in err && 'type' in err && err.type === 'entity.parse.failed') {

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -150,7 +150,15 @@ export async function get(db: knex.Knex, taskId: string): Promise<Result<Task>> 
 
 export async function search(
     db: knex.Knex,
-    params?: { ids?: string[]; groupKey?: string; states?: TaskState[]; scheduleId?: string; limit?: number }
+    params?: {
+        ids?: string[];
+        groupKey?: string;
+        states?: TaskState[];
+        scheduleId?: string;
+        retryKey?: string;
+        ownerKey?: string;
+        limit?: number;
+    }
 ): Promise<Result<Task[]>> {
     const query = db.from<DbTask>(TASKS_TABLE);
     if (params?.ids) {
@@ -164,6 +172,12 @@ export async function search(
     }
     if (params?.scheduleId) {
         query.where('schedule_id', params.scheduleId);
+    }
+    if (params?.retryKey) {
+        query.where('retry_key', params.retryKey);
+    }
+    if (params?.ownerKey) {
+        query.where('owner_key', params.ownerKey);
     }
     const limit = params?.limit || 100;
     const tasks = await query.limit(limit).orderBy('id');

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -96,10 +96,22 @@ export class Scheduler {
      * @param params.ids - Task IDs
      * @param params.groupKey - Group key
      * @param params.state - Task state
+     * @param params.scheduleId - Schedule ID
+     * @param params.retryKey - Retry key
+     * @param params.ownerKey - Owner key
+     * @param params.limit - Limit
      * @example
      * const tasks = await scheduler.search({ groupKey: 'test', state: 'CREATED' });
      */
-    public async searchTasks(params?: { ids?: string[]; groupKey?: string; state?: TaskState; scheduleId?: string; limit?: number }): Promise<Result<Task[]>> {
+    public async searchTasks(params?: {
+        ids?: string[];
+        groupKey?: string;
+        state?: TaskState;
+        scheduleId?: string;
+        retryKey?: string;
+        ownerKey?: string;
+        limit?: number;
+    }): Promise<Result<Task[]>> {
         return tasks.search(this.dbClient.db, params);
     }
 

--- a/packages/server/lib/controllers/action/getAsyncActionResult.integration.test.ts
+++ b/packages/server/lib/controllers/action/getAsyncActionResult.integration.test.ts
@@ -1,0 +1,48 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { isError, runServer, shouldBeProtected } from '../../utils/tests.js';
+import { seeders } from '@nangohq/shared';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+const endpoint = '/action/:id';
+
+describe(`GET ${endpoint}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(endpoint, {
+            method: 'GET',
+            params: { id: '00000000-0000-0000-0000-000000000000' }
+        });
+
+        shouldBeProtected(res);
+    });
+
+    it('should validate request', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(endpoint, {
+            method: 'GET',
+            token: env.secret_key,
+            params: { id: 'not-uuid' }
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'invalid_uri_params',
+                errors: [
+                    {
+                        code: 'invalid_string',
+                        message: 'Invalid uuid',
+                        path: ['id']
+                    }
+                ]
+            }
+        });
+    });
+});

--- a/packages/server/lib/controllers/action/getAsyncActionResult.ts
+++ b/packages/server/lib/controllers/action/getAsyncActionResult.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import type { GetAsyncActionResult } from '@nangohq/types';
+import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { getOrchestrator } from '../../utils/utils.js';
+import { zodErrorToHTTP } from '@nangohq/utils';
+import { errorManager } from '@nangohq/shared';
+
+const orchestrator = getOrchestrator();
+
+const paramValidation = z
+    .object({
+        id: z.string().uuid()
+    })
+    .strict();
+
+export const getAsyncActionResult = asyncWrapper<GetAsyncActionResult>(async (req, res) => {
+    const paramValue = paramValidation.safeParse(req.params);
+    if (!paramValue.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(paramValue.error) } });
+        return;
+    }
+
+    const { environment } = res.locals;
+    const retryKey = paramValue.data.id;
+    const result = await orchestrator.getActionOutput({ retryKey, environmentId: environment.id });
+
+    if (result.isErr()) {
+        errorManager.errResFromNangoErr(res, result.error);
+        return;
+    }
+
+    if (result.value === null) {
+        res.status(404).json({ error: { code: 'not_found', message: `No action '${retryKey}' found` } });
+        return;
+    }
+
+    res.status(200).json(result.value as GetAsyncActionResult['Success']);
+});

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -240,19 +240,7 @@ class SyncController {
                 span.setTag('nango.error', actionResponse.error);
                 await logCtx.failed();
 
-                if (actionResponse.error.type === 'script_http_error') {
-                    res.status(424).json({
-                        error: {
-                            payload: actionResponse.error.payload,
-                            code: actionResponse.error.type,
-                            ...(actionResponse.error.additional_properties && 'upstream_response' in actionResponse.error.additional_properties
-                                ? { upstream: actionResponse.error.additional_properties['upstream_response'] }
-                                : {})
-                        }
-                    });
-                } else {
-                    errorManager.errResFromNangoErr(res, actionResponse.error);
-                }
+                errorManager.errResFromNangoErr(res, actionResponse.error);
 
                 span.finish();
                 return;

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -61,6 +61,7 @@ import { resourceCapping } from './middleware/resource-capping.middleware.js';
 import { isBinaryContentType } from './utils/utils.js';
 
 import type { Request, RequestHandler } from 'express';
+import { getAsyncActionResult } from './controllers/action/getAsyncActionResult.js';
 
 const apiAuth: RequestHandler[] = [authMiddleware.secretKeyAuth.bind(authMiddleware), rateLimiterMiddleware];
 const connectSessionAuth: RequestHandler[] = [authMiddleware.connectSessionAuth.bind(authMiddleware), rateLimiterMiddleware];
@@ -227,6 +228,7 @@ publicAPI.route('/scripts/config').get(apiAuth, getPublicScriptsConfig);
 
 publicAPI.use('/action', jsonContentTypeMiddleware);
 publicAPI.route('/action/trigger').post(apiAuth, syncController.triggerAction.bind(syncController)); //TODO: to deprecate
+publicAPI.route('/action/:id').get(apiAuth, getAsyncActionResult);
 
 publicAPI.use('/connect', jsonContentTypeMiddleware);
 publicAPI.route('/connect/sessions').post(apiAuth, postConnectSessions);

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -51,6 +51,7 @@ export interface RecordsServiceInterface {
     getRecordCountsByModel({ connectionId, environmentId }: { connectionId: number; environmentId: number }): Promise<Result<Record<string, RecordCount>>>;
 }
 
+// TODO: move to @nangohq/types (with the rest of the ochestrator public types)
 export interface OrchestratorClientInterface {
     recurring(props: RecurringProps): Promise<Result<{ scheduleId: string }>>;
     executeAction(props: ExecuteActionProps): Promise<ExecuteReturn>;
@@ -63,6 +64,7 @@ export interface OrchestratorClientInterface {
     updateSyncFrequency({ scheduleName, frequencyMs }: { scheduleName: string; frequencyMs: number }): Promise<VoidReturn>;
     cancel({ taskId, reason }: { taskId: string; reason: string }): Promise<Result<OrchestratorTask>>;
     searchSchedules({ scheduleNames, limit }: { scheduleNames: string[]; limit: number }): Promise<SchedulesReturn>;
+    getOutput({ retryKey, ownerKey }: { retryKey: string; ownerKey: string }): Promise<ExecuteReturn>;
 }
 
 const ScheduleName = {
@@ -154,7 +156,7 @@ export class Orchestrator {
             const actionResult = await this.client.executeAction({
                 name: executionId,
                 group: { key: groupKey, maxConcurrency: 0 },
-                ownerKey: `environment:${connection.environment_id}`,
+                ownerKey: getActionOwnerKey(connection.environment_id),
                 args
             });
 
@@ -459,6 +461,23 @@ export class Orchestrator {
             metrics.duration(metrics.Types.ON_EVENT_SCRIPT_RUNTIME, totalRunTime);
             span.finish();
         }
+    }
+
+    async getActionOutput(props: { retryKey: string; environmentId: number }): Promise<Result<JsonValue, NangoError>> {
+        const res = await this.client.getOutput({
+            retryKey: props.retryKey,
+            ownerKey: getActionOwnerKey(props.environmentId)
+        });
+        if (res.isErr()) {
+            return Err(
+                deserializeNangoError(res.error.payload) ||
+                    new NangoError('action_script_failure', {
+                        error: res.error.message,
+                        ...(res.error.payload ? { payload: res.error.payload } : {})
+                    })
+            );
+        }
+        return Ok(res.value);
     }
 
     async updateSyncFrequency({
@@ -776,4 +795,8 @@ export class Orchestrator {
 
         return Ok(intervalMs);
     }
+}
+
+function getActionOwnerKey(environmentId: number): string {
+    return `environment:${environmentId}`;
 }

--- a/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
@@ -27,7 +27,8 @@ const orchestratorClientNoop: OrchestratorClientInterface = {
     unpauseSync: () => Promise.resolve({}) as any,
     deleteSync: () => Promise.resolve({}) as any,
     updateSyncFrequency: () => Promise.resolve({}) as any,
-    searchSchedules: () => Promise.resolve({}) as any
+    searchSchedules: () => Promise.resolve({}) as any,
+    getOutput: () => Promise.resolve({}) as any
 };
 const mockOrchestrator = new Orchestrator(orchestratorClientNoop);
 

--- a/packages/shared/lib/utils/error.manager.ts
+++ b/packages/shared/lib/utils/error.manager.ts
@@ -43,7 +43,17 @@ class ErrorManager {
     public errResFromNangoErr(res: Response, err: NangoError | null) {
         if (err) {
             logger.error(`Response error`, errorToObject(err));
-            if (!err.message) {
+            if (err.type === 'script_http_error') {
+                res.status(424).json({
+                    error: {
+                        payload: err.payload,
+                        code: err.type,
+                        ...(err.additional_properties && 'upstream_response' in err.additional_properties
+                            ? { upstream: err.additional_properties['upstream_response'] }
+                            : {})
+                    }
+                });
+            } else if (!err.message) {
                 res.status(err.status || 500).send({
                     error: { code: err.type || 'unknown_error', payload: err.payload, additional_properties: err.additional_properties }
                 });

--- a/packages/types/lib/action/api.ts
+++ b/packages/types/lib/action/api.ts
@@ -1,0 +1,10 @@
+import type { Endpoint } from '../api';
+
+export type GetAsyncActionResult = Endpoint<{
+    Method: 'GET';
+    Path: `/action/:id`;
+    Params: {
+        id: string;
+    };
+    Success: Record<string, any>;
+}>;

--- a/packages/types/lib/action/api.ts
+++ b/packages/types/lib/action/api.ts
@@ -6,5 +6,8 @@ export type GetAsyncActionResult = Endpoint<{
     Params: {
         id: string;
     };
+    // This endpoint can actually return any json value (not just object)
+    // but Endpoint definition is not flexible enough to support that.
+    // TODO: fix Endpoint definition to support any json value
     Success: Record<string, any>;
 }>;

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -9,6 +9,7 @@ import type {
     PostSignup,
     PutResetPassword
 } from './account/api';
+import type { GetAsyncActionResult } from './action/api';
 import type { EndpointMethod } from './api';
 import type {
     PostPublicApiKeyAuthorization,
@@ -107,7 +108,8 @@ export type PublicApiEndpoints =
     | PostPublicConnectTelemetry
     | PutPublicSyncConnectionFrequency
     | PostPublicIntegration
-    | PatchPublicIntegration;
+    | PatchPublicIntegration
+    | GetAsyncActionResult;
 
 export type PrivateApiEndpoints =
     | PostSignup

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -9,6 +9,7 @@ export type * from './logs/api.js';
 export type * from './logs/messages.js';
 export type * from './keystore/index.js';
 
+export type * from './action/api.js';
 export type * from './account/api.js';
 export type * from './user/api.js';
 export type * from './user/db.js';


### PR DESCRIPTION
GET /action/:id allows to retrieve the output of an action `id` is tasks retryKey

if action (including retries) isn't completed yet, the endpoint returns a 404: `{ error: 'not_found', message: '...' }`
if action (or retries) is successful, the endpoint returns the same response as if it was trigger synchronously
if action failed, it returns a 500 or 424, the same as if it has been triggerred synchronously:
```
{ "error":
   {
      "message":"An internal error occurred during the script execution",
      "code":"script_internal_error",
      "payload":{
         "message":"...", ...
      }
   }
}
```

# How to test
The endpoint to trigger the action async and return the `id` doesn't exist yet. That's my next task.
To test locally:
1. trigger an action
2. get the  `retryKey` from the db
3. call the endpoint with the retryKey as the `id`

<!-- Summary by @propel-code-bot -->

---

This PR adds a new endpoint `GET /action/:id` that allows retrieving the output of an asynchronous action using a task's retry key as the ID parameter. The endpoint follows the same error handling patterns as synchronous actions, returning appropriate status codes based on the action's completion state.

**Key Changes:**
• Added new GET /action/:id endpoint for retrieving action outputs
• Extended OrchestratorClient to support getOutput for actions by retry key
• Enhanced scheduler to support searching tasks by retryKey and ownerKey
• Added retryKey to PostImmediate response

**Affected Areas:**
• Orchestrator client and routes
• Server controllers and routes
• Task search and retry functionality

*This summary was automatically generated by @propel-code-bot*