### PR TITLE
fix: add primary key to _nango_oauth_sessions

### DIFF
--- a/packages/database/lib/migrations/20250701094655_add_primary_key_to_oauth_sessions.cjs
+++ b/packages/database/lib/migrations/20250701094655_add_primary_key_to_oauth_sessions.cjs
@@ -1,0 +1,13 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE _nango_oauth_sessions ADD CONSTRAINT pk_nango_oauth_sessions_id PRIMARY KEY USING INDEX _nango_oauth_sessions_id_unique;`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = function () {
+    //
+};

--- a/packages/database/lib/migrations/20250701094655_add_primary_key_to_oauth_sessions.cjs
+++ b/packages/database/lib/migrations/20250701094655_add_primary_key_to_oauth_sessions.cjs
@@ -3,6 +3,7 @@
  */
 exports.up = async function (knex) {
     await knex.raw(`ALTER TABLE _nango_oauth_sessions ADD CONSTRAINT pk_nango_oauth_sessions_id PRIMARY KEY USING INDEX _nango_oauth_sessions_id_unique;`);
+    await knex.raw('ALTER TABLE _nango_db_config ADD PRIMARY KEY (encryption_key_hash);');
 };
 
 /**


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR introduces a database migration that adds a primary key constraint to the _nango_oauth_sessions table (using its existing unique index) and sets the primary key for the _nango_db_config table on the encryption_key_hash column. No application logic is changed; updates are limited to schema migrations only.

*This summary was automatically generated by @propel-code-bot*