### PR TITLE
fix(cli): fix global override

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -261,7 +261,7 @@ program
     .command('deploy')
     .description('Deploy a Nango integration')
     .arguments('environment')
-    .option('-v, --version [version]', 'Optional: Set a version of this deployment to tag this integration with. Can be used for rollbacks.')
+    .option('-v, --version [version]', 'Optional: Set a version of this deployment to tag this integration with.')
     .option('-s, --sync [syncName]', 'Optional deploy only this sync name.')
     .option('-a, --action [actionName]', 'Optional deploy only this action name.')
     .option('-i, --integration [integrationId]', 'Optional: Deploy all scripts related to a specific integration.')

--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -90,6 +90,9 @@ NANGO_DEPLOY_AUTO_CONFIRM=false # Default value
     )
     .version(getVersionOutput(), '-v, --version', 'Print the version of the Nango CLI and Nango Server.');
 
+// don't allow global options to leak into sub commands
+program.enablePositionalOptions(true);
+
 program.addHelpText('before', chalk.green(figlet.textSync('Nango CLI')));
 
 program


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
npx nango deploy dev -v 
-- currently shows the nango cli version

Adding this option allows the -v of the sub command to be honored

From the docs:
```
  /**
   * Enable positional options. Positional means global options are specified before subcommands which lets
   * subcommands reuse the same option names, and also enables subcommands to turn on passThroughOptions.
   *
   * The default behaviour is non-positional and global options may appear anywhere on the command line.
   *
   * @returns `this` command for chaining
   */
  enablePositionalOptions(positional?: boolean): this;
```

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the CLI to ensure that the '-v' flag is interpreted by subcommands (e.g., 'npx nango deploy dev -v'), rather than always being handled globally by the root CLI. It does so by enabling positional options, preventing global option leakage and allowing subcommands to use the same option names independently.

*This summary was automatically generated by @propel-code-bot*