### PR TITLE
feat: legacy model to json schema conversion

### DIFF
--- a/packages/nango-yaml/lib/__snapshots__/json-schema.unit.test.ts.snap
+++ b/packages/nango-yaml/lib/__snapshots__/json-schema.unit.test.ts.snap
@@ -13,13 +13,16 @@ exports[`legacySyncModelsToJsonSchema > should handle all primitive types and ba
           "type": "string",
         },
         "numberArray": {
-          "$ref": "#/definitions/number[] ",
+          "items": {
+            "type": "number",
+          },
+          "type": "array",
         },
         "numberField": {
           "type": "number",
         },
         "optionalString": {
-          "$ref": "#/definitions/string ",
+          "type": "string",
         },
         "stringArray": {
           "items": {

--- a/packages/nango-yaml/lib/__snapshots__/json-schema.unit.test.ts.snap
+++ b/packages/nango-yaml/lib/__snapshots__/json-schema.unit.test.ts.snap
@@ -1,5 +1,312 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`legacySyncModelsToJsonSchema > should handle all primitive types and basic features 1`] = `
+{
+  "definitions": {
+    "AllPrimitiveTypes": {
+      "properties": {
+        "booleanField": {
+          "type": "boolean",
+        },
+        "dateField": {
+          "format": "date-time",
+          "type": "string",
+        },
+        "numberArray": {
+          "$ref": "#/definitions/number[] ",
+        },
+        "numberField": {
+          "type": "number",
+        },
+        "optionalString": {
+          "$ref": "#/definitions/string ",
+        },
+        "stringArray": {
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+        "stringField": {
+          "type": "string",
+        },
+        "unknownType": {
+          "$ref": "#/definitions/uuid",
+        },
+      },
+      "required": [
+        "stringField",
+        "numberField",
+        "booleanField",
+        "dateField",
+        "unknownType",
+        "stringArray",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`legacySyncModelsToJsonSchema > should handle arrays of models and primitives 1`] = `
+{
+  "definitions": {
+    "Document": {
+      "properties": {
+        "collaborators": {
+          "items": {
+            "$ref": "#/definitions/User",
+          },
+          "type": "array",
+        },
+        "id": {
+          "type": "string",
+        },
+        "tags": {
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+      },
+      "required": [
+        "id",
+        "tags",
+      ],
+      "type": "object",
+    },
+    "User": {
+      "properties": {
+        "email": {
+          "type": "string",
+        },
+        "id": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "id",
+        "email",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`legacySyncModelsToJsonSchema > should handle empty models array 1`] = `
+{
+  "definitions": {},
+}
+`;
+
+exports[`legacySyncModelsToJsonSchema > should handle literal types 1`] = `
+{
+  "definitions": {
+    "StatusModel": {
+      "properties": {
+        "status": {
+          "oneOf": [
+            {
+              "const": "active",
+            },
+            {
+              "const": "canceled",
+            },
+            {
+              "const": "pending",
+            },
+          ],
+        },
+      },
+      "required": [
+        "status",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`legacySyncModelsToJsonSchema > should handle model with no fields 1`] = `
+{
+  "definitions": {
+    "EmptyModel": {
+      "properties": {},
+      "required": [],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`legacySyncModelsToJsonSchema > should handle references to other models 1`] = `
+{
+  "definitions": {
+    "Profile": {
+      "properties": {
+        "avatar": {
+          "oneOf": [
+            {
+              "type": "string",
+            },
+            {
+              "type": "null",
+            },
+          ],
+        },
+        "bio": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "bio",
+        "avatar",
+      ],
+      "type": "object",
+    },
+    "Role": {
+      "properties": {
+        "name": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "name",
+      ],
+      "type": "object",
+    },
+    "User": {
+      "properties": {
+        "id": {
+          "type": "string",
+        },
+        "profile": {
+          "$ref": "#/definitions/Profile",
+        },
+        "roles": {
+          "items": {
+            "$ref": "#/definitions/Role",
+          },
+          "type": "array",
+        },
+      },
+      "required": [
+        "id",
+        "profile",
+        "roles",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`legacySyncModelsToJsonSchema > should handle unions and optionals 1`] = `
+{
+  "definitions": {
+    "Event": {
+      "properties": {
+        "id": {
+          "type": "string",
+        },
+        "maybeModel": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Profile",
+            },
+            {
+              "type": "null",
+            },
+          ],
+        },
+        "maybeString": {
+          "oneOf": [
+            {
+              "type": "string",
+            },
+            {
+              "type": "null",
+            },
+          ],
+        },
+        "status": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/active",
+            },
+            {
+              "$ref": "#/definitions/canceled",
+            },
+          ],
+        },
+      },
+      "required": [
+        "id",
+        "status",
+        "maybeModel",
+      ],
+      "type": "object",
+    },
+    "Profile": {
+      "properties": {
+        "bio": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "bio",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`legacySyncModelsToJsonSchema > should still reference a non-existent model 1`] = `
+{
+  "definitions": {
+    "HasMissingRef": {
+      "properties": {
+        "id": {
+          "type": "string",
+        },
+        "missing": {
+          "$ref": "#/definitions/NonExistentModel",
+        },
+      },
+      "required": [
+        "id",
+        "missing",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`legacySyncModelsToJsonSchema > should treat reference to a non-existent model as string 1`] = `
+{
+  "definitions": {
+    "HasMissingRef": {
+      "properties": {
+        "id": {
+          "type": "string",
+        },
+        "missing": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "id",
+        "missing",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
 exports[`nangoModelsToJsonSchema > should handle all primitive types and basic features 1`] = `
 {
   "definitions": {

--- a/packages/nango-yaml/lib/json-schema.ts
+++ b/packages/nango-yaml/lib/json-schema.ts
@@ -1,4 +1,4 @@
-import type { NangoModel, NangoModelField } from '@nangohq/types';
+import type { LegacySyncModelSchema, NangoModel, NangoModelField } from '@nangohq/types';
 import type { JSONSchema7 } from 'json-schema';
 
 /**
@@ -80,4 +80,80 @@ const primitiveTypeMap: Record<string, JSONSchema7> = {
     boolean: { type: 'boolean' },
     string: { type: 'string' },
     date: { type: 'string', format: 'date-time' }
+};
+
+/**
+ * Converts a list of LegacySyncModelSchema to a JSON Schema with all the schemas stored in the definitions property.
+ * @param models Array of LegacySyncModelSchema
+ */
+export function legacySyncModelsToJsonSchema(models: LegacySyncModelSchema[]): JSONSchema7 {
+    const definitions: Record<string, JSONSchema7> = {};
+    for (const model of models) {
+        definitions[model.name] = legacySyncModelToJsonSchema(model, models);
+    }
+    return { definitions };
+}
+
+function legacySyncModelToJsonSchema(model: LegacySyncModelSchema, allModels: LegacySyncModelSchema[]): JSONSchema7 {
+    const properties: Record<string, JSONSchema7> = {};
+    const required: string[] = [];
+    const fields = Array.isArray(model.fields) ? model.fields : [];
+    for (const field of fields) {
+        // Optional fields end with '?' or '| undefined'
+        const isOptional = /\?$/.test(field.name) || /\|\s*undefined$/.test(field.type);
+        const cleanName = field.name.replace(/\?$/, '');
+        properties[cleanName] = legacySyncFieldToJsonSchema(field, allModels);
+        if (!isOptional) {
+            required.push(cleanName);
+        }
+    }
+    return {
+        type: 'object',
+        properties,
+        required
+    };
+}
+
+function legacySyncFieldToJsonSchema(field: { name: string; type: string }, allModels: LegacySyncModelSchema[]): JSONSchema7 {
+    let typeStr = field.type?.trim() ?? '';
+    // Handle optional
+    typeStr = typeStr.replace(/\|\s*undefined$/, '').trim();
+    // Handle union
+    if (typeStr.includes('|')) {
+        const types = typeStr
+            .split('|')
+            .map((t) => t.trim())
+            .filter((t) => t !== 'undefined');
+        return {
+            oneOf: types.map((t) => legacySyncTypeToJsonSchema(t, allModels))
+        };
+    }
+    return legacySyncTypeToJsonSchema(typeStr, allModels);
+}
+
+function legacySyncTypeToJsonSchema(typeStr: string, allModels: LegacySyncModelSchema[]): JSONSchema7 {
+    // Array type
+    const arrayMatch = typeStr.match(/^(.*)\[\]$/);
+    if (arrayMatch && typeof arrayMatch[1] === 'string') {
+        const itemType = arrayMatch[1].trim();
+        return {
+            type: 'array',
+            items: legacySyncTypeToJsonSchema(itemType, allModels)
+        };
+    }
+    // Primitive types
+    if (legacyPrimitiveTypeMap[typeStr]) {
+        return legacyPrimitiveTypeMap[typeStr];
+    }
+    // All other types are treated as references
+    return { $ref: `#/definitions/${typeStr}` };
+}
+
+const legacyPrimitiveTypeMap: Record<string, JSONSchema7> = {
+    integer: { type: 'integer' },
+    number: { type: 'number' },
+    boolean: { type: 'boolean' },
+    string: { type: 'string' },
+    date: { type: 'string', format: 'date-time' },
+    null: { type: 'null' }
 };

--- a/packages/nango-yaml/lib/json-schema.unit.test.ts
+++ b/packages/nango-yaml/lib/json-schema.unit.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { nangoModelsToJsonSchema } from './json-schema.js';
+import { legacySyncModelsToJsonSchema, nangoModelsToJsonSchema } from './json-schema.js';
 
-import type { NangoModel } from '@nangohq/types';
+import type { LegacySyncModelSchema, NangoModel } from '@nangohq/types';
 
 describe('nangoModelsToJsonSchema', () => {
     it('should handle all primitive types and basic features', () => {
@@ -227,6 +227,127 @@ describe('nangoModelsToJsonSchema', () => {
         ];
 
         const result = nangoModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+});
+
+describe('legacySyncModelsToJsonSchema', () => {
+    it('should handle all primitive types and basic features', () => {
+        const models: LegacySyncModelSchema[] = [
+            {
+                name: 'AllPrimitiveTypes',
+                fields: [
+                    { name: 'stringField', type: 'string' },
+                    { name: 'numberField', type: 'number' },
+                    { name: 'booleanField', type: 'boolean' },
+                    { name: 'dateField', type: 'date' },
+                    { name: 'optionalString', type: 'string | undefined' },
+                    { name: 'unknownType', type: 'uuid' }, // Should default to string
+                    { name: 'stringArray', type: 'string[]' },
+                    { name: 'numberArray', type: 'number[] | undefined' }
+                ]
+            }
+        ];
+        const result = legacySyncModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should handle references to other models', () => {
+        const models: LegacySyncModelSchema[] = [
+            {
+                name: 'User',
+                fields: [
+                    { name: 'id', type: 'string' },
+                    { name: 'profile', type: 'Profile' },
+                    { name: 'roles', type: 'Role[]' }
+                ]
+            },
+            {
+                name: 'Profile',
+                fields: [
+                    { name: 'bio', type: 'string' },
+                    { name: 'avatar', type: 'string | null' }
+                ]
+            },
+            {
+                name: 'Role',
+                fields: [{ name: 'name', type: 'string' }]
+            }
+        ];
+        const result = legacySyncModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should handle unions and optionals', () => {
+        const models: LegacySyncModelSchema[] = [
+            {
+                name: 'Event',
+                fields: [
+                    { name: 'id', type: 'string' },
+                    { name: 'status', type: 'active | canceled' },
+                    { name: 'maybeString', type: 'string | null | undefined' },
+                    { name: 'maybeModel', type: 'Profile | null' }
+                ]
+            },
+            {
+                name: 'Profile',
+                fields: [{ name: 'bio', type: 'string' }]
+            }
+        ];
+        const result = legacySyncModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should handle arrays of models and primitives', () => {
+        const models: LegacySyncModelSchema[] = [
+            {
+                name: 'Document',
+                fields: [
+                    { name: 'id', type: 'string' },
+                    { name: 'tags', type: 'string[]' },
+                    { name: 'collaborators', type: 'User[] | undefined' }
+                ]
+            },
+            {
+                name: 'User',
+                fields: [
+                    { name: 'id', type: 'string' },
+                    { name: 'email', type: 'string' }
+                ]
+            }
+        ];
+        const result = legacySyncModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should handle empty models array', () => {
+        const models: LegacySyncModelSchema[] = [];
+        const result = legacySyncModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should handle model with no fields', () => {
+        const models: LegacySyncModelSchema[] = [
+            {
+                name: 'EmptyModel',
+                fields: []
+            }
+        ];
+        const result = legacySyncModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should still reference a non-existent model', () => {
+        const models: LegacySyncModelSchema[] = [
+            {
+                name: 'HasMissingRef',
+                fields: [
+                    { name: 'id', type: 'string' },
+                    { name: 'missing', type: 'NonExistentModel' }
+                ]
+            }
+        ];
+        const result = legacySyncModelsToJsonSchema(models);
         expect(result).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
### Description
This is for migrating preBuilt flows that had incorrect json-schemas. I worked based on examples, if there's any case that you know of that I'm not covering, please lmk.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR introduces `legacySyncModelsToJsonSchema`, a new utility that converts arrays of legacy sync model schemas into JSON Schema definitions to aid the migration of prebuilt flows with outdated or incorrect JSON schemas. The implementation robustly covers primitive types, arrays, unions, optionals, model references, and handles edge cases, all validated with extensive new and updated unit tests and corresponding snapshot updates.

**Key Changes:**
• Added `legacySyncModelsToJsonSchema` and helper functions for legacy model schema conversion in `json-schema.ts`.
• Extended type definitions and parsing logic to support primitive types, arrays, unions, optionals, and references as found in legacy schema definitions.
• Significantly expanded and refactored test coverage in `json-schema.unit.test.ts` for both legacy and modern schema conversion APIs.
• Massive update to the snapshot file (`json-schema.unit.test.ts.snap`) to capture the new expected outputs.

**Affected Areas:**
• packages/nango-yaml/lib/json-schema.ts
• packages/nango-yaml/lib/json-schema.unit.test.ts
• packages/nango-yaml/lib/__snapshots__/json-schema.unit.test.ts.snap

*This summary was automatically generated by @propel-code-bot*