### PR TITLE
fix(github-app-docs): [nan-3564] update docs

### DIFF
--- a/docs-v2/integrations/all/github-app-oauth.mdx
+++ b/docs-v2/integrations/all/github-app-oauth.mdx
@@ -60,8 +60,8 @@ import PreBuiltUseCases from "/snippets/generated/github-app-oauth/PreBuiltUseCa
 
 ## Useful links
 
-| Topic | Links | 
-| - | - | 
+| Topic | Links |
+| - | - |
 | General | [GitHub Developer Documentation](https://docs.github.com/en) |
 | | [GitHub Apps Documentation](https://docs.github.com/en/apps) |
 | | [GitHub Marketplace](https://github.com/marketplace) |
@@ -86,7 +86,7 @@ import PreBuiltUseCases from "/snippets/generated/github-app-oauth/PreBuiltUseCa
     - The App Public Link is the URL to your Github App public page (e.g. https://github.com/apps/nango-github-app)
     - The App Private Key needs to be generated in your GitHub App settings and starts with `-----BEGIN RSA PRIVATE KEY-----` (not to be confused with the Client Secrets)
     - The "Callback URL" needs to be filled in with the callback URL which unless customized will be https://api.nango.dev/oauth/callback and the checkbox "Request user authorization (OAuth) during installation" should be checked
-    - The checkbox "Redirect on update" under "Post installation" should NOT be checked and the "Setup URL (optional)" should not be accessible
+    - The checkbox "Redirect on update" under "Post installation" should be checked and the "Setup URL (optional)" should not be accessible
 -   The **GitHub App OAuth** flow is a hybrid between a **GitHub App** and an **OAuth App**. It is recommended when your **GitHub App** needs approval before being installed into an organization.
 -   There are certain API methods that only work with an OAuth App that will not work with an App. Please check the Github documentation and look for a "Works with Github Apps" header under the endpoint.
 -   Nango supports initiating a connection with a GitHub App using the frontend SDK, but not directly from the [GitHub Marketplace](https://github.com/marketplace). Therefore, you should encourage users to install your GitHub App from your product, rather than from the GitHub Marketplace directly. This is a limitation we plan to fix in the future.


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Fixes an issue where if a user updates the repo for a github app the modal didn't close because it wasn't redirecting

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

