### PR TITLE
feat: add async actions function to node-client

### DIFF
--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -939,7 +939,7 @@ export class Nango {
      * @param props - The properties of the action to retrieve the result for (id and/or statusUrl)
      * @returns A promise that resolves with the result of the action
      */
-    public async getAsyncActionResult<Out = object>(props: Partial<Awaited<ReturnType<Nango['triggerActionAsync']>>>): Promise<Out> {
+    public async getAsyncActionResult<Out = unknown>(props: Partial<Awaited<ReturnType<Nango['triggerActionAsync']>>>): Promise<Out> {
         if (!props.id && !props.statusUrl) {
             throw new Error('Either id or statusUrl must be provided');
         }


### PR DESCRIPTION
Adding `triggerActionAsync` and `getActionAsyncResult` functions to Nango node-client
<!-- Summary by @propel-code-bot -->

---

This PR introduces support for asynchronous action execution in the Nango node-client. A new private helper method (_triggerAction) consolidates logic for both synchronous and asynchronous workflows, toggled via an 'X-Async' header. Two new public methods are exposed: triggerActionAsync, which starts an async action and returns an id and statusUrl, and getAsyncActionResult, which polls for completion using either the id or statusUrl. The existing triggerAction method is refactored to utilize the shared helper without affecting its original synchronous behavior. Type annotations are extended to support these changes.

**Key Changes:**
• Adds private _triggerAction<In, Out> helper method to unify sync/async logic
• Refactors triggerAction<In, Out> to use _triggerAction with async=false
• Introduces triggerActionAsync<In> method with async behavior (sets X-Async header)
• Adds getAsyncActionResult<Out> for polling async action completion
• Improves typings for async action result handling

**Affected Areas:**
• packages/node-client/lib/index.ts (action-triggering methods and exports)

*This summary was automatically generated by @propel-code-bot*