### PR TITLE
chore: remove json pretty print pipe from header

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -7185,7 +7185,7 @@ oracle-hcm:
     proxy:
         base_url: https://${connectionConfig.restServerUrl}
         headers:
-            content-type: application/vnd.oracle.adf.resourceitem+json | json_pp
+            content-type: application/vnd.oracle.adf.resourceitem+json
     docs: https://docs.nango.dev/integrations/all/oracle-hcm
     docs_connect: https://docs.nango.dev/integrations/all/oracle-hcm/connect
     credentials:


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
cleanup oracle-hcm header to remove json pipe

[Docs](https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/Quick_Start.html)

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the Oracle HCM provider configuration by removing the '| json_pp' pretty print pipe from the 'content-type' header. The header now specifies only 'application/vnd.oracle.adf.resourceitem+json'.

*This summary was automatically generated by @propel-code-bot*