### PR TITLE
fix: actually send billing events additional properties

### DIFF
--- a/packages/billing/lib/billing.ts
+++ b/packages/billing/lib/billing.ts
@@ -58,14 +58,16 @@ export class Billing {
                 return [];
             }
 
+            const { accountId, idempotencyKey, timestamp, ...rest } = event.properties;
             return [
                 {
                     type: event.type,
-                    accountId: event.properties.accountId,
-                    idempotencyKey: event.properties.idempotencyKey || uuidv7(),
-                    timestamp: event.properties.timestamp || new Date(),
+                    accountId,
+                    idempotencyKey: idempotencyKey || uuidv7(),
+                    timestamp: timestamp || new Date(),
                     properties: {
-                        count: event.value
+                        count: event.value,
+                        ...rest
                     }
                 }
             ];


### PR DESCRIPTION
I've added additional properties to the BillingMetric but forgot to send them 🙈 

<!-- Summary by @propel-code-bot -->

---

This PR updates the billing event construction logic to correctly include all additional properties from BillingMetric when sending billing events. The implementation now merges any extra properties into the properties object of the event payload in the addAll method.

*This summary was automatically generated by @propel-code-bot*