### PR TITLE
chore(orchestrator): add next execution date and task state to schedules

### DIFF
--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -264,20 +264,11 @@ export function validateSchedule(schedule: Schedule): Result<OrchestratorSchedul
             createdAt: z.coerce.date(),
             updatedAt: z.coerce.date(),
             deletedAt: z.coerce.date().nullable(),
-            lastScheduledTaskId: z.string().uuid().nullable()
+            lastScheduledTaskId: z.string().uuid().nullable(),
+            lastScheduledTaskState: z.enum(taskStates).nullable(),
+            nextExecutionAt: z.coerce.date().nullable()
         })
         .strict();
-    const getNextDueDate = (startsAt: Date, frequencyMs: number) => {
-        const now = new Date();
-        const startDate = new Date(startsAt);
-        if (startDate >= now) {
-            return startDate;
-        }
-        const timeDiff = now.getTime() - startDate.getTime();
-        const nextDueDate = new Date(now.getTime() + frequencyMs - (timeDiff % frequencyMs));
-
-        return nextDueDate;
-    };
     const validation = scheduleSchema.safeParse(schedule);
     if (validation.success) {
         const schedule: OrchestratorSchedule = {
@@ -285,7 +276,7 @@ export function validateSchedule(schedule: Schedule): Result<OrchestratorSchedul
             name: validation.data.name,
             state: validation.data.state,
             frequencyMs: validation.data.frequencyMs,
-            nextDueDate: validation.data.state == 'STARTED' ? getNextDueDate(validation.data.startsAt, validation.data.frequencyMs) : null
+            nextDueDate: validation.data.state == 'STARTED' ? validation.data.nextExecutionAt : null
         };
         return Ok(schedule);
     }

--- a/packages/orchestrator/lib/routes/v1/postRecurring.ts
+++ b/packages/orchestrator/lib/routes/v1/postRecurring.ts
@@ -88,7 +88,8 @@ const handler = (scheduler: Scheduler) => {
             createdToStartedTimeoutSecs: res.locals.parsedBody.timeoutSettingsInSecs.createdToStarted,
             startedToCompletedTimeoutSecs: res.locals.parsedBody.timeoutSettingsInSecs.startedToCompleted,
             heartbeatTimeoutSecs: res.locals.parsedBody.timeoutSettingsInSecs.heartbeat,
-            lastScheduledTaskId: null
+            lastScheduledTaskId: null,
+            lastScheduledTaskState: null
         });
         if (schedule.isErr()) {
             res.status(500).json({ error: { code: 'recurring_failed', message: schedule.error.message } });

--- a/packages/scheduler/lib/daemons/scheduling/scheduling.integration.test.ts
+++ b/packages/scheduler/lib/daemons/scheduling/scheduling.integration.test.ts
@@ -112,7 +112,9 @@ async function addSchedule(db: knex.Knex, params?: { state?: ScheduleState; star
         created_at: new Date(),
         updated_at: new Date(),
         deleted_at: params?.state === 'DELETED' ? new Date() : null,
-        last_scheduled_task_id: null
+        last_scheduled_task_id: null,
+        last_scheduled_task_state: null,
+        next_execution_at: params?.startsAt || new Date()
     };
     const res = await db.from<DbSchedule>(SCHEDULES_TABLE).insert(schedule).returning('*');
     const inserted = res[0];

--- a/packages/scheduler/lib/db/migrations/20250724115100_schedule_next_execution_at.ts
+++ b/packages/scheduler/lib/db/migrations/20250724115100_schedule_next_execution_at.ts
@@ -31,9 +31,9 @@ export async function up(knex: Knex): Promise<void> {
             last_scheduled_task_state = ts.last_task_state,
             next_execution_at = (
                 CASE
-                    WHEN ts.last_task_state = 'SUCCEEDED'
-                    THEN s.starts_at + (ceiling(extract(EPOCH FROM (now() - s.starts_at)) / extract(EPOCH FROM s.frequency)) * s.frequency)
-                    ELSE s.starts_at + (floor(extract(EPOCH FROM (now() - s.starts_at)) / extract(EPOCH FROM s.frequency)) * s.frequency)
+                    WHEN ts.last_task_state IS NULL
+                    THEN s.starts_at + (floor(extract(EPOCH FROM (now() - s.starts_at)) / extract(EPOCH FROM s.frequency)) * s.frequency)
+                    ELSE s.starts_at + (ceiling(extract(EPOCH FROM (now() - s.starts_at)) / extract(EPOCH FROM s.frequency)) * s.frequency)
                 END
             )
         FROM task_states ts

--- a/packages/scheduler/lib/db/migrations/20250724115100_schedule_next_execution_at.ts
+++ b/packages/scheduler/lib/db/migrations/20250724115100_schedule_next_execution_at.ts
@@ -1,0 +1,60 @@
+import type { Knex } from 'knex';
+
+import { SCHEDULES_TABLE } from '../../models/schedules.js';
+import { TASKS_TABLE } from '../../models/tasks.js';
+
+export const config = {
+    transaction: false
+};
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(
+        `ALTER TABLE ${SCHEDULES_TABLE}
+            ADD COLUMN IF NOT EXISTS last_scheduled_task_state task_states DEFAULT NULL,
+            ADD COLUMN IF NOT EXISTS next_execution_at TIMESTAMP WITH TIME ZONE DEFAULT NULL;`
+    );
+
+    // Update existing schedules
+    // last_scheduled_task_state is read from tasks table
+    // if task exists and is SUCCEEDED next_execution_at is next due date calculatd using ceiling()
+    // if no task exists or task is not SUCCEEDED, next_execution_at is last due date calculated using floor()
+    await knex.raw(
+        `WITH task_states AS (
+            SELECT
+                s.id as schedule_id,
+                t.state as last_task_state
+            FROM ${SCHEDULES_TABLE} s
+            LEFT JOIN ${TASKS_TABLE} t ON s.last_scheduled_task_id = t.id
+        )
+        UPDATE ${SCHEDULES_TABLE} s
+        SET
+            last_scheduled_task_state = ts.last_task_state,
+            next_execution_at = (
+                CASE
+                    WHEN ts.last_task_state = 'SUCCEEDED'
+                    THEN s.starts_at + (ceiling(extract(EPOCH FROM (now() - s.starts_at)) / extract(EPOCH FROM s.frequency)) * s.frequency)
+                    ELSE s.starts_at + (floor(extract(EPOCH FROM (now() - s.starts_at)) / extract(EPOCH FROM s.frequency)) * s.frequency)
+                END
+            )
+        FROM task_states ts
+        WHERE s.id = ts.schedule_id;`
+    );
+
+    // alter next_execution_at to be not null now that it has been populated
+    await knex.raw(`ALTER TABLE ${SCHEDULES_TABLE} ALTER COLUMN next_execution_at SET NOT NULL;`);
+
+    // index to optimize the scheduling query
+    await knex.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_schedules_scheduling"
+            ON ${SCHEDULES_TABLE} (state, last_scheduled_task_state, next_execution_at)
+            WHERE state = 'STARTED';`
+    );
+    // index on last_scheduled_task_id to update last_scheduled_task_state
+    await knex.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_schedules_last_scheduled_task_id"
+            ON ${SCHEDULES_TABLE} (last_scheduled_task_id)
+            WHERE last_scheduled_task_id IS NOT NULL;`
+    );
+}
+
+export async function down(): Promise<void> {}

--- a/packages/scheduler/lib/models/schedules.integration.test.ts
+++ b/packages/scheduler/lib/models/schedules.integration.test.ts
@@ -69,10 +69,20 @@ describe('Schedules', () => {
     it('should be successfully updated', async () => {
         const schedule = await createSchedule(db);
         await setTimeout(1);
-        const updated = (await schedules.update(db, { id: schedule.id, frequencyMs: 600_000, payload: { i: 2 }, lastScheduledTaskId: uuidv7() })).unwrap();
-        expect(updated.frequencyMs).toBe(600_000);
+        const newFrequency = 600_000; // 10 minutes
+        const updated = (
+            await schedules.update(db, {
+                id: schedule.id,
+                frequencyMs: newFrequency,
+                payload: { i: 2 }
+            })
+        ).unwrap();
+        expect(updated.frequencyMs).toBe(newFrequency);
         expect(updated.payload).toMatchObject({ i: 2 });
         expect(updated.updatedAt.getTime()).toBeGreaterThan(schedule.updatedAt.getTime());
+        expect(updated.lastScheduledTaskId).toBeNull();
+        expect(updated.lastScheduledTaskState).toBeNull();
+        expect(updated.nextExecutionAt).toBeWithinMs(new Date(updated.startsAt.getTime() + newFrequency), 3_000);
     });
     it('should be searchable', async () => {
         const schedule = await createSchedule(db);
@@ -84,6 +94,32 @@ describe('Schedules', () => {
 
         const deleted = (await schedules.search(db, { state: 'DELETED', limit: 10 })).unwrap();
         expect(deleted).toEqual([]);
+    });
+    it('should set last scheduled task', async () => {
+        const schedule = await createSchedule(db);
+        await setTimeout(1);
+        const taskId = uuidv7();
+        const taskState = 'STARTED';
+
+        const [updated] = (await schedules.setLastScheduledTask(db, [{ id: schedule.id, taskId, taskState }])).unwrap();
+        expect(updated?.updatedAt.getTime()).toBeGreaterThan(schedule.updatedAt.getTime());
+        expect(updated?.lastScheduledTaskId).toBe(taskId);
+        expect(updated?.lastScheduledTaskState).toBe(taskState);
+        expect(updated?.nextExecutionAt).toEqual(schedule.nextExecutionAt);
+    });
+    it('should update last scheduled task state', async () => {
+        const schedule = await createSchedule(db);
+        await setTimeout(1);
+        const taskId = uuidv7();
+
+        await schedules.setLastScheduledTask(db, [{ id: schedule.id, taskId, taskState: 'CREATED' }]);
+
+        const taskState = 'SUCCEEDED';
+        const [updated] = (await schedules.updateLastScheduledTaskState(db, { taskIds: [taskId], taskState })).unwrap();
+        expect(updated?.updatedAt.getTime()).toBeGreaterThan(schedule.updatedAt.getTime());
+        expect(updated?.lastScheduledTaskState).toBe(taskState);
+        // The next execution should be set to the next due date based on the frequency
+        expect(updated?.nextExecutionAt).toBeWithinMs(new Date(schedule.startsAt.getTime() + schedule.frequencyMs), 3_000);
     });
 });
 
@@ -100,7 +136,8 @@ async function createSchedule(db: knex.Knex): Promise<Schedule> {
             createdToStartedTimeoutSecs: 1,
             startedToCompletedTimeoutSecs: 1,
             heartbeatTimeoutSecs: 1,
-            lastScheduledTaskId: null
+            lastScheduledTaskId: null,
+            lastScheduledTaskState: null
         })
     ).unwrap();
 }

--- a/packages/scheduler/lib/models/schedules.ts
+++ b/packages/scheduler/lib/models/schedules.ts
@@ -2,7 +2,7 @@ import { uuidv7 } from 'uuidv7';
 
 import { Err, Ok, stringifyError } from '@nangohq/utils';
 
-import type { Schedule, ScheduleProps, ScheduleState } from '../types.js';
+import type { Schedule, ScheduleProps, ScheduleState, TaskState } from '../types.js';
 import type { Result } from '@nangohq/utils';
 import type knex from 'knex';
 import type { JsonValue } from 'type-fest';
@@ -49,6 +49,8 @@ export interface DbSchedule {
     updated_at: Date;
     deleted_at: Date | null;
     last_scheduled_task_id: string | null;
+    last_scheduled_task_state: TaskState | null;
+    next_execution_at: Date;
 }
 
 // knex uses https://github.com/bendrucker/postgres-interval
@@ -88,7 +90,9 @@ export const DbSchedule = {
         created_at: schedule.createdAt,
         updated_at: schedule.updatedAt,
         deleted_at: schedule.deletedAt,
-        last_scheduled_task_id: schedule.lastScheduledTaskId
+        last_scheduled_task_id: schedule.lastScheduledTaskId,
+        last_scheduled_task_state: schedule.lastScheduledTaskState,
+        next_execution_at: schedule.nextExecutionAt
     }),
     from: (dbSchedule: DbSchedule): Schedule => ({
         id: dbSchedule.id,
@@ -105,7 +109,9 @@ export const DbSchedule = {
         createdAt: dbSchedule.created_at,
         updatedAt: dbSchedule.updated_at,
         deletedAt: dbSchedule.deleted_at,
-        lastScheduledTaskId: dbSchedule.last_scheduled_task_id
+        lastScheduledTaskId: dbSchedule.last_scheduled_task_id,
+        lastScheduledTaskState: dbSchedule.last_scheduled_task_state,
+        nextExecutionAt: dbSchedule.next_execution_at
     })
 };
 
@@ -120,7 +126,8 @@ export async function create(db: knex.Knex, props: ScheduleProps): Promise<Resul
         createdAt: now,
         updatedAt: now,
         deletedAt: null,
-        lastScheduledTaskId: null
+        lastScheduledTaskId: null,
+        nextExecutionAt: now
     };
     try {
         const inserted = await db.from<DbSchedule>(SCHEDULES_TABLE).insert(DbSchedule.to(newSchedule)).returning('*');
@@ -171,15 +178,23 @@ export async function transitionState(db: knex.Knex, scheduleId: string, to: Sch
     }
 }
 
-export async function update(
-    db: knex.Knex,
-    props: Partial<Pick<ScheduleProps, 'frequencyMs' | 'payload' | 'lastScheduledTaskId'>> & { id: string }
-): Promise<Result<Schedule>> {
+export async function update(db: knex.Knex, props: Partial<Pick<ScheduleProps, 'frequencyMs' | 'payload'>> & { id: string }): Promise<Result<Schedule>> {
     try {
         const newValues = {
             ...(props.frequencyMs ? { frequency: `${props.frequencyMs} milliseconds` } : {}),
             ...(props.payload ? { payload: props.payload } : {}),
-            ...(props.lastScheduledTaskId ? { last_scheduled_task_id: props.lastScheduledTaskId } : {}),
+            ...(props.frequencyMs
+                ? {
+                      next_execution_at: db.raw(
+                          `starts_at + (
+                                CEILING(
+                                    EXTRACT(EPOCH FROM (NOW() - starts_at)) / (? / 1000.0)
+                                ) * INTERVAL '1 millisecond' * ?
+                          )`,
+                          [props.frequencyMs, props.frequencyMs]
+                      )
+                  }
+                : {}),
             updated_at: new Date()
         };
         const updated = await db.from<DbSchedule>(SCHEDULES_TABLE).where('id', props.id).update(newValues).returning('*');
@@ -189,6 +204,60 @@ export async function update(
         return Ok(DbSchedule.from(updated[0]));
     } catch (err) {
         return Err(new Error(`Error updating schedule '${props.id}': ${stringifyError(err)}`));
+    }
+}
+
+export async function setLastScheduledTask(db: knex.Knex, updates: { id: string; taskId: string; taskState: TaskState }[]): Promise<Result<Schedule[]>> {
+    try {
+        if (updates.length === 0) {
+            return Ok([]);
+        }
+
+        const bindings = updates.flatMap((u) => [u.id, u.taskId, u.taskState]);
+        const values = updates.map(() => '(?, ?::uuid, ?::task_states)').join(', ');
+
+        const updated = await db.raw(
+            `UPDATE ${SCHEDULES_TABLE}
+            SET
+                last_scheduled_task_id = v.task_id,
+                last_scheduled_task_state = v.task_state,
+                updated_at = NOW()
+            FROM (VALUES ${values}) AS v(id, task_id, task_state)
+            WHERE ${SCHEDULES_TABLE}.id = v.id::uuid
+            RETURNING ${SCHEDULES_TABLE}.*`,
+            bindings
+        );
+
+        const result = updated.rows || updated;
+
+        if (result.length === 0) {
+            return Err(new Error(`Error: no schedules updated for tasks ${updates.map((u) => u.taskId).join(', ')}`));
+        }
+        return Ok(result.map(DbSchedule.from));
+    } catch (err) {
+        return Err(new Error(`Error setting last scheduled task ${JSON.stringify(updates)}: ${stringifyError(err)}`));
+    }
+}
+
+export async function updateLastScheduledTaskState(
+    db: knex.Knex,
+    { taskIds, taskState }: { taskIds: string[]; taskState: TaskState }
+): Promise<Result<Schedule[]>> {
+    try {
+        if (taskIds.length <= 0) {
+            return Ok([]);
+        }
+        const updated = await db(SCHEDULES_TABLE)
+            .update({
+                updated_at: db.fn.now(),
+                last_scheduled_task_state: taskState,
+                next_execution_at: db.raw('starts_at + CEILING(EXTRACT(EPOCH FROM (NOW() - starts_at)) / EXTRACT(EPOCH FROM frequency)) * frequency')
+            })
+            .whereIn('last_scheduled_task_id', taskIds)
+            .returning('*');
+        return Ok(updated.map(DbSchedule.from));
+    } catch (err) {
+        return Err(new Error(`Error updating last scheduled tasks ${taskIds.join(', ')}: ${stringifyError(err)}`));
     }
 }
 

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -175,7 +175,8 @@ async function recurring({ scheduler, state = 'PAUSED' }: { scheduler: Scheduler
         createdToStartedTimeoutSecs: 3600,
         startedToCompletedTimeoutSecs: 3600,
         heartbeatTimeoutSecs: 600,
-        lastScheduledTaskId: null
+        lastScheduledTaskId: null,
+        lastScheduledTaskState: null
     };
     return (await scheduler.recurring(recurringProps)).unwrap();
 }

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -4,7 +4,6 @@ import { nanoid } from '@nangohq/utils';
 
 import { getTestDbClient } from './db/helpers.test.js';
 import { envs } from './env.js';
-import * as tasks from './models/tasks.js';
 import { Scheduler } from './scheduler.js';
 
 import type { TaskProps } from './models/tasks.js';
@@ -12,7 +11,6 @@ import type { Schedule, ScheduleState, Task } from './types.js';
 
 describe('Scheduler', () => {
     const dbClient = getTestDbClient();
-    const db = dbClient.db;
     const callbacks = {
         CREATED: vi.fn((task: Task) => expect(task.state).toBe('CREATED')),
         STARTED: vi.fn((task: Task) => expect(task.state).toBe('STARTED')),
@@ -105,24 +103,63 @@ describe('Scheduler', () => {
         const timeoutMs = 1000;
         const task = await immediate(scheduler, { taskProps: { createdToStartedTimeoutSecs: timeoutMs / 1000 } });
         await new Promise((resolve) => setTimeout(resolve, timeoutMs + envs.ORCHESTRATOR_EXPIRING_TICK_INTERVAL_MS));
-        const expired = (await tasks.get(db, task.id)).unwrap();
-        expect(expired.state).toBe('EXPIRED');
+        const [expired] = (await scheduler.searchTasks({ ids: [task.id] })).unwrap();
+        expect(expired?.state).toBe('EXPIRED');
     });
     it('should monitor and expires started tasks if timeout is reached', async () => {
         const timeoutMs = 1000;
         const task = await immediate(scheduler, { taskProps: { startedToCompletedTimeoutSecs: timeoutMs / 1000 } });
         (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
         await new Promise((resolve) => setTimeout(resolve, timeoutMs + envs.ORCHESTRATOR_EXPIRING_TICK_INTERVAL_MS));
-        const taskAfter = (await tasks.get(db, task.id)).unwrap();
-        expect(taskAfter.state).toBe('EXPIRED');
+        const [taskAfter] = (await scheduler.searchTasks({ ids: [task.id] })).unwrap();
+        expect(taskAfter?.state).toBe('EXPIRED');
     });
     it('should monitor and expires started tasks if heartbeat timeout is reached', async () => {
         const timeoutMs = 1000;
         const task = await immediate(scheduler, { taskProps: { heartbeatTimeoutSecs: timeoutMs / 1000 } });
         (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
         await new Promise((resolve) => setTimeout(resolve, timeoutMs + envs.ORCHESTRATOR_EXPIRING_TICK_INTERVAL_MS));
-        const taskAfter = (await tasks.get(db, task.id)).unwrap();
-        expect(taskAfter.state).toBe('EXPIRED');
+        const [taskAfter] = (await scheduler.searchTasks({ ids: [task.id] })).unwrap();
+        expect(taskAfter?.state).toBe('EXPIRED');
+    });
+    it('should set schedule last scheduled task state', async () => {
+        const schedule = await recurring({ scheduler });
+        const task = await immediate(scheduler, { schedule });
+        const [scheduleAfter] = (await scheduler.searchSchedules({ id: schedule.id, limit: 1 })).unwrap();
+        expect(scheduleAfter?.lastScheduledTaskId).toBe(task.id);
+    });
+    it('should update last scheduled task when task is succeeded', async () => {
+        const schedule = await recurring({ scheduler });
+        const task = await immediate(scheduler, { schedule });
+        const dequeued = (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
+        expect(dequeued.length).toBe(1);
+        (await scheduler.succeed({ taskId: task.id, output: { foo: 'bar' } })).unwrap();
+        const [scheduleAfter] = (await scheduler.searchSchedules({ id: schedule.id, limit: 1 })).unwrap();
+        expect(scheduleAfter?.lastScheduledTaskId).toBe(task.id);
+        expect(scheduleAfter?.lastScheduledTaskState).toBe('SUCCEEDED');
+        expect(scheduleAfter?.nextExecutionAt).toEqual(new Date((scheduleAfter?.startsAt.getTime() || 0) + (scheduleAfter?.frequencyMs || 0)));
+    });
+    it('should update last scheduled task when task is failed', async () => {
+        const schedule = await recurring({ scheduler });
+        const task = await immediate(scheduler, { schedule });
+        const dequeued = (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
+        expect(dequeued.length).toBe(1);
+        (await scheduler.fail({ taskId: task.id, error: { message: 'failure happened' } })).unwrap();
+        const [scheduleAfter] = (await scheduler.searchSchedules({ id: schedule.id, limit: 1 })).unwrap();
+        expect(scheduleAfter?.lastScheduledTaskId).toBe(task.id);
+        expect(scheduleAfter?.lastScheduledTaskState).toBe('FAILED');
+        expect(scheduleAfter?.nextExecutionAt).toEqual(new Date((scheduleAfter?.startsAt.getTime() || 0) + (scheduleAfter?.frequencyMs || 0)));
+    });
+    it('should update last scheduled task when task is cancelled', async () => {
+        const schedule = await recurring({ scheduler });
+        const task = await immediate(scheduler, { schedule });
+        const dequeued = (await scheduler.dequeue({ groupKey: task.groupKey, limit: 1 })).unwrap();
+        expect(dequeued.length).toBe(1);
+        (await scheduler.cancel({ taskId: task.id, reason: 'cancelled by user' })).unwrap();
+        const [scheduleAfter] = (await scheduler.searchSchedules({ id: schedule.id, limit: 1 })).unwrap();
+        expect(scheduleAfter?.lastScheduledTaskId).toBe(task.id);
+        expect(scheduleAfter?.lastScheduledTaskState).toBe('CANCELLED');
+        expect(scheduleAfter?.nextExecutionAt).toEqual(new Date((scheduleAfter?.startsAt.getTime() || 0) + (scheduleAfter?.frequencyMs || 0)));
     });
     it('should not run an immediate task for a schedule if another task is already running', async () => {
         const schedule = await recurring({ scheduler });
@@ -143,16 +180,18 @@ describe('Scheduler', () => {
         await immediate(scheduler, { schedule });
         const deleted = (await scheduler.setScheduleState({ scheduleName: schedule.name, state: 'DELETED' })).unwrap();
         expect(deleted.state).toBe('DELETED');
-        const tasks = (await scheduler.searchTasks({ scheduleId: schedule.id })).unwrap();
-        expect(tasks.length).toBe(1);
-        expect(tasks[0]?.state).toBe('CANCELLED');
+        const [task] = (await scheduler.searchTasks({ scheduleId: schedule.id })).unwrap();
+        expect(task?.state).toBe('CANCELLED');
         expect(callbacks.CANCELLED).toHaveBeenCalledOnce();
+        expect(deleted.lastScheduledTaskId).toBe(task?.id);
+        expect(deleted.lastScheduledTaskState).toBe('CANCELLED');
     });
     it('should update schedule frequency', async () => {
         const schedule = await recurring({ scheduler });
         const newFrequency = 1_800_000;
         const updated = (await scheduler.setScheduleFrequency({ scheduleName: schedule.name, frequencyMs: newFrequency })).unwrap();
         expect(updated.frequencyMs).toBe(newFrequency);
+        expect(updated.nextExecutionAt).toEqual(new Date(updated.startsAt.getTime() + newFrequency));
     });
     it('should search schedules by name', async () => {
         const schedule = await recurring({ scheduler });

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -201,7 +201,10 @@ export class Scheduler {
             if (created.isOk()) {
                 const task = created.value;
                 if (task.scheduleId) {
-                    await schedules.update(trx, { id: task.scheduleId, lastScheduledTaskId: task.id });
+                    const scheduleRes = await schedules.setLastScheduledTask(trx, [{ id: task.scheduleId, taskId: task.id, taskState: task.state }]);
+                    if (scheduleRes.isErr()) {
+                        return Err(`Error updating last scheduled task for schedule '${task.scheduleId}': ${stringifyError(scheduleRes.error)}`);
+                    }
                 }
                 this.onCallbacks[task.state](task);
             }
@@ -268,7 +271,17 @@ export class Scheduler {
      * const succeed = await scheduler.succeed({ taskId: '00000000-0000-0000-0000-000000000000', output: {foo: 'bar'} });
      */
     public async succeed({ taskId, output }: { taskId: string; output: JsonValue }): Promise<Result<Task>> {
-        const succeeded = await tasks.transitionState(this.db, { taskId, newState: 'SUCCEEDED', output });
+        const newState: TaskState = 'SUCCEEDED';
+        const succeeded: Result<Task> = await this.db.transaction(async (trx) => {
+            const res = await tasks.transitionState(trx, { taskId, newState, output });
+            if (res.isOk()) {
+                const scheduleRes = await schedules.updateLastScheduledTaskState(trx, { taskIds: [taskId], taskState: newState });
+                if (scheduleRes.isErr()) {
+                    return Err(`Error updating last scheduled task state for task '${taskId}': ${stringifyError(scheduleRes.error)}`);
+                }
+            }
+            return res;
+        });
         if (succeeded.isOk()) {
             const task = succeeded.value;
             this.onCallbacks[task.state](task);
@@ -285,6 +298,7 @@ export class Scheduler {
      * const failed = await scheduler.fail({ taskId: '00000000-0000-0000-0000-000000000000', error: {message: 'error'});
      */
     public async fail({ taskId, error }: { taskId: string; error: JsonValue }): Promise<Result<Task>> {
+        const newState: TaskState = 'FAILED';
         return await this.db.transaction(async (trx) => {
             const task = await tasks.get(trx, taskId);
             if (task.isErr()) {
@@ -297,8 +311,12 @@ export class Scheduler {
                 await schedules.search(trx, { id: task.value.scheduleId, limit: 1, forUpdate: true });
             }
 
-            const failed = await tasks.transitionState(trx, { taskId, newState: 'FAILED', output: error });
+            const failed = await tasks.transitionState(trx, { taskId, newState, output: error });
             if (failed.isOk()) {
+                const scheduleRes = await schedules.updateLastScheduledTaskState(trx, { taskIds: [taskId], taskState: newState });
+                if (scheduleRes.isErr()) {
+                    return Err(`Error updating last scheduled task state for task '${taskId}': ${stringifyError(scheduleRes.error)}`);
+                }
                 const task = failed.value;
                 this.onCallbacks[task.state](task);
                 // Create a new task if the task is retryable
@@ -334,11 +352,21 @@ export class Scheduler {
      * @example
      * const cancelled = await scheduler.cancel({ taskId: '00000000-0000-0000-0000-000000000000' });
      */
-    public async cancel(cancelBy: { taskId: string; reason: JsonValue }): Promise<Result<Task>> {
-        const cancelled = await tasks.transitionState(this.db, {
-            taskId: cancelBy.taskId,
-            newState: 'CANCELLED',
-            output: { reason: cancelBy.reason }
+    public async cancel({ taskId, reason }: { taskId: string; reason: JsonValue }): Promise<Result<Task>> {
+        const newState: TaskState = 'CANCELLED';
+        const cancelled: Result<Task> = await this.db.transaction(async (trx) => {
+            const res = await tasks.transitionState(this.db, {
+                taskId: taskId,
+                newState,
+                output: { reason }
+            });
+            if (res.isOk()) {
+                const scheduleRes = await schedules.updateLastScheduledTaskState(trx, { taskIds: [taskId], taskState: newState });
+                if (scheduleRes.isErr()) {
+                    return Err(`Error updating last scheduled task state for task '${taskId}': ${stringifyError(scheduleRes.error)}`);
+                }
+            }
+            return res;
         });
         if (cancelled.isOk()) {
             const task = cancelled.value;

--- a/packages/scheduler/lib/types.ts
+++ b/packages/scheduler/lib/types.ts
@@ -30,7 +30,7 @@ export interface Task {
 }
 
 export type ImmediateProps = SetOptional<Omit<TaskProps, 'startsAfter' | 'scheduleId'>, 'retryKey'>;
-export type ScheduleProps = Omit<Schedule, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'>;
+export type ScheduleProps = Omit<Schedule, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt' | 'nextExecutionAt'>;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const scheduleStates = ['PAUSED', 'STARTED', 'DELETED'] as const;
@@ -52,6 +52,8 @@ export interface Schedule {
     readonly updatedAt: Date;
     readonly deletedAt: Date | null;
     readonly lastScheduledTaskId: string | null;
+    readonly lastScheduledTaskState: TaskState | null;
+    readonly nextExecutionAt: Date;
 }
 
 export interface Group {

--- a/packages/utils/lib/vitest.d.ts
+++ b/packages/utils/lib/vitest.d.ts
@@ -6,6 +6,7 @@ interface CustomMatchers<TR = unknown> {
     toBeIsoDateTimezone: () => string;
     toBeSha256: () => string;
     toBeUUID: () => TR;
+    toBeWithinMs: (expected: Date, ms: number) => string;
 }
 
 declare module 'vitest' {

--- a/tests/setupFiles.ts
+++ b/tests/setupFiles.ts
@@ -50,5 +50,13 @@ expect.extend({
             };
         }
         return { pass: true, message: () => '' };
+    },
+
+    toBeWithinMs(received: Date, expected: Date, toleranceMs: number) {
+        const diff = Math.abs(received.getTime() - expected.getTime());
+        return {
+            pass: diff <= toleranceMs,
+            message: () => `Expected ${received.toISOString()} to be within ${toleranceMs} ms of ${expected.toISOString()}. Difference was ${diff}ms`
+        };
     }
 });


### PR DESCRIPTION
The goal is to speed up the scheduling query by removing the join with the tasks table and the inline calculation of the due date. This PR:
- duplicates the task state into the schedules table in order to avoid a join in the scheduling query
- Also calculate and store the schedule next execution date when a task completes instead of doing it at scheduling time

The cost is an extra db query to update a schedule when a task completes and the added complexity to keep the state of tasks in sync but the benefits of removing the join and the inlined due date calculation will greatly speed up the scheduling query

This PR doesn't use the new columns for the scheduling of syncs yet. In next PR I would modify the query as such:
```
SELECT
   *
FROM
   "nango_scheduler"."schedules"
WHERE
   "state" = 'STARTED'
   AND "last_scheduled_task_state" NOT IN ('CREATED', 'STARTED')
   AND "next_execution_at" <= CURRENT_TIMESTAMP
   FOR UPDATE SKIP LOCKED
```

<!-- Summary by @propel-code-bot -->

---

This PR introduces a major architectural change by denormalizing key task metadata (last scheduled task state and next execution date) directly into the schedules table, eliminating the need for expensive joins and inline due-date calculation during scheduling queries. This is implemented via a complex DB migration, extensive model and API adjustments, new batch update methods, and wide-ranging changes to daemons and main orchestrator logic to keep schedule state in sync. The new fields are written in all relevant flows (creation, state transitions, expiring), but are not yet actively used to drive the main scheduling query-adoption for that is staged for a future PR. Comprehensive tests cover both the new data flow and the legacy behavior to ensure correctness.

<details>
<summary><strong>Key Changes</strong></summary>

• Database migration: Adds last_scheduled_task_state and next_execution_at columns to schedules, backfills data, and creates optimized indices for fast scheduling queries.
• Model/API changes: Schedule types, DB conversion routines, API contracts, and validation are updated to handle new fields.
• New batch operations: Implements setLastScheduledTask and updateLastScheduledTaskState for atomic, efficient schedule updates after batch task operations.
• Refactored daemons/services: Scheduling and expiring daemons now use batch updates to set schedule fields after task processing; main scheduler logic updated to maintain consistency.
• Tests: Extensive test suite updates and new assertions/matchers verify that schedule/task fields are synchronized as expected throughout the task lifecycle.
• Auxiliary changes: Test matchers are extended for date tolerances; type definitions updated for the new model contracts.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Database schema and migrations (schedules table)
• Task-schedule relationship logic
• Scheduling and expiring daemons, main orchestrator logic
• All API contracts and validation layers around schedules
• Test suites for schedule/task integration

</details>

*This summary was automatically generated by @propel-code-bot*