### PR TITLE
chore: add last_execution_at column to connection table

### DIFF
--- a/packages/database/lib/migrations/20250626163600_connection_last_execution_at.cjs
+++ b/packages/database/lib/migrations/20250626163600_connection_last_execution_at.cjs
@@ -1,0 +1,16 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE "_nango_connections" ADD COLUMN IF NOT EXISTS "last_execution_at" timestamptz;`);
+    await knex.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_nango_connections_last_execution_at" ON "_nango_connections" ("last_execution_at") WHERE "last_execution_at" IS NOT NULL;`
+    );
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = function () {};


### PR DESCRIPTION
we want to add a new metric to automate the billing of some of the legacy scale plan. The metric is "number of connections with at least a script execution during the period". There is currently no source of truth in the db regarding script executions (actions for example are not tracked). In order to avoid sending an event for every single execution, this commit is adding a last_execution_at column to the connection table that will be updated every time a script execution starts

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR introduces a new 'last_execution_at' timestamptz column to the '_nango_connections' table to record the latest script execution per connection. An index is also created on this column to support efficient querying and future billing automation for legacy scale plans.

*This summary was automatically generated by @propel-code-bot*