### PR TITLE
feat(action-usage): [nan-3644] log action size

### DIFF
--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -303,7 +303,8 @@ class SyncController {
         } finally {
             const reqHeaders = getHeaders(req.headers);
             reqHeaders['authorization'] = 'REDACTED';
-            const contentLength = reqHeaders['content-length'];
+            const responseHeaders = getHeaders(res.getHeaders());
+            const contentLength = responseHeaders['content-length'];
             const lengthInMB = contentLength ? Number(contentLength) / (1024 * 1024) : 0;
             if (contentLength && lengthInMB > 0.5) {
                 logger.info(`Action DEBUGGING: contentLength is ${lengthInMB.toFixed(2)} MB`);
@@ -316,7 +317,7 @@ class SyncController {
                 },
                 response: {
                     code: res.statusCode,
-                    headers: redactHeaders({ headers: getHeaders(res.getHeaders()) })
+                    headers: redactHeaders({ headers: responseHeaders })
                 }
             });
         }

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -307,7 +307,7 @@ class SyncController {
             const contentLength = responseHeaders['content-length'];
             const lengthInMB = contentLength ? Number(contentLength) / (1024 * 1024) : 0;
             if (contentLength && lengthInMB > 0.5) {
-                logger.info(`Action DEBUGGING: contentLength is ${lengthInMB.toFixed(2)} MB`);
+                logger.info(`Action DEBUGGING: accountId: ${account.id} contentLength is ${lengthInMB.toFixed(2)} MB`);
             }
             await logCtx?.enrichOperation({
                 request: {

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -20,7 +20,7 @@ import {
     syncManager,
     verifyOwnership
 } from '@nangohq/shared';
-import { Err, Ok, baseUrl, getHeaders, isHosted, redactHeaders, truncateJson } from '@nangohq/utils';
+import { Err, Ok, baseUrl, getHeaders, getLogger, isHosted, redactHeaders, truncateJson } from '@nangohq/utils';
 
 import { getOrchestrator } from '../utils/utils.js';
 import { getPublicRecords } from './records/getRecords.js';
@@ -35,6 +35,7 @@ import type { NextFunction, Request, Response } from 'express';
 
 const orchestrator = getOrchestrator();
 const accountUsageTracker = await getAccountUsageTracker();
+const logger = getLogger('SyncController');
 
 class SyncController {
     public async getSyncsByParams(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
@@ -302,6 +303,11 @@ class SyncController {
         } finally {
             const reqHeaders = getHeaders(req.headers);
             reqHeaders['authorization'] = 'REDACTED';
+            const contentLength = reqHeaders['content-length'];
+            const lengthInMB = contentLength ? Number(contentLength) / (1024 * 1024) : 0;
+            if (contentLength && lengthInMB > 0.5) {
+                logger.info(`Action DEBUGGING: contentLength is ${lengthInMB.toFixed(2)} MB`);
+            }
             await logCtx?.enrichOperation({
                 request: {
                     url: `${req.protocol}://${req.get('host')}${req.originalUrl}`,

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -307,7 +307,7 @@ class SyncController {
             const contentLength = responseHeaders['content-length'];
             const lengthInMB = contentLength ? Number(contentLength) / (1024 * 1024) : 0;
             if (contentLength && lengthInMB > 0.5) {
-                logger.info(`Action DEBUGGING: accountId: ${account.id} contentLength is ${lengthInMB.toFixed(2)} MB`);
+                logger.info(`Action DEBUGGING: accountId: ${account.id} for the action name ${action_name} contentLength is ${lengthInMB.toFixed(2)} MB`);
             }
             await logCtx?.enrichOperation({
                 request: {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This pull request enhances the SyncController to log an informational message when the response payload of a triggered action exceeds 0.5 MB. It adds logic to extract the 'content-length' header from each action's HTTP response and, if the size is above the threshold, logs the account ID, action name, and the response size in megabytes. The update also introduces a dedicated logger and ensures consistent processing and redaction of response headers in operation logs.

*This summary was automatically generated by @propel-code-bot*