### PR TITLE
chore: add async tag to trigger action span

### DIFF
--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -138,7 +138,8 @@ export class Orchestrator {
             'connection.id': connection.id,
             'connection.connection_id': connection.connection_id,
             'connection.provider_config_key': connection.provider_config_key,
-            'connection.environment_id': connection.environment_id
+            'connection.environment_id': connection.environment_id,
+            async
         };
 
         const span = tracer.startSpan('execute.action', {


### PR DESCRIPTION
I realized we couldn't monitor async actions specifically

<!-- Summary by @propel-code-bot -->

---

This PR adds an 'async' tag to the action span metadata in the orchestrator client, enabling more granular monitoring of asynchronous actions. The change introduces a single metadata key to the span context.

*This summary was automatically generated by @propel-code-bot*