### PR TITLE
fix(connect-ui): use custom integration display name

### DIFF
--- a/packages/connect-ui/src/views/Go.tsx
+++ b/packages/connect-ui/src/views/Go.tsx
@@ -98,6 +98,10 @@ export const Go: React.FC = () => {
 
     const preconfigured = session && integration ? session.integrations_config_defaults?.[integration.unique_key]?.connection_config || {} : {};
 
+    const displayName = useMemo(() => {
+        return integration?.display_name ?? provider?.display_name ?? '';
+    }, [integration, provider]);
+
     useMount(() => {
         if (integration) {
             telemetry('view:integration', { integration: integration.unique_key });
@@ -264,7 +268,7 @@ export const Go: React.FC = () => {
                         return;
                     } else if (err.type === 'connection_test_failed') {
                         setConnectionFailed(true);
-                        setError(t('go.invalidCredentials', { provider: provider.display_name }));
+                        setError(t('go.invalidCredentials', { provider: displayName }));
                         return;
                     } else if (err.type === 'resource_capped') {
                         setConnectionFailed(true);
@@ -347,7 +351,7 @@ export const Go: React.FC = () => {
                     <div className="w-[70px] h-[70px] bg-white transition-colors rounded-xl shadow-card p-2.5 group-hover:bg-dark-100">
                         <img src={integration.logo} />
                     </div>
-                    <h1 className="font-semibold text-xl text-dark-800">{t('go.linkAccount', { provider: provider.display_name })}</h1>
+                    <h1 className="font-semibold text-xl text-dark-800">{t('go.linkAccount', { provider: displayName })}</h1>
                 </div>
             </header>
             <main className="h-full overflow-auto p-10 pt-1">
@@ -420,7 +424,7 @@ export const Go: React.FC = () => {
                                 <div></div>
                                 <div className="text-sm text-dark-500 w-full text-center -mt-20">
                                     {/* visual centering */}
-                                    {t('go.willConnect', { provider: provider.display_name })}
+                                    {t('go.willConnect', { provider: displayName })}
                                     {provider.auth_mode === 'OAUTH2' && ` ${t('go.popupWarning')}`}
                                 </div>
                             </>


### PR DESCRIPTION
- `provider.display_name`: the default display name set in providers.yaml.
- `integration.display_name`: the display name override that one can customize.

Fixes https://nangohq.slack.com/archives/C08C889EBND/p1753471505881179

<!-- Summary by @propel-code-bot -->

---

This PR updates the Connect UI logic to display the custom integration display name, when available, instead of always using the provider's default display name. The changes ensure that all relevant UI strings reference the integration's overridden display name, enhancing user clarity for customized integrations.

*This summary was automatically generated by @propel-code-bot*