### PR TITLE
fix(cli): tsconfig correct options, dev mode parallel error display

### DIFF
--- a/packages/cli/example/tsconfig.json
+++ b/packages/cli/example/tsconfig.json
@@ -4,7 +4,7 @@
     "include": ["index.ts", "**/*.ts"],
     "exclude": ["node_modules", "dist", "build", ".nango"],
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "node16",
         "target": "esnext",
         "strict": true,
         "esModuleInterop": true,

--- a/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
+++ b/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
@@ -29,7 +29,7 @@ describe('compileAll', () => {
         console.log('compiling to ', dir);
         await copyDirectoryAndContents(path.join(fixturesPath, 'zero/valid'), dir);
 
-        const pkg = { name: 'test', dependencies: { nango: `file:${path.resolve(path.join(fixturesPath, '..'))}`, zod: '3.24.2' } };
+        const pkg = { name: 'test', type: 'module', dependencies: { nango: `file:${path.resolve(path.join(fixturesPath, '..'))}`, zod: '3.24.2' } };
 
         await fs.promises.writeFile(path.join(dir, 'package.json'), JSON.stringify(pkg, null, 2));
         await exec('npm i', { cwd: dir });

--- a/packages/cli/lib/zeroYaml/constants.ts
+++ b/packages/cli/lib/zeroYaml/constants.ts
@@ -10,13 +10,13 @@ export const npmPackageRegex = /^[^./\s]/;
 export const importRegex = /^import ['"](?<path>\.\/[^'"]+)['"];/gm;
 
 export const tsconfig: ts.CompilerOptions = {
-    module: ts.ModuleKind.CommonJS,
+    module: ts.ModuleKind.Node16,
     target: ts.ScriptTarget.ESNext,
     strict: true,
     esModuleInterop: true,
     skipLibCheck: true,
     forceConsistentCasingInFileNames: true,
-    moduleResolution: ts.ModuleResolutionKind.NodeJs,
+    moduleResolution: ts.ModuleResolutionKind.Node16,
     allowUnusedLabels: false,
     allowUnreachableCode: false,
     exactOptionalPropertyTypes: true,
@@ -35,7 +35,7 @@ export const tsconfig: ts.CompilerOptions = {
 };
 export const tsconfigString: Record<string, any> = {
     ...tsconfig,
-    module: 'commonjs',
+    module: 'node16',
     target: 'esnext',
     importsNotUsedAsValues: 'remove',
     jsx: 'react',

--- a/packages/cli/lib/zeroYaml/utils.ts
+++ b/packages/cli/lib/zeroYaml/utils.ts
@@ -10,7 +10,7 @@ export async function syncTsConfig({ fullPath }: { fullPath: string }) {
     await fs.promises.writeFile(path.join(fullPath, 'tsconfig.json'), await fs.promises.readFile(path.join(exampleFolder, 'tsconfig.json')));
 }
 
-export function fileErrorToText({ filePath, msg, line, character }: { filePath: string; msg: string; line?: number; character?: number }) {
+export function fileErrorToText({ filePath, msg, line, character }: { filePath: string; msg: string; line?: number | undefined; character?: number }) {
     return `${chalk.red('err')} - ${chalk.blue(filePath)}${line ? chalk.yellow(`:${line + 1}${character ? `:${character + 1}` : ''}`) : ''} \r\n  ${msg}\r\n`;
 }
 


### PR DESCRIPTION
## Changes

- Correct options for tsconfig 
(need to find a way to sync all those different representation)

- Correctly display errors and no error message in dev mode `nango dev`

<!-- Summary by @propel-code-bot -->

---

This PR standardizes the TypeScript configuration across the CLI, templates, and example projects to use 'node16' for both the 'module' and 'moduleResolution' settings, replacing 'commonjs' and legacy values for improved ESM compatibility. It also reworks dev mode error tracking in the CLI by introducing a dual error mechanism to accurately track and display concurrent TypeScript and bundler errors, ensuring that error and 'No error' messages are accurately synchronized with the build state. Minor utility, formatting, and type safety improvements are present, alongside an alignment update in the CLI unit test fixture.

**Key Changes:**
• Replaced all instances of `module: 'commonjs'` and related options in tsconfig files and code with `node16` for both 'module' and 'moduleResolution'.
• Refactored `manualWatch` and error buffer logic to track both TypeScript and bundler errors in parallel, improving accuracy of error messages during 'nango dev'.
• Enhanced error formatting utilities to display line numbers and clearer output; handled undefined line numbers properly.
• Updated test fixture package.json to explicitly use ESM modules (`type: 'module'`).

**Affected Areas:**
• packages/cli/lib/zeroYaml/dev.ts
• packages/cli/lib/zeroYaml/constants.ts
• packages/cli/lib/zeroYaml/utils.ts
• packages/cli/example/tsconfig.json
• packages/cli/lib/zeroYaml/compile.unit.cli-test.ts

*This summary was automatically generated by @propel-code-bot*