### PR TITLE
feat: update trial messaging to Auto Idling

### DIFF
--- a/packages/server/lib/controllers/v1/flows/id/patchEnable.ts
+++ b/packages/server/lib/controllers/v1/flows/id/patchEnable.ts
@@ -49,7 +49,7 @@ export const patchFlowEnable = asyncWrapper<PatchFlowEnable>(async (req, res) =>
     }
 
     if (plan && plan.trial_end_at && plan.trial_end_at.getTime() < Date.now()) {
-        res.status(400).send({ error: { code: 'plan_limit', message: "Can't enable more script, upgrade or extend your trial period" } });
+        res.status(400).send({ error: { code: 'plan_limit', message: "Can't enable more scripts, upgrade or extend your auto idling period" } });
         return;
     }
     if (plan && !plan.trial_end_at && plan.auto_idle) {

--- a/packages/server/lib/helpers/email.ts
+++ b/packages/server/lib/helpers/email.ts
@@ -74,14 +74,14 @@ export async function sendTrialAlmostOverEmail({ user, inDays }: { user: Pick<DB
     const emailClient = EmailClient.getInstance();
     await emailClient.send(
         user.email,
-        `Your Nango trial ends in ${inDays} days`,
+        `Some Nango features will pause in ${inDays} days`,
         `<p>Hi ${he.encode(user.name)},</p>
 
-<p>Your free Nango trial expires in ${inDays} days. After that, integration endpoints and scripts will be paused. All authorization features will continue to work.</p>
+<p>Some Nango features (syncs & actions) will pause in 3 days. All other features—like authorization flows, credential retrieval, and the proxy—will keep working as usual.</p>
 
-<p>You can extend your trial for 14 days at a time directly from the Nango UI. Just click on any integration using scripts and select Extend.</p>
+<p>You can delay the idle from the Integrations tab in the <a href="https://app.nango.dev">Nango UI</a>.</p>
 
-<p>More details on free plan limitations are in the <a href="https://docs.nango.dev/guides/resource-limits#free-plan-limits.">documentation</a>.</p>
+<p>We idle syncs & actions because they use dedicated infrastructure, which is too costly to run indefinitely on free plans. <a href="https://app.nango.dev/prod/team/billing">Upgrade</a> to prevent auto idling forever.</p>
 
 <p>Need help or have questions? Join us in the <a href="https://nango.dev/slack">Slack community</a>!</p>
 
@@ -95,14 +95,14 @@ export async function sendTrialHasExpired({ user }: { user: Pick<DBUser, 'name' 
     const emailClient = EmailClient.getInstance();
     await emailClient.send(
         user.email,
-        `Your Nango trial has expired`,
+        `Some Nango features have been paused`,
         `<p>Hi ${he.encode(user.name)},</p>
 
-<p>Your Nango trial has expired. Integration endpoints and scripts have been paused, but authorization features are still active.</p>
+<p>Some Nango features (syncs & actions) have been paused. All other features—like authorization flows, credential retrieval, and the proxy—still work as usual.</p>
 
-<p>You can extend your trial for 14 more days directly in the Nango UI. Just click on any integration using scripts and select Extend.</p>
+<p>You can reactivate any sync or action in the <a href="https://app.nango.dev">Nango UI</a> for 14 more days.</p>
 
-<p>More details on free plan limitations are in the <a href="https://docs.nango.dev/guides/resource-limits#free-plan-limits.">documentation</a>.</p>
+<p>We idle syncs & actions because they use dedicated infrastructure, which is too costly to run indefinitely on free plans. <a href="https://app.nango.dev/prod/team/billing">Upgrade</a> to prevent auto idling forever.</p>
 
 <p>Need help or have questions? Join us in the <a href="https://nango.dev/slack">Slack community</a>!</p>
 

--- a/packages/server/lib/helpers/email.ts
+++ b/packages/server/lib/helpers/email.ts
@@ -77,7 +77,7 @@ export async function sendTrialAlmostOverEmail({ user, inDays }: { user: Pick<DB
         `Some Nango features will pause in ${inDays} days`,
         `<p>Hi ${he.encode(user.name)},</p>
 
-<p>Some Nango features (syncs & actions) will pause in 3 days. All other features—like authorization flows, credential retrieval, and the proxy—will keep working as usual.</p>
+<p>Some Nango features (syncs & actions) will pause in ${inDays} days. All other features—like authorization flows, credential retrieval, and the proxy—will keep working as usual.</p>
 
 <p>You can delay the idle from the Integrations tab in the <a href="https://app.nango.dev">Nango UI</a>.</p>
 

--- a/packages/webapp/src/pages/Integrations/List.tsx
+++ b/packages/webapp/src/pages/Integrations/List.tsx
@@ -14,6 +14,7 @@ import { useListIntegration } from '../../hooks/useIntegration';
 import { useTrial } from '../../hooks/usePlan';
 import DashboardLayout from '../../layout/DashboardLayout';
 import { useStore } from '../../store';
+import { AutoIdlingBanner } from './components/AutoIdlingBanner';
 
 export default function IntegrationList() {
     const navigate = useNavigate();
@@ -56,6 +57,7 @@ export default function IntegrationList() {
                     </Link>
                 )}
             </div>
+            <AutoIdlingBanner />
             {list.length > 0 && (
                 <>
                     <div className="h-fit rounded-md text-white text-sm">

--- a/packages/webapp/src/pages/Integrations/components/AutoIdlingBanner.tsx
+++ b/packages/webapp/src/pages/Integrations/components/AutoIdlingBanner.tsx
@@ -1,0 +1,62 @@
+import { IconBolt, IconRefresh } from '@tabler/icons-react';
+import { useState } from 'react';
+
+import { ErrorCircle } from '../../../components/ErrorCircle';
+import { Button, ButtonLink } from '../../../components/ui/button/Button';
+import { Tag } from '../../../components/ui/label/Tag';
+import { useEnvironment } from '../../../hooks/useEnvironment';
+import { apiPostPlanExtendTrial, useTrial } from '../../../hooks/usePlan';
+import { useToast } from '../../../hooks/useToast';
+import { useStore } from '../../../store';
+
+export const AutoIdlingBanner: React.FC = () => {
+    const { toast } = useToast();
+
+    const env = useStore((state) => state.env);
+    const { plan, mutate: mutateEnv } = useEnvironment(env);
+    const { isTrial, isTrialOver, daysRemaining } = useTrial(plan);
+
+    const [trialLoading, setTrialLoading] = useState(false);
+
+    const onClickExtend = async () => {
+        setTrialLoading(true);
+        const res = await apiPostPlanExtendTrial(env);
+        setTrialLoading(false);
+
+        if ('error' in res.json) {
+            toast({ title: 'There was an issue extending auto idling', variant: 'error' });
+            return;
+        }
+
+        void mutateEnv();
+
+        toast({ title: 'Auto idling was extended successfully!', variant: 'success' });
+    };
+
+    if (!isTrial) {
+        return null;
+    }
+
+    return (
+        <div className="mb-7 rounded-md bg-grayscale-900 border border-grayscale-600 p-4 flex gap-2 justify-between items-center">
+            <div className="flex gap-2 items-center">
+                <div className="flex gap-3 items-center">
+                    <ErrorCircle icon="clock" variant="warning" />
+                    <Tag variant={'warning'}>{isTrialOver ? 'Trial expired' : 'Auto Idling'}</Tag>
+                    {!isTrialOver && <span className="text-white font-semibold">{daysRemaining} days left</span>}
+                </div>
+                <div className="text-grayscale-400 text-s">Actions and syncs endpoints automatically stop every 2 weeks on the free plan.</div>
+            </div>
+            <div className="flex gap-2">
+                <Button size={'sm'} variant={'tertiary'} onClick={onClickExtend} isLoading={trialLoading}>
+                    <IconRefresh stroke={1} size={18} />
+                    {isTrialOver ? 'Restart' : 'Extend'}
+                </Button>
+                <ButtonLink to={`/${env}/team/billing`} size={'sm'} variant={'secondary'}>
+                    <IconBolt stroke={1} size={18} />
+                    Upgrade
+                </ButtonLink>
+            </div>
+        </div>
+    );
+};

--- a/packages/webapp/src/pages/Integrations/components/AutoIdlingBanner.tsx
+++ b/packages/webapp/src/pages/Integrations/components/AutoIdlingBanner.tsx
@@ -42,7 +42,7 @@ export const AutoIdlingBanner: React.FC = () => {
             <div className="flex gap-2 items-center">
                 <div className="flex gap-3 items-center">
                     <ErrorCircle icon="clock" variant="warning" />
-                    <Tag variant={'warning'}>{isTrialOver ? 'Trial expired' : 'Auto Idling'}</Tag>
+                    <Tag variant={'warning'}>{isTrialOver ? 'Endpoints idle' : 'Auto Idling'}</Tag>
                     {!isTrialOver && <span className="text-white font-semibold">{daysRemaining} days left</span>}
                 </div>
                 <div className="text-grayscale-400 text-s">Actions and syncs endpoints automatically stop every 2 weeks on the free plan.</div>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Endpoints/components/List.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Endpoints/components/List.tsx
@@ -31,7 +31,7 @@ export const EndpointsList: React.FC<{ integration: GetIntegration['Success']['d
     const env = useStore((state) => state.env);
 
     const { plan } = useEnvironment(env);
-    const { isTrial } = useTrial(plan);
+    const { isTrial, daysRemaining } = useTrial(plan);
 
     if (byGroup.length <= 0 && v1Flow.length <= 0) {
         return (
@@ -104,7 +104,7 @@ export const EndpointsList: React.FC<{ integration: GetIntegration['Success']['d
                                                     <Table.Cell bordered className="text-white">
                                                         <div className="flex gap-2 items-start">
                                                             {isTrial && flow.enabled && (
-                                                                <SimpleTooltip tooltipContent="Deactivates at the end of your trial.">
+                                                                <SimpleTooltip tooltipContent={`Idles in ${daysRemaining} days`}>
                                                                     <ErrorCircle icon="clock" variant="warning" />
                                                                 </SimpleTooltip>
                                                             )}

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Show.tsx
@@ -1,39 +1,31 @@
 import { BookOpenIcon } from '@heroicons/react/24/outline';
 import { PlusIcon } from '@radix-ui/react-icons';
-import { IconBolt, IconRefresh } from '@tabler/icons-react';
 import { useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet';
-import { Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams } from 'react-router-dom';
 
 import { EndpointsShow } from './Endpoints/Show';
 import { SettingsShow } from './Settings/Show';
-import { ErrorCircle } from '../../../components/ErrorCircle';
 import { ErrorPageComponent } from '../../../components/ErrorComponent';
 import { LeftNavBarItems } from '../../../components/LeftNavBar';
 import IntegrationLogo from '../../../components/ui/IntegrationLogo';
 import { Skeleton } from '../../../components/ui/Skeleton';
-import { Button, ButtonLink } from '../../../components/ui/button/Button';
-import { Tag } from '../../../components/ui/label/Tag';
-import { useEnvironment } from '../../../hooks/useEnvironment';
+import { ButtonLink } from '../../../components/ui/button/Button';
 import { useGetIntegration } from '../../../hooks/useIntegration';
-import { apiPostPlanExtendTrial, useTrial } from '../../../hooks/usePlan';
-import { useToast } from '../../../hooks/useToast';
 import DashboardLayout from '../../../layout/DashboardLayout';
 import { useStore } from '../../../store';
 import PageNotFound from '../../PageNotFound';
+import { AutoIdlingBanner } from '../components/AutoIdlingBanner';
 
 export const ShowIntegration: React.FC = () => {
-    const { toast } = useToast();
     const { providerConfigKey } = useParams();
     const location = useLocation();
     const ref = useRef<HTMLDivElement>(null);
 
     const env = useStore((state) => state.env);
-    const { plan, mutate: mutateEnv } = useEnvironment(env);
     const { data, loading: loadingIntegration, error } = useGetIntegration(env, providerConfigKey!);
 
     const [tab, setTab] = useState<string>('');
-    const [trialLoading, setTrialLoading] = useState(false);
 
     useEffect(() => {
         if (location.pathname.match(/\/settings/)) {
@@ -50,23 +42,6 @@ export const ShowIntegration: React.FC = () => {
             ref.current.scrollTo({ top: 150 });
         }
     }, [location]);
-
-    const { isTrial, isTrialOver, daysRemaining } = useTrial(plan);
-
-    const onClickTrialExtend = async () => {
-        setTrialLoading(true);
-        const res = await apiPostPlanExtendTrial(env);
-        setTrialLoading(false);
-
-        if ('error' in res.json) {
-            toast({ title: 'There was an issue extending your trial', variant: 'error' });
-            return;
-        }
-
-        void mutateEnv();
-
-        toast({ title: 'Your trial was extended successfully!', variant: 'success' });
-    };
 
     if (loadingIntegration) {
         return (
@@ -149,30 +124,7 @@ export const ShowIntegration: React.FC = () => {
                     {data.integration.missing_fields.length > 0 && <span className="ml-2 bg-yellow-base h-1.5 w-1.5 rounded-full inline-block"></span>}
                 </ButtonLink>
             </nav>
-            {isTrial && (
-                <div className="mb-7 rounded-md bg-grayscale-900 border border-grayscale-600 p-4 flex gap-2 justify-between items-center">
-                    <div className="flex gap-2 items-center">
-                        <div className="flex gap-3 items-center">
-                            <ErrorCircle icon="clock" variant="warning" />
-                            <Tag variant={'warning'}>{isTrialOver ? 'Trial expired' : 'Trial'}</Tag>
-                            {!isTrialOver && <span className="text-white font-semibold">{daysRemaining} days left!</span>}
-                        </div>
-                        <div className="text-grayscale-400 text-sm">Actions & syncs are subject to a 2-week trial</div>
-                    </div>
-                    <div className="flex gap-2">
-                        <Button size={'sm'} variant={'tertiary'} onClick={onClickTrialExtend} isLoading={trialLoading}>
-                            <IconRefresh stroke={1} size={18} />
-                            {isTrialOver ? 'Restart trial' : 'Extend trial'}
-                        </Button>
-                        <Link to={`mailto:upgrade@nango.dev?subject=Upgrade%20my%20plan%20`}>
-                            <Button size={'sm'} variant={'secondary'}>
-                                <IconBolt stroke={1} size={18} />
-                                Upgrade plan
-                            </Button>
-                        </Link>
-                    </div>
-                </div>
-            )}
+            <AutoIdlingBanner />
             <Routes>
                 <Route path="/*" element={<EndpointsShow integration={data} />} />
                 <Route path="/settings" element={<SettingsShow data={data} />} />


### PR DESCRIPTION
- Adds banner to integrations list as well
- Updates copies
- Updates email copies

<!-- Summary by @propel-code-bot -->

---

This PR overhauls trial period communication across Nango's frontend and backend, replacing 'trial' language and logic with a new 'Auto Idling' concept to improve user clarity and plan enforcement. Changes include the introduction of the AutoIdlingBanner React component, integration of updated messaging throughout UI (list, details, endpoints), modernization of all related email notifications, and refactoring of backend resource limit logic and error messages for consistency.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced AutoIdlingBanner component, added to integrations list, integration details, and endpoint pages
• Replaced all 'trial' terminology/processes in frontend UI, tooltips, and emails with 'auto idling'
• Unified backend enforcement around account-wide auto idling/resource capping, with improved API error responses
• Rewrote and centralized email copy/templates regarding plan limits, auto idling, and feature pausing
• Simplified and updated hooks (usePlan, useEnvironment) and made minor fixes for consistency

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Web UI: Integrations list, integration details, endpoints tables/tooltips
• Frontend hooks: usePlan, useEnvironment
• React components: banners, tooltips
• Backend: resource capping and flow enablement controllers
• Email notification system (copies and logic)

</details>

*This summary was automatically generated by @propel-code-bot*