### PR TITLE
chore: move json-schema converters to utils

### DIFF
--- a/packages/utils/lib/index.ts
+++ b/packages/utils/lib/index.ts
@@ -6,7 +6,7 @@ export * from './logger.js';
 export * from './path.js';
 export * from './id.js';
 export * from './json.js';
-export * from './json-schema.js';
+export * from './jsonSchema/index.js';
 export * from './result.js';
 export * from './encryption.js';
 export * as metrics from './telemetry/metrics.js';

--- a/packages/utils/lib/jsonSchema/__snapshots__/legacySyncModelToJsonSchema.unit.test.ts.snap
+++ b/packages/utils/lib/jsonSchema/__snapshots__/legacySyncModelToJsonSchema.unit.test.ts.snap
@@ -1,0 +1,261 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`legacySyncModelsToJsonSchema > should handle all primitive types and basic features 1`] = `
+{
+  "definitions": {
+    "AllPrimitiveTypes": {
+      "properties": {
+        "booleanField": {
+          "type": "boolean",
+        },
+        "dateField": {
+          "format": "date-time",
+          "type": "string",
+        },
+        "numberArray": {
+          "items": {
+            "type": "number",
+          },
+          "type": "array",
+        },
+        "numberField": {
+          "type": "number",
+        },
+        "optionalString": {
+          "type": "string",
+        },
+        "stringArray": {
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+        "stringField": {
+          "type": "string",
+        },
+        "unknownType": {
+          "$ref": "#/definitions/uuid",
+        },
+      },
+      "required": [
+        "stringField",
+        "numberField",
+        "booleanField",
+        "dateField",
+        "unknownType",
+        "stringArray",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`legacySyncModelsToJsonSchema > should handle arrays of models and primitives 1`] = `
+{
+  "definitions": {
+    "Document": {
+      "properties": {
+        "collaborators": {
+          "items": {
+            "$ref": "#/definitions/User",
+          },
+          "type": "array",
+        },
+        "id": {
+          "type": "string",
+        },
+        "tags": {
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+      },
+      "required": [
+        "id",
+        "tags",
+      ],
+      "type": "object",
+    },
+    "User": {
+      "properties": {
+        "email": {
+          "type": "string",
+        },
+        "id": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "id",
+        "email",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`legacySyncModelsToJsonSchema > should handle empty models array 1`] = `
+{
+  "definitions": {},
+}
+`;
+
+exports[`legacySyncModelsToJsonSchema > should handle model with no fields 1`] = `
+{
+  "definitions": {
+    "EmptyModel": {
+      "properties": {},
+      "required": [],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`legacySyncModelsToJsonSchema > should handle references to other models 1`] = `
+{
+  "definitions": {
+    "Profile": {
+      "properties": {
+        "avatar": {
+          "oneOf": [
+            {
+              "type": "string",
+            },
+            {
+              "type": "null",
+            },
+          ],
+        },
+        "bio": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "bio",
+        "avatar",
+      ],
+      "type": "object",
+    },
+    "Role": {
+      "properties": {
+        "name": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "name",
+      ],
+      "type": "object",
+    },
+    "User": {
+      "properties": {
+        "id": {
+          "type": "string",
+        },
+        "profile": {
+          "$ref": "#/definitions/Profile",
+        },
+        "roles": {
+          "items": {
+            "$ref": "#/definitions/Role",
+          },
+          "type": "array",
+        },
+      },
+      "required": [
+        "id",
+        "profile",
+        "roles",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`legacySyncModelsToJsonSchema > should handle unions and optionals 1`] = `
+{
+  "definitions": {
+    "Event": {
+      "properties": {
+        "id": {
+          "type": "string",
+        },
+        "maybeModel": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Profile",
+            },
+            {
+              "type": "null",
+            },
+          ],
+        },
+        "maybeString": {
+          "oneOf": [
+            {
+              "type": "string",
+            },
+            {
+              "type": "null",
+            },
+          ],
+        },
+        "status": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/active",
+            },
+            {
+              "$ref": "#/definitions/canceled",
+            },
+          ],
+        },
+      },
+      "required": [
+        "id",
+        "status",
+        "maybeModel",
+      ],
+      "type": "object",
+    },
+    "Profile": {
+      "properties": {
+        "bio": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "bio",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`legacySyncModelsToJsonSchema > should still reference a non-existent model 1`] = `
+{
+  "definitions": {
+    "HasMissingRef": {
+      "properties": {
+        "id": {
+          "type": "string",
+        },
+        "missing": {
+          "$ref": "#/definitions/NonExistentModel",
+        },
+      },
+      "required": [
+        "id",
+        "missing",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;

--- a/packages/utils/lib/jsonSchema/__snapshots__/nangoModelToJsonSchema.unit.test.ts.snap
+++ b/packages/utils/lib/jsonSchema/__snapshots__/nangoModelToJsonSchema.unit.test.ts.snap
@@ -1,0 +1,427 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`nangoModelsToJsonSchema > should handle all primitive types and basic features 1`] = `
+{
+  "definitions": {
+    "AllPrimitiveTypes": {
+      "properties": {
+        "booleanField": {
+          "type": "boolean",
+        },
+        "dateField": {
+          "format": "date-time",
+          "type": "string",
+        },
+        "numberArray": {
+          "items": {
+            "type": "number",
+          },
+          "type": "array",
+        },
+        "numberField": {
+          "type": "number",
+        },
+        "optionalString": {
+          "type": "string",
+        },
+        "stringArray": {
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+        "stringField": {
+          "type": "string",
+        },
+        "unknownType": {
+          "additionalProperties": {
+            "type": "string",
+          },
+          "type": "object",
+        },
+      },
+      "required": [
+        "stringField",
+        "numberField",
+        "booleanField",
+        "dateField",
+        "unknownType",
+        "stringArray",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`nangoModelsToJsonSchema > should handle circular model references 1`] = `
+{
+  "definitions": {
+    "Category": {
+      "properties": {
+        "id": {
+          "type": "string",
+        },
+        "name": {
+          "type": "string",
+        },
+        "parentCategory": {
+          "$ref": "#/definitions/Category",
+        },
+        "subcategories": {
+          "items": {
+            "$ref": "#/definitions/Category",
+          },
+          "type": "array",
+        },
+      },
+      "required": [
+        "id",
+        "name",
+      ],
+      "type": "object",
+    },
+    "Comment": {
+      "properties": {
+        "author": {
+          "$ref": "#/definitions/User",
+        },
+        "content": {
+          "type": "string",
+        },
+        "id": {
+          "type": "string",
+        },
+        "post": {
+          "$ref": "#/definitions/Post",
+        },
+        "replies": {
+          "items": {
+            "$ref": "#/definitions/Comment",
+          },
+          "type": "array",
+        },
+      },
+      "required": [
+        "id",
+        "content",
+        "author",
+        "post",
+      ],
+      "type": "object",
+    },
+    "Post": {
+      "properties": {
+        "author": {
+          "$ref": "#/definitions/User",
+        },
+        "comments": {
+          "items": {
+            "$ref": "#/definitions/Comment",
+          },
+          "type": "array",
+        },
+        "id": {
+          "type": "string",
+        },
+        "title": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "id",
+        "title",
+        "author",
+      ],
+      "type": "object",
+    },
+    "User": {
+      "properties": {
+        "comments": {
+          "items": {
+            "$ref": "#/definitions/Comment",
+          },
+          "type": "array",
+        },
+        "id": {
+          "type": "string",
+        },
+        "posts": {
+          "items": {
+            "$ref": "#/definitions/Post",
+          },
+          "type": "array",
+        },
+        "username": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "id",
+        "username",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`nangoModelsToJsonSchema > should handle complex arrays with nested structures 1`] = `
+{
+  "definitions": {
+    "ArrayShowcase": {
+      "properties": {
+        "flexibleArray": {
+          "items": {
+            "oneOf": [
+              {
+                "type": "string",
+              },
+              {
+                "$ref": "#/definitions/Metadata",
+              },
+            ],
+          },
+          "type": "array",
+        },
+        "id": {
+          "type": "string",
+        },
+        "metadata": {
+          "items": {
+            "$ref": "#/definitions/Metadata",
+          },
+          "type": "array",
+        },
+        "scores": {
+          "items": {
+            "type": "number",
+          },
+          "type": "array",
+        },
+        "tags": {
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+      },
+      "required": [
+        "id",
+        "tags",
+        "metadata",
+      ],
+      "type": "object",
+    },
+    "Metadata": {
+      "properties": {
+        "key": {
+          "type": "string",
+        },
+        "value": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "key",
+        "value",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`nangoModelsToJsonSchema > should handle empty models array 1`] = `
+{
+  "definitions": {},
+}
+`;
+
+exports[`nangoModelsToJsonSchema > should handle model with no fields 1`] = `
+{
+  "definitions": {
+    "EmptyModel": {
+      "properties": {},
+      "required": [],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`nangoModelsToJsonSchema > should handle nested model references 1`] = `
+{
+  "definitions": {
+    "Address": {
+      "properties": {
+        "city": {
+          "type": "string",
+        },
+        "street": {
+          "type": "string",
+        },
+        "zipCode": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "street",
+        "city",
+      ],
+      "type": "object",
+    },
+    "Country": {
+      "properties": {
+        "code": {
+          "type": "string",
+        },
+        "name": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "code",
+        "name",
+      ],
+      "type": "object",
+    },
+    "DetailedAddress": {
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/Address",
+        },
+        "country": {
+          "$ref": "#/definitions/Country",
+        },
+      },
+      "required": [
+        "address",
+        "country",
+      ],
+      "type": "object",
+    },
+    "User": {
+      "properties": {
+        "addresses": {
+          "items": {
+            "$ref": "#/definitions/Address",
+          },
+          "type": "array",
+        },
+        "name": {
+          "type": "string",
+        },
+        "primaryAddress": {
+          "$ref": "#/definitions/DetailedAddress",
+        },
+      },
+      "required": [
+        "name",
+        "primaryAddress",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`nangoModelsToJsonSchema > should handle unions with primitives and models 1`] = `
+{
+  "definitions": {
+    "Company": {
+      "properties": {
+        "companyName": {
+          "type": "string",
+        },
+        "employees": {
+          "type": "number",
+        },
+      },
+      "required": [
+        "companyName",
+        "employees",
+      ],
+      "type": "object",
+    },
+    "FlexibleEntity": {
+      "properties": {
+        "entityUnion": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Person",
+            },
+            {
+              "$ref": "#/definitions/Company",
+            },
+          ],
+        },
+        "id": {
+          "type": "string",
+        },
+        "mixedUnion": {
+          "oneOf": [
+            {
+              "type": "string",
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/Tag",
+              },
+              "type": "array",
+            },
+          ],
+        },
+        "primitiveUnion": {
+          "oneOf": [
+            {
+              "type": "string",
+            },
+            {
+              "type": "number",
+            },
+            {
+              "type": "boolean",
+            },
+          ],
+        },
+      },
+      "required": [
+        "id",
+        "primitiveUnion",
+        "entityUnion",
+      ],
+      "type": "object",
+    },
+    "Person": {
+      "properties": {
+        "age": {
+          "type": "number",
+        },
+        "name": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "name",
+        "age",
+      ],
+      "type": "object",
+    },
+    "Tag": {
+      "properties": {
+        "color": {
+          "type": "string",
+        },
+        "label": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "label",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;

--- a/packages/utils/lib/jsonSchema/index.ts
+++ b/packages/utils/lib/jsonSchema/index.ts
@@ -1,0 +1,3 @@
+export * from './jsonSchema.js';
+export * from './legacySyncModelToJsonSchema.js';
+export * from './nangoModelToJsonSchema.js';

--- a/packages/utils/lib/jsonSchema/jsonSchema.ts
+++ b/packages/utils/lib/jsonSchema/jsonSchema.ts
@@ -1,4 +1,4 @@
-import { Err, Ok } from './result.js';
+import { Err, Ok } from '../result.js';
 
 import type { Result } from '@nangohq/types';
 import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';

--- a/packages/utils/lib/jsonSchema/jsonSchema.unit.test.ts
+++ b/packages/utils/lib/jsonSchema/jsonSchema.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { filterJsonSchemaForModels, getDefinition, getDefinitionsRecursively } from './json-schema.js';
+import { filterJsonSchemaForModels, getDefinition, getDefinitionsRecursively } from './jsonSchema.js';
 
 import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 

--- a/packages/utils/lib/jsonSchema/legacySyncModelToJsonSchema.ts
+++ b/packages/utils/lib/jsonSchema/legacySyncModelToJsonSchema.ts
@@ -1,0 +1,78 @@
+import type { LegacySyncModelSchema } from '@nangohq/types';
+import type { JSONSchema7 } from 'json-schema';
+
+/**
+ * Converts a list of LegacySyncModelSchema to a JSON Schema with all the schemas stored in the definitions property.
+ * @param models Array of LegacySyncModelSchema
+ */
+export function legacySyncModelsToJsonSchema(models: LegacySyncModelSchema[]): JSONSchema7 {
+    const definitions: Record<string, JSONSchema7> = {};
+    for (const model of models) {
+        definitions[model.name] = legacySyncModelToJsonSchema(model, models);
+    }
+    return { definitions };
+}
+
+function legacySyncModelToJsonSchema(model: LegacySyncModelSchema, allModels: LegacySyncModelSchema[]): JSONSchema7 {
+    const properties: Record<string, JSONSchema7> = {};
+    const required: string[] = [];
+    const fields = Array.isArray(model.fields) ? model.fields : [];
+    for (const field of fields) {
+        // Optional fields end with '?' or '| undefined'
+        const isOptional = /\?$/.test(field.name) || /\|\s*undefined$/.test(field.type);
+        const cleanName = field.name.replace(/\?$/, '');
+        properties[cleanName] = legacySyncFieldToJsonSchema(field, allModels);
+        if (!isOptional) {
+            required.push(cleanName);
+        }
+    }
+    return {
+        type: 'object',
+        properties,
+        required
+    };
+}
+
+function legacySyncFieldToJsonSchema(field: { name: string; type: string }, allModels: LegacySyncModelSchema[]): JSONSchema7 {
+    let typeStr = field.type?.trim() ?? '';
+    // Handle optional
+    typeStr = typeStr.replace(/\|\s*undefined$/, '').trim();
+    // Handle union
+    if (typeStr.includes('|')) {
+        const types = typeStr
+            .split('|')
+            .map((t) => t.trim())
+            .filter((t) => t !== 'undefined');
+        return {
+            oneOf: types.map((t) => legacySyncTypeToJsonSchema(t, allModels))
+        };
+    }
+    return legacySyncTypeToJsonSchema(typeStr, allModels);
+}
+
+function legacySyncTypeToJsonSchema(typeStr: string, allModels: LegacySyncModelSchema[]): JSONSchema7 {
+    // Array type
+    const arrayMatch = typeStr.match(/^(.*)\[\]$/);
+    if (arrayMatch && typeof arrayMatch[1] === 'string') {
+        const itemType = arrayMatch[1].trim();
+        return {
+            type: 'array',
+            items: legacySyncTypeToJsonSchema(itemType, allModels)
+        };
+    }
+    // Primitive types
+    if (legacyPrimitiveTypeMap[typeStr]) {
+        return legacyPrimitiveTypeMap[typeStr];
+    }
+    // All other types are treated as references
+    return { $ref: `#/definitions/${typeStr}` };
+}
+
+const legacyPrimitiveTypeMap: Record<string, JSONSchema7> = {
+    integer: { type: 'integer' },
+    number: { type: 'number' },
+    boolean: { type: 'boolean' },
+    string: { type: 'string' },
+    date: { type: 'string', format: 'date-time' },
+    null: { type: 'null' }
+};

--- a/packages/utils/lib/jsonSchema/legacySyncModelToJsonSchema.unit.test.ts
+++ b/packages/utils/lib/jsonSchema/legacySyncModelToJsonSchema.unit.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import { legacySyncModelsToJsonSchema } from './legacySyncModelToJsonSchema.js';
+
+import type { LegacySyncModelSchema } from '@nangohq/types';
+
+describe('legacySyncModelsToJsonSchema', () => {
+    it('should handle all primitive types and basic features', () => {
+        const models: LegacySyncModelSchema[] = [
+            {
+                name: 'AllPrimitiveTypes',
+                fields: [
+                    { name: 'stringField', type: 'string' },
+                    { name: 'numberField', type: 'number' },
+                    { name: 'booleanField', type: 'boolean' },
+                    { name: 'dateField', type: 'date' },
+                    { name: 'optionalString', type: 'string | undefined' },
+                    { name: 'unknownType', type: 'uuid' }, // Should default to string
+                    { name: 'stringArray', type: 'string[]' },
+                    { name: 'numberArray', type: 'number[] | undefined' }
+                ]
+            }
+        ];
+        const result = legacySyncModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should handle references to other models', () => {
+        const models: LegacySyncModelSchema[] = [
+            {
+                name: 'User',
+                fields: [
+                    { name: 'id', type: 'string' },
+                    { name: 'profile', type: 'Profile' },
+                    { name: 'roles', type: 'Role[]' }
+                ]
+            },
+            {
+                name: 'Profile',
+                fields: [
+                    { name: 'bio', type: 'string' },
+                    { name: 'avatar', type: 'string | null' }
+                ]
+            },
+            {
+                name: 'Role',
+                fields: [{ name: 'name', type: 'string' }]
+            }
+        ];
+        const result = legacySyncModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should handle unions and optionals', () => {
+        const models: LegacySyncModelSchema[] = [
+            {
+                name: 'Event',
+                fields: [
+                    { name: 'id', type: 'string' },
+                    { name: 'status', type: 'active | canceled' },
+                    { name: 'maybeString', type: 'string | null | undefined' },
+                    { name: 'maybeModel', type: 'Profile | null' }
+                ]
+            },
+            {
+                name: 'Profile',
+                fields: [{ name: 'bio', type: 'string' }]
+            }
+        ];
+        const result = legacySyncModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should handle arrays of models and primitives', () => {
+        const models: LegacySyncModelSchema[] = [
+            {
+                name: 'Document',
+                fields: [
+                    { name: 'id', type: 'string' },
+                    { name: 'tags', type: 'string[]' },
+                    { name: 'collaborators', type: 'User[] | undefined' }
+                ]
+            },
+            {
+                name: 'User',
+                fields: [
+                    { name: 'id', type: 'string' },
+                    { name: 'email', type: 'string' }
+                ]
+            }
+        ];
+        const result = legacySyncModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should handle empty models array', () => {
+        const models: LegacySyncModelSchema[] = [];
+        const result = legacySyncModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should handle model with no fields', () => {
+        const models: LegacySyncModelSchema[] = [
+            {
+                name: 'EmptyModel',
+                fields: []
+            }
+        ];
+        const result = legacySyncModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should still reference a non-existent model', () => {
+        const models: LegacySyncModelSchema[] = [
+            {
+                name: 'HasMissingRef',
+                fields: [
+                    { name: 'id', type: 'string' },
+                    { name: 'missing', type: 'NonExistentModel' }
+                ]
+            }
+        ];
+        const result = legacySyncModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+});

--- a/packages/utils/lib/jsonSchema/nangoModelToJsonSchema.ts
+++ b/packages/utils/lib/jsonSchema/nangoModelToJsonSchema.ts
@@ -1,0 +1,83 @@
+import type { NangoModel, NangoModelField } from '@nangohq/types';
+import type { JSONSchema7 } from 'json-schema';
+
+/**
+ * Converts a list of Nango models to a JSON Schema with all the schemas stored in the definitions property.
+ */
+export function nangoModelsToJsonSchema(models: NangoModel[]): JSONSchema7 {
+    const definitions: Record<string, JSONSchema7> = {};
+
+    for (const model of models) {
+        definitions[model.name] = nangoModelToJsonSchema(model);
+    }
+
+    return { definitions };
+}
+
+function nangoModelToJsonSchema(model: NangoModel): JSONSchema7 {
+    const properties: Record<string, JSONSchema7> = {};
+    const required: string[] = [];
+
+    for (const field of model.fields) {
+        const fieldSchema = nangoFieldToJsonSchema(field);
+        properties[field.name] = fieldSchema;
+
+        if (!field.optional) {
+            required.push(field.name);
+        }
+    }
+
+    return {
+        type: 'object',
+        properties,
+        required
+    };
+}
+
+function nangoFieldToJsonSchema(field: NangoModelField): JSONSchema7 {
+    if (field.array) {
+        return {
+            type: 'array',
+            items: nangoFieldToJsonSchema({ ...field, array: false })
+        };
+    }
+
+    if (field.model) {
+        if (typeof field.value !== 'string') {
+            throw new Error('field is model but value is not a string');
+        }
+
+        const modelName = field.value;
+        return {
+            $ref: `#/definitions/${modelName}`
+        };
+    }
+
+    if (field.union) {
+        if (!Array.isArray(field.value)) {
+            throw new Error('field is union but value is not an array');
+        }
+
+        return {
+            oneOf: field.value.map((v) => nangoFieldToJsonSchema(v))
+        };
+    }
+
+    if (typeof field.value === 'string' && primitiveTypeMap[field.value]) {
+        return primitiveTypeMap[field.value] as JSONSchema7;
+    }
+
+    return {
+        type: 'object',
+        additionalProperties: {
+            type: 'string'
+        }
+    };
+}
+
+const primitiveTypeMap: Record<string, JSONSchema7> = {
+    number: { type: 'number' },
+    boolean: { type: 'boolean' },
+    string: { type: 'string' },
+    date: { type: 'string', format: 'date-time' }
+};

--- a/packages/utils/lib/jsonSchema/nangoModelToJsonSchema.unit.test.ts
+++ b/packages/utils/lib/jsonSchema/nangoModelToJsonSchema.unit.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest';
+
+import { nangoModelsToJsonSchema } from './nangoModelToJsonSchema.js';
+
+import type { NangoModel } from '@nangohq/types';
+
+describe('nangoModelsToJsonSchema', () => {
+    it('should handle all primitive types and basic features', () => {
+        const models: NangoModel[] = [
+            {
+                name: 'AllPrimitiveTypes',
+                fields: [
+                    { name: 'stringField', value: 'string', optional: false },
+                    { name: 'numberField', value: 'number', optional: false },
+                    { name: 'booleanField', value: 'boolean', optional: false },
+                    { name: 'dateField', value: 'date', optional: false },
+                    { name: 'optionalString', value: 'string', optional: true },
+                    { name: 'unknownType', value: 'uuid', optional: false }, // Should default to string record
+                    { name: 'stringArray', value: 'string', array: true, optional: false },
+                    { name: 'numberArray', value: 'number', array: true, optional: true }
+                ]
+            }
+        ];
+
+        const result = nangoModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should handle nested model references', () => {
+        const models: NangoModel[] = [
+            {
+                name: 'Address',
+                fields: [
+                    { name: 'street', value: 'string', optional: false },
+                    { name: 'city', value: 'string', optional: false },
+                    { name: 'zipCode', value: 'string', optional: true }
+                ]
+            },
+            {
+                name: 'Country',
+                fields: [
+                    { name: 'code', value: 'string', optional: false },
+                    { name: 'name', value: 'string', optional: false }
+                ]
+            },
+            {
+                name: 'DetailedAddress',
+                fields: [
+                    { name: 'address', value: 'Address', model: true, optional: false },
+                    { name: 'country', value: 'Country', model: true, optional: false }
+                ]
+            },
+            {
+                name: 'User',
+                fields: [
+                    { name: 'name', value: 'string', optional: false },
+                    { name: 'primaryAddress', value: 'DetailedAddress', model: true, optional: false },
+                    { name: 'addresses', value: 'Address', model: true, array: true, optional: true }
+                ]
+            }
+        ];
+
+        const result = nangoModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should handle circular model references', () => {
+        const models: NangoModel[] = [
+            {
+                name: 'Category',
+                fields: [
+                    { name: 'id', value: 'string', optional: false },
+                    { name: 'name', value: 'string', optional: false },
+                    { name: 'parentCategory', value: 'Category', model: true, optional: true },
+                    { name: 'subcategories', value: 'Category', model: true, array: true, optional: true }
+                ]
+            },
+            {
+                name: 'Post',
+                fields: [
+                    { name: 'id', value: 'string', optional: false },
+                    { name: 'title', value: 'string', optional: false },
+                    { name: 'author', value: 'User', model: true, optional: false },
+                    { name: 'comments', value: 'Comment', model: true, array: true, optional: true }
+                ]
+            },
+            {
+                name: 'Comment',
+                fields: [
+                    { name: 'id', value: 'string', optional: false },
+                    { name: 'content', value: 'string', optional: false },
+                    { name: 'author', value: 'User', model: true, optional: false },
+                    { name: 'post', value: 'Post', model: true, optional: false },
+                    { name: 'replies', value: 'Comment', model: true, array: true, optional: true }
+                ]
+            },
+            {
+                name: 'User',
+                fields: [
+                    { name: 'id', value: 'string', optional: false },
+                    { name: 'username', value: 'string', optional: false },
+                    { name: 'posts', value: 'Post', model: true, array: true, optional: true },
+                    { name: 'comments', value: 'Comment', model: true, array: true, optional: true }
+                ]
+            }
+        ];
+
+        const result = nangoModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should handle unions with primitives and models', () => {
+        const models: NangoModel[] = [
+            {
+                name: 'Person',
+                fields: [
+                    { name: 'name', value: 'string', optional: false },
+                    { name: 'age', value: 'number', optional: false }
+                ]
+            },
+            {
+                name: 'Company',
+                fields: [
+                    { name: 'companyName', value: 'string', optional: false },
+                    { name: 'employees', value: 'number', optional: false }
+                ]
+            },
+            {
+                name: 'Tag',
+                fields: [
+                    { name: 'label', value: 'string', optional: false },
+                    { name: 'color', value: 'string', optional: true }
+                ]
+            },
+            {
+                name: 'FlexibleEntity',
+                fields: [
+                    { name: 'id', value: 'string', optional: false },
+                    // Union of primitive types
+                    {
+                        name: 'primitiveUnion',
+                        union: true,
+                        value: [
+                            { name: 'string_option', value: 'string' },
+                            { name: 'number_option', value: 'number' },
+                            { name: 'boolean_option', value: 'boolean' }
+                        ],
+                        optional: false
+                    },
+                    // Union of model references
+                    {
+                        name: 'entityUnion',
+                        union: true,
+                        value: [
+                            { name: 'person_option', value: 'Person', model: true },
+                            { name: 'company_option', value: 'Company', model: true }
+                        ],
+                        optional: false
+                    },
+                    // Union with arrays
+                    {
+                        name: 'mixedUnion',
+                        union: true,
+                        value: [
+                            { name: 'string_option', value: 'string' },
+                            { name: 'tags_array_option', value: 'Tag', model: true, array: true }
+                        ],
+                        optional: true
+                    }
+                ]
+            }
+        ];
+
+        const result = nangoModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should handle complex arrays with nested structures', () => {
+        const models: NangoModel[] = [
+            {
+                name: 'Metadata',
+                fields: [
+                    { name: 'key', value: 'string', optional: false },
+                    { name: 'value', value: 'string', optional: false }
+                ]
+            },
+            {
+                name: 'ArrayShowcase',
+                fields: [
+                    { name: 'id', value: 'string', optional: false },
+                    // Array of primitives
+                    { name: 'tags', value: 'string', array: true, optional: false },
+                    { name: 'scores', value: 'number', array: true, optional: true },
+                    // Array of models
+                    { name: 'metadata', value: 'Metadata', model: true, array: true, optional: false },
+                    // Array with union types
+                    {
+                        name: 'flexibleArray',
+                        array: true,
+                        union: true,
+                        value: [
+                            { name: 'string_option', value: 'string' },
+                            { name: 'metadata_option', value: 'Metadata', model: true }
+                        ],
+                        optional: true
+                    }
+                ]
+            }
+        ];
+
+        const result = nangoModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should handle empty models array', () => {
+        const models: NangoModel[] = [];
+        const result = nangoModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should handle model with no fields', () => {
+        const models: NangoModel[] = [
+            {
+                name: 'EmptyModel',
+                fields: []
+            }
+        ];
+
+        const result = nangoModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
### Description
I need to access them in `packages/database` now, so I need it to be in a shared place.

This is just moving files, no manual changes.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR relocates the JSON schema converter utilities (including their tests and related files) into a central shared directory (packages/utils/lib/jsonSchema/) so they can be reused by other packages such as packages/database. The changes update import/export paths and the main utility index file while ensuring all references, tests, and exports use the new structure.

**Key Changes:**
• Moved nangoModelToJsonSchema and legacySyncModelToJsonSchema utilities (plus tests and snapshots) to packages/utils/lib/jsonSchema/
• Updated import/export paths and restructured utils' main index to point to the new shared jsonSchema location
• Relocated and updated unit tests and snapshots to align with new file locations
• Fixed internal imports in jsonSchema.ts to reflect directory changes

**Affected Areas:**
• packages/utils/lib/jsonSchema/
• packages/utils/lib/index.ts
• packages/utils/lib/jsonSchema/ (all converter utilities, tests, and snapshots)

*This summary was automatically generated by @propel-code-bot*