### PR TITLE
fix(dryrun save-responses): fix check

### DIFF
--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -392,10 +392,9 @@ export class DryRunService {
                     }
                 };
             }
-            console.log('---');
 
             if (options.saveResponses && stubbedMetadata) {
-                responseSaver.ensureDirectoryExists(saveResponsesSyncDir);
+                responseSaver.ensureDirectoryExists(`${saveResponsesDir}/mocks/nango`);
                 const filePath = `${saveResponsesDir}/mocks/nango/getMetadata.json`;
                 fs.writeFileSync(filePath, JSON.stringify(stubbedMetadata, null, 2));
             }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Introduced with https://github.com/NangoHQ/nango/commit/3d8cb530a0674ee684b93883b84d2a76b6a7d6f4#diff-a159ae11e9f2a4877483b046305971040d805c57d12a7478d66fee904a610727L346. If no `nango` directory exists an attempt to save-responses would silently fail because the code was not able to create the directory. 

Earlier in the code we're already doing a check for `saveResponsesSyncDir` so the check I'm replacing was redundant at that spot regardless -> https://github.com/NangoHQ/nango/blob/master/packages/cli/lib/services/dryrun.service.ts#L285
<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR fixes a bug where the CLI would silently fail when trying to save responses during a dry run if the 'nango' directory didn't exist. The fix ensures the proper directory path is passed to the ensureDirectoryExists function.

*This summary was automatically generated by @propel-code-bot*