### PR TITLE
fix(billing): do not backfill sub for non-free plan

### DIFF
--- a/packages/server/lib/controllers/v1/orb/postWebhooks.ts
+++ b/packages/server/lib/controllers/v1/orb/postWebhooks.ts
@@ -6,7 +6,7 @@ import { Err, Ok, report } from '@nangohq/utils';
 import { envs } from '../../../env.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 
-import type { PostOrbWebhooks, Result } from '@nangohq/types';
+import type { DBPlan, PostOrbWebhooks, Result } from '@nangohq/types';
 
 /**
  * Orb is sending webhooks when subscription changes or else
@@ -96,7 +96,7 @@ async function handleWebhook(body: Webhooks): Promise<Result<void>> {
 
                 const updated = await updatePlanByTeam(trx, {
                     account_id: team.id,
-                    name: planExternalId,
+                    name: planExternalId as unknown as DBPlan['name'],
                     trial_start_at: null,
                     trial_end_at: null,
                     trial_end_notified_at: null,

--- a/packages/server/lib/controllers/v1/plans/usage/getUsage.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getUsage.ts
@@ -29,7 +29,7 @@ export const getUsage = asyncWrapper<GetUsage>(async (req, res) => {
     }
 
     // Backfill orb subscription (free by default)
-    if (!plan.orb_subscription_id) {
+    if (!plan.orb_subscription_id && plan.name === 'free') {
         const linkOrbSubscriptionRes = await linkBillingFreeSubscription(account);
         if (linkOrbSubscriptionRes.isErr()) {
             res.status(500).send({ error: { code: 'server_error', message: 'Failed to link billing subscription' } });

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -20,22 +20,19 @@ export const freePlan: PlanDefinition = {
     }
 };
 
-export const ycPlan: PlanDefinition = {
-    code: 'yc',
-    title: 'YC Plan',
-    description: 'For our friends at YC.',
-    canUpgrade: true,
+export const starterPlan: PlanDefinition = {
+    code: 'starter',
+    title: 'Starter',
+    description: 'Tailored to your scale.',
+    canUpgrade: false,
     canDowngrade: false,
-    cta: 'Contact Us',
-    hidden: true,
-    orbId: 'yc',
     flags: {
         api_rate_limit_size: 'l',
         connection_with_scripts_max: null,
         environments_max: 3,
         has_otel: false,
         has_sync_variants: true,
-        name: 'yc',
+        name: 'starter',
         sync_frequency_secs_min: 30,
         auto_idle: false
     }
@@ -80,31 +77,10 @@ export const enterprisePlan: PlanDefinition = {
     }
 };
 
-export const internalPlan: PlanDefinition = {
-    code: 'internal',
-    title: 'Internal',
-    description: 'Congrats, you are an insider.',
-    canUpgrade: false,
-    canDowngrade: false,
-    cta: 'Contact Us',
-    hidden: true,
-    orbId: 'internal',
-    flags: {
-        api_rate_limit_size: 'l',
-        connection_with_scripts_max: null,
-        environments_max: 10,
-        has_otel: false,
-        has_sync_variants: true,
-        name: 'yc',
-        sync_frequency_secs_min: 30,
-        auto_idle: false
-    }
-};
-
 // Old plans
-export const starterPlan: PlanDefinition = {
-    code: 'starter',
-    title: 'Starter',
+export const starterLegacyPlan: PlanDefinition = {
+    code: 'starter-legacy',
+    title: 'Starter (legacy)',
     description: 'Tailored to your scale.',
     canUpgrade: false,
     canDowngrade: false,
@@ -115,15 +91,14 @@ export const starterPlan: PlanDefinition = {
         environments_max: 3,
         has_otel: false,
         has_sync_variants: true,
-        name: 'starter',
+        name: 'starter-legacy',
         sync_frequency_secs_min: 30,
         auto_idle: false
     }
 };
-
-export const scalePlan: PlanDefinition = {
-    code: 'scale',
-    title: 'Scale',
+export const scaleLegacyPlan: PlanDefinition = {
+    code: 'scale-legacy',
+    title: 'Scale (legacy)',
     description: 'Tailored to your scale.',
     canUpgrade: false,
     canDowngrade: false,
@@ -134,7 +109,25 @@ export const scalePlan: PlanDefinition = {
         environments_max: 3,
         has_otel: false,
         has_sync_variants: true,
-        name: 'scale',
+        name: 'scale-legacy',
+        sync_frequency_secs_min: 30,
+        auto_idle: false
+    }
+};
+export const growthLegacyPlan: PlanDefinition = {
+    code: 'growth-legacy',
+    title: 'Growth (legacy)',
+    description: 'Tailored to your scale.',
+    canUpgrade: false,
+    canDowngrade: false,
+    hidden: true,
+    flags: {
+        api_rate_limit_size: 'l',
+        connection_with_scripts_max: null,
+        environments_max: 3,
+        has_otel: false,
+        has_sync_variants: true,
+        name: 'growth-legacy',
         sync_frequency_secs_min: 30,
         auto_idle: false
     }
@@ -142,12 +135,12 @@ export const scalePlan: PlanDefinition = {
 
 export const plansList: PlanDefinition[] = [
     freePlan,
-    ycPlan,
+    starterPlan,
     growthPlan,
     enterprisePlan,
-    internalPlan,
 
     // Old plans
-    starterPlan,
-    scalePlan
+    starterLegacyPlan,
+    scaleLegacyPlan,
+    growthLegacyPlan
 ];

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -3,7 +3,7 @@ import type { Timestamps } from '../db.js';
 export interface DBPlan extends Timestamps {
     id: number;
     account_id: number;
-    name: string;
+    name: 'free' | 'starter' | 'starter-legacy' | 'growth' | 'scale-legacy' | 'growth-legacy' | 'enterprise';
 
     // Stripe
     stripe_customer_id: string | null;

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -15,7 +15,7 @@ export type PostPlanExtendTrial = Endpoint<{
 }>;
 
 export interface PlanDefinition {
-    code: string;
+    code: DBPlan['name'];
     title: string;
     description: string;
     canUpgrade: boolean;

--- a/packages/webapp/src/components/CreateEnvironmentButton.tsx
+++ b/packages/webapp/src/components/CreateEnvironmentButton.tsx
@@ -55,7 +55,7 @@ export const CreateEnvironmentButton: React.FC = () => {
         tooltipContent = (
             <div>
                 Max number of environments reached.{' '}
-                {environment?.plan?.name === 'scale' ? (
+                {environment?.plan?.name.includes('legacy') ? (
                     <>Contact Nango to add more</>
                 ) : (
                     <>

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -36,7 +36,12 @@ export const TeamBilling: React.FC = () => {
         }
 
         // No self downgrade or old plan
-        if (currentPlan.name === 'scale' || currentPlan.name === 'enterprise' || currentPlan.name === 'starter' || currentPlan.name === 'internal') {
+        if (
+            currentPlan.name === 'scale-legacy' ||
+            currentPlan.name === 'enterprise' ||
+            currentPlan.name === 'starter-legacy' ||
+            currentPlan.name === 'growth-legacy'
+        ) {
             return [{ plan: plansList.data.find((p) => p.code === currentPlan.name)!, active: true }];
         }
 


### PR DESCRIPTION
## Changes

- Do not backfill sub for non-free plan
This could accidentally downgrade some customers that are not yet on Orb

- Type DBPlan["name"] to avoid some mistakes
- Fix missing legacy plan 
- Remove YC and internal

<!-- Summary by @propel-code-bot -->

---

This PR refines billing plan management by ensuring subscription backfill is only triggered for 'free' plans, preventing potential unintended downgrades for other plans. It removes deprecated YC and internal plans, adds explicit legacy plans, and enforces stronger type safety on plan names across the backend, API, and UI. Related logic in billing, environment creation, and plan display has been updated to reflect these changes.

<details>
<summary><strong>Key Changes</strong></summary>

• Restricts Orb subscription backfill to accounts explicitly on the free plan.
• Removes deprecated 'yc' and 'internal' billing plans from shared definitions and plan logic.
• Introduces explicit legacy plan objects: starterLegacyPlan, scaleLegacyPlan, and growthLegacyPlan, with updated handling.
• Adds stricter typing for DBPlan['name'] and uses it throughout types and logic.
• Updates plan-handling logic in billing pages, the subscription webhook handler, and the environment creation UI to account for new and legacy plan types.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Plan definitions and shared billing plan logic
• UI components and pages related to billing and environment creation
• Type definitions in packages/types/lib/plans/db.ts and http.api.ts
• Server-side Orb webhook controller and usage/billing API logic

</details>

*This summary was automatically generated by @propel-code-bot*