### PR TITLE
fix: add index to sync_jobs

### DIFF
--- a/packages/database/lib/migrations/20250703112700_sync_jobs_running_index.cjs
+++ b/packages/database/lib/migrations/20250703112700_sync_jobs_running_index.cjs
@@ -1,0 +1,15 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_jobs_syncid_running_createdat ON nango._nango_sync_jobs (sync_id, created_at DESC) WHERE status = 'RUNNING';`
+    );
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = function () {};


### PR DESCRIPTION
query to check if sync is running must filter on status=RUNNING adding a partial index to speed up the query

query plan before:
```
Limit  (cost=0.57..1343.49 rows=1 width=320)
  ->  Index Scan using idx_jobs_syncid_createdat on _nango_sync_jobs  (cost=0.57..9401.02 rows=7 width=320)
        Index Cond: (sync_id = '02a49f20-a5df-4c81-8404-b96806d2a08e'::uuid)
        Filter: (status = 'RUNNING'::text)
```

query plan after
```
Limit  (cost=0.42..1.69 rows=1 width=320)
  ->  Index Scan using idx_jobs_syncid_running_createdat on _nango_sync_jobs  (cost=0.42..9.34 rows=7 width=320)
        Index Cond: (sync_id = '02a49f20-a5df-4c81-8404-b96806d2a08e'::uuid)
```


<!-- Summary by @propel-code-bot -->

---

This PR introduces a database migration that creates a partial index on the nango._nango_sync_jobs table for (sync_id, created_at DESC) where status is 'RUNNING'. The change is designed to optimize query performance when filtering for currently running jobs, with the migration using CREATE INDEX CONCURRENTLY to minimize locking and maintain availability during deployment.

*This summary was automatically generated by @propel-code-bot*