### PR TITLE
fix: handle dynamic models in NangoModel to json-schema converter

### DIFF
--- a/packages/utils/lib/jsonSchema/__snapshots__/nangoModelToJsonSchema.unit.test.ts.snap
+++ b/packages/utils/lib/jsonSchema/__snapshots__/nangoModelToJsonSchema.unit.test.ts.snap
@@ -265,6 +265,42 @@ exports[`nangoModelsToJsonSchema > should handle complex arrays with nested stru
 }
 `;
 
+exports[`nangoModelsToJsonSchema > should handle dynamic fields 1`] = `
+{
+  "definitions": {
+    "DynamicFields": {
+      "properties": {
+        "fields": {
+          "items": {
+            "$ref": "#/definitions/Field",
+          },
+          "type": "array",
+        },
+      },
+      "required": [
+        "fields",
+      ],
+      "type": "object",
+    },
+    "Field": {
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/Field",
+          },
+          {
+            "type": "string",
+          },
+        ],
+      },
+      "properties": {},
+      "required": [],
+      "type": "object",
+    },
+  },
+}
+`;
+
 exports[`nangoModelsToJsonSchema > should handle empty models array 1`] = `
 {
   "definitions": {},

--- a/packages/utils/lib/jsonSchema/nangoModelToJsonSchema.ts
+++ b/packages/utils/lib/jsonSchema/nangoModelToJsonSchema.ts
@@ -17,8 +17,14 @@ export function nangoModelsToJsonSchema(models: NangoModel[]): JSONSchema7 {
 function nangoModelToJsonSchema(model: NangoModel): JSONSchema7 {
     const properties: Record<string, JSONSchema7> = {};
     const required: string[] = [];
+    let dynamicField: NangoModelField | null = null;
 
     for (const field of model.fields || []) {
+        if (field.dynamic && field.name === '__string') {
+            dynamicField = field;
+            continue;
+        }
+
         const fieldSchema = nangoFieldToJsonSchema(field);
         properties[field.name] = fieldSchema;
 
@@ -30,7 +36,8 @@ function nangoModelToJsonSchema(model: NangoModel): JSONSchema7 {
     return {
         type: 'object',
         properties,
-        required
+        required,
+        ...(dynamicField && { additionalProperties: nangoFieldToJsonSchema(dynamicField) })
     };
 }
 

--- a/packages/utils/lib/jsonSchema/nangoModelToJsonSchema.unit.test.ts
+++ b/packages/utils/lib/jsonSchema/nangoModelToJsonSchema.unit.test.ts
@@ -334,4 +334,31 @@ describe('nangoModelsToJsonSchema', () => {
         const result = nangoModelsToJsonSchema(models);
         expect(result).toMatchSnapshot();
     });
+
+    it('should handle dynamic fields', () => {
+        const models: NangoModel[] = [
+            {
+                name: 'DynamicFields',
+                fields: [{ name: 'fields', array: true, model: true, value: 'Field', optional: false }]
+            },
+            {
+                name: 'Field',
+                fields: [
+                    {
+                        name: '__string',
+                        union: true,
+                        value: [
+                            { name: '0', array: false, model: true, value: 'Field', optional: false },
+                            { name: '1', array: false, value: 'string', tsType: true, optional: false }
+                        ],
+                        dynamic: true,
+                        optional: false
+                    }
+                ]
+            }
+        ];
+
+        const result = nangoModelsToJsonSchema(models);
+        expect(result).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
## Description
nango.yaml:
```yaml
Model:
  __string: number
  otherProp: string
```
NangoModel:
```yaml
name: Model
fields:
  - name: __string
    dynamic: true
    value: number
  - name: otherProp
    value: string
```
JsonSchema:
```yaml
Model:
  type: object
  properties:
    otherProp:
      type: string
  additionalProperties:
    type: number
```

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR enhances the nangoModelToJsonSchema function to correctly handle dynamic fields (particularly those named '__string') within Nango models, translating them to JSON Schema's additionalProperties. It introduces detection logic for dynamic fields, updates the main conversion and tests, and adds new unit tests with snapshots to verify this functionality.

**Key Changes:**
• Detection of dynamic fields (field.dynamic && field.name === '__string') in nangoModelToJsonSchema.ts
• Addition of dynamic fields as additionalProperties in the generated JSON schema objects
• New unit test case and snapshot for models with dynamic fields


**Affected Areas:**
• packages/utils/lib/jsonSchema/nangoModelToJsonSchema.ts
• packages/utils/lib/jsonSchema/nangoModelToJsonSchema.unit.test.ts
• packages/utils/lib/jsonSchema/__snapshots__/nangoModelToJsonSchema.unit.test.ts.snap


*This summary was automatically generated by @propel-code-bot*