### PR TITLE
fix(cli): missing export for zeroyaml

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,8 +12,10 @@
     "exports": {
         ".": {
             "require": "./dist/sdkScripts.js",
-            "types": "./dist/sdkScripts.d.ts"
-        }
+            "types": "./dist/sdkScripts.d.ts",
+            "default": "./dist/sdkScripts.js"
+        },
+        "./package.json": "./package.json"
     },
     "keywords": [],
     "author": "bastien@nango.dev",


### PR DESCRIPTION
## Changes

- missing export for zeroyaml
Until now we haven't had the need to execute the file (it was bundled and those functions stripped) but when running unit test in integration templates we don't have the luxury of pre-bundling. So vitest needs an other export to be able to load the file

<!-- Summary by @propel-code-bot -->

---

This PR updates the CLI's package.json to add a missing export for zeroyaml, enabling direct file loading for test environments that do not use pre-bundling. The change ensures compatibility with vitest and similar testing tools.

*This summary was automatically generated by @propel-code-bot*