### PR TITLE
fix(zero): correctly support on-event execution

### DIFF
--- a/packages/jobs/lib/execution/onEvent.ts
+++ b/packages/jobs/lib/execution/onEvent.ts
@@ -70,7 +70,7 @@ export async function startOnEvent(task: TaskOnEvent): Promise<Result<void>> {
             models_json_schema: null,
             pre_built: false,
             sync_type: null,
-            sdk_version: null,
+            sdk_version: task.sdkVersion,
             created_at: new Date(),
             updated_at: new Date()
         };

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -45,6 +45,7 @@ interface OnEventArgs {
     version: string;
     fileLocation: string;
     activityLogId: string;
+    sdkVersion: string | null;
 }
 export type SchedulesReturn = Result<OrchestratorSchedule[]>;
 export type VoidReturn = Result<void, ClientError>;
@@ -234,6 +235,7 @@ export function TaskOnEvent(props: TaskCommonFields & OnEventArgs): TaskOnEvent 
         version: props.version,
         connection: props.connection,
         fileLocation: props.fileLocation,
+        sdkVersion: props.sdkVersion,
         activityLogId: props.activityLogId,
         groupKey: props.groupKey,
         groupMaxConcurrency: props.groupMaxConcurrency,

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -68,6 +68,7 @@ export const onEventArgsSchema = z.object({
     onEventName: z.string().min(1),
     version: z.string().min(1),
     fileLocation: z.string().min(1),
+    sdkVersion: z.string().nullable(),
     activityLogId: z.string(),
     ...commonSchemaArgsFields
 });
@@ -217,6 +218,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 ownerKey: onEvent.data.ownerKey,
                 retryKey: onEvent.data.retryKey,
                 fileLocation: onEvent.data.payload.fileLocation,
+                sdkVersion: onEvent.data.payload.sdkVersion,
                 activityLogId: onEvent.data.payload.activityLogId,
                 heartbeatTimeoutSecs: onEvent.data.heartbeatTimeoutSecs
             })

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -158,6 +158,24 @@ export async function exec({
                 return { success: true, response: output, error: null };
             }
 
+            // Action
+            if (nangoProps.scriptType === 'on-event') {
+                let output: unknown;
+                if (isZeroYaml) {
+                    const payload = def;
+                    if (payload.type !== 'onEvent') {
+                        throw new Error('Incorrect script loaded for action');
+                    }
+                    if (!payload.exec) {
+                        throw new Error(`Missing exec function`);
+                    }
+                    output = await payload.exec(nango as any);
+                } else {
+                    output = await def(nango);
+                }
+                return { success: true, response: output, error: null };
+            }
+
             // Sync
             if (isZeroYaml) {
                 const payload = def;

--- a/packages/server/lib/hooks/connection/on/connection-created.ts
+++ b/packages/server/lib/hooks/connection/on/connection-created.ts
@@ -44,15 +44,18 @@ export async function postConnectionCreation(
             }
         );
         logCtx.attachSpan(new OtlpSpan(logCtx.operation));
+
         const res = await getOrchestrator().triggerOnEventScript({
             accountId: account.id,
             connection: createdConnection.connection,
             version,
             name,
             fileLocation,
+            sdkVersion: script.sdk_version,
             async: true,
             logCtx
         });
+
         if (res.isErr()) {
             await logCtx.failed();
         }

--- a/packages/server/lib/hooks/connection/on/connection-deleted.ts
+++ b/packages/server/lib/hooks/connection/on/connection-deleted.ts
@@ -73,6 +73,7 @@ export async function preConnectionDeletion({
             version,
             name,
             fileLocation,
+            sdkVersion: script.sdk_version,
             async: false,
             logCtx
         });

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -370,6 +370,7 @@ export class Orchestrator {
         version,
         name,
         fileLocation,
+        sdkVersion,
         async,
         logCtx
     }: {
@@ -378,6 +379,7 @@ export class Orchestrator {
         version: string;
         name: string;
         fileLocation: string;
+        sdkVersion: string | null;
         async: boolean;
         logCtx: LogContext;
     }): Promise<Result<T, NangoError>> {
@@ -398,7 +400,7 @@ export class Orchestrator {
         try {
             const groupKey: TaskType = 'on-event';
             const executionId = `${groupKey}:environment:${connection.environment_id}:connection:${connection.id}:on-event-script:${name}:at:${new Date().toISOString()}:${uuid()}`;
-            const args = {
+            const args: ExecuteOnEventProps['args'] = {
                 onEventName: name,
                 connection: {
                     id: connection.id,
@@ -408,7 +410,8 @@ export class Orchestrator {
                 },
                 version,
                 activityLogId: logCtx.id,
-                fileLocation
+                fileLocation,
+                sdkVersion: sdkVersion
             };
             const result = await this.client.executeOnEvent({
                 name: executionId,


### PR DESCRIPTION
## Changes

- correctly support on-event execution
We were not passing sdkVersion, so we had no way to detect zero yaml, so the scripts were not loaded from the right path.

<!-- Summary by @propel-code-bot -->

---

This PR fixes an issue where zero YAML on-event scripts were not loaded from the correct path due to the absence of the sdkVersion property in orchestrator and execution flows. sdkVersion is now correctly propagated through task creation, validation, interfaces, orchestrator logic, and server event hooks to allow accurate resolution and execution of on-event scripts for both connection-created and connection-deleted events.

<details>
<summary><strong>Key Changes</strong></summary>

• Added sdkVersion field to orchestrator, job execution paths, and validation schemas for on-event execution.
• Modified types and function signatures (including OnEventArgs and relevant triggers) to accept sdkVersion.
• Patched runner/lib/exec.ts to properly dispatch on-event scripts based on sdkVersion when handling zero YAML.
• Updated server connection-created and connection-deleted hooks to pass sdkVersion to on-event triggers.
• Ensured sdkVersion flows into script config creation for accurate script type detection and execution.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• On-event orchestrator invocation and validation
• Job execution for onEvent tasks
• Script execution in runner (exec.ts)
• Server-side connection lifecycle event hooks
• Interface/type definitions relating to on-event execution

</details>

*This summary was automatically generated by @propel-code-bot*