### PR TITLE
fix(api): tmp fix for rewriting express query

### DIFF
--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -136,6 +136,7 @@ class SyncController {
                 req.body['input'] = input;
                 await this.triggerAction(req, res, next);
             } else if (model) {
+                Object.defineProperty(req, 'query', { ...Object.getOwnPropertyDescriptor(req, 'query'), value: req.query, writable: true });
                 req.query['model'] = model;
                 getPublicRecords(req, res, next);
             } else {


### PR DESCRIPTION
##

- API: /v1 tmp fix for rewriting express query
We can't write to req.query but TS doesn't seems to catch this one.
Ideally we would do better, but it's a legacy endpoint, will rewrite later

<!-- Summary by @propel-code-bot -->

---

This PR applies a temporary fix to the /v1 API handler for rewriting Express's `req.query` object, enabling the assignment of the 'model' value. This resolves an issue where direct assignment to `req.query` is not allowed by Express, bypassing the limitation with `Object.defineProperty`.

*This summary was automatically generated by @propel-code-bot*