### PR TITLE
chore: add env var for server public routes body limit

### DIFF
--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -51,6 +51,7 @@ import { postPublicTrigger } from './controllers/sync/postTrigger.js';
 import { putSyncConnectionFrequency } from './controllers/sync/putSyncConnectionFrequency.js';
 import syncController from './controllers/sync.controller.js';
 import { postWebhook } from './controllers/webhook/environmentUuid/postWebhook.js';
+import { envs } from './env.js';
 import { acceptLanguageMiddleware } from './middleware/accept-language.middleware.js';
 import authMiddleware from './middleware/access.middleware.js';
 import { cliMaxVersion, cliMinVersion } from './middleware/cliVersionCheck.js';
@@ -70,7 +71,7 @@ const connectSessionOrPublicAuth: RequestHandler[] = [authMiddleware.connectSess
 
 export const publicAPI = express.Router();
 
-const bodyLimit = '75mb';
+const bodyLimit = envs.NANGO_SERVER_PUBLIC_BODY_LIMIT;
 
 if (flagEnforceCLIVersion) {
     publicAPI.use(cliMaxVersion());

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -25,6 +25,7 @@ export const ENVS = z.object({
     NANGO_CACHE_ENV_KEYS: z.stringbool().optional().default(false),
     NANGO_SERVER_WEBSOCKETS_PATH: z.string().optional(),
     NANGO_ADMIN_INVITE_TOKEN: z.string().optional(),
+    NANGO_SERVER_PUBLIC_BODY_LIMIT: z.string().optional().default('75mb'),
 
     // Connect
     NANGO_PUBLIC_CONNECT_URL: z.url().optional(),


### PR DESCRIPTION
self-hosted customer might need to tweak the size limit of the public API


