### PR TITLE
chore(billing): add dimensions to billing events 

### DIFF
--- a/packages/persist/lib/records.ts
+++ b/packages/persist/lib/records.ts
@@ -157,7 +157,7 @@ export async function persistRecords({
         const mar = new Set(summary.billedKeys).size;
 
         if (plan) {
-            billing.add('monthly_active_records', mar, { accountId });
+            billing.add('monthly_active_records', mar, { accountId, environmentId, providerConfigKey, connectionId, syncId, model });
         }
 
         metrics.increment(metrics.Types.BILLED_RECORDS_COUNT, mar, { accountId });

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -249,7 +249,14 @@ class SyncController {
                 }
 
                 if (plan) {
-                    billing.add('billable_actions', 1, { accountId: account.id, idempotencyKey: logCtx.id });
+                    billing.add('billable_actions', 1, {
+                        accountId: account.id,
+                        idempotencyKey: logCtx.id,
+                        environmentId: connection.environment_id,
+                        providerConfigKey,
+                        connectionId,
+                        actionName: action_name
+                    });
                 }
 
                 return;

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -27,11 +27,11 @@ export interface BillingIngestEvent {
     idempotencyKey: string;
     accountId: number;
     timestamp: Date;
-    properties: Record<string, string | number>;
+    properties: Record<string, string | number | Date>;
 }
 
 export interface BillingMetric {
     type: BillingIngestEvent['type'];
     value: number;
-    properties: { accountId: number; timestamp?: Date | undefined; idempotencyKey?: string | undefined };
+    properties: { accountId: number; timestamp?: Date | undefined; idempotencyKey?: string | undefined } & BillingIngestEvent['properties'];
 }


### PR DESCRIPTION
Adding properties like environmentId, connectionId, etc... to billing events.
Even though those properties are not being used for billable metrics
they might be used in the future and/or to display more granular data to
customers
Note: for billable_connections, since we are already sending the
aggregated value, we cannot easily split it to add dimensions. I
therefore haven't added any dimension to it

<!-- Summary by @propel-code-bot -->

---

This PR enhances billing event tracking by including additional dimensional properties (such as environmentId, providerConfigKey, connectionId, syncId, model, and actionName) in the data attached to 'billable_actions' and 'monthly_active_records' events. These properties do not affect current billing but are intended to support future use cases and more granular analytics for customers. The 'billable_connections' billing event remains unchanged due to aggregation constraints.

**Key Changes:**
• Augmented 'billable_actions' event properties to include environmentId, providerConfigKey, connectionId, and actionName in sync.controller.ts.
• Expanded 'monthly_active_records' event payload with environmentId, providerConfigKey, connectionId, syncId, and model in records.ts.
• Broadened BillingIngestEvent and BillingMetric type definitions in billing/types.ts to support richer property types.

**Affected Areas:**
• packages/server/lib/controllers/sync.controller.ts
• packages/persist/lib/records.ts
• packages/types/lib/billing/types.ts

*This summary was automatically generated by @propel-code-bot*