### PR TITLE
chore(scheduler): remove unused groups table

### DIFF
--- a/packages/scheduler/lib/db/migrations/20250522183200_remove_groups_table.ts
+++ b/packages/scheduler/lib/db/migrations/20250522183200_remove_groups_table.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex';
+
+const GROUPS_TABLE = 'groups';
+
+export const config = {
+    transaction: false
+};
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`DROP TABLE IF EXISTS ${GROUPS_TABLE} CASCADE;`);
+}
+
+export async function down(): Promise<void> {}


### PR DESCRIPTION
last PR of the series, removing the groups table once it is not used anymore

<!-- Summary by @propel-code-bot -->

---

This PR adds a database migration to drop the now-unused 'groups' table from the scheduler package. The migration includes an up function to remove the table if present and an empty down method.

*This summary was automatically generated by @propel-code-bot*