### PR TITLE
fix(runner): implement MaxLifetimeAgent for persist client socket management

### DIFF
--- a/packages/runner/lib/sdk/persist.ts
+++ b/packages/runner/lib/sdk/persist.ts
@@ -62,7 +62,7 @@ export class MaxLifetimeAgent extends Agent {
         }
 
         // https://nodejs.org/docs/latest/api/http.html#agentkeepsocketalivesocket
-        // @ts-expect-error - @types/node does not define kkeepSocketAlive
+        // @ts-expect-error - @types/node does not define keepSocketAlive
         return super.keepSocketAlive(socket);
     }
 

--- a/packages/runner/lib/sdk/persist.ts
+++ b/packages/runner/lib/sdk/persist.ts
@@ -1,5 +1,6 @@
-import https from 'node:https';
-
+import type { RequestOptions } from 'node:https';
+import { Agent } from 'node:https';
+import type { Socket } from 'net';
 import axios, { AxiosError, isAxiosError } from 'axios';
 
 import { getUserAgent } from '@nangohq/node';
@@ -19,6 +20,57 @@ import type {
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { envs } from '../env.js';
+
+export class MaxLifetimeAgent extends Agent {
+    private readonly maxSocketLifetime: number;
+    private readonly socketsCreatedAt: Map<Socket, number>;
+
+    constructor(options: { maxSocketLifetimeMs: number }) {
+        const lifetime = options.maxSocketLifetimeMs;
+
+        super({
+            keepAlive: true,
+            timeout: lifetime
+        });
+
+        this.maxSocketLifetime = lifetime;
+        this.socketsCreatedAt = new Map<Socket, number>();
+    }
+
+    public createConnection(options: RequestOptions, callback: (err: Error | null, socket: Socket) => void): Socket {
+        // https://nodejs.org/docs/latest/api/http.html#agentcreateconnectionoptions-callback
+        // @ts-expect-error - @types/node does not define createConnection
+        const socket = super.createConnection(options, callback);
+
+        this.socketsCreatedAt.set(socket, Date.now());
+        socket.once('close', () => {
+            this.socketsCreatedAt.delete(socket);
+        });
+
+        return socket;
+    }
+
+    public keepSocketAlive(socket: Socket): boolean {
+        const birthTime = this.socketsCreatedAt.get(socket);
+
+        if (birthTime) {
+            const age = Date.now() - birthTime;
+            if (age >= this.maxSocketLifetime) {
+                return false;
+            }
+        }
+
+        // https://nodejs.org/docs/latest/api/http.html#agentkeepsocketalivesocket
+        // @ts-expect-error - @types/node does not define kkeepSocketAlive
+        return super.keepSocketAlive(socket);
+    }
+
+    public override destroy(): void {
+        super.destroy();
+        this.socketsCreatedAt.clear();
+    }
+}
 
 export class PersistClient {
     private httpClient: AxiosInstance;
@@ -28,7 +80,7 @@ export class PersistClient {
         this.secretKey = secretKey;
         this.httpClient = axios.create({
             baseURL: getPersistAPIUrl(),
-            httpsAgent: new https.Agent({ keepAlive: true }),
+            httpsAgent: new MaxLifetimeAgent({ maxSocketLifetimeMs: envs.RUNNER_PERSIST_MAX_SOCKET_MAX_LIFETIME_MS }),
             headers: {
                 'User-Agent': getUserAgent('sdk')
             },

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -81,6 +81,7 @@ export const ENVS = z.object({
     RUNNER_NODE_ID: z.coerce.number().optional(),
     RUNNER_URL: z.string().url().optional(),
     RUNNER_MEMORY_WARNING_THRESHOLD: z.coerce.number().optional().default(85),
+    RUNNER_PERSIST_MAX_SOCKET_MAX_LIFETIME_MS: z.coerce.number().optional().default(30_000),
 
     // FLEET
     RUNNERS_DATABASE_URL: z.string().url().optional(),

--- a/vite.integration.config.ts
+++ b/vite.integration.config.ts
@@ -15,7 +15,8 @@ export default defineConfig({
             NANGO_ENCRYPTION_KEY: 'RzV4ZGo5RlFKMm0wYWlXdDhxTFhwb3ZrUG5KNGg3TmU=',
             NANGO_LOGS_ENABLED: 'true',
             FLAG_PLAN_ENABLED: 'true',
-            ORCHESTRATOR_SERVICE_URL: 'http://orchestrator'
+            ORCHESTRATOR_SERVICE_URL: 'http://orchestrator',
+            RUNNER_NODE_ID: '1'
         },
         fileParallelism: false,
         pool: 'forks',


### PR DESCRIPTION
Requests from runner to `persist` (records, logs, ...) are not evenly balanced between `persist` instances since a single execution will use a single connection (`keepalive=true`) that is always routed to the same persist instance. (Render confirmed they are using connection-based routing)
This is an attempt at more evenly-balanced requests from runners to persist by adding a custom HTTPS agent that enforces maximum socket lifetime to prevent a single script requests to always be routed to the same persist instance, potentially overwhelming it.
Configurable via RUNNER_PERSIST_MAX_SOCKET_MAX_LIFETIME_MS environment variable (defaults to 30s).

<!-- Summary by @propel-code-bot -->

---

This PR introduces a custom HTTPS agent (MaxLifetimeAgent) for the runner's persist client, which enforces a configurable maximum socket lifetime to address uneven load balancing across persist service instances when connection-based routing is used (e.g., Render). The maximum socket lifetime is controlled via a new environment variable, RUNNER_PERSIST_MAX_SOCKET_MAX_LIFETIME_MS (default 30s), with updates to the environment schema and integration test config for validation and coverage.

**Key Changes:**
• Introduced MaxLifetimeAgent, a custom subclass of node:https.Agent that limits socket lifetime.
• PersistClient now uses MaxLifetimeAgent for outgoing HTTPS requests to persist.
• Added RUNNER_PERSIST_MAX_SOCKET_MAX_LIFETIME_MS to environment variable schema with a default of 30,000 ms.
• Integration test configuration updated to include RUNNER_NODE_ID.

**Affected Areas:**
• packages/runner/lib/sdk/persist.ts (PersistClient, HTTP agent behavior)
• packages/utils/lib/environment/parse.ts (environment validation/config)
• vite.integration.config.ts (test runner env config)

*This summary was automatically generated by @propel-code-bot*