### PR TITLE
chore: use last_scheduled_task_state/next_execution_at in scheduling query

### DIFF
--- a/packages/scheduler/lib/daemons/scheduling/scheduling.integration.test.ts
+++ b/packages/scheduler/lib/daemons/scheduling/scheduling.integration.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { dueSchedules } from './scheduling.js';
 import { getTestDbClient } from '../../db/helpers.test.js';
 import { DbSchedule, SCHEDULES_TABLE } from '../../models/schedules.js';
+import * as schedules from '../../models/schedules.js';
 import { DbTask, TASKS_TABLE } from '../../models/tasks.js';
 
 import type { DBTask } from '../../models/tasks.js';
@@ -161,7 +162,13 @@ async function addTask(
         throw new Error('Failed to insert task');
     }
     if (params?.scheduleId) {
-        await db.from<DbSchedule>(SCHEDULES_TABLE).where('id', params.scheduleId).update({ last_scheduled_task_id: inserted.id });
+        await schedules.setLastScheduledTask(db, [
+            {
+                id: params.scheduleId,
+                taskId: inserted.id,
+                taskState: inserted.state
+            }
+        ]);
     }
     return DbTask.from(inserted);
 }

--- a/packages/scheduler/lib/daemons/scheduling/scheduling.ts
+++ b/packages/scheduler/lib/daemons/scheduling/scheduling.ts
@@ -1,7 +1,6 @@
 import { Err, Ok, stringifyError } from '@nangohq/utils';
 
 import { DbSchedule, SCHEDULES_TABLE } from '../../models/schedules.js';
-import { TASKS_TABLE } from '../../models/tasks.js';
 
 import type { Schedule } from '../../types.js';
 import type { Result } from '@nangohq/utils';
@@ -10,24 +9,15 @@ import type knex from 'knex';
 export async function dueSchedules(db: knex.Knex): Promise<Result<Schedule[]>> {
     try {
         const schedules: DbSchedule[] = await db
-            .select('s.*')
-            .from({ s: SCHEDULES_TABLE })
-            .leftJoin(`${TASKS_TABLE} AS t`, 's.last_scheduled_task_id', 't.id')
-            .where('s.state', 'STARTED')
-            .where('s.starts_at', '<=', db.fn.now())
+            .select('*')
+            .from(SCHEDULES_TABLE)
+            .where('state', 'STARTED')
+            .where('starts_at', '<=', db.fn.now())
             .where(function () {
-                // schedule has never been run
-                this.where('s.last_scheduled_task_id', 'IS', null)
-                    // schedule with last task not running and was started before the last due time
-                    .orWhere(function () {
-                        this.whereNotIn('t.state', ['CREATED', 'STARTED']).andWhere(
-                            't.starts_after',
-                            '<',
-                            db.raw(`s.starts_at + (floor(extract(EPOCH FROM (now() - s.starts_at)) / extract(EPOCH FROM s.frequency)) * s.frequency)`)
-                        );
-                    });
+                this.whereNotIn('last_scheduled_task_state', ['CREATED', 'STARTED']).orWhereNull('last_scheduled_task_state');
             })
-            .forUpdate('s')
+            .where('next_execution_at', '<=', db.fn.now())
+            .forUpdate()
             .skipLocked();
         return Ok(schedules.map(DbSchedule.from));
     } catch (err) {


### PR DESCRIPTION
Using the recently introduced last_scheduled_task_state and next_execution_at columns from schedules table in order to remove the join with tasks table and inline due date calculation.

query plan BEFORE
```
LockRows  (cost=0.56..459460.47 rows=24390 width=447)
  ->  Nested Loop Left Join  (cost=0.56..459216.57 rows=24390 width=447)
        Filter: ((s.last_scheduled_task_id IS NULL) OR ((t.state <> ALL ('{CREATED,STARTED}'::nango_scheduler.task_states[])) AND (t.starts_after < (s.starts_at + ((floor((EXTRACT(epoch FROM (now() - s.starts_at)) / EXTRACT(epoch FROM s.frequency))))::double precision * s.frequency)))))
        ->  Seq Scan on schedules s  (cost=0.00..10545.25 rows=55390 width=441)
              Filter: ((state = 'STARTED'::nango_scheduler.schedule_states) AND (starts_at <= CURRENT_TIMESTAMP))
        ->  Index Scan using tasks_pkey on tasks t  (cost=0.56..8.06 rows=1 width=34)
              Index Cond: (id = s.last_scheduled_task_id)
```

query plan AFTER 
```
LockRows  (cost=0.00..11241.38 rows=11373 width=441)
  ->  Seq Scan on schedules  (cost=0.00..11127.65 rows=11373 width=441)
        Filter: (((last_scheduled_task_state IS NULL) OR (last_scheduled_task_state <> ALL ('{CREATED,STARTED}'::nango_scheduler.task_states[]))) AND (state = 'STARTED'::nango_scheduler.schedule_states) AND (starts_at <= CURRENT_TIMESTAMP) AND (next_execution_at < CURRENT_TIMESTAMP))
```
Note that pg prefers a scan and ignores the index. Probably because the number of schedules is pretty low (77k) and the partial index condition not selective enough at this point.

<!-- Summary by @propel-code-bot -->

---

This PR refactors the scheduling logic to utilize the last_scheduled_task_state and next_execution_at columns directly from the schedules table, eliminating the need for a join with the tasks table and removing the inline due date calculation. The dueSchedules query is streamlined, resulting in a significant simplification of both application logic and the underlying SQL, and related integration tests are updated to respect these changes and invoke the new state management helper.

<details>
<summary><strong>Key Changes</strong></summary>

• Rewrote dueSchedules to filter schedules entirely using last_scheduled_task_state and next_execution_at, eliminating tasks table join.
• Simplified query logic, removed complex date calculations in SQL.
• Updated scheduling integration tests to use setLastScheduledTask and new schedule fields.
• Adjusted imports for schedules model usage in tests.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/scheduler/lib/daemons/scheduling/scheduling.ts
• packages/scheduler/lib/daemons/scheduling/scheduling.integration.test.ts

</details>

*This summary was automatically generated by @propel-code-bot*