### PR TITLE
fix(shared): remove explicit setting of AWS credentials

### DIFF
--- a/packages/shared/lib/services/file/remote.service.ts
+++ b/packages/shared/lib/services/file/remote.service.ts
@@ -17,21 +17,15 @@ import type { Response } from 'express';
 
 let client: S3Client | null = null;
 let useS3 = !isLocal && !isTest;
+let region = process.env['AWS_REGION'] as string;
 
 if (isEnterprise) {
     useS3 = Boolean(process.env['AWS_REGION'] && process.env['AWS_BUCKET_NAME']);
-    client = new S3Client({
-        region: (process.env['AWS_REGION'] as string) || 'us-west-2'
-    });
-} else {
-    client = new S3Client({
-        region: process.env['AWS_REGION'] as string,
-        credentials: {
-            accessKeyId: process.env['AWS_ACCESS_KEY_ID'] as string,
-            secretAccessKey: process.env['AWS_SECRET_ACCESS_KEY'] as string
-        }
-    });
+    region = region ?? 'us-west-2';
 }
+client = new S3Client({
+    region
+});
 
 class RemoteFileService {
     bucket = (process.env['AWS_BUCKET_NAME'] as string) || 'nangodev-customer-integrations';
@@ -136,7 +130,6 @@ class RemoteFileService {
                 Bucket: this.bucket,
                 Key: fileName
             });
-
             client
                 ?.send(getObjectCommand)
                 .then((response: GetObjectCommandOutput) => {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Removed the explicit setting of the AWS credentials when creating the S3 client as the credentials use the default names and will automatically be detected by the AWS credentials provider. More details [here](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html) and for JavaScipt specifically, [here](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html#credchain)

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the S3 client initialization in remote.service.ts to remove the explicit specification of AWS access key and secret key, relying instead on the AWS SDK's default credential provider chain. Region selection logic is preserved with an enterprise-specific fallback, resulting in a cleaner and more standardized setup.

*This summary was automatically generated by @propel-code-bot*