### PR TITLE
fix(file): correctly zip from s3

### DIFF
--- a/packages/server/lib/controllers/flow.controller.ts
+++ b/packages/server/lib/controllers/flow.controller.ts
@@ -2,6 +2,7 @@ import { configService, flowService, getSyncConfigById, getSyncConfigsAsStandard
 
 import type { RequestLocals } from '../utils/express.js';
 import type { FlowDownloadBody } from '@nangohq/shared';
+import type { ScriptTypeLiteral } from '@nangohq/types';
 import type { NextFunction, Request, Response } from 'express';
 
 class FlowController {
@@ -35,7 +36,12 @@ class FlowController {
             }
 
             if (!id && is_public) {
-                await remoteFileService.zipAndSendPublicFiles({ res, integrationName: name, providerPath: provider, flowType });
+                const flow = flowService.getFlowByIntegrationAndName({ provider, type: flowType as ScriptTypeLiteral, scriptName: name });
+                if (!flow) {
+                    res.status(400).send({ error: { code: 'invalid_query' } });
+                    return;
+                }
+                await remoteFileService.zipAndSendPublicFiles({ res, scriptName: name, providerPath: provider, flowType });
                 return;
             } else {
                 // it has an id, so it's either a public template that is active, or a private template
@@ -48,7 +54,7 @@ class FlowController {
 
                 await remoteFileService.zipAndSendFiles({
                     res,
-                    integrationName: name,
+                    scriptName: name,
                     syncConfig,
                     providerConfigKey
                 });

--- a/packages/shared/lib/services/file/local.service.ts
+++ b/packages/shared/lib/services/file/local.service.ts
@@ -104,12 +104,12 @@ class LocalFileService {
      */
     public async zipAndSendFiles({
         res,
-        integrationName,
+        scriptName,
         providerConfigKey,
         syncConfig
     }: {
         res: Response;
-        integrationName: string;
+        scriptName: string;
         providerConfigKey: string;
         syncConfig: DBSyncConfig;
     }) {
@@ -124,7 +124,7 @@ class LocalFileService {
             files.push(yamlPath);
         }
 
-        const tsFilePath = this.resolveTsFile({ scriptName: integrationName, providerConfigKey, syncConfig });
+        const tsFilePath = this.resolveTsFile({ scriptName, providerConfigKey, syncConfig });
         if (!tsFilePath) {
             errorManager.errResFromNangoErr(res, new NangoError('integration_file_not_found'));
             return;

--- a/packages/shared/lib/services/file/remote.service.ts
+++ b/packages/shared/lib/services/file/remote.service.ts
@@ -195,83 +195,81 @@ class RemoteFileService {
 
     async zipAndSendPublicFiles({
         res,
-        integrationName,
+        scriptName,
         providerPath,
         flowType
     }: {
         res: Response;
-        integrationName: string;
+        scriptName: string;
         providerPath: string;
         flowType: string;
     }): Promise<void> {
+        // TODO: handle zero yaml here
+
+        const files: { name: string; content: Readable }[] = [];
         const { success, error, response: nangoYaml } = await this.getStream(`${this.publicRoute}/${providerPath}/${nangoConfigFile}`);
         if (!success || nangoYaml === null) {
             errorManager.errResFromNangoErr(res, error);
             return;
         }
+        files.push({ name: 'nango.yaml', content: nangoYaml });
+
         const {
             success: tsSuccess,
             error: tsError,
             response: tsFile
-        } = await this.getStream(`${this.publicRoute}/${providerPath}/${flowType}s/${integrationName}.ts`);
+        } = await this.getStream(`${this.publicRoute}/${providerPath}/${flowType}s/${scriptName}.ts`);
         if (!tsSuccess || tsFile === null) {
             errorManager.errResFromNangoErr(res, tsError);
             return;
         }
-        await this.zipAndSend({ res, integrationName, nangoYaml, tsFile });
+        files.push({ name: `${scriptName}.ts`, content: tsFile });
+
+        await this.zipAndSend({ res, files });
     }
 
     async zipAndSendFiles({
         res,
-        integrationName,
+        scriptName,
         providerConfigKey,
         syncConfig
     }: {
         res: Response;
-        integrationName: string;
+        scriptName: string;
         providerConfigKey: string;
         syncConfig: DBSyncConfig;
     }): Promise<void> {
         if (!isCloud && !useS3) {
-            return localFileService.zipAndSendFiles({ res, integrationName, providerConfigKey, syncConfig });
+            return localFileService.zipAndSendFiles({ res, scriptName, providerConfigKey, syncConfig });
         } else {
-            const nangoConfigLocation = syncConfig.file_location.split('/').slice(0, -3).join('/');
-            const { success, error, response: nangoYaml } = await this.getStream(`${nangoConfigLocation}/${nangoConfigFile}`);
-
-            if (!success || nangoYaml === null) {
-                errorManager.errResFromNangoErr(res, error);
-                return;
+            const files: { name: string; content: Readable }[] = [];
+            if (!syncConfig.sdk_version?.includes('-zero')) {
+                const nangoConfigLocation = syncConfig.file_location.split('/').slice(0, -3).join('/');
+                const resGet = await this.getStream(`${nangoConfigLocation}/${nangoConfigFile}`);
+                if (!resGet.success || !resGet.response) {
+                    errorManager.errResFromNangoErr(res, resGet.error);
+                    return;
+                }
+                files.push({ name: 'nango.yaml', content: resGet.response });
             }
 
             const integrationFileLocation = syncConfig.file_location.split('/').slice(0, -1).join('/');
-            const { success: tsSuccess, error: tsError, response: tsFile } = await this.getStream(`${integrationFileLocation}/${integrationName}.ts`);
-
+            const { success: tsSuccess, error: tsError, response: tsFile } = await this.getStream(`${integrationFileLocation}/${scriptName}.ts`);
             if (!tsSuccess || tsFile === null) {
                 errorManager.errResFromNangoErr(res, tsError);
                 return;
             }
+            files.push({ name: `${scriptName}.ts`, content: tsFile });
 
-            await this.zipAndSend({ res, integrationName, nangoYaml, tsFile, nangoConfigId: syncConfig.nango_config_id });
+            await this.zipAndSend({ res, files, nangoConfigId: syncConfig.nango_config_id });
         }
     }
 
-    async zipAndSend({
-        res,
-        integrationName,
-        nangoYaml,
-        tsFile,
-        nangoConfigId
-    }: {
-        res: Response;
-        integrationName: string;
-        nangoYaml: Readable;
-        tsFile: Readable;
-        nangoConfigId?: number;
-    }) {
+    async zipAndSend({ res, files, nangoConfigId }: { res: Response; files: { name: string; content: Readable }[]; nangoConfigId?: number }) {
         const archive = archiver('zip');
 
         archive.on('error', (err) => {
-            report(err, { integrationName, nangoConfigId });
+            report(err, { files: files.map((f) => f.name).join(', '), nangoConfigId });
 
             errorManager.errResFromNangoErr(res, new NangoError('error_creating_zip_file'));
             return;
@@ -282,8 +280,9 @@ class RemoteFileService {
 
         archive.pipe(res);
 
-        archive.append(nangoYaml, { name: nangoConfigFile });
-        archive.append(tsFile, { name: `${integrationName}.ts` });
+        for (const file of files) {
+            archive.append(file.content, { name: file.name });
+        }
 
         await archive.finalize();
     }


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-3255/fix-zip-s3

- Correctly zip zeroyaml script
- Ensure a flow do exists before initiating a download
- Fixes integrationName -> scriptName
That's my bad


<!-- Summary by @propel-code-bot -->

---

This PR addresses a bug where integration files (scripts and YAML) were inconsistently zipped and downloaded from S3. The changes unify the zipping logic by introducing a flexible array-based approach for collecting files to zip, switch all parameters from 'integrationName' to 'scriptName' for improved naming consistency, and ensure existence of a flow before serving downloads for public templates.

**Key Changes:**
• Refactored remote and local zipping logic to use a generic array-of-files approach, improving extensibility and consistency for both S3 and local sources.
• Replaced all references of 'integrationName' with 'scriptName' throughout the affected services and controllers.
• In controller, added existence check for the flow before download in public flow cases.
• Error handling was improved during file lookup and zipping, with appropriate status codes and error responses on failure.

**Affected Areas:**
• Remote file service (S3 zip logic)
• Local file service (local zip logic)
• Flow controller (download endpoint logic)

*This summary was automatically generated by @propel-code-bot*