### PR TITLE
feat: add info to sync records usage

### DIFF
--- a/packages/account-usage/lib/accountUsageStore/accountUsageStore.ts
+++ b/packages/account-usage/lib/accountUsageStore/accountUsageStore.ts
@@ -1,4 +1,4 @@
-import type { AccountUsageIncrementableMetric } from '../metrics.js';
+import type { AccountUsageIncrementableMetric } from '@nangohq/types';
 
 export interface GetUsageParams {
     accountId: number;

--- a/packages/account-usage/lib/accountUsageStore/kvAccountUsageStore.ts
+++ b/packages/account-usage/lib/accountUsageStore/kvAccountUsageStore.ts
@@ -1,8 +1,8 @@
 import { startOfMonth } from '@nangohq/utils';
 
 import type { AccountUsageStore, GetUsageParams, IncrementUsageParams, SetUsageParams } from './accountUsageStore.js';
-import type { AccountUsageIncrementableMetric } from '../metrics.js';
 import type { KVStore } from '@nangohq/kvstore';
+import type { AccountUsageIncrementableMetric } from '@nangohq/types';
 
 const MONTH_IN_MS = 31 * 24 * 60 * 60 * 1000;
 

--- a/packages/account-usage/lib/accountUsageTracker.ts
+++ b/packages/account-usage/lib/accountUsageTracker.ts
@@ -4,8 +4,7 @@ import { report } from '@nangohq/utils';
 import { metricFlags } from './metrics.js';
 
 import type { AccountUsageStore, IncrementUsageParams } from './accountUsageStore/accountUsageStore.js';
-import type { AccountUsageMetric } from './metrics.js';
-import type { DBPlan, DBTeam, MetricUsage } from '@nangohq/types';
+import type { AccountMetricsUsageSummary, AccountUsageMetric, DBPlan, DBTeam } from '@nangohq/types';
 
 /**
  * Tracks usage for an account. Prioritizes performance over precision.
@@ -67,10 +66,9 @@ export class AccountUsageTracker {
         return plan[flag as keyof DBPlan] as number | null;
     }
 
-    public async getAccountMetricsUsage(account: DBTeam, plan: DBPlan): Promise<MetricUsage[]> {
-        return [
-            {
-                metric: 'connections',
+    public async getAccountMetricsUsageSummary(account: DBTeam, plan: DBPlan): Promise<AccountMetricsUsageSummary> {
+        return {
+            connections: {
                 label: 'Connections',
                 usage:
                     (await this.getUsage({
@@ -79,8 +77,7 @@ export class AccountUsageTracker {
                     })) ?? 0,
                 limit: plan.connections_max
             },
-            {
-                metric: 'actions',
+            actions: {
                 label: 'Actions',
                 usage:
                     (await this.getUsage({
@@ -89,8 +86,7 @@ export class AccountUsageTracker {
                     })) ?? 0,
                 limit: plan.monthly_actions_max
             },
-            {
-                metric: 'active_records',
+            active_records: {
                 label: 'Synced Records',
                 usage:
                     (await this.getUsage({
@@ -99,6 +95,6 @@ export class AccountUsageTracker {
                     })) ?? 0,
                 limit: plan.monthly_active_records_max
             }
-        ];
+        };
     }
 }

--- a/packages/account-usage/lib/emails.ts
+++ b/packages/account-usage/lib/emails.ts
@@ -93,7 +93,7 @@ Team Nango
 function formatUsageSummary(usageSummary: AccountMetricsUsageSummary, triggeringMetric: AccountUsageMetric) {
     const usageLines = Object.entries(usageSummary).map(([metric, u]) => {
         const isPerMonth = metric !== 'connections';
-        const postfix = isPerMonth ? 'per month' : '';
+        const postfix = isPerMonth && u.limit ? 'per month' : '';
 
         const overLimit = u.limit && u.usage >= u.limit;
         const over80Percent = u.limit && u.usage >= u.limit * 0.8;
@@ -104,7 +104,7 @@ function formatUsageSummary(usageSummary: AccountMetricsUsageSummary, triggering
               ? `<span style="color: #e6a70d; font-weight: bold;">${u.usage}</span>`
               : u.usage.toString();
 
-        const line = `${u.label}: ${usageNumber}/${u.limit} ${postfix}`;
+        const line = `${u.label}: ${usageNumber}${u.limit ? `/${u.limit}` : ''} ${postfix}`;
 
         const isTriggeringMetric = metric === triggeringMetric;
         return isTriggeringMetric ? `<b>${line}</b>` : line;

--- a/packages/account-usage/lib/events/onUsageIncreased.ts
+++ b/packages/account-usage/lib/events/onUsageIncreased.ts
@@ -8,8 +8,7 @@ import { report, stringifyError } from '@nangohq/utils';
 import { sendUsageLimitReachedEmail, sendUsageNearLimitEmail } from '../emails.js';
 import { getAccountUsageTracker } from '../index.js';
 
-import type { AccountUsageMetric } from '../index.js';
-import type { DBPlan } from '@nangohq/types';
+import type { AccountUsageMetric, DBPlan } from '@nangohq/types';
 
 export async function onUsageIncreased({
     accountId,
@@ -72,17 +71,17 @@ export async function onUsageIncreased({
                 throw new Error(`Account not found for accountId ${accountId}`);
             }
 
-            const usage = await accountUsageTracker.getAccountMetricsUsage(account, resolvedPlan);
+            const usageSummary = await accountUsageTracker.getAccountMetricsUsageSummary(account, resolvedPlan);
             const users = await userService.getUsersByAccountId(accountId);
 
             await Promise.all(
                 users.map((user) => {
                     // Full limit reached prioritized in case usage jumps directly to it
                     if (crossedLimit) {
-                        return sendUsageLimitReachedEmail({ user, account, usage, triggeringMetric: metric });
+                        return sendUsageLimitReachedEmail({ user, account, usageSummary, triggeringMetric: metric });
                     }
 
-                    return sendUsageNearLimitEmail({ user, account, usage, triggeringMetric: metric });
+                    return sendUsageNearLimitEmail({ user, account, usageSummary, triggeringMetric: metric });
                 })
             );
 

--- a/packages/account-usage/lib/index.ts
+++ b/packages/account-usage/lib/index.ts
@@ -10,7 +10,6 @@ export type { AccountUsageStore } from './accountUsageStore/accountUsageStore.js
 export { DbAccountUsageStore } from './accountUsageStore/dbAccountUsageStore.js';
 export { HybridAccountUsageStore } from './accountUsageStore/hybridAccountUsageStore.js';
 export { KvAccountUsageStore } from './accountUsageStore/kvAccountUsageStore.js';
-export type { AccountUsageIncrementableMetric, AccountUsageMetric } from './metrics.js';
 export { onUsageIncreased } from './events/onUsageIncreased.js';
 
 let usageTracker: AccountUsageTracker | undefined;

--- a/packages/account-usage/lib/metrics.ts
+++ b/packages/account-usage/lib/metrics.ts
@@ -1,6 +1,4 @@
-export type AccountUsageIncrementableMetric = 'actions' | 'active_records';
-
-export type AccountUsageMetric = AccountUsageIncrementableMetric | 'connections';
+import type { AccountUsageMetric } from '@nangohq/types';
 
 export const metricFlags: Record<AccountUsageMetric, string> = {
     actions: 'monthly_actions_max',

--- a/packages/server/lib/controllers/v1/plans/usage/getUsage.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getUsage.ts
@@ -19,7 +19,7 @@ export const getUsage = asyncWrapper<GetUsage>(async (req, res) => {
     }
 
     const accountUsageTracker = await getAccountUsageTracker();
-    const usage = await accountUsageTracker.getAccountMetricsUsage(account, plan);
+    const usage = await accountUsageTracker.getAccountMetricsUsageSummary(account, plan);
 
     res.status(200).send({
         data: usage

--- a/packages/server/lib/crons/persistAccountUsage.ts
+++ b/packages/server/lib/crons/persistAccountUsage.ts
@@ -11,7 +11,7 @@ import { getKVStore } from '@nangohq/kvstore';
 import { envs } from '@nangohq/logs';
 import { flagHasPlan, getLogger, metrics, report, startOfMonth } from '@nangohq/utils';
 
-import type { AccountUsageIncrementableMetric } from '@nangohq/account-usage';
+import type { AccountUsageIncrementableMetric } from '@nangohq/types';
 
 const cronMinutes = envs.CRON_PERSIST_ACCOUNT_USAGE_MINUTES;
 const logger = getLogger('cron.persistAccountUsage');

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -1,5 +1,5 @@
 import type { BillingCustomer, BillingUsageMetric } from '../billing/types.js';
-import type { MetricUsage } from '../usage/dto.js';
+import type { AccountMetricsUsageSummary } from '../usage/dto.js';
 import type { ReplaceInObject } from '../utils.js';
 import type { DBPlan } from './db.js';
 import type { Endpoint } from '../api.js';
@@ -61,7 +61,7 @@ export type GetUsage = Endpoint<{
     Path: '/api/v1/plans/usage';
     Querystring: { env: string };
     Success: {
-        data: MetricUsage[];
+        data: AccountMetricsUsageSummary;
     };
 }>;
 

--- a/packages/types/lib/usage/dto.ts
+++ b/packages/types/lib/usage/dto.ts
@@ -12,8 +12,13 @@ export interface UpdateAccountUsageDto {
     activeRecords?: DBAccountUsage['active_records'];
 }
 
-export interface MetricUsage {
-    metric: string;
+export type AccountUsageIncrementableMetric = 'actions' | 'active_records';
+
+export type AccountUsageMetric = AccountUsageIncrementableMetric | 'connections';
+
+export type AccountMetricsUsageSummary = Record<AccountUsageMetric, MetricUsageSummary>;
+
+export interface MetricUsageSummary {
     label: string;
     usage: number;
     limit: number | null;

--- a/packages/webapp/src/components/UsageCard.tsx
+++ b/packages/webapp/src/components/UsageCard.tsx
@@ -1,7 +1,9 @@
+import { IconInfoCircle } from '@tabler/icons-react';
 import { useMemo } from 'react';
 
 import { useApiGetUsage } from '../hooks/usePlan.js';
 import { useStore } from '../store.js';
+import { SimpleTooltip } from './SimpleTooltip.js';
 import { Skeleton } from './ui/Skeleton.js';
 import { cn } from '../utils/utils.js';
 import { ButtonLink } from './ui/button/Button.js';
@@ -65,7 +67,18 @@ export default function UsageCard() {
                     ) : (
                         Object.entries(usage?.data ?? {}).map(([metric, usage]) => (
                             <div key={metric} className="flex flex-row justify-between items-center">
-                                <span className="text-text-secondary text-s">{usage.label}</span>
+                                <div className="flex flex-row items-center gap-1">
+                                    <span className="text-text-secondary text-s">{usage.label}</span>
+                                    {metric === 'active_records' && (
+                                        <SimpleTooltip
+                                            className="text-text-secondary"
+                                            tooltipContent="Synced records are only counted for connections that are at least 1 month old"
+                                            side="bottom"
+                                        >
+                                            <IconInfoCircle className="w-3 h-3 text-text-tertiary" />
+                                        </SimpleTooltip>
+                                    )}
+                                </div>
                                 <div>
                                     <span className={cn('text-s', getColorForUsage(usage.usage, usage.limit))}>{usage.usage}</span>
                                     {usage.limit && <span className="text-text-tertiary text-s">/{formatLimit(usage.limit)}</span>}

--- a/packages/webapp/src/components/UsageCard.tsx
+++ b/packages/webapp/src/components/UsageCard.tsx
@@ -63,12 +63,12 @@ export default function UsageCard() {
                             <Skeleton className="h-[24px]" />
                         </>
                     ) : (
-                        usage?.data?.map((metric) => (
-                            <div key={metric.metric} className="flex flex-row justify-between items-center">
-                                <span className="text-text-secondary text-s">{metric.label}</span>
+                        Object.entries(usage?.data ?? {}).map(([metric, usage]) => (
+                            <div key={metric} className="flex flex-row justify-between items-center">
+                                <span className="text-text-secondary text-s">{usage.label}</span>
                                 <div>
-                                    <span className={cn('text-s', getColorForUsage(metric.usage, metric.limit))}>{metric.usage}</span>
-                                    {metric.limit && <span className="text-text-tertiary text-s">/{formatLimit(metric.limit)}</span>}
+                                    <span className={cn('text-s', getColorForUsage(usage.usage, usage.limit))}>{usage.usage}</span>
+                                    {usage.limit && <span className="text-text-tertiary text-s">/{formatLimit(usage.limit)}</span>}
                                 </div>
                             </div>
                         ))

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -57,7 +57,7 @@ export const CreateConnectionSelector: React.FC = () => {
         if (usageLoading) {
             return false;
         }
-        const connectionsUsage = usage?.data.find((v) => v.metric === 'connections');
+        const connectionsUsage = usage?.data.connections;
         return connectionsUsage && connectionsUsage.limit && connectionsUsage.usage >= connectionsUsage.limit;
     }, [usage, usageLoading]);
 


### PR DESCRIPTION
Adds this to `Synced records` in the UI:
<img width="565" height="243" alt="image" src="https://github.com/user-attachments/assets/c00d5a0b-4292-4fc3-bd36-a74a51e9e489" />

However, I took the chance to change a few things that bothered me:
- Change "usage summary" from an array (`MetricUsageSummary[]`) to a record `Record<AccountUsageMetric, MetricUsageSummary>`. It was bothering me that getting the summary for a specific metric required an `array.find`.
- Fixed "bug" in email when there's no limit for a given metric. It would show something like: `Actions: 50/null per month`, now it shows `Actions: 50` if there's no limit.

> Refactor and features are split in separate commits to facilitate review

<!-- Summary by @propel-code-bot -->

---

**Refactor Usage Summary to Record Format & UI/Email Improvements for Usage Metrics**

This PR introduces a refactor to the usage summary structure, converting it from an array of MetricUsageSummary objects to a Record keyed by AccountUsageMetric. This change spans API, backend logic, DTO types, and UI usage, enabling more direct and efficient access to specific metrics. Additionally, the PR enhances the Synced Records UI by adding an info tooltip, and addresses an email formatting bug relating to how unlimited usage limits are displayed.

**Key Changes:**
• Refactored usage data model from `MetricUsageSummary`[] to Record<`AccountUsageMetric`, `MetricUsageSummary`> (object/record type) across backend, ``API``, and frontend.
• Updated `DTOs`, ``API`` response types, and `TypeScript` interfaces both in shared/@nangohq/types and service code to reflect the new usage summary shape.
• Refactored business logic, usage tracker, and event handling to use the new usage summary format.
• Updated frontend components (`UsageCard`, `ConnectionSelector`) to process usage as an object instead of an array, improving access patterns.
• Added a tooltip to the `Synced Records` usage row in the ``UI`` clarifying counting logic.
• Fixed a bug in notification/email templates so that usage limits display clearly when there are no limits (e.g., showing `Actions: 50` instead of `Actions: 50/null per month`).

**Affected Areas:**
• Backend usage tracking logic (@nangohq/account-usage)
• `TypeScript` types and `DTOs` (@nangohq/types)
• ``API`` routes and controller for plan usage
• Frontend dashboard/components (`UsageCard`, `CreateConnectionSelector`)
• Plan ``API`` response contract
• Notification/email logic that presents usage data

**Potential Impact:**
**Functionality**: Improves developer and internal code ergonomics for accessing usage metrics; no functional changes to business logic. User-facing dashboard and emails show usage information more clearly and with enhanced UI cues.

**Performance**: Potentially more efficient metric lookups thanks to object keying; no negative performance impact expected.

**Security**: No security implications introduced.

**Scalability**: Model change (object instead of array) simplifies scaling to more usage metrics in the future and makes code less error-prone.
**Review Focus:**
• ``API`` compatibility: Ensure no breaking contract for clients that expect usage as an array; check change management/communication.
• Correctness of object property key mapping for each usage metric.
• ``UI`` components: Confirm correct fallback and loading states, tooltip displays, accurate limit checking.
• Thorough review of all type/``DTO`` import locations for potential stale usage of the old array pattern.
• Edge case handling in emails (no limits, missing metrics, long metric lists).

<details>
<summary><strong>Testing Needed</strong></summary>

• Validate ``GET`` /plans/usage ``API`` returns the new object/record-style usage summary shape.
• Check ``UI`` (`UsageCard`) for correct per-metric reads and correct display, especially for `Synced Records` tooltip.
• Test `ConnectionSelector` gating logic for connection limits with new usage format.
• Trigger usage near/over limit to test email notification formatting (no limits, partial limits, normal).
• Check integration across upstream/downstream service boundaries for compatibility.

</details>

<details>
<summary><strong>Code Quality Assessment</strong></summary>

**packages/account-usage/lib/emails.ts**: Refactored cleanly; function and variable names updated consistently to match new shape. Email formatting logic improved for null limits.

**packages/webapp/src/components/UsageCard.tsx**: Updated to correctly iterate object entries; tooltip integration looks standard and clear.

**packages/account-usage/lib/accountUsageTracker.ts**: Query code and summary building reflect new format; method naming consistent and intent clear.

**packages/types/lib/usage/dto.ts**: Types refactored neatly; type/alias naming is clear and explicit.

**packages/account-usage/lib/events/onUsageIncreased.ts**: Logic migrated to use usageSummary throughout, consistent error handling maintained.


</details>

<details>
<summary><strong>Best Practices</strong></summary>

**Type Safety**:
• Centralize canonical metric keys/types; ensure all imports reference @nangohq/types.
• Avoid implicit any/object in usage data for future maintainability.

**Data Modeling**:
• Use object/record for keyed lookups rather than search in arrays.
• Keep ``DTO`` shape and ``API`` response shape closely aligned.

**UI/UX**:
• Tooltip text is clear and concise; consider documentation for other possible metric caveats in future.
• Dashboard render code is resilient to missing fields.


</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Backward-compatibility risks for any external consumers of the GET /plans/usage endpoint expecting an array instead of the new object format.
• Missed usages of the old array-based structure in less frequently used code paths.
• Potential confusion if other metrics are added and not reflected in all Record<> usages or email templates.
• Edge cases if a metric is missing from the summary record (should not happen with current structure, but worth confirming).

</details>

---
*This summary was automatically generated by @propel-code-bot*