### PR TITLE
feat(orch): add task state and next execution columns to schedules table

### DIFF
--- a/packages/scheduler/lib/db/migrations/20250724115100_schedule_next_execution_at.ts
+++ b/packages/scheduler/lib/db/migrations/20250724115100_schedule_next_execution_at.ts
@@ -1,0 +1,60 @@
+import type { Knex } from 'knex';
+
+import { SCHEDULES_TABLE } from '../../models/schedules.js';
+import { TASKS_TABLE } from '../../models/tasks.js';
+
+export const config = {
+    transaction: false
+};
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(
+        `ALTER TABLE ${SCHEDULES_TABLE}
+            ADD COLUMN IF NOT EXISTS last_scheduled_task_state task_states DEFAULT NULL,
+            ADD COLUMN IF NOT EXISTS next_execution_at TIMESTAMP WITH TIME ZONE DEFAULT NULL;`
+    );
+
+    // Update existing schedules
+    // last_scheduled_task_state is read from tasks table
+    // if task exists and is SUCCEEDED next_execution_at is next due date calculatd using ceiling()
+    // if no task exists or task is not SUCCEEDED, next_execution_at is last due date calculated using floor()
+    await knex.raw(
+        `WITH task_states AS (
+            SELECT
+                s.id as schedule_id,
+                t.state as last_task_state
+            FROM ${SCHEDULES_TABLE} s
+            LEFT JOIN ${TASKS_TABLE} t ON s.last_scheduled_task_id = t.id
+        )
+        UPDATE ${SCHEDULES_TABLE} s
+        SET
+            last_scheduled_task_state = ts.last_task_state,
+            next_execution_at = (
+                CASE
+                    WHEN ts.last_task_state = 'SUCCEEDED'
+                    THEN s.starts_at + (ceiling(extract(EPOCH FROM (now() - s.starts_at)) / extract(EPOCH FROM s.frequency)) * s.frequency)
+                    ELSE s.starts_at + (floor(extract(EPOCH FROM (now() - s.starts_at)) / extract(EPOCH FROM s.frequency)) * s.frequency)
+                END
+            )
+        FROM task_states ts
+        WHERE s.id = ts.schedule_id;`
+    );
+
+    // alter next_execution_at to be not null now that it has been populated
+    await knex.raw(`ALTER TABLE ${SCHEDULES_TABLE} ALTER COLUMN next_execution_at SET NOT NULL;`);
+
+    // index to optimize the scheduling query
+    await knex.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_schedules_scheduling"
+            ON ${SCHEDULES_TABLE} (state, last_scheduled_task_state, next_execution_at)
+            WHERE state = 'STARTED';`
+    );
+    // index on last_scheduled_task_id to update last_scheduled_task_state
+    await knex.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_schedules_last_scheduled_task_id"
+            ON ${SCHEDULES_TABLE} (last_scheduled_task_id)
+            WHERE last_scheduled_task_id IS NOT NULL;`
+    );
+}
+
+export async function down(): Promise<void> {}


### PR DESCRIPTION
db migration for the folloowing PR: https://github.com/NangoHQ/nango/pull/4383


<!-- Summary by @propel-code-bot -->

---

This PR introduces a database migration that adds two columns to the schedules table: last_scheduled_task_state (of type task_states) and next_execution_at (timestamp with time zone). It also populates the new columns for existing records based on the latest related task state and recalculates next_execution_at, then enforces NOT NULL for next_execution_at and adds two new indexes for query optimization.

<details>
<summary><strong>Key Changes</strong></summary>

• Added last_scheduled_task_state (task_states) and next_execution_at (timestamp) columns to schedules table
• Populated new columns by joining with tasks and using task state logic for next_execution_at calculation
• Set NOT NULL constraint on next_execution_at after population
• Created CONCURRENT indexes on (state, last_scheduled_task_state, next_execution_at) and last_scheduled_task_id for performance

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• database schema for schedules table
• database migrations
• query performance for scheduling logic

</details>

*This summary was automatically generated by @propel-code-bot*