### PR TITLE
fix(es): disable refresh on operation creation

### DIFF
--- a/packages/logs/lib/models/messages.ts
+++ b/packages/logs/lib/models/messages.ts
@@ -44,7 +44,7 @@ export async function createOperation(row: OperationRow): Promise<{ index: strin
         index: indexMessages.index,
         id: row.id,
         document: row,
-        refresh: true,
+        refresh: isTest,
         pipeline: `daily.${indexMessages.index}`
     });
     return { index: res._index };


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-2927/remove-refresh-true

- Disable refresh on operation creation
It was set as true when we needed to get the operation back to update it in an other service. It's no longer the case since a few months now. I'm not 100% sure there will be no side-effect. Tried locally with `autocannon` to spot race condition but seems to work.
This should drastically help with indexing time but hard to say, worst case it doesn't change anything

<!-- Summary by @propel-code-bot -->

---

This PR updates the operation creation logic by changing the Elasticsearch 'refresh' parameter from always true to being conditionally set by isTest (typically false outside of tests). The intent is to reduce unnecessary index refreshes for production writes, potentially improving indexing performance.

*This summary was automatically generated by @propel-code-bot*