### PR TITLE
feat: create new free-plan caps

### DIFF
--- a/packages/database/lib/migrations/20250716152123_add_new_caps.cjs
+++ b/packages/database/lib/migrations/20250716152123_add_new_caps.cjs
@@ -1,0 +1,17 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE plans ADD COLUMN monthly_actions_max INTEGER DEFAULT 1000;`);
+    await knex.raw(`ALTER TABLE plans ADD COLUMN monthly_active_records_max INTEGER DEFAULT 5000;`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.raw(`ALTER TABLE plans DROP COLUMN monthly_actions_max;`);
+    await knex.raw(`ALTER TABLE plans DROP COLUMN monthly_active_records_max;`);
+};

--- a/packages/shared/lib/seeders/plan.seeder.ts
+++ b/packages/shared/lib/seeders/plan.seeder.ts
@@ -19,6 +19,8 @@ export function getTestPlan(override?: Partial<DBPlan>): DBPlan {
         environments_max: 2,
         sync_frequency_secs_min: 60,
         connections_max: 1000,
+        monthly_actions_max: 1000,
+        monthly_active_records_max: 5000,
         has_sync_variants: false,
         has_otel: false,
         api_rate_limit_size: 'm',

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -15,7 +15,9 @@ export const freePlan: PlanDefinition = {
         connections_max: 10,
         name: 'free',
         sync_frequency_secs_min: 3600,
-        auto_idle: true
+        auto_idle: true,
+        monthly_actions_max: 1000,
+        monthly_active_records_max: 5000
     }
 };
 
@@ -32,7 +34,9 @@ export const starterPlan: PlanDefinition = {
         has_sync_variants: true,
         name: 'starter',
         sync_frequency_secs_min: 30,
-        auto_idle: false
+        auto_idle: false,
+        monthly_actions_max: null,
+        monthly_active_records_max: null
     }
 };
 
@@ -50,7 +54,9 @@ export const growthPlan: PlanDefinition = {
         has_sync_variants: true,
         name: 'growth',
         sync_frequency_secs_min: 30,
-        auto_idle: false
+        auto_idle: false,
+        monthly_actions_max: null,
+        monthly_active_records_max: null
     }
 };
 
@@ -69,7 +75,9 @@ export const enterprisePlan: PlanDefinition = {
         has_sync_variants: true,
         name: 'enterprise',
         sync_frequency_secs_min: 30,
-        auto_idle: false
+        auto_idle: false,
+        monthly_actions_max: null,
+        monthly_active_records_max: null
     }
 };
 
@@ -88,7 +96,9 @@ export const starterLegacyPlan: PlanDefinition = {
         has_sync_variants: true,
         name: 'starter-legacy',
         sync_frequency_secs_min: 30,
-        auto_idle: false
+        auto_idle: false,
+        monthly_actions_max: null,
+        monthly_active_records_max: null
     }
 };
 export const scaleLegacyPlan: PlanDefinition = {
@@ -105,7 +115,9 @@ export const scaleLegacyPlan: PlanDefinition = {
         has_sync_variants: true,
         name: 'scale-legacy',
         sync_frequency_secs_min: 30,
-        auto_idle: false
+        auto_idle: false,
+        monthly_actions_max: null,
+        monthly_active_records_max: null
     }
 };
 export const growthLegacyPlan: PlanDefinition = {
@@ -122,7 +134,9 @@ export const growthLegacyPlan: PlanDefinition = {
         has_sync_variants: true,
         name: 'growth-legacy',
         sync_frequency_secs_min: 30,
-        auto_idle: false
+        auto_idle: false,
+        monthly_actions_max: null,
+        monthly_active_records_max: null
     }
 };
 

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -37,6 +37,18 @@ export interface DBPlan extends Timestamps {
     environments_max: number;
 
     /**
+     * Limit the number of actions that can be triggered in a month
+     * @default 1000
+     */
+    monthly_actions_max: number | null;
+
+    /**
+     * Limit the amount of monthly active records (Records created or updated in a month)
+     * @default 5000
+     */
+    monthly_active_records_max: number | null;
+
+    /**
      * Limit the minimum frequency of a sync
      * Not used yet
      * @default 86400


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Not used anywhere yet.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR adds two new capability fields, `monthly_actions_max` and `monthly_active_records_max`, to all plan definitions, assigns default values to the 'free' plan, and sets them to null for others. It updates the database schema by introducing corresponding fields with defaults through a migration, and extends TypeScript interfaces and seeders to include/document these fields; however, this logic is not yet used in application flows.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `monthly_actions_max` and `monthly_active_records_max` (default 1000 and 5000 on 'free', null for others) to all plan definitions
• Introduced a migration that adds `monthly_actions_max` and `monthly_active_records_max` columns to the 'plans' table (with defaults)
• Updated the DBPlan TypeScript interface and seeder utility to include/document the new fields

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Plan definitions (packages/shared/lib/services/plans/definitions.ts)
• Database schema and migrations
• TypeScript DBPlan interface (packages/types/lib/plans/db.ts)
• Test plan seeder

</details>

*This summary was automatically generated by @propel-code-bot*