### PR TITLE
fix(script): support array of objects in exports

### DIFF
--- a/packages/cli/fixtures/nango-yaml/v2/advanced-syntax/nango.yaml
+++ b/packages/cli/fixtures/nango-yaml/v2/advanced-syntax/nango.yaml
@@ -19,6 +19,11 @@ models:
             - Ref
             - true
         literal: hello
+        test:
+            - foo: bar
+              id: number
+            - bar: foo
+              id: number
         num: 1
         literalNull: null[]
         obj:

--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -16,6 +16,8 @@ export interface Foo {
 export interface Bar {
   value: null;
   top: boolean[];
+  arrayOfModel: Foo[];
+  arrayOfObject: ({  nes: 'ted';})[];
   ref?: Foo | undefined;
   union: 'literal1' | 'literal2';
   array: ('arr1' | 'arr2')[];
@@ -23,9 +25,7 @@ export interface Bar {
 };
 
 export type Anonymous_unauthenticated_action_returnType_input = number
-// ------ /Models
-
-// ------ SDK"
+// ------ /Models"
 `;
 
 exports[`buildModelTs > should return empty (with sdk) 1`] = `
@@ -490,6 +490,9 @@ export interface Base {
   unions: string | null | Ref | true[] | Ref2[];
   arrUnion: (Ref | true)[];
   literal: 'hello';
+  test: ({  foo: 'bar';
+  id: number;} | {  bar: 'foo';
+  id: number;})[];
   num: 1;
   literalNull: null[];
   obj: {  nested: string;};

--- a/packages/cli/lib/services/model.service.ts
+++ b/packages/cli/lib/services/model.service.ts
@@ -142,10 +142,16 @@ export function fieldToTypescript({ field }: { field: NangoModelField }): string
     if (Array.isArray(field.value)) {
         if (field.union) {
             output = field.value.map((f) => fieldToTypescript({ field: f })).join(' | ');
-        } else if (field.array) {
-            output = `(${field.value.map((f) => fieldToTypescript({ field: f })).join(' | ')})[]`;
         } else {
-            output = `{${fieldsToTypescript({ fields: field.value }).join('\n')}}`;
+            if (!field.tsType && field.array) {
+                output = field.value.map((f) => fieldToTypescript({ field: f })).join(' | ');
+            } else {
+                // Due to bad decision an object is an array of values without any other flag
+                output = `{${fieldsToTypescript({ fields: field.value }).join('\n')}}`;
+            }
+            if (field.array) {
+                output = `(${output})[]`;
+            }
         }
     } else if (field.model || field.tsType) {
         output = `${field.value}${field.array ? '[]' : ''}`;

--- a/packages/cli/lib/services/model.service.unit.test.ts
+++ b/packages/cli/lib/services/model.service.unit.test.ts
@@ -30,6 +30,8 @@ describe('buildModelTs', () => {
                 fields: [
                     { name: 'value', value: null, tsType: true },
                     { name: 'top', value: 'boolean', tsType: true, array: true },
+                    { name: 'arrayOfModel', value: 'Foo', tsType: false, array: true, model: true },
+                    { name: 'arrayOfObject', value: [{ name: 'nes', value: 'ted' }], tsType: true, array: true },
                     { name: 'ref', value: 'Foo', tsType: false, model: true, optional: true },
                     {
                         name: 'union',

--- a/packages/cli/lib/zeroYaml/zodToNango.ts
+++ b/packages/cli/lib/zeroYaml/zodToNango.ts
@@ -43,8 +43,11 @@ export function zodToNangoModelField(name: string, schema: z.core.$ZodType): Nan
         return { name, value: [{ ...zodToNangoModelField('__string', schema.def.valueType), dynamic: true }], optional };
     } else if (isZodArray(schema)) {
         // console.log('array', schema.def);
-        const value = zodToNangoModelField('0', schema.def.element).value;
-        return { name, value, tsType: true, array: true, optional };
+        const value = zodToNangoModelField('0', schema.def.element);
+        if (isZodObject(schema.def.element)) {
+            return { name, value: [value], array: true, optional };
+        }
+        return { name, value: value.value, tsType: true, array: true, optional };
     } else if (isZodUnion(schema)) {
         const values: NangoModelField['value'] = [];
 

--- a/packages/cli/lib/zeroYaml/zodToNango.unit.test.ts
+++ b/packages/cli/lib/zeroYaml/zodToNango.unit.test.ts
@@ -98,7 +98,12 @@ describe('zodToNango', () => {
             optional: false,
             value: [
                 { name: 'foo', optional: false, value: [{ name: 'id', optional: false, tsType: true, value: 'string' }] },
-                { array: true, name: 'arr', optional: false, tsType: true, value: [{ name: 'id', optional: false, tsType: true, value: 'string' }] }
+                {
+                    array: true,
+                    name: 'arr',
+                    optional: false,
+                    value: [{ name: '0', optional: false, value: [{ name: 'id', optional: false, tsType: true, value: 'string' }] }]
+                }
             ]
         });
     });

--- a/packages/cli/lib/zeroYaml/zodToNango.unit.test.ts
+++ b/packages/cli/lib/zeroYaml/zodToNango.unit.test.ts
@@ -90,4 +90,16 @@ describe('zodToNango', () => {
             ]
         });
     });
+
+    it('should support nested objects', () => {
+        const ref = z.object({ id: z.string() });
+        expect(zodToNangoModelField('test', z.object({ foo: ref, arr: z.array(ref) }))).toStrictEqual({
+            name: 'test',
+            optional: false,
+            value: [
+                { name: 'foo', optional: false, value: [{ name: 'id', optional: false, tsType: true, value: 'string' }] },
+                { array: true, name: 'arr', optional: false, tsType: true, value: [{ name: 'id', optional: false, tsType: true, value: 'string' }] }
+            ]
+        });
+    });
 });


### PR DESCRIPTION
## Changes

- Support an array of objects in ZeroYaml
Also added some general tests to avoid regression
<!-- Summary by @propel-code-bot -->

---

This PR updates ZeroYaml export handling to support arrays of objects in model schema exports. It expands zodToNango conversion logic to distinguish between arrays of objects and other array types, adjusts TypeScript generation in model.service.ts to serialize these structures correctly, and broadens test and fixture coverage to prevent regressions.

<details>
<summary><strong>Key Changes</strong></summary>

• Enhanced zodToNango.ts to differentiate arrays of objects, returning the correct internal type structure.
• Refactored model.service.ts TypeScript code generation to output valid representations for arrays of objects.
• Updated test files (unit and snapshots) to add/expand coverage for nested and array-of-object scenarios.
• Modified advanced-syntax YAML fixture to include new test cases for arrays of objects.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• ZeroYaml schema conversion logic (zodToNango.ts)
• TypeScript export/type generation (model.service.ts)
• Schema/model conversion test coverage
• YAML fixtures for integration tests

</details>

*This summary was automatically generated by @propel-code-bot*