### PR TITLE
fix(deploy-version): if a version is passed in, don't attempt to bump

### DIFF
--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -248,7 +248,9 @@ async function compileDeployInfo({
     let bumpedVersion = '';
 
     if (previousSyncAndActionConfig) {
-        bumpedVersion = increment(previousSyncAndActionConfig.version as string | number).toString();
+        if (!optionalVersion) {
+            bumpedVersion = increment(previousSyncAndActionConfig.version as string | number).toString();
+        }
 
         if (debug) {
             void logCtx.debug('A previous sync config was found', { syncName, prevVersion: previousSyncAndActionConfig.version });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This pull request modifies the deployment logic for sync/action configuration so that if a specific version (optionalVersion) is provided via the input, the system will no longer attempt to auto-increment ('bump') the version from previous configurations. The change introduces a conditional check to only bump the version when 'optionalVersion' is not provided. This prevents unintended version increments and respects explicit user-supplied versions.

*This summary was automatically generated by @propel-code-bot*