### PR TITLE
fix(billing): correctly compute initial base fee

### DIFF
--- a/packages/billing/lib/billing.ts
+++ b/packages/billing/lib/billing.ts
@@ -119,7 +119,7 @@ export class Billing {
         return await this.client.getUsage(subscriptionId, period);
     }
 
-    async upgrade(opts: { subscriptionId: string; planExternalId: string }): Promise<Result<{ pendingChangeId: string; amount: string | null }>> {
+    async upgrade(opts: { subscriptionId: string; planExternalId: string }): Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>> {
         return await this.client.upgrade(opts);
     }
 

--- a/packages/billing/lib/clients/orb.ts
+++ b/packages/billing/lib/clients/orb.ts
@@ -149,7 +149,7 @@ export class OrbClient implements BillingClient {
         }
     }
 
-    async upgrade(opts: { subscriptionId: string; planExternalId: string }): Promise<Result<{ pendingChangeId: string; amount: string | null }>> {
+    async upgrade(opts: { subscriptionId: string; planExternalId: string }): Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>> {
         try {
             // We schedule the upgrade but we don't apply it yet
             // We apply it when the first payment is made to confirm the card
@@ -163,10 +163,28 @@ export class OrbClient implements BillingClient {
                 { headers: { 'Create-Pending-Subscription-Change': 'true' } }
             );
 
+            // Invoices created are ordered by due date
+            // The first one is the pending one (if there was one) and the second is what we will charge
+            // Since the order and numbers are unreliable, we need to find the one that is due today
+            let amountDue = 0;
+            for (const invoice of pendingUpgrade.changed_resources?.created_invoices || []) {
+                if (!invoice.due_date) {
+                    continue;
+                }
+                if (new Date(invoice.due_date).getTime() > Date.now()) {
+                    continue;
+                }
+                if (invoice.amount_due === '0.00') {
+                    continue;
+                }
+                amountDue = Number(invoice.amount_due) * 100;
+                break;
+            }
+
             return Ok({
                 pendingChangeId: pendingUpgrade.pending_subscription_change!.id,
                 // We return the amount due for the first invoice, it's the pending one that contains the pro-rated amount if any
-                amount: pendingUpgrade.changed_resources?.created_invoices[0]?.amount_due || null
+                amountInCents: amountDue || null
             });
         } catch (err) {
             return Err(new Error('failed_to_upgrade_customer', { cause: err }));

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -10,7 +10,7 @@ export interface BillingClient {
     getSubscription: (accountId: number) => Promise<Result<BillingSubscription | null>>;
     createSubscription: (team: DBTeam, planExternalId: string) => Promise<Result<BillingSubscription>>;
     getUsage: (subscriptionId: string, period?: 'previous') => Promise<Result<BillingUsageMetric[]>>;
-    upgrade: (opts: { subscriptionId: string; planExternalId: string }) => Promise<Result<{ pendingChangeId: string; amount: string | null }>>;
+    upgrade: (opts: { subscriptionId: string; planExternalId: string }) => Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>>;
     downgrade: (opts: { subscriptionId: string; planExternalId: string }) => Promise<Result<void>>;
     applyPendingChanges: (opts: {
         pendingChangeId: string;


### PR DESCRIPTION
## Changes

- Correctly compute the initial base fee
I had mostly tested one main scenario, but turns out sometimes we don't get the future invoices in the same order, leading to an incorrect `amount_due`.

- Add more log for debugging and traceability 
<!-- Summary by @propel-code-bot -->

---

This PR improves the billing system by correctly computing the initial base fee during subscription upgrades using Orb. It addresses a bug where invoices were sometimes processed in an unexpected order, leading to incorrect amount calculations, and enhances traceability by adding more logging for upgrade and downgrade flows.

<details>
<summary><strong>Key Changes</strong></summary>

• Revised the logic in `OrbClient.upgrade` to reliably determine the correct invoice for the initial base fee using due date and value checks.
• Changed the billing upgrade return value from `amount` (string) to `amountInCents` (number) with updates propagated to corresponding method signatures and usages.
• Enhanced error handling on plan changes by logging and immediately returning 500 on server errors.
• Integrated detailed logging throughout the plan change controller for both upgrades and downgrades.
• Improved type safety and return types in `@nangohq/types` and aligned interface signatures accordingly.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Billing client integration with Orb (`packages/billing/lib/clients/orb.ts`)
• Billing logic and interface (`packages/billing/lib/billing.ts`, `packages/types/lib/billing/types.ts`)
• Plan change controller endpoint (`packages/server/lib/controllers/v1/plans/change/postChange.ts`)

</details>

*This summary was automatically generated by @propel-code-bot*