### PR TITLE
fix: mcp sdk installation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29092,7 +29092,7 @@
             "version": "1.0.0",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@modelcontextprotocol/sdk": "^1.11.4",
+                "@modelcontextprotocol/sdk": "1.11.4",
                 "@nangohq/billing": "file:../billing",
                 "@nangohq/database": "file:../database",
                 "@nangohq/fleet": "file:../fleet",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
                 "packages/*",
                 "scripts"
             ],
-            "dependencies": {
-                "@modelcontextprotocol/sdk": "^1.11.0"
-            },
             "devDependencies": {
                 "@eslint/js": "9.25.1",
                 "@testcontainers/elasticsearch": "10.24.2",
@@ -4556,14 +4553,15 @@
             }
         },
         "node_modules/@modelcontextprotocol/sdk": {
-            "version": "1.11.2",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.2.tgz",
-            "integrity": "sha512-H9vwztj5OAqHg9GockCQC06k1natgcxWQSRpQcPJf6i5+MWBzfKkRtxGbjQf0X2ihii0ffLZCRGbYV2f2bjNCQ==",
+            "version": "1.11.4",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.4.tgz",
+            "integrity": "sha512-OTbhe5slIjiOtLxXhKalkKGhIQrwvhgCDs/C2r8kcBTy5HR/g43aDQU0l7r8O0VGbJPTNJvDc7ZdQMdQDJXmbw==",
             "license": "MIT",
             "dependencies": {
+                "ajv": "^8.17.1",
                 "content-type": "^1.0.5",
                 "cors": "^2.8.5",
-                "cross-spawn": "^7.0.3",
+                "cross-spawn": "^7.0.5",
                 "eventsource": "^3.0.2",
                 "express": "^5.0.1",
                 "express-rate-limit": "^7.5.0",
@@ -4587,6 +4585,22 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
             }
         },
         "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
@@ -4744,6 +4758,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT"
         },
         "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
             "version": "1.1.0",
@@ -29072,7 +29092,7 @@
             "version": "1.0.0",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@modelcontextprotocol/sdk": "^1.11.2",
+                "@modelcontextprotocol/sdk": "^1.11.4",
                 "@nangohq/billing": "file:../billing",
                 "@nangohq/database": "file:../database",
                 "@nangohq/fleet": "file:../fleet",

--- a/package.json
+++ b/package.json
@@ -90,8 +90,5 @@
     },
     "engines": {
         "node": ">=18.0.0 || >=20.0.0"
-    },
-    "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.11.0"
     }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,7 +23,7 @@
         "npm": ">=6.14.11"
     },
     "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.11.4",
+        "@modelcontextprotocol/sdk": "1.11.4",
         "@nangohq/billing": "file:../billing",
         "@nangohq/database": "file:../database",
         "@nangohq/fleet": "file:../fleet",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,7 +23,7 @@
         "npm": ">=6.14.11"
     },
     "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.11.2",
+        "@modelcontextprotocol/sdk": "^1.11.4",
         "@nangohq/billing": "file:../billing",
         "@nangohq/database": "file:../database",
         "@nangohq/fleet": "file:../fleet",


### PR DESCRIPTION
<!-- Describe the problem and your solution -->


<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

Removes the SDK from the monorepo root and pins @modelcontextprotocol/sdk at v1.11.4 inside packages/server, resolving install issues and aligning with the repo’s version-pinning convention.

*This summary was automatically generated by @propel-code-bot*