### PR TITLE
fix(webhook > metric): add breakdown per customer

### DIFF
--- a/packages/webhooks/lib/forward.ts
+++ b/packages/webhooks/lib/forward.ts
@@ -68,10 +68,10 @@ export const forwardWebhook = async ({
         });
 
         if (result.isOk()) {
-            metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_SUCCESS);
+            metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_SUCCESS, 1, { accountId: account.id });
             await logCtx.success();
         } else {
-            metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_FAILED);
+            metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_FAILED, 1, { accountId: account.id });
             await logCtx.failed();
         }
 
@@ -93,9 +93,9 @@ export const forwardWebhook = async ({
         });
 
         if (result.isOk()) {
-            metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_SUCCESS);
+            metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_SUCCESS, 1, { accountId: account.id });
         } else {
-            metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_FAILED);
+            metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_FAILED, 1, { accountId: account.id });
             success = false;
         }
     }


### PR DESCRIPTION
## Changes

- add breakdown per customer

<!-- Summary by @propel-code-bot -->

---

This PR modifies the webhook forwarding logic to increment success and failure metrics with an additional breakdown per customer by including the accountId in the metrics tracking. Both single and multiple connection webhook delivery paths now record metrics per account, allowing for more granular tracking of webhook events.

*This summary was automatically generated by @propel-code-bot*