### PR TITLE
feat(webapp): refresh usage on connection deleted

### DIFF
--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -63,7 +63,7 @@ export function useApiGetUsage(env: string) {
 
             return json;
         },
-        refetchInterval: 1000 * 60 // 1 minute
+        refetchInterval: 1000 * 10 // 10 seconds
     });
 }
 

--- a/packages/webapp/src/pages/Connection/Show.tsx
+++ b/packages/webapp/src/pages/Connection/Show.tsx
@@ -1,4 +1,5 @@
 import { IconTrash } from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
@@ -20,6 +21,7 @@ import { Button } from '../../components/ui/button/Button';
 import { apiDeleteConnection, clearConnectionsCache, useConnection } from '../../hooks/useConnections';
 import { useEnvironment } from '../../hooks/useEnvironment';
 import { clearIntegrationsCache } from '../../hooks/useIntegration';
+import { GetUsageQueryKey } from '../../hooks/usePlan';
 import { useSyncs } from '../../hooks/useSyncs';
 import { useToast } from '../../hooks/useToast';
 import DashboardLayout from '../../layout/DashboardLayout';
@@ -43,6 +45,7 @@ export const ConnectionShow: React.FC = () => {
     const { connectionId, providerConfigKey } = useParams();
     const [showSlackBanner, setShowSlackBanner] = useLocalStorage(`nango:connection:slack_banner_show`, true);
 
+    const queryClient = useQueryClient();
     const env = useStore((state) => state.env);
 
     const { environmentAndAccount, mutate: environmentMutate } = useEnvironment(env);
@@ -93,6 +96,7 @@ export const ConnectionShow: React.FC = () => {
             );
             clearConnectionsCache(cache, mutate);
             clearIntegrationsCache(cache, mutate);
+            queryClient.invalidateQueries({ queryKey: GetUsageQueryKey });
 
             navigate(`/${env}/connections`, { replace: true });
         } else {


### PR DESCRIPTION
Small feat to make sidebar usage update immediately when a connection is deleted.
Also, making usage update more often. The usage query should be quick (fetches from redis), and it feels very nice to see it update "live".

<!-- Summary by @propel-code-bot -->

---

This PR updates the webapp to immediately refresh the usage statistics shown in the sidebar when a connection is deleted. It also decreases the refetch interval for usage stats from 1 minute to 10 seconds, ensuring more real-time updates across the UI.

*This summary was automatically generated by @propel-code-bot*