### PR TITLE
feat: local pubsub transport

### DIFF
--- a/packages/pubsub/lib/index.ts
+++ b/packages/pubsub/lib/index.ts
@@ -5,5 +5,7 @@ import { LocalTransport } from './transport/local.js';
 export * from './publisher.js';
 export * from './subscriber.js';
 
-export const publisher = new Publisher(new LocalTransport());
-export const subscriber = new Subscriber(new LocalTransport());
+const transport = new LocalTransport();
+
+export const publisher = new Publisher(transport);
+export const subscriber = new Subscriber(transport);

--- a/packages/pubsub/lib/index.ts
+++ b/packages/pubsub/lib/index.ts
@@ -1,2 +1,9 @@
+import { Publisher } from './publisher.js';
+import { Subscriber } from './subscriber.js';
+import { LocalTransport } from './transport/local.js';
+
 export * from './publisher.js';
 export * from './subscriber.js';
+
+export const publisher = new Publisher(new LocalTransport());
+export const subscriber = new Subscriber(new LocalTransport());

--- a/packages/pubsub/lib/transport/local.integration.test.ts
+++ b/packages/pubsub/lib/transport/local.integration.test.ts
@@ -1,0 +1,217 @@
+/* eslint-disable import/order */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { LocalTransport } from './local.js';
+
+import type { Event } from '../event.js';
+import type { DBTeam, DBUser } from '@nangohq/types';
+
+describe('LocalTransport', () => {
+    let transport: LocalTransport;
+
+    beforeEach(async () => {
+        transport = new LocalTransport();
+        await transport.connect();
+    });
+
+    afterEach(async () => {
+        await transport.disconnect();
+    });
+
+    it('should publish and subscribe to events without blocking', async () => {
+        const events: Event[] = [];
+        let callbackExecuted = false;
+
+        // Subscribe to events
+        transport.subscribe({
+            consumerGroup: 'test-group',
+            subscriptions: [
+                {
+                    subject: 'user',
+                    callback: (event: Event) => {
+                        events.push(event);
+                        callbackExecuted = true;
+                    }
+                }
+            ]
+        });
+
+        // Publish an event
+        const publishResult = await transport.publish({
+            idempotencyKey: 'test-key',
+            subject: 'user',
+            type: 'user.created',
+            payload: {
+                user: { id: 123, name: 'Test User' } as DBUser,
+                team: { id: 456, name: 'Test Team' } as DBTeam
+            },
+            createdAt: new Date()
+        });
+
+        expect(publishResult.isOk()).toBe(true);
+
+        // Immediately after publish, the callback should NOT have been executed yet
+        expect(callbackExecuted).toBe(false);
+        expect(events).toHaveLength(0);
+
+        // Wait for the next tick of the event loop where setImmediate callbacks run
+        await new Promise((resolve) => setImmediate(resolve));
+
+        // The callback should now have been executed (since it uses setImmediate)
+        expect(callbackExecuted).toBe(true);
+        expect(events).toHaveLength(1);
+
+        expect(events[0]?.subject).toBe('user');
+        expect(events[0]?.type).toBe('user.created');
+    });
+
+    it('should handle multiple subscribers for the same subject', async () => {
+        const events1: Event[] = [];
+        const events2: Event[] = [];
+
+        // Subscribe with two different consumer groups
+        transport.subscribe({
+            consumerGroup: 'group1',
+            subscriptions: [
+                {
+                    subject: 'user',
+                    callback: (event: Event) => {
+                        events1.push(event);
+                    }
+                }
+            ]
+        });
+
+        transport.subscribe({
+            consumerGroup: 'group2',
+            subscriptions: [
+                {
+                    subject: 'user',
+                    callback: (event: Event) => {
+                        events2.push(event);
+                    }
+                }
+            ]
+        });
+
+        // Publish an event
+        await transport.publish({
+            idempotencyKey: 'test-key',
+            subject: 'user',
+            type: 'user.created',
+            payload: {
+                user: { id: 123, name: 'Test User' } as DBUser,
+                team: { id: 456, name: 'Test Team' } as DBTeam
+            },
+            createdAt: new Date()
+        });
+
+        // Wait for the next tick of the event loop where setImmediate callbacks run
+        await new Promise((resolve) => setImmediate(resolve));
+
+        // Both subscribers should receive the event
+        expect(events1).toHaveLength(1);
+        expect(events2).toHaveLength(1);
+        expect(events1[0]?.idempotencyKey).toBe('test-key');
+        expect(events2[0]?.idempotencyKey).toBe('test-key');
+    });
+
+    it('should handle errors in callbacks gracefully', async () => {
+        let successCallbackExecuted = false;
+
+        transport.subscribe({
+            consumerGroup: 'test-group',
+            subscriptions: [
+                {
+                    subject: 'user',
+                    callback: () => {
+                        throw new Error('Test error');
+                    }
+                },
+                {
+                    subject: 'billing',
+                    callback: () => {
+                        successCallbackExecuted = true;
+                    }
+                }
+            ]
+        });
+
+        // Publish events
+        await transport.publish({
+            idempotencyKey: 'error-test',
+            subject: 'user',
+            type: 'user.created',
+            payload: {
+                user: { id: 123, name: 'Test User' } as DBUser,
+                team: { id: 456, name: 'Test Team' } as DBTeam
+            },
+            createdAt: new Date()
+        });
+
+        await transport.publish({
+            idempotencyKey: 'success-test',
+            subject: 'billing',
+            type: 'billing.metric',
+            payload: [{ type: 'billable_actions', value: 1, properties: { accountId: 1 } }],
+            createdAt: new Date()
+        });
+
+        // Wait for callbacks to execute
+        await new Promise((resolve) => setImmediate(resolve));
+
+        // Error in one callback should not affect others
+        expect(successCallbackExecuted).toBe(true);
+    });
+
+    it('should not invoke callbacks for different subjects', async () => {
+        const userEvents: Event[] = [];
+        const billingEvents: Event[] = [];
+        let userCallbackExecuted = false;
+        let billingCallbackExecuted = false;
+
+        // Subscribe to different subjects
+        transport.subscribe({
+            consumerGroup: 'test-group',
+            subscriptions: [
+                {
+                    subject: 'user',
+                    callback: (event: Event) => {
+                        userEvents.push(event);
+                        userCallbackExecuted = true;
+                    }
+                },
+                {
+                    subject: 'billing',
+                    callback: (event: Event) => {
+                        billingEvents.push(event);
+                        billingCallbackExecuted = true;
+                    }
+                }
+            ]
+        });
+
+        // Publish an event for 'user' subject only
+        await transport.publish({
+            idempotencyKey: 'user-only-test',
+            subject: 'user',
+            type: 'user.created',
+            payload: {
+                user: { id: 123, name: 'Test User' } as DBUser,
+                team: { id: 456, name: 'Test Team' } as DBTeam
+            },
+            createdAt: new Date()
+        });
+
+        // Wait for the next tick of the event loop where setImmediate callbacks run
+        await new Promise((resolve) => setImmediate(resolve));
+
+        // Only the 'user' callback should be executed
+        expect(userCallbackExecuted).toBe(true);
+        expect(billingCallbackExecuted).toBe(false);
+        expect(userEvents).toHaveLength(1);
+        expect(billingEvents).toHaveLength(0);
+        expect(userEvents[0]?.subject).toBe('user');
+        expect(userEvents[0]?.idempotencyKey).toBe('user-only-test');
+    });
+});

--- a/packages/pubsub/lib/transport/local.ts
+++ b/packages/pubsub/lib/transport/local.ts
@@ -1,0 +1,136 @@
+import { Ok, getLogger, report } from '@nangohq/utils';
+
+import type { Subscription, Transport } from './transport.js';
+import type { Event } from '../event.js';
+import type { Result } from '@nangohq/utils';
+
+const logger = getLogger('pubsub.local');
+
+interface LocalSubscription {
+    subject: Event['subject'];
+    callback: (event: Event) => void;
+    consumerGroup: string;
+}
+
+/**
+ * Local in-memory transport.
+ * Events are processed asynchronously, publishing events is non-blocking.
+ */
+export class LocalTransport implements Transport {
+    private subscriptions: LocalSubscription[] = [];
+    private isConnected = false;
+    private processingQueue: { event: Event; subject: Event['subject'] }[] = [];
+    private isProcessing = false;
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public async connect(): Promise<Result<void>> {
+        this.isConnected = true;
+        logger.info('Local transport connected');
+        return Ok(undefined);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public async disconnect(): Promise<Result<void>> {
+        this.isConnected = false;
+        this.subscriptions = [];
+        this.processingQueue = [];
+        this.isProcessing = false;
+        logger.info('Local transport disconnected');
+        return Ok(undefined);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public async publish(event: Event): Promise<Result<void>> {
+        if (!this.isConnected) {
+            return Ok(undefined); // Silently succeed when not connected
+        }
+
+        try {
+            // Add to processing queue and trigger async processing
+            this.processingQueue.push({ event, subject: event.subject });
+            void this.processQueueAsync();
+
+            return Ok(undefined);
+        } catch (err) {
+            report(new Error('Error publishing event to local transport'), { error: err, subject: event.subject });
+            return Ok(undefined); // Still return success to not block publisher
+        }
+    }
+
+    public subscribe({ consumerGroup, subscriptions }: { consumerGroup: string; subscriptions: Subscription[] }): void {
+        if (!this.isConnected) {
+            logger.warning('Local transport not connected, cannot subscribe to events');
+            return;
+        }
+
+        for (const { subject, callback } of subscriptions) {
+            const localSubscription: LocalSubscription = {
+                subject,
+                callback,
+                consumerGroup
+            };
+
+            this.subscriptions.push(localSubscription);
+            logger.info(`Subscribed to ${subject} for consumer group ${consumerGroup}`);
+        }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    private async processQueueAsync(): Promise<void> {
+        if (this.isProcessing || this.processingQueue.length === 0) {
+            return;
+        }
+
+        this.isProcessing = true;
+
+        try {
+            while (this.processingQueue.length > 0) {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                const { event, subject } = this.processingQueue.shift()!;
+
+                // Find all subscriptions for this subject
+                const relevantSubscriptions = this.subscriptions.filter((sub) => sub.subject === subject);
+
+                // Process each subscription asynchronously without blocking
+                for (const subscription of relevantSubscriptions) {
+                    void this.processSubscriptionAsync(subscription, event);
+                }
+            }
+        } catch (err) {
+            report(new Error('Error processing local transport queue'), { error: err });
+        } finally {
+            this.isProcessing = false;
+
+            // Check if more items were added while processing
+            if (this.processingQueue.length > 0) {
+                // Use setImmediate to avoid blocking the current execution
+                setImmediate(() => void this.processQueueAsync());
+            }
+        }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    private async processSubscriptionAsync(subscription: LocalSubscription, event: Event): Promise<void> {
+        try {
+            // Use setImmediate to ensure the callback runs in the next tick
+            // This prevents blocking the publisher thread
+            setImmediate(() => {
+                try {
+                    subscription.callback(event);
+                } catch (err) {
+                    report(new Error('Error in local transport subscription callback'), {
+                        error: err,
+                        subject: subscription.subject,
+                        consumerGroup: subscription.consumerGroup
+                    });
+                }
+            });
+        } catch (err) {
+            report(new Error('Error scheduling local transport subscription callback'), {
+                error: err,
+                subject: subscription.subject,
+                consumerGroup: subscription.consumerGroup
+            });
+        }
+    }
+}


### PR DESCRIPTION
Adding a local pubsub transport so we can start using it for non-critical operations, and eventually replace it when ActiveMQ infra is setup.

> Note: heavily used cursor, but had to do many manual adjustments.

<!-- Summary by @propel-code-bot -->

---

This PR adds a local, in-memory pubsub transport named LocalTransport as a non-blocking, fully asynchronous event delivery mechanism intended for non-critical scenarios and to be later replaced by ActiveMQ-based infrastructure. It includes the LocalTransport implementation, integration into the public pubsub API using singleton/shared instances to ensure event delivery, and comprehensive integration tests covering event delivery semantics (multi-subscriber, subject isolation, async delivery, and error handling in callbacks).

<details>
<summary><strong>Key Changes</strong></summary>

• Implemented a LocalTransport class providing in-memory, fully asynchronous pubsub (publish/subscribe) handling.
• Added robust integration tests (local.integration.test.ts) to verify correct delivery across multiple subscribers, subjects, async execution, and error robustness.
• Exported default publisher and subscriber instances in the public API, ensuring they share the same LocalTransport instance for correct event routing.
• Resolved a critical issue (via review/iteration) to use a shared LocalTransport instance for both publisher and subscriber.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• pubsub transport layer (local.ts)
• pubsub test suite (local.integration.test.ts)
• pubsub public API (index.ts)

</details>

*This summary was automatically generated by @propel-code-bot*