### PR TITLE
fix(server): fix nested query params parsing

### DIFF
--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -6,6 +6,7 @@ import http from 'node:http';
 import express from 'express';
 import * as cron from 'node-cron';
 import { WebSocketServer } from 'ws';
+import qs from 'qs';
 
 import db, { KnexDatabase } from '@nangohq/database';
 import { migrate as migrateKeystore } from '@nangohq/keystore';
@@ -46,6 +47,12 @@ process.on('uncaughtException', (err) => {
 });
 
 const app = express();
+app.set('query parser', (str: string) =>
+    qs.parse(str, {
+        allowDots: true,
+        depth: 10
+    })
+);
 app.disable('x-powered-by');
 app.set('trust proxy', 1);
 

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -6,7 +6,6 @@ import http from 'node:http';
 import express from 'express';
 import * as cron from 'node-cron';
 import { WebSocketServer } from 'ws';
-import qs from 'qs';
 
 import db, { KnexDatabase } from '@nangohq/database';
 import { migrate as migrateKeystore } from '@nangohq/keystore';
@@ -47,12 +46,7 @@ process.on('uncaughtException', (err) => {
 });
 
 const app = express();
-app.set('query parser', (str: string) =>
-    qs.parse(str, {
-        allowDots: true,
-        depth: 10
-    })
-);
+app.set('query parser', 'extended');
 app.disable('x-powered-by');
 app.set('trust proxy', 1);
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -60,7 +60,6 @@
         "passport": "0.6.0",
         "passport-http": "0.3.0",
         "passport-local": "1.0.0",
-        "qs": "^6.14.0",
         "rate-limiter-flexible": "5.0.3",
         "redis": "4.6.13",
         "semver": "7.6.3",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -60,6 +60,7 @@
         "passport": "0.6.0",
         "passport-http": "0.3.0",
         "passport-local": "1.0.0",
+        "qs": "^6.14.0",
         "rate-limiter-flexible": "5.0.3",
         "redis": "4.6.13",
         "semver": "7.6.3",


### PR DESCRIPTION
Describe the problem and your solution

- After upgrading Express, nested query parameters (e.g., authorization_params[display_ui]=always) were no longer parsed correctly, they became flattened, causing issues during OAuth and other parameter i.e credentials.
- This PR explicitly sets a custom query parser using the `qs` library to restore correct parsing behavior for deeply nested query structures.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR addresses an issue with nested query parameters parsing that arose after an Express upgrade, which caused parameters like authorization_params[display_ui]=always to be flattened incorrectly. The fix explicitly sets Express's query parser to 'extended' to restore handling of deeply nested query structures, such as those required for OAuth.

*This summary was automatically generated by @propel-code-bot*