### PR TITLE
chore(docs): mention the action output 10mb limit

### DIFF
--- a/docs-v2/guides/actions/use-an-action.mdx
+++ b/docs-v2/guides/actions/use-an-action.mdx
@@ -15,6 +15,10 @@ Actions let you trigger tasks on third-party APIs from your backend — like fet
 - Perform multiple API calls and transformations,
 - Return a result (either synchronously or asynchronously).
 
+<Warning>
+The output of an action cannot exceed 10MB.
+</Warning>
+
 For more details, see [Action Overview](/guides/actions/overview).
 
 # Activate an action integration

--- a/docs-v2/reference/sdks/node.mdx
+++ b/docs-v2/reference/sdks/node.mdx
@@ -1550,6 +1550,10 @@ await nango.triggerAction('<INTEGRATION-ID>', '<CONNECTION_ID>', '<ACTION-NAME>'
 ```
 </Expandable>
 
+<Warning>
+The output of an action cannot exceed 10MB.
+</Warning>
+
 ### Trigger an action asynchronously
 
 Triggers an action asynchronously for a connection. This allows you to start an action and retrieve the results later.

--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -1701,7 +1701,7 @@ paths:
                   description: The ID of the asynchronous action (returned from triggering an action with X-Async header)
             responses:
                 '200':
-                    description: The action has completed successfully
+                    description: The action has completed successfully (output cannot exceed 10MB)
                     content:
                         application/json:
                             schema:
@@ -1842,20 +1842,20 @@ paths:
 
             responses:
                 '200':
-                    description: Returns the result of the action. When triggered synchronously, returns the action result directly. When triggered asynchronously (X-Async header is true), returns a status URL and ID for polling the result.
+                    description: The result of the action.
                     content:
                         application/json:
                             schema:
                                 oneOf:
                                     - type: object
-                                      description: Synchronous action response
+                                      description: The result of the action when triggered synchronously. (cannot exceed 10MB)
                                       properties:
                                           your-properties:
                                               type: object
                                               description: The data returned by the action
                                               example: 'The data returned by the action'
                                     - type: object
-                                      description: Asynchronous action response
+                                      description: The ID and the status URL of the action to poll for the result when triggered asynchronously.
                                       required:
                                           - statusUrl
                                           - id


### PR DESCRIPTION
Mentioning the action output 10mb limit in the docs (action guides, api, node)

<!-- Summary by @propel-code-bot -->

---

This PR updates documentation to explicitly mention the 10MB maximum output limit for action results. The limit is now clearly described in the OpenAPI spec, in the Actions usage guide, and in the Node SDK reference.

*This summary was automatically generated by @propel-code-bot*