### PR TITLE
fix: commit hash added to success path tag

### DIFF
--- a/.github/workflows/managed-release.yaml
+++ b/.github/workflows/managed-release.yaml
@@ -335,8 +335,8 @@ jobs:
                       docker push nangohq/nango:managed-${{ steps.bump-major.outputs.image_version }}-${{ steps.bump-major.outputs.app_version }}-${{ needs.manage-versions.outputs.commit_hash }}
                   else
                       echo "Test deployment successful, using original versions"
-                      docker tag nangohq/nango:${{ needs.manage-versions.outputs.commit_hash }} nangohq/nango:managed-${{ needs.manage-versions.outputs.image_version }}-${{ needs.manage-versions.outputs.app_version }}
-                      docker push nangohq/nango:managed-${{ needs.manage-versions.outputs.image_version }}-${{ needs.manage-versions.outputs.app_version }}
+                      docker tag nangohq/nango:${{ needs.manage-versions.outputs.commit_hash }} nangohq/nango:managed-${{ needs.manage-versions.outputs.image_version }}-${{ needs.manage-versions.outputs.app_version }}-${{ needs.manage-versions.outputs.commit_hash }}
+                      docker push nangohq/nango:managed-${{ needs.manage-versions.outputs.image_version }}-${{ needs.manage-versions.outputs.app_version }}-${{ needs.manage-versions.outputs.commit_hash }}
                   fi
 
             - name: Commit and create PR for version changes


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Discrepancy between what was executed locally and the actual image tag that was pushed. In a standard successful scenario, the image tag did not include the commit hash. Changed to always append the commit hash to the docker tag.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the managed-release GitHub Actions workflow to ensure that Docker image tags in both success and failure release paths always include the commit hash. This change addresses discrepancies where images built locally differed from those pushed due to missing commit hashes in the tag, improving traceability and tag consistency.

*This summary was automatically generated by @propel-code-bot*