### PR TITLE
docs: add warning about getMetadata caching in sync

### DIFF
--- a/docs-v2/guides/customer-configuration.mdx
+++ b/docs-v2/guides/customer-configuration.mdx
@@ -96,6 +96,12 @@ curl --request GET \
 
 </Tabs>
 
+<Warning>
+When accessing metadata from within a sync using `nango.getMetadata()`, the metadata is cached for up to 60 seconds. Changes made to metadata while a sync is running may not be visible until the cache expires.
+
+The next execution of the sync will always have access to the latest metadata.
+</Warning>
+
 # Use custom field mappings
 
 Field mappings are necessary when a [sync](/guides/syncs/overview) needs to access information stored in external custom fields. Nango provides dedicated tools to support complex field mappings.


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the customer configuration guide to include a warning about the 60-second caching behavior when using `nango.getMetadata()` within a sync. The note clarifies that metadata changes during a running sync may not be immediately reflected and will only be visible after the cache expires or in the next sync execution.

*This summary was automatically generated by @propel-code-bot*