### PR TITLE
fix(node-client): add PUT method support for API consistency

### DIFF
--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -1078,6 +1078,18 @@ export class Nango {
     }
 
     /**
+     * Sends a PUT request using the proxy based on the provided configuration
+     * @param config - The configuration object for the PUT request
+     * @returns A promise that resolves with the response from the PUT request
+     */
+    public async put<T = any>(config: ProxyConfiguration): Promise<AxiosResponse<T>> {
+        return this.proxy({
+            ...config,
+            method: 'PUT'
+        });
+    }
+
+    /**
      * Sends a PATCH request using the proxy based on the provided configuration
      * @param config - The configuration object for the PATCH request
      * @returns A promise that resolves with the response from the PATCH request


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
The Nango node client currently provides convenience methods for GET, POST, PATCH, and DELETE requests through the proxy, but is missing a dedicated PUT method.

This creates an inconsistent developer experience where users need to use the generic proxy() method for PUT requests while having dedicated methods for other HTTP verbs.

<!-- Issue ticket number and link (if applicable) -->
Fixes #4231 

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR introduces a dedicated put() method to the Nango node client, aligning its API with existing convenience methods for GET, POST, PATCH, and DELETE. This update improves developer experience and API consistency by eliminating the need to use the generic proxy() method for PUT requests.

*This summary was automatically generated by @propel-code-bot*