### PR TITLE
docs: add step for enabling 2GP in Salesforce

### DIFF
--- a/docs-v2/integrations/all/salesforce.mdx
+++ b/docs-v2/integrations/all/salesforce.mdx
@@ -178,7 +178,7 @@ description: 'Access the Salesforce API in 2 minutes 💨'
         1. **Create Developer Hub Account**: 
            - Go to [Salesforce Developer Edition signup](https://developer.salesforce.com/signup) and create your first account
            - Enable Dev Hub: **Setup** → **Dev Hub** → **Enable Dev Hub**
-           - Enabled 2GP: **Setup** → **Dev Hub** → **Enable Dev Hub** → **Enable Unlocked Packages and Second-Generation Managed Packages**
+           - Enable 2GP: **Setup** → **Dev Hub** → **Enable Dev Hub** → **Enable Unlocked Packages and Second-Generation Managed Packages**
            <Note>Please note that this change is irreversible</Note>
         
         2. **Create Namespace Account**: 

--- a/docs-v2/integrations/all/salesforce.mdx
+++ b/docs-v2/integrations/all/salesforce.mdx
@@ -178,6 +178,7 @@ description: 'Access the Salesforce API in 2 minutes 💨'
         1. **Create Developer Hub Account**: 
            - Go to [Salesforce Developer Edition signup](https://developer.salesforce.com/signup) and create your first account
            - Enable Dev Hub: **Setup** → **Dev Hub** → **Enable Dev Hub**
+           - Enabled 2GP: **Setup** → **Dev Hub** → **Enable Dev Hub** → **Enable Unlocked Packages and Second-Generation Managed Packages**
            <Note>Please note that this change is irreversible</Note>
         
         2. **Create Namespace Account**: 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
This step is important otherwise the following error will returned in step 9: 

`$ sf package list --target-dev-hub my-dev-hub  `

```
PackageErrorUsername,AppAnalyticsEnabled from Package2 ORDER BY NamespacePrefix
                                              ^
ERROR at Row:1:Column:261
sObject type 'Package2' is not supported
```

<!-- Summary by @propel-code-bot -->

---

This PR updates the Salesforce integration documentation by adding an explicit instruction for enabling Second-Generation Packaging (2GP) during Developer Hub setup. The documentation change highlights that omitting this step can cause an error ('sObject type 'Package2' is not supported') during package listing, which is a common point of failure for users setting up external packaged integrations.

*This summary was automatically generated by @propel-code-bot*