### PR TITLE
fix(docs): add mention of smtp for self-hosted and remove Mailgun

### DIFF
--- a/docs-v2/guides/self-hosting/infrastructure.mdx
+++ b/docs-v2/guides/self-hosting/infrastructure.mdx
@@ -34,9 +34,9 @@ The primary differences are:
 
 ### Email service
 
-Nango uses Mailgun exclusively for password reset emails. 
+Nango uses emails for account verification, password reset, and sending invitations, etc...
 
-For self-hosted instances, we provide a default Mailgun API key, but you can configure your own if preferred.
+Any SMTP server can be configured to be used by Nango for these email communications.
 
 <Tip>
 **Questions, problems, feedback?** Please reach out in the [Slack community](https://nango.dev/slack).


### PR DESCRIPTION
Mailgun is not a dependency for self-hosted anymore. Customers can now plug any smtp server. 
This commit removes mention of Mailgun in the self-hosted docs

<!-- Summary by @propel-code-bot -->

---

This PR updates the self-hosting infrastructure documentation to reflect that Nango no longer uses Mailgun exclusively and now supports any SMTP server for email communications. It removes specific Mailgun references and clarifies the email service requirements.

*This summary was automatically generated by @propel-code-bot*