### PR TITLE
chore: add 'count of active connections' billing metric

### DIFF
--- a/packages/jobs/lib/execution/operations/start.ts
+++ b/packages/jobs/lib/execution/operations/start.ts
@@ -1,6 +1,6 @@
 import tracer from 'dd-trace';
 
-import { localFileService, remoteFileService } from '@nangohq/shared';
+import { localFileService, remoteFileService, connectionService } from '@nangohq/shared';
 import { Err, Ok, integrationFilesAreRemote, isCloud, stringifyError } from '@nangohq/utils';
 
 import { getRunner } from '../../runner/runner.js';
@@ -66,6 +66,8 @@ export async function startScript({
             span.setTag('error', true);
             return Err(`Error starting script for sync ${nangoProps.syncId}`);
         }
+
+        await connectionService.trackExecution(nangoProps.nangoConnectionId);
         return Ok(undefined);
     } catch (err) {
         span.setTag('error', err);

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1456,8 +1456,6 @@ class ConnectionService {
      * Note:
      * a billable connection is a connection that is not deleted and has not been deleted during the month
      * connections are pro-rated based on the number of seconds they were existing in the month
-     *
-     * This method only returns returns data for paying customer
      */
     async billableConnections(referenceDate: Date): Promise<
         Result<
@@ -1563,6 +1561,56 @@ class ConnectionService {
 
     async hardDelete(id: number): Promise<number> {
         return await db.knex.from<DBConnection>('_nango_connections').where('id', id).delete();
+    }
+
+    async trackExecution(id: number): Promise<Result<void>> {
+        try {
+            await db.knex.from('_nango_connections').where({ id, deleted_at: null }).update({ last_execution_at: db.knex.fn.now() });
+            return Ok(undefined);
+        } catch (err: unknown) {
+            return Err(new NangoError('failed_to_track_execution', { id, error: err }));
+        }
+    }
+
+    /**
+     * Note:
+     * Some plan are billed per active connections in prod environment
+     * A connection is considered active if it has at least one script execution during the month
+     */
+    async billableActiveConnections(referenceDate: Date): Promise<
+        Result<
+            {
+                accountId: number;
+                count: number;
+                year: number;
+                month: number;
+            }[],
+            NangoError
+        >
+    > {
+        const year = referenceDate.getUTCFullYear();
+        const month = referenceDate.getUTCMonth();
+
+        const start = new Date(Date.UTC(year, month, 1));
+        const end = new Date(Date.UTC(year, month + 1, 1));
+
+        const res = await db.readOnly
+            .select('e.account_id as accountId')
+            .count('c.id as count')
+            .select(db.readOnly.raw(`${year} as year`))
+            .select(db.readOnly.raw(`${month + 1} as month`)) // js months are 0-based
+            .from('_nango_connections as c')
+            .join('_nango_environments as e', 'c.environment_id', 'e.id')
+            .where('c.last_execution_at', '>=', start)
+            .where('c.last_execution_at', '<', end)
+            .where('e.name', 'prod') // only consider prod environment
+            .groupBy('e.account_id')
+            .havingRaw('count(c.id) > 0');
+
+        if (res) {
+            return Ok(res);
+        }
+        return Err(new NangoError('failed_to_get_billable_active_connections'));
     }
 }
 

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -35,7 +35,7 @@ export interface BillingPlan {
 }
 
 export interface BillingIngestEvent {
-    type: 'monthly_active_records' | 'billable_connections' | 'billable_actions';
+    type: 'monthly_active_records' | 'billable_connections' | 'billable_actions' | 'billable_active_connections';
     idempotencyKey: string;
     accountId: number;
     timestamp: Date;


### PR DESCRIPTION
- track connection last_execution_at every time a script starts
- count all connections with last_execution_at in current month
- send metric in cron

<!-- Summary by @propel-code-bot -->

---

This PR introduces a new 'active connections' metric to support legacy billing requirements. Each time a script runs, the associated connection's last_execution_at timestamp is updated; a cron job now emits a metric counting all connections per account that have executed any script in the current calendar month (restricted to prod environments). The changes involve backend service logic, database schema migration (adding and indexing last_execution_at), cron job updates, and the types defining available billing metrics.

**Key Changes:**
• Schema change: adds last_execution_at column (with index) to _nango_connections
• Service: adds trackExecution (set timestamp) and billableActiveConnections (query by last_execution_at in month)
• Script execution: updates to call trackExecution when a script starts
• Cron: new billing.exportActiveConnections sends 'billable_active_connections' metric events
• Expanded billing metric types and ingest event definitions

**Affected Areas:**
• Database schema and migrations
• Connection service implementation
• Job execution flow (script start ops)
• Billing/usage cron logic
• Billing types and metrics

*This summary was automatically generated by @propel-code-bot*