### PR TITLE
fix: move ES index to warm storage after 48h (instead of 24)

### DIFF
--- a/packages/logs/lib/es/schema.ts
+++ b/packages/logs/lib/es/schema.ts
@@ -296,7 +296,7 @@ export const policyMessages = {
         phases: {
             hot: { actions: { set_priority: { priority: 100 } }, min_age: '0ms' },
             warm: {
-                min_age: '25h',
+                min_age: envs.NANGO_LOGS_ES_WARM_MIN_AGE,
                 actions: {
                     set_priority: { priority: 50 },
                     shrink: { max_primary_shard_size: '8gb' },

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -171,6 +171,7 @@ export const ENVS = z.object({
     NANGO_LOGS_ES_INDEX_MESSAGES: z.string().optional(),
     NANGO_LOGS_ES_SHARD_PER_DAY_OPERATIONS: z.coerce.number().optional().default(1),
     NANGO_LOGS_ES_SHARD_PER_DAY_MESSAGES: z.coerce.number().optional().default(1),
+    NANGO_LOGS_ES_WARM_MIN_AGE: z.string().optional().default('48h'),
 
     // Koala
     PUBLIC_KOALA_API_URL: z.url().optional(),


### PR DESCRIPTION
An incident was caused by ES moving an index to read-only warm storage while it was still "live" (aka: before the end of the day) While we are determining the root cause we are setting the retention policy min_age to 48h to minimize the likehood of the same issue reocurring

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR adjusts the Elasticsearch (ES) index lifecycle policy to postpone the transition from 'hot' (writable) to 'warm' (read-only) storage from 24-25 hours to 48 hours. The minimum age for the warm phase is now configurable via the NANGO_LOGS_ES_WARM_MIN_AGE environment variable, defaulting to '48h'. This is a mitigation following an incident where indices were moved to read-only too early, potentially interfering with log writing before the day ended.

*This summary was automatically generated by @propel-code-bot*