### PR TITLE
chore(orch): more tracing and prevent multiple concurrent cleaning/expiring

### DIFF
--- a/packages/scheduler/lib/daemons/daemon.ts
+++ b/packages/scheduler/lib/daemons/daemon.ts
@@ -41,13 +41,8 @@ export abstract class SchedulerDaemon {
             }
             this.status = 'running';
             while (!this.abortSignal.aborted) {
-                await tracer.trace(`scheduler.${this.name.toLowerCase()}.run`, async (span) => {
-                    try {
-                        await this.run();
-                    } catch (err) {
-                        span?.setTag('error', err);
-                        throw err;
-                    }
+                await tracer.trace(`scheduler.${this.name.toLowerCase()}.run`, async () => {
+                    await this.run();
                 });
                 await setTimeout(this.tickIntervalMs);
             }

--- a/packages/scheduler/lib/daemons/expiring/expiring.daemon.ts
+++ b/packages/scheduler/lib/daemons/expiring/expiring.daemon.ts
@@ -5,6 +5,7 @@ import { logger } from '../../utils/logger.js';
 import { SchedulerDaemon } from '../daemon.js';
 import { envs } from '../../env.js';
 import type { Task } from '../../types.js';
+import { setTimeout } from 'node:timers/promises';
 
 export class ExpiringDaemon extends SchedulerDaemon {
     private onExpiring: (task: Task) => void;
@@ -31,16 +32,26 @@ export class ExpiringDaemon extends SchedulerDaemon {
     }
 
     async run(): Promise<void> {
-        const expired = await tasks.expiresIfTimeout(this.db);
-        if (expired.isErr()) {
-            logger.error(`Error expiring tasks: ${stringifyError(expired.error)}`);
-            return;
-        }
-        if (expired.value.length > 0) {
-            for (const task of expired.value) {
-                this.onExpiring(task);
+        return this.db.transaction(async (trx) => {
+            // Try to acquire a lock to prevent multiple instances from expiring at the same time
+            const res = await trx.raw<{ rows: { lock_expire: boolean }[] }>('SELECT pg_try_advisory_xact_lock(?) AS lock_expire', [5003001108]);
+            const lockGranted = res?.rows.length > 0 ? res.rows[0]!.lock_expire : false;
+
+            if (lockGranted) {
+                const expired = await tasks.expiresIfTimeout(trx);
+                if (expired.isErr()) {
+                    logger.error(`Error expiring tasks: ${stringifyError(expired.error)}`);
+                    return;
+                }
+                if (expired.value.length > 0) {
+                    for (const task of expired.value) {
+                        this.onExpiring(task);
+                    }
+                    logger.info(`Expired tasks: ${JSON.stringify(expired.value.map((t) => t.id))}`);
+                }
+            } else {
+                await setTimeout(1000); // wait for 1s to prevent retrying too quickly
             }
-            logger.info(`Expired tasks: ${JSON.stringify(expired.value.map((t) => t.id))}`);
-        }
+        });
     }
 }

--- a/packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts
+++ b/packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts
@@ -36,70 +36,62 @@ export class SchedulingDaemon extends SchedulerDaemon {
 
     async run(): Promise<void> {
         return this.db.transaction(async (trx) => {
-            const span = tracer.startSpan('scheduler.scheduling.schedule');
             try {
                 // Try to acquire a lock to prevent multiple instances from scheduling at the same time
-                const lockSpan = tracer.startSpan('scheduler.scheduling.acquire_lock', { childOf: span });
-                const res = await tracer.scope().activate(lockSpan, async () => {
+                const res = await tracer.trace('scheduler.scheduling.acquire_lock', async () => {
                     return trx.raw<{ rows: { lock_schedule: boolean }[] }>('SELECT pg_try_advisory_xact_lock(?) AS lock_schedule', [5003001106]);
                 });
                 const lockGranted = res?.rows.length > 0 ? res.rows[0]!.lock_schedule : false;
-                lockSpan.finish();
 
                 if (lockGranted) {
-                    const dueSchedulesSpan = tracer.startSpan('scheduler.scheduling.due_schedules', { childOf: span });
-                    const getDueSchedules = await tracer.scope().activate(dueSchedulesSpan, async () => {
-                        return dueSchedules(trx);
-                    });
-                    dueSchedulesSpan.finish();
-
-                    if (getDueSchedules.isErr()) {
-                        throw new Error(`Failed to get due schedules: ${stringifyError(getDueSchedules.error)}`);
-                    } else {
-                        const tasksCreationSpan = tracer.startSpan('scheduler.scheduling.tasks_creation', { childOf: span });
-                        await tracer.scope().activate(tasksCreationSpan, async () => {
-                            const now = new Date();
-                            const createTasks = getDueSchedules.value.map((schedule) =>
-                                tasks.create(trx, {
-                                    scheduleId: schedule.id,
-                                    startsAfter: now,
-                                    name: `${schedule.name}:${now.toISOString()}`,
-                                    payload: schedule.payload,
-                                    groupKey: schedule.groupKey,
-                                    groupMaxConcurrency: 0,
-                                    retryCount: 0,
-                                    retryMax: schedule.retryMax,
-                                    createdToStartedTimeoutSecs: schedule.createdToStartedTimeoutSecs,
-                                    startedToCompletedTimeoutSecs: schedule.startedToCompletedTimeoutSecs,
-                                    heartbeatTimeoutSecs: schedule.heartbeatTimeoutSecs,
-                                    ownerKey: null
-                                })
-                            );
-                            const res = await Promise.allSettled(createTasks);
-                            for (const taskRes of res) {
-                                if (taskRes.status === 'rejected') {
-                                    logger.error(`Failed to schedule task: ${taskRes.reason}`);
-                                } else if (taskRes.value.isErr()) {
-                                    logger.error(`Failed to schedule task: ${stringifyError(taskRes.value.error)}`);
-                                } else {
-                                    const task = taskRes.value.value;
-                                    if (task.scheduleId) {
-                                        await schedules.update(trx, { id: task.scheduleId, lastScheduledTaskId: task.id });
-                                    }
-                                    this.onScheduling(task);
-                                }
-                            }
+                    await tracer.trace('scheduler.scheduling.schedule_tasks', async () => {
+                        const getDueSchedules = await tracer.trace('scheduler.scheduling.due_schedules', async () => {
+                            return dueSchedules(trx);
                         });
-                        tasksCreationSpan.finish();
-                    }
+
+                        if (getDueSchedules.isErr()) {
+                            throw new Error(`Failed to get due schedules: ${stringifyError(getDueSchedules.error)}`);
+                        } else {
+                            await tracer.trace('scheduler.scheduling.tasks_creation', async () => {
+                                const now = new Date();
+                                const createTasks = getDueSchedules.value.map((schedule) =>
+                                    tasks.create(trx, {
+                                        scheduleId: schedule.id,
+                                        startsAfter: now,
+                                        name: `${schedule.name}:${now.toISOString()}`,
+                                        payload: schedule.payload,
+                                        groupKey: schedule.groupKey,
+                                        groupMaxConcurrency: 0,
+                                        retryCount: 0,
+                                        retryMax: schedule.retryMax,
+                                        createdToStartedTimeoutSecs: schedule.createdToStartedTimeoutSecs,
+                                        startedToCompletedTimeoutSecs: schedule.startedToCompletedTimeoutSecs,
+                                        heartbeatTimeoutSecs: schedule.heartbeatTimeoutSecs,
+                                        ownerKey: null
+                                    })
+                                );
+                                const res = await Promise.allSettled(createTasks);
+                                for (const taskRes of res) {
+                                    if (taskRes.status === 'rejected') {
+                                        logger.error(`Failed to schedule task: ${taskRes.reason}`);
+                                    } else if (taskRes.value.isErr()) {
+                                        logger.error(`Failed to schedule task: ${stringifyError(taskRes.value.error)}`);
+                                    } else {
+                                        const task = taskRes.value.value;
+                                        if (task.scheduleId) {
+                                            await schedules.update(trx, { id: task.scheduleId, lastScheduledTaskId: task.id });
+                                        }
+                                        this.onScheduling(task);
+                                    }
+                                }
+                            });
+                        }
+                    });
                 } else {
                     await setTimeout(1000); // wait for 1s to prevent retrying too quickly
                 }
             } catch (err) {
-                span.setTag('error', err);
                 logger.error(err);
-            } finally {
-                span.finish();
             }
         });
     }

--- a/packages/scheduler/lib/daemons/scheduling/scheduling.ts
+++ b/packages/scheduler/lib/daemons/scheduling/scheduling.ts
@@ -29,7 +29,6 @@ export async function dueSchedules(db: knex.Knex): Promise<Result<Schedule[]>> {
             .skipLocked();
         return Ok(schedules.map(DbSchedule.from));
     } catch (err) {
-        console.log(err);
         return Err(new Error(`Error getting due schedules: ${stringifyError(err)}`));
     }
 }


### PR DESCRIPTION
add locking around the cleaning/expiring logic to ensure only one instance is executing at a time.
This prevent:
- executing expensive db queries more than necessary
- double deletion or expiration of tasks
Also add tracing around cleaning and expiring logic Simplify tracing logic in scheduling
Also add a trace in scheduling so we can have a metric/alert that doesn't include instances that couldn't acquire the lock and are actually not scheduling tasks

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR introduces PostgreSQL advisory locks to the cleaning, expiring, and scheduling daemons to ensure only one instance can execute critical logic at a time, preventing race conditions such as double deletion/expiration and unnecessary database load under high-availability deployments. Additionally, it simplifies and expands tracing across these daemons for improved observability, enabling more accurate metrics and alerting, and cleans up redundant trace logic to better encapsulate task scheduling behavior.

**Key Changes:**
• Added PostgreSQL advisory locks (pg_try_advisory_xact_lock) to cleaning, expiring, and scheduling daemons.
• Conditional execution of cleaning, expiring, or scheduling logic only when a lock is obtained; otherwise, instances wait before retrying.
• Refactored tracing: replaced manual span management with tracer.trace, applied consistent nested tracing for key operations.
• Removed redundant console logging and streamlined error handling in scheduling query logic.
• Updated the SchedulerDaemon base class to add tracing at the run-cycle level.

**Affected Areas:**
• scheduler/daemon.ts (Core daemon logic & tracing)
• scheduler/daemons/cleaning/cleaning.daemon.ts
• scheduler/daemons/expiring/expiring.daemon.ts
• scheduler/daemons/scheduling/scheduling.daemon.ts
• scheduler/daemons/scheduling/scheduling.ts (dueSchedules query logic)

*This summary was automatically generated by @propel-code-bot*