### PR TITLE
fix: add primary key to oauth_sessions without unique index

### DIFF
--- a/packages/database/lib/migrations/20250701094655_add_primary_key_to_oauth_sessions.cjs
+++ b/packages/database/lib/migrations/20250701094655_add_primary_key_to_oauth_sessions.cjs
@@ -2,7 +2,7 @@
  * @param {import('knex').Knex} knex
  */
 exports.up = async function (knex) {
-    await knex.raw(`ALTER TABLE _nango_oauth_sessions ADD CONSTRAINT pk_nango_oauth_sessions_id PRIMARY KEY USING INDEX _nango_oauth_sessions_id_unique;`);
+    await knex.raw('ALTER TABLE _nango_oauth_sessions ADD PRIMARY KEY (id);');
     await knex.raw('ALTER TABLE _nango_db_config ADD PRIMARY KEY (encryption_key_hash);');
 };
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates a database migration to correctly add a primary key on the `id` column of the `_nango_oauth_sessions` table, replacing the previous attempt that used a non-existent unique index. The migration for `_nango_db_config` remains unchanged.

*This summary was automatically generated by @propel-code-bot*