### PR TITLE
fix(db): add fields in plans for self-serve billing

### DIFF
--- a/packages/database/lib/migrations/20250617095905_plans_stripe.cjs
+++ b/packages/database/lib/migrations/20250617095905_plans_stripe.cjs
@@ -1,0 +1,19 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE "plans"
+ADD COLUMN "stripe_customer_id" varchar(256),
+ADD COLUMN "stripe_payment_id" varchar(256),
+ADD COLUMN "orb_customer_id" varchar(256),
+ADD COLUMN "orb_subscription_id" varchar(256),
+ADD COLUMN "orb_future_plan" varchar(256),
+ADD COLUMN "orb_future_plan_at" timestamptz;`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = function () {
+    //
+};


### PR DESCRIPTION
## Changes

-  add fields in plans for self-serve billing
    - `stripe_customer_id` -> to link in orb
    - `stripe_payment_id` -> to link in orb
    - `orb_customer_id` -> to know which customer has been linked to orb
    - `orb_subscription_id` -> to know which subscription a customer has
    - `orb_future_plan` -> future (when we downgrade the next plan is kickin at the start of the next billing period)
    - `orb_future_plan_at` -> handy to not have to compute or if an admin choose a different start period

<!-- Summary by @propel-code-bot -->

---

This PR introduces a database migration that adds several new columns to the 'plans' table in support of self-serve billing workflows. The fields include identifiers for Stripe and Orb integrations and columns for tracking future plan changes, all implemented in a Knex migration script.

*This summary was automatically generated by @propel-code-bot*