### PR TITLE
chore: use decryptAsync for decrypting records

### DIFF
--- a/packages/records/lib/utils/encryption.ts
+++ b/packages/records/lib/utils/encryption.ts
@@ -16,12 +16,12 @@ function isEncrypted(data: UnencryptedRecordData | EncryptedRecordData): data is
     return 'encryptedValue' in data;
 }
 
-export function decryptRecordData(record: FormattedRecord): UnencryptedRecordData {
+export async function decryptRecordData(record: FormattedRecord): Promise<UnencryptedRecordData> {
     const encryptionManager = getEncryption();
     const { json } = record;
     if (isEncrypted(json)) {
         const { encryptedValue, iv, authTag } = json;
-        const decryptedString = encryptionManager.decryptSync(encryptedValue, iv, authTag);
+        const decryptedString = await encryptionManager.decryptAsync(encryptedValue, iv, authTag);
         return JSON.parse(decryptedString) as UnencryptedRecordData;
     }
     return json;


### PR DESCRIPTION
Decrypting records using async function to evaluate the impact of synchronous decryption on the performance of server (and persist)

<!-- Summary by @propel-code-bot -->

---

This PR refactors record decryption within the records model and encryption utilities, replacing the synchronous decryptRecordData function with an async implementation. All usages of record decryption now await the asynchronous decryptRecordData, leveraging the underlying encryptionManager.decryptAsync and allowing for evaluation of the impact of async decryption on overall server performance.

<details>
<summary><strong>Key Changes</strong></summary>

• Refactored decryptRecordData in encryption utilities to be async and use encryptionManager.decryptAsync.
• Updated all consumer sites in records.ts to use await decryptRecordData, including record retrieval, update, and upsertion logic.
• Changed all code paths that processed encrypted record data to follow async patterns, preparing the codebase for batch async decryption in future iterations (noted by a TODO comment).

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/records/lib/models/records.ts
• packages/records/lib/utils/encryption.ts

</details>

*This summary was automatically generated by @propel-code-bot*