### PR TITLE
fix(github-app): handle update without auth code

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -977,7 +977,7 @@ class ConnectionService {
         connectionConfig: ConnectionConfig,
         logCtx: LogContext,
         connectionCreatedHook: (res: ConnectionUpsertResponse) => MaybePromise<void>
-    ): Promise<Result<void, AuthCredentialsError>> {
+    ): Promise<Result<ConnectionUpsertResponse | undefined, AuthCredentialsError>> {
         const create = await githubAppClient.createCredentials({
             integration,
             provider,
@@ -1000,7 +1000,7 @@ class ConnectionService {
         }
 
         void logCtx.info('App connection was approved and credentials were saved');
-        return Ok(undefined);
+        return Ok(updatedConnection);
     }
 
     public async getOauthClientCredentials({


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
If a github app has already been installed the OAuth flow isn't kicked off for some reason. In this case we don't need the auth user since there is no approval flow since the app has already been installed. So on an update short circuit the flow to allow the connection to be created

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the OAuth flow for GitHub App integrations to support cases where the app has already been installed and an OAuth code is not present during an 'update' action. It introduces logic in the OAuth controller to conditionally bypass the need for an authorization code on such updates, and adjusts connection service response values to support proper handling.

<details>
<summary><strong>Key Changes</strong></summary>

• Added a conditional path in oauth.controller.ts to allow updates without an authorization code if authMode is 'CUSTOM' and setupAction is 'update'.
• Creates the connection using available installation/app IDs without requiring a new OAuth token when updating an already installed GitHub app.
• Changed the return type of getAppCredentialsAndFinishConnection in connection.service.ts to return the upserted connection result, aligning with the needs of the new callback flow.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• OAuth2 callback handling in packages/server/lib/controllers/oauth.controller.ts
• App credentials connection flow in packages/shared/lib/services/connection.service.ts

</details>

*This summary was automatically generated by @propel-code-bot*