### PR TITLE
feat(webapp): add duration to logs and sub-logs

### DIFF
--- a/packages/webapp/src/pages/Logs/Operation/Message/Show.tsx
+++ b/packages/webapp/src/pages/Logs/Operation/Message/Show.tsx
@@ -1,9 +1,9 @@
 import { Prism } from '@mantine/prism';
-import { IconCalendar } from '@tabler/icons-react';
+import { IconCalendar, IconClockHour4 } from '@tabler/icons-react';
 import { useMemo } from 'react';
 
 import { Tag } from '../../../../components/ui/label/Tag';
-import { formatDateToLogFormat } from '../../../../utils/utils';
+import { formatDateToLogFormat, millisecondsToRuntime } from '../../../../utils/utils';
 import { LevelTag } from '../../components/LevelTag';
 
 import type { MessageRow } from '@nangohq/types';
@@ -40,6 +40,17 @@ export const ShowMessage: React.FC<{ message: MessageRow }> = ({ message }) => {
         return pl;
     }, [message.meta, message.error]);
 
+    const duration = useMemo<string>(() => {
+        if (!message) {
+            return '';
+        }
+        if (!message.durationMs) {
+            return 'n/a';
+        }
+
+        return millisecondsToRuntime(message.durationMs);
+    }, [message]);
+
     return (
         <div className="py-8 px-6 flex flex-col gap-5 h-full">
             <header className="flex gap-2 flex-col border-b border-b-gray-400 pb-5">
@@ -50,6 +61,15 @@ export const ShowMessage: React.FC<{ message: MessageRow }> = ({ message }) => {
                     <div className="flex">
                         <LevelTag level={message.level} />
                     </div>
+                    {message.durationMs ? (
+                        <div className="flex gap-2 items-center">
+                            <div className="flex bg-border-gray-400 w-[1px] h-[16px]">&nbsp;</div>
+                            <div className="flex gap-2 items-center">
+                                <IconClockHour4 stroke={1} size={18} />
+                                <div className="text-gray-400 text-s pt-[1px] font-code">{duration}</div>
+                            </div>
+                        </div>
+                    ) : null}
                     <div className="flex bg-border-gray-400 w-[1px] h-[16px]">&nbsp;</div>
                     <div className="flex gap-2 items-center">
                         <IconCalendar stroke={1} size={18} />

--- a/packages/webapp/src/pages/Logs/Operation/constants.tsx
+++ b/packages/webapp/src/pages/Logs/Operation/constants.tsx
@@ -1,7 +1,7 @@
 import { IconChevronRight } from '@tabler/icons-react';
 
 import { Tag } from '../../../components/ui/label/Tag';
-import { formatDateToLogFormat } from '../../../utils/utils';
+import { formatDateToLogFormat, millisecondsToRuntime } from '../../../utils/utils';
 import { LevelTag } from '../components/LevelTag';
 
 import type { SearchMessagesData } from '@nangohq/types';
@@ -16,6 +16,17 @@ export const columns: ColumnDef<SearchMessagesData>[] = [
         size: 180,
         cell: ({ row }) => {
             return <div className="font-code text-s">{formatDateToLogFormat(row.original.createdAt)}</div>;
+        }
+    },
+    {
+        accessorKey: 'duration',
+        header: 'Duration',
+        size: 100,
+        cell: ({ row }) => {
+            if (!row.original.durationMs) {
+                return 'n/a';
+            }
+            return <div className="font-code text-s">{millisecondsToRuntime(row.original.durationMs)}</div>;
         }
     },
     {

--- a/packages/webapp/src/pages/Logs/constants.tsx
+++ b/packages/webapp/src/pages/Logs/constants.tsx
@@ -3,7 +3,7 @@ import { ChevronRightIcon } from '@radix-ui/react-icons';
 import { OperationTag } from './components/OperationTag';
 import { ProviderTag } from './components/ProviderTag';
 import { StatusTag } from './components/StatusTag';
-import { formatDateToLogFormat } from '../../utils/utils';
+import { formatDateToLogFormat, getRunTime } from '../../utils/utils';
 
 import type { MultiSelectArgs } from '../../components/MultiSelect';
 import type { SearchOperationsData, SearchOperationsState, SearchOperationsType } from '@nangohq/types';
@@ -16,6 +16,19 @@ export const columns: ColumnDef<SearchOperationsData>[] = [
         size: 180,
         cell: ({ row }) => {
             return <div className="font-code text-s">{formatDateToLogFormat(row.original.createdAt)}</div>;
+        }
+    },
+    {
+        accessorKey: 'duration',
+        header: 'Duration',
+        size: 100,
+        cell: ({ row }) => {
+            if (!row.original.endedAt || !row.original.startedAt) {
+                return 'n/a';
+            }
+
+            const duration = getRunTime(new Date(row.original.startedAt).toISOString(), new Date(row.original.endedAt).toISOString());
+            return <div className="font-code text-s">{duration}</div>;
         }
     },
     {

--- a/packages/webapp/src/utils/utils.tsx
+++ b/packages/webapp/src/utils/utils.tsx
@@ -159,7 +159,10 @@ export function getRunTime(created_at: string, updated_at: string): string {
     const updatedAt = new Date(updated_at);
 
     const diffMilliseconds = updatedAt.getTime() - createdAt.getTime();
+    return millisecondsToRuntime(diffMilliseconds);
+}
 
+export function millisecondsToRuntime(diffMilliseconds: number): string {
     const milliseconds = diffMilliseconds % 1000;
     const seconds = Math.floor((diffMilliseconds / 1000) % 60);
     const minutes = Math.floor((diffMilliseconds / (1000 * 60)) % 60);


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR enhances the web application's logging views by introducing duration tracking and display for both logs and sub-logs. It adds a new utility function, millisecondsToRuntime, that is reused throughout table and detail components to present human-readable duration values (where available), providing greater visibility into the run time of log events.

**Key Changes:**
• Added a 'Duration' column to logs and sub-logs tables; displays formatted run times using a new millisecondsToRuntime utility.
• Updated detail/log views to conditionally show duration with a clock icon if durationMs is provided, improving visual log details.
• Refactored utilities and imports in relevant files to use/getRunTime and millisecondsToRuntime appropriately.

**Affected Areas:**
• packages/webapp/src/pages/Logs/constants.tsx
• packages/webapp/src/pages/Logs/Operation/constants.tsx
• packages/webapp/src/pages/Logs/Operation/Message/Show.tsx
• packages/webapp/src/utils/utils.tsx

*This summary was automatically generated by @propel-code-bot*