### PR TITLE
fix(kvstore): add incr methods 

### DIFF
--- a/packages/kvstore/lib/InMemoryStore.ts
+++ b/packages/kvstore/lib/InMemoryStore.ts
@@ -73,10 +73,10 @@ export class InMemoryKVStore implements KVStore {
 
     public incr(key: string, opts?: { ttlInMs?: number }) {
         const res = this.store.get(key);
-        if (res === undefined) {
-            this.store.set(key, { value: '1', timestamp: Date.now(), ttlInMs: opts?.ttlInMs || 0 });
-            return 1;
-        }
-        return Number(res.value) + 1;
+
+        const nextVal = res ? String(parseInt(res.value, 10) + 1) : '1';
+        this.store.set(key, { value: nextVal, timestamp: Date.now(), ttlInMs: opts?.ttlInMs || 0 });
+
+        return Number(nextVal);
     }
 }

--- a/packages/kvstore/lib/InMemoryStore.ts
+++ b/packages/kvstore/lib/InMemoryStore.ts
@@ -70,4 +70,13 @@ export class InMemoryKVStore implements KVStore {
         }
         this.interval = setTimeout(() => this.clearExpired(), KVSTORE_INTERVAL_CLEANUP);
     }
+
+    public incr(key: string, opts?: { ttlInMs?: number }) {
+        const res = this.store.get(key);
+        if (res === undefined) {
+            this.store.set(key, { value: '1', timestamp: Date.now(), ttlInMs: opts?.ttlInMs || 0 });
+            return 1;
+        }
+        return Number(res.value) + 1;
+    }
 }

--- a/packages/kvstore/lib/KVStore.ts
+++ b/packages/kvstore/lib/KVStore.ts
@@ -6,4 +6,5 @@ export interface KVStore {
     get(key: string): Promise<string | null>;
     delete(key: string): Promise<void>;
     exists(key: string): Promise<boolean>;
+    incr(key: string, opts?: { ttlInMs?: number }): MaybePromise<number>;
 }

--- a/packages/kvstore/lib/RedisStore.ts
+++ b/packages/kvstore/lib/RedisStore.ts
@@ -39,4 +39,14 @@ export class RedisKVStore implements KVStore {
     public async delete(key: string): Promise<void> {
         await this.client.del(key);
     }
+
+    public async incr(key: string, opts?: { ttlInMs?: number }): Promise<number> {
+        const multi = this.client.multi();
+        multi.incrBy(key, 1);
+        if (opts?.ttlInMs) {
+            multi.pExpire(key, opts.ttlInMs);
+        }
+        const [count] = await multi.exec();
+        return count as number;
+    }
 }

--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -45,7 +45,7 @@ export async function destroy() {
     }
 }
 
-async function createKVStore() {
+async function createKVStore(): Promise<KVStore> {
     const url = process.env['NANGO_REDIS_URL'];
     if (url) {
         const store = new RedisKVStore(await getRedis(url));


### PR DESCRIPTION
## Changes

- add incr methods 
Barely tested, but it's going to be useful for multiple projects so committing that early

e.g: incrementing a daily key for an account, with a self destruction after a day:
```ts
kvstore.incr('logs-<accountId>-2025-07-17', { ttl: 86400 });
```
NB: because TTL is set every time you increment a key, the key will actually live twice as long, so if it's a monthly key, it will survive 60d. I don't think it's a big issue tbh, but happy to get a better implementation

<!-- Summary by @propel-code-bot -->

---

This PR introduces a new incr method to the KVStore interface, enabling atomic increment operations with optional TTL (time-to-live) support. Implementations for both RedisKVStore and InMemoryKVStore are provided, and the type signature in the KVStore factory is made explicit.

<details>
<summary><strong>Key Changes</strong></summary>

• Added incr(key, opts) method to KVStore interface, with optional TTL
• Implemented incr in RedisKVStore using Redis multi/incrBy and pExpire
• Implemented incr in InMemoryKVStore with internal TTL tracking
• Updated createKVStore factory to explicitly return Promise<KVStore>

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• KVStore interface
• RedisKVStore implementation
• InMemoryKVStore implementation
• kvstore factory typing

</details>

*This summary was automatically generated by @propel-code-bot*