### PR TITLE
fix(cli): catch bad import earlier 

### DIFF
--- a/packages/cli/lib/zeroYaml/compile.ts
+++ b/packages/cli/lib/zeroYaml/compile.ts
@@ -11,7 +11,7 @@ import ts from 'typescript';
 import { generateAdditionalExports } from '../services/model.service.js';
 import { Err, Ok } from '../utils/result.js';
 import { printDebug } from '../utils.js';
-import { importRegex, npmPackageRegex, tsconfig, tsconfigString } from './constants.js';
+import { allowedPackages, importRegex, npmPackageRegex, tsconfig, tsconfigString } from './constants.js';
 import { buildDefinitions } from './definitions.js';
 import { CompileError, ReadableError, badExportCompilerError, fileErrorToText, tsDiagnosticToText } from './utils.js';
 
@@ -304,34 +304,56 @@ function nangoPlugin() {
         setMergingStrategyLines
     };
 
+    const allowedExports = ['createAction', 'createSync', 'createOnEvent'];
+    const needsAwait = [
+        'batchSend',
+        'batchSave',
+        'batchDelete',
+        'log',
+        'getFieldMapping',
+        'setFieldMapping',
+        'getMetadata',
+        'setMetadata',
+        'proxy',
+        'get',
+        'post',
+        'put',
+        'patch',
+        'delete',
+        'getConnection',
+        'getEnvironmentVariables',
+        'triggerAction'
+    ];
+    const callsProxy = ['proxy', 'get', 'post', 'put', 'patch', 'delete'];
+    const callsBatchingRecords = ['batchSave', 'batchDelete', 'batchUpdate'];
+
     return {
         bag,
         plugin: ({ types: t }: { types: typeof babel.types }): babel.PluginObj<any> => {
-            const allowedExports = ['createAction', 'createSync', 'createOnEvent'];
-            const needsAwait = [
-                'batchSend',
-                'batchSave',
-                'batchDelete',
-                'log',
-                'getFieldMapping',
-                'setFieldMapping',
-                'getMetadata',
-                'setMetadata',
-                'proxy',
-                'get',
-                'post',
-                'put',
-                'patch',
-                'delete',
-                'getConnection',
-                'getEnvironmentVariables',
-                'triggerAction'
-            ];
-            const callsProxy = ['proxy', 'get', 'post', 'put', 'patch', 'delete'];
-            const callsBatchingRecords = ['batchSave', 'batchDelete', 'batchUpdate'];
-
             return {
                 visitor: {
+                    ImportDeclaration(path) {
+                        const lineNumber = path.node.loc?.start.line || 0;
+                        const source = path.node.source.value;
+                        if (typeof source !== 'string') {
+                            return;
+                        }
+
+                        // Allow relative path imports (./path or ../path)
+                        if (source.startsWith('./') || source.startsWith('../')) {
+                            return;
+                        }
+
+                        // Check if the imported package is in the allowed list
+                        if (!allowedPackages.includes(source)) {
+                            throw new CompileError(
+                                'disallowed_import',
+                                lineNumber,
+                                `Import of package '${source}' is not allowed. Allowed packages are: ${allowedPackages.join(', ')}`
+                            );
+                        }
+                    },
+
                     CallExpression(path) {
                         const lineNumber = path.node.loc?.start.line || 0;
                         const callee = path.node.callee;

--- a/packages/cli/lib/zeroYaml/constants.ts
+++ b/packages/cli/lib/zeroYaml/constants.ts
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 export const exampleFolder = path.join(__dirname, '../../example');
 export const npmPackageRegex = /^[^./\s]/;
-export const importRegex = /^import ['"](?<path>\.\/[^'"]+)['"];/gm;
+export const importRegex = /^import ['"](?<path>\.\/[^'"]+)['"];?/gm;
 
 export const tsconfig: ts.CompilerOptions = {
     module: ts.ModuleKind.Node16,
@@ -41,3 +41,5 @@ export const tsconfigString: Record<string, any> = {
     jsx: 'react',
     moduleResolution: 'node16'
 };
+
+export const allowedPackages = ['url', 'crypto', 'node:crypto', 'nango', 'zod', 'unzipper', 'soap', 'botbuilder'];

--- a/packages/cli/lib/zeroYaml/constants.ts
+++ b/packages/cli/lib/zeroYaml/constants.ts
@@ -42,4 +42,4 @@ export const tsconfigString: Record<string, any> = {
     moduleResolution: 'node16'
 };
 
-export const allowedPackages = ['url', 'crypto', 'node:crypto', 'nango', 'zod', 'unzipper', 'soap', 'botbuilder'];
+export const allowedPackages = ['url', 'node:url', 'crypto', 'node:crypto', 'nango', 'zod', 'unzipper', 'soap', 'botbuilder'];

--- a/packages/cli/lib/zeroYaml/utils.ts
+++ b/packages/cli/lib/zeroYaml/utils.ts
@@ -34,7 +34,8 @@ export type CompileErrorType =
     | 'nango_invalid_export_constant'
     | 'failed_to_build_unknown'
     | 'method_need_await'
-    | 'retryon_need_retries';
+    | 'retryon_need_retries'
+    | 'disallowed_import';
 
 export const badExportCompilerError = 'Invalid default export: should be createAction(), createSync() or createOnEvent()';
 


### PR DESCRIPTION
## Changes

- Catch bad import earlier
Right now you have to use dryrun or deploy and text your script in prod to know if an import is bad. It used to be checked by the previous compiler

- Do not require semicolon on import since some eslint install are removing them

<!-- Summary by @propel-code-bot -->

---

This PR improves the CLI's TypeScript compilation by checking for disallowed imports at compile time (rather than during dryrun/deploy), preventing the use of unauthorized node modules and packages much earlier in the development workflow. It also updates the import regex to allow, but not require, semicolons at the end of import statements, accommodating differing linting configurations.

**Key Changes:**
• Adds an early compile-time check to throw an error when disallowed packages are imported (only allows an explicit allowlist) in zeroYaml/compile.ts.
• Moves package import validation logic into the Babel plugin visitor for ImportDeclaration.
• Exposes allowedPackages as a constant; extends list to include 'node:url'.
• Updates importRegex in constants.ts to match imports with or without a semicolon.
• Extends error types in CompileErrorType to include 'disallowed_import'.


**Affected Areas:**
• packages/cli/lib/zeroYaml/compile.ts
• packages/cli/lib/zeroYaml/constants.ts
• packages/cli/lib/zeroYaml/utils.ts


*This summary was automatically generated by @propel-code-bot*