### PR TITLE
fix(cli): dryrun with --integration-id flag has incorrect check

### DIFF
--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -158,7 +158,7 @@ export class DryRunService {
             parsed = parsing.value.parsed!;
         }
 
-        if (options.optionalProviderConfigKey && parsed.integrations.some((inte) => inte.providerConfigKey === options.optionalProviderConfigKey)) {
+        if (options.optionalProviderConfigKey && !parsed.integrations.some((inte) => inte.providerConfigKey === options.optionalProviderConfigKey)) {
             console.log(chalk.red(`Integration "${options.optionalProviderConfigKey}" does not exist`));
             return;
         }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
### Description
Samuel recently touched this for zeroYaml and removed the negation by mistake (https://github.com/NangoHQ/nango/pull/4115/files#diff-a159ae11e9f2a4877483b046305971040d805c57d12a7478d66fee904a610727R161).

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR corrects a logic error in the CLI's dryrun feature where specifying the --integration-id flag performed an incorrect existence check due to a missing negation. The bug was introduced during a prior update related to zeroYaml handling and is now fixed by restoring the negation in the condition.

*This summary was automatically generated by @propel-code-bot*