### PR TITLE
fix: failed starting supervisor error when remote runner

### DIFF
--- a/packages/fleet/lib/fleet.ts
+++ b/packages/fleet/lib/fleet.ts
@@ -30,19 +30,13 @@ export class Fleet {
     private supervisor: Supervisor | undefined = undefined;
     private nodeProvider: NodeProvider;
 
-    constructor({
-        fleetId,
-        dbUrl = defaultDbUrl,
-        nodeProvider = noopNodeProvider
-    }: {
-        fleetId: FleetId;
-        dbUrl?: string | undefined;
-        nodeProvider?: NodeProvider;
-    }) {
+    constructor({ fleetId, dbUrl = defaultDbUrl, nodeProvider }: { fleetId: FleetId; dbUrl?: string | undefined; nodeProvider?: NodeProvider }) {
         this.fleetId = fleetId;
         this.dbClient = new DatabaseClient({ url: dbUrl, schema: fleetId });
-        this.supervisor = new Supervisor({ dbClient: this.dbClient, nodeProvider: nodeProvider });
-        this.nodeProvider = nodeProvider;
+        if (nodeProvider) {
+            this.supervisor = new Supervisor({ dbClient: this.dbClient, nodeProvider: nodeProvider });
+        }
+        this.nodeProvider = nodeProvider || noopNodeProvider;
     }
 
     public async migrate(): Promise<void> {


### PR DESCRIPTION
Do not initialize `Fleet.supervisor` if no node provider (which is the case on enterprise setup with remote runners). Making start/stop no op operations
 

<!-- Summary by @propel-code-bot -->

---

This PR updates the Fleet class to only initialize the Supervisor instance if a node provider is provided. This change addresses errors encountered when using remote runners in enterprise setups, where a node provider may not exist.

*This summary was automatically generated by @propel-code-bot*