### PR TITLE
fix(webapp): show logs from connection page

### DIFF
--- a/packages/webapp/src/utils/logs.ts
+++ b/packages/webapp/src/utils/logs.ts
@@ -21,8 +21,7 @@ export function getLogsUrl(
             from.setHours(0, 0);
             const to = new Date(val);
             to.setHours(23, 59);
-            usp.set('from', from.toISOString());
-            usp.set('to', to.toISOString());
+            usp.set('period', `${from.getTime()},${to.getTime()}`);
             continue;
         }
         usp.set(key, val as any);


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
### Description
Fixes: https://nangohq.slack.com/archives/C07242ZTXCK/p1748593999526559
I can only assume this either worked before by some coincidence, or this has been broken for a while, cause we don't capture the `from` and `to` query parameters.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the logs utility in the webapp to store date range parameters as a single 'period' query parameter, rather than separate 'from' and 'to' parameters. This change ensures logs from the connection page are displayed correctly by capturing the required timeframe as intended.

*This summary was automatically generated by @propel-code-bot*