### PR TITLE
fix(server): mistake on getting json_schema models

### DIFF
--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -489,7 +489,7 @@ export async function deployPreBuilt({
 
             if (jsonSchemaString) {
                 const jsonSchema = JSON.parse(jsonSchemaString) as JSONSchema7;
-                const allModels = [...models, config.input].filter(Boolean) as string[];
+                const allModels = [...models, config.input?.name].filter(Boolean) as string[];
                 const result = filterJsonSchemaForModels(jsonSchema, allModels);
                 if (result.isErr()) {
                     return { success: false, error: new NangoError('deploy_missing_json_schema_model', result.error), response: null };


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR corrects the process of collecting model names when filtering json_schema models during sync config deployment. The change ensures that the model names array properly includes 'config.input?.name' instead of potentially passing the input object itself.

*This summary was automatically generated by @propel-code-bot*