### PR TITLE
fix(cli): use old syntax for dirname

### DIFF
--- a/packages/cli/lib/zeroYaml/constants.ts
+++ b/packages/cli/lib/zeroYaml/constants.ts
@@ -1,8 +1,11 @@
-import path from 'node:path';
+import path, { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import ts from 'typescript';
 
-export const exampleFolder = path.join(import.meta.dirname, '../../example');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+export const exampleFolder = path.join(__dirname, '../../example');
 export const npmPackageRegex = /^[^./\s]/;
 export const importRegex = /^import ['"](?<path>\.\/[^'"]+)['"];/gm;
 

--- a/packages/cli/lib/zeroYaml/init.ts
+++ b/packages/cli/lib/zeroYaml/init.ts
@@ -1,7 +1,6 @@
 import { exec } from 'node:child_process';
 import fs from 'node:fs';
-import path, { dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import { promisify } from 'node:util';
 
 import chalk from 'chalk';
@@ -10,9 +9,7 @@ import ora from 'ora';
 import { printDebug } from '../utils.js';
 import { NANGO_VERSION } from '../version.js';
 import { compileAll } from './compile.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import { exampleFolder } from './constants.js';
 
 const execAsync = promisify(exec);
 
@@ -37,12 +34,11 @@ export async function initZero({ absolutePath, debug = false }: { absolutePath: 
     // Copy example folder
     {
         const spinner = ora({ text: 'Copy example' }).start();
-        const exampleFolderPath = path.join(__dirname, '..', '..', 'example');
         try {
             printDebug(`Copy example folder`, debug);
 
             await fs.promises.mkdir(absolutePath, { recursive: true });
-            await copyRecursive(exampleFolderPath, absolutePath);
+            await copyRecursive(exampleFolder, absolutePath);
             await fs.promises.rename(path.join(absolutePath, '.env.example'), path.join(absolutePath, '.env'));
             spinner.succeed();
         } catch (err) {


### PR DESCRIPTION
## Changes

- Use retro compatible syntax for dirname to avoid error in Node < 20.11.0
- Reuse example path

<!-- Summary by @propel-code-bot -->

---

This PR updates the CLI to use the older, backward-compatible syntax for resolving __dirname, ensuring compatibility with Node.js versions prior to 20.11.0. Additionally, it refactors example folder path logic for reuse and consistency by centralizing it in a constants file.

*This summary was automatically generated by @propel-code-bot*