### PR TITLE
fix: temporarily add model_schema back to /scripts/config

### DIFF
--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -778,6 +778,17 @@ paths:
                                                     type: array
                                                     items:
                                                         type: string
+                                                models:
+                                                    type: array
+                                                    items:
+                                                        type: object
+                                                        properties:
+                                                            name:
+                                                                type: string
+                                                            fields:
+                                                                type: array
+                                                        required:
+                                                            - name
                                     actions:
                                         type: array
                                         items:
@@ -821,6 +832,17 @@ paths:
                                                     type: array
                                                     items:
                                                         type: object
+                                                models:
+                                                    type: array
+                                                    items:
+                                                        type: object
+                                                        properties:
+                                                            name:
+                                                                type: string
+                                                            fields:
+                                                                type: array
+                                                        required:
+                                                            - name
                                     on-events:
                                         type: array
                                         items:

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
@@ -188,7 +188,12 @@ describe(`POST ${endpoint}`, () => {
                                     },
                                     Ref: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'], additionalProperties: false }
                                 }
-                            }
+                            },
+                            models: [
+                                { name: 'Output', fields: [] },
+                                { name: 'Ref', fields: [] },
+                                { name: 'Input', fields: [] }
+                            ]
                         }
                     ]
                 }

--- a/packages/types/lib/flow/index.ts
+++ b/packages/types/lib/flow/index.ts
@@ -1,5 +1,5 @@
-import type { NangoConfigMetadata } from '../deploy/incomingFlow.js';
-import type { NangoSyncEndpointV2, ScriptTypeLiteral, SyncTypeLiteral } from '../nangoYaml/index.js';
+import type { LegacySyncModelSchema, NangoConfigMetadata } from '../deploy/incomingFlow.js';
+import type { NangoModel, NangoSyncEndpointV2, ScriptTypeLiteral, SyncTypeLiteral } from '../nangoYaml/index.js';
 import type { JSONSchema7 } from 'json-schema';
 
 // TODO: Split by type
@@ -28,6 +28,8 @@ export interface NangoSyncConfig {
     upgrade_version?: string;
     is_zero_yaml: boolean;
     sdk_version: string | null;
+    // Temporary regression
+    models?: NangoModel[] | LegacySyncModelSchema[] | undefined;
 }
 
 export interface StandardNangoConfig {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR temporarily reintroduces the legacy `model_schema` as the `models` property in the `/scripts/config` endpoint to facilitate customer migrations. The change updates TypeScript types, runtime objects, YAML spec, and integration tests to support and expose this property in the API response, ensuring that older clients can continue accessing expected data formats.

<details>
<summary><strong>Key Changes</strong></summary>

• Restores the `models` property (based on the legacy `model_schema`) in StandardNangoConfig and config service runtime responses.
• Implements a helper function (`modelsFromJsonSchema`) to extract model names from JSON schema if `model_schema` is unavailable.
• Extends TypeScript types to include the legacy model support.
• Updates OpenAPI spec (spec.yaml) and an integration test to reflect and check the reintroduced `models` property.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• OpenAPI spec definition (`docs-v2/spec.yaml`)
• Config service logic (`packages/shared/lib/services/sync/config/config.service.ts`)
• Type definitions (`packages/types/lib/flow/index.ts`)
• Integration tests (`packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts`)

</details>

*This summary was automatically generated by @propel-code-bot*