### PR TITLE
fix: sync status shouldn't return finishedAt when RUNNING

### DIFF
--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -532,7 +532,7 @@ export class SyncManagerService {
             id: sync.id,
             connection_id: sync.connection_id,
             type: latestJob?.type === SyncJobsType.INCREMENTAL ? latestJob.type : 'INITIAL',
-            finishedAt: latestJob?.updated_at,
+            finishedAt: latestJob?.status !== 'RUNNING' ? latestJob?.updated_at : undefined,
             nextScheduledSyncAt: schedule.nextDueDate,
             name: sync.name,
             variant: sync.variant,


### PR DESCRIPTION
The sync status endpoint is currently returning `finishedAt` attribute even when the sync is RUNNING. With this commit finishedAt is not returning when the sync is executing

<!-- Summary by @propel-code-bot -->

---

This PR updates the sync status endpoint to ensure that the `finishedAt` attribute is not returned when the sync job status is RUNNING. Previously, the endpoint would return a `finishedAt` timestamp in all cases, even if the job wasn't yet finished.

*This summary was automatically generated by @propel-code-bot*