### PR TITLE
feat(providers): localize oracle-hcm

### DIFF
--- a/packages/providers/i18n/providers.de.json
+++ b/packages/providers/i18n/providers.de.json
@@ -20,5 +20,23 @@
                 "description": "Workday API Passwort"
             }
         }
+    },
+    "oracle-hcm": {
+        "connection_config": {
+            "restServerUrl": {
+                "title": "REST-Server-URL",
+                "description": "Die REST-Server-URL für Ihre Oracle Fusion Cloud"
+            }
+        },
+        "credentials": {
+            "username": {
+                "title": "Benutzername",
+                "description": "Ihr Oracle Cloud Service Benutzername"
+            },
+            "password": {
+                "title": "Passwort",
+                "description": "Ihr Oracle Cloud Service Passwort"
+            }
+        }
     }
 }

--- a/packages/providers/i18n/providers.es.json
+++ b/packages/providers/i18n/providers.es.json
@@ -20,5 +20,23 @@
                 "description": "Contraseña de la API de Workday"
             }
         }
+    },
+    "oracle-hcm": {
+        "connection_config": {
+            "restServerUrl": {
+                "title": "URL del servidor REST",
+                "description": "La URL del servidor REST para su Oracle Fusion Cloud"
+            }
+        },
+        "credentials": {
+            "username": {
+                "title": "Nombre de usuario",
+                "description": "Su nombre de usuario del servicio Oracle Cloud"
+            },
+            "password": {
+                "title": "Contraseña",
+                "description": "Su contraseña del servicio Oracle Cloud"
+            }
+        }
     }
 }

--- a/packages/providers/i18n/providers.fr.json
+++ b/packages/providers/i18n/providers.fr.json
@@ -25,17 +25,17 @@
         "connection_config": {
             "restServerUrl": {
                 "title": "URL du serveur REST",
-                "description": "L'URL du serveur REST pour votre Oracle Fusion Cloud"
+                "description": "L'URL du serveur REST de votre compte Oracle Fusion Cloud"
             }
         },
         "credentials": {
             "username": {
                 "title": "Nom d'utilisateur",
-                "description": "Votre nom d'utilisateur du service Oracle Cloud"
+                "description": "Votre nom d'utilisateur Oracle Fusion Cloud"
             },
             "password": {
                 "title": "Mot de passe",
-                "description": "Votre mot de passe du service Oracle Cloud"
+                "description": "Votre mot de passe Oracle Fusion Cloud"
             }
         }
     }

--- a/packages/providers/i18n/providers.fr.json
+++ b/packages/providers/i18n/providers.fr.json
@@ -20,5 +20,23 @@
                 "description": "Mot de passe de l'API Workday"
             }
         }
+    },
+    "oracle-hcm": {
+        "connection_config": {
+            "restServerUrl": {
+                "title": "URL du serveur REST",
+                "description": "L'URL du serveur REST pour votre Oracle Fusion Cloud"
+            }
+        },
+        "credentials": {
+            "username": {
+                "title": "Nom d'utilisateur",
+                "description": "Votre nom d'utilisateur du service Oracle Cloud"
+            },
+            "password": {
+                "title": "Mot de passe",
+                "description": "Votre mot de passe du service Oracle Cloud"
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR adds German, Spanish, and French localization entries for the 'oracle-hcm' provider within the existing provider i18n JSON files. It introduces new translated labels and descriptions for the provider's connection configuration and credential fields, without any logic or functional changes.

*This summary was automatically generated by @propel-code-bot*