### PR TITLE
fix: allow orchestrator db to support ssl

### DIFF
--- a/packages/scheduler/lib/db/client.ts
+++ b/packages/scheduler/lib/db/client.ts
@@ -24,6 +24,7 @@ export class DatabaseClient {
             client: 'postgres',
             connection: {
                 connectionString: url,
+                ssl: envs.ORCHESTRATOR_DB_SSL ? { rejectUnauthorized: false } : false,
                 statement_timeout: 60000,
                 application_name: process.env['NANGO_DB_APPLICATION_NAME'] || '[unknown]'
             },

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -62,6 +62,7 @@ export const ENVS = z.object({
     ORCHESTRATOR_CLEANING_TICK_INTERVAL_MS: z.coerce.number().optional().default(10000),
     ORCHESTRATOR_CLEANING_OLDER_THAN_DAYS: z.coerce.number().optional().default(5),
     ORCHESTRATOR_SCHEDULING_TICK_INTERVAL_MS: z.coerce.number().optional().default(100),
+    ORCHESTRATOR_DB_SSL: z.stringbool().optional().default(false),
 
     // Jobs
     JOBS_SERVICE_URL: z.url().optional().default('http://localhost:3005'),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR adds SSL support to the orchestrator's Postgres database connectivity by introducing an `ORCHESTRATOR_DB_SSL` environment variable. The environment parsing and database client setup have been updated to parse this value and use it when initializing the connection, with `rejectUnauthorized: false` for SSL connections for now to match existing behavior.

*This summary was automatically generated by @propel-code-bot*