### PR TITLE
fix(cli): detect nango folder correctly

### DIFF
--- a/packages/cli/lib/services/verification.service.ts
+++ b/packages/cli/lib/services/verification.service.ts
@@ -138,7 +138,7 @@ class VerificationService {
         const hasIndexTs = files.includes('index.ts');
         const isZeroYaml = !hasNangoYaml && hasNangoFolder && hasIndexTs;
 
-        if (isZeroYaml) {
+        if (isZeroYaml || hasNangoYaml) {
             printDebug(isZeroYaml ? 'Mode: zero yaml' : 'Model: classic yaml', debug);
         }
         return {

--- a/packages/cli/lib/services/verification.service.ts
+++ b/packages/cli/lib/services/verification.service.ts
@@ -134,15 +134,15 @@ class VerificationService {
         const files = await fs.promises.readdir(fullPath);
 
         const hasNangoYaml = files.includes('nango.yaml');
-        const isNango = files.includes('.nango');
+        const hasNangoFolder = files.includes('.nango');
         const hasIndexTs = files.includes('index.ts');
-        const isZeroYaml = !hasNangoYaml && isNango && hasIndexTs;
+        const isZeroYaml = !hasNangoYaml && hasNangoFolder && hasIndexTs;
 
-        if (isNango) {
+        if (isZeroYaml) {
             printDebug(isZeroYaml ? 'Mode: zero yaml' : 'Model: classic yaml', debug);
         }
         return {
-            isNango,
+            isNango: hasNangoFolder || hasNangoYaml,
             folderName: path.basename(fullPath),
             hasNangoYaml,
             hasIndexTs,


### PR DESCRIPTION
## Changes

- detect nango folder correctly
Was optimistic about .nango, turns out some customers never committed it.
<!-- Summary by @propel-code-bot -->

---

This PR updates the CLI verification logic to more robustly detect a Nango folder by checking for either a '.nango' directory or a 'nango.yaml' file, instead of relying solely on the presence of '.nango'. This supports projects where '.nango' may not be committed and increases compatibility with different user setups.

*This summary was automatically generated by @propel-code-bot*