### PR TITLE
fix: GH_TOKEN required to interact with  CLI tool

### DIFF
--- a/.github/workflows/managed-release.yaml
+++ b/.github/workflows/managed-release.yaml
@@ -353,6 +353,8 @@ jobs:
 
             - name: Commit and create PR for version changes
               if: ${{ !env.ACT }}
+              env:
+                  GH_TOKEN: ${{ github.token }}
               run: |
                   # Create a new branch and commit changes
                   BRANCH_NAME="version-update-$(date +%Y%m%d-%H%M%S)"


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the managed-release GitHub Actions workflow to explicitly set the GH_TOKEN environment variable using github.token before running the CLI tool that creates version bump PRs. This change resolves issues where the CLI required GH_TOKEN to interact with GitHub's API.

*This summary was automatically generated by @propel-code-bot*