### PR TITLE
fix: upgrade dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "@types/node": "22.15.29",
                 "@typescript-eslint/eslint-plugin": "8.38.0",
                 "@typescript-eslint/parser": "8.38.0",
-                "concurrently": "8.2.2",
+                "concurrently": "9.2.0",
                 "eslint": "9.31.0",
                 "eslint-config-prettier": "10.1.5",
                 "eslint-plugin-import": "2.31.0",
@@ -30,13 +30,13 @@
                 "husky": "8.0.3",
                 "lint-staged": "15.5.1",
                 "onchange": "7.1.0",
-                "prettier": "3.5.3",
+                "prettier": "3.6.2",
                 "rimraf": "6.0.1",
                 "testcontainers": "10.24.2",
-                "tsx": "4.19.4",
+                "tsx": "4.20.3",
                 "typescript": "5.8.3",
                 "typescript-eslint": "8.38.0",
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             },
             "engines": {
                 "node": ">=20.0.0"
@@ -1505,21 +1505,21 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.27.3",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.3.tgz",
-            "integrity": "sha512-hyrN8ivxfvJ4i0fIJuV4EOlV0WDMz5Ui4StRTgVaAvWeiRCilXgwVvxJKtFQ3TKtHgJscB2YiXKGNJuVwhQMtA==",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
+            "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
             "license": "MIT",
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.27.3",
+                "@babel/generator": "^7.28.0",
                 "@babel/helper-compilation-targets": "^7.27.2",
                 "@babel/helper-module-transforms": "^7.27.3",
-                "@babel/helpers": "^7.27.3",
-                "@babel/parser": "^7.27.3",
+                "@babel/helpers": "^7.27.6",
+                "@babel/parser": "^7.28.0",
                 "@babel/template": "^7.27.2",
-                "@babel/traverse": "^7.27.3",
-                "@babel/types": "^7.27.3",
+                "@babel/traverse": "^7.28.0",
+                "@babel/types": "^7.28.0",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -1547,15 +1547,15 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.27.3",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.3.tgz",
-            "integrity": "sha512-xnlJYj5zepml8NXtjkG0WquFUv8RskFqyFcVgTBp5k+NaA/8uw/K+OSVf8AMGw5e9HKP2ETd5xpK5MLZQD6b4Q==",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
+            "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.27.3",
-                "@babel/types": "^7.27.3",
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25",
+                "@babel/parser": "^7.28.0",
+                "@babel/types": "^7.28.0",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
             },
             "engines": {
@@ -1563,9 +1563,9 @@
             }
         },
         "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "version": "0.3.29",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+            "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -1652,6 +1652,15 @@
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
@@ -1776,25 +1785,25 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.27.3",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.3.tgz",
-            "integrity": "sha512-h/eKy9agOya1IGuLaZ9tEUgz+uIRXcbtOhRtUyyMf8JFmn1iT13vnl/IGVWSkdOCG/pC57U4S1jnAabAavTMwg==",
+            "version": "7.28.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
+            "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
             "license": "MIT",
             "dependencies": {
                 "@babel/template": "^7.27.2",
-                "@babel/types": "^7.27.3"
+                "@babel/types": "^7.28.2"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.27.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.3.tgz",
-            "integrity": "sha512-xyYxRj6+tLNDTWi0KCBcZ9V7yg3/lwL9DWh9Uwh/RIVlIfFidggcgxKX3GCXwCiswwcGRawBKbEg2LG/Y8eJhw==",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
+            "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.27.3"
+                "@babel/types": "^7.28.0"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -2142,34 +2151,27 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.27.3",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.3.tgz",
-            "integrity": "sha512-lId/IfN/Ye1CIu8xG7oKBHXd2iNb2aW1ilPszzGcJug6M8RCKfVNcYhpI5+bMvFYjK7lXIM0R+a+6r8xhHp2FQ==",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
+            "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.27.3",
-                "@babel/parser": "^7.27.3",
+                "@babel/generator": "^7.28.0",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/parser": "^7.28.0",
                 "@babel/template": "^7.27.2",
-                "@babel/types": "^7.27.3",
-                "debug": "^4.3.1",
-                "globals": "^11.1.0"
+                "@babel/types": "^7.28.0",
+                "debug": "^4.3.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/traverse/node_modules/globals": {
-            "version": "11.12.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/@babel/types": {
-            "version": "7.27.3",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
-            "integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
+            "version": "7.28.2",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+            "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
@@ -2877,9 +2879,9 @@
             }
         },
         "node_modules/@google-cloud/bigquery": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-8.1.0.tgz",
-            "integrity": "sha512-eDleD/IHKQIRm4GmMnwJvPkx4PgSaK8m8DCmDmVOf0gIhqPLSdvOAEeM4QjyyZGUGjV4yHyJfEJxzULTzl22Aw==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-8.1.1.tgz",
+            "integrity": "sha512-2GHlohfA/VJffTvibMazMsZi6jPRx8MmaMberyDTL8rnhVs/frKSXVVRtLU83uSAy2j/5SD4mOs4jMQgJPON2g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@google-cloud/common": "^6.0.0",
@@ -2890,7 +2892,6 @@
                 "big.js": "^6.2.2",
                 "duplexify": "^4.1.3",
                 "extend": "^3.0.2",
-                "is": "^3.3.0",
                 "stream-events": "^1.0.5",
                 "teeny-request": "^10.0.0"
             },
@@ -3223,16 +3224,13 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+            "version": "0.3.12",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
+            "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+            "license": "MIT",
             "dependencies": {
-                "@jridgewell/set-array": "^1.2.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
@@ -3247,14 +3245,6 @@
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.0",
             "license": "MIT",
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@jridgewell/set-array": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -8805,15 +8795,14 @@
             }
         },
         "node_modules/@swc/core": {
-            "version": "1.11.16",
-            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.11.16.tgz",
-            "integrity": "sha512-wgjrJqVUss8Lxqilg0vkiE0tkEKU3mZkoybQM1Ehy+PKWwwB6lFAwKi20cAEFlSSWo8jFR8hRo19ZELAoLDowg==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.2.tgz",
+            "integrity": "sha512-YWqn+0IKXDhqVLKoac4v2tV6hJqB/wOh8/Br8zjqeqBkKa77Qb0Kw2i7LOFzjFNZbZaPH6AlMGlBwNrxaauaAg==",
             "hasInstallScript": true,
-            "optional": true,
-            "peer": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "@swc/counter": "^0.1.3",
-                "@swc/types": "^0.1.21"
+                "@swc/types": "^0.1.23"
             },
             "engines": {
                 "node": ">=10"
@@ -8823,19 +8812,19 @@
                 "url": "https://opencollective.com/swc"
             },
             "optionalDependencies": {
-                "@swc/core-darwin-arm64": "1.11.16",
-                "@swc/core-darwin-x64": "1.11.16",
-                "@swc/core-linux-arm-gnueabihf": "1.11.16",
-                "@swc/core-linux-arm64-gnu": "1.11.16",
-                "@swc/core-linux-arm64-musl": "1.11.16",
-                "@swc/core-linux-x64-gnu": "1.11.16",
-                "@swc/core-linux-x64-musl": "1.11.16",
-                "@swc/core-win32-arm64-msvc": "1.11.16",
-                "@swc/core-win32-ia32-msvc": "1.11.16",
-                "@swc/core-win32-x64-msvc": "1.11.16"
+                "@swc/core-darwin-arm64": "1.13.2",
+                "@swc/core-darwin-x64": "1.13.2",
+                "@swc/core-linux-arm-gnueabihf": "1.13.2",
+                "@swc/core-linux-arm64-gnu": "1.13.2",
+                "@swc/core-linux-arm64-musl": "1.13.2",
+                "@swc/core-linux-x64-gnu": "1.13.2",
+                "@swc/core-linux-x64-musl": "1.13.2",
+                "@swc/core-win32-arm64-msvc": "1.13.2",
+                "@swc/core-win32-ia32-msvc": "1.13.2",
+                "@swc/core-win32-x64-msvc": "1.13.2"
             },
             "peerDependencies": {
-                "@swc/helpers": "*"
+                "@swc/helpers": ">=0.5.17"
             },
             "peerDependenciesMeta": {
                 "@swc/helpers": {
@@ -8844,161 +8833,161 @@
             }
         },
         "node_modules/@swc/core-darwin-arm64": {
-            "version": "1.11.16",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.11.16.tgz",
-            "integrity": "sha512-l6uWMU+MUdfLHCl3dJgtVEdsUHPskoA4BSu0L1hh9SGBwPZ8xeOz8iLIqZM27lTuXxL4KsYH6GQR/OdQ/vhLtg==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.13.2.tgz",
+            "integrity": "sha512-44p7ivuLSGFJ15Vly4ivLJjg3ARo4879LtEBAabcHhSZygpmkP8eyjyWxrH3OxkY1eRZSIJe8yRZPFw4kPXFPw==",
             "cpu": [
                 "arm64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/@swc/core-darwin-x64": {
-            "version": "1.11.16",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.11.16.tgz",
-            "integrity": "sha512-TH0IW8Ao1WZ4ARFHIh29dAQHYBEl4YnP74n++rjppmlCjY+8v3s5nXMA7IqxO3b5LVHyggWtU4+46DXTyMJM7g==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.13.2.tgz",
+            "integrity": "sha512-Lb9EZi7X2XDAVmuUlBm2UvVAgSCbD3qKqDCxSI4jEOddzVOpNCnyZ/xEampdngUIyDDhhJLYU9duC+Mcsv5Y+A==",
             "cpu": [
                 "x64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/@swc/core-linux-arm-gnueabihf": {
-            "version": "1.11.16",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.11.16.tgz",
-            "integrity": "sha512-2IxD9t09oNZrbv37p4cJ9cTHMUAK6qNiShi9s2FJ9LcqSnZSN4iS4hvaaX6KZuG54d58vWnMU7yycjkdOTQcMg==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.13.2.tgz",
+            "integrity": "sha512-9TDe/92ee1x57x+0OqL1huG4BeljVx0nWW4QOOxp8CCK67Rpc/HHl2wciJ0Kl9Dxf2NvpNtkPvqj9+BUmM9WVA==",
             "cpu": [
                 "arm"
             ],
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/@swc/core-linux-arm64-gnu": {
-            "version": "1.11.16",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.11.16.tgz",
-            "integrity": "sha512-AYkN23DOiPh1bf3XBf/xzZQDKSsgZTxlbyTyUIhprLJpAAAT0ZCGAUcS5mHqydk0nWQ13ABUymodvHoroutNzw==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.13.2.tgz",
+            "integrity": "sha512-KJUSl56DBk7AWMAIEcU83zl5mg3vlQYhLELhjwRFkGFMvghQvdqQ3zFOYa4TexKA7noBZa3C8fb24rI5sw9Exg==",
             "cpu": [
                 "arm64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/@swc/core-linux-arm64-musl": {
-            "version": "1.11.16",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.11.16.tgz",
-            "integrity": "sha512-n/nWXDRCIhM51dDGELfBcTMNnCiFatE7LDvsbYxb7DJt1HGjaCNvHHCKURb/apJTh/YNtWfgFap9dbsTgw8yPA==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.13.2.tgz",
+            "integrity": "sha512-teU27iG1oyWpNh9CzcGQ48ClDRt/RCem7mYO7ehd2FY102UeTws2+OzLESS1TS1tEZipq/5xwx3FzbVgiolCiQ==",
             "cpu": [
                 "arm64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/@swc/core-linux-x64-gnu": {
-            "version": "1.11.16",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.11.16.tgz",
-            "integrity": "sha512-xr182YQrF47n7Awxj+/ruI21bYw+xO/B26KFVnb+i3ezF9NOhqoqTX+33RL1ZLA/uFTq8ksPZO/y+ZVS/odtQA==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.13.2.tgz",
+            "integrity": "sha512-dRPsyPyqpLD0HMRCRpYALIh4kdOir8pPg4AhNQZLehKowigRd30RcLXGNVZcc31Ua8CiPI4QSgjOIxK+EQe4LQ==",
             "cpu": [
                 "x64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/@swc/core-linux-x64-musl": {
-            "version": "1.11.16",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.11.16.tgz",
-            "integrity": "sha512-k2JBfiwWfXCIKrBRjFO9/vEdLSYq0QLJ+iNSLdfrejZ/aENNkbEg8O7O2GKUSb30RBacn6k8HMfJrcPLFiEyCQ==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.13.2.tgz",
+            "integrity": "sha512-CCxETW+KkYEQDqz1SYC15YIWYheqFC+PJVOW76Maa/8yu8Biw+HTAcblKf2isrlUtK8RvrQN94v3UXkC2NzCEw==",
             "cpu": [
                 "x64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/@swc/core-win32-arm64-msvc": {
-            "version": "1.11.16",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.11.16.tgz",
-            "integrity": "sha512-taOb5U+abyEhQgex+hr6cI48BoqSvSdfmdirWcxprIEUBHCxa1dSriVwnJRAJOFI9T+5BEz88by6rgbB9MjbHA==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.13.2.tgz",
+            "integrity": "sha512-Wv/QTA6PjyRLlmKcN6AmSI4jwSMRl0VTLGs57PHTqYRwwfwd7y4s2fIPJVBNbAlXd795dOEP6d/bGSQSyhOX3A==",
             "cpu": [
                 "arm64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/@swc/core-win32-ia32-msvc": {
-            "version": "1.11.16",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.11.16.tgz",
-            "integrity": "sha512-b7yYggM9LBDiMY+XUt5kYWvs5sn0U3PXSOGvF3CbLufD/N/YQiDcYON2N3lrWHYL8aYnwbuZl45ojmQHSQPcdA==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.13.2.tgz",
+            "integrity": "sha512-PuCdtNynEkUNbUXX/wsyUC+t4mamIU5y00lT5vJcAvco3/r16Iaxl5UCzhXYaWZSNVZMzPp9qN8NlSL8M5pPxw==",
             "cpu": [
                 "ia32"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/@swc/core-win32-x64-msvc": {
-            "version": "1.11.16",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.11.16.tgz",
-            "integrity": "sha512-/ibq/YDc3B5AROkpOKPGxVkSyCKOg+ml8k11RxrW7FAPy6a9y5y9KPcWIqV74Ahq4RuaMNslTQqHWAGSm0xJsQ==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.13.2.tgz",
+            "integrity": "sha512-qlmMkFZJus8cYuBURx1a3YAG2G7IW44i+FEYV5/32ylKkzGNAr9tDJSA53XNnNXkAB5EXSPsOz7bn5C3JlEtdQ==",
             "cpu": [
                 "x64"
             ],
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -9009,18 +8998,19 @@
             "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
         },
         "node_modules/@swc/helpers": {
-            "version": "0.5.15",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-            "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+            "version": "0.5.17",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+            "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.8.0"
             }
         },
         "node_modules/@swc/types": {
-            "version": "0.1.21",
-            "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.21.tgz",
-            "integrity": "sha512-2YEtj5HJVbKivud9N4bpPBAyZhj4S2Ipe5LkUG94alTpr7in/GU/EARgPAd3BwU+YOmFVJC2+kjqhGRi3r0ZpQ==",
+            "version": "0.1.23",
+            "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.23.tgz",
+            "integrity": "sha512-u1iIVZV9Q0jxY+yM2vw/hZGDNudsN85bBpTqzAQ9rzkxW9D+e3aEM4Han+ow518gSewkXgjmEK0BD79ZcNVgPw==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@swc/counter": "^0.1.3"
             }
@@ -9361,6 +9351,16 @@
             "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
             "license": "MIT"
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+            "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*"
+            }
+        },
         "node_modules/@types/columnify": {
             "version": "1.5.4",
             "resolved": "https://registry.npmjs.org/@types/columnify/-/columnify-1.5.4.tgz",
@@ -9477,6 +9477,13 @@
         },
         "node_modules/@types/d3-timer": {
             "version": "3.0.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
             "dev": true,
             "license": "MIT"
         },
@@ -10311,13 +10318,15 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.2.tgz",
-            "integrity": "sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+            "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "3.1.2",
-                "@vitest/utils": "3.1.2",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "3.2.4",
+                "@vitest/utils": "3.2.4",
                 "chai": "^5.2.0",
                 "tinyrainbow": "^2.0.0"
             },
@@ -10326,12 +10335,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.2.tgz",
-            "integrity": "sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+            "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "3.1.2",
+                "@vitest/spy": "3.2.4",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.17"
             },
@@ -10340,7 +10350,7 @@
             },
             "peerDependencies": {
                 "msw": "^2.4.9",
-                "vite": "^5.0.0 || ^6.0.0"
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
             },
             "peerDependenciesMeta": {
                 "msw": {
@@ -10352,10 +10362,11 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.0.tgz",
-            "integrity": "sha512-gUUhaUmPBHFkrqnOokmfMGRBMHhgpICud9nrz/xpNV3/4OXCn35oG+Pl8rYYsKaTNd/FAIrqRHnwpDpmYxCYZw==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+            "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "tinyrainbow": "^2.0.0"
             },
@@ -10364,25 +10375,28 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.2.tgz",
-            "integrity": "sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+            "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "3.1.2",
-                "pathe": "^2.0.3"
+                "@vitest/utils": "3.2.4",
+                "pathe": "^2.0.3",
+                "strip-literal": "^3.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.2.tgz",
-            "integrity": "sha512-Q1qkpazSF/p4ApZg1vfZSQ5Yw6OCQxVMVrLjslbLFA1hMDrT2uxtqMaw8Tc/jy5DLka1sNs1Y7rBcftMiaSH/Q==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+            "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "3.1.2",
+                "@vitest/pretty-format": "3.2.4",
                 "magic-string": "^0.30.17",
                 "pathe": "^2.0.3"
             },
@@ -10390,50 +10404,28 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
-        "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
-            "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
-            "dev": true,
-            "dependencies": {
-                "tinyrainbow": "^2.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
         "node_modules/@vitest/spy": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.2.tgz",
-            "integrity": "sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+            "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "tinyspy": "^3.0.2"
+                "tinyspy": "^4.0.3"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.2.tgz",
-            "integrity": "sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+            "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "3.1.2",
-                "loupe": "^3.1.3",
-                "tinyrainbow": "^2.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
-        "node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
-            "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
-            "dev": true,
-            "dependencies": {
+                "@vitest/pretty-format": "3.2.4",
+                "loupe": "^3.1.4",
                 "tinyrainbow": "^2.0.0"
             },
             "funding": {
@@ -11251,11 +11243,31 @@
                 "safer-buffer": "~2.1.0"
             }
         },
+        "node_modules/asn1.js": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "node_modules/asn1.js/node_modules/bn.js": {
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+            "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/assertion-error": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
             "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             }
@@ -11345,12 +11357,13 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-            "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+            "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
+                "form-data": "^4.0.4",
                 "proxy-from-env": "^1.1.0"
             }
         },
@@ -11577,6 +11590,13 @@
         },
         "node_modules/bluebird": {
             "version": "3.7.2",
+            "license": "MIT"
+        },
+        "node_modules/bn.js": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
+            "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/body-parser": {
@@ -12069,6 +12089,137 @@
                 "npm": ">=6"
             }
         },
+        "node_modules/brorand": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/browserify-aes": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+            "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/browserify-cipher": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+            "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserify-aes": "^1.0.4",
+                "browserify-des": "^1.0.0",
+                "evp_bytestokey": "^1.0.0"
+            }
+        },
+        "node_modules/browserify-des": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+            "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cipher-base": "^1.0.1",
+                "des.js": "^1.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
+        "node_modules/browserify-rsa": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+            "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^5.2.1",
+                "randombytes": "^2.1.0",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/browserify-sign": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
+            "integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "bn.js": "^5.2.1",
+                "browserify-rsa": "^4.1.0",
+                "create-hash": "^1.2.0",
+                "create-hmac": "^1.1.7",
+                "elliptic": "^6.5.5",
+                "hash-base": "~3.0",
+                "inherits": "^2.0.4",
+                "parse-asn1": "^5.1.7",
+                "readable-stream": "^2.3.8",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.12"
+            }
+        },
+        "node_modules/browserify-sign/node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/browserify-sign/node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/browserify-sign/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/browserslist": {
             "version": "4.25.1",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
@@ -12138,6 +12289,13 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/buffer-xor": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+            "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/buildcheck": {
             "version": "0.0.6",
@@ -12327,10 +12485,11 @@
             "license": "CC-BY-4.0"
         },
         "node_modules/chai": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
-            "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.1.tgz",
+            "integrity": "sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "assertion-error": "^2.0.1",
                 "check-error": "^2.1.1",
@@ -12339,7 +12498,7 @@
                 "pathval": "^2.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/chalk": {
@@ -12401,6 +12560,7 @@
             "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
             "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 16"
             }
@@ -12469,6 +12629,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/cipher-base": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+            "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
             }
         },
         "node_modules/cjs-module-lexer": {
@@ -13005,17 +13179,16 @@
             }
         },
         "node_modules/concurrently": {
-            "version": "8.2.2",
-            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
-            "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.0.tgz",
+            "integrity": "sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.2",
-                "date-fns": "^2.30.0",
                 "lodash": "^4.17.21",
                 "rxjs": "^7.8.1",
                 "shell-quote": "^1.8.1",
-                "spawn-command": "0.0.2",
                 "supports-color": "^8.1.1",
                 "tree-kill": "^1.2.2",
                 "yargs": "^17.7.2"
@@ -13025,7 +13198,7 @@
                 "concurrently": "dist/bin/concurrently.js"
             },
             "engines": {
-                "node": "^14.13.0 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
@@ -13448,6 +13621,53 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
+        "node_modules/create-ecdh": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+            "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.1.0",
+                "elliptic": "^6.5.3"
+            }
+        },
+        "node_modules/create-ecdh/node_modules/bn.js": {
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+            "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/create-hash": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+            "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "md5.js": "^1.3.4",
+                "ripemd160": "^2.0.1",
+                "sha.js": "^2.4.0"
+            }
+        },
+        "node_modules/create-hmac": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+            "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
+            }
+        },
         "node_modules/create-require": {
             "version": "1.1.1",
             "license": "MIT"
@@ -13478,6 +13698,33 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/crypto-browserify": {
+            "version": "3.12.1",
+            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
+            "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserify-cipher": "^1.0.1",
+                "browserify-sign": "^4.2.3",
+                "create-ecdh": "^4.0.4",
+                "create-hash": "^1.2.0",
+                "create-hmac": "^1.1.7",
+                "diffie-hellman": "^5.0.3",
+                "hash-base": "~3.0.4",
+                "inherits": "^2.0.4",
+                "pbkdf2": "^3.1.2",
+                "public-encrypt": "^4.0.3",
+                "randombytes": "^2.1.0",
+                "randomfill": "^1.0.4"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/crypto-randomuuid": {
@@ -13757,6 +14004,7 @@
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
             "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.21.0"
             },
@@ -13919,6 +14167,7 @@
             "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
             "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -14139,6 +14388,25 @@
             "engines": {
                 "node": ">=0.3.1"
             }
+        },
+        "node_modules/diffie-hellman": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+            "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.1.0",
+                "miller-rabin": "^4.0.0",
+                "randombytes": "^2.0.0"
+            }
+        },
+        "node_modules/diffie-hellman/node_modules/bn.js": {
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+            "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/dlv": {
             "version": "1.1.3",
@@ -14411,6 +14679,29 @@
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.189.tgz",
             "integrity": "sha512-y9D1ntS1ruO/pZ/V2FtLE+JXLQe28XoRpZ7QCCo0T8LdQladzdcOVQZH/IWLVJvCw12OGMb6hYOeOAjntCmJRQ==",
             "license": "ISC"
+        },
+        "node_modules/elliptic": {
+            "version": "6.6.1",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+            "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
+        "node_modules/elliptic/node_modules/bn.js": {
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+            "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -15655,6 +15946,7 @@
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
             "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0"
             }
@@ -15715,6 +16007,17 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18.0.0"
+            }
+        },
+        "node_modules/evp_bytestokey": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+            "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
             }
         },
         "node_modules/execa": {
@@ -16092,7 +16395,9 @@
             "license": "MIT"
         },
         "node_modules/figlet": {
-            "version": "1.6.0",
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.8.2.tgz",
+            "integrity": "sha512-iPCpE9B/rOcjewIzDnagP9F2eySzGeHReX8WlrZQJkqFBk2wvq8gY0c6U6Hd2y9HnX1LQcYSeP7aEHoPt6sVKQ==",
             "license": "MIT",
             "bin": {
                 "figlet": "bin/index.js"
@@ -16751,10 +17056,11 @@
             "license": "MIT"
         },
         "node_modules/git-cliff": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/git-cliff/-/git-cliff-2.8.0.tgz",
-            "integrity": "sha512-iKF5QTXAb9+iVvmu5HpnMPWYw7fs74xkpAaRbSf29+dZaMTTNRIUST/y+Ir2S1bDUWWJNjXlwT9ZT62JuYLQnA==",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/git-cliff/-/git-cliff-2.10.0.tgz",
+            "integrity": "sha512-V7rIKfGsmXq5oUqFn8GJ+hkZcdl/enbrUwZIQl7dDgo/PxLOdiXD69+XG4zB7ufaPqhHcMzzH5TZwpFaPK3qNg==",
             "dev": true,
+            "license": "MIT OR Apache-2.0",
             "dependencies": {
                 "execa": "^8.0.1"
             },
@@ -16765,87 +17071,93 @@
                 "node": ">=18.19 || >=20.6 || >=21"
             },
             "optionalDependencies": {
-                "git-cliff-darwin-arm64": "2.8.0",
-                "git-cliff-darwin-x64": "2.8.0",
-                "git-cliff-linux-arm64": "2.8.0",
-                "git-cliff-linux-x64": "2.8.0",
-                "git-cliff-windows-arm64": "2.8.0",
-                "git-cliff-windows-x64": "2.8.0"
+                "git-cliff-darwin-arm64": "2.10.0",
+                "git-cliff-darwin-x64": "2.10.0",
+                "git-cliff-linux-arm64": "2.10.0",
+                "git-cliff-linux-x64": "2.10.0",
+                "git-cliff-windows-arm64": "2.10.0",
+                "git-cliff-windows-x64": "2.10.0"
             }
         },
         "node_modules/git-cliff-darwin-arm64": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/git-cliff-darwin-arm64/-/git-cliff-darwin-arm64-2.8.0.tgz",
-            "integrity": "sha512-rurUV2d1Z2n+c2+wUrO0gZaFb3c1G+ej0bPfKTPfde/CblxiysMkh+4dz23NrVbc8IlS5rSYv/JFGVaVSBNJRw==",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/git-cliff-darwin-arm64/-/git-cliff-darwin-arm64-2.10.0.tgz",
+            "integrity": "sha512-/x+KW+CRCpfn3xG71YD0lpQd1MmKH+fhUI7aki5QkU8dRp+IBxieswwb+lJcU4+FcLEbAEL/8hVxrBawrcmLcA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
                 "darwin"
             ]
         },
         "node_modules/git-cliff-darwin-x64": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/git-cliff-darwin-x64/-/git-cliff-darwin-x64-2.8.0.tgz",
-            "integrity": "sha512-Wtj+FGWZBWmeYUAGlkfz7QPz4+VVxxDPMhQ/7iwKVA3iryIX0slGfzYpqMurEFnTAMr0r+4IU3Q4O/ib7iUscg==",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/git-cliff-darwin-x64/-/git-cliff-darwin-x64-2.10.0.tgz",
+            "integrity": "sha512-Yiufjb9wNEJ6Y//Na/BvfSd68sB4kp3NPKHtA9keO4UX+EM7xd4qy4daWUTnbDyvqJw4ZHWrdXND0SYoZ1qUqA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
                 "darwin"
             ]
         },
         "node_modules/git-cliff-linux-arm64": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/git-cliff-linux-arm64/-/git-cliff-linux-arm64-2.8.0.tgz",
-            "integrity": "sha512-k4RdfMdORXyefznWlQb+7wDgo7XgQF9qg8hJC34bwyJK2sODirrGau3uTx1/9Fi37g+pAOM7wM+LYppHCTZ2bQ==",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/git-cliff-linux-arm64/-/git-cliff-linux-arm64-2.10.0.tgz",
+            "integrity": "sha512-rGhsuItIwZlYmoW0h74dox7hJNVwG9H6h61URIh+Ey6EJaQGt7toh7GmgPBnhOnzKXHiVgMAfZaVNuhuuaYTKQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/git-cliff-linux-x64": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/git-cliff-linux-x64/-/git-cliff-linux-x64-2.8.0.tgz",
-            "integrity": "sha512-FcWX4GHgodYrQlZR03fzooanStgR03JNWvyaMQB1asplQ18nlziK2UyA+PESCIxOQmeLXauqoCApfzmdtp5myg==",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/git-cliff-linux-x64/-/git-cliff-linux-x64-2.10.0.tgz",
+            "integrity": "sha512-MSXv/vvZuSfjfB81i3LiqnjwJm63Go+Ns2L+USLYktHZ69uq1iEWuhqNrCAU4V1xP1i6VMdXeax8Q6gc4Msehg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/git-cliff-windows-arm64": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/git-cliff-windows-arm64/-/git-cliff-windows-arm64-2.8.0.tgz",
-            "integrity": "sha512-GJSrqmBVTbMtBJI3/YCDxLviZZDgYgnKqYgquBk2u2AELAnnuWFnVFQ7ZEBUqgFF2UJu9EdV2Nv6MV8d/wnP0g==",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/git-cliff-windows-arm64/-/git-cliff-windows-arm64-2.10.0.tgz",
+            "integrity": "sha512-38iGWPi8O+0c3ejIYZ00d1cXmJ+0Sx0j9WzFBwE2HS2I938sJssrEdkzQyg+/1m8HG+a8yWK86wPEOxvfJ6kQQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
                 "win32"
             ]
         },
         "node_modules/git-cliff-windows-x64": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/git-cliff-windows-x64/-/git-cliff-windows-x64-2.8.0.tgz",
-            "integrity": "sha512-8jl0YMXPYjUmVygUEeQ4wf1zte3Rv8LPq1sIklUKl80XE4g2Gm/8EIWbKpUPLQH6IncRwepY6VuMgpVpPXbwNw==",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/git-cliff-windows-x64/-/git-cliff-windows-x64-2.10.0.tgz",
+            "integrity": "sha512-ke5yHH2BKtOyQWEtvasw2Dfd18PRbVJjbU/0FrBNBh/AjPOIKctDR0IaApxDDuEk+tJcSmrOA8s44Hw+Pd72Ig==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
                 "win32"
@@ -17215,6 +17527,31 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/hash-base": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
+            "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/hash.js": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
+            }
+        },
         "node_modules/hasown": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -17239,6 +17576,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">=16.0.0"
+            }
+        },
+        "node_modules/hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
             }
         },
         "node_modules/hoist-non-react-statics": {
@@ -17577,13 +17926,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/is": {
-            "version": "3.3.0",
-            "license": "MIT",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/is-array-buffer": {
@@ -19611,10 +19953,11 @@
             }
         },
         "node_modules/loupe": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
-            "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
-            "dev": true
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.0.tgz",
+            "integrity": "sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lower-case": {
             "version": "2.0.2",
@@ -19696,6 +20039,18 @@
                 "is-buffer": "~1.1.6"
             }
         },
+        "node_modules/md5.js": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+            "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
         "node_modules/media-typer": {
             "version": "0.3.0",
             "license": "MIT",
@@ -19737,6 +20092,27 @@
             "engines": {
                 "node": ">=8.6"
             }
+        },
+        "node_modules/miller-rabin": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+            "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.0.0",
+                "brorand": "^1.0.1"
+            },
+            "bin": {
+                "miller-rabin": "bin/miller-rabin"
+            }
+        },
+        "node_modules/miller-rabin/node_modules/bn.js": {
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+            "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/mime-db": {
             "version": "1.52.0",
@@ -19794,6 +20170,13 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
             "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+        },
+        "node_modules/minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/minimatch": {
             "version": "3.1.2",
@@ -20716,6 +21099,24 @@
                 "node": ">=6"
             }
         },
+        "node_modules/parse-asn1": {
+            "version": "5.1.7",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
+            "integrity": "sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "asn1.js": "^4.10.1",
+                "browserify-aes": "^1.2.0",
+                "evp_bytestokey": "^1.0.3",
+                "hash-base": "~3.0",
+                "pbkdf2": "^3.1.2",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/parse-json": {
             "version": "5.2.0",
             "dev": true,
@@ -20873,16 +21274,69 @@
             "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
         },
         "node_modules/pathval": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
-            "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+            "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 14.16"
             }
         },
         "node_modules/pause": {
             "version": "0.0.1"
+        },
+        "node_modules/pbkdf2": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
+            "integrity": "sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "create-hash": "~1.1.3",
+                "create-hmac": "^1.1.7",
+                "ripemd160": "=2.0.1",
+                "safe-buffer": "^5.2.1",
+                "sha.js": "^2.4.11",
+                "to-buffer": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=0.12"
+            }
+        },
+        "node_modules/pbkdf2/node_modules/create-hash": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+            "integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "sha.js": "^2.4.0"
+            }
+        },
+        "node_modules/pbkdf2/node_modules/hash-base": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+            "integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.1"
+            }
+        },
+        "node_modules/pbkdf2/node_modules/ripemd160": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+            "integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hash-base": "^2.0.0",
+                "inherits": "^2.0.1"
+            }
         },
         "node_modules/pg": {
             "version": "8.11.3",
@@ -21322,10 +21776,11 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-            "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+            "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -21466,6 +21921,28 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/public-encrypt": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+            "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
+        "node_modules/public-encrypt/node_modules/bn.js": {
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+            "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/pump": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
@@ -21533,8 +22010,18 @@
             "version": "2.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "node_modules/randomfill": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+            "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "randombytes": "^2.0.5",
                 "safe-buffer": "^5.1.0"
             }
         },
@@ -22388,6 +22875,17 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/ripemd160": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+            "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
+            }
+        },
         "node_modules/rollup": {
             "version": "4.40.1",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.40.1.tgz",
@@ -23046,6 +23544,27 @@
             "version": "1.2.0",
             "license": "ISC"
         },
+        "node_modules/sha.js": {
+            "version": "2.4.12",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+            "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+            "dev": true,
+            "license": "(MIT AND BSD-3-Clause)",
+            "dependencies": {
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.0"
+            },
+            "bin": {
+                "sha.js": "bin.js"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/shallow-clone": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
@@ -23254,11 +23773,12 @@
             }
         },
         "node_modules/soap": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/soap/-/soap-1.1.12.tgz",
-            "integrity": "sha512-bfgy09VAA2Pnv8I/qDpMvPFPV//eIGr/DOeaLx3uexpMrI+gq8Xuvp3KlTZYMhKFwjwgcLd+YpabFbOv82R5gQ==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/soap/-/soap-1.2.1.tgz",
+            "integrity": "sha512-QRkgCb8C99x1SxZ84jCJAd5VDFpp0MNL5O1X6vKtHp3Hba6UnN1Wdy0Lq+o1CmvBkxyxBYIW/Y+xPQLPq+Sv6g==",
+            "license": "MIT",
             "dependencies": {
-                "axios": "^1.9.0",
+                "axios": "^1.11.0",
                 "axios-ntlm": "^1.4.4",
                 "debug": "^4.4.1",
                 "formidable": "^3.5.4",
@@ -23366,12 +23886,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/spawn-command": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
-            "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
-            "dev": true
         },
         "node_modules/split-ca": {
             "version": "1.0.1",
@@ -23771,6 +24285,26 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/strip-literal": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+            "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^9.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/strip-literal/node_modules/js-tokens": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/stripe": {
             "version": "18.2.1",
@@ -24417,9 +24951,10 @@
             "license": "MIT"
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-            "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+            "version": "0.2.14",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+            "license": "MIT",
             "dependencies": {
                 "fdir": "^6.4.4",
                 "picomatch": "^4.0.2"
@@ -24456,10 +24991,11 @@
             }
         },
         "node_modules/tinypool": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.0.tgz",
-            "integrity": "sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^18.0.0 || >=20.0.0"
             }
@@ -24469,15 +25005,17 @@
             "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
             "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/tinyspy": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-            "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+            "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -24517,6 +25055,28 @@
             "engines": {
                 "node": ">=14.14"
             }
+        },
+        "node_modules/to-buffer": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
+            "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "isarray": "^2.0.5",
+                "safe-buffer": "^5.2.1",
+                "typed-array-buffer": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/to-buffer/node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
@@ -24729,7 +25289,9 @@
             }
         },
         "node_modules/ts-node": {
-            "version": "10.9.1",
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "license": "MIT",
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
@@ -24992,10 +25554,11 @@
             }
         },
         "node_modules/tsx": {
-            "version": "4.19.4",
-            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.4.tgz",
-            "integrity": "sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==",
+            "version": "4.20.3",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
+            "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
             "devOptional": true,
+            "license": "MIT",
             "dependencies": {
                 "esbuild": "~0.25.0",
                 "get-tsconfig": "^4.7.5"
@@ -25579,23 +26142,24 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.3.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-            "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.6.tgz",
+            "integrity": "sha512-MHFiOENNBd+Bd9uvc8GEsIzdkn1JxMmEeYX35tI3fv0sJBUTfW5tQsoaOwuY4KhBI09A3dUJ/DXf2yxPVPUceg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.25.0",
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2",
-                "postcss": "^8.5.3",
-                "rollup": "^4.34.9",
-                "tinyglobby": "^0.2.13"
+                "fdir": "^6.4.6",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.6",
+                "rollup": "^4.40.0",
+                "tinyglobby": "^0.2.14"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -25604,14 +26168,14 @@
                 "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@types/node": "^20.19.0 || >=22.12.0",
                 "jiti": ">=1.21.0",
-                "less": "*",
+                "less": "^4.0.0",
                 "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
                 "terser": "^5.16.0",
                 "tsx": "^4.8.1",
                 "yaml": "^2.4.2"
@@ -25653,16 +26217,17 @@
             }
         },
         "node_modules/vite-node": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.2.tgz",
-            "integrity": "sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+            "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "cac": "^6.7.14",
-                "debug": "^4.4.0",
-                "es-module-lexer": "^1.6.0",
+                "debug": "^4.4.1",
+                "es-module-lexer": "^1.7.0",
                 "pathe": "^2.0.3",
-                "vite": "^5.0.0 || ^6.0.0"
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
             },
             "bin": {
                 "vite-node": "vite-node.mjs"
@@ -25679,6 +26244,7 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -25695,7 +26261,8 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/vite-plugin-checker": {
             "version": "0.9.3",
@@ -26120,10 +26687,11 @@
             }
         },
         "node_modules/vite/node_modules/fdir": {
-            "version": "6.4.4",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
-            "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+            "version": "6.4.6",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+            "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
             "dev": true,
+            "license": "MIT",
             "peerDependencies": {
                 "picomatch": "^3 || ^4"
             },
@@ -26144,6 +26712,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -26152,10 +26721,11 @@
             }
         },
         "node_modules/vite/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -26164,9 +26734,9 @@
             }
         },
         "node_modules/vite/node_modules/postcss": {
-            "version": "8.5.3",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-            "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+            "version": "8.5.6",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
             "dev": true,
             "funding": [
                 {
@@ -26182,8 +26752,9 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.8",
+                "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -26192,31 +26763,34 @@
             }
         },
         "node_modules/vitest": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.2.tgz",
-            "integrity": "sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+            "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "3.1.2",
-                "@vitest/mocker": "3.1.2",
-                "@vitest/pretty-format": "^3.1.2",
-                "@vitest/runner": "3.1.2",
-                "@vitest/snapshot": "3.1.2",
-                "@vitest/spy": "3.1.2",
-                "@vitest/utils": "3.1.2",
+                "@types/chai": "^5.2.2",
+                "@vitest/expect": "3.2.4",
+                "@vitest/mocker": "3.2.4",
+                "@vitest/pretty-format": "^3.2.4",
+                "@vitest/runner": "3.2.4",
+                "@vitest/snapshot": "3.2.4",
+                "@vitest/spy": "3.2.4",
+                "@vitest/utils": "3.2.4",
                 "chai": "^5.2.0",
-                "debug": "^4.4.0",
+                "debug": "^4.4.1",
                 "expect-type": "^1.2.1",
                 "magic-string": "^0.30.17",
                 "pathe": "^2.0.3",
+                "picomatch": "^4.0.2",
                 "std-env": "^3.9.0",
                 "tinybench": "^2.9.0",
                 "tinyexec": "^0.3.2",
-                "tinyglobby": "^0.2.13",
-                "tinypool": "^1.0.2",
+                "tinyglobby": "^0.2.14",
+                "tinypool": "^1.1.1",
                 "tinyrainbow": "^2.0.0",
-                "vite": "^5.0.0 || ^6.0.0",
-                "vite-node": "3.1.2",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+                "vite-node": "3.2.4",
                 "why-is-node-running": "^2.3.0"
             },
             "bin": {
@@ -26232,8 +26806,8 @@
                 "@edge-runtime/vm": "*",
                 "@types/debug": "^4.1.12",
                 "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-                "@vitest/browser": "3.1.2",
-                "@vitest/ui": "3.1.2",
+                "@vitest/browser": "3.2.4",
+                "@vitest/ui": "3.2.4",
                 "happy-dom": "*",
                 "jsdom": "*"
             },
@@ -26283,6 +26857,19 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/vscode-uri": {
             "version": "3.1.0",
@@ -26341,11 +26928,12 @@
             "license": "Apache-2.0"
         },
         "node_modules/webflow-api": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webflow-api/-/webflow-api-3.0.1.tgz",
-            "integrity": "sha512-Wx8e9mkZSUNYWCnr7AgpujnDu4ZCJ3IOE/W4zU1ulaXUtytXjzYmA2QyyQVMdbaT9uvHPtbYfHLrh4MuBwt3Pw==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/webflow-api/-/webflow-api-3.1.3.tgz",
+            "integrity": "sha512-BF0AdAAQwoDuug7oyeqERXo2eBn1HuMieU/3//OxHxLkIyD7W0QEsH1NnaY0sSmStb5R3HPKBup7B+KktrSuiA==",
             "dev": true,
             "dependencies": {
+                "crypto-browserify": "^3.12.0",
                 "form-data": "^4.0.0",
                 "formdata-node": "^6.0.3",
                 "js-base64": "3.7.2",
@@ -27040,10 +27628,11 @@
             }
         },
         "node_modules/zx": {
-            "version": "8.5.4",
-            "resolved": "https://registry.npmjs.org/zx/-/zx-8.5.4.tgz",
-            "integrity": "sha512-44oKea9Sa8ZnOkTnS6fRJpg3quzgnbB43nLrVfYnqE86J4sxgZMUDLezzKET/FdOAVkF4X+Alm9Bume+W+RW9Q==",
+            "version": "8.7.1",
+            "resolved": "https://registry.npmjs.org/zx/-/zx-8.7.1.tgz",
+            "integrity": "sha512-28u1w2LlIfvyvJvYe6pmCipesk8oL5AFMVp+P/U445LcaPgzrU5lNDtAPd6nJvWmoCNyXZz37R/xKOGokccjsw==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "zx": "build/cli.js"
             },
@@ -27072,7 +27661,7 @@
                 "uuidv7": "1.0.2"
             },
             "devDependencies": {
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             }
         },
         "packages/billing/node_modules/uuidv7": {
@@ -27088,20 +27677,20 @@
             "version": "0.64.3",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@babel/core": "7.27.3",
-                "@babel/parser": "7.27.3",
+                "@babel/core": "7.28.0",
+                "@babel/parser": "7.28.0",
                 "@babel/preset-typescript": "7.27.1",
-                "@babel/traverse": "7.27.3",
-                "@babel/types": "7.27.3",
+                "@babel/traverse": "7.28.0",
+                "@babel/types": "7.28.2",
                 "@nangohq/nango-yaml": "0.64.3",
                 "@nangohq/node": "0.64.3",
                 "@nangohq/runner-sdk": "0.64.3",
-                "@swc/core": "1.5.25",
+                "@swc/core": "1.13.2",
                 "@types/unzipper": "0.10.11",
                 "ajv": "8.17.1",
                 "ajv-errors": "3.0.0",
                 "axios": "1.11.0",
-                "chalk": "5.3.0",
+                "chalk": "5.4.1",
                 "chokidar": "3.5.3",
                 "columnify": "1.6.0",
                 "commander": "10.0.1",
@@ -27110,7 +27699,7 @@
                 "dotenv": "16.5.0",
                 "ejs": "3.1.10",
                 "esbuild": "0.25.5",
-                "figlet": "1.6.0",
+                "figlet": "1.8.2",
                 "glob": "10.3.10",
                 "import-meta-resolve": "4.1.0",
                 "js-yaml": "4.1.0",
@@ -27121,7 +27710,7 @@
                 "semver": "7.5.4",
                 "serialize-error": "11.0.3",
                 "ts-json-schema-generator": "2.4.0",
-                "ts-node": "10.9.1",
+                "ts-node": "10.9.2",
                 "tsup": "8.5.0",
                 "typescript": "5.8.3",
                 "unzipper": "0.12.3",
@@ -27148,208 +27737,10 @@
                 "json-schema": "0.4.0",
                 "strip-ansi": "7.1.0",
                 "type-fest": "4.41.0",
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             },
             "engines": {
                 "node": ">=20.0"
-            }
-        },
-        "packages/cli/node_modules/@swc/core": {
-            "version": "1.5.25",
-            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.25.tgz",
-            "integrity": "sha512-qdGEIdLVoTjEQ7w72UyyQ0wLFY4XbHfZiidmPHKJQsvSXzdpHXxPdlTCea/mY4AhMqo/M+pvkJSXJAxZnFl7qw==",
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@swc/counter": "^0.1.3",
-                "@swc/types": "^0.1.7"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/swc"
-            },
-            "optionalDependencies": {
-                "@swc/core-darwin-arm64": "1.5.25",
-                "@swc/core-darwin-x64": "1.5.25",
-                "@swc/core-linux-arm-gnueabihf": "1.5.25",
-                "@swc/core-linux-arm64-gnu": "1.5.25",
-                "@swc/core-linux-arm64-musl": "1.5.25",
-                "@swc/core-linux-x64-gnu": "1.5.25",
-                "@swc/core-linux-x64-musl": "1.5.25",
-                "@swc/core-win32-arm64-msvc": "1.5.25",
-                "@swc/core-win32-ia32-msvc": "1.5.25",
-                "@swc/core-win32-x64-msvc": "1.5.25"
-            },
-            "peerDependencies": {
-                "@swc/helpers": "*"
-            },
-            "peerDependenciesMeta": {
-                "@swc/helpers": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/cli/node_modules/@swc/core-darwin-arm64": {
-            "version": "1.5.25",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.25.tgz",
-            "integrity": "sha512-YbD0SBgVJS2DM0vwJTU5m7+wOyCjHPBDMf3nCBJQzFZzOLzK11eRW7SzU2jhJHr9HI9sKcNFfN4lIC2Sj+4inA==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/cli/node_modules/@swc/core-darwin-x64": {
-            "version": "1.5.25",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.25.tgz",
-            "integrity": "sha512-OhP4TROT6gQuozn+ah0Y4UidSdgDmxwtQq3lgCUIAxJYErJAQ82/Y0kve2UaNmkSGjOHU+/b4siHPrYTkXOk0Q==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/cli/node_modules/@swc/core-linux-arm-gnueabihf": {
-            "version": "1.5.25",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.5.25.tgz",
-            "integrity": "sha512-tNmUfrAHxN2gvYPyYNnHx2CYlPO7DGAUuK/bZrqawu++djcg+atAV3eI3XYJgmHId7/sYAlDQ9wjkrOLofFjVg==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/cli/node_modules/@swc/core-linux-arm64-gnu": {
-            "version": "1.5.25",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.5.25.tgz",
-            "integrity": "sha512-stzpke+bRaNFM/HrZPRjX0aQZ86S/2DChVCwb8NAV1n5lu9mz1CS750y7WbbtX/KZjk92FsCeRy2qwkvjI0gWw==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/cli/node_modules/@swc/core-linux-arm64-musl": {
-            "version": "1.5.25",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.25.tgz",
-            "integrity": "sha512-UckUfDYedish/bj2V1jgQDGgouLhyRpG7jgF3mp8jHir11V2K6JiTyjFoz99eOiclS3+hNdr4QLJ+ifrQMJNZw==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/cli/node_modules/@swc/core-linux-x64-gnu": {
-            "version": "1.5.25",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.5.25.tgz",
-            "integrity": "sha512-LwbJEgNT3lXbvz4WFzVNXNvs8DvxpoXjMZk9K9Hig8tmZQJKHC2qZTGomcyK5EFzfj2HBuBXZnAEW8ZT9PcEaA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/cli/node_modules/@swc/core-linux-x64-musl": {
-            "version": "1.5.25",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.5.25.tgz",
-            "integrity": "sha512-rsepMTgml0EkswWkBpg3Wrjj5eqjwTzZN5omAn1klzXSZnClTrfeHvBuoIJYVr1yx+jmBkqySgME2p7+magUAw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/cli/node_modules/@swc/core-win32-arm64-msvc": {
-            "version": "1.5.25",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.5.25.tgz",
-            "integrity": "sha512-DJDsLBsRBV3uQBShRK2x6fqzABp9RLNVxDUpTTvUjc7qywJ8vS/yn+POK/zCyVEqLagf1z/8D5CEQ+RAIJq1NA==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/cli/node_modules/@swc/core-win32-ia32-msvc": {
-            "version": "1.5.25",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.5.25.tgz",
-            "integrity": "sha512-BARL1ulHol53MEKC1ZVWM3A3FP757UUgG5Q8v97za+4a1SaIgbwvAQyHDxMYWi9+ij+OapK8YnWjJcFa17g8dw==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/cli/node_modules/@swc/core-win32-x64-msvc": {
-            "version": "1.5.25",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.5.25.tgz",
-            "integrity": "sha512-o+MHUWrQI9iR6EusEV8eNU2Ezi3KtlhUR4gfptQN5MbVzlgjTvQbhiKpE1GYOxp+0BLBbKRwITKOcdhxfEJ2Uw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
             }
         },
         "packages/cli/node_modules/ajv": {
@@ -27385,17 +27776,6 @@
                 "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
-        "packages/cli/node_modules/axios": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
         "packages/cli/node_modules/brace-expansion": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -27403,18 +27783,6 @@
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
-            }
-        },
-        "packages/cli/node_modules/chalk": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-            "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-            "license": "MIT",
-            "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "packages/cli/node_modules/chokidar": {
@@ -27575,7 +27943,7 @@
                 "tailwindcss": "3.4.14",
                 "tailwindcss-animate": "1.0.7",
                 "typescript": "5.8.3",
-                "vite": "7.0.4",
+                "vite": "7.0.6",
                 "vite-plugin-svgr": "4.3.0",
                 "zod": "4.0.5",
                 "zustand": "5.0.3"
@@ -27629,237 +27997,6 @@
                 }
             }
         },
-        "packages/connect-ui/node_modules/@swc/core": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.12.14.tgz",
-            "integrity": "sha512-CJSn2vstd17ddWIHBsjuD4OQnn9krQfaq6EO+w9YfId5DKznyPmzxAARlOXG99cC8/3Kli8ysKy6phL43bSr0w==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@swc/counter": "^0.1.3",
-                "@swc/types": "^0.1.23"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/swc"
-            },
-            "optionalDependencies": {
-                "@swc/core-darwin-arm64": "1.12.14",
-                "@swc/core-darwin-x64": "1.12.14",
-                "@swc/core-linux-arm-gnueabihf": "1.12.14",
-                "@swc/core-linux-arm64-gnu": "1.12.14",
-                "@swc/core-linux-arm64-musl": "1.12.14",
-                "@swc/core-linux-x64-gnu": "1.12.14",
-                "@swc/core-linux-x64-musl": "1.12.14",
-                "@swc/core-win32-arm64-msvc": "1.12.14",
-                "@swc/core-win32-ia32-msvc": "1.12.14",
-                "@swc/core-win32-x64-msvc": "1.12.14"
-            },
-            "peerDependencies": {
-                "@swc/helpers": ">=0.5.17"
-            },
-            "peerDependenciesMeta": {
-                "@swc/helpers": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/connect-ui/node_modules/@swc/core-darwin-arm64": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.12.14.tgz",
-            "integrity": "sha512-HNukQoOKgMsHSETj8vgGGKK3SEcH7Cz6k4bpntCxBKNkO3sH7RcBTDulWGGHJfZaDNix7Rw2ExUVWtLZlzkzXg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/connect-ui/node_modules/@swc/core-darwin-x64": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.12.14.tgz",
-            "integrity": "sha512-4Ttf3Obtk3MvFrR0e04qr6HfXh4L1Z+K3dRej63TAFuYpo+cPXeOZdPUddAW73lSUGkj+61IHnGPoXD3OQYy4Q==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/connect-ui/node_modules/@swc/core-linux-arm-gnueabihf": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.12.14.tgz",
-            "integrity": "sha512-zhJOH2KWjtQpzJ27Xjw/RKLVOa1aiEJC2b70xbCwEX6ZTVAl8tKbhkZ3GMphhfVmLJ9gf/2UQR58oxVnsXqX5Q==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/connect-ui/node_modules/@swc/core-linux-arm64-gnu": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.12.14.tgz",
-            "integrity": "sha512-akUAe1YrBqZf1EDdUxahQ8QZnJi8Ts6Ya0jf6GBIMvnXL4Y6QIuvKTRwfNxy7rJ+x9zpzP1Vlh14ZZkSKZ1EGA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/connect-ui/node_modules/@swc/core-linux-arm64-musl": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.12.14.tgz",
-            "integrity": "sha512-ZkOOIpSMXuPAjfOXEIAEQcrPOgLi6CaXvA5W+GYnpIpFG21Nd0qb0WbwFRv4K8BRtl993Q21v0gPpOaFHU+wdA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/connect-ui/node_modules/@swc/core-linux-x64-gnu": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.12.14.tgz",
-            "integrity": "sha512-71EPPccwJiJUxd2aMwNlTfom2mqWEWYGdbeTju01tzSHsEuD7E6ePlgC3P3ngBqB3urj41qKs87z7zPOswT5Iw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/connect-ui/node_modules/@swc/core-linux-x64-musl": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.12.14.tgz",
-            "integrity": "sha512-nImF1hZJqKTcl0WWjHqlelOhvuB9rU9kHIw/CmISBUZXogjLIvGyop1TtJNz0ULcz2Oxr3Q2YpwfrzsgvgbGkA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/connect-ui/node_modules/@swc/core-win32-arm64-msvc": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.12.14.tgz",
-            "integrity": "sha512-sABFQFxSuStFoxvEWZUHWYldtB1B4A9eDNFd4Ty50q7cemxp7uoscFoaCqfXSGNBwwBwpS5EiPB6YN4y6hqmLQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/connect-ui/node_modules/@swc/core-win32-ia32-msvc": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.12.14.tgz",
-            "integrity": "sha512-KBznRB02NASkpepRdWIK4f1AvmaJCDipKWdW1M1xV9QL2tE4aySJFojVuG1+t0tVDkjRfwcZjycQfRoJ4RjD7Q==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/connect-ui/node_modules/@swc/core-win32-x64-msvc": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.12.14.tgz",
-            "integrity": "sha512-SymoP2CJHzrYaFKjWvuQljcF7BkTpzaS1vpywv7K9EzdTb5N8qPDvNd+PhWUqBz9JHBhbJxpaeTDQBXF/WWPmw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/connect-ui/node_modules/@swc/helpers": {
-            "version": "0.5.17",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
-            "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.8.0"
-            }
-        },
-        "packages/connect-ui/node_modules/@swc/types": {
-            "version": "0.1.23",
-            "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.23.tgz",
-            "integrity": "sha512-u1iIVZV9Q0jxY+yM2vw/hZGDNudsN85bBpTqzAQ9rzkxW9D+e3aEM4Han+ow518gSewkXgjmEK0BD79ZcNVgPw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@swc/counter": "^0.1.3"
-            }
-        },
         "packages/connect-ui/node_modules/@types/react": {
             "version": "18.3.3",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
@@ -27893,53 +28030,6 @@
                 "node": ">=6"
             }
         },
-        "packages/connect-ui/node_modules/fdir": {
-            "version": "6.4.6",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-            "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/connect-ui/node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "bin": {
-                "nanoid": "bin/nanoid.cjs"
-            },
-            "engines": {
-                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-            }
-        },
-        "packages/connect-ui/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "packages/connect-ui/node_modules/react-hook-form": {
             "version": "7.60.0",
             "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.60.0.tgz",
@@ -27957,127 +28047,6 @@
                 "react": "^16.8.0 || ^17 || ^18 || ^19"
             }
         },
-        "packages/connect-ui/node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "packages/connect-ui/node_modules/vite": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.4.tgz",
-            "integrity": "sha512-SkaSguuS7nnmV7mfJ8l81JGBFV7Gvzp8IzgE8A8t23+AxuNX61Q5H1Tpz5efduSN7NHC8nQXD3sKQKZAu5mNEA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "esbuild": "^0.25.0",
-                "fdir": "^6.4.6",
-                "picomatch": "^4.0.2",
-                "postcss": "^8.5.6",
-                "rollup": "^4.40.0",
-                "tinyglobby": "^0.2.14"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^20.19.0 || >=22.12.0",
-                "jiti": ">=1.21.0",
-                "less": "^4.0.0",
-                "lightningcss": "^1.21.0",
-                "sass": "^1.70.0",
-                "sass-embedded": "^1.70.0",
-                "stylus": ">=0.54.8",
-                "sugarss": "^5.0.0",
-                "terser": "^5.16.0",
-                "tsx": "^4.8.1",
-                "yaml": "^2.4.2"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "jiti": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                },
-                "tsx": {
-                    "optional": true
-                },
-                "yaml": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/connect-ui/node_modules/vite/node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.11",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            }
-        },
         "packages/connect-ui/node_modules/zod": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
@@ -28093,7 +28062,7 @@
             "version": "1.0.0",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@google-cloud/bigquery": "8.1.0",
+                "@google-cloud/bigquery": "8.1.1",
                 "@nangohq/utils": "file:../utils"
             },
             "devDependencies": {}
@@ -28110,7 +28079,7 @@
             },
             "devDependencies": {
                 "typescript": "5.8.3",
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             }
         },
         "packages/fleet": {
@@ -28123,7 +28092,7 @@
             },
             "devDependencies": {
                 "@nangohq/types": "file:../types",
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             }
         },
         "packages/frontend": {
@@ -28164,18 +28133,7 @@
                 "nodemon": "3.1.10",
                 "type-fest": "4.41.0",
                 "typescript": "5.8.3",
-                "vitest": "3.1.2"
-            }
-        },
-        "packages/jobs/node_modules/axios": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
+                "vitest": "3.2.4"
             }
         },
         "packages/jobs/node_modules/zod": {
@@ -28197,7 +28155,7 @@
             },
             "devDependencies": {
                 "@nangohq/types": "file:../types",
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             }
         },
         "packages/kvstore": {
@@ -28208,7 +28166,7 @@
                 "redis": "4.6.13"
             },
             "devDependencies": {
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             }
         },
         "packages/logs": {
@@ -28229,7 +28187,7 @@
             "devDependencies": {
                 "@nangohq/types": "file:../types",
                 "type-fest": "4.41.0",
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             }
         },
         "packages/logs/node_modules/@opentelemetry/api-logs": {
@@ -28448,7 +28406,7 @@
             },
             "devDependencies": {
                 "@nangohq/types": "0.64.3",
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             }
         },
         "packages/nango-yaml/node_modules/ms": {
@@ -28464,11 +28422,11 @@
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@nangohq/types": "0.64.3",
-                "axios": "1.9.0"
+                "axios": "1.11.0"
             },
             "devDependencies": {
                 "tsup": "8.5.0",
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             },
             "engines": {
                 "node": ">=20.0"
@@ -28490,7 +28448,7 @@
             "devDependencies": {
                 "@nangohq/types": "file:../types",
                 "type-fest": "4.41.0",
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             }
         },
         "packages/orchestrator/node_modules/zod": {
@@ -28522,7 +28480,7 @@
                 "@nangohq/types": "file:../types",
                 "node-fetch": "3.3.2",
                 "typescript": "5.8.3",
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             }
         },
         "packages/persist/node_modules/node-fetch": {
@@ -28559,7 +28517,7 @@
             },
             "devDependencies": {
                 "@nangohq/types": "0.64.3",
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             }
         },
         "packages/pubsub": {
@@ -28576,7 +28534,7 @@
                 "@nangohq/types": "file:../types",
                 "@types/uuid": "9.0.0",
                 "@types/ws": "8.18.1",
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             }
         },
         "packages/pubsub/node_modules/@types/uuid": {
@@ -28636,7 +28594,7 @@
             },
             "devDependencies": {
                 "@types/md5": "2.3.2",
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             }
         },
         "packages/runner": {
@@ -28656,7 +28614,7 @@
                 "connect-timeout": "1.9.1",
                 "dd-trace": "5.52.0",
                 "express": "5.1.0",
-                "soap": "1.1.12",
+                "soap": "1.2.1",
                 "superjson": "2.2.1",
                 "undici": "6.21.2",
                 "unzipper": "0.12.3",
@@ -28668,7 +28626,7 @@
                 "@types/connect-timeout": "1.9.0",
                 "@types/unzipper": "0.10.10",
                 "typescript": "5.8.3",
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             }
         },
         "packages/runner-sdk": {
@@ -28687,7 +28645,7 @@
                 "@types/json-schema": "7.0.15",
                 "axios": "1.11.0",
                 "json-schema": "0.4.0",
-                "vitest": "3.1.2",
+                "vitest": "3.2.4",
                 "zod": "4.0.5"
             }
         },
@@ -28720,18 +28678,6 @@
                 "ajv": {
                     "optional": true
                 }
-            }
-        },
-        "packages/runner-sdk/node_modules/axios": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
             }
         },
         "packages/runner-sdk/node_modules/json-schema-traverse": {
@@ -28776,17 +28722,6 @@
                 "@types/node": "*"
             }
         },
-        "packages/runner/node_modules/axios": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
         "packages/runner/node_modules/zod": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
@@ -28807,7 +28742,7 @@
             },
             "devDependencies": {
                 "type-fest": "4.41.0",
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             }
         },
         "packages/server": {
@@ -28887,7 +28822,7 @@
                 "nodemon": "3.1.10",
                 "type-fest": "4.41.0",
                 "typescript": "5.8.3",
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             }
         },
         "packages/server/node_modules/@modelcontextprotocol/sdk": {
@@ -28929,17 +28864,6 @@
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
-            }
-        },
-        "packages/server/node_modules/axios": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
             }
         },
         "packages/server/node_modules/node-cron": {
@@ -29045,7 +28969,7 @@
                 "knex": "3.1.0",
                 "type-fest": "4.41.0",
                 "typescript": "5.8.3",
-                "vitest": "3.1.2"
+                "vitest": "3.2.4"
             }
         },
         "packages/shared/node_modules/@types/uuid": {
@@ -29083,17 +29007,6 @@
                 "ajv": {
                     "optional": true
                 }
-            }
-        },
-        "packages/shared/node_modules/axios": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
             }
         },
         "packages/shared/node_modules/fast-xml-parser": {
@@ -29196,17 +29109,6 @@
                 "@types/json-schema": "7.0.15"
             }
         },
-        "packages/types/node_modules/axios": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
         "packages/utils": {
             "name": "@nangohq/utils",
             "version": "1.0.0",
@@ -29219,10 +29121,10 @@
                 "exponential-backoff": "3.1.1",
                 "fast-safe-stringify": "2.1.1",
                 "http-proxy-agent": "7.0.2",
-                "https-proxy-agent": "7.0.4",
+                "https-proxy-agent": "7.0.6",
                 "json-schema": "0.4.0",
                 "nanoid": "5.0.9",
-                "serialize-error": "11.0.3",
+                "serialize-error": "12.0.0",
                 "truncate-json": "3.0.0",
                 "winston": "3.13.0",
                 "zod": "4.0.5"
@@ -29231,29 +29133,7 @@
                 "@nangohq/types": "file:../types",
                 "express": "5.1.0",
                 "ms": "3.0.0-canary.1",
-                "vitest": "3.1.2"
-            }
-        },
-        "packages/utils/node_modules/axios": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
-        "packages/utils/node_modules/https-proxy-agent": {
-            "version": "7.0.4",
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.0.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
+                "vitest": "3.2.4"
             }
         },
         "packages/utils/node_modules/ms": {
@@ -29262,6 +29142,21 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12.13"
+            }
+        },
+        "packages/utils/node_modules/serialize-error": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-12.0.0.tgz",
+            "integrity": "sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==",
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^4.31.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "packages/utils/node_modules/zod": {
@@ -29342,10 +29237,10 @@
                 "tailwindcss": "3.4.14",
                 "typescript": "5.8.3",
                 "vaul": "1.1.2",
-                "vite": "7.0.4",
+                "vite": "7.0.6",
                 "vite-plugin-checker": "0.9.3",
                 "vite-plugin-svgr": "4.3.0",
-                "vitest": "3.1.2",
+                "vitest": "3.2.4",
                 "web-vitals": "2.1.4",
                 "zustand": "5.0.3"
             }
@@ -29624,237 +29519,6 @@
                 }
             }
         },
-        "packages/webapp/node_modules/@swc/core": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.12.14.tgz",
-            "integrity": "sha512-CJSn2vstd17ddWIHBsjuD4OQnn9krQfaq6EO+w9YfId5DKznyPmzxAARlOXG99cC8/3Kli8ysKy6phL43bSr0w==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@swc/counter": "^0.1.3",
-                "@swc/types": "^0.1.23"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/swc"
-            },
-            "optionalDependencies": {
-                "@swc/core-darwin-arm64": "1.12.14",
-                "@swc/core-darwin-x64": "1.12.14",
-                "@swc/core-linux-arm-gnueabihf": "1.12.14",
-                "@swc/core-linux-arm64-gnu": "1.12.14",
-                "@swc/core-linux-arm64-musl": "1.12.14",
-                "@swc/core-linux-x64-gnu": "1.12.14",
-                "@swc/core-linux-x64-musl": "1.12.14",
-                "@swc/core-win32-arm64-msvc": "1.12.14",
-                "@swc/core-win32-ia32-msvc": "1.12.14",
-                "@swc/core-win32-x64-msvc": "1.12.14"
-            },
-            "peerDependencies": {
-                "@swc/helpers": ">=0.5.17"
-            },
-            "peerDependenciesMeta": {
-                "@swc/helpers": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/webapp/node_modules/@swc/core-darwin-arm64": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.12.14.tgz",
-            "integrity": "sha512-HNukQoOKgMsHSETj8vgGGKK3SEcH7Cz6k4bpntCxBKNkO3sH7RcBTDulWGGHJfZaDNix7Rw2ExUVWtLZlzkzXg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/webapp/node_modules/@swc/core-darwin-x64": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.12.14.tgz",
-            "integrity": "sha512-4Ttf3Obtk3MvFrR0e04qr6HfXh4L1Z+K3dRej63TAFuYpo+cPXeOZdPUddAW73lSUGkj+61IHnGPoXD3OQYy4Q==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/webapp/node_modules/@swc/core-linux-arm-gnueabihf": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.12.14.tgz",
-            "integrity": "sha512-zhJOH2KWjtQpzJ27Xjw/RKLVOa1aiEJC2b70xbCwEX6ZTVAl8tKbhkZ3GMphhfVmLJ9gf/2UQR58oxVnsXqX5Q==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/webapp/node_modules/@swc/core-linux-arm64-gnu": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.12.14.tgz",
-            "integrity": "sha512-akUAe1YrBqZf1EDdUxahQ8QZnJi8Ts6Ya0jf6GBIMvnXL4Y6QIuvKTRwfNxy7rJ+x9zpzP1Vlh14ZZkSKZ1EGA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/webapp/node_modules/@swc/core-linux-arm64-musl": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.12.14.tgz",
-            "integrity": "sha512-ZkOOIpSMXuPAjfOXEIAEQcrPOgLi6CaXvA5W+GYnpIpFG21Nd0qb0WbwFRv4K8BRtl993Q21v0gPpOaFHU+wdA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/webapp/node_modules/@swc/core-linux-x64-gnu": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.12.14.tgz",
-            "integrity": "sha512-71EPPccwJiJUxd2aMwNlTfom2mqWEWYGdbeTju01tzSHsEuD7E6ePlgC3P3ngBqB3urj41qKs87z7zPOswT5Iw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/webapp/node_modules/@swc/core-linux-x64-musl": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.12.14.tgz",
-            "integrity": "sha512-nImF1hZJqKTcl0WWjHqlelOhvuB9rU9kHIw/CmISBUZXogjLIvGyop1TtJNz0ULcz2Oxr3Q2YpwfrzsgvgbGkA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/webapp/node_modules/@swc/core-win32-arm64-msvc": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.12.14.tgz",
-            "integrity": "sha512-sABFQFxSuStFoxvEWZUHWYldtB1B4A9eDNFd4Ty50q7cemxp7uoscFoaCqfXSGNBwwBwpS5EiPB6YN4y6hqmLQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/webapp/node_modules/@swc/core-win32-ia32-msvc": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.12.14.tgz",
-            "integrity": "sha512-KBznRB02NASkpepRdWIK4f1AvmaJCDipKWdW1M1xV9QL2tE4aySJFojVuG1+t0tVDkjRfwcZjycQfRoJ4RjD7Q==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/webapp/node_modules/@swc/core-win32-x64-msvc": {
-            "version": "1.12.14",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.12.14.tgz",
-            "integrity": "sha512-SymoP2CJHzrYaFKjWvuQljcF7BkTpzaS1vpywv7K9EzdTb5N8qPDvNd+PhWUqBz9JHBhbJxpaeTDQBXF/WWPmw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0 AND MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/webapp/node_modules/@swc/helpers": {
-            "version": "0.5.17",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
-            "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.8.0"
-            }
-        },
-        "packages/webapp/node_modules/@swc/types": {
-            "version": "0.1.23",
-            "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.23.tgz",
-            "integrity": "sha512-u1iIVZV9Q0jxY+yM2vw/hZGDNudsN85bBpTqzAQ9rzkxW9D+e3aEM4Han+ow518gSewkXgjmEK0BD79ZcNVgPw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@swc/counter": "^0.1.3"
-            }
-        },
         "packages/webapp/node_modules/@tanstack/query-core": {
             "version": "5.72.2",
             "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.72.2.tgz",
@@ -29985,21 +29649,6 @@
                 "node": ">=6"
             }
         },
-        "packages/webapp/node_modules/fdir": {
-            "version": "6.4.6",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-            "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
-            }
-        },
         "packages/webapp/node_modules/is-obj": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-3.0.0.tgz",
@@ -30022,38 +29671,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "packages/webapp/node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "bin": {
-                "nanoid": "bin/nanoid.cjs"
-            },
-            "engines": {
-                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-            }
-        },
-        "packages/webapp/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "packages/webapp/node_modules/postcss-loader": {
@@ -30123,127 +29740,6 @@
                 "url": "https://github.com/yeoman/stringify-object?sponsor=1"
             }
         },
-        "packages/webapp/node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "packages/webapp/node_modules/vite": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.4.tgz",
-            "integrity": "sha512-SkaSguuS7nnmV7mfJ8l81JGBFV7Gvzp8IzgE8A8t23+AxuNX61Q5H1Tpz5efduSN7NHC8nQXD3sKQKZAu5mNEA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "esbuild": "^0.25.0",
-                "fdir": "^6.4.6",
-                "picomatch": "^4.0.2",
-                "postcss": "^8.5.6",
-                "rollup": "^4.40.0",
-                "tinyglobby": "^0.2.14"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^20.19.0 || >=22.12.0",
-                "jiti": ">=1.21.0",
-                "less": "^4.0.0",
-                "lightningcss": "^1.21.0",
-                "sass": "^1.70.0",
-                "sass-embedded": "^1.70.0",
-                "stylus": ">=0.54.8",
-                "sugarss": "^5.0.0",
-                "terser": "^5.16.0",
-                "tsx": "^4.8.1",
-                "yaml": "^2.4.2"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "jiti": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                },
-                "tsx": {
-                    "optional": true
-                },
-                "yaml": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/webapp/node_modules/vite/node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.11",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            }
-        },
         "packages/webhooks": {
             "name": "@nangohq/webhooks",
             "version": "1.0.0",
@@ -30257,18 +29753,7 @@
             "devDependencies": {
                 "@nangohq/types": "file:../types",
                 "typescript": "5.8.3",
-                "vitest": "3.1.2"
-            }
-        },
-        "packages/webhooks/node_modules/axios": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
+                "vitest": "3.2.4"
             }
         },
         "packages/webhooks/node_modules/dayjs": {
@@ -30283,11 +29768,11 @@
                 "ajv": "8.17.1",
                 "chalk": "5.4.1",
                 "figures": "6.1.0",
-                "git-cliff": "2.8.0",
+                "git-cliff": "2.10.0",
                 "js-yaml": "4.1.0",
                 "semver": "^7.7.2",
-                "webflow-api": "3.0.1",
-                "zx": "8.5.4"
+                "webflow-api": "3.1.3",
+                "zx": "8.7.1"
             }
         },
         "scripts/node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "@types/node": "22.15.29",
         "@typescript-eslint/eslint-plugin": "8.38.0",
         "@typescript-eslint/parser": "8.38.0",
-        "concurrently": "8.2.2",
+        "concurrently": "9.2.0",
         "eslint": "9.31.0",
         "eslint-config-prettier": "10.1.5",
         "eslint-plugin-import": "2.31.0",
@@ -72,13 +72,13 @@
         "husky": "8.0.3",
         "lint-staged": "15.5.1",
         "onchange": "7.1.0",
-        "prettier": "3.5.3",
+        "prettier": "3.6.2",
         "rimraf": "6.0.1",
         "testcontainers": "10.24.2",
-        "tsx": "4.19.4",
+        "tsx": "4.20.3",
         "typescript": "5.8.3",
         "typescript-eslint": "8.38.0",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     },
     "lint-staged": {
         "*.{js,jsx,ts,tsx,cjs}": [

--- a/packages/billing/package.json
+++ b/packages/billing/package.json
@@ -18,7 +18,7 @@
         "uuidv7": "1.0.2"
     },
     "devDependencies": {
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     },
     "files": [
         "dist/**/*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,20 +30,20 @@
         "prepublishOnly": "npm run copy:files"
     },
     "dependencies": {
-        "@babel/core": "7.27.3",
-        "@babel/parser": "7.27.3",
-        "@babel/traverse": "7.27.3",
-        "@babel/types": "7.27.3",
+        "@babel/core": "7.28.0",
+        "@babel/parser": "7.28.0",
+        "@babel/traverse": "7.28.0",
+        "@babel/types": "7.28.2",
         "@babel/preset-typescript": "7.27.1",
         "@nangohq/nango-yaml": "0.64.3",
         "@nangohq/node": "0.64.3",
         "@nangohq/runner-sdk": "0.64.3",
-        "@swc/core": "1.5.25",
+        "@swc/core": "1.13.2",
         "@types/unzipper": "0.10.11",
         "ajv": "8.17.1",
         "ajv-errors": "3.0.0",
         "axios": "1.11.0",
-        "chalk": "5.3.0",
+        "chalk": "5.4.1",
         "chokidar": "3.5.3",
         "columnify": "1.6.0",
         "commander": "10.0.1",
@@ -52,7 +52,7 @@
         "dotenv": "16.5.0",
         "ejs": "3.1.10",
         "esbuild": "0.25.5",
-        "figlet": "1.6.0",
+        "figlet": "1.8.2",
         "glob": "10.3.10",
         "import-meta-resolve": "4.1.0",
         "jscodeshift": "17.3.0",
@@ -63,7 +63,7 @@
         "semver": "7.5.4",
         "serialize-error": "11.0.3",
         "ts-json-schema-generator": "2.4.0",
-        "ts-node": "10.9.1",
+        "ts-node": "10.9.2",
         "tsup": "8.5.0",
         "typescript": "5.8.3",
         "unzipper": "0.12.3",
@@ -87,7 +87,7 @@
         "json-schema": "0.4.0",
         "strip-ansi": "7.1.0",
         "type-fest": "4.41.0",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     },
     "engines": {
         "node": ">=20.0"

--- a/packages/connect-ui/package.json
+++ b/packages/connect-ui/package.json
@@ -38,7 +38,7 @@
         "tailwindcss": "3.4.14",
         "tailwindcss-animate": "1.0.7",
         "typescript": "5.8.3",
-        "vite": "7.0.4",
+        "vite": "7.0.6",
         "vite-plugin-svgr": "4.3.0",
         "zod": "4.0.5",
         "zustand": "5.0.3"

--- a/packages/data-ingestion/package.json
+++ b/packages/data-ingestion/package.json
@@ -15,7 +15,7 @@
     },
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
-        "@google-cloud/bigquery": "8.1.0",
+        "@google-cloud/bigquery": "8.1.1",
         "@nangohq/utils": "file:../utils"
     },
     "devDependencies": {}

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -23,7 +23,7 @@
     },
     "devDependencies": {
         "typescript": "5.8.3",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     },
     "files": [
         "dist/**/*"

--- a/packages/fleet/package.json
+++ b/packages/fleet/package.json
@@ -23,6 +23,6 @@
     },
     "devDependencies": {
         "@nangohq/types": "file:../types",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     }
 }

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -41,6 +41,6 @@
         "nodemon": "3.1.10",
         "type-fest": "4.41.0",
         "typescript": "5.8.3",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     }
 }

--- a/packages/keystore/package.json
+++ b/packages/keystore/package.json
@@ -23,6 +23,6 @@
     },
     "devDependencies": {
         "@nangohq/types": "file:../types",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     }
 }

--- a/packages/kvstore/package.json
+++ b/packages/kvstore/package.json
@@ -18,7 +18,7 @@
         "redis": "4.6.13"
     },
     "devDependencies": {
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     },
     "files": [
         "dist/**/*"

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -28,7 +28,7 @@
     "devDependencies": {
         "@nangohq/types": "file:../types",
         "type-fest": "4.41.0",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     },
     "files": [
         "dist/**/*"

--- a/packages/nango-yaml/package.json
+++ b/packages/nango-yaml/package.json
@@ -18,7 +18,7 @@
     },
     "devDependencies": {
         "@nangohq/types": "0.64.3",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     },
     "files": [
         "dist/**/*"

--- a/packages/node-client/package.json
+++ b/packages/node-client/package.json
@@ -26,7 +26,7 @@
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
         "@nangohq/types": "0.64.3",
-        "axios": "1.9.0"
+        "axios": "1.11.0"
     },
     "engines": {
         "node": ">=20.0"
@@ -38,6 +38,6 @@
     ],
     "devDependencies": {
         "tsup": "8.5.0",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     }
 }

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -26,6 +26,6 @@
     "devDependencies": {
         "@nangohq/types": "file:../types",
         "type-fest": "4.41.0",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     }
 }

--- a/packages/persist/package.json
+++ b/packages/persist/package.json
@@ -33,6 +33,6 @@
         "@nangohq/types": "file:../types",
         "node-fetch": "3.3.2",
         "typescript": "5.8.3",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     }
 }

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -12,7 +12,7 @@
     },
     "devDependencies": {
         "@nangohq/types": "0.64.3",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     },
     "files": [
         "dist/**/*",

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -21,6 +21,6 @@
         "@nangohq/types": "file:../types",
         "@types/ws": "8.18.1",
         "@types/uuid": "9.0.0",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     }
 }

--- a/packages/records/package.json
+++ b/packages/records/package.json
@@ -27,6 +27,6 @@
     },
     "devDependencies": {
         "@types/md5": "2.3.2",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     }
 }

--- a/packages/runner-sdk/package.json
+++ b/packages/runner-sdk/package.json
@@ -17,7 +17,7 @@
         "@types/json-schema": "7.0.15",
         "axios": "1.11.0",
         "json-schema": "0.4.0",
-        "vitest": "3.1.2",
+        "vitest": "3.2.4",
         "zod": "4.0.5"
     },
     "files": [

--- a/packages/runner/lib/sdk/sdk.unit.test.ts
+++ b/packages/runner/lib/sdk/sdk.unit.test.ts
@@ -300,10 +300,10 @@ describe('Pagination', () => {
             const firstBatch: any[] = [{ id: 1 }, { id: 2 }, { id: 3 }];
             const emptyBatch: any[] = [];
 
-            vi.spyOn(ProxyRequest.prototype, 'httpCall')
+            const spy = vi
+                .spyOn(ProxyRequest.prototype, 'httpCall')
                 .mockReturnValueOnce(Promise.resolve({ data: { issues: firstBatch, metadata: { next_cursor: '' } } } as AxiosResponse))
                 .mockReturnValueOnce(Promise.resolve({ data: { issues: emptyBatch, metadata: { next_cursor: '' } } } as AxiosResponse));
-
             const endpoint = '/issues';
 
             const generator = nangoAction.paginate({ endpoint });
@@ -314,6 +314,7 @@ describe('Pagination', () => {
             }
 
             expect(actualRecords).toStrictEqual(firstBatch);
+            spy.mockRestore(); // If this test fails, the mock is not restored and the next test will fail
         }
     );
 
@@ -362,6 +363,7 @@ describe('Pagination', () => {
 
         const expectedRecords = [...firstBatch, ...secondBatch, ...thirdBatch];
         expect(actualRecords).toStrictEqual(expectedRecords);
+        spy.mockRestore(); // If this test fails, the mock is not restored and the next test will fail
     });
 
     const stubProviderTemplate = async (paginationConfig: Pagination) => {

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -30,7 +30,7 @@
         "connect-timeout": "1.9.1",
         "dd-trace": "5.52.0",
         "express": "5.1.0",
-        "soap": "1.1.12",
+        "soap": "1.2.1",
         "superjson": "2.2.1",
         "undici": "6.21.2",
         "unzipper": "0.12.3",
@@ -42,6 +42,6 @@
         "@types/connect-timeout": "1.9.0",
         "@types/unzipper": "0.10.10",
         "typescript": "5.8.3",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     }
 }

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -24,6 +24,6 @@
     },
     "devDependencies": {
         "type-fest": "4.41.0",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -91,6 +91,6 @@
         "nodemon": "3.1.10",
         "type-fest": "4.41.0",
         "typescript": "5.8.3",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -64,7 +64,7 @@
         "knex": "3.1.0",
         "type-fest": "4.41.0",
         "typescript": "5.8.3",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     },
     "files": [
         "dist/**/*",

--- a/packages/utils/lib/errors.ts
+++ b/packages/utils/lib/errors.ts
@@ -4,10 +4,20 @@ import { serializeError } from 'serialize-error';
 import { getLogger } from './logger.js';
 import { NANGO_VERSION } from './version.js';
 
+import type { ErrorObject } from 'serialize-error';
+
 /**
  * Transform any Error or primitive to a json object
  */
-export function errorToObject(err: unknown) {
+export function errorToObject(err: unknown): ErrorObject {
+    if (!err) {
+        return { message: 'Unknown error' };
+    }
+
+    if (typeof err === 'string' || typeof err === 'number' || typeof err === 'boolean') {
+        return { message: String(err) };
+    }
+
     return serializeError(err, { maxDepth: 5 });
 }
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -22,10 +22,10 @@
         "exponential-backoff": "3.1.1",
         "fast-safe-stringify": "2.1.1",
         "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.4",
+        "https-proxy-agent": "7.0.6",
         "json-schema": "0.4.0",
         "nanoid": "5.0.9",
-        "serialize-error": "11.0.3",
+        "serialize-error": "12.0.0",
         "truncate-json": "3.0.0",
         "winston": "3.13.0",
         "zod": "4.0.5"
@@ -34,7 +34,7 @@
         "@nangohq/types": "file:../types",
         "express": "5.1.0",
         "ms": "3.0.0-canary.1",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     },
     "files": [
         "dist/**/*"

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -87,10 +87,10 @@
         "tailwindcss": "3.4.14",
         "typescript": "5.8.3",
         "vaul": "1.1.2",
-        "vite": "7.0.4",
+        "vite": "7.0.6",
         "vite-plugin-checker": "0.9.3",
         "vite-plugin-svgr": "4.3.0",
-        "vitest": "3.1.2",
+        "vitest": "3.2.4",
         "web-vitals": "2.1.4",
         "zustand": "5.0.3"
     },

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -24,7 +24,7 @@
     "devDependencies": {
         "@nangohq/types": "file:../types",
         "typescript": "5.8.3",
-        "vitest": "3.1.2"
+        "vitest": "3.2.4"
     },
     "files": [
         "dist/**/*"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,10 +6,10 @@
         "ajv": "8.17.1",
         "chalk": "5.4.1",
         "figures": "6.1.0",
-        "git-cliff": "2.8.0",
+        "git-cliff": "2.10.0",
         "js-yaml": "4.1.0",
         "semver": "^7.7.2",
-        "webflow-api": "3.0.1",
-        "zx": "8.5.4"
+        "webflow-api": "3.1.3",
+        "zx": "8.7.1"
     }
 }


### PR DESCRIPTION
## Changes

Upgrade dependencies

- Some related to recent different CVEs (axios, concurrently, babel, bigquery, soap)
- Some because they are "mostly" consequence-free (vitest, vite, prettier, etc.)

<!-- Summary by @propel-code-bot -->

---

This PR performs a systematic upgrade of both production and development dependencies across nearly all packages within the monorepo. The updates address recent CVEs, modernize core libraries (e.g., axios, concurrently, babel, bigquery, soap), and align development tools (notably standardizing vitest across packages). Aside from dependency bumps, there is one notable source code refactor in packages/utils/lib/errors.ts, enhancing errorToObject to provide more robust handling of primitives and nulls with explicit type safety. Several test files-particularly in runner and related infra-have minor adjustments for improved reliability and consistency with updated tooling.

<details>
<summary><strong>Key Changes</strong></summary>

• Upgraded dependencies in almost all package.json files, resolving CVEs in critical libraries (axios, concurrently, babel, bigquery, soap)
• Standardized developer tooling versions, notably updating and aligning vitest to 3.2.4 across all relevant sub-packages
• Refactored errorToObject in packages/utils/lib/errors.ts to handle primitive and null/undefined error inputs with stronger type annotation
• Minor test suite improvements, including restoration of vi.mockRestore to prevent test interference

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• All package.json and devDependencies across monorepo
• Error utility: packages/utils/lib/errors.ts
• Test infrastructure in runner, utils, and several other packages

</details>

*This summary was automatically generated by @propel-code-bot*