### PR TITLE
fix(api): import or reconnect sending incorrect webhooks

### DIFF
--- a/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import db from '@nangohq/database';
 import { connectionService, seeders } from '@nangohq/shared';
 
 import { isError, isSuccess, runServer } from '../../utils/tests.js';
@@ -144,7 +145,11 @@ describe(`GET ${endpoint}`, () => {
         });
         isSuccess(resConnect.json);
 
-        const connectionBefore = await connectionService.checkIfConnectionExists(resConnect.json.connectionId, resConnect.json.providerConfigKey, env.id);
+        const connectionBefore = await connectionService.checkIfConnectionExists(db.knex, {
+            connectionId: resConnect.json.connectionId,
+            providerConfigKey: resConnect.json.providerConfigKey,
+            environmentId: env.id
+        });
 
         // Reconnect session token
         const resSessionReconnect = await api.fetch('/connect/sessions/reconnect', {
@@ -168,7 +173,11 @@ describe(`GET ${endpoint}`, () => {
 
         // Check that the connection was updated
         // Nothing is different except the dates
-        const connectionAfter = await connectionService.checkIfConnectionExists(resConnect.json.connectionId, resConnect.json.providerConfigKey, env.id);
+        const connectionAfter = await connectionService.checkIfConnectionExists(db.knex, {
+            connectionId: resConnect.json.connectionId,
+            providerConfigKey: resConnect.json.providerConfigKey,
+            environmentId: env.id
+        });
         expect(connectionAfter).toMatchObject({
             ...connectionBefore,
             credentials_expires_at: expect.toBeIsoDate(), // new credentials means new date

--- a/packages/server/lib/controllers/config/getListIntegrations.ts
+++ b/packages/server/lib/controllers/config/getListIntegrations.ts
@@ -1,3 +1,4 @@
+import db from '@nangohq/database';
 import { configService, getProviders } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
@@ -14,7 +15,7 @@ export const getPublicListIntegrationsLegacy = asyncWrapper<GetPublicListIntegra
     }
 
     const { environment } = res.locals;
-    const configs = await configService.listProviderConfigs(environment.id);
+    const configs = await configService.listProviderConfigs(db.knex, environment.id);
 
     const providers = getProviders();
     if (!providers) {

--- a/packages/server/lib/controllers/connect/postReconnect.ts
+++ b/packages/server/lib/controllers/connect/postReconnect.ts
@@ -45,7 +45,11 @@ export const postConnectSessionsReconnect = asyncWrapper<PostPublicConnectSessio
     const body: PostPublicConnectSessionsReconnect['Body'] = val.data;
 
     const { status, response }: Reply = await db.knex.transaction<Reply>(async (trx) => {
-        const connection = await connectionService.checkIfConnectionExists(body.connection_id, body.integration_id, environment.id);
+        const connection = await connectionService.checkIfConnectionExists(trx, {
+            connectionId: body.connection_id,
+            providerConfigKey: body.integration_id,
+            environmentId: environment.id
+        });
         if (!connection) {
             return {
                 status: 400,
@@ -83,7 +87,7 @@ export const postConnectSessionsReconnect = asyncWrapper<PostPublicConnectSessio
         }
 
         if (body.integrations_config_defaults) {
-            const integrations = await configService.listProviderConfigs(environment.id);
+            const integrations = await configService.listProviderConfigs(trx, environment.id);
 
             // Enforce that integrations exists in `integrations_config_defaults`
             const check = checkIntegrationsDefault(body, integrations);

--- a/packages/server/lib/controllers/connect/postSessions.ts
+++ b/packages/server/lib/controllers/connect/postSessions.ts
@@ -102,7 +102,7 @@ export async function generateSession(res: Response<any, Required<RequestLocals>
         }
 
         if (body.allowed_integrations || body.integrations_config_defaults) {
-            const integrations = await configService.listProviderConfigs(environment.id, trx);
+            const integrations = await configService.listProviderConfigs(trx, environment.id);
 
             // Enforce that integrations exists in `allowed_integrations`
             if (body.allowed_integrations && body.allowed_integrations.length > 0) {

--- a/packages/server/lib/controllers/integrations/getListIntegrations.ts
+++ b/packages/server/lib/controllers/integrations/getListIntegrations.ts
@@ -1,3 +1,4 @@
+import db from '@nangohq/database';
 import { configService, getProviders } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
@@ -14,7 +15,7 @@ export const getPublicListIntegrations = asyncWrapper<GetPublicListIntegrations>
     }
 
     const { environment, connectSession } = res.locals;
-    let configs = await configService.listProviderConfigs(environment.id);
+    let configs = await configService.listProviderConfigs(db.knex, environment.id);
 
     const providers = getProviders();
     if (!providers) {

--- a/packages/shared/lib/services/config.service.ts
+++ b/packages/shared/lib/services/config.service.ts
@@ -9,6 +9,7 @@ import { deleteByConfigId as deleteSyncConfigByConfigId, deleteSyncFilesForConfi
 
 import type { Orchestrator } from '../clients/orchestrator.js';
 import type { Config as ProviderConfig } from '../models/Provider.js';
+import type { Knex } from '@nangohq/database';
 import type { AuthModeType, DBConnection, DBCreateIntegration, DBIntegrationCrypted, IntegrationConfig, Provider } from '@nangohq/types';
 
 interface ValidationRule {
@@ -46,7 +47,7 @@ class ConfigService {
         return encryptionManager.decryptProviderConfig(result);
     }
 
-    async listProviderConfigs(environment_id: number, trx = db.knex): Promise<ProviderConfig[]> {
+    async listProviderConfigs(trx: Knex, environment_id: number): Promise<ProviderConfig[]> {
         return (
             await trx
                 .select('*')

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1,7 +1,7 @@
 import { XMLBuilder, XMLParser } from 'fast-xml-parser';
 import ms from 'ms';
-import { v4 as uuidv4 } from 'uuid';
 import { Agent } from 'undici';
+import { v4 as uuidv4 } from 'uuid';
 
 import db, { dbNamespace } from '@nangohq/database';
 import { Err, Ok, axiosInstance as axios, getLogger, stringifyError } from '@nangohq/utils';
@@ -23,14 +23,14 @@ import { productTracking } from '../utils/productTracking.js';
 import {
     extractStepNumber,
     extractValueByPath,
+    formatPem,
     getStepResponse,
     interpolateObject,
     interpolateObjectValues,
     interpolateString,
     parseTokenExpirationDate,
     stripCredential,
-    stripStepResponse,
-    formatPem
+    stripStepResponse
 } from '../utils/utils.js';
 
 import type { Orchestrator } from '../clients/orchestrator.js';
@@ -104,7 +104,7 @@ class ConnectionService {
         environmentId: number;
         metadata?: Metadata | null;
     }): Promise<ConnectionUpsertResponse[]> {
-        const storedConnection = await this.checkIfConnectionExists(connectionId, providerConfigKey, environmentId);
+        const storedConnection = await this.checkIfConnectionExists(db.knex, { connectionId, providerConfigKey, environmentId });
         const config_id = await configService.getIdByProviderConfigKey(environmentId, providerConfigKey);
 
         if (storedConnection) {
@@ -175,53 +175,55 @@ class ConnectionService {
         metadata?: Metadata | null;
         environment: DBEnvironment;
     }): Promise<ConnectionUpsertResponse[]> {
-        const { id, ...encryptedConnection } = encryptionManager.encryptConnection({
-            connection_id: connectionId,
-            provider_config_key: providerConfigKey,
-            config_id: config.id as number,
-            credentials,
-            connection_config: connectionConfig || {},
-            environment_id: environment.id,
-            metadata: metadata || null,
-            created_at: new Date(),
-            updated_at: new Date(),
-            id: -1,
-            last_fetched_at: new Date(),
-            credentials_expires_at: getExpiresAtFromCredentials(credentials),
-            last_refresh_success: new Date(),
-            last_refresh_failure: null,
-            refresh_attempts: null,
-            refresh_exhausted: false,
-            deleted: false,
-            deleted_at: null
+        return await db.knex.transaction(async (trx) => {
+            const exists = await this.checkIfConnectionExists(trx, { connectionId, providerConfigKey, environmentId: environment.id });
+
+            const { id, ...encryptedConnection } = encryptionManager.encryptConnection({
+                connection_id: connectionId,
+                provider_config_key: providerConfigKey,
+                config_id: config.id as number,
+                credentials,
+                connection_config: connectionConfig || {},
+                environment_id: environment.id,
+                metadata: metadata || null,
+                created_at: new Date(),
+                updated_at: new Date(),
+                id: -1,
+                last_fetched_at: new Date(),
+                credentials_expires_at: getExpiresAtFromCredentials(credentials),
+                last_refresh_success: new Date(),
+                last_refresh_failure: null,
+                refresh_attempts: null,
+                refresh_exhausted: false,
+                deleted: false,
+                deleted_at: null
+            });
+
+            const [connection] = await db.knex
+                .from<DBConnection>(`_nango_connections`)
+                .insert(encryptedConnection)
+                .onConflict(['connection_id', 'provider_config_key', 'environment_id', 'deleted_at'])
+                .merge({
+                    connection_id: encryptedConnection.connection_id,
+                    provider_config_key: encryptedConnection.provider_config_key,
+                    config_id: encryptedConnection.config_id,
+                    credentials: encryptedConnection.credentials,
+                    credentials_iv: encryptedConnection.credentials_iv,
+                    credentials_tag: encryptedConnection.credentials_tag,
+                    connection_config: encryptedConnection.connection_config,
+                    environment_id: encryptedConnection.environment_id,
+                    metadata: encryptedConnection.connection_config,
+                    credentials_expires_at: encryptedConnection.credentials_expires_at,
+                    last_refresh_success: encryptedConnection.last_refresh_success,
+                    last_refresh_failure: encryptedConnection.last_refresh_failure,
+                    refresh_attempts: encryptedConnection.refresh_attempts,
+                    refresh_exhausted: encryptedConnection.refresh_exhausted,
+                    updated_at: new Date()
+                })
+                .returning('*');
+
+            return [{ connection: connection!, operation: exists ? 'override' : 'creation' }];
         });
-
-        const [connection] = await db.knex
-            .from<DBConnection>(`_nango_connections`)
-            .insert(encryptedConnection)
-            .onConflict(['connection_id', 'provider_config_key', 'environment_id', 'deleted_at'])
-            .merge({
-                connection_id: encryptedConnection.connection_id,
-                provider_config_key: encryptedConnection.provider_config_key,
-                config_id: encryptedConnection.config_id,
-                credentials: encryptedConnection.credentials,
-                credentials_iv: encryptedConnection.credentials_iv,
-                credentials_tag: encryptedConnection.credentials_tag,
-                connection_config: encryptedConnection.connection_config,
-                environment_id: encryptedConnection.environment_id,
-                metadata: encryptedConnection.connection_config,
-                credentials_expires_at: encryptedConnection.credentials_expires_at,
-                last_refresh_success: encryptedConnection.last_refresh_success,
-                last_refresh_failure: encryptedConnection.last_refresh_failure,
-                refresh_attempts: encryptedConnection.refresh_attempts,
-                refresh_exhausted: encryptedConnection.refresh_exhausted,
-                updated_at: new Date()
-            })
-            .returning('*');
-
-        const operation = connection ? 'creation' : 'override';
-
-        return [{ connection: connection!, operation }];
     }
 
     public async upsertUnauthConnection({
@@ -237,7 +239,7 @@ class ConnectionService {
         connectionConfig?: ConnectionConfig;
         environment: DBEnvironment;
     }): Promise<ConnectionUpsertResponse[]> {
-        const storedConnection = await this.checkIfConnectionExists(connectionId, providerConfigKey, environment.id);
+        const storedConnection = await this.checkIfConnectionExists(db.knex, { connectionId, providerConfigKey, environmentId: environment.id });
         const config_id = await configService.getIdByProviderConfigKey(environment.id, providerConfigKey); // TODO remove that
         const expiresAt = getExpiresAtFromCredentials({});
 
@@ -364,14 +366,17 @@ class ConnectionService {
         return result || null;
     }
 
-    public async checkIfConnectionExists(connection_id: string, provider_config_key: string, environment_id: number): Promise<null | DBConnection> {
-        const result = await db.knex
+    public async checkIfConnectionExists(
+        db: Knex,
+        { connectionId, providerConfigKey, environmentId }: { connectionId: string; providerConfigKey: string; environmentId: number }
+    ): Promise<null | DBConnection> {
+        const result = await db
             .select<DBConnection>('*')
             .from<DBConnection>('_nango_connections')
             .where({
-                connection_id,
-                provider_config_key,
-                environment_id,
+                connection_id: connectionId,
+                provider_config_key: providerConfigKey,
+                environment_id: environmentId,
                 deleted: false
             })
             .first();

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -468,7 +468,7 @@ class EnvironmentService {
     }
 
     async softDelete({ environmentId, orchestrator }: { environmentId: number; orchestrator: Orchestrator }): Promise<void> {
-        const configs = await configService.listProviderConfigs(environmentId);
+        const configs = await configService.listProviderConfigs(db.knex, environmentId);
         for (const config of configs) {
             // This handles deleting connections and syncs down the line
             await configService.deleteProviderConfig({


### PR DESCRIPTION
## Changes

- Re-Import or reconnect incorrect webhooks
It would send creation instead of override
- Add transaction in this method

- Bonus: incorrect use of transaction for listProviderConfigs 
The parameter was optional which of course lead to one place not using it correctly

<!-- Summary by @propel-code-bot -->

---

This PR corrects webhook emission logic to properly distinguish between 'creation' and 'override' operations when importing or reconnecting authentication connections. It also enforces explicit transactional consistency for connection upserts and config listing by requiring a Knex transaction object, refactoring service, controller, and test code accordingly.

<details>
<summary><strong>Key Changes</strong></summary>

• Correct operation detection in upsertAuthConnection (distinguishing 'creation' vs 'override' using a DB check in a transaction).
• Wrap upsertAuthConnection and related methods in explicit transactions to ensure atomic updates and consistent webhook messaging.
• Refactor checkIfConnectionExists and listProviderConfigs to require a Knex instance, eliminating optional signature misuse.
• Update all call sites (controllers, tests, services) to pass explicit Knex transaction objects.
• Adjust integration tests and multiple controllers (connect, config, integrations) to match new signatures and transactional patterns.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• connection.service.ts (auth connection upsert, existence check, transaction handling)
• config.service.ts (provider config listing signature and usage)
• Controllers: connect/postReconnect.ts, connect/postSessions.ts, config/getListIntegrations.ts, integrations/getListIntegrations.ts
• Integration tests: postUnauthenticated.integration.test.ts
• environment.service.ts (environment soft-delete logic and config cleanup)

</details>

*This summary was automatically generated by @propel-code-bot*