### PR TITLE
fix: use nango.dev domain to send email

### DIFF
--- a/packages/server/lib/clients/email.client.ts
+++ b/packages/server/lib/clients/email.client.ts
@@ -78,7 +78,7 @@ class MailgunEmailProvider implements EmailProvider<MessagesSendResult> {
     }
 
     async send(email: string, subject: string, html: string): Promise<MessagesSendResult> {
-        return this.client.messages.create('email.nango.dev', {
+        return this.client.messages.create('nango.dev', {
             from: envs.SMTP_FROM,
             to: [email],
             subject,


### PR DESCRIPTION
wer are using an email address @nango.dev to send emails but the domain setup in mailgun is emai.nango.dev
Some email server don't like when the email address domain and mail-from header is different

Tested in staging. Domain is verified with Mailgun

<!-- Summary by @propel-code-bot -->

---

This PR updates the Mailgun email client configuration by changing the sending domain in the messages.create call from 'email.nango.dev' to 'nango.dev', aiming to ensure the sending domain matches the email address domain and potentially improve email deliverability. However, there is a discrepancy between the PR description, which indicates 'emai.nango.dev' is the Mailgun-configured domain, and the actual code change to 'nango.dev'.

*This summary was automatically generated by @propel-code-bot*