### PR TITLE
fix: allow SSL for records database

### DIFF
--- a/packages/records/lib/db/config.ts
+++ b/packages/records/lib/db/config.ts
@@ -15,6 +15,7 @@ const config: Knex.Config = {
     connection: {
         connectionString: databaseUrl,
         statement_timeout: 60000,
+        ssl: envs.RECORDS_DATABASE_SSL ? { rejectUnauthorized: false } : false,
         application_name: process.env['NANGO_DB_APPLICATION_NAME'] || '[unknown]'
     },
     searchPath: schema,

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -210,6 +210,7 @@ export const ENVS = z.object({
     RECORDS_DATABASE_URL: z.url().optional(),
     RECORDS_DATABASE_READ_URL: z.url().optional(),
     RECORDS_DATABASE_SCHEMA: z.string().optional().default('nango_records'),
+    RECORDS_DATABASE_SSL: z.stringbool().optional().default(false),
 
     // Redis
     NANGO_REDIS_URL: z.url().optional(),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR adds configuration to support SSL connections for the records PostgreSQL database. It introduces a new environment variable (RECORDS_DATABASE_SSL) and updates the database config to use SSL if enabled.

*This summary was automatically generated by @propel-code-bot*