### PR TITLE
fix(cli): replace depreciated endpoint

### DIFF
--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -236,7 +236,7 @@ export class DryRunService {
         }
 
         const {
-            config: { provider }
+            data: { name: provider }
         } = await getConfig(providerConfigKey, debug);
         if (!provider) {
             console.log(chalk.red('Provider not found'));

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -201,7 +201,7 @@ export async function getConnection(
 }
 
 export async function getConfig(providerConfigKey: string, debug = false) {
-    const url = process.env['NANGO_HOSTPORT'] + `/config/${providerConfigKey}`;
+    const url = process.env['NANGO_HOSTPORT'] + `/providers/${providerConfigKey}`;
     const headers = enrichHeaders();
     if (debug) {
         printDebug(`getConfig endpoint to the URL: ${url} with headers: ${JSON.stringify(headers, null, 2)}`);


### PR DESCRIPTION
## Describe the problem and your solution

-  Replace usage of a deprecated endpoint with the new current version

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR replaces usage of the deprecated `/config/{providerConfigKey}` endpoint with the updated `/providers/{providerConfigKey}` endpoint in the CLI codebase. The change affects two files to ensure the CLI interacts with the correct API version.

*This summary was automatically generated by @propel-code-bot*