### PR TITLE
fix(plan): modify free plan

### DIFF
--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -10,11 +10,11 @@ export const plansList: PlanDefinition[] = [
         orbId: 'free',
         flags: {
             api_rate_limit_size: 'm',
-            connection_with_scripts_max: 50,
+            connection_with_scripts_max: null,
             environments_max: 2,
             has_otel: false,
             has_sync_variants: false,
-            connections_max: 1000,
+            connections_max: 10,
             name: 'free',
             sync_frequency_secs_min: 3600,
             auto_idle: true


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-3508/modify-default-caps

- modify free plan
max connections = 10, scripts or not

<!-- Summary by @propel-code-bot -->

---

This PR updates the free plan in the plan definitions by setting 'connections_max' to 10 and changing 'connection_with_scripts_max' to null, reducing the maximum allowed connections for free users. The change aligns the plan limits with issue NAN-3508 requirements.

*This summary was automatically generated by @propel-code-bot*