### PR TITLE
fix(jira-post-connection): [nan-3592] wrap potential failing call in a try catch

### DIFF
--- a/packages/cli/fixtures/zero/valid/github/actions/createIssue.ts
+++ b/packages/cli/fixtures/zero/valid/github/actions/createIssue.ts
@@ -34,4 +34,3 @@ export default createAction({
         });
     }
 });
-

--- a/packages/server/lib/hooks/connection/providers/jira/post-connection.ts
+++ b/packages/server/lib/hooks/connection/providers/jira/post-connection.ts
@@ -1,6 +1,10 @@
 import axios from 'axios';
 
+import { getLogger } from '@nangohq/utils';
+
 import type { InternalNango as Nango } from '../../internal-nango.js';
+
+const logger = getLogger('post-connection:jira');
 
 export default async function execute(nango: Nango) {
     const connection = await nango.getConnection();
@@ -35,11 +39,22 @@ export default async function execute(nango: Nango) {
 
     const endpoint = isConfluence ? `ex/confluence/${site.id}/wiki/rest/api/user/current` : `ex/jira/${site.id}/rest/api/3/myself`;
 
-    const accountResponse = await nango.proxy({
-        endpoint,
-        providerConfigKey: connection.provider_config_key
-    });
-    const accountId = accountResponse && !axios.isAxiosError(accountResponse) ? accountResponse.data?.accountId : undefined;
+    let accountId: string | null = null;
+
+    // we are making calls to endpoints that require certain scopes. Wrap these
+    // calls in a try/catch to avoid breaking the connection if the scopes are not available.
+    try {
+        const accountResponse = await nango.proxy({
+            // jira: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-myself/#api-rest-api-3-myself-get
+            // confluence https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-users/#api-wiki-rest-api-user-current-get
+            endpoint,
+            providerConfigKey: connection.provider_config_key
+        });
+        accountId = accountResponse && !axios.isAxiosError(accountResponse) ? accountResponse.data?.accountId : null;
+    } catch {
+        logger.warning('Failed to fetch account ID from Jira/Confluence API. This may be due to insufficient scopes or permissions.');
+    }
+
     await nango.updateConnectionConfig({
         cloudId: site.id,
         baseUrl: site.url,


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Wrap potentially failing calls in a try, catch. I thought about checking explicitly for scopes but this seemed like a potential cat/mouse game in case granular or classic scopes change.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR enhances the reliability of the Jira post-connection logic by wrapping API calls that require specific permissions or scopes in a try/catch block. It introduces logging for failed calls and prevents the entire connection process from breaking due to insufficient scopes, without explicitly checking for scope presence.

*This summary was automatically generated by @propel-code-bot*