### PR TITLE
fix(es): change warm tier settings

### DIFF
--- a/packages/logs/lib/es/schema.ts
+++ b/packages/logs/lib/es/schema.ts
@@ -280,6 +280,7 @@ export const indexOperations: estypes.IndicesCreateRequest = {
             'sort.order': ['desc', 'desc']
         },
         // They are recommending 1 shard per 20gb-40gb
+        // but it's not true for us with the current throughput it's working better with more shards
         number_of_shards: envs.NANGO_LOGS_ES_SHARD_PER_DAY_OPERATIONS
     },
     mappings: {
@@ -297,9 +298,8 @@ export const policyMessages = {
             warm: {
                 min_age: '25h',
                 actions: {
-                    allocate: { require: { data: 'warm' } },
                     set_priority: { priority: 50 },
-                    shrink: { max_primary_shard_size: '10gb' },
+                    shrink: { max_primary_shard_size: '8gb' },
                     readonly: {}
                 }
             },


### PR DESCRIPTION
## Changes

- Allocate is working better when es is choosing the tier automatically
- Reducing the size of each shards to see if it improves performance

<!-- Summary by @propel-code-bot -->

---

This PR updates the Elasticsearch ILM policy for the warm tier in the schema configuration. The explicit 'allocate' action has been removed to let Elasticsearch automatically choose the tier, and the maximum primary shard size for shrinking has been reduced from 10GB to 8GB.

*This summary was automatically generated by @propel-code-bot*