### PR TITLE
feat: send webhook when async actions complete

### DIFF
--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -1,4 +1,5 @@
 import db from '@nangohq/database';
+import type { LogContext } from '@nangohq/logs';
 import { logContextGetter } from '@nangohq/logs';
 import {
     ErrorSourceEnum,
@@ -7,6 +8,7 @@ import {
     configService,
     environmentService,
     errorManager,
+    externalWebhookService,
     getApiUrl,
     getEndUserByConnectionId,
     getSyncConfigRaw
@@ -23,6 +25,7 @@ import type { Config } from '@nangohq/shared';
 import type { ConnectionJobs, DBEnvironment, DBSyncConfig, DBTeam, NangoProps } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { JsonValue } from 'type-fest';
+import { sendAsyncActionWebhook } from '@nangohq/webhooks';
 
 export async function startAction(task: TaskAction): Promise<Result<void>> {
     let account: DBTeam | undefined;
@@ -129,10 +132,34 @@ export async function startAction(task: TaskAction): Promise<Result<void>> {
     }
 }
 export async function handleActionSuccess({ taskId, nangoProps, output }: { taskId: string; nangoProps: NangoProps; output: JsonValue }): Promise<void> {
-    const task = await setTaskSuccess({ taskId, output });
-
     const logCtx = logContextGetter.get({ id: nangoProps.activityLogId, accountId: nangoProps.team.id });
+    const { environment, account } = (await environmentService.getAccountAndEnvironment({ environmentId: nangoProps.environmentId })) || {
+        environment: undefined,
+        account: undefined
+    };
 
+    const task = await setTaskSuccess({ taskId, output });
+    if (task.isErr()) {
+        onFailure({
+            connection: {
+                id: nangoProps.nangoConnectionId,
+                connection_id: nangoProps.connectionId,
+                environment_id: nangoProps.environmentId,
+                provider_config_key: nangoProps.providerConfigKey
+            },
+            syncName: nangoProps.syncConfig.sync_name,
+            provider: nangoProps.provider,
+            providerConfigKey: nangoProps.providerConfigKey,
+            activityLogId: nangoProps.activityLogId,
+            runTime: (new Date().getTime() - nangoProps.startedAt.getTime()) / 1000,
+            error: new NangoError('action_script_failure', { error: task.error }),
+            team: account,
+            environment: environment,
+            syncConfig: nangoProps.syncConfig,
+            endUser: nangoProps.endUser
+        });
+        return;
+    }
     void logCtx.info(`The action was successfully run${formatAttempts(task)}`, {
         action: nangoProps.syncConfig.sync_name,
         connection: nangoProps.connectionId,
@@ -154,6 +181,14 @@ export async function handleActionSuccess({ taskId, nangoProps, output }: { task
         type: 'action',
         originalActivityLogId: nangoProps.activityLogId as unknown as string,
         provider: nangoProps.provider
+    });
+
+    await sendWebhookIfNeeded({
+        environment,
+        connectionId: nangoProps.connectionId,
+        providerConfigKey: nangoProps.providerConfigKey,
+        task: task.value,
+        logCtx
     });
 
     void bigQueryClient.insert({
@@ -179,13 +214,34 @@ export async function handleActionSuccess({ taskId, nangoProps, output }: { task
 }
 
 export async function handleActionError({ taskId, nangoProps, error }: { taskId: string; nangoProps: NangoProps; error: NangoError }): Promise<void> {
-    const task = await setTaskFailed({ taskId, error });
-
     const accountAndEnv = await environmentService.getAccountAndEnvironment({ environmentId: nangoProps.environmentId });
     if (!accountAndEnv) {
         throw new Error(`Account and environment not found`);
     }
     const { account, environment } = accountAndEnv;
+
+    const task = await setTaskFailed({ taskId, error });
+    if (task.isErr()) {
+        onFailure({
+            connection: {
+                id: nangoProps.nangoConnectionId,
+                connection_id: nangoProps.connectionId,
+                environment_id: nangoProps.environmentId,
+                provider_config_key: nangoProps.providerConfigKey
+            },
+            syncName: nangoProps.syncConfig.sync_name,
+            provider: nangoProps.provider,
+            providerConfigKey: nangoProps.providerConfigKey,
+            activityLogId: nangoProps.activityLogId,
+            runTime: (new Date().getTime() - nangoProps.startedAt.getTime()) / 1000,
+            error: new NangoError('action_script_failure', { error: task.error }),
+            team: account,
+            environment: environment,
+            syncConfig: nangoProps.syncConfig,
+            endUser: nangoProps.endUser
+        });
+        return;
+    }
 
     const logCtx = logContextGetter.get({ id: nangoProps.activityLogId, accountId: account.id });
 
@@ -196,9 +252,15 @@ export async function handleActionError({ taskId, nangoProps, error }: { taskId:
         integration: nangoProps.providerConfigKey
     });
 
-    // fail the log operation if this is the last attempt
-    if (task.isOk() && task.value.attempt === task.value.attemptMax) {
+    if (task.value.attempt === task.value.attemptMax) {
         void logCtx.failed();
+        await sendWebhookIfNeeded({
+            environment,
+            connectionId: nangoProps.connectionId,
+            providerConfigKey: nangoProps.providerConfigKey,
+            task: task.value,
+            logCtx
+        });
     }
 
     onFailure({
@@ -300,4 +362,39 @@ function formatAttempts(task: OrchestratorTask | Result<OrchestratorTask>): stri
         return '';
     }
     return t.attemptMax > 1 ? ` (attempt ${t.attempt}/${t.attemptMax})` : '';
+}
+
+async function sendWebhookIfNeeded({
+    environment,
+    connectionId,
+    providerConfigKey,
+    task,
+    logCtx
+}: {
+    environment: DBEnvironment | undefined;
+    connectionId: string;
+    providerConfigKey: string;
+    task: OrchestratorTask;
+    logCtx: LogContext;
+}) {
+    if (!task.isAction()) {
+        return;
+    }
+    if (!environment || !task.retryKey || !task.async) {
+        return;
+    }
+    const webhookSettings = await externalWebhookService.get(environment.id);
+    if (webhookSettings) {
+        await sendAsyncActionWebhook({
+            environment: environment,
+            connectionId: connectionId,
+            providerConfigKey: providerConfigKey,
+            payload: {
+                id: task.retryKey,
+                statusUrl: `/action/${task.retryKey}`
+            },
+            webhookSettings,
+            logCtx
+        });
+    }
 }

--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -184,6 +184,7 @@ const runJob = async (
         syncName: sync.name,
         syncVariant: 'base',
         groupKey: 'group-key',
+        retryKey: 'retry-key',
         attempt: 1,
         attemptMax: 1,
         state: 'CREATED',

--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -190,7 +190,8 @@ describe('OrchestratorClient', async () => {
                             environment_id: 5678
                         },
                         activityLogId: '9876',
-                        input: { foo: 'bar' }
+                        input: { foo: 'bar' },
+                        async: false
                     }
                 });
                 expect(res.unwrap()).toEqual(output);
@@ -221,7 +222,8 @@ describe('OrchestratorClient', async () => {
                             environment_id: 5678
                         },
                         activityLogId: '9876',
-                        input: { foo: 'bar' }
+                        input: { foo: 'bar' },
+                        async: false
                     }
                 });
                 expect(res.isOk()).toBe(false);

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -29,6 +29,7 @@ interface ActionArgs {
     connection: ConnectionJobs;
     activityLogId: string;
     input: JsonValue;
+    async: boolean;
 }
 interface WebhookArgs {
     webhookName: string;
@@ -73,6 +74,7 @@ interface TaskCommonFields {
     attempt: number;
     attemptMax: number;
     ownerKey: string | null;
+    retryKey: string | null;
 }
 interface TaskCommon extends TaskCommonFields {
     isSync(this: OrchestratorTask): this is TaskSync;
@@ -89,6 +91,7 @@ export function TaskAbort(props: TaskCommonFields & AbortArgs): TaskAbort {
         abortedTask: props.abortedTask,
         name: props.name,
         state: props.state,
+        retryKey: props.retryKey,
         attempt: props.attempt,
         attemptMax: props.attemptMax,
         connection: props.connection,
@@ -110,6 +113,7 @@ export function TaskSync(props: TaskCommonFields & SyncArgs): TaskSync {
         id: props.id,
         name: props.name,
         state: props.state,
+        retryKey: props.retryKey,
         attempt: props.attempt,
         attemptMax: props.attemptMax,
         syncId: props.syncId,
@@ -135,6 +139,7 @@ export function TaskSyncAbort(props: TaskCommonFields & SyncArgs & AbortArgs): T
         abortedTask: props.abortedTask,
         name: props.name,
         state: props.state,
+        retryKey: props.retryKey,
         attempt: props.attempt,
         attemptMax: props.attemptMax,
         syncId: props.syncId,
@@ -161,6 +166,7 @@ export function TaskAction(props: TaskCommonFields & ActionArgs): TaskAction {
         name: props.name,
         state: props.state,
         attempt: props.attempt,
+        retryKey: props.retryKey,
         attemptMax: props.attemptMax,
         actionName: props.actionName,
         connection: props.connection,
@@ -168,6 +174,7 @@ export function TaskAction(props: TaskCommonFields & ActionArgs): TaskAction {
         input: props.input,
         groupKey: props.groupKey,
         ownerKey: props.ownerKey,
+        async: props.async,
         isSync: (): this is TaskSync => false,
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => true,
@@ -183,6 +190,7 @@ export function TaskWebhook(props: TaskCommonFields & WebhookArgs): TaskWebhook 
         id: props.id,
         name: props.name,
         state: props.state,
+        retryKey: props.retryKey,
         attempt: props.attempt,
         attemptMax: props.attemptMax,
         webhookName: props.webhookName,
@@ -207,6 +215,7 @@ export function TaskOnEvent(props: TaskCommonFields & OnEventArgs): TaskOnEvent 
         id: props.id,
         state: props.state,
         name: props.name,
+        retryKey: props.retryKey,
         attempt: props.attempt,
         attemptMax: props.attemptMax,
         onEventName: props.onEventName,

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -49,6 +49,7 @@ export const actionArgsSchema = z.object({
     actionName: z.string().min(1),
     activityLogId: z.string(),
     input: jsonSchema,
+    async: z.boolean().optional().default(false),
     ...commonSchemaArgsFields
 });
 export const webhookArgsSchema = z.object({
@@ -73,6 +74,7 @@ const commonSchemaFields = {
     name: z.string().min(1),
     groupKey: z.string().min(1),
     state: z.enum(taskStates),
+    retryKey: z.string().min(1).nullable(),
     retryCount: z.number().int(),
     retryMax: z.number().int(),
     ownerKey: z.string().min(1).nullable()
@@ -117,6 +119,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 syncVariant: sync.data.payload.syncVariant,
                 connection: sync.data.payload.connection,
                 groupKey: sync.data.groupKey,
+                retryKey: sync.data.retryKey,
                 ownerKey: sync.data.ownerKey,
                 debug: sync.data.payload.debug
             })
@@ -138,6 +141,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 connection: syncAbort.data.payload.connection,
                 groupKey: syncAbort.data.groupKey,
                 ownerKey: syncAbort.data.ownerKey,
+                retryKey: syncAbort.data.retryKey,
                 reason: syncAbort.data.payload.reason,
                 debug: syncAbort.data.payload.debug
             })
@@ -157,7 +161,9 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 activityLogId: action.data.payload.activityLogId,
                 groupKey: action.data.groupKey,
                 ownerKey: action.data.ownerKey,
-                input: action.data.payload.input
+                retryKey: action.data.retryKey,
+                input: action.data.payload.input,
+                async: action.data.payload.async
             })
         );
     }
@@ -176,6 +182,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 activityLogId: webhook.data.payload.activityLogId,
                 groupKey: webhook.data.groupKey,
                 ownerKey: webhook.data.ownerKey,
+                retryKey: webhook.data.retryKey,
                 input: webhook.data.payload.input
             })
         );
@@ -194,6 +201,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 connection: onEvent.data.payload.connection,
                 groupKey: onEvent.data.groupKey,
                 ownerKey: onEvent.data.ownerKey,
+                retryKey: onEvent.data.retryKey,
                 fileLocation: onEvent.data.payload.fileLocation,
                 activityLogId: onEvent.data.payload.activityLogId
             })
@@ -212,6 +220,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 connection: abort.data.payload.connection,
                 groupKey: abort.data.groupKey,
                 ownerKey: abort.data.ownerKey,
+                retryKey: abort.data.retryKey,
                 reason: abort.data.payload.reason
             })
         );

--- a/packages/server/lib/controllers/v1/environment/getEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.ts
@@ -83,6 +83,7 @@ export const getEnvironment = asyncWrapper<GetEnvironment>(async (req, res) => {
                     on_auth_creation: false,
                     on_auth_refresh_error: false,
                     on_sync_completion_always: false,
+                    on_async_action_completion: false,
                     on_sync_error: false,
                     primary_url: null,
                     secondary_url: null

--- a/packages/server/lib/controllers/v1/environment/webhook/patchWebhook.ts
+++ b/packages/server/lib/controllers/v1/environment/webhook/patchWebhook.ts
@@ -11,7 +11,8 @@ const validation = z
         on_sync_completion_always: z.boolean().optional(),
         on_auth_creation: z.boolean().optional(),
         on_auth_refresh_error: z.boolean().optional(),
-        on_sync_error: z.boolean().optional()
+        on_sync_error: z.boolean().optional(),
+        on_async_action_completion: z.boolean().optional()
     })
     .strict();
 
@@ -50,6 +51,9 @@ export const patchWebhook = asyncWrapper<PatchWebhook>(async (req, res) => {
     }
     if (typeof body.on_sync_error !== 'undefined') {
         data.on_sync_error = body.on_sync_error;
+    }
+    if (typeof body.on_async_action_completion !== 'undefined') {
+        data.on_async_action_completion = body.on_async_action_completion;
     }
 
     if (Object.keys(data).length <= 0) {

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -32,7 +32,16 @@ import type {
     VoidReturn
 } from '@nangohq/nango-orchestrator';
 import type { RecordCount } from '@nangohq/records';
-import type { ConnectionInternal, ConnectionJobs, DBConnection, DBConnectionDecrypted, DBEnvironment, DBSyncConfig, DBTeam } from '@nangohq/types';
+import type {
+    AsyncActionResponse,
+    ConnectionInternal,
+    ConnectionJobs,
+    DBConnection,
+    DBConnectionDecrypted,
+    DBEnvironment,
+    DBSyncConfig,
+    DBTeam
+} from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { StringValue } from 'ms';
 import type { JsonValue } from 'type-fest';
@@ -121,7 +130,7 @@ export class Orchestrator {
         retryMax: number;
         async: boolean;
         logCtx: LogContext;
-    }): Promise<Result<{ id: string; statusUrl: string } | { data: T }, NangoError>> {
+    }): Promise<Result<AsyncActionResponse | { data: T }, NangoError>> {
         const activeSpan = tracer.scope().active();
         const spanTags = {
             'account.id': accountId,
@@ -157,7 +166,8 @@ export class Orchestrator {
                     environment_id: connection.environment_id
                 },
                 activityLogId: logCtx.id,
-                input: parsedInput
+                input: parsedInput,
+                async
             };
 
             if (async) {

--- a/packages/shared/lib/services/external-webhook.service.ts
+++ b/packages/shared/lib/services/external-webhook.service.ts
@@ -10,7 +10,16 @@ export async function get(id: number): Promise<DBExternalWebhook | null> {
 export async function update(
     environment_id: number,
     data: Partial<
-        Pick<DBExternalWebhook, 'primary_url' | 'secondary_url' | 'on_auth_creation' | 'on_auth_refresh_error' | 'on_sync_completion_always' | 'on_sync_error'>
+        Pick<
+            DBExternalWebhook,
+            | 'primary_url'
+            | 'secondary_url'
+            | 'on_auth_creation'
+            | 'on_auth_refresh_error'
+            | 'on_sync_completion_always'
+            | 'on_sync_error'
+            | 'on_async_action_completion'
+        >
     >
 ): Promise<void> {
     await db.knex

--- a/packages/types/lib/action/api.ts
+++ b/packages/types/lib/action/api.ts
@@ -1,5 +1,10 @@
 import type { Endpoint } from '../api';
 
+export interface AsyncActionResponse {
+    id: string;
+    statusUrl: string;
+}
+
 export type GetAsyncActionResult = Endpoint<{
     Method: 'GET';
     Path: `/action/:id`;

--- a/packages/types/lib/environment/api/webhook.ts
+++ b/packages/types/lib/environment/api/webhook.ts
@@ -13,6 +13,7 @@ export type PatchWebhook = Endpoint<{
         on_auth_creation?: boolean | undefined;
         on_auth_refresh_error?: boolean | undefined;
         on_sync_error?: boolean | undefined;
+        on_async_action_completion?: boolean | undefined;
     };
     Success: {
         success: boolean;

--- a/packages/types/lib/environment/db.ts
+++ b/packages/types/lib/environment/db.ts
@@ -57,4 +57,5 @@ export interface DBExternalWebhook extends Timestamps {
     on_auth_creation: boolean;
     on_auth_refresh_error: boolean;
     on_sync_error: boolean;
+    on_async_action_completion: boolean;
 }

--- a/packages/types/lib/webhooks/api.ts
+++ b/packages/types/lib/webhooks/api.ts
@@ -1,8 +1,9 @@
 import type { AuthOperationType, AuthModeType } from '../auth/api.js';
 import type { SyncResult } from '../scripts/syncs/api.js';
 import type { ErrorPayload } from '../api.js';
+import type { AsyncActionResponse } from '../action/api.js';
 
-export type WebhookTypes = 'sync' | 'auth' | 'forward';
+export type WebhookTypes = 'sync' | 'auth' | 'forward' | 'async_action';
 
 export interface NangoWebhookBase {
     from: string;
@@ -79,4 +80,14 @@ export interface NangoForwardWebhookBody extends NangoWebhookBase {
     connectionId?: string;
     providerConfigKey: string;
     payload: unknown;
+}
+
+// -----
+// Async action
+//
+export interface NangoAsyncActionWebhookBody extends NangoWebhookBase {
+    type: 'async_action';
+    connectionId: string;
+    providerConfigKey: string;
+    payload: AsyncActionResponse;
 }

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -66,6 +66,8 @@ export enum Types {
     WEBHOOK_INCOMING_FORWARDED_FAILED = 'nango.webhook.incoming.forwarded.failed',
     WEBHOOK_OUTGOING_SUCCESS = 'nango.webhook.outgoing.success',
     WEBHOOK_OUTGOING_FAILED = 'nango.webhook.outgoing.failed',
+    WEBHOOK_ASYNC_ACTION_SUCCESS = 'nango.webhook.async_action.success',
+    WEBHOOK_ASYNC_ACTION_FAILED = 'nango.webhook.async_action.failed',
 
     ORCH_TASKS_CREATED = 'nango.orch.tasks.created',
     ORCH_TASKS_STARTED = 'nango.orch.tasks.started',

--- a/packages/webapp/src/pages/Environment/Settings/WebhookCheckboxes.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/WebhookCheckboxes.tsx
@@ -31,6 +31,11 @@ const checkboxesConfig: CheckboxConfig[] = [
         label: 'Syncs: no update webhooks',
         tooltip: 'If checked, a webhook will be sent on every sync run completion, even if no data has changed.',
         stateKey: 'on_sync_completion_always'
+    },
+    {
+        label: 'Async Actions: completion',
+        tooltip: 'If checked, a webhook will be sent when an async action completes.',
+        stateKey: 'on_async_action_completion'
     }
 ];
 
@@ -56,6 +61,7 @@ export const WebhookCheckboxes: React.FC<CheckboxFormProps> = ({ env, checkboxSt
             on_auth_refresh_error: checkboxState['on_auth_refresh_error'],
             on_sync_completion_always: checkboxState['on_sync_completion_always'],
             on_sync_error: checkboxState['on_sync_error'],
+            on_async_action_completion: checkboxState['on_async_action_completion'],
             [name]: checked
         });
         setLoading(false);

--- a/packages/webhooks/lib/asyncAction.ts
+++ b/packages/webhooks/lib/asyncAction.ts
@@ -1,0 +1,57 @@
+import type { LogContext } from '@nangohq/logs';
+import { metrics } from '@nangohq/utils';
+
+import { deliver, shouldSend } from './utils.js';
+
+import type { AsyncActionResponse, DBEnvironment, DBExternalWebhook, NangoAsyncActionWebhookBody } from '@nangohq/types';
+
+export const sendAsyncActionWebhook = async ({
+    environment,
+    connectionId,
+    providerConfigKey,
+    webhookSettings,
+    payload,
+    logCtx
+}: {
+    environment: DBEnvironment;
+    connectionId: string;
+    providerConfigKey: string;
+    webhookSettings: DBExternalWebhook | null;
+    payload: AsyncActionResponse;
+    logCtx: LogContext;
+}): Promise<void> => {
+    if (!webhookSettings) {
+        return;
+    }
+
+    if (!shouldSend({ success: true, type: 'async_action', webhookSettings })) {
+        return;
+    }
+
+    const body: NangoAsyncActionWebhookBody = {
+        type: 'async_action',
+        from: 'nango',
+        connectionId,
+        providerConfigKey,
+        payload: payload
+    };
+
+    const webhooks = [
+        { url: webhookSettings.primary_url, type: 'webhook url' },
+        { url: webhookSettings.secondary_url, type: 'secondary webhook url' }
+    ].filter((webhook) => webhook.url) as { url: string; type: string }[];
+
+    const result = await deliver({
+        webhooks,
+        body,
+        webhookType: 'async_action',
+        environment,
+        logCtx
+    });
+
+    if (result.isOk()) {
+        metrics.increment(metrics.Types.WEBHOOK_ASYNC_ACTION_SUCCESS);
+    } else {
+        metrics.increment(metrics.Types.WEBHOOK_ASYNC_ACTION_FAILED);
+    }
+};

--- a/packages/webhooks/lib/asyncAction.unit.test.ts
+++ b/packages/webhooks/lib/asyncAction.unit.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { logContextGetter } from '@nangohq/logs';
+import { axiosInstance } from '@nangohq/utils';
+
+import { sendAsyncActionWebhook } from './asyncAction.js';
+
+import type { DBEnvironment, DBExternalWebhook } from '@nangohq/types';
+
+const spy = vi.spyOn(axiosInstance, 'post');
+
+const webhookSettings: DBExternalWebhook = {
+    id: 1,
+    environment_id: 1,
+    primary_url: 'http://example.com/webhook',
+    secondary_url: 'http://example.com/webhook-secondary',
+    on_sync_completion_always: true,
+    on_auth_creation: true,
+    on_auth_refresh_error: true,
+    on_sync_error: true,
+    on_async_action_completion: true,
+    created_at: new Date(),
+    updated_at: new Date()
+};
+const environment = {
+    name: 'dev',
+    id: 1,
+    secret_key: 'secret'
+} as DBEnvironment;
+
+describe('AsyncAction webhookds', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('should not be sent if on_async_action_completion is false', async () => {
+        const logCtx = await logContextGetter.create(
+            { operation: { type: 'sync', action: 'run' } },
+            { account: { id: environment.account_id, name: '' }, environment: { id: environment.id, name: environment.name } }
+        );
+        await sendAsyncActionWebhook({
+            connectionId: '123',
+            environment,
+            providerConfigKey: 'some-provider',
+            webhookSettings: {
+                ...webhookSettings,
+                on_async_action_completion: false
+            },
+            payload: { id: '00000000-0000-0000-0000-000000000000', statusUrl: '/action/00000000-0000-0000-0000-000000000000' },
+            logCtx
+        });
+        expect(spy).toHaveBeenCalledTimes(0);
+    });
+
+    it('should be sent if on_async_action_completion is true', async () => {
+        const logCtx = await logContextGetter.create(
+            { operation: { type: 'sync', action: 'run' } },
+            { account: { id: environment.account_id, name: '' }, environment: { id: environment.id, name: environment.name } }
+        );
+        const props = {
+            connectionId: '123',
+            environment,
+            providerConfigKey: 'some-provider',
+            webhookSettings: {
+                ...webhookSettings,
+                on_async_action_completion: true
+            },
+            payload: { id: '00000000-0000-0000-0000-000000000000', statusUrl: '/action/00000000-0000-0000-0000-000000000000' },
+            logCtx
+        };
+
+        await sendAsyncActionWebhook(props);
+
+        expect(spy).toHaveBeenCalledTimes(2);
+        const expectedArgs = {
+            type: 'async_action',
+            from: 'nango',
+            connectionId: props.connectionId,
+            payload: props.payload,
+            providerConfigKey: props.providerConfigKey
+        };
+        expect(spy).toHaveBeenNthCalledWith(1, webhookSettings.primary_url, expectedArgs, { headers: { 'X-Nango-Signature': expect.any(String) } });
+        expect(spy).toHaveBeenNthCalledWith(2, webhookSettings.secondary_url, expectedArgs, { headers: { 'X-Nango-Signature': expect.any(String) } });
+    });
+});

--- a/packages/webhooks/lib/auth.ts
+++ b/packages/webhooks/lib/auth.ts
@@ -45,7 +45,11 @@ export async function sendAuth({
         return;
     }
 
-    if (!shouldSend({ success, type: 'auth', webhookSettings, operation })) {
+    if (operation !== 'creation' && operation !== 'refresh') {
+        return;
+    }
+
+    if (!shouldSend({ success, type: operation === 'creation' ? 'auth_creation' : 'auth_refresh', webhookSettings })) {
         return;
     }
 

--- a/packages/webhooks/lib/auth.unit.test.ts
+++ b/packages/webhooks/lib/auth.unit.test.ts
@@ -31,6 +31,7 @@ const webhookSettings: DBExternalWebhook = {
     on_auth_creation: true,
     on_auth_refresh_error: true,
     on_sync_error: true,
+    on_async_action_completion: true,
     created_at: new Date(),
     updated_at: new Date()
 };

--- a/packages/webhooks/lib/forward.ts
+++ b/packages/webhooks/lib/forward.ts
@@ -28,8 +28,7 @@ export const forwardWebhook = async ({
     if (!webhookSettings) {
         return;
     }
-
-    if (!shouldSend({ success: true, type: 'forward', webhookSettings, operation: 'incoming_webhook' })) {
+    if (!shouldSend({ success: true, type: 'forward', webhookSettings })) {
         return;
     }
 

--- a/packages/webhooks/lib/forward.unit.test.ts
+++ b/packages/webhooks/lib/forward.unit.test.ts
@@ -26,6 +26,7 @@ const webhookSettings: DBExternalWebhook = {
     on_auth_creation: true,
     on_auth_refresh_error: true,
     on_sync_error: true,
+    on_async_action_completion: true,
     created_at: new Date(),
     updated_at: new Date()
 };

--- a/packages/webhooks/lib/index.ts
+++ b/packages/webhooks/lib/index.ts
@@ -1,4 +1,5 @@
 export { sendAuth } from './auth.js';
+export { sendAsyncActionWebhook } from './asyncAction.js';
 import { sendSync } from './sync.js';
 
 export { forwardWebhook } from './forward.js';

--- a/packages/webhooks/lib/sync.ts
+++ b/packages/webhooks/lib/sync.ts
@@ -56,7 +56,7 @@ export const sendSync = async ({
         return Ok(undefined);
     }
 
-    if (!shouldSend({ success, type: 'sync', webhookSettings, operation })) {
+    if (!shouldSend({ success, type: 'sync', webhookSettings })) {
         return Ok(undefined);
     }
 

--- a/packages/webhooks/lib/sync.unit.test.ts
+++ b/packages/webhooks/lib/sync.unit.test.ts
@@ -73,6 +73,7 @@ const webhookSettings: DBExternalWebhook = {
     on_auth_creation: true,
     on_auth_refresh_error: true,
     on_sync_error: true,
+    on_async_action_completion: true,
     created_at: new Date(),
     updated_at: new Date()
 };


### PR DESCRIPTION
Sending webhook to customer when an async action completes.

How to test locally:
- enable/disable webhooks and the `Async Actions: completion` setting in environment setting
- trigger async action
- check the webhook endpoint receives (or not) the request from Nango.
<!-- Summary by @propel-code-bot -->

---

**Add ‘async_action’ webhooks + plumbing across API, orches­trator, UI & metrics**

Introduces a full end-to-end capability to emit webhooks when asynchronous actions finish (success or final failure).  The change set adds a new webhook type (`async_action`), extends DB/webhook settings, orchestrator task schema, telemetry, REST/SDK types, delivery utilities, and front-end toggles.  All execution paths for actions now call the new helper (`sendWebhookIfNeeded`) so the correct payload is delivered under the right conditions.

**Key Changes:**
• New packages/webhooks/lib/`asyncAction`.ts: delivery logic + metric counters
• Task schema & orchestrator client updated with ``retryKey``, `async` flags, and ``AsyncActionResponse`` typing
• Action execution flow (packages/jobs/lib/execution/action.ts) calls ``sendWebhookIfNeeded`` on success and last-attempt failure
• Webhook filtering utility (``shouldSend``) refactored to support new type and simpler signature
• `DBExternalWebhook`, ``API`` endpoints, server patch controller and webapp ``UI`` extended with ``on_async_action_completion`` flag
• Telemetry: adds ``WEBHOOK_ASYNC_ACTION_``{``SUCCESS``|``FAILED``} counters
• Comprehensive unit tests for `async_action` webhook delivery + updated existing tests
• Docs/types: new ``NangoAsyncActionWebhookBody``, ``AsyncActionResponse``, and ``WebhookTypes`` enum value

**Affected Areas:**
• Action executor
• Webhook delivery utils
• Orchestrator task/types & validation
• Shared external-webhook service & ``DB`` model
• Server ``API`` (``PATCH`` /environments/webhook, ``GET`` /environment)
• Webapp settings page (checkbox)
• Telemetry metrics
• Tests

**Potential Impact:**

**Functionality**: Customers can now opt-in to receive a webhook per async action; existing behaviour unchanged unless flag enabled.

**Performance**: Negligible; webhook send is async and guarded. Minor overhead in action completion path.

**Security**: Same HMAC signature mechanism reused; no new attack surface.

**Scalability**: Async actions may be high-volume; ensure delivery/retry strategy & metric cardinality handle burst.

**Review Focus:**
• `sendWebhookIfNeeded` logic in action.ts (correct guards, `retryKey` presence)
• `shouldSend` refactor – verify old webhook types still gated properly
• `DBExternalWebhook` migration (may need ``SQL`` migration in prod)
• Concurrency/race on `retryKey` & final-attempt detection
• Backward compatibility for existing ``SDK``/types consumers

<details>
<summary><strong>Testing Needed</strong></summary>

• Toggle new checkbox in ``UI`` and verify ``PATCH`` endpoint persists setting
• Run async action success & failure paths; ensure 2xx response from customer endpoint increments success metric
• Confirm no webhook emitted when flag disabled
• Regression test normal sync/auth webhooks
• Check `BigQuery` inserts and `logCtx` states still correct

</details>

<details>
<summary><strong>Code Quality Assessment</strong></summary>

**packages/jobs/lib/execution/action.ts**: Large diff; mostly straightforward but contains unrelated error-handling tweaks – worth a second look for side effects

</details>

<details>
<summary><strong>Best Practices</strong></summary>

**Testing**:
• Added unit tests for new flow

**Metrics**:
• Emits detailed success/failure counters

**Error Handling**:
• Retries & signature headers maintained

**Typing**:
• Centralised `AsyncActionResponse` type

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Missing DB migration for new column on_async_action_completion
• Legacy clients referencing old WebhookTypes enum may break at compile time
• High volume of async actions could flood webhooks if mis-configured
• sendWebhookIfNeeded silently returns when environment undefined – ensure this is always loaded

</details>

---
*This summary was automatically generated by @propel-code-bot*

