### PR TITLE
feat(pubsub): add pubsub package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ COPY packages/fleet/package.json ./packages/fleet/package.json
 COPY packages/providers/package.json ./packages/providers/package.json
 COPY packages/runner-sdk/package.json ./packages/runner-sdk/package.json
 COPY packages/billing/package.json ./packages/billing/package.json
+COPY packages/pubsub/package.json ./packages/pubsub/package.json
 COPY package*.json  ./
 
 # Install every dependencies

--- a/dev/docker-compose.dev.yaml
+++ b/dev/docker-compose.dev.yaml
@@ -44,6 +44,16 @@ services:
                 limits:
                     memory: 2GB
 
+    activemq:
+        container_name: activemq
+        image: apache/activemq-classic:5.18.3
+        ports:
+            - '8161:8161' # Web console
+            - '61613:61613' # STOMP
+            - '61614:61614' # WS
+        networks:
+            - nango
+
 networks:
     nango:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3522,6 +3522,10 @@
             "resolved": "packages/providers",
             "link": true
         },
+        "node_modules/@nangohq/pubsub": {
+            "resolved": "packages/pubsub",
+            "link": true
+        },
         "node_modules/@nangohq/records": {
             "resolved": "packages/records",
             "link": true
@@ -8787,6 +8791,11 @@
             "engines": {
                 "node": ">=18.0.0"
             }
+        },
+        "node_modules/@stomp/stompjs": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.1.1.tgz",
+            "integrity": "sha512-chcDs6YkAnKp1FqzwhGvh3i7v0+/ytzqWdKYw6XzINEKAzke/iD00dNgFPWSZEqktHOK+C1gSzXhLkLbARIaZw=="
         },
         "node_modules/@swc/core": {
             "version": "1.11.16",
@@ -28034,6 +28043,66 @@
             "devDependencies": {
                 "@nangohq/types": "0.63.0",
                 "vitest": "3.1.2"
+            }
+        },
+        "packages/pubsub": {
+            "name": "@nangohq/pubsub",
+            "version": "1.0.0",
+            "dependencies": {
+                "@nangohq/utils": "file:../utils",
+                "@stomp/stompjs": "7.1.1",
+                "dd-trace": "5.52.0",
+                "uuid": "9.0.0",
+                "ws": "8.18.3"
+            },
+            "devDependencies": {
+                "@nangohq/types": "file:../types",
+                "@types/uuid": "9.0.0",
+                "@types/ws": "8.18.1",
+                "vitest": "3.1.2"
+            }
+        },
+        "packages/pubsub/node_modules/@types/uuid": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.0.tgz",
+            "integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==",
+            "dev": true
+        },
+        "packages/pubsub/node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "packages/pubsub/node_modules/uuid": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+            "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "packages/pubsub/node_modules/ws": {
+            "version": "8.18.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "packages/records": {

--- a/packages/pubsub/lib/env.ts
+++ b/packages/pubsub/lib/env.ts
@@ -1,0 +1,3 @@
+import { ENVS, parseEnvs } from '@nangohq/utils';
+
+export const envs = parseEnvs(ENVS);

--- a/packages/pubsub/lib/event.ts
+++ b/packages/pubsub/lib/event.ts
@@ -1,4 +1,4 @@
-import type { DBUser, DBTeam, BillingMetric } from '@nangohq/types';
+import type { BillingMetric, DBTeam, DBUser } from '@nangohq/types';
 
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue } | Record<string, any>;
 

--- a/packages/pubsub/lib/event.ts
+++ b/packages/pubsub/lib/event.ts
@@ -1,0 +1,28 @@
+import type { DBUser, DBTeam, BillingMetric } from '@nangohq/types';
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue } | Record<string, any>;
+
+interface EventBase<TSubject extends string, TType extends string, TPayload extends JsonValue> {
+    idempotencyKey: string;
+    subject: TSubject;
+    type: TType;
+    payload: TPayload;
+    source?: string | undefined;
+    createdAt: Date;
+}
+
+// Enforce that all events extend the base Event type
+type EnforceEventBase<T extends EventBase<any, any, any>> = T;
+
+type UserCreatedEvent = EventBase<
+    'user',
+    'user.created',
+    {
+        user: DBUser;
+        team: DBTeam;
+    }
+>;
+
+type BillingEvent = EventBase<'billing', 'billing.metric', BillingMetric[]>;
+
+export type Event = EnforceEventBase<UserCreatedEvent | BillingEvent>;

--- a/packages/pubsub/lib/index.ts
+++ b/packages/pubsub/lib/index.ts
@@ -1,0 +1,2 @@
+export * from './publisher.js';
+export * from './subscriber.js';

--- a/packages/pubsub/lib/publisher.ts
+++ b/packages/pubsub/lib/publisher.ts
@@ -1,8 +1,9 @@
-import type { SetOptional } from 'type-fest';
 import { v4 as uuidv4 } from 'uuid';
-import type { Result } from '@nangohq/utils';
-import type { Transport } from './transport/transport.js';
+
 import type { Event } from './event.js';
+import type { Transport } from './transport/transport.js';
+import type { Result } from '@nangohq/utils';
+import type { SetOptional } from 'type-fest';
 
 export class Publisher {
     private transport: Transport;

--- a/packages/pubsub/lib/publisher.ts
+++ b/packages/pubsub/lib/publisher.ts
@@ -1,0 +1,21 @@
+import type { SetOptional } from 'type-fest';
+import { v4 as uuidv4 } from 'uuid';
+import type { Result } from '@nangohq/utils';
+import type { Transport } from './transport/transport.js';
+import type { Event } from './event.js';
+
+export class Publisher {
+    private transport: Transport;
+
+    constructor(transport: Transport) {
+        this.transport = transport;
+    }
+
+    public async publish(event: SetOptional<Event, 'idempotencyKey' | 'createdAt'>): Promise<Result<void>> {
+        return this.transport.publish({
+            ...event,
+            idempotencyKey: event.idempotencyKey ?? uuidv4(),
+            createdAt: event.createdAt ?? new Date()
+        });
+    }
+}

--- a/packages/pubsub/lib/subscriber.ts
+++ b/packages/pubsub/lib/subscriber.ts
@@ -1,0 +1,13 @@
+import type { Subscription, Transport } from './transport/transport.js';
+
+export class Subscriber {
+    private transport: Transport;
+
+    constructor(transport: Transport) {
+        this.transport = transport;
+    }
+
+    public subscribe({ consumerGroup, subscriptions }: { consumerGroup: string; subscriptions: Subscription[] }): void {
+        this.transport.subscribe({ consumerGroup, subscriptions });
+    }
+}

--- a/packages/pubsub/lib/trace.ts
+++ b/packages/pubsub/lib/trace.ts
@@ -1,0 +1,5 @@
+import tracer from 'dd-trace';
+
+tracer.init({
+    service: 'nango-pubsub'
+});

--- a/packages/pubsub/lib/transport/activemq.integration.test.ts
+++ b/packages/pubsub/lib/transport/activemq.integration.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeAll, afterAll, assert, vi } from 'vitest';
+import { ActiveMQ } from './activemq.js';
+import type { Event } from '../event.js';
+
+describe('ActiveMQ Transport', () => {
+    it('should connect successfully', async () => {
+        const activemq = new ActiveMQ();
+        const res = await activemq.connect({ timeoutMs: 1000 });
+        assert(res.isOk(), 'Connecting to ActiveMQ was not successful');
+    });
+
+    it('should handle connection error', async () => {
+        const activemq = new ActiveMQ({ url: 'ws://invalid:12345/ws', user: '', password: '' });
+        const res = await activemq.connect({ timeoutMs: 1000 });
+        assert(res.isErr(), 'Expected connection to fail with invalid URL');
+    });
+
+    it('should disconnect successfully', async () => {
+        const activemq = new ActiveMQ();
+        await activemq.connect({ timeoutMs: 1000 });
+        const res = await activemq.disconnect();
+        assert(res.isOk(), 'Disconnecting was not successful');
+    });
+
+    describe('Publisher/Subscriber', () => {
+        const publisher = new ActiveMQ();
+        const consumer = new ActiveMQ();
+        beforeAll(async () => {
+            await publisher.connect({ timeoutMs: 1000 });
+            await consumer.connect({ timeoutMs: 1000 });
+        });
+
+        afterAll(async () => {
+            await publisher.disconnect();
+            await consumer.disconnect();
+        });
+        it('should publish and consume event', async () => {
+            const event: Event = {
+                idempotencyKey: 'test-idempotency-key',
+                subject: 'billing',
+                type: 'billing.metric',
+                payload: [
+                    {
+                        type: 'billable_actions',
+                        value: 10,
+                        properties: {
+                            accountId: 1,
+                            idempotencyKey: '12345',
+                            tag1: 'value1'
+                        }
+                    }
+                ],
+                createdAt: new Date()
+            };
+            const callback = vi.fn();
+            consumer.subscribe({
+                consumerGroup: 'test-consumer-group',
+                subscriptions: [
+                    {
+                        subject: event.subject,
+                        callback
+                    }
+                ]
+            });
+
+            const published = await publisher.publish(event);
+            assert(published.isOk(), 'Publishing event was not successful');
+            await vi.waitFor(() => {
+                expect(callback).toHaveBeenCalledTimes(1);
+            });
+            expect(callback).toHaveBeenCalledWith(event);
+        });
+    });
+});

--- a/packages/pubsub/lib/transport/activemq.integration.test.ts
+++ b/packages/pubsub/lib/transport/activemq.integration.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, beforeAll, afterAll, assert, vi } from 'vitest';
+import { afterAll, assert, beforeAll, describe, expect, it, vi } from 'vitest';
+
 import { ActiveMQ } from './activemq.js';
+
 import type { Event } from '../event.js';
 
 describe('ActiveMQ Transport', () => {

--- a/packages/pubsub/lib/transport/activemq.ts
+++ b/packages/pubsub/lib/transport/activemq.ts
@@ -1,0 +1,149 @@
+import { setTimeout } from 'node:timers/promises';
+
+import { Client } from '@stomp/stompjs';
+import WebSocket from 'ws';
+
+import { Err, Ok, getLogger } from '@nangohq/utils';
+
+import { envs } from '../env.js';
+import { serde } from '../utils/serde.js';
+
+import type { Subscription, Transport } from './transport.js';
+import type { Event } from '../event.js';
+import type { Result } from '@nangohq/utils';
+import type { StompConfig } from '@stomp/stompjs';
+
+const logger = getLogger('pubsub.activemq');
+
+export class ActiveMQ implements Transport {
+    private client: Client | null = null;
+    private isConnected = false;
+    private messageEncoding: BufferEncoding = 'binary';
+
+    constructor(props?: { url: string; user: string; password: string }) {
+        const stompConfig: StompConfig = {
+            webSocketFactory: () => new WebSocket(props?.url ?? envs.NANGO_ACTIVEMQ_URL, ['stomp']),
+            connectHeaders: {
+                login: props?.user ?? envs.NANGO_ACTIVEMQ_USER,
+                passcode: props?.password ?? envs.NANGO_ACTIVEMQ_PASSWORD
+            },
+            heartbeatIncoming: 10000,
+            heartbeatOutgoing: 10000,
+            reconnectDelay: 5000,
+            onConnect: () => {
+                this.isConnected = true;
+                logger.info('ActiveMQ publisher connected');
+            },
+            onDisconnect: () => {
+                this.isConnected = false;
+                logger.warning('ActiveMQ publisher disconnected');
+            },
+            onStompError: (frame) => {
+                this.isConnected = false;
+                logger.error('ActiveMQ STOMP error:', frame.body);
+            },
+            onWebSocketError: (error) => {
+                this.isConnected = false;
+                logger.error('ActiveMQ WebSocket error:', error);
+            }
+        };
+
+        this.client = new Client(stompConfig);
+    }
+
+    public async connect(props?: { timeoutMs: number }): Promise<Result<void>> {
+        if (!this.client) {
+            return Err(new Error('ActiveMQ client is not initialized'));
+        }
+        if (this.isConnected) {
+            return Ok(undefined);
+        }
+
+        try {
+            this.client.activate();
+
+            const timeoutMs = props?.timeoutMs ?? envs.NANGO_ACTIVEMQ_CONNECT_TIMEOUT_MS;
+            const start = Date.now();
+            while (!this.isConnected && Date.now() - start < timeoutMs) {
+                await setTimeout(100);
+            }
+
+            if (!this.isConnected) {
+                throw new Error(`Failed to connect to ActiveMQ within ${timeoutMs}ms`);
+            }
+
+            return Ok(undefined);
+        } catch (err) {
+            logger.error('Error connecting to ActiveMQ:', err);
+            return Err(new Error('Failed to connect to ActiveMQ', { cause: err }));
+        }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public async disconnect(): Promise<Result<void>> {
+        if (this.client) {
+            try {
+                this.client.deactivate();
+                this.client = null;
+                this.isConnected = false;
+                logger.info('ActiveMQ publisher disconnected');
+                return Ok(undefined);
+            } catch (err) {
+                logger.error('Error disconnecting from ActiveMQ:', err);
+                return Err(new Error('Failed to disconnect from ActiveMQ', { cause: err }));
+            }
+        }
+        return Ok(undefined); // no client to disconnect
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public async publish(event: Event): Promise<Result<void>> {
+        if (!this.client || !this.isConnected) {
+            return Err('ActiveMQ publisher not available');
+        }
+
+        try {
+            const encoded = serde.encode(event);
+            if (encoded.isErr()) {
+                return Err(new Error(`Failed to encode event: ${encoded.error}`));
+            }
+            // ActiveMQ supports virtual topics, which allows messages to be sent to multiple consumer groups
+            // https://activemq.apache.org/components/classic/documentation/virtual-destinations
+            // Consumers can subscribe to corresponding queues. ie: Consumer.${group}.VirtualTopic.${topic}
+            this.client.publish({
+                destination: `/topic/VirtualTopic.${event.subject}`,
+                body: encoded.value.toString(this.messageEncoding),
+                headers: {
+                    'content-type': 'application/json'
+                }
+            });
+
+            return Ok(undefined);
+        } catch (err) {
+            return Err(new Error(`Failed to publish message to ActiveMQ topic ${event.subject}`, { cause: err }));
+        }
+    }
+
+    public subscribe({ consumerGroup, subscriptions }: { consumerGroup: string; subscriptions: Subscription[] }): void {
+        if (!this.client || !this.isConnected) {
+            logger.error('ActiveMQ publisher not connected, cannot subscribe to events');
+            return;
+        }
+
+        // ActiveMQ supports virtual topics, which allows messages to be sent to multiple consumer groups
+        // https://activemq.apache.org/components/classic/documentation/virtual-destinations
+        // Consumers can subscribe to corresponding queues. ie: Consumer.${group}.VirtualTopic.${topic}
+        for (const { subject, callback } of subscriptions) {
+            this.client.subscribe(`/queue/Consumer.${consumerGroup}.VirtualTopic.${subject}`, (message) => {
+                if (message.body) {
+                    const decoded = serde.decode<Event>(Buffer.from(message.body, this.messageEncoding));
+                    if (decoded.isErr()) {
+                        logger.error('Failed to parse message body:', decoded.error);
+                        return;
+                    }
+                    callback(decoded.value);
+                }
+            });
+        }
+    }
+}

--- a/packages/pubsub/lib/transport/transport.ts
+++ b/packages/pubsub/lib/transport/transport.ts
@@ -1,0 +1,14 @@
+import type { Result } from '@nangohq/utils';
+import type { Event } from '../event.js';
+
+export interface Subscription {
+    subject: Event['subject'];
+    callback: (event: Event) => void;
+}
+
+export interface Transport {
+    publish(event: Event): Promise<Result<void>>;
+    subscribe({ consumerGroup, subscriptions }: { consumerGroup: string; subscriptions: Subscription[] }): void;
+    connect(props?: { timeoutMs: number }): Promise<Result<void>>;
+    disconnect(): Promise<Result<void>>;
+}

--- a/packages/pubsub/lib/transport/transport.ts
+++ b/packages/pubsub/lib/transport/transport.ts
@@ -1,6 +1,7 @@
-import type { Result } from '@nangohq/utils';
 import type { Event } from '../event.js';
+import type { Result } from '@nangohq/utils';
 
+// TODO: add support for subscriber ack/nack
 export interface Subscription {
     subject: Event['subject'];
     callback: (event: Event) => void;

--- a/packages/pubsub/lib/utils/serde.ts
+++ b/packages/pubsub/lib/utils/serde.ts
@@ -1,9 +1,11 @@
-import { serialize, deserialize } from 'v8';
+import { deserialize, serialize } from 'node:v8';
+
+import { Err, Ok } from '@nangohq/utils';
+
 import type { Result } from '@nangohq/utils';
-import { Ok, Err } from '@nangohq/utils';
 
 export const serde = {
-    encode: <T>(obj: T): Result<Buffer> => {
+    serialize: <T>(obj: T): Result<Buffer> => {
         try {
             const res = serialize(obj);
             return Ok(res);
@@ -12,7 +14,7 @@ export const serde = {
         }
     },
 
-    decode: <T>(encoded: Buffer): Result<T> => {
+    deserialize: <T>(encoded: Buffer): Result<T> => {
         try {
             const res = deserialize(encoded) as T;
             return Ok(res);

--- a/packages/pubsub/lib/utils/serde.ts
+++ b/packages/pubsub/lib/utils/serde.ts
@@ -1,0 +1,23 @@
+import { serialize, deserialize } from 'v8';
+import type { Result } from '@nangohq/utils';
+import { Ok, Err } from '@nangohq/utils';
+
+export const serde = {
+    encode: <T>(obj: T): Result<Buffer> => {
+        try {
+            const res = serialize(obj);
+            return Ok(res);
+        } catch (err) {
+            return Err(new Error(`Serialization failed`, { cause: err }));
+        }
+    },
+
+    decode: <T>(encoded: Buffer): Result<T> => {
+        try {
+            const res = deserialize(encoded) as T;
+            return Ok(res);
+        } catch (err) {
+            return Err(new Error(`Deserialization failed`, { cause: err }));
+        }
+    }
+};

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "@nangohq/pubsub",
+    "version": "1.0.0",
+    "type": "module",
+    "main": "dist/index.js",
+    "private": true,
+    "keywords": [],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/NangoHQ/nango.git",
+        "directory": "packages/pubsub"
+    },
+    "dependencies": {
+        "@nangohq/utils": "file:../utils",
+        "@stomp/stompjs": "7.1.1",
+        "dd-trace": "5.52.0",
+        "uuid": "9.0.0",
+        "ws": "8.18.3"
+    },
+    "devDependencies": {
+        "@nangohq/types": "file:../types",
+        "@types/ws": "8.18.1",
+        "@types/uuid": "9.0.0",
+        "vitest": "3.1.2"
+    }
+}

--- a/packages/pubsub/tsconfig.json
+++ b/packages/pubsub/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "lib",
+        "outDir": "dist"
+    },
+    "references": [{ "path": "../utils" }],
+    "include": ["lib/**/*", "../utils/lib/vitest.d.ts"]
+}

--- a/packages/scheduler/lib/daemons/daemon.ts
+++ b/packages/scheduler/lib/daemons/daemon.ts
@@ -39,7 +39,7 @@ export abstract class SchedulerDaemon {
         try {
             logger.info(`Starting ${this.name}...`);
             if (this.status !== 'stopped') {
-                logger.warn(`${this.name} is already running or cancelled. Cannot start.`);
+                logger.warning(`${this.name} is already running or cancelled. Cannot start.`);
                 return;
             }
             this.status = 'running';

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -240,6 +240,12 @@ export const ENVS = z.object({
     // LIMITS
     MAX_SYNCS_PER_CONNECTION: z.coerce.number().optional().default(100),
 
+    // ActiveMQ
+    NANGO_ACTIVEMQ_URL: z.string().url().optional().default('ws://localhost:61614/ws'),
+    NANGO_ACTIVEMQ_USER: z.string().optional().default('admin'),
+    NANGO_ACTIVEMQ_PASSWORD: z.string().optional().default('admin'),
+    NANGO_ACTIVEMQ_CONNECT_TIMEOUT_MS: z.coerce.number().optional().default(10_000),
+
     // ----- Others
     SERVER_RUN_MODE: z.enum(['DOCKERIZED', '']).optional(),
     NANGO_CLOUD: bool,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -77,6 +77,9 @@
             "path": "packages/billing"
         },
         {
+            "path": "packages/pubsub"
+        },
+        {
             "path": "packages/types"
         }
     ]


### PR DESCRIPTION
Add new @nangohq/pubsub package with ActiveMQ transport implementation. 
Add docker configuration for ActiveMQ development environment.


<!-- Summary by @propel-code-bot -->

---

This PR introduces a new core package, @nangohq/pubsub, providing a strongly-typed publish/subscribe abstraction for event streaming within the monorepo. The initial implementation includes an ActiveMQ transport using STOMP over WebSocket, with v8-based serialization/deserialization, publisher and subscriber classes, comprehensive test coverage using Vitest and testcontainers, and integration hooks for Docker/CI environments. Related global configuration, Dockerfiles, and build scripts are updated, with environment variable parsing extended to support ActiveMQ configuration, and minor logging adjustments made for consistency elsewhere in the codebase.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced 'packages/pubsub' with generic pub/sub API and type-safe event model.
• Implemented ActiveMQ transport layer with STOMP over WebSocket, using node:v8 serialization.
• Publisher and subscriber abstractions with usage documentation and full test suite (unit + integration using Vitest and testcontainers).
• Added docker-compose service for ActiveMQ to dev and CI environments; build scripts recognize and build the new package.
• Extended environment variable parsing and schema validation to cover ActiveMQ configuration (URL, username, password, timeouts).
• Minor infrastructure updates: package-lock.json, tsconfig.build.json, Dockerfile augmented for the new package.
• Fixed logging inconsistency: changed logger.warn to logger.warning in scheduler daemon.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/pubsub (new code, tests, serialization, tracing)
• dev/docker-compose.dev.yaml
• Dockerfile
• tsconfig.build.json
• package-lock.json
• package.json
• packages/utils/lib/environment/parse.ts
• tests/setup.ts
• packages/scheduler/lib/daemons/daemon.ts

</details>

*This summary was automatically generated by @propel-code-bot*