### PR TITLE
chore(runner): remove input/output validation

### DIFF
--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -51,8 +51,6 @@ export enum Types {
     REFRESH_CONNECTIONS_UNKNOWN = 'nango.server.refreshConnections.unknown',
 
     RUNNER_SDK = 'nango.runner.sdk',
-    RUNNER_INVALID_ACTION_INPUT = 'nango.runner.invalidActionInput',
-    RUNNER_INVALID_ACTION_OUTPUT = 'nango.runner.invalidActionOutput',
     RUNNER_INVALID_SYNCS_RECORDS = 'nango.runner.invalidSyncsRecords',
 
     SYNC_EXECUTION = 'nango.jobs.syncExecution',


### PR DESCRIPTION
It was never fully implemented. The validation is currently executed but it is only shown as a warning.
Since it can have an impact on actions latency, it is being removed for now
<!-- Summary by @propel-code-bot -->

---

This PR removes the input and output validation logic for actions in the Runner (packages/runner/lib/exec.ts). The associated metric constants and their usages have also been eliminated from the telemetry metrics (packages/utils/lib/telemetry/metrics.ts) to reduce potential latency, as validation was only issuing warnings and not fully implemented.

*This summary was automatically generated by @propel-code-bot*