### PR TITLE
fix(zeroyaml): various bug fixes

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -229,7 +229,7 @@ program
         }
 
         if (precheck.isZeroYaml) {
-            dev({ fullPath, debug });
+            await dev({ fullPath, debug });
             return;
         }
 

--- a/packages/cli/lib/migrations/toZeroYaml.ts
+++ b/packages/cli/lib/migrations/toZeroYaml.ts
@@ -16,6 +16,8 @@ import { loadYamlAndGenerate } from '../services/model.service.js';
 
 import type { NangoModel, NangoModelField, NangoYamlParsed, ParsedNangoAction, ParsedNangoSync, Result } from '@nangohq/types';
 import type { Collection, ImportSpecifier } from 'jscodeshift';
+import { exampleFolder } from '../zeroYaml/constants.js';
+import { syncTsConfig } from '../zeroYaml/utils.js';
 
 const allowedTypesImports = ['ActionError', 'ProxyConfiguration'];
 const batchMethods = ['batchSave', 'batchUpdate', 'batchDelete'];
@@ -37,8 +39,9 @@ export async function migrateToZeroYaml({ fullPath, debug }: { fullPath: string;
     spinner.succeed();
 
     {
-        const spinner = ora({ text: 'Add package.json' }).start();
+        const spinner = ora({ text: 'Init folder' }).start();
         await addPackageJson({ fullPath, debug });
+        await syncTsConfig({ fullPath });
         spinner.succeed();
     }
 
@@ -636,7 +639,7 @@ function reImportTypes({ root, j, usedModels }: { root: Collection; j: jscodeshi
 async function addPackageJson({ fullPath, debug }: { fullPath: string; debug: boolean }) {
     // Ensure package.json exists and has nango in devDependencies
     const packageJsonPath = path.join(fullPath, 'package.json');
-    const examplePackageJsonPath = path.join(import.meta.dirname, '../../example/package.json');
+    const examplePackageJsonPath = path.join(exampleFolder, 'package.json');
     let packageJsonExists = false;
     try {
         await fs.promises.access(packageJsonPath, fs.constants.F_OK);

--- a/packages/cli/lib/zeroYaml/constants.ts
+++ b/packages/cli/lib/zeroYaml/constants.ts
@@ -1,5 +1,8 @@
+import path from 'node:path';
+
 import ts from 'typescript';
 
+export const exampleFolder = path.join(import.meta.dirname, '../../example');
 export const npmPackageRegex = /^[^./\s]/;
 export const importRegex = /^import ['"](?<path>\.\/[^'"]+)['"];/gm;
 

--- a/packages/cli/lib/zeroYaml/dev.ts
+++ b/packages/cli/lib/zeroYaml/dev.ts
@@ -11,10 +11,11 @@ import ts from 'typescript';
 import { printDebug } from '../utils.js';
 import { compileOne, tsToJsPath } from './compile.js';
 import { CompileError, tsconfig } from './constants.js';
+import { syncTsConfig } from './utils.js';
 
 import type { Ora } from 'ora';
 
-export function dev({ fullPath, debug }: { fullPath: string; debug: boolean }) {
+export async function dev({ fullPath, debug }: { fullPath: string; debug: boolean }) {
     const outDir = path.join(fullPath, 'build');
 
     if (!fs.existsSync(outDir)) {
@@ -22,6 +23,7 @@ export function dev({ fullPath, debug }: { fullPath: string; debug: boolean }) {
         fs.mkdirSync(outDir);
     }
 
+    await syncTsConfig({ fullPath });
     manualWatch({ fullPath, debug });
     typescriptWatchSimple({ fullPath, debug });
 }

--- a/packages/cli/lib/zeroYaml/utils.ts
+++ b/packages/cli/lib/zeroYaml/utils.ts
@@ -1,0 +1,8 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { exampleFolder } from './constants.js';
+
+export async function syncTsConfig({ fullPath }: { fullPath: string }) {
+    await fs.promises.writeFile(path.join(fullPath, 'tsconfig.json'), await fs.promises.readFile(path.join(exampleFolder, 'tsconfig.json')));
+}

--- a/packages/shared/lib/services/file/local.service.ts
+++ b/packages/shared/lib/services/file/local.service.ts
@@ -161,7 +161,7 @@ class LocalFileService {
         providerConfigKey: string;
     }): string {
         if (syncConfig.sdk_version && syncConfig.sdk_version.includes('zero')) {
-            return path.resolve(basePath, `build/${providerConfigKey}-${scriptTypeToPath[scriptType]}-${syncConfig.sync_name}.cjs`);
+            return path.resolve(basePath, `build/${providerConfigKey}_${scriptTypeToPath[scriptType]}_${syncConfig.sync_name}.cjs`);
         } else {
             return path.resolve(basePath, `dist/${syncConfig.sync_name}-${providerConfigKey}.js`);
         }


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-3354/ensure-tsconfigjson-is-there-an-not-updated

- Ensure tsconfig.json is always there and unmodified
- Fix script file path locally
<!-- Summary by @propel-code-bot -->

---

This PR resolves several bugs related to the zero-yaml workflow by consistently ensuring that a valid tsconfig.json is present and synchronized from the example directory during both initialization and development. It also updates script file path conventions for zero-yaml integrations, replacing dash separators with underscores, and refactors relevant utilities and logic to accommodate these changes.

**Key Changes:**
• Introduced syncTsConfig utility to copy tsconfig.json from the example directory on init and dev
• Updated migration and development workflows to ensure tsconfig.json is always present and up to date
• Changed script file naming convention for zero-yaml from dash-separated to underscore-separated in local service
• Refactored constants and moved exampleFolder reference to a common location
• Updated related imports and helpers to use new path conventions

**Affected Areas:**
• Zero-yaml CLI project initialization and migration (migrations/toZeroYaml.ts)
• Zero-yaml development workflow (zeroYaml/dev.ts, index.ts)
• Shared script file path logic (shared/services/file/local.service.ts)
• Utility and constants management for zero-yaml

*This summary was automatically generated by @propel-code-bot*