### PR TITLE
chore(orchestrator): tasks events via pg LISTEN/NOTIFY

### DIFF
--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -10,13 +10,15 @@ import { nanoid } from '@nangohq/utils';
 import type { PostImmediate } from '../routes/v1/postImmediate.js';
 
 const dbClient = getTestDbClient();
-const eventsHandler = new TaskEventsHandler({
-    CREATED: () => {},
-    STARTED: () => {},
-    SUCCEEDED: () => {},
-    FAILED: () => {},
-    EXPIRED: () => {},
-    CANCELLED: () => {}
+const eventsHandler = new TaskEventsHandler(dbClient.db, {
+    on: {
+        CREATED: () => {},
+        STARTED: () => {},
+        SUCCEEDED: () => {},
+        FAILED: () => {},
+        EXPIRED: () => {},
+        CANCELLED: () => {}
+    }
 });
 const scheduler = new Scheduler({
     db: dbClient.db,

--- a/packages/orchestrator/lib/clients/processor.integration.test.ts
+++ b/packages/orchestrator/lib/clients/processor.integration.test.ts
@@ -13,13 +13,15 @@ import { tracer } from 'dd-trace';
 import { setTimeout } from 'timers/promises';
 
 const dbClient = getTestDbClient();
-const taskEventsHandler = new TaskEventsHandler({
-    CREATED: () => {},
-    STARTED: () => {},
-    SUCCEEDED: () => {},
-    FAILED: () => {},
-    EXPIRED: () => {},
-    CANCELLED: () => {}
+const taskEventsHandler = new TaskEventsHandler(dbClient.db, {
+    on: {
+        CREATED: () => {},
+        STARTED: () => {},
+        SUCCEEDED: () => {},
+        FAILED: () => {},
+        EXPIRED: () => {},
+        CANCELLED: () => {}
+    }
 });
 const scheduler = new Scheduler({
     db: dbClient.db,

--- a/packages/orchestrator/lib/events.integration.test.ts
+++ b/packages/orchestrator/lib/events.integration.test.ts
@@ -1,0 +1,169 @@
+import { expect, describe, it, beforeEach, afterEach, vi } from 'vitest';
+import type { Task } from '@nangohq/scheduler';
+import { getTestDbClient } from '@nangohq/scheduler';
+import { taskEvents, TaskEventsHandler } from './events.js';
+
+const dbClient = getTestDbClient();
+const mockCallbacks = {
+    CREATED: vi.fn(),
+    STARTED: vi.fn(),
+    SUCCEEDED: vi.fn(),
+    FAILED: vi.fn(),
+    EXPIRED: vi.fn(),
+    CANCELLED: vi.fn()
+};
+const mockTask: Task = {
+    id: 'task-123',
+    name: 'task-name',
+    groupKey: 'taskGroup:myKey',
+    state: 'CREATED',
+    createdAt: new Date(),
+    lastHeartbeatAt: new Date(),
+    retryCount: 0,
+    output: null,
+    terminated: false,
+    groupMaxConcurrency: 1,
+    retryKey: 'retry-key',
+    retryMax: 3,
+    startsAfter: new Date(),
+    createdToStartedTimeoutSecs: 60,
+    startedToCompletedTimeoutSecs: 60,
+    heartbeatTimeoutSecs: 30,
+    lastStateTransitionAt: new Date(),
+    scheduleId: null,
+    ownerKey: 'owner-key',
+    payload: {}
+};
+
+describe('TaskEventsHandler', () => {
+    let eventsHandler: TaskEventsHandler;
+
+    beforeEach(async () => {
+        await dbClient.migrate();
+        eventsHandler = new TaskEventsHandler(dbClient.db, { on: mockCallbacks });
+        await eventsHandler.connect();
+    });
+
+    afterEach(async () => {
+        await eventsHandler.disconnect();
+        await dbClient.clearDatabase();
+    });
+
+    describe('emit', () => {
+        it('should throw error for empty event name', () => {
+            expect(() => eventsHandler.emit('')).toThrow('Event name must be a non-empty string');
+        });
+
+        it('should throw error for non-string event', () => {
+            expect(() => eventsHandler.emit(123 as any)).toThrow('Event name must be a non-empty string');
+        });
+
+        it('should emit locally when not connected', async () => {
+            await eventsHandler.disconnect();
+
+            const localEmitSpy = vi.spyOn(eventsHandler, 'emitLocally');
+            eventsHandler.emit('test-event', 'arg1', 'arg2');
+
+            expect(localEmitSpy).toHaveBeenCalledWith('test-event', 'arg1', 'arg2');
+        });
+
+        it('should handle payload too large error', async () => {
+            const largePayload = 'x'.repeat(9000);
+            await new Promise((resolve) => {
+                eventsHandler.on('payloadTooLarge', () => resolve(undefined));
+                eventsHandler.emit('my-large-event', largePayload);
+            });
+        });
+    });
+
+    describe('emitLocally', () => {
+        it('should return true when listeners exist', () => {
+            const handler = vi.fn();
+            eventsHandler.on('test-event', handler);
+
+            const result = eventsHandler.emitLocally('test-event', 'arg1');
+
+            expect(result).toBe(true);
+            expect(handler).toHaveBeenCalledWith('arg1');
+        });
+
+        it('should return false when no listeners exist', () => {
+            const result = eventsHandler.emitLocally('test-event', 'arg1');
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('connection management', () => {
+        it('should emit connected event on successful connection', async () => {
+            const newEmitter = new TaskEventsHandler(dbClient.db, { on: mockCallbacks });
+
+            await new Promise((resolve) => {
+                newEmitter.on('connected', () => {
+                    newEmitter.disconnect();
+                });
+                newEmitter.connect().finally(() => resolve(undefined));
+            });
+        });
+
+        it('should handle disconnection gracefully', async () => {
+            const disconnectedHandler = vi.fn();
+            eventsHandler.on('disconnected', disconnectedHandler);
+
+            await eventsHandler.disconnect();
+
+            expect(disconnectedHandler).toHaveBeenCalled();
+        });
+    });
+
+    describe.each([taskEvents.taskCreated(mockTask), taskEvents.taskStarted(mockTask), taskEvents.taskCompleted(mockTask)])(
+        'cross-process communication',
+        (event) => {
+            it('should receive task event from other emitter', async () => {
+                const emitter2 = new TaskEventsHandler(dbClient.db, { on: mockCallbacks });
+                await emitter2.connect();
+
+                await new Promise((resolve) => {
+                    eventsHandler.on(event, (taskId: string) => {
+                        expect(taskId).toBe(mockTask.id);
+                        emitter2.disconnect();
+                        resolve(undefined);
+                    });
+                    emitter2.emit(event, mockTask.id);
+                });
+            });
+        }
+    );
+});
+
+describe('taskEvents', () => {
+    describe('taskCreated', () => {
+        it('should generate event name from task object', () => {
+            const eventName = taskEvents.taskCreated(mockTask);
+            expect(eventName).toBe('task:created:taskGroup');
+        });
+
+        it('should generate event name from string', () => {
+            const eventName = taskEvents.taskCreated('myGroup');
+            expect(eventName).toBe('task:created:myGroup');
+        });
+    });
+
+    describe('taskStarted', () => {
+        it('should generate event name from task', () => {
+            const eventName = taskEvents.taskStarted(mockTask);
+            expect(eventName).toBe('task:started:task-123');
+        });
+    });
+
+    describe('taskCompleted', () => {
+        it('should generate event name from task object', () => {
+            const eventName = taskEvents.taskCompleted(mockTask);
+            expect(eventName).toBe('task:completed:task-123');
+        });
+
+        it('should generate event name from string', () => {
+            const eventName = taskEvents.taskCompleted('task-456');
+            expect(eventName).toBe('task:completed:task-456');
+        });
+    });
+});

--- a/packages/orchestrator/lib/events.ts
+++ b/packages/orchestrator/lib/events.ts
@@ -1,8 +1,196 @@
 import type { Task } from '@nangohq/scheduler';
 import { GROUP_PREFIX_SEPARATOR } from '@nangohq/scheduler';
 import EventEmitter from 'node:events';
+import type knex from 'knex';
+import { logger } from './utils.js';
+import { retryWithBackoff } from '@nangohq/utils';
 
-export class TaskEventsHandler extends EventEmitter {
+class PgEventEmitter extends EventEmitter {
+    private knex: knex.Knex;
+    private channel: string;
+    private client: any = null;
+    private connected: boolean = false;
+    private shouldReconnect: boolean = true;
+
+    constructor(
+        knex: knex.Knex,
+        options: {
+            channel: string;
+        }
+    ) {
+        super();
+
+        this.knex = knex;
+        this.channel = options.channel;
+    }
+
+    async connect(): Promise<void> {
+        try {
+            if (this.connected) {
+                return; // Already connected, no need to reconnect
+            }
+
+            this.client = await this.knex.client.acquireRawConnection();
+            await this.client.query(`LISTEN ${this.channel}`);
+            this.connected = true;
+
+            this.client.on('notification', (notification: { pid: number; channel: string; payload?: string }) => {
+                try {
+                    const { event, args }: { event: string; args: any } = JSON.parse(notification.payload || '{}');
+                    super.emit(event, ...args);
+                } catch (err) {
+                    logger.error('Error parsing PostgreSQL notification', err);
+                    super.emit('parseError', err, notification.payload);
+                }
+            });
+
+            this.client.on('error', (err: Error) => {
+                logger.error('PostgreSQL client error:', err);
+                this.connected = false;
+                super.emit('error', err);
+                this.reconnect();
+            });
+
+            this.client.on('end', () => {
+                logger.info('PostgreSQL connection ended');
+                this.connected = false;
+                this.reconnect();
+            });
+
+            super.emit('connected');
+            logger.info(`Successfully listening to channel: ${this.channel}`);
+        } catch (err) {
+            logger.error('PostgreSQL connection error:', err);
+            super.emit('error', err);
+            this.reconnect();
+        }
+    }
+
+    private async reconnect(): Promise<void> {
+        if (!this.shouldReconnect) {
+            return;
+        }
+        try {
+            await retryWithBackoff(
+                () => {
+                    return this.connect();
+                },
+                {
+                    startingDelay: 100,
+                    timeMultiple: 3,
+                    numOfAttempts: 3
+                }
+            );
+        } catch (err) {
+            logger.error('Failed to reconnect to PostgreSQL:', err);
+        }
+    }
+
+    async disconnect(): Promise<void> {
+        if (this.client) {
+            try {
+                this.shouldReconnect = false;
+
+                this.client.removeAllListeners('notification');
+                this.client.removeAllListeners('error');
+                this.client.removeAllListeners('end');
+
+                if (this.connected) {
+                    try {
+                        await this.client.query(`UNLISTEN ${this.channel}`);
+                    } catch (_err: unknown) {
+                        // Ignore errors during UNLISTEN
+                    }
+                }
+
+                await this.knex.client.releaseConnection(this.client);
+
+                this.connected = false;
+                this.client = null;
+
+                super.emit('disconnected');
+                logger.info(`Successfully disconnected from channel: ${this.channel}`);
+            } catch (err) {
+                logger.error(`Error disconnecting from channel ${this.channel}`, err);
+                super.emit('disconnectError', err);
+                this.connected = false;
+                this.client = null;
+            }
+        }
+    }
+
+    override emit(event: string | symbol, ...args: any[]): boolean {
+        if (!this.connected) {
+            logger.warning(`Not connected to PostgreSQL, emitting event locally: ${String(event)}`);
+            return this.emitLocally(event, ...args);
+        }
+
+        if (typeof event !== 'string' || !event.trim()) {
+            throw new Error('Event name must be a non-empty string');
+        }
+
+        this.notify(event, args).catch((err: unknown) => {
+            logger.error('Error notifying PostgreSQL:', err);
+            super.emit('notifyError', err, event, args);
+        });
+        return true;
+    }
+
+    emitLocally(event: string | symbol, ...args: any[]): boolean {
+        const hasListeners = this.listenerCount(event) > 0;
+        if (hasListeners) {
+            return super.emit(event, ...args);
+        }
+        return false;
+    }
+
+    private async notify(event: string, args: any[]): Promise<void> {
+        if (!this.connected || !this.client) {
+            throw new Error('Not connected to PostgreSQL');
+        }
+
+        const payload = JSON.stringify({ event, args });
+
+        // Check payload size (PostgreSQL NOTIFY has ~8KB limit)
+        const maxPayloadSize = 8_000;
+        if (payload.length > maxPayloadSize) {
+            const error = new Error(`Payload too large: ${payload.length} bytes (max: ${maxPayloadSize})`);
+            super.emit('payloadTooLarge', error, event, args);
+            throw error;
+        }
+
+        try {
+            await this.client.query(`NOTIFY ${this.channel}, '${payload}'`);
+        } catch (err: any) {
+            if (err.code === 'ECONNRESET' || err.code === 'ENOTCONN') {
+                this.connected = false;
+                this.reconnect();
+            }
+            throw err;
+        }
+    }
+}
+
+export const taskEvents = {
+    taskCreated: (prop: Task | string): string => {
+        if (typeof prop === 'string') {
+            return `task:created:${prop}`;
+        }
+        const groupKeyPrefix = prop.groupKey.split(GROUP_PREFIX_SEPARATOR)[0];
+        return `task:created:${groupKeyPrefix}`;
+    },
+    taskStarted: (task: Task): string => {
+        return `task:started:${task.id}`;
+    },
+    taskCompleted: (prop: Task | string): string => {
+        if (typeof prop === 'string') {
+            return `task:completed:${prop}`;
+        }
+        return `task:completed:${prop.id}`;
+    }
+};
+
+export class TaskEventsHandler extends PgEventEmitter {
     public readonly onCallbacks: {
         CREATED: (task: Task) => void;
         STARTED: (task: Task) => void;
@@ -12,40 +200,32 @@ export class TaskEventsHandler extends EventEmitter {
         CANCELLED: (task: Task) => void;
     };
 
-    constructor(on: {
-        CREATED: (task: Task) => void;
-        STARTED: (task: Task) => void;
-        SUCCEEDED: (task: Task) => void;
-        FAILED: (task: Task) => void;
-        EXPIRED: (task: Task) => void;
-        CANCELLED: (task: Task) => void;
-    }) {
-        super();
+    constructor(db: knex.Knex, { on }: { on: TaskEventsHandler['onCallbacks'] }) {
+        super(db, { channel: 'nango_task_events' });
         this.onCallbacks = {
             CREATED: (task: Task) => {
                 on.CREATED(task);
-                const groupKeyPrefix = task.groupKey.split(GROUP_PREFIX_SEPARATOR)[0]; // Emitting event on the group key prefix if any
-                this.emit(`task:created:${groupKeyPrefix}`, task);
+                this.emit(taskEvents.taskCreated(task), task.id);
             },
             STARTED: (task: Task) => {
                 on.STARTED(task);
-                this.emit(`task:started:${task.id}`, task);
+                this.emit(taskEvents.taskStarted(task), task.id);
             },
             SUCCEEDED: (task: Task) => {
                 on.SUCCEEDED(task);
-                this.emit(`task:completed:${task.id}`, task);
+                this.emit(taskEvents.taskCompleted(task), task.id);
             },
             FAILED: (task: Task) => {
                 on.FAILED(task);
-                this.emit(`task:completed:${task.id}`, task);
+                this.emit(taskEvents.taskCompleted(task), task.id);
             },
             EXPIRED: (task: Task) => {
                 on.EXPIRED(task);
-                this.emit(`task:completed:${task.id}`, task);
+                this.emit(taskEvents.taskCompleted(task), task.id);
             },
             CANCELLED: (task: Task) => {
                 on.CANCELLED(task);
-                this.emit(`task:completed:${task.id}`, task);
+                this.emit(taskEvents.taskCompleted(task), task.id);
             }
         };
     }

--- a/packages/orchestrator/lib/helpers.test.ts
+++ b/packages/orchestrator/lib/helpers.test.ts
@@ -13,13 +13,15 @@ export class TestOrchestratorService {
 
     constructor({ port }: { port: number }) {
         this.dbClient = getTestDbClient();
-        this.eventsHandler = new TaskEventsHandler({
-            CREATED: () => {},
-            STARTED: () => {},
-            SUCCEEDED: () => {},
-            FAILED: () => {},
-            EXPIRED: () => {},
-            CANCELLED: () => {}
+        this.eventsHandler = new TaskEventsHandler(this.dbClient.db, {
+            on: {
+                CREATED: () => {},
+                STARTED: () => {},
+                SUCCEEDED: () => {},
+                FAILED: () => {},
+                EXPIRED: () => {},
+                CANCELLED: () => {}
+            }
         });
         this.port = port;
         this.scheduler = null;


### PR DESCRIPTION
in order to make orchestrator multi-instances, task event notifications cannot be only emitted/received locally.
This commit is using postgres LISTEN/NOTIFY mechanism as a way to broadcast the task events (task created, completed, ...) to all instances of the orchestrator

<!-- Summary by @propel-code-bot -->

---

This PR replaces local-only EventEmitter-based task event handling in the orchestrator with a new PgEventEmitter system that leverages PostgreSQL LISTEN/NOTIFY for broadcasting task events (e.g., task created, started, completed) across multiple orchestrator instances. It introduces the PgEventEmitter class, modifies TaskEventsHandler to use this abstraction, updates event naming conventions, adapts API route handlers and test/integration code, and adds an extensive integration test suite to validate event delivery, error conditions (including payload limitations), and distributed behaviors. Changes include constructor and invocation signature updates for event handlers, improved connection lifecycle management, and enforcement of best practices around PostgreSQL NOTIFY's 8KB payload limit.

**Key Changes:**
• Replaced Node.js EventEmitter-based event propagation with PgEventEmitter using PostgreSQL LISTEN/NOTIFY for inter-instance broadcast.
• Introduced new PgEventEmitter class to manage notification emission, subscription, connection errors, reconnection, and payload sizing.
• Refactored TaskEventsHandler to extend PgEventEmitter and updated callbacks to only emit lightweight event payloads (e.g., taskId) due to NOTIFY payload limits.
• Updated all usage points, server/app bootstrap, and API route handlers (e.g., getOutput, postDequeue) to use new event abstractions and event naming.
• Enhanced integration and unit tests with scenarios covering connection lifecycle, event parsing, payload too large, and multiple orchestrator instances.
• Modified test harnesses and helper classes to work with new TaskEventsHandler constructor and behavior.
• Ensured proper disconnect/release of PgEventEmitter on orchestrator shutdown to avoid PG connection leaks.

**Affected Areas:**
• TaskEventsHandler and events.ts module
• Orchestrator service/app bootstrap logic (app.ts)
• API endpoints/routes relying on task event notifications (getOutput, postDequeue, etc.)
• Integration and unit tests (including helpers, processor, client, and API tests)
• TestOrchestratorService and other test harnesses

*This summary was automatically generated by @propel-code-bot*