### PR TITLE
fix(scheduler): max concurrency race condition

### DIFF
--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -22,7 +22,7 @@ describe('Task', () => {
         const props = {
             name: 'Test Task',
             payload: { foo: 'bar' },
-            groupKey: 'groupA',
+            groupKey: nanoid(),
             retryMax: 3,
             retryCount: 1,
             startsAfter: new Date(),
@@ -84,7 +84,7 @@ describe('Task', () => {
         }
     });
     it('should be dequeued', async () => {
-        const t0 = await createTask(db, { groupKey: 'A' });
+        const t0 = await createTask(db, { groupKey: nanoid() });
         const t1 = await createTask(db);
         const t2 = await createTask(db, { groupKey: t1.groupKey });
         await createTask(db, { groupKey: t0.groupKey });
@@ -123,7 +123,7 @@ describe('Task', () => {
         expect(dequeued).toHaveLength(0);
     });
     it('should be dequeued according to group max concurrency ', async () => {
-        const groupKey = 'A';
+        const groupKey = nanoid();
         const groupMaxConcurrency = 2;
         const t0 = await createTask(db, { groupKey, groupMaxConcurrency });
         const t1 = await createTask(db, { groupKey, groupMaxConcurrency });
@@ -139,8 +139,8 @@ describe('Task', () => {
         expect(dequeued).toHaveLength(0);
 
         // dequeuing tasks with different group key should not be affected
-        const t3 = await createTask(db, { groupKey: 'B', groupMaxConcurrency });
-        dequeued = (await tasks.dequeue(db, { groupKey: 'B', limit: 10 })).unwrap();
+        const t3 = await createTask(db, { groupKey: nanoid(), groupMaxConcurrency });
+        dequeued = (await tasks.dequeue(db, { groupKey: t3.groupKey, limit: 10 })).unwrap();
         expect(dequeued).toHaveLength(1);
         expect(dequeued[0]).toMatchObject({ id: t3.id, state: 'STARTED' });
 
@@ -154,7 +154,7 @@ describe('Task', () => {
         expect(dequeued[0]).toMatchObject({ id: t2.id, state: 'STARTED' });
     });
     it('should respect group max concurrency with parallel dequeue calls', async () => {
-        const groupKey = 'A';
+        const groupKey = nanoid();
         const groupMaxConcurrency = 2;
 
         // creating and dequeing tasks in parallel in a tight loop
@@ -168,7 +168,7 @@ describe('Task', () => {
             dequeuePromises.push(tasks.dequeue(db, { groupKey, limit: 100 }).then((d) => d.unwrap()));
         }, 1);
 
-        await new Promise((resolve) => void setTimeout(resolve, 2000));
+        await new Promise((resolve) => void setTimeout(resolve, 200));
         clearInterval(createInterval);
         clearInterval(dequeueInterval);
 
@@ -257,27 +257,32 @@ async function createTaskWithState(db: knex.Knex, state: TaskState): Promise<Tas
 
 async function createTask(db: knex.Knex, props?: Partial<tasks.TaskProps> & { groupMaxConcurrency?: number | undefined }): Promise<Task> {
     const now = new Date();
-    await groups.upsert(db, {
+    const group = await groups.upsert(db, {
         key: props?.groupKey || nanoid(),
         maxConcurrency: props?.groupMaxConcurrency || 0,
         lastTaskAddedAt: now
     });
-    return tasks
-        .create(db, {
-            name: props?.name || nanoid(),
-            payload: props?.payload || {},
-            groupKey: props?.groupKey || nanoid(),
-            retryMax: props?.retryMax || 3,
-            retryCount: props?.retryCount || 1,
-            startsAfter: props?.startsAfter || now,
-            createdToStartedTimeoutSecs: props?.createdToStartedTimeoutSecs || 10,
-            startedToCompletedTimeoutSecs: props?.startedToCompletedTimeoutSecs || 20,
-            heartbeatTimeoutSecs: props?.heartbeatTimeoutSecs || 5,
-            scheduleId: props?.scheduleId || null,
-            retryKey: props?.retryKey || null,
-            ownerKey: props?.ownerKey || null
-        })
-        .then((t) => t.unwrap());
+    if (group.isErr()) {
+        throw new Error(`Failed to create group: ${group.error.message}`);
+    }
+    const task = await tasks.create(db, {
+        name: props?.name || nanoid(),
+        payload: props?.payload || {},
+        groupKey: props?.groupKey || nanoid(),
+        retryMax: props?.retryMax || 3,
+        retryCount: props?.retryCount || 1,
+        startsAfter: props?.startsAfter || now,
+        createdToStartedTimeoutSecs: props?.createdToStartedTimeoutSecs || 10,
+        startedToCompletedTimeoutSecs: props?.startedToCompletedTimeoutSecs || 20,
+        heartbeatTimeoutSecs: props?.heartbeatTimeoutSecs || 5,
+        scheduleId: props?.scheduleId || null,
+        retryKey: props?.retryKey || null,
+        ownerKey: props?.ownerKey || null
+    });
+    if (task.isErr()) {
+        throw new Error(`Failed to create task: ${task.error.message}`);
+    }
+    return task.unwrap();
 }
 
 async function startTask(db: knex.Knex, props?: Partial<tasks.TaskProps>): Promise<Task> {

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -1,7 +1,7 @@
 import type { JsonValue, SetOptional } from 'type-fest';
 import type knex from 'knex';
 import type { Result } from '@nangohq/utils';
-import { Ok, Err, stringifyError } from '@nangohq/utils';
+import { Ok, Err, stringifyError, stringToHash } from '@nangohq/utils';
 import { taskStates } from '../types.js';
 import type { TaskState, Task, TaskTerminalState, TaskNonTerminalState } from '../types.js';
 import { uuidv7, uuidv4 } from 'uuidv7';
@@ -258,75 +258,72 @@ export async function dequeue(db: knex.Knex, { groupKey, limit }: { groupKey: st
     try {
         const groupKeyPattern = groupKey.replace(/\*/g, '%');
 
-        const tasks = await db
-            // 1. select created tasks that are ready to be started alongside their group
-            // Note: tasks and groups are locked for update, preventing concurrent queries
-            // to dequeue the same tasks and/or groups
-            .with('candidates', (qb) => {
-                qb.select('t.id', 't.group_key', 't.created_at', 'g.max_concurrency')
-                    .from(`${TASKS_TABLE} as t`)
-                    .join(`${GROUPS_TABLE} as g`, 'g.key', 't.group_key')
-                    .where('t.state', 'CREATED')
-                    .whereLike('group_key', groupKeyPattern)
-                    .where('t.starts_after', '<=', db.fn.now())
-                    .forUpdate()
-                    .skipLocked();
-            })
-            // 2. count the number of running tasks for each group
-            .with('running', (qb) => {
-                qb.select(db.raw('count(id) as running_count'), 'group_key')
-                    .from(TASKS_TABLE)
-                    .where('state', 'STARTED')
-                    .whereIn('group_key', function () {
-                        this.distinct('group_key').from('candidates');
+        const tasks = await db.transaction(async (trx) => {
+            // Acquire a lock to prevent concurrent dequeueing of the same group
+            // in order to ensure max concurrency is respected
+            await trx.raw(`SELECT pg_advisory_xact_lock(?) as "lock_dequeue_${groupKey}"`, [stringToHash(groupKey)]);
+            return (
+                trx
+                    // 1. select created tasks that are ready to be started alongside their group
+                    // Note: tasks and groups are locked for update, preventing concurrent queries
+                    // to dequeue the same tasks and/or groups
+                    .with('candidates', (qb) => {
+                        qb.select('t.id', 't.group_key', 't.created_at', 'g.max_concurrency')
+                            .from(`${TASKS_TABLE} as t`)
+                            .join(`${GROUPS_TABLE} as g`, 'g.key', 't.group_key')
+                            .where('t.state', 'CREATED')
+                            .whereLike('group_key', groupKeyPattern)
+                            .where('t.starts_after', '<=', db.fn.now())
+                            .forUpdate()
+                            .skipLocked();
                     })
-                    .groupBy('group_key');
-            })
-            // 3. rank the candidate tasks by created_at for each group
-            .with('with_rank', (qb) => {
-                qb.select(
-                    'c.*',
-                    db.raw('ROW_NUMBER() OVER (PARTITION BY c.group_key ORDER BY c.created_at ASC) as rank'),
-                    db.raw('COALESCE(r.running_count, 0) as current_running')
-                )
-                    .from('candidates as c')
-                    .leftJoin('running as r', 'c.group_key', 'r.group_key');
-            })
-            // 4. select the tasks that can be started based on the max_concurrency
-            .with('to_start', (qb) => {
-                qb.select('id', 'group_key', 'created_at')
-                    .from('with_rank')
-                    .whereRaw('max_concurrency = 0 OR (rank + current_running <= max_concurrency)')
+                    // 2. count the number of running tasks for each group
+                    .with('running', (qb) => {
+                        qb.select(db.raw('count(id) as running_count'), 'group_key')
+                            .from(TASKS_TABLE)
+                            .where('state', 'STARTED')
+                            .whereIn('group_key', function () {
+                                this.distinct('group_key').from('candidates');
+                            })
+                            .groupBy('group_key');
+                    })
+                    // 3. rank the candidate tasks by created_at for each group
+                    .with('with_rank', (qb) => {
+                        qb.select(
+                            'c.*',
+                            db.raw('ROW_NUMBER() OVER (PARTITION BY c.group_key ORDER BY c.created_at ASC) as rank'),
+                            db.raw('COALESCE(r.running_count, 0) as current_running')
+                        )
+                            .from('candidates as c')
+                            .leftJoin('running as r', 'c.group_key', 'r.group_key');
+                    })
+                    // 4. select the tasks that can be started based on the max_concurrency
+                    .with('to_start', (qb) => {
+                        qb.select('id', 'group_key', 'created_at')
+                            .from('with_rank')
+                            .whereRaw('max_concurrency = 0 OR (rank + current_running <= max_concurrency)')
 
-                    .orderBy('created_at', 'asc')
-                    .limit(limit);
-            })
-            // 5. starts the tasks
-            .with(
-                'updated_tasks',
-                db
-                    .update({
-                        state: 'STARTED',
-                        last_state_transition_at: new Date()
+                            .orderBy('created_at', 'asc')
+                            .limit(limit);
                     })
-                    .from(TASKS_TABLE)
-                    .whereIn('id', db.select('id').from('to_start'))
-                    .returning('*')
-            )
-            // 6. update the group last_task_added_at
-            .with(
-                'updated_groups',
-                db
-                    .update({
-                        last_task_added_at: new Date()
-                    })
-                    .from(GROUPS_TABLE)
-                    .whereIn('key', db.select('group_key').from('updated_tasks'))
-            )
-            // 7. return the updated tasks
-            .select('*')
-            .from<DbTask>('updated_tasks')
-            .orderBy('id');
+                    // 5. starts the tasks
+                    .with(
+                        'updated_tasks',
+                        db
+                            .update({
+                                state: 'STARTED',
+                                last_state_transition_at: new Date()
+                            })
+                            .from(TASKS_TABLE)
+                            .whereIn('id', db.select('id').from('to_start'))
+                            .returning('*')
+                    )
+                    // 6. return the updated tasks
+                    .select('*')
+                    .from<DbTask>('updated_tasks')
+                    .orderBy('id')
+            );
+        });
 
         if (!tasks?.[0]) {
             return Ok([]);


### PR DESCRIPTION
fixing the race condition, using pg advisory lock to ensure max one single dequeue per groupKey and correct max concurrency handling.
The groups table is now unnecessary since it sole purpose was to have something to lock against. I will followup with PRs to remove the group table and denormalize the max concurrency value into the tasks table. Will save a few queries and table maintenance.
<!-- Summary by @propel-code-bot -->

---

This PR addresses a race condition in the scheduler's dequeue logic related to max concurrency per group. It introduces PostgreSQL advisory locks (pg_advisory_xact_lock) keyed by groupKey hash to serialize dequeues and properly enforce max concurrency semantics. The change also refactors transaction handling in task dequeuing, removes unnecessary updates to the groups table, and hardens the integration tests for group uniqueness and error handling.

**Key Changes:**
• Introduced use of pg_advisory_xact_lock on groupKey in scheduler dequeue logic (tasks.ts)
• Wrapped dequeue logic in a transaction to ensure advisory lock consistency
• Removed group table update on dequeue, as it's now redundant
• Strengthened integration tests to use random groupKeys (nanoid) and added group/task creation error checks
• Reduced test durations for improved efficiency

**Affected Areas:**
• packages/scheduler/lib/models/tasks.ts (task dequeue logic, group locking)
• packages/scheduler/lib/models/tasks.integration.test.ts (integration tests for scheduler/task handling)

*This summary was automatically generated by @propel-code-bot*