### PR TITLE
feat: actually send usage emails

### DIFF
--- a/packages/account-usage/lib/emails.ts
+++ b/packages/account-usage/lib/emails.ts
@@ -22,12 +22,6 @@ export async function sendUsageNearLimitEmail({
 
     logger.info(`Sending usage near limit email for ${metricName} to ${user.email}`);
 
-    // TODO: Remove after testing
-    const dryRun = true;
-    if (dryRun) {
-        return;
-    }
-
     const formattedUsage = formatUsage(usage, triggeringMetric);
 
     const emailClient = EmailClient.getInstance();
@@ -68,13 +62,7 @@ export async function sendUsageLimitReachedEmail({
 }) {
     const metricName = usage.find((u) => u.metric === triggeringMetric)?.label ?? triggeringMetric;
 
-    logger.info(`Sending usage near limit email for ${metricName} to ${user.email}`);
-
-    // TODO: Remove after testing
-    const dryRun = true;
-    if (dryRun) {
-        return;
-    }
+    logger.info(`Sending usage limit reached email for ${metricName} to ${user.email}`);
 
     const formattedUsage = formatUsage(usage, triggeringMetric);
 


### PR DESCRIPTION
After confirming over the weekend that no unexpected spam behavior is happening, removing dryRun to actually send usage emails.

<!-- Summary by @propel-code-bot -->

---

This PR deletes the 'dryRun' logic from the account usage notification email functions, resulting in actual sending of emails to users when their usage approaches or exceeds predefined limits. The change follows a monitoring period to confirm that no spam or unwanted email behavior results from enabling live emails.

*This summary was automatically generated by @propel-code-bot*