### PR TITLE
fix(providers): fix lever authorization params

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -5904,8 +5904,7 @@ lever:
     token_url: https://auth.lever.co/oauth/token
     authorization_params:
         response_type: code
-        prompt: consent
-        audience: https://api.lever.co/v1
+        audience: https://api.lever.co/v1/
     proxy:
         base_url: https://api.lever.co
     docs: https://docs.nango.dev/integrations/all/lever


### PR DESCRIPTION
## Describe the problem and your solution

- According to the docs provided;

1. https://hire.lever.co/developer/documentation#authentication
2. https://hire.lever.co/developer/oauth#getting-set-up-with-oauth

- Lever requires a backslash at the end of the audience, and there is also no prompt: consent parameter.

This is untested. 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR fixes the Lever OAuth provider configuration by adding a required trailing slash to the audience URL and removing the unnecessary 'prompt: consent' parameter. These changes align with Lever's official documentation requirements.

*This summary was automatically generated by @propel-code-bot*