### PR TITLE
feat(pre-connection-deletion): add linear token revocation

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -6211,6 +6211,7 @@ linear:
     disable_pkce: true
     webhook_routing_script: linearWebhookRouting
     post_connection_script: linearPostConnection
+    pre_connection_deletion_script: linearPreConnectionDeletion
     webhook_user_defined_secret: true
     docs: https://docs.nango.dev/integrations/all/linear
 

--- a/packages/server/lib/hooks/connection/index.ts
+++ b/packages/server/lib/hooks/connection/index.ts
@@ -23,3 +23,4 @@ export { default as ripplingShopAppPostConnection } from './providers/rippling-s
 export { default as azureDevopsCredentialsVerification } from './providers/azure-devops/credentials-verification.js';
 export { default as apolloCredentialsVerification } from './providers/apollo/credentials-verification.js';
 export { default as sentryOauthPostConnection } from './providers/sentry-oauth/post-connection.js';
+export { default as linearPreConnectionDeletion } from './providers/linear/pre-connection-deletion.js';

--- a/packages/server/lib/hooks/connection/providers/linear/pre-connection-deletion.ts
+++ b/packages/server/lib/hooks/connection/providers/linear/pre-connection-deletion.ts
@@ -1,0 +1,24 @@
+import { isAxiosError } from 'axios';
+
+import type { InternalNango } from '../../internal-nango.js';
+import type { LinearTokenRevokeResponse } from './types.js';
+
+export default async function execute(nango: InternalNango) {
+    try {
+        const connection = await nango.getConnection();
+        await nango.proxy<LinearTokenRevokeResponse>({
+            method: 'POST',
+            // https://linear.app/developers/oauth-2-0-authentication#revoke-an-access-token
+            endpoint: '/oauth/revoke',
+            providerConfigKey: connection.provider_config_key
+        });
+
+        return;
+    } catch (err) {
+        if (isAxiosError(err)) {
+            const linearError = err.response?.data?.error || err;
+            throw new Error(`Error revoking Linear token: ${linearError}`);
+        }
+        throw err;
+    }
+}

--- a/packages/server/lib/hooks/connection/providers/linear/types.ts
+++ b/packages/server/lib/hooks/connection/providers/linear/types.ts
@@ -1,0 +1,4 @@
+export interface LinearTokenRevokeResponse {
+    success?: boolean;
+    error?: string;
+}


### PR DESCRIPTION
Describe the problem and your solution

- Add token revocation `pre-connection-deletion` script for linear.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR introduces a pre-connection-deletion script for the Linear provider, enabling token revocation when a connection is deleted. It updates the Linear integration's provider configuration, exports the new script, and adds supporting type definitions.

*This summary was automatically generated by @propel-code-bot*