### PR TITLE
feat: ingest billing events from metering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28482,6 +28482,7 @@
             "dependencies": {
                 "@nangohq/billing": "file:../billing",
                 "@nangohq/pubsub": "file:../pubsub",
+                "@nangohq/shared": "file:../shared",
                 "@nangohq/utils": "file:../utils",
                 "dd-trace": "5.52.0",
                 "zod": "4.0.5"
@@ -28568,7 +28569,6 @@
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@nangohq/account-usage": "file:../account-usage",
-                "@nangohq/billing": "file:../billing",
                 "@nangohq/database": "file:../database",
                 "@nangohq/logs": "file:../logs",
                 "@nangohq/pubsub": "file:../pubsub",

--- a/packages/metering/lib/app.ts
+++ b/packages/metering/lib/app.ts
@@ -1,5 +1,6 @@
 import './tracer.js';
 
+import { billing } from '@nangohq/billing';
 import { DefaultTransport } from '@nangohq/pubsub';
 import { initSentry, once, report } from '@nangohq/utils';
 
@@ -29,8 +30,8 @@ try {
     }
 
     // Billing processor
-    const billing = new Billing(pubsubTransport);
-    billing.start();
+    const billingProc = new Billing(pubsubTransport);
+    billingProc.start();
 
     // Graceful shutdown
     const close = once(async () => {
@@ -38,6 +39,8 @@ try {
         if (disconnect.isErr()) {
             logger.error('Error disconnecting from ActiveMQ', disconnect.error);
         }
+        await billing.shutdown();
+        process.exit();
     });
 
     process.on('SIGINT', () => {

--- a/packages/metering/lib/processors/billing.ts
+++ b/packages/metering/lib/processors/billing.ts
@@ -1,8 +1,14 @@
+import { billing } from '@nangohq/billing';
 import { Subscriber } from '@nangohq/pubsub';
+import { connectionService } from '@nangohq/shared';
+import { Err, Ok, stringifyError } from '@nangohq/utils';
 
 import { logger } from '../utils.js';
 
-import type { Transport } from '@nangohq/pubsub';
+import type { Transport, UsageEvent } from '@nangohq/pubsub';
+import type { Result } from '@nangohq/utils';
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
 export class Billing {
     private subscriber: Subscriber;
@@ -16,15 +22,48 @@ export class Billing {
 
         this.subscriber.subscribe({
             consumerGroup: 'billing',
-            subscriptions: [
-                {
-                    subject: 'usage',
-                    callback: (event) => {
-                        // TODO
-                        logger.info(`Received billing event: ${event.subject}`, event);
-                    }
+            subject: 'usage',
+            callback: async (event) => {
+                logger.info(`Processing billing event`, { event });
+                const result = await process(event);
+                if (result.isErr()) {
+                    logger.error(`Failed to process billing event: ${result.error}`, { event });
+                    return;
                 }
-            ]
+            }
         });
+    }
+}
+
+async function process(event: UsageEvent): Promise<Result<void>> {
+    try {
+        switch (event.type) {
+            case 'usage.monthly_active_records': {
+                const { connectionId } = event.payload.properties;
+                const connection = await connectionService.getConnectionById(connectionId);
+                if (!connection) {
+                    return Err(`Connection ${connectionId} not found`);
+                }
+                if (connection.created_at > new Date(Date.now() - 30 * DAY_IN_MS)) {
+                    return Ok(undefined); // Skip MAR for connections younger than 30 days
+                }
+                return billing.add('monthly_active_records', event.payload.value, {
+                    idempotencyKey: event.idempotencyKey,
+                    timestamp: event.createdAt,
+                    ...event.payload.properties
+                });
+            }
+            case 'usage.actions': {
+                return billing.add('billable_actions', event.payload.value, {
+                    idempotencyKey: event.idempotencyKey,
+                    timestamp: event.createdAt,
+                    ...event.payload.properties
+                });
+            }
+            default:
+                return Err(`Unknown billing event type: ${event.type}`);
+        }
+    } catch (err) {
+        return Err(`Error processing billing event: ${stringifyError(err)}`);
     }
 }

--- a/packages/metering/package.json
+++ b/packages/metering/package.json
@@ -17,6 +17,7 @@
         "@nangohq/utils": "file:../utils",
         "@nangohq/pubsub": "file:../pubsub",
         "@nangohq/billing": "file:../billing",
+        "@nangohq/shared": "file:../shared",
         "dd-trace": "5.52.0",
         "zod": "4.0.5"
     },

--- a/packages/persist/lib/app.ts
+++ b/packages/persist/lib/app.ts
@@ -1,6 +1,5 @@
 import './tracer.js';
 
-import { billing } from '@nangohq/billing';
 import db from '@nangohq/database';
 import { destroy as destroyLogs } from '@nangohq/logs';
 import { destroy as destroyRecords } from '@nangohq/records';
@@ -54,7 +53,6 @@ const close = once(() => {
         await db.knex.destroy();
         await db.readOnly.destroy();
         await destroyRecords();
-        await billing.shutdown();
         await pubsub.disconnect();
 
         logger.close();

--- a/packages/persist/lib/logger.ts
+++ b/packages/persist/lib/logger.ts
@@ -1,0 +1,3 @@
+import { getLogger } from '@nangohq/utils';
+
+export const logger = getLogger('Persist');

--- a/packages/persist/lib/records.ts
+++ b/packages/persist/lib/records.ts
@@ -190,7 +190,6 @@ export async function persistRecords({
         } catch (err) {
             logger.warning('Failed to calculate record sizes in bytes', { environmentId, connectionId, syncId, model, error: stringifyError(err) });
         }
-        metrics.increment(metrics.Types.BILLED_RECORDS_COUNT, mar, { accountId });
         metrics.increment(metrics.Types.MONTHLY_ACTIVE_RECORDS_COUNT, mar, { accountId });
         metrics.increment(metrics.Types.PERSIST_RECORDS_COUNT, records.length);
         metrics.increment(metrics.Types.PERSIST_RECORDS_MODIFIED_COUNT, allModifiedKeys.size);

--- a/packages/persist/lib/records.ts
+++ b/packages/persist/lib/records.ts
@@ -1,12 +1,12 @@
 import tracer from 'dd-trace';
 
 import { getAccountUsageTracker, onUsageIncreased } from '@nangohq/account-usage';
-import { billing } from '@nangohq/billing';
 import { logContextGetter } from '@nangohq/logs';
 import { format as recordsFormatter, records as recordsService } from '@nangohq/records';
 import { ErrorSourceEnum, LogActionEnum, connectionService, errorManager, getSyncConfigByJobId, updateSyncJobResult } from '@nangohq/shared';
 import { Err, Ok, metrics, stringifyError } from '@nangohq/utils';
 
+import { logger } from './logger.js';
 import { pubsub } from './pubsub.js';
 
 import type { FormattedRecord, UnencryptedRecordData, UpsertSummary } from '@nangohq/records';
@@ -154,14 +154,6 @@ export async function persistRecords({
             }
         );
 
-        const recordsSizeInBytes = Buffer.byteLength(JSON.stringify(records), 'utf8');
-        const modifiedRecordsSizeInBytes = recordsData.reduce((acc, record) => {
-            if (allModifiedKeys.has(record.id)) {
-                return acc + Buffer.byteLength(JSON.stringify(record), 'utf8');
-            }
-            return acc;
-        }, 0);
-
         const thirtyDaysAgo = new Date();
         thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
         const isConnectionOlderThan30Days = new Date(connection.created_at) < thirtyDaysAgo;
@@ -169,30 +161,41 @@ export async function persistRecords({
 
         const mar = new Set(summary.activatedKeys).size;
 
-        // Billing metrics
         if (shouldBillMonthlyActiveRecords) {
-            if (plan) {
-                billing.add('monthly_active_records', mar, { accountId, environmentId, providerConfigKey, connectionId, syncId, model });
-                metrics.increment(metrics.Types.BILLED_RECORDS_COUNT, mar, { accountId });
-            }
-            const accountUsageTracker = await getAccountUsageTracker();
             // Account usage tracking for capping
+            const accountUsageTracker = await getAccountUsageTracker();
             void accountUsageTracker.incrementUsage({ accountId, metric: 'active_records', delta: mar });
             void onUsageIncreased({ accountId, metric: 'active_records', delta: mar, plan: plan ?? undefined });
         }
 
-        void pubsub.publisher.publish({
-            subject: 'usage',
-            type: 'usage.monthly_active_records',
-            payload: { value: mar, accountId, properties: { environmentId, providerConfigKey, connectionId, syncId, model } }
-        });
+        if (mar > 0) {
+            void pubsub.publisher.publish({
+                subject: 'usage',
+                type: 'usage.monthly_active_records',
+                payload: { value: mar, properties: { accountId, environmentId, providerConfigKey, connectionId, syncId, model } }
+            });
+        }
 
         // Datadog metrics
+        let recordsSizeInBytes = 0;
+        let modifiedRecordsSizeInBytes = 0;
+        try {
+            recordsSizeInBytes = Buffer.byteLength(JSON.stringify(records), 'utf8');
+            modifiedRecordsSizeInBytes = recordsData.reduce((acc, record) => {
+                if (allModifiedKeys.has(record.id)) {
+                    return acc + Buffer.byteLength(JSON.stringify(record), 'utf8');
+                }
+                return acc;
+            }, 0);
+        } catch (err) {
+            logger.warning('Failed to calculate record sizes in bytes', { environmentId, connectionId, syncId, model, error: stringifyError(err) });
+        }
+        metrics.increment(metrics.Types.BILLED_RECORDS_COUNT, mar, { accountId });
         metrics.increment(metrics.Types.MONTHLY_ACTIVE_RECORDS_COUNT, mar, { accountId });
         metrics.increment(metrics.Types.PERSIST_RECORDS_COUNT, records.length);
-        metrics.increment(metrics.Types.PERSIST_RECORDS_SIZE_IN_BYTES, recordsSizeInBytes, { accountId });
         metrics.increment(metrics.Types.PERSIST_RECORDS_MODIFIED_COUNT, allModifiedKeys.size);
         metrics.increment(metrics.Types.PERSIST_RECORDS_MODIFIED_SIZE_IN_BYTES, modifiedRecordsSizeInBytes);
+        metrics.increment(metrics.Types.PERSIST_RECORDS_SIZE_IN_BYTES, recordsSizeInBytes, { accountId });
 
         span.addTags({
             'records.in.count': records.length,

--- a/packages/persist/lib/server.ts
+++ b/packages/persist/lib/server.ts
@@ -1,7 +1,8 @@
 import express from 'express';
 
-import { createRoute, getLogger, requestLoggerMiddleware } from '@nangohq/utils';
+import { createRoute, requestLoggerMiddleware } from '@nangohq/utils';
 
+import { logger } from './logger.js';
 import { authMiddleware } from './middleware/auth.middleware.js';
 import { recordsPath } from './records.js';
 import { path as cursorPath, routeHandler as getCursorHandler } from './routes/environment/environmentId/connection/connectionId/getCursor.js';
@@ -15,7 +16,6 @@ import { routeHandler as getHealthHandler } from './routes/getHealth.js';
 import type { ApiError } from '@nangohq/types';
 import type { NextFunction, Request, Response } from 'express';
 
-const logger = getLogger('Persist');
 const maxSizeJsonLog = '100kb';
 const maxSizeJsonRecords = '100mb';
 

--- a/packages/persist/package.json
+++ b/packages/persist/package.json
@@ -23,7 +23,6 @@
         "@nangohq/records": "file:../records",
         "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",
-        "@nangohq/billing": "file:../billing",
         "@nangohq/account-usage": "file:../account-usage",
         "@nangohq/pubsub": "file:../pubsub",
         "dd-trace": "5.52.0",

--- a/packages/pubsub/lib/event.ts
+++ b/packages/pubsub/lib/event.ts
@@ -1,8 +1,8 @@
 import type { DBTeam, DBUser } from '@nangohq/types';
 
-type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue } | Record<string, any>;
+type Serializable = string | number | boolean | Date | null | undefined | Serializable[] | { [key: string]: Serializable };
 
-interface EventBase<TSubject extends string, TType extends string, TPayload extends JsonValue> {
+interface EventBase<TSubject extends string, TType extends string, TPayload extends Serializable> {
     idempotencyKey: string;
     subject: TSubject;
     type: TType;
@@ -14,22 +14,24 @@ interface EventBase<TSubject extends string, TType extends string, TPayload exte
 // Enforce that all events extend the base Event type
 type EnforceEventBase<T extends EventBase<any, any, any>> = T;
 
-type UserCreatedEvent = EventBase<
+export type UserCreatedEvent = EventBase<
     'user',
     'user.created',
     {
-        user: DBUser;
-        team: DBTeam;
+        userId: DBUser['id'];
+        teamId: DBTeam['id'];
     }
 >;
 
-type UsageEvent = EventBase<
+export type UsageEvent = EventBase<
     'usage',
     'usage.monthly_active_records' | 'usage.actions',
     {
         value: number;
-        accountId: number;
-        properties: Record<string, JsonValue>;
+        properties: {
+            accountId: number;
+            connectionId: number;
+        } & Record<string, Serializable>;
     }
 >;
 

--- a/packages/pubsub/lib/index.ts
+++ b/packages/pubsub/lib/index.ts
@@ -1,4 +1,5 @@
+export type * from './transport/transport.js';
+export type * from './event.js';
 export * from './publisher.js';
 export * from './subscriber.js';
-export type * from './transport/transport.js';
 export * from './transport/default.js';

--- a/packages/pubsub/lib/subscriber.ts
+++ b/packages/pubsub/lib/subscriber.ts
@@ -1,4 +1,5 @@
-import type { Subscription, Transport } from './transport/transport.js';
+import type { Event } from './event.js';
+import type { SubscribeProps, Transport } from './transport/transport.js';
 
 export class Subscriber {
     private transport: Transport;
@@ -7,7 +8,7 @@ export class Subscriber {
         this.transport = transport;
     }
 
-    public subscribe({ consumerGroup, subscriptions }: { consumerGroup: string; subscriptions: Subscription[] }): void {
-        this.transport.subscribe({ consumerGroup, subscriptions });
+    subscribe<TSubject extends Event['subject']>(params: SubscribeProps<TSubject>): void {
+        this.transport.subscribe(params);
     }
 }

--- a/packages/pubsub/lib/transport/activemq.integration.test.ts
+++ b/packages/pubsub/lib/transport/activemq.integration.test.ts
@@ -46,8 +46,9 @@ describe('ActiveMQ Transport', () => {
                 type: 'usage.actions',
                 payload: {
                     value: 10,
-                    accountId: 1,
                     properties: {
+                        accountId: 1,
+                        connectionId: 2,
                         tag1: 'someTag1'
                     }
                 },
@@ -56,12 +57,8 @@ describe('ActiveMQ Transport', () => {
             const callback = vi.fn();
             consumer.subscribe({
                 consumerGroup: 'test-consumer-group',
-                subscriptions: [
-                    {
-                        subject: event.subject,
-                        callback
-                    }
-                ]
+                subject: event.subject,
+                callback
             });
 
             const published = await publisher.publish(event);
@@ -78,8 +75,9 @@ describe('ActiveMQ Transport', () => {
                 type: 'usage.actions',
                 payload: {
                     value: 20,
-                    accountId: 2,
                     properties: {
+                        accountId: 2,
+                        connectionId: 3,
                         tag2: 'someTag2'
                     }
                 },
@@ -88,12 +86,8 @@ describe('ActiveMQ Transport', () => {
             const callback = vi.fn();
             consumer.subscribe({
                 consumerGroup: 'test-consumer-group',
-                subscriptions: [
-                    {
-                        subject: event.subject,
-                        callback
-                    }
-                ]
+                subject: event.subject,
+                callback
             });
 
             await consumer.disconnect();

--- a/packages/pubsub/lib/transport/default.ts
+++ b/packages/pubsub/lib/transport/default.ts
@@ -4,7 +4,8 @@ import { ActiveMQ } from './activemq.js';
 import { NoOpTransport } from './noop.js';
 import { envs } from '../env.js';
 
-import type { Transport } from './transport.js';
+import type { Event } from '../event.js';
+import type { SubscribeProps, Transport } from './transport.js';
 import type { Result } from '@nangohq/utils';
 
 export class DefaultTransport implements Transport {
@@ -40,11 +41,11 @@ export class DefaultTransport implements Transport {
         return Ok(undefined);
     }
 
-    async publish(event: any): Promise<Result<void>> {
+    async publish(event: Event): Promise<Result<void>> {
         return this.transport.publish(event);
     }
 
-    subscribe(subscription: any): void {
-        return this.transport.subscribe(subscription);
+    subscribe<TSubject extends Event['subject']>(params: SubscribeProps<TSubject>): void {
+        return this.transport.subscribe(params);
     }
 }

--- a/packages/pubsub/lib/transport/transport.ts
+++ b/packages/pubsub/lib/transport/transport.ts
@@ -2,14 +2,16 @@ import type { Event } from '../event.js';
 import type { Result } from '@nangohq/utils';
 
 // TODO: add support for subscriber ack/nack
-export interface Subscription {
-    subject: Event['subject'];
-    callback: (event: Event) => void;
+
+export interface SubscribeProps<TSubject extends Event['subject'] = Event['subject']> {
+    consumerGroup: string;
+    subject: TSubject;
+    callback: (event: Extract<Event, { subject: TSubject }>) => Promise<void> | void;
 }
 
 export interface Transport {
     publish(event: Event): Promise<Result<void>>;
-    subscribe({ consumerGroup, subscriptions }: { consumerGroup: string; subscriptions: Subscription[] }): void;
+    subscribe<TSubject extends Event['subject']>(params: SubscribeProps<TSubject>): void;
     connect(props?: { timeoutMs: number }): Promise<Result<void>>;
     disconnect(): Promise<Result<void>>;
 }

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -1,7 +1,6 @@
 import tracer from 'dd-trace';
 
 import { getAccountUsageTracker, onUsageIncreased } from '@nangohq/account-usage';
-import { billing } from '@nangohq/billing';
 import { OtlpSpan, defaultOperationExpiration, logContextGetter } from '@nangohq/logs';
 import { records as recordsService } from '@nangohq/records';
 import {
@@ -271,27 +270,17 @@ class SyncController {
                     res.status(200).json(actionResponse.value.data);
                 }
 
-                if (plan) {
-                    billing.add('billable_actions', 1, {
-                        accountId: account.id,
-                        idempotencyKey: logCtx.id,
-                        environmentId: connection.environment_id,
-                        providerConfigKey,
-                        connectionId: connection.id,
-                        actionName: action_name
-                    });
-                }
                 void pubsub.publisher.publish({
                     subject: 'usage',
                     type: 'usage.actions',
                     idempotencyKey: logCtx.id,
                     payload: {
                         value: 1,
-                        accountId: account.id,
                         properties: {
+                            accountId: account.id,
+                            connectionId: connection.id,
                             environmentId: connection.environment_id,
                             providerConfigKey,
-                            connectionId: connection.id,
                             actionName: action_name
                         }
                     }


### PR DESCRIPTION
Stop ingesting mar and actions billing events inline. 
Ingestion of those billing events is now done by metering

We rely on orb's idempotency key to avoid ingesting the same event twice during the deployment/transition



<!-- Summary by @propel-code-bot -->

---

**Refactor: Move Billing Event Ingestion to Metering Service (Event-Driven Architecture)**

This PR introduces a major architectural overhaul for how billing events (monthly active records and billable actions) are ingested and processed. Inline billing event ingestion logic is removed from core persistence and API layers; instead, events are emitted to a pub/sub event bus, and dedicated asynchronous consumers in the metering service now process the billing events. The PR refactors event schemas for stricter typing, restructures event transport and subscription interfaces for improved type safety and flexibility, and enforces event idempotency via Orb's idempotency key to safeguard against duplicate processing during deployment/transition. It updates metrics handling, logging, test contracts, dependencies, and removes direct billing logic from the persist and API layers, centralizing it in the metering consumer.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed direct (inline) ingestion of ``MAR`` and billable actions billing events from persistence (records.ts) and ``API`` (sync.controller.ts) layers.
• Introduced structured `usage` event publication to a pub/sub infrastructure, processed asynchronously in the metering service.
• Refactored billing processor in metering to consume and handle these events, performing the billing side-effects.
• Enforced idempotency using event keys to prevent double ingestion during migration.
• Enriched event and pub/sub types for stricter validation and developer safety (including improved usage event schema requiring `accountId`, `connectionId`, etc.).
• Centralized metric incrementing (e.g., ``BILLED_RECORDS_COUNT``) to the metering consumer and only when billing actually occurs (e.g., after 30 days).
• Refactored and simplified pubsub subscription `APIs` for clarity and better typing.
• Added/updated integration/unit/contract tests to verify the new ingestion flow.
• Updated dependency management (lockfiles, package.json) to reflect new service boundaries and removed unnecessary cross-service dependencies.
• Improved logging in persist for error situations (such as record size calculation failures).

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• persistence service (records.ts, server.ts, app.ts)
• ``API`` layer (sync.controller.ts)
• metering service (processors/billing.ts, app.ts)
• pubsub/event bus system (event.ts, transport/)
• billing metrics and logging
• test suites (integration, contract, transport)
• dependency and package management (package.json, package-lock.json)

</details>

---
*This summary was automatically generated by @propel-code-bot*