### PR TITLE
fix(cli): prepare zero yaml 

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -111,7 +111,7 @@ program
     .action(async function (this: Command) {
         const { debug } = this.opts<GlobalOptions>();
         const fullPath = process.cwd();
-        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        const precheck = await verificationService.ensureNangoYaml({ fullPath, debug });
         if (!precheck) {
             return;
         }
@@ -149,7 +149,7 @@ program
         const { autoConfirm, debug, e: environment, integrationId, validation, saveResponses } = this.opts();
         const fullPath = process.cwd();
 
-        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        const precheck = await verificationService.ensureNangoYaml({ fullPath, debug });
         if (!precheck) {
             return;
         }
@@ -178,7 +178,7 @@ program
         const { compileInterfaces, autoConfirm, debug } = this.opts();
         const fullPath = process.cwd();
 
-        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        const precheck = await verificationService.ensureNangoYaml({ fullPath, debug });
         if (!precheck) {
             return;
         }
@@ -202,7 +202,7 @@ program
         const options = this.opts<DeployOptions>();
         const { debug } = options;
         const fullPath = process.cwd();
-        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        const precheck = await verificationService.ensureNangoYaml({ fullPath, debug });
         if (!precheck) {
             return;
         }
@@ -216,7 +216,7 @@ program
     .action(async function (this: Command) {
         const { debug } = this.opts<DeployOptions>();
         const fullPath = process.cwd();
-        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        const precheck = await verificationService.ensureNangoYaml({ fullPath, debug });
         if (!precheck) {
             return;
         }
@@ -230,7 +230,7 @@ program
     .action(async function (this: Command) {
         const { debug } = this.opts<DeployOptions>();
         const fullPath = process.cwd();
-        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        const precheck = await verificationService.ensureNangoYaml({ fullPath, debug });
         if (!precheck) {
             return;
         }
@@ -244,7 +244,7 @@ program
     .action(async function (this: Command) {
         const { debug } = this.opts<DeployOptions>();
         const fullPath = process.cwd();
-        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        const precheck = await verificationService.ensureNangoYaml({ fullPath, debug });
         if (!precheck) {
             return;
         }
@@ -260,7 +260,7 @@ program
     .action(async function (this: Command) {
         const { debug, path: optionalPath, integrationTemplates } = this.opts();
         const absolutePath = path.resolve(process.cwd(), this.args[0] || '');
-        const precheck = await verificationService.ensureNangoV1({ fullPath: absolutePath, debug });
+        const precheck = await verificationService.ensureNangoYaml({ fullPath: absolutePath, debug });
         if (!precheck) {
             return;
         }
@@ -286,7 +286,7 @@ program
     .action(async function (this: Command, environment: string) {
         const options = this.opts<DeployOptions>();
         const fullPath = process.cwd();
-        const precheck = await verificationService.ensureNangoV1({ fullPath, debug: options.debug });
+        const precheck = await verificationService.ensureNangoYaml({ fullPath, debug: options.debug });
         if (!precheck) {
             return;
         }
@@ -308,7 +308,7 @@ program
         const { autoConfirm, debug } = this.opts();
         const fullPath = process.cwd();
 
-        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        const precheck = await verificationService.ensureNangoYaml({ fullPath, debug });
         if (!precheck) {
             return;
         }
@@ -336,7 +336,7 @@ program
         const { autoConfirm, debug } = this.opts<GlobalOptions>();
         const fullPath = process.cwd();
 
-        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        const precheck = await verificationService.ensureNangoYaml({ fullPath, debug });
         if (!precheck) {
             return;
         }
@@ -360,7 +360,7 @@ program
     .action(async function (this: Command, environmentName: string) {
         const { debug } = this.opts<GlobalOptions>();
         const fullPath = process.cwd();
-        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        const precheck = await verificationService.ensureNangoYaml({ fullPath, debug });
         if (!precheck) {
             return;
         }
@@ -378,7 +378,7 @@ program
         const { debug, nangoRemoteEnvironment, integration } = this.opts();
         const fullPath = process.cwd();
 
-        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        const precheck = await verificationService.ensureNangoYaml({ fullPath, debug });
         if (!precheck) {
             return;
         }

--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /*
- * Copyright (c) 2024 Nango, all rights reserved.
+ * Copyright (c) 2025 Nango, all rights reserved.
  */
 
 import fs from 'fs';
@@ -25,20 +25,18 @@ import { directoryMigration, endpointMigration, v1toV2Migration } from './servic
 import verificationService from './services/verification.service.js';
 import { NANGO_INTEGRATIONS_LOCATION, getNangoRootPath, isCI, printDebug, upgradeAction } from './utils.js';
 
-import type { DeployOptions } from './types.js';
+import type { DeployOptions, GlobalOptions } from './types.js';
 
 class NangoCommand extends Command {
     override createCommand(name: string) {
         const cmd = new Command(name);
         cmd.option('--auto-confirm', 'Auto confirm yes to all prompts.');
-        cmd.option('--debug', 'Run cli in debug mode, outputting verbose logs.');
+        cmd.option('--debug', 'Run cli in debug mode, outputting verbose logs.', false);
         cmd.hook('preAction', async function (this: Command, actionCommand: Command) {
             const { debug } = actionCommand.opts();
-            if (debug) {
-                printDebug('Debug mode enabled');
-                if (fs.existsSync('.env')) {
-                    printDebug('.env file detected and loaded');
-                }
+            printDebug('Debug mode enabled', debug);
+            if (debug && fs.existsSync('.env')) {
+                printDebug('.env file detected and loaded', debug);
             }
 
             if (!isCI) {
@@ -98,7 +96,7 @@ program
     .argument('[path]', 'Optional: The path to initialize the Nango project in. Defaults to the current directory.')
     .description('Initialize a new Nango project')
     .action(function (this: Command) {
-        const { debug } = this.opts();
+        const { debug } = this.opts<GlobalOptions>();
         const absolutePath = path.resolve(process.cwd(), this.args[0] || '');
         const ok = init({ absolutePath, debug });
 
@@ -110,8 +108,14 @@ program
 program
     .command('generate')
     .description('Generate a new Nango integration')
-    .action(function (this: Command) {
-        const { debug } = this.opts();
+    .action(async function (this: Command) {
+        const { debug } = this.opts<GlobalOptions>();
+        const fullPath = process.cwd();
+        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        if (!precheck) {
+            return;
+        }
+
         generate({ fullPath: process.cwd(), debug });
     });
 
@@ -144,7 +148,20 @@ program
     .action(async function (this: Command, sync: string, connectionId: string) {
         const { autoConfirm, debug, e: environment, integrationId, validation, saveResponses } = this.opts();
         const fullPath = process.cwd();
+
+        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        if (!precheck) {
+            return;
+        }
+
         await verificationService.necessaryFilesExist({ fullPath, autoConfirm, debug });
+        const { success } = await compileAllFiles({ fullPath, debug });
+        if (!success) {
+            console.log(chalk.red('Failed to compile. Exiting'));
+            process.exitCode = 1;
+            return;
+        }
+
         const dryRun = new DryRunService({ fullPath, validation });
         await dryRun.run(
             {
@@ -166,6 +183,12 @@ program
     .action(async function (this: Command) {
         const { compileInterfaces, autoConfirm, debug } = this.opts();
         const fullPath = process.cwd();
+
+        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        if (!precheck) {
+            return;
+        }
+
         await verificationService.necessaryFilesExist({ fullPath, autoConfirm, debug, checkDist: false });
 
         tscWatch({ fullPath, debug, watchConfigFile: compileInterfaces });
@@ -182,32 +205,57 @@ program
     .option('--no-compile-interfaces', `Don't compile the ${nangoConfigFile}`, true)
     .option('--allow-destructive', 'Allow destructive changes to be deployed without confirmation', false)
     .action(async function (this: Command, environment: string) {
-        const options: DeployOptions = this.opts();
+        const options = this.opts<DeployOptions>();
         const { debug } = options;
         const fullPath = process.cwd();
+        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        if (!precheck) {
+            return;
+        }
+
         await deployService.prep({ fullPath, options: { ...options, env: 'cloud' }, environment, debug });
     });
 
 program
     .command('migrate-config')
     .description('Migrate the nango.yaml from v1 (deprecated) to v2')
-    .action(function (this: Command) {
-        v1toV2Migration(path.resolve(process.cwd(), NANGO_INTEGRATIONS_LOCATION));
+    .action(async function (this: Command) {
+        const { debug } = this.opts<DeployOptions>();
+        const fullPath = process.cwd();
+        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        if (!precheck) {
+            return;
+        }
+
+        v1toV2Migration(path.resolve(fullPath, NANGO_INTEGRATIONS_LOCATION));
     });
 
 program
     .command('migrate-to-directories')
     .description('Migrate the script files from root level to structured directories.')
     .action(async function (this: Command) {
-        const { debug } = this.opts();
-        await directoryMigration(path.resolve(process.cwd(), NANGO_INTEGRATIONS_LOCATION), debug);
+        const { debug } = this.opts<DeployOptions>();
+        const fullPath = process.cwd();
+        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        if (!precheck) {
+            return;
+        }
+
+        await directoryMigration(path.resolve(fullPath, NANGO_INTEGRATIONS_LOCATION), debug);
     });
 
 program
     .command('migrate-endpoints')
     .description('Migrate the endpoint format')
-    .action(function (this: Command) {
-        endpointMigration(path.resolve(process.cwd(), NANGO_INTEGRATIONS_LOCATION));
+    .action(async function (this: Command) {
+        const { debug } = this.opts<DeployOptions>();
+        const fullPath = process.cwd();
+        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        if (!precheck) {
+            return;
+        }
+
+        endpointMigration(path.resolve(fullPath, NANGO_INTEGRATIONS_LOCATION));
     });
 
 program
@@ -218,6 +266,11 @@ program
     .action(async function (this: Command) {
         const { debug, path: optionalPath, integrationTemplates } = this.opts();
         const absolutePath = path.resolve(process.cwd(), this.args[0] || '');
+        const precheck = await verificationService.ensureNangoV1({ fullPath: absolutePath, debug });
+        if (!precheck) {
+            return;
+        }
+
         const ok = await generateDocs({ absolutePath, path: optionalPath, debug, isForIntegrationTemplates: integrationTemplates });
 
         if (ok) {
@@ -237,8 +290,13 @@ program
     .option('--no-compile-interfaces', `Don't compile the ${nangoConfigFile}`, true)
     .option('--allow-destructive', 'Allow destructive changes to be deployed without confirmation', false)
     .action(async function (this: Command, environment: string) {
-        const options: DeployOptions = this.opts();
+        const options = this.opts<DeployOptions>();
         const fullPath = process.cwd();
+        const precheck = await verificationService.ensureNangoV1({ fullPath, debug: options.debug });
+        if (!precheck) {
+            return;
+        }
+
         await deployService.prep({ fullPath, options: { ...options, env: 'local' }, environment, debug: options.debug });
     });
 
@@ -255,6 +313,12 @@ program
     .action(async function (this: Command) {
         const { autoConfirm, debug } = this.opts();
         const fullPath = process.cwd();
+
+        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        if (!precheck) {
+            return;
+        }
+
         await verificationService.necessaryFilesExist({ fullPath, autoConfirm, debug, checkDist: false });
 
         const match = verificationService.filesMatchConfig({ fullPath });
@@ -275,8 +339,14 @@ program
     .alias('scc')
     .description('Verify the parsed sync config and output the object for verification')
     .action(async function (this: Command) {
-        const { autoConfirm, debug } = this.opts();
+        const { autoConfirm, debug } = this.opts<GlobalOptions>();
         const fullPath = process.cwd();
+
+        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        if (!precheck) {
+            return;
+        }
+
         await verificationService.necessaryFilesExist({ fullPath, autoConfirm, debug });
         const parsing = parse(path.resolve(fullPath, NANGO_INTEGRATIONS_LOCATION));
         if (parsing.isErr()) {
@@ -294,8 +364,13 @@ program
     .description('Deploy a Nango integration to an account')
     .arguments('environmentName')
     .action(async function (this: Command, environmentName: string) {
-        const { debug } = this.opts();
+        const { debug } = this.opts<GlobalOptions>();
         const fullPath = process.cwd();
+        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        if (!precheck) {
+            return;
+        }
+
         await deployService.admin({ fullPath, environmentName, debug });
     });
 
@@ -308,6 +383,12 @@ program
     .action(async function (this: Command, environment: string) {
         const { debug, nangoRemoteEnvironment, integration } = this.opts();
         const fullPath = process.cwd();
+
+        const precheck = await verificationService.ensureNangoV1({ fullPath, debug });
+        if (!precheck) {
+            return;
+        }
+
         await deployService.internalDeploy({ fullPath, environment, debug, options: { env: nangoRemoteEnvironment || 'prod', integration } });
     });
 

--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -155,12 +155,6 @@ program
         }
 
         await verificationService.necessaryFilesExist({ fullPath, autoConfirm, debug });
-        const { success } = await compileAllFiles({ fullPath, debug });
-        if (!success) {
-            console.log(chalk.red('Failed to compile. Exiting'));
-            process.exitCode = 1;
-            return;
-        }
 
         const dryRun = new DryRunService({ fullPath, validation });
         await dryRun.run(

--- a/packages/cli/lib/services/verification.service.ts
+++ b/packages/cli/lib/services/verification.service.ts
@@ -150,7 +150,7 @@ class VerificationService {
         };
     }
 
-    public async ensureNangoV1({ fullPath, debug }: { fullPath: string; debug: boolean }) {
+    public async ensureNangoYaml({ fullPath, debug }: { fullPath: string; debug: boolean }) {
         const precheck = await this.preCheck({ fullPath, debug });
         if (!precheck.isNango) {
             console.log(chalk.red(`Not inside a Nango folder`));

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -1,20 +1,23 @@
-import axios, { AxiosError } from 'axios';
+import { spawn } from 'child_process';
 import fs from 'fs';
-import os from 'os';
-import npa from 'npm-package-arg';
+import https from 'node:https';
 import Module from 'node:module';
+import os from 'os';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
-import semver from 'semver';
-import { spawn } from 'child_process';
-import promptly from 'promptly';
+
+import axios, { AxiosError } from 'axios';
 import chalk from 'chalk';
 import * as dotenv from 'dotenv';
-import { state } from './state.js';
-import https from 'node:https';
-import type { GetPublicConnection } from '@nangohq/types';
-import { NANGO_VERSION } from './version.js';
+import npa from 'npm-package-arg';
+import promptly from 'promptly';
+import semver from 'semver';
+
 import { cloudHost } from './constants.js';
+import { state } from './state.js';
+import { NANGO_VERSION } from './version.js';
+
+import type { GetPublicConnection } from '@nangohq/types';
 import type { PackageJson } from 'type-fest';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -36,8 +39,10 @@ if (parsedHostport.slice(-1) === '/') {
 
 export const hostport = parsedHostport;
 
-export function printDebug(message: string) {
-    console.log(chalk.gray(message));
+export function printDebug(message: string, debug?: boolean) {
+    if (debug === true || debug === undefined) {
+        console.log(chalk.gray(message));
+    }
 }
 
 export function isLocallyInstalled(packageName: string, debug = false) {


### PR DESCRIPTION
## Changes

- (cli): prepare zero yaml 
Just block stuff that are not ready to be used with zero yaml

<!-- Summary by @propel-code-bot -->

---

This PR introduces formal support and early validation for 'zero-yaml' projects within the Nango CLI, where projects have a `.nango` marker and an `index.ts`, but no `nango.yaml`. Core CLI commands now run a centralized pre-check to block commands incompatible with zero-yaml project layouts, centralizing this logic in `verificationService`. As part of this refactor, CLI option typings have been unified for consistency, and debug logging has been made more systematic. User-facing error handling and help messaging have also seen framework-wide improvements, increasing clarity for both valid and invalid project states.

**Key Changes:**
• Added `verificationService.preCheck` and `verificationService.ensureNangoYaml` for project structure/type validation (classic yaml vs. zero-yaml)
• Most CLI commands now perform an early pre-check and block execution if run in an unsupported (zero-yaml) project context
• Refactored and enforced CLI option typings (now using `GlobalOptions`); reduced ad-hoc debug flag logic and standardized `printDebug` usage
• Restructured imports and improved modularity across CLI entrypoint, utilities, and services
• Enhanced error and debug outputs, providing earlier and clearer user feedback on project validity

**Affected Areas:**
• CLI entrypoint (index.ts)
• verificationService (services/verification.service.ts)
• CLI utility and option parsing (utils.ts)

*This summary was automatically generated by @propel-code-bot*

