### PR TITLE
feat(integrations): handle hubspot rate limiting

### DIFF
--- a/docs-v2/integrations/all/hubspot.mdx
+++ b/docs-v2/integrations/all/hubspot.mdx
@@ -53,13 +53,13 @@ import PreBuiltUseCases from "/snippets/generated/hubspot/PreBuiltUseCases.mdx"
 | - | - | 
 | General | [Website](https://www.hubspot.com/) |
 | | [Create a test account](https://app.hubspot.com/signup-hubspot/crm) |
-| Developer | [API documentation](https://developers.hubspot.com/beta-docs/reference/api/overview) |
+| Developer | [API documentation](https://developers.hubspot.com/docs/reference/api/overview) |
 | | [Create a developer account](https://app.hubspot.com/signup-hubspot/developers) |
 | | [Developer console](https://app.hubspot.com/) |
 | | [Authorization documentation](https://developers.hubspot.com/docs/api/oauth-quickstart-guide) |
 | | [Register an OAuth app](https://developers.hubspot.com/docs/api/working-with-oauth#initiating-an-integration-with-oauth-2-0) |
 | | [List of OAuth scopes](https://developers.hubspot.com/docs/api/working-with-oauth#scopes) |
-| | [Details on rate limits](https://developers.hubspot.com/beta-docs/guides/apps/api-usage/usage-details) |
+| | [Details on rate limits](https://developers.hubspot.com/docs/guides/apps/api-usage/usage-details#rate-limits) |
 
 <Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/hubspot.mdx)</Note>
 

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -5177,6 +5177,8 @@ hubspot:
     post_connection_script: hubspotPostConnection
     webhook_routing_script: hubspotWebhookRouting
     proxy:
+        retry:
+            remaining: 'x-hubspot-ratelimit-remaining'
         base_url: https://api.hubapi.com
         decompress: true
         paginate:


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR adds rate limit handling for HubSpot integration by configuring the retry mechanism to use the 'x-hubspot-ratelimit-remaining' header. It also updates documentation with correct API links and rate limit information.

*This summary was automatically generated by @propel-code-bot*