### PR TITLE
feat: do not await webhook forwarding

### DIFF
--- a/packages/server/lib/webhook/webhook.manager.ts
+++ b/packages/server/lib/webhook/webhook.manager.ts
@@ -91,8 +91,10 @@ export async function routeWebhook({
 
         const webhookSettings = await externalWebhookService.get(environment.id);
 
-        await tracer.trace('webhook.forward', async () => {
-            await forwardWebhook({
+        tracer.trace('webhook.forward', () => {
+            // Forward the webhook to the customer asynchronously to avoid provider timeouts.
+            // Some providers stop sending webhooks if Nango doesn't respond quickly due to slow customer endpoints
+            void forwardWebhook({
                 integration,
                 account,
                 environment,

--- a/packages/server/lib/webhook/webhook.manager.ts
+++ b/packages/server/lib/webhook/webhook.manager.ts
@@ -91,20 +91,19 @@ export async function routeWebhook({
 
         const webhookSettings = await externalWebhookService.get(environment.id);
 
-        tracer.trace('webhook.forward', () => {
-            // Forward the webhook to the customer asynchronously to avoid provider timeouts.
-            // Some providers stop sending webhooks if Nango doesn't respond quickly due to slow customer endpoints
-            void forwardWebhook({
-                integration,
-                account,
-                environment,
-                webhookSettings,
-                connectionIds,
-                payload: webhookBodyToForward,
-                webhookOriginalHeaders: headers,
-                logContextGetter
-            });
-        });
+        // Forward the webhook to the customer asynchronously to avoid provider timeouts.
+        // Some providers stop sending webhooks if Nango doesn't respond quickly due to slow customer endpoints
+        const forwardSpan = tracer.startSpan('webhook.forward');
+        void forwardWebhook({
+            integration,
+            account,
+            environment,
+            webhookSettings,
+            connectionIds,
+            payload: webhookBodyToForward,
+            webhookOriginalHeaders: headers,
+            logContextGetter
+        }).finally(() => forwardSpan.finish());
     }
 
     return res;


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR changes the webhook forwarding process in webhook.manager.ts to operate asynchronously, preventing slow customer endpoints from delaying responses to webhook providers. The forwarding operation no longer blocks on await and is now traced explicitly via a started span, improving handling of provider response time expectations and maintaining traceability.

**Key Changes:**
• Replaced 'await' with 'void' for the forwardWebhook call, making it non-blocking and truly asynchronous.
• Introduced a manual tracing span (forwardSpan) around the forwardWebhook operation to retain observability.
• Added inline comments explaining why forwarding is made asynchronous-specifically, to avoid webhook delivery termination by certain providers.

**Affected Areas:**
• packages/server/lib/webhook/webhook.manager.ts

*This summary was automatically generated by @propel-code-bot*