### PR TITLE
fix(webapp): sublogs scrolling

### DIFF
--- a/packages/webapp/src/pages/Logs/Operation/components/Logs.tsx
+++ b/packages/webapp/src/pages/Logs/Operation/components/Logs.tsx
@@ -187,7 +187,7 @@ export const Logs: React.FC<{ operationId: string; isLive: boolean }> = ({ opera
     }, [flatData, period]);
 
     return (
-        <div className="flex flex-col gap-4">
+        <div className="flex-grow-0 overflow-hidden flex flex-col gap-4">
             <div className="flex justify-between items-center">
                 <h4 className="font-semibold text-sm flex items-center gap-2">Logs {(isLoading || isFetching) && <Spinner size={1} />}</h4>
                 <div className="text-white text-xs">
@@ -213,10 +213,10 @@ export const Logs: React.FC<{ operationId: string; isLive: boolean }> = ({ opera
                     }
                     value={search}
                     placeholder="Search logs..."
-                    className="w-full border-border-gray-400"
+                    className="flex-grow border-border-gray-400"
                     onChange={(e) => setSearch(e.target.value)}
                 />
-                <div>
+                <div className="border border-transparent">
                     <PeriodSelector
                         period={period}
                         isLive={isLive}


### PR DESCRIPTION
<!-- Describe the problem and your solution -->
### Description
I broke the sublogs scrolling by modifying the overflow properties from this div. This is the fix.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

Re-applies proper Tailwind utility classes in Logs.tsx to bring back vertical scrolling inside the sub-logs pane and keep the search bar/period selector layout intact.

*This summary was automatically generated by @propel-code-bot*