### PR TITLE
fix(deps): upgrade ws, jsdom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -351,6 +351,31 @@
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true
         },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+            "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@csstools/css-calc": "^2.1.3",
+                "@csstools/css-color-parser": "^3.0.9",
+                "@csstools/css-parser-algorithms": "^3.0.4",
+                "@csstools/css-tokenizer": "^3.0.3",
+                "lru-cache": "^10.4.3"
+            }
+        },
+        "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC",
+            "optional": true,
+            "peer": true
+        },
         "node_modules/@aws-crypto/crc32": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
@@ -1295,18 +1320,6 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
             "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/@azure/core-rest-pipeline/node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
             "engines": {
                 "node": ">= 14"
             }
@@ -3238,6 +3251,131 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+            "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.3.tgz",
+            "integrity": "sha512-XBG3talrhid44BY1x3MHzUx/aTG8+x/Zi57M4aTKK9RFB4aLlF3TTSzfzn8nWVHWL3FgAXAxmupmDd6VWww+pw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.4",
+                "@csstools/css-tokenizer": "^3.0.3"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.9.tgz",
+            "integrity": "sha512-wILs5Zk7BU86UArYBJTPy/FMPPKVKHMj1ycCEyf3VUptol0JNRLFU/BZsJ4aiIHJEbSLiizzRrw8Pc1uAEDrXw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@csstools/color-helpers": "^5.0.2",
+                "@csstools/css-calc": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.4",
+                "@csstools/css-tokenizer": "^3.0.3"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
+            "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^3.0.3"
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz",
+            "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@dabh/diagnostics": {
@@ -10670,16 +10808,6 @@
                 "testcontainers": "^10.24.2"
             }
         },
-        "node_modules/@tootallnate/once": {
-            "version": "1.1.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.9",
             "license": "MIT"
@@ -11903,13 +12031,6 @@
             "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
             "integrity": "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg=="
         },
-        "node_modules/abab": {
-            "version": "2.0.6",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/abbrev": {
             "version": "1.1.1",
             "dev": true,
@@ -11946,40 +12067,6 @@
             "bin": {
                 "acorn": "bin/acorn"
             },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/acorn-globals": {
-            "version": "6.0.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "acorn": "^7.1.1",
-                "acorn-walk": "^7.1.1"
-            }
-        },
-        "node_modules/acorn-globals/node_modules/acorn": {
-            "version": "7.4.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/acorn-globals/node_modules/acorn-walk": {
-            "version": "7.2.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -13378,13 +13465,6 @@
                 "npm": ">=6"
             }
         },
-        "node_modules/browser-process-hrtime": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/browserslist": {
             "version": "4.24.4",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
@@ -14764,32 +14844,21 @@
                 "node": ">=4"
             }
         },
-        "node_modules/cssom": {
-            "version": "0.4.4",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/cssstyle": {
-            "version": "2.3.0",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.3.1.tgz",
+            "integrity": "sha512-ZgW+Jgdd7i52AaLYCriF8Mxqft0gD/R9i9wi6RWBhs1pqdPEzPjym7rvRKi397WmQFf3SlyUsszhw+VVCbx79Q==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "peer": true,
             "dependencies": {
-                "cssom": "~0.3.6"
+                "@asamuzakjp/css-color": "^3.1.2",
+                "rrweb-cssom": "^0.8.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=18"
             }
-        },
-        "node_modules/cssstyle/node_modules/cssom": {
-            "version": "0.3.8",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/csstype": {
             "version": "3.1.3",
@@ -14915,56 +14984,62 @@
             }
         },
         "node_modules/data-urls": {
-            "version": "2.0.0",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "peer": true,
             "dependencies": {
-                "abab": "^2.0.3",
-                "whatwg-mimetype": "^2.3.0",
-                "whatwg-url": "^8.0.0"
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/data-urls/node_modules/tr46": {
-            "version": "2.1.0",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "peer": true,
             "dependencies": {
-                "punycode": "^2.1.1"
+                "punycode": "^2.3.1"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=18"
             }
         },
         "node_modules/data-urls/node_modules/webidl-conversions": {
-            "version": "6.1.0",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
             "dev": true,
             "license": "BSD-2-Clause",
             "optional": true,
             "peer": true,
             "engines": {
-                "node": ">=10.4"
+                "node": ">=12"
             }
         },
         "node_modules/data-urls/node_modules/whatwg-url": {
-            "version": "8.7.0",
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "peer": true,
             "dependencies": {
-                "lodash": "^4.7.0",
-                "tr46": "^2.1.0",
-                "webidl-conversions": "^6.1.0"
+                "tr46": "^5.1.0",
+                "webidl-conversions": "^7.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/data-view-buffer": {
@@ -15164,7 +15239,9 @@
             }
         },
         "node_modules/decimal.js": {
-            "version": "10.4.3",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+            "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -15533,29 +15610,6 @@
             ],
             "license": "BSD-2-Clause"
         },
-        "node_modules/domexception": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "webidl-conversions": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/domexception/node_modules/webidl-conversions": {
-            "version": "5.0.0",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/dot-case": {
             "version": "3.0.4",
             "dev": true,
@@ -15760,6 +15814,21 @@
         "node_modules/ent": {
             "version": "2.2.0",
             "license": "MIT"
+        },
+        "node_modules/entities": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
+            "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
         },
         "node_modules/env-cmd": {
             "version": "10.1.0",
@@ -16462,48 +16531,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/escodegen": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "esprima": "^4.0.1",
-                "estraverse": "^5.2.0",
-                "esutils": "^2.0.2"
-            },
-            "bin": {
-                "escodegen": "bin/escodegen.js",
-                "esgenerate": "bin/esgenerate.js"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "optionalDependencies": {
-                "source-map": "~0.6.1"
-            }
-        },
-        "node_modules/escodegen/node_modules/estraverse": {
-            "version": "5.3.0",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/escodegen/node_modules/source-map": {
-            "version": "0.6.1",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/eslint": {
@@ -18562,16 +18589,18 @@
             }
         },
         "node_modules/html-encoding-sniffer": {
-            "version": "2.0.1",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "peer": true,
             "dependencies": {
-                "whatwg-encoding": "^1.0.5"
+                "whatwg-encoding": "^3.1.1"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/http-errors": {
@@ -18589,18 +18618,25 @@
             }
         },
         "node_modules/http-proxy-agent": {
-            "version": "4.0.1",
-            "dev": true,
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "license": "MIT",
-            "optional": true,
-            "peer": true,
             "dependencies": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4"
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
+            }
+        },
+        "node_modules/http-proxy-agent/node_modules/agent-base": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+            "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/https-proxy-agent": {
@@ -19566,45 +19602,40 @@
             }
         },
         "node_modules/jsdom": {
-            "version": "16.7.0",
+            "version": "26.1.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+            "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "peer": true,
             "dependencies": {
-                "abab": "^2.0.5",
-                "acorn": "^8.2.4",
-                "acorn-globals": "^6.0.0",
-                "cssom": "^0.4.4",
-                "cssstyle": "^2.3.0",
-                "data-urls": "^2.0.0",
-                "decimal.js": "^10.2.1",
-                "domexception": "^2.0.1",
-                "escodegen": "^2.0.0",
-                "form-data": "^3.0.0",
-                "html-encoding-sniffer": "^2.0.1",
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "^5.0.0",
+                "cssstyle": "^4.2.1",
+                "data-urls": "^5.0.0",
+                "decimal.js": "^10.5.0",
+                "html-encoding-sniffer": "^4.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.6",
                 "is-potential-custom-element-name": "^1.0.1",
-                "nwsapi": "^2.2.0",
-                "parse5": "6.0.1",
-                "saxes": "^5.0.1",
+                "nwsapi": "^2.2.16",
+                "parse5": "^7.2.1",
+                "rrweb-cssom": "^0.8.0",
+                "saxes": "^6.0.0",
                 "symbol-tree": "^3.2.4",
-                "tough-cookie": "^4.0.0",
-                "w3c-hr-time": "^1.0.2",
-                "w3c-xmlserializer": "^2.0.0",
-                "webidl-conversions": "^6.1.0",
-                "whatwg-encoding": "^1.0.5",
-                "whatwg-mimetype": "^2.3.0",
-                "whatwg-url": "^8.5.0",
-                "ws": "^7.4.6",
-                "xml-name-validator": "^3.0.0"
+                "tough-cookie": "^5.1.1",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-encoding": "^3.1.1",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.1.1",
+                "ws": "^8.18.0",
+                "xml-name-validator": "^5.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "peerDependencies": {
-                "canvas": "^2.5.0"
+                "canvas": "^3.0.0"
             },
             "peerDependenciesMeta": {
                 "canvas": {
@@ -19612,79 +19643,75 @@
                 }
             }
         },
-        "node_modules/jsdom/node_modules/form-data": {
-            "version": "3.0.1",
+        "node_modules/jsdom/node_modules/agent-base": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+            "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/jsdom/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "peer": true,
             "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
+                "agent-base": "^7.1.2",
+                "debug": "4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/jsdom/node_modules/tr46": {
-            "version": "2.1.0",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "peer": true,
             "dependencies": {
-                "punycode": "^2.1.1"
+                "punycode": "^2.3.1"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=18"
             }
         },
         "node_modules/jsdom/node_modules/webidl-conversions": {
-            "version": "6.1.0",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
             "dev": true,
             "license": "BSD-2-Clause",
             "optional": true,
             "peer": true,
             "engines": {
-                "node": ">=10.4"
+                "node": ">=12"
             }
         },
         "node_modules/jsdom/node_modules/whatwg-url": {
-            "version": "8.7.0",
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "peer": true,
             "dependencies": {
-                "lodash": "^4.7.0",
-                "tr46": "^2.1.0",
-                "webidl-conversions": "^6.1.0"
+                "tr46": "^5.1.0",
+                "webidl-conversions": "^7.0.0"
             },
             "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/jsdom/node_modules/ws": {
-            "version": "7.5.9",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
+                "node": ">=18"
             }
         },
         "node_modules/jsesc": {
@@ -21439,7 +21466,9 @@
             }
         },
         "node_modules/nwsapi": {
-            "version": "2.2.7",
+            "version": "2.2.20",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
+            "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -21847,11 +21876,19 @@
             }
         },
         "node_modules/parse5": {
-            "version": "6.0.1",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true
+            "peer": true,
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
         },
         "node_modules/parseurl": {
             "version": "1.3.3",
@@ -22549,13 +22586,6 @@
             "version": "1.1.0",
             "license": "MIT"
         },
-        "node_modules/psl": {
-            "version": "1.9.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/pstree.remy": {
             "version": "1.1.8",
             "dev": true,
@@ -22572,7 +22602,9 @@
             }
         },
         "node_modules/punycode": {
-            "version": "2.1.1",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -22590,13 +22622,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/querystringify": {
-            "version": "2.2.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -23353,13 +23378,6 @@
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "dev": true
         },
-        "node_modules/requires-port": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/resize-observer-polyfill": {
             "version": "1.5.1",
             "dev": true,
@@ -23669,6 +23687,15 @@
                 "node": ">=16"
             }
         },
+        "node_modules/rrweb-cssom": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+            "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true
+        },
         "node_modules/rsa-pem-from-mod-exp": {
             "version": "0.8.6",
             "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.6.tgz",
@@ -23820,7 +23847,9 @@
             "license": "ISC"
         },
         "node_modules/saxes": {
-            "version": "5.0.1",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
             "dev": true,
             "license": "ISC",
             "optional": true,
@@ -23829,7 +23858,7 @@
                 "xmlchars": "^2.2.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=v12.22.7"
             }
         },
         "node_modules/scheduler": {
@@ -24487,14 +24516,6 @@
             "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/soap/node_modules/whatwg-mimetype": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/source-map": {
@@ -25599,6 +25620,30 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/tldts": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+            "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tldts-core": "^6.1.86"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+            "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true
+        },
         "node_modules/tlhunter-sorted-set": {
             "version": "0.1.0",
             "license": "MIT"
@@ -25653,29 +25698,18 @@
             }
         },
         "node_modules/tough-cookie": {
-            "version": "4.1.3",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+            "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
             "dev": true,
             "license": "BSD-3-Clause",
             "optional": true,
             "peer": true,
             "dependencies": {
-                "psl": "^1.1.33",
-                "punycode": "^2.1.1",
-                "universalify": "^0.2.0",
-                "url-parse": "^1.5.3"
+                "tldts": "^6.1.32"
             },
             "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/tough-cookie/node_modules/universalify": {
-            "version": "0.2.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 4.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/tr46": {
@@ -26539,17 +26573,6 @@
         "node_modules/url-join": {
             "version": "4.0.1",
             "license": "MIT"
-        },
-        "node_modules/url-parse": {
-            "version": "1.5.10",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "querystringify": "^2.1.1",
-                "requires-port": "^1.0.0"
-            }
         },
         "node_modules/use-callback-ref": {
             "version": "1.3.3",
@@ -27453,27 +27476,19 @@
             "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
             "dev": true
         },
-        "node_modules/w3c-hr-time": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "browser-process-hrtime": "^1.0.0"
-            }
-        },
         "node_modules/w3c-xmlserializer": {
-            "version": "2.0.0",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "peer": true,
             "dependencies": {
-                "xml-name-validator": "^3.0.0"
+                "xml-name-validator": "^5.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/watchpack": {
@@ -27641,21 +27656,43 @@
             }
         },
         "node_modules/whatwg-encoding": {
-            "version": "1.0.5",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "peer": true,
             "dependencies": {
-                "iconv-lite": "0.4.24"
+                "iconv-lite": "0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
-        "node_modules/whatwg-mimetype": {
-            "version": "2.3.0",
+        "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true
+            "peer": true,
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
@@ -27940,7 +27977,9 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.18.0",
+            "version": "8.18.2",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+            "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -27972,11 +28011,16 @@
             }
         },
         "node_modules/xml-name-validator": {
-            "version": "3.0.0",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
             "dev": true,
             "license": "Apache-2.0",
             "optional": true,
-            "peer": true
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/xml2js": {
             "version": "0.5.0",
@@ -27998,6 +28042,8 @@
         },
         "node_modules/xmlchars": {
             "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -29150,7 +29196,7 @@
                 "simple-oauth2": "5.1.0",
                 "ua-parser-js": "2.0.2",
                 "uuid": "9.0.0",
-                "ws": "8.18.0",
+                "ws": "8.18.2",
                 "zod": "3.24.2"
             },
             "devDependencies": {
@@ -30923,17 +30969,6 @@
             "version": "7.1.1",
             "license": "MIT",
             "dependencies": {
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "packages/utils/node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
                 "debug": "^4.3.4"
             },
             "engines": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -66,7 +66,7 @@
         "simple-oauth2": "5.1.0",
         "ua-parser-js": "2.0.2",
         "uuid": "9.0.0",
-        "ws": "8.18.0",
+        "ws": "8.18.2",
         "zod": "3.24.2"
     },
     "devDependencies": {


### PR DESCRIPTION
## Changes

- Upgrade ws
- Upgrade ws through upgrading jsdom 
jsdom is a transient dependency from vitest, they allow "*" so I had to manually upgrade by forcing resolution and removing it. I set 26.1.0, as this is the one they use in dev.

<!-- Summary by @propel-code-bot -->

---

This PR updates the 'ws' library from 8.18.0 to 8.18.2 and upgrades the transient 'jsdom' dependency (used via vitest) from 16.7.0 to 26.1.0. As a result, several associated transitive dependencies in package-lock.json are updated or replaced (such as tough-cookie, parse5, cssstyle, data-urls, and others) to their latest compatible versions, modernizing the development environment.

*This summary was automatically generated by @propel-code-bot*