### PR TITLE
fix(response-saver): filter out undefined as well

### DIFF
--- a/packages/cli/lib/services/response-saver.service.ts
+++ b/packages/cli/lib/services/response-saver.service.ts
@@ -180,7 +180,7 @@ function computeConfigIdentity(config: AxiosRequestConfig): ConfigIdentity {
                 if (FILTER_HEADERS.includes(lowerKey)) return false;
 
                 // Skip application/json
-                if (lowerKey === 'content-type' && value.toLowerCase() === 'application/json') return false;
+                if (lowerKey === 'content-type' && (value.toLowerCase() === 'application/json' || value === 'undefined')) return false;
 
                 return true;
             });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
undefined somehow slips into the header so filter that out as well

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the response-saver.service.ts to filter out headers where the 'content-type' value is the string 'undefined', in addition to the existing check for 'application/json'.

*This summary was automatically generated by @propel-code-bot*