### PR TITLE
feat: add on_async_action_completion column to webhook table

### DIFF
--- a/packages/database/lib/migrations/20250516155900_async_action_webhook.cjs
+++ b/packages/database/lib/migrations/20250516155900_async_action_webhook.cjs
@@ -1,0 +1,11 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE "_nango_external_webhooks" ADD COLUMN "on_async_action_completion" boolean DEFAULT true`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};


### PR DESCRIPTION
We want to send webhook when async actions complete. Adding a column in the db to store the setting value
<!-- Summary by @propel-code-bot -->

---

This PR adds a new boolean column `on_async_action_completion` to the `_nango_external_webhooks` table with a default value of true. This change enables the system to track whether webhooks should be sent when asynchronous actions are completed.

*This summary was automatically generated by @propel-code-bot*