### PR TITLE
fix(sync): disallow incremental and trackDeletes

### DIFF
--- a/packages/cli/lib/zeroYaml/definitions.ts
+++ b/packages/cli/lib/zeroYaml/definitions.ts
@@ -11,7 +11,8 @@ import {
     DuplicateModelDefinitionError,
     EndpointMismatchDefinitionError,
     InvalidIntervalDefinitionError,
-    InvalidModelDefinitionError
+    InvalidModelDefinitionError,
+    TrackDeletesDefinitionError
 } from './utils.js';
 
 import type { CreateActionResponse, CreateOnEventResponse, CreateSyncResponse } from '@nangohq/runner-sdk';
@@ -151,6 +152,9 @@ export function buildSync({
     }
     if (Object.keys(params.models).length !== params.endpoints.length) {
         return Err(new EndpointMismatchDefinitionError(filePath, ['createSync', 'endpoints']));
+    }
+    if (params.syncType === 'incremental' && params.trackDeletes) {
+        return Err(new TrackDeletesDefinitionError(filePath, ['createSync', 'trackDeletes']));
     }
 
     const seen = new Set();

--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -370,7 +370,11 @@ async function postConfirmation({ body }: { body: PostDeployConfirmation['Body']
 
         const json = (await res.json()) as PostDeployConfirmation['Reply'];
         if ('error' in json) {
-            return Err(new Error(`Error checking state:\n${json.error.message} ${chalk.gray(`(${json.error.code})`)}`));
+            return Err(
+                new Error(
+                    `Error checking state:\n${json.error.message || 'Error'} ${chalk.gray(`(${json.error.code})`)}${json.error.errors ? `\n${json.error.errors.map((e) => `- ${e.message}`).join('\n')}` : ''}`
+                )
+            );
         }
 
         return Ok(json);

--- a/packages/cli/lib/zeroYaml/utils.ts
+++ b/packages/cli/lib/zeroYaml/utils.ts
@@ -118,3 +118,9 @@ export class DuplicateModelDefinitionError extends DefinitionError {
         super(`Model "${modelName}" is defined multiple times. Please make sure all models are unique per integration.`, filePath, property);
     }
 }
+
+export class TrackDeletesDefinitionError extends DefinitionError {
+    constructor(filePath: string, property: string[]) {
+        super(`Track deletes is not supported for incremental syncs`, filePath, property);
+    }
+}

--- a/packages/server/lib/controllers/sync/deploy/validation.ts
+++ b/packages/server/lib/controllers/sync/deploy/validation.ts
@@ -83,6 +83,10 @@ export const flowConfig = z
         sync_type: z.enum(['incremental', 'full']).optional(),
         webhookSubscriptions: z.array(z.string().max(255)).optional()
     })
+    .refine((data) => data.sync_type === 'incremental' && data.track_deletes, {
+        message: 'Track deletes is not supported for incremental syncs',
+        path: ['track_deletes']
+    })
     .strict();
 const flowConfigs = z.array(flowConfig);
 const onEventScriptsByProvider = z.array(

--- a/packages/server/lib/controllers/sync/deploy/validation.ts
+++ b/packages/server/lib/controllers/sync/deploy/validation.ts
@@ -83,10 +83,15 @@ export const flowConfig = z
         sync_type: z.enum(['incremental', 'full']).optional(),
         webhookSubscriptions: z.array(z.string().max(255)).optional()
     })
-    .refine((data) => data.sync_type === 'incremental' && data.track_deletes, {
-        message: 'Track deletes is not supported for incremental syncs',
-        path: ['track_deletes']
-    })
+    .refine(
+        (data) => {
+            if (data.sync_type === 'incremental' && data.track_deletes) {
+                return false;
+            }
+            return true;
+        },
+        { message: 'Track deletes is not supported for incremental syncs', path: ['track_deletes'] }
+    )
     .strict();
 const flowConfigs = z.array(flowConfig);
 const onEventScriptsByProvider = z.array(

--- a/packages/types/lib/api.ts
+++ b/packages/types/lib/api.ts
@@ -1,4 +1,4 @@
-export interface ApiError<TCode extends string, TErrors = any, TPayload = unknown> {
+export interface ApiError<TCode extends string, TErrors = Error[] | ValidationError[] | undefined, TPayload = unknown> {
     error: {
         code: TCode;
         message?: string | undefined;


### PR DESCRIPTION
## Changes

- disallow incremental and trackDeletes
It's going to be easier to prevent errors like this than documentation

<img width="612" height="215" alt="Screenshot 2025-07-25 at 10 40 32" src="https://github.com/user-attachments/assets/4ca8b22c-81b4-45f5-b1bd-292f3a292690" />

<!-- Summary by @propel-code-bot -->

---

This PR introduces validation at both the server- and CLI-level to explicitly prevent the unsupported configuration where a sync uses both 'incremental' sync_type and the 'trackDeletes' option. A new TrackDeletesDefinitionError is added for clear error reporting, and deploy error messages are improved to display all validation errors. API error type definitions were also updated to handle structured error payloads more robustly.

<details>
<summary><strong>Key Changes</strong></summary>

• Added Zod .refine() validation in server sync definition to block 'incremental' + 'trackDeletes' combination
• Introduced TrackDeletesDefinitionError for use in CLI validation
• Inserted checks in CLI build logic to enforce the new rule before script definition is accepted
• Enhanced deploy error handler to show all validation error messages to users
• Updated ApiError typings to support multiple errors in the payload

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Server sync config validation (validation.ts)
• CLI YAML sync definition/build (definitions.ts, utils.ts)
• CLI deploy confirmation and error reporting (deploy.ts)
• Type definitions for API errors (types/lib/api.ts)

</details>

*This summary was automatically generated by @propel-code-bot*