### PR TITLE
chore(orch): clean schedules and tasks older than 5 days

### DIFF
--- a/packages/scheduler/lib/daemons/cleaning/cleaning.daemon.ts
+++ b/packages/scheduler/lib/daemons/cleaning/cleaning.daemon.ts
@@ -26,15 +26,15 @@ export class CleaningDaemon extends SchedulerDaemon {
             const lockGranted = res?.rows.length > 0 ? res.rows[0]!.lock_clean : false;
 
             if (lockGranted) {
-                // hard delete schedules where deletedAt is older than 10 days
-                const deletedSchedules = await schedules.hardDeleteOlderThanNDays(trx, 10);
+                // hard delete schedules where deletedAt is older than N days
+                const deletedSchedules = await schedules.hardDeleteOlderThanNDays(trx, envs.ORCHESTRATOR_CLEANING_OLDER_THAN_DAYS);
                 if (deletedSchedules.isErr()) {
                     logger.error(deletedSchedules.error);
                 } else if (deletedSchedules.value.length > 0) {
                     logger.info(`Hard deleted ${deletedSchedules.value.length} schedules`);
                 }
-                // hard delete terminated tasks older than 10 days unless it is the last task for an active schedule
-                const deletedTasks = await tasks.hardDeleteOlderThanNDays(trx, 10);
+                // hard delete terminated tasks older than N days unless it is the last task for an active schedule
+                const deletedTasks = await tasks.hardDeleteOlderThanNDays(trx, envs.ORCHESTRATOR_CLEANING_OLDER_THAN_DAYS);
                 if (deletedTasks.isErr()) {
                     logger.error(deletedTasks.error);
                 } else if (deletedTasks.value.length > 0) {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -64,6 +64,7 @@ export const ENVS = z.object({
     ORCHESTRATOR_DB_POOL_MAX: z.coerce.number().optional().default(50),
     ORCHESTRATOR_EXPIRING_TICK_INTERVAL_MS: z.coerce.number().optional().default(1000),
     ORCHESTRATOR_CLEANING_TICK_INTERVAL_MS: z.coerce.number().optional().default(10000),
+    ORCHESTRATOR_CLEANING_OLDER_THAN_DAYS: z.coerce.number().optional().default(5),
     ORCHESTRATOR_SCHEDULING_TICK_INTERVAL_MS: z.coerce.number().optional().default(100),
 
     // Jobs


### PR DESCRIPTION
Keep only 5 days of completed tasks in orchestrator db. (instead of 10 days)
We could lower this number even more. It impacts how long a async action output is available for though and debuggability in case we need to look back at what happen for a given task (that's pretty rare though I have only had to do it a few times since the orchestrator exists)

<!-- Summary by @propel-code-bot -->

---

This PR updates the orchestrator cleaning logic to parameterize the deletion interval for completed schedules and tasks, reducing the default retention window from 10 days to 5 days. The interval is now controlled by a new environment variable (ORCHESTRATOR_CLEANING_OLDER_THAN_DAYS) to allow easier configuration.

*This summary was automatically generated by @propel-code-bot*