### PR TITLE
fix(jira-provider): add offline_access as a default scope

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -5472,6 +5472,8 @@ jira:
     auth_mode: OAUTH2
     authorization_url: https://auth.atlassian.com/authorize
     token_url: https://auth.atlassian.com/oauth/token
+    default_scopes:
+        - offline_access
     authorization_params:
         audience: api.atlassian.com
         prompt: consent


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Add a default scope for jira that enables token refreshes: https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/#faq1
<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the Jira OAuth2 provider configuration by adding 'offline_access' to its default scopes. This enables token refresh capability for Jira integrations, aligning with Atlassian's recommendations for long-lived access.

*This summary was automatically generated by @propel-code-bot*