### PR TITLE
fix(runner): allow webhooks and syncs to run in parallel

### DIFF
--- a/packages/runner/lib/monitor.ts
+++ b/packages/runner/lib/monitor.ts
@@ -122,7 +122,8 @@ export class RunnerMonitor {
 
         for (const task of this.tracked.values()) {
             // Should cover sync and sync variant
-            if (task.syncId === newTask.syncId) {
+            // Webhooks have the same syncId so we allow them to run in parallel
+            if (task.syncId === newTask.syncId && task.scriptType === 'sync') {
                 return true;
             }
         }


### PR DESCRIPTION
## Changes

- allow webhooks and syncs to run in parallel
Didn't realize we were using the same syncId

<!-- Summary by @propel-code-bot -->

---

This PR updates the runner logic to distinguish between sync tasks and webhooks by adding a scriptType check when determining task conflicts. Now, only tasks with matching syncId and scriptType 'sync' are treated as conflicting, which allows webhooks (sharing the same syncId) to execute concurrently with sync tasks.

*This summary was automatically generated by @propel-code-bot*