### PR TITLE
feat: remove connection_with_scripts_max cap

### DIFF
--- a/packages/database/lib/migrations/20250716104853_delete_connection_with_scripts_max_flag.cjs
+++ b/packages/database/lib/migrations/20250716104853_delete_connection_with_scripts_max_flag.cjs
@@ -1,0 +1,13 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE plans DROP COLUMN connection_with_scripts_max;`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = function () {};

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.ts
@@ -56,7 +56,6 @@ export const postDeploy = asyncWrapper<PostDeploy>(async (req, res) => {
     } = await deploy({
         environment,
         account,
-        plan,
         flows: cleanIncomingFlow(body.flowConfigs),
         nangoYamlBody: body.nangoYamlBody,
         onEventScriptsByProvider: body.onEventScriptsByProvider,

--- a/packages/server/lib/controllers/sync/deploy/postDeployInternal.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeployInternal.ts
@@ -86,7 +86,6 @@ export const postDeployInternal = asyncWrapper<PostDeployInternal>(async (req, r
     } = await deploy({
         environment,
         account,
-        plan: null, // We don't care it's our own stuff
         flows: cleanIncomingFlow(body.flowConfigs),
         nangoYamlBody: body.nangoYamlBody,
         onEventScriptsByProvider: body.onEventScriptsByProvider,

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -71,26 +71,6 @@ export const connectionCreationStartCapCheck = async ({
         return { capped: true, code: 'max' };
     }
 
-    if (plan.connection_with_scripts_max) {
-        for (const byProvider of connectionCount.data) {
-            const totalByProvider = parseInt(byProvider.connectionsWithScripts, 10);
-            if (byProvider.providerConfigKey !== providerConfigKey) {
-                continue;
-            }
-            if (totalByProvider < plan.connection_with_scripts_max) {
-                continue;
-            }
-
-            logger.info(`Reached cap for providerConfigKey: ${providerConfigKey} and environmentId: ${environmentId}`);
-            if (creationType === 'create') {
-                productTracking.track({ name: 'server:resource_capped:connection_creation', team });
-            } else {
-                productTracking.track({ name: 'server:resource_capped:connection_imported', team });
-            }
-            return { capped: true, code: 'max_with_scripts' };
-        }
-    }
-
     return { capped: false };
 };
 

--- a/packages/shared/lib/seeders/plan.seeder.ts
+++ b/packages/shared/lib/seeders/plan.seeder.ts
@@ -18,7 +18,6 @@ export function getTestPlan(override?: Partial<DBPlan>): DBPlan {
         trial_expired: null,
         environments_max: 2,
         sync_frequency_secs_min: 60,
-        connection_with_scripts_max: 3,
         connections_max: 1000,
         has_sync_variants: false,
         has_otel: false,

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -19,7 +19,6 @@ import syncManager from './sync/manager.service.js';
 import encryptionManager from '../utils/encryption.manager.js';
 import { NangoError } from '../utils/error.js';
 import { loggedFetch } from '../utils/http.js';
-import { productTracking } from '../utils/productTracking.js';
 import {
     extractStepNumber,
     extractValueByPath,
@@ -59,9 +58,7 @@ import type {
     DBConnectionDecrypted,
     DBEndUser,
     DBEnvironment,
-    DBPlan,
     DBTeam,
-    DBUser,
     JwtCredentials,
     MaybePromise,
     Metadata,
@@ -1271,40 +1268,6 @@ class ConnectionService {
 
             return { success: false, error, response: null };
         }
-    }
-
-    public async shouldCapUsage({
-        providerConfigKey,
-        environmentId,
-        type,
-        team,
-        user,
-        plan
-    }: {
-        providerConfigKey: string;
-        environmentId: number;
-        type: 'activate' | 'deploy';
-        team: DBTeam;
-        user?: DBUser;
-        plan: DBPlan | null;
-    }): Promise<boolean> {
-        if (!plan || !plan.connection_with_scripts_max) {
-            return false;
-        }
-
-        const count = await this.countConnections({ environmentId, providerConfigKey });
-
-        if (count > plan.connection_with_scripts_max) {
-            logger.info(`Reached cap for providerConfigKey: ${providerConfigKey} and environmentId: ${environmentId}`);
-            if (type === 'deploy') {
-                productTracking.track({ name: 'server:resource_capped:script_deploy_is_disabled', team, user });
-            } else {
-                productTracking.track({ name: 'server:resource_capped:script_activate', team, user });
-            }
-            return true;
-        }
-
-        return false;
     }
 
     public async getNewCredentials({

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -9,7 +9,6 @@ export const freePlan: PlanDefinition = {
     orbId: 'free',
     flags: {
         api_rate_limit_size: 'm',
-        connection_with_scripts_max: null,
         environments_max: 2,
         has_otel: false,
         has_sync_variants: false,
@@ -28,7 +27,6 @@ export const starterPlan: PlanDefinition = {
     canDowngrade: false,
     flags: {
         api_rate_limit_size: 'l',
-        connection_with_scripts_max: null,
         environments_max: 3,
         has_otel: false,
         has_sync_variants: true,
@@ -47,7 +45,6 @@ export const growthPlan: PlanDefinition = {
     orbId: 'growth',
     flags: {
         api_rate_limit_size: 'l',
-        connection_with_scripts_max: null,
         environments_max: 3,
         has_otel: false,
         has_sync_variants: true,
@@ -67,7 +64,6 @@ export const enterprisePlan: PlanDefinition = {
     orbId: 'enterprise',
     flags: {
         api_rate_limit_size: '2xl',
-        connection_with_scripts_max: null,
         environments_max: 10,
         has_otel: true,
         has_sync_variants: true,
@@ -87,7 +83,6 @@ export const starterLegacyPlan: PlanDefinition = {
     hidden: true,
     flags: {
         api_rate_limit_size: 'l',
-        connection_with_scripts_max: null,
         environments_max: 3,
         has_otel: false,
         has_sync_variants: true,
@@ -105,7 +100,6 @@ export const scaleLegacyPlan: PlanDefinition = {
     hidden: true,
     flags: {
         api_rate_limit_size: 'l',
-        connection_with_scripts_max: null,
         environments_max: 3,
         has_otel: false,
         has_sync_variants: true,
@@ -123,7 +117,6 @@ export const growthLegacyPlan: PlanDefinition = {
     hidden: true,
     flags: {
         api_rate_limit_size: 'l',
-        connection_with_scripts_max: null,
         environments_max: 3,
         has_otel: false,
         has_sync_variants: true,

--- a/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
@@ -11,7 +11,6 @@ import configService from '../../config.service.js';
 import environmentService from '../../environment.service.js';
 import * as SyncService from '../sync.service.js';
 import * as DeployConfigService from './deploy.service.js';
-import connectionService from '../../connection.service.js';
 
 import type { OrchestratorClientInterface } from '../../../clients/orchestrator.js';
 import type { CleanedIncomingFlowConfig, DBTeam } from '@nangohq/types';
@@ -50,7 +49,6 @@ describe('Sync config create', () => {
         const emptyConfig = await DeployConfigService.deploy({
             account,
             environment,
-            plan: null,
             flows: syncs,
             nangoYamlBody: '',
             logContextGetter,
@@ -91,7 +89,6 @@ describe('Sync config create', () => {
         const { error } = await DeployConfigService.deploy({
             account,
             environment,
-            plan: null,
             flows: syncs,
             nangoYamlBody: '',
             logContextGetter,
@@ -237,10 +234,6 @@ describe('Sync config create', () => {
             });
         });
 
-        vi.spyOn(connectionService, 'shouldCapUsage').mockImplementation(() => {
-            return Promise.resolve(false);
-        });
-
         vi.spyOn(SyncService, 'getSyncsByProviderConfigKey').mockImplementation(() => {
             return Promise.resolve([]);
         });
@@ -251,7 +244,6 @@ describe('Sync config create', () => {
             DeployConfigService.deploy({
                 environment,
                 account,
-                plan: null,
                 flows: syncs,
                 nangoYamlBody: '',
                 logContextGetter,

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -24,13 +24,6 @@ export interface DBPlan extends Timestamps {
     trial_expired: boolean | null;
 
     /**
-     * Limit the number of connections with active scripts
-     * Set to null to remove limit
-     * @default 3
-     */
-    connection_with_scripts_max: number | null;
-
-    /**
      * Limit the number of total non-deleted connections
      * Set to null to remove limit
      * @default null


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Contributes to https://linear.app/nango/issue/NAN-3610/create-new-caps and bigger goal https://linear.app/nango/issue/NAN-3382/explicit-caps-for-free-plans

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR removes the 'connection_with_scripts_max' cap, which previously limited the number of connections with active scripts per plan. It eliminates related code, types, checks, and database fields, streamlining cap logic to focus on total connection limits.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed 'connection_with_scripts_max' column from the database (new migration added).
• Deleted all code checks, logic, and tracking tied to 'connection_with_scripts_max' in backend services, controllers, hooks, and tests.
• Updated plan definitions, types, and seed data to remove references to the scripts cap.
• Refactored affected API controllers, deployment logic, and plan objects to only use the total connections cap.
• Modified tests and test helpers for compatibility with new cap logic.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Database (plans table, migration)
• Plans/type definitions and seeders
• Sync deployment, enable/disable, and deploy template controllers (backend APIs)
• Connection and plan logic/services
• Test suites for deployment and plans

</details>

*This summary was automatically generated by @propel-code-bot*