### PR TITLE
feat(webapp): show year in connection dates

### DIFF
--- a/packages/webapp/src/pages/Connection/Authorization.tsx
+++ b/packages/webapp/src/pages/Connection/Authorization.tsx
@@ -12,7 +12,7 @@ import { apiRefreshConnection } from '../../hooks/useConnections';
 import { useToast } from '../../hooks/useToast';
 import { useStore } from '../../store';
 import { getLogsUrl } from '../../utils/logs';
-import { formatDateToShortUSFormat } from '../../utils/utils';
+import { formatDateToPreciseUSFormat } from '../../utils/utils';
 
 import type { ActiveLog, ApiConnectionFull, ApiEndUser } from '@nangohq/types';
 import type React from 'react';
@@ -110,7 +110,7 @@ export const Authorization: React.FC<AuthorizationProps> = ({ connection, errorL
                 {connection.created_at && (
                     <div className="flex flex-col">
                         <span className="text-gray-400 text-xs uppercase mb-1">Creation Date</span>
-                        <span className="text-white">{formatDateToShortUSFormat(connection.created_at.toString())}</span>
+                        <span className="text-white">{formatDateToPreciseUSFormat(connection.created_at.toString())}</span>
                     </div>
                 )}
                 <div className="flex flex-col">
@@ -126,7 +126,7 @@ export const Authorization: React.FC<AuthorizationProps> = ({ connection, errorL
                 {'expires_at' in connection.credentials && connection.credentials.expires_at && (
                     <div className="flex flex-col">
                         <span className="text-gray-400 text-xs uppercase mb-1">Access Token Expiration</span>
-                        <span className="text-white">{formatDateToShortUSFormat(connection.credentials.expires_at as unknown as string)}</span>
+                        <span className="text-white">{formatDateToPreciseUSFormat(connection.credentials.expires_at as unknown as string)}</span>
                     </div>
                 )}
             </div>

--- a/packages/webapp/src/utils/utils.tsx
+++ b/packages/webapp/src/utils/utils.tsx
@@ -35,7 +35,8 @@ export function formatDateToShortUSFormat(dateString: string): string {
         second: '2-digit',
         month: 'short',
         day: '2-digit',
-        hour12: false
+        hour12: false,
+        year: 'numeric'
     };
 
     const formattedDate = date.toLocaleString('en-US', options);
@@ -44,8 +45,10 @@ export function formatDateToShortUSFormat(dateString: string): string {
         return '-';
     }
 
+    console.log('formattedDate', formattedDate);
+
     const parts = formattedDate.split(', ');
-    return `${parts[1]}, ${parts[0]}`;
+    return `${parts[2]}, ${parts[0]}, ${parts[1]}`;
 }
 
 export function formatDateToUSFormat(dateString?: string): string {

--- a/packages/webapp/src/utils/utils.tsx
+++ b/packages/webapp/src/utils/utils.tsx
@@ -27,7 +27,7 @@ export function defaultCallback() {
     return globalEnv.apiUrl + '/oauth/callback';
 }
 
-export function formatDateToShortUSFormat(dateString: string): string {
+export function formatDateToPreciseUSFormat(dateString: string): string {
     const date = new Date(dateString);
     const options: Intl.DateTimeFormatOptions = {
         hour: '2-digit',
@@ -44,9 +44,6 @@ export function formatDateToShortUSFormat(dateString: string): string {
     if (formattedDate === 'Invalid Date') {
         return '-';
     }
-
-    console.log('formattedDate', formattedDate);
-
     const parts = formattedDate.split(', ');
     return `${parts[2]}, ${parts[0]}, ${parts[1]}`;
 }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
## Description
Adding year to the dates in the connection page:
Before:
![image](https://github.com/user-attachments/assets/71aaf10c-6b1e-4cda-9101-df61369bab5a)

After:
<img width="1004" alt="image" src="https://github.com/user-attachments/assets/d879bd46-c0cc-40b3-b11a-edfb0d5dea5b" />


<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the date formatting for connection creation and token expiration in the webapp UI, ensuring that the displayed dates now include the year for added clarity. It replaces the old formatting utility with a new `formatDateToPreciseUSFormat()` function, updating its usage in the authorization component.

*This summary was automatically generated by @propel-code-bot*