### PR TITLE
fix: GET /connection/id consistent response when invalid credentials

### DIFF
--- a/docs-v2/guides/api-authorization/credentials-refresh-and-validity.mdx
+++ b/docs-v2/guides/api-authorization/credentials-refresh-and-validity.mdx
@@ -21,7 +21,7 @@ OAuth credentials are refreshed upon request, but only if they have expired or a
 
 Some APIs expire refresh tokens that are not used, requiring the end user to reconnect. To prevent this, Nango ensures that OAuth credentials are refreshed at least once every 24 hours.
 
-If a connection fails to refresh for 3 consecutive days, Nango will stop attempting automatic refreshes. However, fetching the connection via the API or UI will still attempt a refresh.
+If a connection fails to refresh for 3 consecutive days, Nango will stop attempting automatic refreshes. However, fetching the connection via the API with `force_refresh=true` will still attempt a refresh.
 
 Nango implements locking mechanisms to ensure that only one refresh happens at a time, and all requests for connection credentials receive the latest valid tokens, regardless of concurrent requests.
 

--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -700,6 +700,22 @@ paths:
                                 properties:
                                     message:
                                         type: string
+                '424':
+                    description: Connection refresh exhausted
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    error:
+                                        type: object
+                                        properties:
+                                            code:
+                                                type: string
+                                                description: The error code
+                                            message:
+                                                type: string
+                                                description: A human-readable error message
                 '404':
                     description: Unknown Connection
                     content:

--- a/packages/server/lib/controllers/connection/connectionId/getConnection.integration.test.ts
+++ b/packages/server/lib/controllers/connection/connectionId/getConnection.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, it, expect } from 'vitest';
 import { runServer, shouldBeProtected, isSuccess, isError } from '../../../utils/tests.js';
-import { seeders } from '@nangohq/shared';
+import { connectionService, seeders } from '@nangohq/shared';
+import { MAX_CONSECUTIVE_DAYS_FAILED_REFRESH } from '@nangohq/shared/lib/services/connections/utils.js';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 
@@ -159,6 +160,120 @@ describe(`GET ${endpoint}`, () => {
             provider: 'algolia',
             provider_config_key: 'algolia',
             updated_at: expect.toBeIsoDateTimezone()
+        });
+    });
+    it('should return an error if connection refreshs are exhausted', async () => {
+        const provider = 'hubspot';
+        const { env, account } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, provider, provider);
+        const endUser = await seeders.createEndUser({ environment: env, account });
+        const conn = await seeders.createConnectionSeed({
+            env,
+            provider,
+            endUser,
+            rawCredentials: { type: 'OAUTH2', access_token: 'test_access_token', raw: {} }
+        });
+        await connectionService.setRefreshFailure({
+            id: conn.id,
+            lastRefreshFailure: new Date(),
+            currentAttempt: MAX_CONSECUTIVE_DAYS_FAILED_REFRESH
+        });
+
+        const res = await api.fetch(endpoint, {
+            method: 'GET',
+            token: env.secret_key,
+            params: { connectionId: conn.connection_id },
+            query: { provider_config_key: provider }
+        });
+
+        expect(res.res.status).toBe(424);
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'invalid_credentials',
+                message: 'The refresh limit has been reached for this connection.',
+                payload: {
+                    connection: {
+                        id: conn.id,
+                        connection_id: conn.connection_id,
+                        created_at: expect.toBeIsoDateTimezone(),
+                        credentials: {},
+                        connection_config: {},
+                        end_user: {
+                            display_name: null,
+                            email: endUser.email,
+                            id: endUser.endUserId,
+                            organization: {
+                                display_name: null,
+                                id: endUser.organization!.organizationId
+                            }
+                        },
+                        errors: [],
+                        last_fetched_at: expect.toBeIsoDateTimezone(),
+                        metadata: null,
+                        provider,
+                        provider_config_key: provider,
+                        updated_at: expect.toBeIsoDateTimezone()
+                    }
+                }
+            }
+        });
+    });
+    it('should return an error if connection fails to refresh', async () => {
+        const provider = 'hubspot';
+        const { env, account } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, provider, provider);
+        const endUser = await seeders.createEndUser({ environment: env, account });
+        const conn = await seeders.createConnectionSeed({
+            env,
+            provider,
+            endUser,
+            rawCredentials: { type: 'OAUTH2', access_token: 'test_access_token', refresh_token: 'not_working', raw: {} }
+        });
+
+        const res = await api.fetch(endpoint, {
+            method: 'GET',
+            token: env.secret_key,
+            params: { connectionId: conn.connection_id },
+            query: { provider_config_key: provider, force_refresh: true }
+        });
+
+        expect(res.res.status).toBe(400);
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'invalid_credentials',
+                message: 'The external API returned an error when trying to refresh the access token. Please try again later.',
+                payload: {
+                    connection: {
+                        id: conn.id,
+                        connection_id: conn.connection_id,
+                        created_at: expect.toBeIsoDateTimezone(),
+                        credentials: {},
+                        connection_config: {},
+                        end_user: {
+                            display_name: null,
+                            email: endUser.email,
+                            id: endUser.endUserId,
+                            organization: {
+                                display_name: null,
+                                id: endUser.organization!.organizationId
+                            }
+                        },
+                        errors: [
+                            {
+                                log_id: expect.any(String),
+                                type: 'auth'
+                            }
+                        ],
+                        last_fetched_at: expect.toBeIsoDateTimezone(),
+                        metadata: null,
+                        provider: provider,
+                        provider_config_key: provider,
+                        updated_at: expect.toBeIsoDateTimezone()
+                    }
+                }
+            }
         });
     });
 });

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -84,9 +84,8 @@ export async function refreshOrTestCredentials(props: RefreshProps): Promise<Res
         props.connection = { ...props.connection, last_fetched_at: new Date() };
 
         // short-circuit if we know the refresh will fail
-        // we can't return an error because it would a breaking change in GET /connection
         if (props.connection.refresh_exhausted && !props.instantRefresh) {
-            return Ok(props.connection);
+            return Err(new NangoError('connection_refresh_exhausted'));
         }
 
         let res: Result<DBConnectionDecrypted, NangoError>;

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -282,6 +282,11 @@ export class NangoError extends NangoInternalError {
                 this.message = 'Provider configuration cannot be edited for API key based authentication.';
                 break;
 
+            case 'connection_refresh_exhausted':
+                this.status = 424;
+                this.message = 'The refresh limit has been reached for this connection.';
+                break;
+
             case 'connection_test_failed':
                 this.status = status || 400;
                 this.message = `The given credentials were found to be invalid${status ? ` and received a ${status} on a test API call` : ''}. Please check the credentials and try again.`;

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -104,7 +104,7 @@ export type GetPublicConnection = Endpoint<{
         force_refresh?: boolean | undefined;
     };
     Path: '/connection/:connectionId';
-    Error: ApiError<'unknown_provider_config'>;
+    Error: ApiError<'unknown_provider_config' | 'invalid_credentials'>;
     Success: ApiPublicConnectionFull;
 }>;
 


### PR DESCRIPTION
GET /connection/id to return:
- 424 with connection data in error payload if connection refresh attempts are exhausted. (we currently returns a 200)
- 4XX with connection data in error payload if refresh fails

<!-- Summary by @propel-code-bot -->

---

**Standardize Error Handling and Response for GET /connection/:id on Invalid Credentials**

This PR overhauls the error handling and response patterns for the GET /connection/:connectionId endpoint to ensure consistent, standardized status codes and response payloads when credential refresh fails. It introduces a 424 status code with connection data in the error payload when refresh attempts are exhausted, surfaces 4XX errors with detailed connection data for refresh/test failures, and updates both the server logic and documentation accordingly. The PR modifies core refresh logic, error type definitions, OpenAPI spec, and public API types, and adds robust integration tests for these branches. This work helps client applications reliably detect and recover from authentication issues by providing structured, predictable error responses.

**Key Changes:**
• ``GET`` /connection/:id now returns ``HTTP`` 424 with connection data in payload when refresh attempts are exhausted, rather than 200.
• Credential refresh or test failures now return 4XX errors (with appropriate status codes) and embed current connection data in the error payload.
• New error type ``connection_refresh_exhausted`` added with 424 status in error.ts.
• Core refresh logic (shared/services/connections/credentials/refresh.ts) updated to return errors on exhausted refresh attempts, not silent success.
• Controller code refactored to ensure consistent error propagation and response formatting, including the public ``API`` formatter.
• Integration tests expanded to cover new error-handling scenarios and response shapes for exhausted/failed refresh attempts.
• `OpenAPI` spec (spec.yaml) and developer docs updated to describe new status codes and error response schemas.
• Public ``API`` types (`GetPublicConnection`) updated to allow ``invalid_credentials`` error.

**Affected Areas:**
• ``GET`` /connection/:`connectionId` ``API`` controller
• Shared credential refresh logic
• ``API`` error types and error handling utilities
• ``API`` specification and documentation
• Integration and unit test suites
• Type definitions (``API`` response types)

**Potential Impact:**

**Functionality**: Clients integrating with the public API will now consistently receive error status codes and payloads for credential-related failures, which may change control flow for error handling. Exhausted refresh attempts will clearly trigger HTTP 424, not subtle 200s.

**Performance**: No significant impact; response logic changes are straightforward, and error handling does not introduce significant overhead.

**Security**: No direct security implication, but improved error structure helps downstream consumers handle expired or exhausted credentials more safely.

**Scalability**: No scalability impact anticipated as only error-handling pathways are affected, with minimal additional computation.

**Review Focus:**
• Correctness of error propagation and status codes (424, 4XX) in controller.
• Backward compatibility for clients and `SDKs` expecting older response shapes.
• Clarity and completeness of error payload, including connection context.
• Coverage and completeness of new/updated tests around error scenarios.
• Consistency between documentation/spec, types, and implementation.
• Any risk of leaking sensitive information in error payloads.

<details>
<summary><strong>Testing Needed</strong></summary>

• Verify ``GET`` /connection/:id returns 424 and proper error payload when refresh attempts are exhausted (via manual and automated tests).
• Test `force_refresh`=true scenarios and verify error handling/response typing.
• Ensure no regression for successful credential fetches (should still return 200 and payload).
• Validate against `OpenAPI` schema and check integration with consumers.
• Test with malformed/invalid requests to verify robustness and error message clarity.

</details>

<details>
<summary><strong>Code Quality Assessment</strong></summary>

**packages/server/lib/controllers/connection/connectionId/getConnection.ts**: Refactored for more robust error typing and response flow, but some duplication remains (e.g., manual API shape construction); responses now consistently wrap errors and use utility types.

**packages/shared/lib/services/connections/credentials/refresh.ts**: Logic improved to return explicit errors on exhaustion rather than silent success; comments clarify code intent.

**packages/shared/lib/utils/error.ts**: Error type definitions extended with new code/status; comprehensive messaging for clarity.

**docs-v2/spec.yaml**: Spec updated to include 424 errors; schema definitions match new response shapes.

**packages/types/lib/connection/api/get.ts**: Type system updated to support new error types for public API surface.

**docs-v2/guides/api-authorization/credentials-refresh-and-validity.mdx**: Docs updated for new force_refresh behavior and exhaustion handling.

**packages/server/lib/controllers/connection/connectionId/getConnection.integration.test.ts**: New test cases added for all relevant error-handling branches, with clear assertions on status and payload.

</details>

<details>
<summary><strong>Best Practices</strong></summary>

**Testing**:
• Comprehensive integration and unit tests added for error branches.
• Type safety via explicit ``API`` type definitions.

**Documentation**:
• `OpenAPI` spec and guides updated for new status codes and error structures.
• Change clearly documented for client developers.

**Error Handling**:
• Consistent use of ``HTTP`` status codes (e.g., 424 for exhausted refresh).
• Structured error payloads with additional context for client recovery.
• Centralized error typing via utils/error.ts.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Potential mismatches between real responses and OpenAPI spec/schema for less-common error states.
• Consumers relying on 200 status for exhausted/failed refresh cases may break if not handling 424/4XX correctly.
• Minor risk of over-exposing connection metadata in error payloads; should audit to ensure no leak of sensitive fields.
• Internal API/SDKs may require updates to match new response/typing patterns if not kept in sync.

</details>

---
*This summary was automatically generated by @propel-code-bot*
