### PR TITLE
fix: fix processor flacky test

### DIFF
--- a/packages/orchestrator/lib/clients/processor.integration.test.ts
+++ b/packages/orchestrator/lib/clients/processor.integration.test.ts
@@ -67,20 +67,23 @@ describe('OrchestratorProcessor', () => {
 });
 
 async function processN(handler: (task: OrchestratorTask) => Promise<Result<void>>, groupKey: string, n: number) {
+    let processCount = 0;
     const processor = new OrchestratorProcessor({
-        handler,
+        handler: (task: OrchestratorTask) => {
+            processCount++;
+            return handler(task);
+        },
         opts: { orchestratorClient, groupKey, maxConcurrency: n, checkForTerminatedInterval: 100 }
     });
     processor.start({ tracer });
     for (let i = 0; i < n; i++) {
         await immediateTask({ groupKey });
     }
-    // Wait so the processor can process all tasks
-    while (processor.queueSize() > 0) {
+    // wait for all tasks to be processed
+    while (processCount < n) {
         await setTimeout(100);
     }
-    await setTimeout(500);
-
+    processor.stop();
     return processor;
 }
 


### PR DESCRIPTION
This tasks processor flacky test has been bothering me for a loooong time. Finally managed to reproduce and fix it.

The test relied on the processor's internal queue being empty to determine if all tasks were processed, which is flawed. The queue only tracks dequeued tasks, not whether all pending tasks have been processed.

This fix implements an explicit count to verify the handler has been called the expected number of times before completing the test. 
A alternative fix would be to start the processor after all the tasks have been added so all the tasks are dequeued at once but it is less representative of real-world usage.

<!-- Summary by @propel-code-bot -->

---

This PR fixes a flaky test in the tasks processor by replacing an unreliable queue size check with an explicit counter. The test now accurately counts when handler functions are executed rather than relying on the processor's internal queue state.

*This summary was automatically generated by @propel-code-bot*