### PR TITLE
feat(cli): add --ai options to nango init

### DIFF
--- a/packages/cli/lib/ai/init.ts
+++ b/packages/cli/lib/ai/init.ts
@@ -1,0 +1,100 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import chalk from 'chalk';
+import { getNangoRootPath, printDebug } from '../utils.js';
+import { isArray } from 'node:util';
+
+const srcPath = path.join(getNangoRootPath(), 'lib', 'ai', 'instructions', 'basics.md');
+const supportedAgents = ['claude', 'cursor'];
+
+export async function initAI({
+    absolutePath,
+    aiOpts,
+    debug = false
+}: {
+    absolutePath: string;
+    aiOpts: string[] | undefined;
+    debug?: boolean;
+}): Promise<boolean> {
+    if (!isArray(aiOpts)) {
+        printDebug(`Invalid options. Expected an array of AI agents.`, debug);
+        return false;
+    }
+
+    const [validAgents, invalidAgents] = aiOpts.reduce<[string[], string[]]>(
+        (acc, agent) => {
+            if (supportedAgents.includes(agent)) {
+                acc[0].push(agent);
+            } else {
+                acc[1].push(agent);
+            }
+            return acc;
+        },
+        [[], []]
+    );
+    if (invalidAgents.length > 0) {
+        console.log(chalk.red(`Invalid AI agents provided: ${invalidAgents.join(', ')}. Supported agents are: ${supportedAgents.join(', ')}.`));
+        return false;
+    }
+
+    for (const agent of validAgents) {
+        if (agent === 'claude') {
+            const ok = await initClaude({ absolutePath, debug });
+            if (!ok) {
+                return false;
+            }
+        } else if (agent === 'cursor') {
+            const ok = await initCursor({ absolutePath, debug });
+            if (!ok) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+async function initCursor({ absolutePath, debug = false }: { absolutePath: string; debug: boolean }): Promise<boolean> {
+    try {
+        printDebug(`Creating the Cursor agent rules files in ${absolutePath}`, debug);
+        const destPath = path.join(absolutePath, '.cursor', 'rules', 'nango.mdc');
+        const stat = fs.statSync(destPath, { throwIfNoEntry: false });
+        if (stat) {
+            console.log(chalk.yellow(`${destPath} already exists. Skipping.`));
+            return true;
+        }
+        await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
+        const header = `---
+description: Nango Custom Integration Development
+globs:
+alwaysApply: false
+---
+
+`;
+        const fileContent = await fs.promises.readFile(srcPath, 'utf-8');
+        await fs.promises.writeFile(destPath, header + fileContent, 'utf-8');
+        return true;
+    } catch (err) {
+        console.error(chalk.red(`Failed to initialize Cursor: ${err instanceof Error ? err.message : 'unknown error'}`));
+        return false;
+    }
+}
+
+async function initClaude({ absolutePath, debug = false }: { absolutePath: string; debug: boolean }): Promise<boolean> {
+    try {
+        printDebug(`Creating the Claude agent instructions file in ${absolutePath}`, debug);
+        const destPath = path.join(absolutePath, 'claude.md');
+
+        const stat = fs.statSync(destPath, { throwIfNoEntry: false });
+        if (stat) {
+            console.log(chalk.yellow(`${destPath} already exists. Skipping.`));
+            return true;
+        }
+
+        await fs.promises.copyFile(srcPath, destPath);
+        return true;
+    } catch (err) {
+        console.error(chalk.red(`Failed to initialize Claude: ${err instanceof Error ? err.message : 'unknown error'}`));
+        return false;
+    }
+}

--- a/packages/cli/lib/ai/instructions/basics.md
+++ b/packages/cli/lib/ai/instructions/basics.md
@@ -1,0 +1,81 @@
+You are an expert at building custom integrations for Nango. Follow the instructions below to build robust, well-tested integrations that follow Nango architecture and patterns.
+
+## About Nango
+
+Nango is a platform for building and managing API integrations. You'll be working with:
+- **Syncs**: Continuous data synchronization from external APIs
+- **Actions**: One-time operations that interact with external APIs
+- **Providers**: External services (like GitHub, Slack, HubSpot, etc.)
+
+Official Nango documentation is available at https://docs.nango.dev
+
+## Development Environment
+
+Before starting any integration work:
+
+1. **Working Nango integrations folder**: Ensure you are in an existing `nango-integrations` directory or run `nango init`
+2. **Environment setup**: `.env` file must be configured with development environment secret. If not, ask the user to provide the secret key (found in [dashboard settings](https://app.nango.dev/dev/environment-settings)) 
+3. **Provider configured**: The provider should be configured in the [Nango dashboard](https://app.nango.dev/dev/integrations)
+4. **Test connection**: If possible at least one working test connection for the target provider
+
+## When Building Integrations
+
+### Essential Information to Gather
+
+Before implementing, always ask for:
+- **Provider name** (e.g., "github", "slack", "hubspot")
+- **Integration name** (descriptive name for the specific integration. ex: create-contact, list-issues)
+- **Type**: sync or action. Try to infer from the instructions. if in doubt, ask the user
+
+If possible the users must also provide:
+- **Output schema**: Expected data structure
+- **Field mapping**: How API fields map to desired output
+- **API documentation links**
+- **Specific API endpoints** to call
+- **Test connection ID** (enables testing with `nango dryrun`)
+
+### Effective Implementation Process
+
+1. **Start simple**: For example, begin with basic data fetching
+2. **Search the web for API documentation**: Retrieve details about how to use API endpoints from provider official documentation
+3. **Test frequently**: Use `nango dryrun <integration-name> <connection-id> --validation [--input '{...}']` after each change
+4. **Review thoroughly**: Check for code artifacts and ensure code quality
+
+### DO NOT
+
+- Do NOT set Authorization header (Nango handles this automatically)
+- Do NOT run `nango deploy`
+- Do NOT edit the models.ts file. It is automatically generated at compilation time.
+- Do NOT prefix the integration name and/or folder with `integrations`
+
+### Compile 
+
+Run `nango compile` to generate the models and compile the typescript code.
+
+### Testing Commands
+
+Always use these commands to validate your integration:
+```bash
+# Basic test
+nango dryrun <integration-name> <connection-id>
+
+# Test with validation
+nango dryrun <integration-name> <connection-id> --validation
+
+# Test action with input
+nango dryrun <integration-name> <connection-id> --validation --input '{"key": "value"}'
+```
+
+### Code Quality Checklist
+
+Always verify:
+- [ ] Code is compiling without any error: `nango compile`
+- [ ] API endpoints are correctly implemented (search for actual API docs)
+- [ ] Proper query parameters and/or request body are used 
+- [ ] Input and output validation is implemented
+- [ ] Error handling covers common failure scenarios
+- [ ] Pagination is implemented correctly if needed
+- [ ] Data models match the expected schema
+- [ ] All debugging code and artifacts are removed
+- [ ] `nango dryrun` run successfully without errors. If input are required, provider JSON input examples.
+

--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -112,12 +112,10 @@ program
         const absolutePath = path.resolve(currentPath, this.args[0] || '');
 
         const setupAI = async (): Promise<void> => {
-            const initAiOk = await initAI({ absolutePath, debug, aiOpts: ai });
-            if (!initAiOk) {
-                console.error(chalk.red(`Failed to initialize AI agent instructions files.`));
-                return;
+            const ok = await initAI({ absolutePath, debug, aiOpts: ai });
+            if (ok) {
+                printDebug(`AI agent instructions files initialized in ${absolutePath}`, debug);
             }
-            printDebug(`AI agent instructions files initialized in ${absolutePath}`, debug);
         };
 
         const check = await verificationService.preCheck({ fullPath: absolutePath, debug });
@@ -139,8 +137,8 @@ program
             return;
         }
 
-        const initOk = init({ absolutePath, debug });
-        if (!initOk) {
+        const ok = init({ absolutePath, debug });
+        if (!ok) {
             process.exitCode = 1;
             return;
         }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -94,6 +94,7 @@
         "example/**/*",
         "lib/nango.yaml.schema.v1.json",
         "lib/nango.yaml.schema.v2.json",
+        "lib/ai/instructions/*",
         "scripts/v1-v2.js",
         "tsconfig.dev.json",
         "README.md"


### PR DESCRIPTION
running `nango init --ai cursor` will initialize instructions file for AI agents (currently supported Cursor and Claude code).

Keeping the instructions minimal for now. I know IEs have more exhaustive cursor rules in the prebuilt template repo but from my experience not all of it is necessary anymore. I prefer to a small set of instructions and extend it from there.

<!-- Summary by @propel-code-bot -->

---

This PR introduces a new --ai option for the nango init CLI command to scaffold minimal instructions files for AI agents, currently supporting Cursor and Claude. The implementation adds agent-specific validation, integration of these instruction files during project bootstrap, and updates asset packaging to ensure distribution.

**Key Changes:**
• Added --ai [claude|cursor...] flag to nango init CLI, enabling the initialization of AI agent instruction files.
• Implemented ai/init.ts with agent validation (using Zod), copy logic for templates, and agent-specific flows for Cursor (.cursor/rules/nango.mdc) and Claude (claude.md).
• Introduced a new instructions template (ai/instructions/basics.md) with integration checklists and best practices.
• Wired up new logic into index.ts and extended CLI options accordingly.
• Modified package.json to include AI instruction files in the package distribution.

**Affected Areas:**
• CLI: nango init command (index.ts)
• AI agent initialization logic (ai/init.ts)
• Documentation/templates for agents (ai/instructions/basics.md)
• NPM package file list (package.json)

*This summary was automatically generated by @propel-code-bot*