### PR TITLE
fix: use special render instances for runners

### DIFF
--- a/packages/jobs/lib/runner/render.api.ts
+++ b/packages/jobs/lib/runner/render.api.ts
@@ -2,6 +2,11 @@ import axios from 'axios';
 
 import type { AxiosInstance, AxiosResponse } from 'axios';
 
+// Render is somehow restarting services arbitrarily, which is causing the long running scripts to fail.
+// We have asked them not to do that, and they came up with a workaround, making special instances available to us that are not restarted according to them.
+// Note: Not all sizes are available for those special instances.
+export type RenderPlan = 'Starter Nango' | 'Standard Nango' | 'Pro Nango' | 'pro_plus' | 'Pro Max Nango' | 'pro_ultra';
+
 export class RenderAPI {
     httpClient: AxiosInstance;
     constructor(apiKey: string) {
@@ -23,7 +28,7 @@ export class RenderAPI {
         name: string;
         ownerId: string;
         image: { ownerId: string; imagePath: string };
-        serviceDetails: { runtime: 'image'; plan: 'starter' | 'standard' | 'pro' | 'pro_plus' | 'pro_max' | 'pro_ultra' };
+        serviceDetails: { runtime: 'image'; plan: RenderPlan };
         envVars: { key: string; value: string }[];
     }): Promise<AxiosResponse> {
         return await this.httpClient.post('/services', data);

--- a/packages/jobs/lib/runner/render.ts
+++ b/packages/jobs/lib/runner/render.ts
@@ -10,6 +10,7 @@ import { Err, Ok, getLogger } from '@nangohq/utils';
 import { RenderAPI } from './render.api.js';
 import { envs } from '../env.js';
 
+import type { RenderPlan } from './render.api.js';
 import type { Node, NodeProvider } from '@nangohq/fleet';
 import type { Result } from '@nangohq/utils';
 import type { AxiosResponse } from 'axios';
@@ -152,23 +153,23 @@ async function withRateLimitHandling<T>(rateLimitGroup: 'create' | 'delete' | 'r
     }
 }
 
-function getPlan(node: Node): 'starter' | 'standard' | 'pro' | 'pro_plus' | 'pro_max' | 'pro_ultra' {
+function getPlan(node: Node): RenderPlan {
     if (node.cpuMilli >= 8000 && node.memoryMb >= 32000) {
         return 'pro_ultra';
     }
     if (node.cpuMilli >= 4000 && node.memoryMb >= 16000) {
-        return 'pro_max';
+        return 'Pro Max Nango';
     }
     if (node.cpuMilli >= 4000 && node.memoryMb >= 8000) {
         return 'pro_plus';
     }
     if (node.cpuMilli > 2000 || node.memoryMb >= 4000) {
-        return 'pro';
+        return 'Pro Nango';
     }
     if (node.cpuMilli > 1000 || node.memoryMb >= 2000) {
-        return 'standard';
+        return 'Standard Nango';
     }
-    return 'starter';
+    return 'Starter Nango';
 }
 
 // Render has a hard limit of 1000 service creations per hour


### PR DESCRIPTION
Render is somehow restarting runner services arbitrarily, which is causing long running scripts to fail. We have asked them not to do that, and they came up with a workaround: making special instances available to us that are not restarted according to them.

Tested in staging

<!-- Summary by @propel-code-bot -->

---

This PR updates the runner provisioning logic to use Render's new, dedicated 'Nango' instance types (e.g., 'Pro Nango', 'Standard Nango', etc.) to prevent arbitrary restarts of runner services by Render. Changes include the introduction of a new RenderPlan type, adjustments to plan selection logic, and updated API contracts to align with Render's workaround for service stability issues.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced new RenderPlan type supporting special 'Nango' instance plans.
• Updated runner provisioning logic in getPlan to select the special Render instances.
• Modified render.api.ts method signatures and types to use the new RenderPlan.
• Added explanatory comments about the workaround and plan availability constraints.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/jobs/lib/runner/render.ts
• packages/jobs/lib/runner/render.api.ts

</details>

*This summary was automatically generated by @propel-code-bot*