### PR TITLE
fix(atlassian-admin-api): [nan-3578] add in organization id as a connection config param

### DIFF
--- a/docs-v2/integrations/all/atlassian-admin/connect.mdx
+++ b/docs-v2/integrations/all/atlassian-admin/connect.mdx
@@ -7,6 +7,7 @@ sidebarTitle: Atlassian Cloud Admin
 
 To authenticate with Atlassian Cloud Admin, you will need:
 1. **API Key** - A key that grants Nango permission to interact with Atlassian Cloud Admin APIs resources and services.
+2. **Organization ID** - ID that is associated with your Atlassian organization. This is optional.
 
 This guide will walk you through generating your **API Key** within Atlassian.
 
@@ -37,15 +38,16 @@ This guide will walk you through generating your **API Key** within Atlassian.
 8. Review all details and selected scopes (if applicable).
 <img src="/integrations/all/atlassian-admin/review_key_details.png" />
 9. Click **Create API Key**.
-
-<Tip>Copy and securely save the API key when prompted — you won’t be able to view it again later.</Tip>
+10. Copy and securely save the API key when prompted — you won’t be able to view it again later.
+11. Copy and save the organization ID. You can optionally enter this in the Connect UI.
 
 #### Step 2: Enter credentials in the Connect UI
 
 Once you have your **API Key**:
 1. Open the form where you need to authenticate with Atlassian Cloud Admin.
 2. Enter your **API Key** in its respective field.
-3. Submit the form, and you should be successfully authenticated.
+3. Optionally enter your **Organization ID** in the correct field.
+4. Submit the form, and you should be successfully authenticated.
 
 
 <img src="/integrations/all/atlassian-admin/form.png" style={{maxWidth: "450px" }}/>

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -844,6 +844,7 @@ atlassian-admin:
             example: ATCTT3xFfGN0_a1B2-c3D4_E5F6-G7H8I9JKLMNOPQRSTUVWXYZ1234567890=DEADBEEF
             pattern: '^ATCTT3xFfGN0[\w\-]+=[A-Z0-9]{8}$'
             doc_section: '#step-1-generating-your-api-key'
+    connection_config:
         organizationId:
             type: string
             title: Atlassian Organization Id

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -832,6 +832,8 @@ atlassian-admin:
             at: 'x-ratelimit-reset'
         headers:
             authorization: Bearer ${apiKey}
+        connection_config:
+            organizationId: ${connectionConfig.organizationId}
     docs: https://docs.nango.dev/integrations/all/atlassian-admin
     docs_connect: https://docs.nango.dev/integrations/all/atlassian-admin/connect
     credentials:
@@ -841,6 +843,14 @@ atlassian-admin:
             description: The API key for your Atlassian account
             example: ATCTT3xFfGN0_a1B2-c3D4_E5F6-G7H8I9JKLMNOPQRSTUVWXYZ1234567890=DEADBEEF
             pattern: '^ATCTT3xFfGN0[\w\-]+=[A-Z0-9]{8}$'
+            doc_section: '#step-1-generating-your-api-key'
+        organizationId:
+            type: string
+            title: Atlassian Organization Id
+            optional: true
+            description: The organization ID of your Atlassian account
+            pattern: '^[a-f0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$'
+            example: '9fa3d2b7-k9l3-4bq1-z3d8-7x1m0a9e2b76'
             doc_section: '#step-1-generating-your-api-key'
 
 attio:


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR introduces an optional 'organizationId' parameter to the Atlassian Cloud Admin provider's connection configuration. It updates both the provider's YAML configuration and the related documentation, reflecting the new parameter and guiding users on its use.

*This summary was automatically generated by @propel-code-bot*