### PR TITLE
fix(plans): add webhooks flags

### DIFF
--- a/packages/database/lib/migrations/20250724174012_plans_flags_webhooks.cjs
+++ b/packages/database/lib/migrations/20250724174012_plans_flags_webhooks.cjs
@@ -1,0 +1,15 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE "plans"
+ADD COLUMN "has_webhooks_script" bool DEFAULT 'false',
+ADD COLUMN "has_webhooks_forward" bool DEFAULT 'false'`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};

--- a/packages/shared/lib/seeders/plan.seeder.ts
+++ b/packages/shared/lib/seeders/plan.seeder.ts
@@ -25,6 +25,8 @@ export function getTestPlan(override?: Partial<DBPlan>): DBPlan {
         has_otel: false,
         api_rate_limit_size: 'm',
         auto_idle: true,
+        has_webhooks_script: false,
+        has_webhooks_forward: false,
         created_at: new Date(),
         updated_at: new Date(),
         ...override

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -19,7 +19,9 @@ export const freePlan: PlanDefinition = {
         sync_frequency_secs_min: 3600,
         auto_idle: true,
         monthly_actions_max: 1000,
-        monthly_active_records_max: 5000
+        monthly_active_records_max: 5000,
+        has_webhooks_script: false,
+        has_webhooks_forward: false
     },
     display: {
         features: [
@@ -60,7 +62,9 @@ export const starterPlan: PlanDefinition = {
         trial_end_at: null,
         trial_end_notified_at: null,
         trial_extension_count: 0,
-        trial_expired: null
+        trial_expired: null,
+        has_webhooks_script: false,
+        has_webhooks_forward: false
     },
     display: {
         featuresHeading: 'Everything in Free, plus:',
@@ -98,7 +102,9 @@ export const growthPlan: PlanDefinition = {
         trial_end_at: null,
         trial_end_notified_at: null,
         trial_extension_count: 0,
-        trial_expired: null
+        trial_expired: null,
+        has_webhooks_script: true,
+        has_webhooks_forward: true
     },
     display: {
         featuresHeading: 'Everything in Starter, plus:',
@@ -138,7 +144,9 @@ export const enterprisePlan: PlanDefinition = {
         trial_end_at: null,
         trial_end_notified_at: null,
         trial_extension_count: 0,
-        trial_expired: null
+        trial_expired: null,
+        has_webhooks_script: true,
+        has_webhooks_forward: true
     },
     display: {
         features: [{ title: 'Custom usage' }, { title: 'Unlimited environments' }, { title: 'Self-hosting' }, { title: 'SAML SSO' }, { title: 'SLAs' }]
@@ -169,7 +177,9 @@ export const starterLegacyPlan: PlanDefinition = {
         trial_end_at: null,
         trial_end_notified_at: null,
         trial_extension_count: 0,
-        trial_expired: null
+        trial_expired: null,
+        has_webhooks_script: true,
+        has_webhooks_forward: true
     }
 };
 export const scaleLegacyPlan: PlanDefinition = {
@@ -195,7 +205,9 @@ export const scaleLegacyPlan: PlanDefinition = {
         trial_end_at: null,
         trial_end_notified_at: null,
         trial_extension_count: 0,
-        trial_expired: null
+        trial_expired: null,
+        has_webhooks_script: true,
+        has_webhooks_forward: true
     }
 };
 export const growthLegacyPlan: PlanDefinition = {
@@ -221,7 +233,9 @@ export const growthLegacyPlan: PlanDefinition = {
         trial_end_at: null,
         trial_end_notified_at: null,
         trial_extension_count: 0,
-        trial_expired: null
+        trial_expired: null,
+        has_webhooks_script: true,
+        has_webhooks_forward: true
     }
 };
 

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -78,4 +78,16 @@ export interface DBPlan extends Timestamps {
      * @default true
      */
     auto_idle: boolean;
+
+    /**
+     * Enable or disable webhooks script
+     * @default false
+     */
+    has_webhooks_script: boolean;
+
+    /**
+     * Enable or disable webhooks forward
+     * @default false
+     */
+    has_webhooks_forward: boolean;
 }


### PR DESCRIPTION
## Changes

- Add webhooks flags
not used
<!-- Summary by @propel-code-bot -->

---

This PR introduces two new boolean flags, `has_webhooks_script` and `has_webhooks_forward`, to the plan definitions, corresponding type definitions, plan seeder utility, and the database schema via a migration. The flags are initialized per plan, documented in types, included with default values in seeders, and added as new fields in the `plans` table with default values of `false`.

*This summary was automatically generated by @propel-code-bot*