### PR TITLE
fix: add missing index for sync endpoint table

### DIFF
--- a/packages/database/lib/migrations/20250529002200_sync_endpoint_sync_config_id_index.cjs
+++ b/packages/database/lib/migrations/20250529002200_sync_endpoint_sync_config_id_index.cjs
@@ -1,0 +1,9 @@
+exports.config = { transaction: false };
+
+exports.up = async function (knex) {
+    await knex.schema.raw(
+        'CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_nango_sync_endpoints_sync_config_id" ON _nango_sync_endpoints USING BTREE ("sync_config_id")'
+    );
+};
+
+exports.down = async function () {};


### PR DESCRIPTION
We are joining on sync_config_id here:
https://github.com/NangoHQ/nango/blob/a093baae68861bce97b7ede53074eb9ab710c9da/packages/shared/lib/services/sync/config/config.service.ts#L707 but there were no index

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR adds a database migration that creates a btree index on the sync_config_id column of the _nango_sync_endpoints table, which is used in join operations but previously lacked an index. The migration utilizes CREATE INDEX CONCURRENTLY to avoid locking the table during index creation.

*This summary was automatically generated by @propel-code-bot*