### PR TITLE
feat(syncConfig): store sdk version along syncConfigs, onevents

### DIFF
--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -341,6 +341,7 @@ export class DryRunService {
                 is_public: false,
                 metadata: {},
                 pre_built: false,
+                sdk_version: null,
                 sync_type: lastSyncDate ? 'incremental' : 'full',
                 version: '0.0.1'
             };

--- a/packages/database/lib/migrations/20250519153421_sync_config_sdk_version.cjs
+++ b/packages/database/lib/migrations/20250519153421_sync_config_sdk_version.cjs
@@ -1,0 +1,9 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE "_nango_sync_configs" ADD COLUMN "sdk_version" varchar(25)`);
+    await knex.raw(`ALTER TABLE "on_event_scripts" ADD COLUMN "sdk_version" varchar(25)`);
+};
+
+exports.down = function () {};

--- a/packages/jobs/lib/execution/onEvent.ts
+++ b/packages/jobs/lib/execution/onEvent.ts
@@ -70,6 +70,7 @@ export async function startOnEvent(task: TaskOnEvent): Promise<Result<void>> {
             models_json_schema: null,
             pre_built: false,
             sync_type: null,
+            sdk_version: null,
             created_at: new Date(),
             updated_at: new Date()
         };

--- a/packages/jobs/lib/routes/tasks/putTask.ts
+++ b/packages/jobs/lib/routes/tasks/putTask.ts
@@ -49,7 +49,8 @@ const nangoPropsSchema = z
                 is_public: z.boolean(),
                 input: z.string().nullable(),
                 sync_type: z.enum(['full', 'incremental']).nullable(),
-                metadata: z.record(z.string(), z.any())
+                metadata: z.record(z.string(), z.any()),
+                sdk_version: z.string().nullable()
                 // TODO: fix this missing fields
                 // deleted: z.boolean().optional(),
                 // deleted_at: z.coerce.date().optional().nullable(),

--- a/packages/server/lib/controllers/sync/deploy/postConfirmation.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postConfirmation.integration.test.ts
@@ -1,6 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { isError, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
+
 import { seeders } from '@nangohq/shared';
+
+import { isError, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
 
 const endpoint = '/sync/deploy/confirmation';
 let api: Awaited<ReturnType<typeof runServer>>;
@@ -80,7 +82,7 @@ describe(`POST ${endpoint}`, () => {
     it('should show correct on-events scripts diff', async () => {
         const { account, env: environment } = await seeders.seedAccountEnvAndUser();
         const { unique_key: providerConfigKey } = await seeders.createConfigSeed(environment, 'notion-123', 'notion');
-        const existingOnEvent = await seeders.createOnEventScript({ account, environment, providerConfigKey });
+        const existingOnEvent = await seeders.createOnEventScript({ account, environment, providerConfigKey, sdkVersion: '0.0.0-yaml' });
 
         const res = await api.fetch(endpoint, {
             method: 'POST',

--- a/packages/server/lib/controllers/sync/deploy/postConfirmation.ts
+++ b/packages/server/lib/controllers/sync/deploy/postConfirmation.ts
@@ -45,7 +45,8 @@ export const postDeployConfirmation = asyncWrapper<PostDeployConfirmation>(async
         const diff = await onEventScriptService.diffChanges({
             environmentId,
             onEventScriptsByProvider: body.onEventScriptsByProvider,
-            singleDeployMode: body.singleDeployMode || false
+            singleDeployMode: body.singleDeployMode || false,
+            sdkVersion: body.sdkVersion
         });
         result = {
             ...syncAndActionDifferences,

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.ts
@@ -61,8 +61,9 @@ export const postDeploy = asyncWrapper<PostDeploy>(async (req, res) => {
         nangoYamlBody: body.nangoYamlBody,
         onEventScriptsByProvider: body.onEventScriptsByProvider,
         debug: body.debug,
-        jsonSchema: req.body.jsonSchema,
+        jsonSchema: body.jsonSchema,
         logContextGetter,
+        sdkVersion: body.sdkVersion,
         orchestrator
     });
 

--- a/packages/server/lib/controllers/sync/deploy/postDeployInternal.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeployInternal.ts
@@ -91,8 +91,9 @@ export const postDeployInternal = asyncWrapper<PostDeployInternal>(async (req, r
         nangoYamlBody: body.nangoYamlBody,
         onEventScriptsByProvider: body.onEventScriptsByProvider,
         debug: body.debug,
-        jsonSchema: req.body.jsonSchema,
+        jsonSchema: body.jsonSchema,
         logContextGetter,
+        sdkVersion: body.sdkVersion,
         orchestrator
     });
 

--- a/packages/server/lib/controllers/sync/deploy/validation.ts
+++ b/packages/server/lib/controllers/sync/deploy/validation.ts
@@ -125,7 +125,11 @@ const commonValidation = z
         jsonSchema: jsonSchema.optional(),
         reconcile: z.boolean(),
         debug: z.boolean(),
-        singleDeployMode: z.boolean().optional().default(false)
+        singleDeployMode: z.boolean().optional().default(false),
+        sdkVersion: z
+            .string()
+            .regex(/[0-9]+\.[0-9]+\.[0-9]+-(zero|yaml)/)
+            .optional()
     })
     .strict();
 

--- a/packages/server/lib/controllers/sync/deploy/validation.ts
+++ b/packages/server/lib/controllers/sync/deploy/validation.ts
@@ -9,7 +9,7 @@ const jsonSchema = z
     .object({
         $schema: z.literal('http://json-schema.org/draft-07/schema#'),
         $comment: z.string(),
-        definitions: z.record(z.string(), z.object({}))
+        definitions: z.record(z.string(), z.object({}).passthrough())
     })
     .strict();
 

--- a/packages/shared/lib/seeders/onEventScript.seeder.ts
+++ b/packages/shared/lib/seeders/onEventScript.seeder.ts
@@ -1,14 +1,17 @@
-import type { DBEnvironment, DBTeam, OnEventScript, OnEventScriptsByProvider } from '@nangohq/types';
 import { onEventScriptService } from '../services/on-event-scripts.service.js';
+
+import type { DBEnvironment, DBTeam, OnEventScript, OnEventScriptsByProvider } from '@nangohq/types';
 
 export async function createOnEventScript({
     account,
     environment,
-    providerConfigKey
+    providerConfigKey,
+    sdkVersion
 }: {
     account: DBTeam;
     environment: DBEnvironment;
     providerConfigKey: string;
+    sdkVersion: string | undefined;
 }): Promise<OnEventScript> {
     const scripts: OnEventScriptsByProvider[] = [
         {
@@ -25,7 +28,8 @@ export async function createOnEventScript({
     const [added] = await onEventScriptService.update({
         environment,
         account,
-        onEventScriptsByProvider: scripts
+        onEventScriptsByProvider: scripts,
+        sdkVersion
     });
     if (!added) {
         throw new Error('failed_to_create_on_event_script');

--- a/packages/shared/lib/services/on-event-scripts.service.ts
+++ b/packages/shared/lib/services/on-event-scripts.service.ts
@@ -38,6 +38,7 @@ const dbMapper = {
             version: script.version,
             active: script.active,
             event: eventTypeMapper.toDb(script.event),
+            sdk_version: script.sdkVersion,
             created_at: script.createdAt,
             updated_at: script.updatedAt
         };
@@ -52,6 +53,7 @@ const dbMapper = {
             version: dbScript.version,
             active: dbScript.active,
             event: eventTypeMapper.fromDb(dbScript.event),
+            sdkVersion: dbScript.sdk_version,
             createdAt: dbScript.created_at,
             updatedAt: dbScript.updated_at
         };
@@ -62,11 +64,13 @@ export const onEventScriptService = {
     async update({
         environment,
         account,
-        onEventScriptsByProvider
+        onEventScriptsByProvider,
+        sdkVersion
     }: {
         environment: DBEnvironment;
         account: DBTeam;
         onEventScriptsByProvider: OnEventScriptsByProvider[];
+        sdkVersion: string | undefined;
     }): Promise<OnEventScript[]> {
         return db.knex.transaction(async (trx) => {
             const onEventInserts: Omit<DBOnEventScript, 'id' | 'created_at' | 'updated_at'>[] = [];
@@ -121,7 +125,8 @@ export const onEventScriptService = {
                         file_location,
                         version: version.toString(),
                         active: true,
-                        event
+                        event,
+                        sdk_version: sdkVersion || null
                     });
                 }
             }
@@ -158,11 +163,13 @@ export const onEventScriptService = {
     diffChanges: async ({
         environmentId,
         onEventScriptsByProvider,
-        singleDeployMode = false
+        singleDeployMode = false,
+        sdkVersion
     }: {
         environmentId: number;
         onEventScriptsByProvider: OnEventScriptsByProvider[];
         singleDeployMode?: boolean;
+        sdkVersion: string | undefined;
     }): Promise<{
         added: Omit<OnEventScript, 'id' | 'fileLocation' | 'createdAt' | 'updatedAt'>[];
         deleted: OnEventScript[];
@@ -212,7 +219,8 @@ export const onEventScriptService = {
                         version: '0.0.1',
                         active: true,
                         event,
-                        providerConfigKey
+                        providerConfigKey,
+                        sdkVersion: sdkVersion || null
                     });
                 }
             }

--- a/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
@@ -56,6 +56,7 @@ describe('Sync config create', () => {
             logContextGetter,
             orchestrator: mockOrchestrator,
             debug,
+            sdkVersion: '0.0.0-yaml',
             onEventScriptsByProvider: []
         });
 
@@ -97,6 +98,7 @@ describe('Sync config create', () => {
             logContextGetter,
             orchestrator: mockOrchestrator,
             debug,
+            sdkVersion: '0.0.0-yaml',
             onEventScriptsByProvider: []
         });
         expect(error?.message).toBe(
@@ -169,6 +171,7 @@ describe('Sync config create', () => {
                     input: null,
                     sync_type: 'full',
                     models_json_schema: null,
+                    sdk_version: null,
                     created_at: new Date(),
                     updated_at: new Date()
                 }
@@ -199,6 +202,7 @@ describe('Sync config create', () => {
                 input: null,
                 sync_type: 'full',
                 models_json_schema: null,
+                sdk_version: null,
                 created_at: new Date(),
                 updated_at: new Date()
             });
@@ -228,6 +232,7 @@ describe('Sync config create', () => {
                 input: null,
                 sync_type: 'full',
                 models_json_schema: null,
+                sdk_version: null,
                 created_at: new Date(),
                 updated_at: new Date()
             });
@@ -253,6 +258,7 @@ describe('Sync config create', () => {
                 logContextGetter,
                 orchestrator: mockOrchestrator,
                 debug,
+                sdkVersion: '0.0.0-yaml',
                 onEventScriptsByProvider: []
             })
         ).rejects.toThrowError('Error creating sync config from a deploy. Please contact support with the sync name and connection details');

--- a/packages/types/lib/deploy/api.ts
+++ b/packages/types/lib/deploy/api.ts
@@ -1,9 +1,8 @@
-import type { JSONSchema7 } from 'json-schema';
-
-import type { Endpoint, ApiError } from '../api.js';
+import type { ApiError, Endpoint } from '../api.js';
 import type { CLIDeployFlowConfig, OnEventScriptsByProvider } from './incomingFlow.js';
 import type { SyncDeploymentResult } from './index.js';
 import type { OnEventType } from '../scripts/on-events/api.js';
+import type { JSONSchema7 } from 'json-schema';
 
 export type PostDeployConfirmation = Endpoint<{
     Method: 'POST';
@@ -15,6 +14,7 @@ export type PostDeployConfirmation = Endpoint<{
         debug: boolean;
         singleDeployMode?: boolean;
         jsonSchema?: JSONSchema7 | undefined;
+        sdkVersion?: string | undefined;
     };
     Success: ScriptDifferences;
 }>;
@@ -30,6 +30,7 @@ export type PostDeploy = Endpoint<{
         debug: boolean;
         singleDeployMode?: boolean;
         jsonSchema?: JSONSchema7 | undefined;
+        sdkVersion?: string | undefined;
     };
     Success: SyncDeploymentResult[];
 }>;
@@ -48,6 +49,7 @@ export type PostDeployInternal = Endpoint<{
         debug: boolean;
         singleDeployMode?: boolean;
         jsonSchema?: JSONSchema7 | undefined;
+        sdkVersion?: string | undefined;
     };
     Error: ApiError<'forbidden'> | ApiError<'environment_creation_error'>;
     Success: SyncDeploymentResult[];

--- a/packages/types/lib/scripts/on-events/api.ts
+++ b/packages/types/lib/scripts/on-events/api.ts
@@ -11,6 +11,7 @@ export interface OnEventScript {
     version: DBOnEventScript['version'];
     active: DBOnEventScript['active'];
     event: OnEventType;
+    sdkVersion: DBOnEventScript['sdk_version'];
     createdAt: DBOnEventScript['created_at'];
     updatedAt: DBOnEventScript['updated_at'];
 }

--- a/packages/types/lib/scripts/on-events/db.ts
+++ b/packages/types/lib/scripts/on-events/db.ts
@@ -8,4 +8,5 @@ export interface DBOnEventScript extends Timestamps {
     version: string;
     active: boolean;
     event: 'POST_CONNECTION_CREATION' | 'PRE_CONNECTION_DELETION';
+    sdk_version: string | null;
 }

--- a/packages/types/lib/syncConfigs/db.ts
+++ b/packages/types/lib/syncConfigs/db.ts
@@ -26,5 +26,6 @@ export interface DBSyncConfig extends TimestampsAndDeleted {
     webhook_subscriptions: string[] | null;
     enabled: boolean;
     models_json_schema: JSONSchema7 | null;
+    sdk_version: string | null;
 }
 export type DBSyncConfigInsert = Omit<DBSyncConfig, 'id'>;

--- a/packages/webhooks/lib/sync.unit.test.ts
+++ b/packages/webhooks/lib/sync.unit.test.ts
@@ -53,6 +53,7 @@ const syncConfig: DBSyncConfig = {
     webhook_subscriptions: null,
     enabled: true,
     models_json_schema: null,
+    sdk_version: null,
     created_at: new Date(),
     updated_at: new Date()
 };


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-3311/store-sdk-version-in-db

- Store sdk version along syncConfigs, onEvents
To be able to know which sdk the scripts are using, and also determines if it's a yaml or not. This will help refine some logic of the code without having to load the actual code. Also in general it will give us the ability to know what's the lowest version we can support.

NB: it's only types and default value, it's not used yet


<!-- Summary by @propel-code-bot -->

---

This PR adds support for persisting the SDK version (sdk_version) used during deployments of sync configurations and on-event scripts. These changes introduce new database columns, update relevant TypeScript types, validation schemas, service logic, API endpoints, and test/seed logic to accept and store the SDK version as a first-class, optional property. The version value is currently only captured, stored, and exposed, but not yet actively used for any runtime logic or compatibility decisions.

**Key Changes:**
• Database migration adds `sdk_version` columns to `_nango_sync_configs` and `on_event_scripts` tables.
• TypeScript types/interfaces for sync configs and on-event scripts extended to include `sdk_version`.
• API types, endpoints (`/sync/deploy`, `/sync/deploy/confirmation`, `/sync/deploy/internal`), and validation updated to support and validate the `sdkVersion` property (with regex constraint).
• Service layers (deployment, on-event script service) refactored to propagate and persist the new field.
• Seeder utilities, unit and integration tests updated to set and check `sdkVersion`.
• SDK version is defaulted to `null` if unset; no behavioral change yet.

**Affected Areas:**
• Database schema and migrations
• Sync config and on-event script types, validation and service layers
• All sync deployment API routes and controllers
• Seeders and test suites across CLI, server, jobs, and types packages

*This summary was automatically generated by @propel-code-bot*