### PR TITLE
feat(cli): zeroyaml single script deploy 

### DIFF
--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -263,7 +263,6 @@ async function createPackage({
         return Err(new Error('No scripts to deploy'));
     }
 
-    // TODO: reup
     const jsonSchema = loadSchemaJson({ fullPath });
     if (!jsonSchema) {
         return Err(new Error('Failed to load schema.json'));

--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -11,6 +11,7 @@ import { Err, Ok } from '../utils/result.js';
 import { hostport, isCI, parseSecretKey, printDebug } from '../utils.js';
 import { NANGO_VERSION } from '../version.js';
 import { ReadableError } from './utils.js';
+import { loadSchemaJson } from '../services/model.service.js';
 
 import type { DeployOptions } from '../types.js';
 import type {
@@ -25,13 +26,8 @@ import type {
     ScriptDifferences,
     ScriptFileType
 } from '@nangohq/types';
-import type { JSONSchema7 } from 'json-schema';
 
-interface Package {
-    flowConfigs: CLIDeployFlowConfig[];
-    onEventScriptsByProvider: OnEventScriptsByProvider[] | undefined;
-    jsonSchema: JSONSchema7 | undefined;
-}
+type Package = Pick<PostDeployConfirmation['Body'], 'flowConfigs' | 'onEventScriptsByProvider' | 'singleDeployMode' | 'jsonSchema'>;
 
 export async function deploy({
     fullPath,
@@ -42,7 +38,7 @@ export async function deploy({
     options: DeployOptions;
     environmentName: string;
 }): Promise<Result<boolean>> {
-    const { version, sync: optionalSyncName, action: optionalActionName, debug } = options;
+    const { version, debug } = options;
 
     let pkg: Package;
     const spinnerPackage = ora({ text: 'Packaging' }).start();
@@ -57,7 +53,15 @@ export async function deploy({
         }
 
         // Create deploy package
-        const postData = await createPackage({ parsed: def.value, fullPath, debug, version, optionalSyncName, optionalActionName });
+        const postData = await createPackage({
+            parsed: def.value,
+            fullPath,
+            debug,
+            version,
+            optionalIntegrationId: options.integration,
+            optionalSyncName: options.sync,
+            optionalActionName: options.action
+        });
         if (postData.isErr()) {
             spinnerPackage.fail();
             console.log(chalk.red(postData.error.message));
@@ -132,6 +136,7 @@ async function createPackage({
     fullPath,
     debug,
     version = '',
+    optionalIntegrationId,
     optionalSyncName,
     optionalActionName
 }: {
@@ -139,6 +144,7 @@ async function createPackage({
     fullPath: string;
     debug: boolean;
     version?: string | undefined;
+    optionalIntegrationId?: string | undefined;
     optionalSyncName?: string | undefined;
     optionalActionName?: string | undefined;
 }): Promise<Result<Package>> {
@@ -146,9 +152,14 @@ async function createPackage({
 
     const postData: CLIDeployFlowConfig[] = [];
     const onEventScriptsByProvider: OnEventScriptsByProvider[] | undefined = optionalActionName || optionalSyncName ? undefined : []; // only load on-event scripts if we're not deploying a single sync or action
+    const singleDeployMode = Boolean(optionalSyncName || optionalActionName);
 
     for (const integration of parsed.integrations) {
         const { providerConfigKey, onEventScripts } = integration;
+
+        if (optionalIntegrationId && integration.providerConfigKey !== optionalIntegrationId) {
+            continue;
+        }
 
         if (onEventScriptsByProvider) {
             const scripts: OnEventScriptsByProvider['scripts'] = [];
@@ -248,18 +259,21 @@ async function createPackage({
         }
     }
 
-    // TODO: reup
-    // const jsonSchema = loadSchemaJson({ fullPath });
-    // if (!jsonSchema) {
-    //     return null;
-    // }
+    if (postData.length <= 0) {
+        return Err(new Error('No scripts to deploy'));
+    }
 
-    // console.log(postData);
+    // TODO: reup
+    const jsonSchema = loadSchemaJson({ fullPath });
+    if (!jsonSchema) {
+        return Err(new Error('Failed to load schema.json'));
+    }
 
     return Ok({
         flowConfigs: postData,
         onEventScriptsByProvider,
-        jsonSchema: undefined
+        jsonSchema,
+        singleDeployMode
     });
 }
 
@@ -503,6 +517,19 @@ async function handleConfirmation({
                 "WARNING: Renaming a model is the equivalent of deleting the old model and creating a new one. Records from the old model won't be transferred to the new model. Consider running a full sync to transfer records."
             )
         );
+    }
+
+    if (
+        newSyncs.length <= 0 &&
+        deletedSyncs.length <= 0 &&
+        newActions.length <= 0 &&
+        deletedActions.length <= 0 &&
+        newOnEventScripts.length <= 0 &&
+        deletedOnEventScripts.length <= 0 &&
+        deletedModels.length <= 0
+    ) {
+        console.log('');
+        console.log(chalk.gray.italic('  Only updates'));
     }
 
     console.log('');


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-3310/single-script-deploy


- ZeroYaml: support for single script deploy


## Tests

- ` node ../packages/cli/dist/index.js deploy dev -i github`
- ` node ../packages/cli/dist/index.js deploy dev -a createIssue`
<!-- Summary by @propel-code-bot -->

---

This PR introduces support for deploying a single script (sync or action) using the ZeroYaml format in the CLI, as part of resolving issue NAN-3310. Changes focus on enhancing the deploy command to accept granular deploy targets and update the underlying packaging and validation logic to support deploying only the specified script or integration.

**Key Changes:**
• Added support for single script deploy (by sync, action, or integration) in the ZeroYaml CLI flow.
• Refactored and generalized the package assembly process to accept targeted deploy options (integration, sync, or action).
• Introduced 'singleDeployMode' flag and proper runtime schema validation via 'loadSchemaJson'.
• Added input validation for deploy (returns errors if no scripts or schema found).
• Enhanced summary outputs when no new, deleted, or updated items are present.


**Affected Areas:**
• packages/cli/lib/zeroYaml/deploy.ts


*This summary was automatically generated by @propel-code-bot*