### PR TITLE
fix: mcp imports

### DIFF
--- a/packages/server/lib/controllers/mcp/server.ts
+++ b/packages/server/lib/controllers/mcp/server.ts
@@ -1,5 +1,5 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import tracer from 'dd-trace';
 
 import { OtlpSpan, defaultOperationExpiration, logContextGetter } from '@nangohq/logs';
@@ -8,7 +8,7 @@ import { Err, Ok, truncateJson } from '@nangohq/utils';
 
 import { getOrchestrator } from '../../utils/utils.js';
 
-import type { CallToolRequest, CallToolResult, Tool } from '@modelcontextprotocol/sdk/types';
+import type { CallToolRequest, CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { Config } from '@nangohq/shared';
 import type { DBConnectionDecrypted, DBEnvironment, DBSyncConfig, DBTeam, Result } from '@nangohq/types';
 import type { Span } from 'dd-trace';


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

Adds missing `.js` extension to two @modelcontextprotocol/sdk import statements in packages/server/lib/controllers/mcp/server.ts to align with ESM resolution. No functional logic is touched.

*This summary was automatically generated by @propel-code-bot*