### PR TITLE
feat(docs): add securityScheme to OpenAPI spec

### DIFF
--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -9,6 +9,8 @@ servers:
       description: Production server
     - url: http://localhost:3003
       description: Local server
+security:
+    - bearerAuth: []
 paths:
     /providers:
         get:
@@ -2320,6 +2322,11 @@ paths:
                     $ref: '#/components/responses/NotFound'
 
 components:
+    securitySchemes:
+        bearerAuth:
+            type: http
+            scheme: bearer
+            description: The secret key from your Nango environment.
     responses:
         BadRequest:
             description: Bad request


### PR DESCRIPTION
<!-- Describe the problem and your solution -->
## Description
Our OpenAPI spec had no security definitions, causing our Playground to not be usable (no auth params). This adds a global bearer token requirement.

How it looks in the playground:
<img width="1129" alt="image" src="https://github.com/user-attachments/assets/e13f97d1-d54b-4f12-a48b-affbeb0b4d11" />


<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the OpenAPI specification by introducing a global 'bearerAuth' security scheme. All endpoints now require a bearer token for authorization, improving the API Playground usability and aligning documentation with the backend's authentication model.

*This summary was automatically generated by @propel-code-bot*