### PR TITLE
feat(jobs): network policies for kubernetes runners

### DIFF
--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -85,6 +85,7 @@ export const ENVS = z.object({
     RUNNER_PERSIST_MAX_SOCKET_MAX_LIFETIME_MS: z.coerce.number().optional().default(30_000),
     RUNNER_NAMESPACE: z.string().optional().default('nango'),
     NAMESPACE_PER_RUNNER: bool,
+    JOBS_NAMESPACE: z.string().optional().default('nango'),
 
     // FLEET
     RUNNERS_DATABASE_URL: z.string().url().optional(),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR introduces explicit management of Kubernetes NetworkPolicy resources for each runner namespace within the jobs runner system. Three core policies are created and cleaned up with each runner lifecycle: a default deny-all-ingress policy, an allow-ingress-from-nango policy, and an allow-egress-to-nango-and-internet policy. The jobs namespace for allowed sources is now configurable via the JOBS_NAMESPACE environment variable. Network policies are integrated into the runner creation and teardown flows to enforce fine-grained network security and isolation.

<details>
<summary><strong>Key Changes</strong></summary>

• Added Kubernetes.NetworkingV1Api usage to manage network policies.
• Implemented createNetworkPolicies() and deleteNetworkPolicies() methods for per-namespace policy creation and cleanup.
• Network policies are created after service/deployment during runner instantiation and deleted with runner teardown.
• Introduced JOBS_NAMESPACE environment variable with parsing support in environment/parse.ts.
• Error handling and log warnings in network policy operations.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/jobs/lib/runner/kubernetes.ts
• packages/utils/lib/environment/parse.ts
• Runner instantiation/termination lifecycle
• Pod-level security and network segmentation

</details>

*This summary was automatically generated by @propel-code-bot*