### PR TITLE
fix(refresh): fix github app refresh

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1016,7 +1016,7 @@ class ConnectionService {
             });
 
             if (appResult.isErr()) {
-                return Err(new NangoError('github_app_token_fetch_error'));
+                return Err(appResult.error);
             }
 
             return Ok(appResult.value);

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1008,6 +1008,20 @@ class ConnectionService {
         connection: DBConnectionDecrypted,
         logCtx: LogContextStateless
     ): Promise<Result<CombinedOauth2AppCredentials | AppCredentials, AuthCredentialsError>> {
+        if (provider.auth_mode === 'APP') {
+            const appResult = await githubAppClient.createCredentials({
+                integration: config,
+                provider: provider as ProviderGithubApp,
+                connectionConfig: connection.connection_config
+            });
+
+            if (appResult.isErr()) {
+                return Err(new NangoError('github_app_token_fetch_error'));
+            }
+
+            return Ok(appResult.value);
+        }
+
         const [userResult, appResult] = await Promise.all([
             getFreshOAuth2Credentials({
                 connection,


### PR DESCRIPTION
## Describe the problem and your solution

- Fix refresh for Github App

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the refreshGithubAppCredentials logic in connection.service.ts to properly handle providers using the 'APP' auth_mode. When the provider uses 'APP' auth, the method now directly calls the GitHub App credential creation flow, bypassing unnecessary parallel refresh attempts and providing improved error handling that forwards underlying error details.

*This summary was automatically generated by @propel-code-bot*