### PR TITLE
chore(docs): update enterprise self-hosting docs to match announcement

### DIFF
--- a/docs-v2/guides/self-hosting/enterprise-self-hosting/overview.mdx
+++ b/docs-v2/guides/self-hosting/enterprise-self-hosting/overview.mdx
@@ -26,9 +26,22 @@ We don't provide a CloudFormation template or AWS CDK script at this time, but w
 
 ## Updates
 
-Updates are distributed via versioned Helm charts. A staging environment is recommended to test updates before production.
+Managed image updates are published on a **two-month cadence**, with occasional **hotfixes** as needed. Notifications about new releases will be posted to your dedicated Nango Slack channel.
 
-Update cadence is flexible based on your needs.
+Managed image tags follow this format:
+
+```
+nangohq/nango:managed-{managed-release-version}-{application-version}-{commit-sha}
+```
+
+* `managed-release-version`: Semantic versioning for the image lifecycle (major = breaking, minor/patch = features/fixes)
+* `application-version`: Semantic version of the Nango application baked into the image
+
+Customers should **pin their CLI version to the `application-version`** specified in the tag for compatibility.
+
+You can find the latest version by checking the [`managed-manifest.json`](https://github.com/NangoHQ/nango/blob/master/managed-manifest.json).
+
+See the full [changelog](https://docs.nango.dev/changelog/overview) for details on each release.
 
 ## Cloud provider support
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the enterprise self-hosting documentation to align with the latest public announcement regarding update cadence, managed image tag conventions, and CLI version pinning. The revised docs provide explicit information on release notification channels, semantic versioning of managed images, and guidance for maintaining compatibility.

*This summary was automatically generated by @propel-code-bot*