### PR TITLE
fix: docker credentials secret names were incorrect

### DIFF
--- a/.github/workflows/managed-release.yaml
+++ b/.github/workflows/managed-release.yaml
@@ -309,8 +309,8 @@ jobs:
               if: ${{ !env.ACT }}
               uses: docker/login-action@v3
               with:
-                  username: ${{ secrets.DOCKERHUB_USERNAME }}
-                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+                  username: ${{ secrets.DOCKER_USERNAME }}
+                  password: ${{ secrets.DOCKER_PASSWORD }}
 
             - name: Log Docker operations (act)
               if: ${{ env.ACT }}


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the managed-release GitHub Actions workflow to use the correct Docker secret names for authentication. The previous secrets (DOCKERHUB_USERNAME and DOCKERHUB_TOKEN) have been replaced with DOCKER_USERNAME and DOCKER_PASSWORD to match the actual secret names in use.

*This summary was automatically generated by @propel-code-bot*