### PR TITLE
fix(cli): send sdkVersion

### DIFF
--- a/packages/cli/lib/services/config.service.ts
+++ b/packages/cli/lib/services/config.service.ts
@@ -1,15 +1,18 @@
 import fs from 'fs';
 import path from 'path';
+
 import Ajv from 'ajv';
 import addErrors from 'ajv-errors';
 import chalk from 'chalk';
 
-import { getNangoRootPath, printDebug } from '../utils.js';
-import type { NangoYamlParser } from '@nangohq/nango-yaml';
 import { determineVersion, loadNangoYaml } from '@nangohq/nango-yaml';
+
 import { CLIError } from '../utils/errors.js';
 import { Err, Ok } from '../utils/result.js';
-import type { Result } from '../utils/result.js';
+import { getNangoRootPath, printDebug } from '../utils.js';
+
+import type { NangoYamlParser } from '@nangohq/nango-yaml';
+import type { Result } from '@nangohq/types';
 
 export interface ValidationMessage {
     msg: string;

--- a/packages/cli/lib/services/deploy.service.ts
+++ b/packages/cli/lib/services/deploy.service.ts
@@ -11,6 +11,7 @@ import { enrichHeaders, http, isCI, parseSecretKey, printDebug } from '../utils.
 import { parse } from './config.service.js';
 import { loadSchemaJson } from './model.service.js';
 import { cloudHost, localhostUrl } from '../constants.js';
+import { NANGO_VERSION } from '../version.js';
 
 import type { DeployOptions, InternalDeployOptions } from '../types.js';
 import type {
@@ -232,13 +233,15 @@ class DeployService {
 
         const nangoYamlBody = parser.yaml;
 
+        const sdkVersion = `${NANGO_VERSION}-yaml`;
         const url = process.env['NANGO_HOSTPORT'] + `/sync/deploy`;
         const bodyDeploy: PostDeploy['Body'] = {
             ...postData,
             reconcile: true,
             debug,
             nangoYamlBody,
-            singleDeployMode
+            singleDeployMode,
+            sdkVersion
         };
 
         const shouldConfirm = process.env['NANGO_DEPLOY_AUTO_CONFIRM'] !== 'true' && !autoConfirm;
@@ -249,7 +252,8 @@ class DeployService {
                 ...postData,
                 reconcile: false,
                 debug,
-                singleDeployMode
+                singleDeployMode,
+                sdkVersion
             };
             const response = await http.post(confirmationUrl, bodyConfirmation, { headers: enrichHeaders() });
 

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -1,20 +1,23 @@
-import axios, { AxiosError } from 'axios';
+import { spawn } from 'child_process';
 import fs from 'fs';
-import os from 'os';
-import npa from 'npm-package-arg';
+import https from 'node:https';
 import Module from 'node:module';
+import os from 'os';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
-import semver from 'semver';
-import { spawn } from 'child_process';
-import promptly from 'promptly';
+
+import axios, { AxiosError } from 'axios';
 import chalk from 'chalk';
 import * as dotenv from 'dotenv';
-import { state } from './state.js';
-import https from 'node:https';
-import type { GetPublicConnection } from '@nangohq/types';
-import { NANGO_VERSION } from './version.js';
+import npa from 'npm-package-arg';
+import promptly from 'promptly';
+import semver from 'semver';
+
 import { cloudHost } from './constants.js';
+import { state } from './state.js';
+import { NANGO_VERSION } from './version.js';
+
+import type { GetPublicConnection } from '@nangohq/types';
 import type { PackageJson } from 'type-fest';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -36,8 +39,10 @@ if (parsedHostport.slice(-1) === '/') {
 
 export const hostport = parsedHostport;
 
-export function printDebug(message: string) {
-    console.log(chalk.gray(message));
+export function printDebug(message: string, debug?: boolean) {
+    if (debug === true || debug === undefined) {
+        console.log(chalk.gray(message));
+    }
 }
 
 export function isLocallyInstalled(packageName: string, debug = false) {


### PR DESCRIPTION
## Changes

Contributes to https://linear.app/nango/issue/NAN-3246/make-it-work-in-runner

- CLI: send sdkVersion
<!-- Summary by @propel-code-bot -->

---

This PR updates the Nango CLI so that it now sends an explicit sdkVersion property in the payloads during deploy operations. Related minor refactoring of imports and typings have also been done in service files.

*This summary was automatically generated by @propel-code-bot*