### PR TITLE
fix: add upload/download actions to share data across jobs

### DIFF
--- a/.github/workflows/managed-release.yaml
+++ b/.github/workflows/managed-release.yaml
@@ -50,6 +50,12 @@ jobs:
                   echo "image_version=$(node -p "require('./managed-manifest.json').latest.imageVersion")" >> $GITHUB_OUTPUT
                   echo "app_version=$(node -p "require('./managed-manifest.json').latest.appVersion")" >> $GITHUB_OUTPUT
 
+            - name: Upload manifest artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: managed-manifest
+                  path: managed-manifest.json
+
     test-deployment:
         needs: manage-versions
         runs-on: ubuntu-latest
@@ -290,6 +296,12 @@ jobs:
                   fetch-depth: 1
                   token: ${{ secrets.GITHUB_TOKEN }}
 
+            - name: Download manifest artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: managed-manifest
+                  path: .
+
             # The workflow will only get to this step under two conditions:
             # 1. The test deployment was successful and no breaking changes were identified
             # 2. The test deployment failed and the user approved the release - if this is the case, we need to bump the major version
@@ -363,6 +375,7 @@ jobs:
                   echo "Running in act - would create PR:"
                   echo "Would create branch: version-update-$(date +%Y%m%d-%H%M%S)"
                   echo "Would commit changes to managed-manifest.json"
+                  cat managed-manifest.json
                   echo "Would create PR with title: Update version in manifest"
                   echo "Would create PR with body: This PR updates the version in the manifest. Please review and merge to ensure the next release uses the correct version."
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the managed-release GitHub Actions workflow to persist the managed-manifest.json file between jobs using actions/upload-artifact and actions/download-artifact steps. It ensures that versioning data generated in the manage-versions job is uploaded as an artifact and later downloaded for use in the finalize-release job, enabling reliable data sharing across workflow stages.

*This summary was automatically generated by @propel-code-bot*