### PR TITLE
feat: ability to override docs_connect in connect_sessions

### DIFF
--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -2481,6 +2481,16 @@ components:
                                     oauth_scopes_override:
                                         type: string
                                         description: Override oauth scopes
+                overrides:
+                    type: object
+                    additionalProperties:
+                        type: object
+                        description: The unique name of an integration
+                        additionalProperties: false
+                        properties:
+                            docs_connect:
+                                type: string
+                                description: Override the url of the docs we point to in the connect flow
 
         ConnectSessionReconnectInput:
             type: object
@@ -2498,6 +2508,8 @@ components:
                     $ref: '#/components/schemas/ConnectSessionInput/properties/organization'
                 integrations_config_defaults:
                     $ref: '#/components/schemas/ConnectSessionInput/properties/integrations_config_defaults'
+                overrides:
+                    $ref: '#/components/schemas/ConnectSessionInput/properties/overrides'
 
         ConnectSession:
             type: object

--- a/packages/connect-ui/src/views/Go.tsx
+++ b/packages/connect-ui/src/views/Go.tsx
@@ -102,6 +102,13 @@ export const Go: React.FC = () => {
         return integration?.display_name ?? provider?.display_name ?? '';
     }, [integration, provider]);
 
+    const [docsConnectUrl, urlOverride] = useMemo(() => {
+        if (!integration?.unique_key) return [null, false];
+        const override = session?.overrides?.[integration?.unique_key]?.docs_connect;
+        if (override) return [override, true];
+        return [provider?.docs_connect, false];
+    }, [provider, integration, session]);
+
     useMount(() => {
         if (integration) {
             telemetry('view:integration', { integration: integration.unique_key });
@@ -386,10 +393,10 @@ export const Go: React.FC = () => {
                                                                 {isOptional && (
                                                                     <span className="bg-dark-300 rounded-lg px-2 py-0.5 text-xs text-dark-500">optional</span>
                                                                 )}
-                                                                {definition?.doc_section && (
+                                                                {docsConnectUrl && (
                                                                     <Link
                                                                         target="_blank"
-                                                                        to={`${provider.docs_connect}${definition.doc_section}`}
+                                                                        to={`${docsConnectUrl}${urlOverride ? '' : `${definition?.doc_section}`}`}
                                                                         onClick={() => telemetry('click:doc_section')}
                                                                     >
                                                                         <IconInfoCircle size={16} />
@@ -446,10 +453,10 @@ export const Go: React.FC = () => {
                                     {t('go.invalidPreconfigured')}
                                 </div>
                             )}
-                            {provider.docs_connect && (
+                            {docsConnectUrl && (
                                 <p className="text-dark-500 text-center">
                                     {t('common.needHelp')}{' '}
-                                    <Link className="underline text-dark-800" target="_blank" to={provider.docs_connect} onClick={() => telemetry('click:doc')}>
+                                    <Link className="underline text-dark-800" target="_blank" to={docsConnectUrl} onClick={() => telemetry('click:doc')}>
                                         {t('common.viewGuide')}
                                     </Link>
                                 </p>

--- a/packages/server/lib/controllers/connect/getSession.ts
+++ b/packages/server/lib/controllers/connect/getSession.ts
@@ -76,6 +76,9 @@ export const getConnectSession = asyncWrapper<GetConnectSession>(async (req, res
     if (connectSession.connectionId) {
         response.data.isReconnecting = true;
     }
+    if (connectSession.overrides) {
+        response.data.overrides = connectSession.overrides;
+    }
 
     res.status(200).send(response);
 });

--- a/packages/server/lib/services/connectSession.service.ts
+++ b/packages/server/lib/services/connectSession.service.ts
@@ -3,7 +3,7 @@ import { EndUserMapper } from '@nangohq/shared';
 import { Err, Ok } from '@nangohq/utils';
 
 import type { Knex } from '@nangohq/database';
-import type { ConnectSession, ConnectSessionIntegrationConfigDefaults, DBEndUser, EndUser } from '@nangohq/types';
+import type { ConnectSession, ConnectSessionIntegrationConfigDefaults, ConnectSessionOverrides, DBEndUser, EndUser } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { SetOptional } from 'type-fest';
 
@@ -20,6 +20,7 @@ export interface DBConnectSession {
     readonly updated_at: Date | null;
     readonly allowed_integrations: string[] | null;
     readonly integrations_config_defaults: Record<string, ConnectSessionIntegrationConfigDefaults> | null;
+    readonly overrides: Record<string, ConnectSessionOverrides> | null;
 }
 type DbInsertConnectSession = Omit<DBConnectSession, 'id' | 'created_at' | 'updated_at'>;
 
@@ -35,7 +36,8 @@ const ConnectSessionMapper = {
             created_at: session.createdAt,
             updated_at: session.updatedAt,
             allowed_integrations: session.allowedIntegrations || null,
-            integrations_config_defaults: session.integrationsConfigDefaults || null
+            integrations_config_defaults: session.integrationsConfigDefaults || null,
+            overrides: session.overrides || null
         };
     },
     from: (dbSession: DBConnectSession): ConnectSession => {
@@ -49,7 +51,8 @@ const ConnectSessionMapper = {
             createdAt: dbSession.created_at,
             updatedAt: dbSession.updated_at,
             allowedIntegrations: dbSession.allowed_integrations || null,
-            integrationsConfigDefaults: dbSession.integrations_config_defaults || null
+            integrationsConfigDefaults: dbSession.integrations_config_defaults || null,
+            overrides: dbSession.overrides || null
         };
     }
 };
@@ -79,11 +82,12 @@ export async function createConnectSession(
         connectionId,
         allowedIntegrations,
         integrationsConfigDefaults,
-        operationId
+        operationId,
+        overrides
     }: SetOptional<
         Pick<
             ConnectSession,
-            'endUserId' | 'allowedIntegrations' | 'connectionId' | 'integrationsConfigDefaults' | 'accountId' | 'environmentId' | 'operationId'
+            'endUserId' | 'allowedIntegrations' | 'connectionId' | 'integrationsConfigDefaults' | 'accountId' | 'environmentId' | 'operationId' | 'overrides'
         >,
         'connectionId'
     >
@@ -95,7 +99,8 @@ export async function createConnectSession(
         connection_id: connectionId || null,
         allowed_integrations: allowedIntegrations,
         integrations_config_defaults: integrationsConfigDefaults,
-        operation_id: operationId
+        operation_id: operationId,
+        overrides: overrides || null
     };
     const [session] = await db.insert<DBConnectSession>(dbSession).into(CONNECT_SESSIONS_TABLE).returning('*');
     if (!session) {

--- a/packages/types/lib/connect/api.ts
+++ b/packages/types/lib/connect/api.ts
@@ -28,6 +28,7 @@ export interface ConnectSessionInput {
               display_name?: string | undefined;
           }
         | undefined;
+    overrides?: Record<string, { docs_connect?: string | undefined }> | undefined;
 }
 export type ConnectSessionOutput = ConnectSessionInput & {
     isReconnecting?: boolean;
@@ -54,6 +55,7 @@ export type PostPublicConnectSessionsReconnect = Endpoint<{
         integrations_config_defaults?: ConnectSessionInput['integrations_config_defaults'];
         end_user?: ConnectSessionInput['end_user'] | undefined;
         organization?: ConnectSessionInput['organization'];
+        overrides?: ConnectSessionInput['overrides'];
     };
     Success: {
         data: {

--- a/packages/types/lib/connect/session.ts
+++ b/packages/types/lib/connect/session.ts
@@ -7,6 +7,7 @@ export interface ConnectSession {
     readonly operationId: string | null;
     readonly allowedIntegrations: string[] | null;
     readonly integrationsConfigDefaults: Record<string, ConnectSessionIntegrationConfigDefaults> | null;
+    readonly overrides: Record<string, ConnectSessionOverrides> | null;
     readonly createdAt: Date;
     readonly updatedAt: Date | null;
 }
@@ -21,4 +22,8 @@ export interface ConnectSessionIntegrationConfigDefaults {
               oauth_scopes_override?: string | undefined;
           }
         | undefined;
+}
+
+export interface ConnectSessionOverrides {
+    docs_connect?: string | undefined;
 }


### PR DESCRIPTION
> DB migration in this PR #4426

https://linear.app/nango/issue/NAN-3639/user-guide-url-override-for-connect-ui

We want customers (more specifically ACA) to be able to override the docs urls for specific integrations to point to their docs instead of nango. 

<img width="692" height="921" alt="image" src="https://github.com/user-attachments/assets/ed0f0152-923d-4034-b90c-516e7f93589c" />

The simple suggested approach is to add an overrides field to a connect-session.

> Why not use integration_config_defaults?

That's clearly meant to set defaults for fields that shouldn't be shown to the end-user, while overrides is for overriding settings.

Usage example in sdk:
```ts
await nango.createConnectSession({
  allowed_integrations: ['oracle-hcm'],
  end_user: { id: 1 },
  overrides: {
    'oracle-hcm': {
      docs_connect: 'https://docs.foo.com/oracle-hcm'
    }
  }
});
```

<!-- Summary by @propel-code-bot -->

---

**Add Per-Integration `docs_connect` URL Override to Connect Sessions**

This PR implements a new feature allowing customers-if permitted by a feature flag-to provide per-integration documentation URL overrides (`docs_connect`) within connect session objects. The mechanism is introduced through an optional `overrides` field on the connect session payload, propagated from backend to frontend and used at runtime in the Connect UI. This includes extensive type, contract, and schema changes across API, backend services, the frontend connect experience, and adds thorough tests (unit/integration) to cover various validation, permission, and error scenarios. Associated database schema changes (the `overrides` JSONB column) are handled in migration PR #4426, which must be applied prior to deployment.

**Key Changes:**
• Introduces `overrides` field to connect session requests for providers, supporting per-integration ``docs_connect`` ``URL`` overrides.
• Updates validation to enforce integration existence and permission-gated access to the override feature (checks plan's ``can_override_docs_connect_url`` flag).
• Extends type definitions (``ConnectSession``, ``API`` schemas, `OpenAPI` spec) to include `overrides` on connect session create and reconnect endpoints.
• Enhances ``connect_sessions`` table with an `overrides` column (migration in ``PR`` #4426).
• Adjusts backend session controllers/services to support the new field and validation logic.
• Front-end (`Go.tsx`) updated to detect and use the docs ``URL`` override for each integration if present, with a safe fallback.
• Comprehensive test extensions in both creation and reconnect flows, including regressions, negative cases, and plan gating.
• Contracts and `OpenAPI` documentation expanded for clarity and backward compatibility.

**Affected Areas:**
• Database: ``connect_sessions`` table (migration for `overrides` column)
• Backend: session controllers (``postSessions`.ts`, ``postReconnect`.ts`)
• Type system: connect session types/``API`` definitions
• Services: ``connectSession`.service.ts` mapping and persistence
• Frontend: Connect ``UI`` (`Go.tsx`) docs/help link rendering logic
• ``API`` schema & `OpenAPI`: `spec.yaml`, endpoint contracts
• Test suite: creation/reconnect session integration tests

**Potential Impact:**
**Functionality**: Enables feature-gated customers to specify custom documentation URLs for end users on a per-integration basis during the connect UI flow. All legacy and non-feature-flagged flows are unchanged.

**Performance**: No meaningful performance impact; the optional `overrides` object is small, and additional validation logic is lightweight.

**Security**: Override URLs are only used for rendering as anchor hrefs. Frontend logic protects against DOM injection, but any new use of override values should maintain untrusted treatment to avoid XSS/open redirect issues.

**Scalability**: No scalability concerns. The data added is highly bounded (per session and per integration).
**Review Focus:**
• Backend access/perms validation (integration existence and ``can_override_docs_connect_url`` gating).
• ``UI`` logic for safe/fallback rendering of docs `URLs` (including override/fallback logic and anchor rendering).
• `OpenAPI` and type definition completeness, accuracy, and backward compatibility.
• Comprehensiveness and correctness of new and updated integration tests.
• Coordination with the database migration ``PR`` (#4426) for roll-out sequencing.

<details>
<summary><strong>Testing Needed</strong></summary>

• Test creation and reconnect of connect sessions with valid, invalid, and missing `overrides`, including edge cases and permission/plan checks.
• Regressions on existing connect session flows for backward compatibility.
• ``UI`` validation of docs/help links across both override and fallback cases.
• Validate that migration ``PR`` (#4426) for database schema is safely applied prior to rollout.
• ``API`` docs and type output consistency checks.

</details>

<details>
<summary><strong>Code Quality Assessment</strong></summary>

**packages/server/lib/controllers/connect/postSessions.integration.test.ts**: Broad extension with positive/negative and plan-gated test scenarios, well-factored.

**packages/server/lib/controllers/connect/postReconnect.ts**: Mirrors session controller pattern, centralizes key checks and gating.

**packages/server/lib/services/connectSession.service.ts**: All serialization, mapping, and persistence logic extended non-breaking for new field.

**packages/types/lib/connect/api.ts**: Contracts and documentation updated to reflect new field.

**packages/server/lib/controllers/connect/postReconnect.integration.test.ts**: New test suite ensures feature parity and edge case enforcement.

**docs-v2/spec.yaml**: Extensively updated for new override field, maintains backward compatibility.

**packages/shared/lib/seeders/plan.seeder.ts**: Seeder updated to ensure full flag/test coverage.

**packages/server/lib/controllers/connect/postSessions.ts**: Refactored for modular validation of all integration-keyed input, incorporates permission gating and consistent error handling.

**packages/types/lib/connect/session.ts**: Proper extension of types/models for backward-compatible overrides support.

**packages/connect-ui/src/views/Go.tsx**: Safe, concise, and clear logic for selecting correct help URL; maintains clear user flow.

</details>

<details>
<summary><strong>Best Practices</strong></summary>

**Testing**:
• Comprehensive, positive and negative cases; full regression and edge case coverage.

**Validation**:
• Centralized integration existence checks for all keyed config records.
• Plan-level feature gating enforced at validation.

**API Schema**:
• `OpenAPI`/spec/type contract changes made in an additive and optional (backward compatible) manner.
• Schemas, backend, and frontend kept in sync.

**Security**:
• No direct ``DOM`` injection; `URLs` exclusively used as anchor hrefs.
• Fallbacks and defensive null-handling prevent ``UI`` failures.

**Migration**:
• All ``DB`` changes isolated to separate migration with a safe down/rollback path.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Overrides supplied by users must continue to be treated as untrusted to prevent XSS/open redirect vulnerabilities.
• Any future extension of the `overrides` field for more options must extend API, DB, contract, validation, and frontend logic accordingly.
• Connect sessions with docs_connect overrides may remain after plan-level permission changes (such as downgrades); audit for lingering overrides if business rules change.
• Database migration (separate PR) must be deployed prior to this code to avoid runtime and persistence errors.

</details>

---
*This summary was automatically generated by @propel-code-bot*