### PR TITLE
fix(frontend-sdk): encode connectionConfig params to preserve special characters in URL

### DIFF
--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -556,7 +556,7 @@ export default class Nango {
             for (const param in connectionConfig.params) {
                 const val = connectionConfig.params[param];
                 if (typeof val === 'string') {
-                    query.push(`params[${param}]=${val}`);
+                    query.push(`params[${encodeURIComponent(param)}]=${encodeURIComponent(val)}`);
                 }
             }
 


### PR DESCRIPTION
## Describe the problem and your solution
- Fix frontend sdk to encode `connectionConfig` params to preserve special characters in URL
<!-- Issue ticket number and link (if applicable) -->

## Testing instructions (skip if just adding/editing providers)
- Create a connection with a `connectionConfig` that includes special characters like `+` for both the `key` and `value`. These characters should be preserved as-is.

<!-- Summary by @propel-code-bot -->

---

This PR updates the frontend SDK to ensure that keys and values in the connectionConfig.params object are properly URL-encoded when constructing query strings. This prevents loss or misinterpretation of special characters in params (e.g., '+') during URL construction.

*This summary was automatically generated by @propel-code-bot*