### PR TITLE
fix: do not send external facing connection id inside billing events

### DIFF
--- a/packages/persist/lib/records.ts
+++ b/packages/persist/lib/records.ts
@@ -21,7 +21,6 @@ export async function persistRecords({
     connectionId,
     plan,
     providerConfigKey,
-    nangoConnectionId,
     syncId,
     syncJobId,
     model,
@@ -32,10 +31,9 @@ export async function persistRecords({
     persistType: PersistType;
     accountId: number;
     environmentId: number;
-    connectionId: string;
+    connectionId: number;
     plan: DBPlan | null;
     providerConfigKey: string;
-    nangoConnectionId: number;
     syncId: string;
     syncJobId: number;
     model: string;
@@ -51,7 +49,6 @@ export async function persistRecords({
             environmentId,
             connectionId,
             providerConfigKey,
-            nangoConnectionId,
             syncId,
             syncJobId,
             model,
@@ -61,9 +58,9 @@ export async function persistRecords({
 
     const logCtx = logContextGetter.getStateLess({ id: String(activityLogId), accountId });
 
-    const connection = await connectionService.getConnectionById(nangoConnectionId);
+    const connection = await connectionService.getConnectionById(connectionId);
     if (!connection) {
-        const err = new Error(`Connection ${nangoConnectionId} not found`);
+        const err = new Error(`Connection ${connectionId} not found`);
         void logCtx.error('Connection not found', { error: err, persistType });
         span.setTag('error', err).finish();
         return Err(err);
@@ -74,18 +71,16 @@ export async function persistRecords({
     switch (persistType) {
         case 'save':
             softDelete = false;
-            persistFunction = async (records: FormattedRecord[]) =>
-                recordsService.upsert({ records, connectionId: nangoConnectionId, environmentId, model, softDelete, merging });
+            persistFunction = async (records: FormattedRecord[]) => recordsService.upsert({ records, connectionId, environmentId, model, softDelete, merging });
             break;
         case 'delete':
             softDelete = true;
-            persistFunction = async (records: FormattedRecord[]) =>
-                recordsService.upsert({ records, connectionId: nangoConnectionId, environmentId, model, softDelete, merging });
+            persistFunction = async (records: FormattedRecord[]) => recordsService.upsert({ records, connectionId, environmentId, model, softDelete, merging });
             break;
         case 'update':
             softDelete = false;
             persistFunction = async (records: FormattedRecord[]) => {
-                return recordsService.update({ records, connectionId: nangoConnectionId, model, merging });
+                return recordsService.update({ records, connectionId, model, merging });
             };
             break;
     }
@@ -93,7 +88,7 @@ export async function persistRecords({
     const recordsData = records as UnencryptedRecordData[];
     const formatting = recordsFormatter.formatRecords({
         data: recordsData,
-        connectionId: nangoConnectionId,
+        connectionId,
         model,
         syncId,
         syncJobId,
@@ -200,10 +195,9 @@ export async function persistRecords({
             source: ErrorSourceEnum.CUSTOMER,
             operation: LogActionEnum.SYNC,
             metadata: {
-                connectionId: connectionId,
+                connectionId,
                 providerConfigKey: providerConfigKey,
                 syncId: syncId,
-                nangoConnectionId: nangoConnectionId,
                 syncJobId: syncJobId
             }
         });

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteRecords.ts
@@ -35,16 +35,15 @@ const validate = validateRequest<DeleteRecords>(recordsRequestParser);
 
 const handler = async (_req: EndpointRequest, res: EndpointResponse<DeleteRecords, AuthLocals>) => {
     const { environmentId, nangoConnectionId, syncId, syncJobId }: DeleteRecords['Params'] = res.locals.parsedParams;
-    const { model, records, providerConfigKey, connectionId, activityLogId, merging }: DeleteRecords['Body'] = res.locals.parsedBody;
+    const { model, records, providerConfigKey, activityLogId, merging }: DeleteRecords['Body'] = res.locals.parsedBody;
     const { account, plan } = res.locals;
     const result = await persistRecords({
         plan,
         persistType: 'delete',
         environmentId,
         accountId: account.id,
-        connectionId,
+        connectionId: nangoConnectionId,
         providerConfigKey,
-        nangoConnectionId,
         syncId,
         syncJobId,
         model,

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/postRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/postRecords.ts
@@ -35,16 +35,15 @@ const validate = validateRequest<PostRecords>(recordsRequestParser);
 
 const handler = async (_req: EndpointRequest, res: EndpointResponse<PostRecords, AuthLocals>) => {
     const { environmentId, nangoConnectionId, syncId, syncJobId }: PostRecords['Params'] = res.locals.parsedParams;
-    const { model, records, providerConfigKey, connectionId, activityLogId, merging }: PostRecords['Body'] = res.locals.parsedBody;
+    const { model, records, providerConfigKey, activityLogId, merging }: PostRecords['Body'] = res.locals.parsedBody;
     const { account, plan } = res.locals;
     const result = await persistRecords({
         plan,
         persistType: 'save',
         accountId: account.id,
         environmentId,
-        connectionId,
+        connectionId: nangoConnectionId,
         providerConfigKey,
-        nangoConnectionId,
         syncId,
         syncJobId,
         model,

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/putRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/putRecords.ts
@@ -35,16 +35,15 @@ const validate = validateRequest<PutRecords>(recordsRequestParser);
 
 const handler = async (_req: EndpointRequest, res: EndpointResponse<PutRecords, AuthLocals>) => {
     const { environmentId, nangoConnectionId, syncId, syncJobId }: PutRecords['Params'] = res.locals.parsedParams;
-    const { model, records, providerConfigKey, connectionId, activityLogId, merging }: PutRecords['Body'] = res.locals.parsedBody;
+    const { model, records, providerConfigKey, activityLogId, merging }: PutRecords['Body'] = res.locals.parsedBody;
     const { account, plan } = res.locals;
     const result = await persistRecords({
         plan,
         persistType: 'update',
         accountId: account.id,
         environmentId,
-        connectionId,
+        connectionId: nangoConnectionId,
         providerConfigKey,
-        nangoConnectionId,
         syncId,
         syncJobId,
         model,

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -260,7 +260,7 @@ class SyncController {
                         idempotencyKey: logCtx.id,
                         environmentId: connection.environment_id,
                         providerConfigKey,
-                        connectionId,
+                        connectionId: connection.id,
                         actionName: action_name
                     });
                 }


### PR DESCRIPTION
Customers used to be able to set the connectionId and therefore it can contain customer data.
This commit ensures we attach the internal connection id (the auto-incremented int) to billing events

<!-- Summary by @propel-code-bot -->

---

This PR replaces the external, user-controllable `connectionId` with the internal auto-incremented numeric connection ID (`nangoConnectionId` / `connection.id`) across persistence flows and billing event emission. This unifies usage of identifiers to prevent exposure of customer data and ensures that internal IDs are consistently propagated within billing events and record APIs, with appropriate updates to types, APIs, endpoints, and log metadata.

**Key Changes:**
• Replaced all usage of external-facing `connectionId` with internal numeric connection ID (`nangoConnectionId`/`connection.id`) in record persistence and billing logic.
• Refactored and clarified parameter usage in the persist records API and handler files to exclusively use internal connection ID.
• Removed trust in user-supplied `connectionId` from API inputs, extracting internal ID from router parameters.
• Updated sync controller to emit billing events with the internal connection ID in the payload.
• Unified and updated types and logger metadata to reflect the new internal ID usage.

**Affected Areas:**
• Record persistence logic (packages/persist/lib/records.ts)
• Record API endpoints (POST/PUT/DELETE for records)
• Sync controller billing event code (packages/server/lib/controllers/sync.controller.ts)
• API type definitions and parameter parsing in routes

*This summary was automatically generated by @propel-code-bot*