### PR TITLE
fix(billing): add tracing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27670,6 +27670,7 @@
             "dependencies": {
                 "@nangohq/types": "file:../types",
                 "@nangohq/utils": "file:../utils",
+                "dd-trace": "5.52.0",
                 "orb-billing": "5.0.0",
                 "uuidv7": "1.0.2"
             },

--- a/packages/billing/lib/logger.ts
+++ b/packages/billing/lib/logger.ts
@@ -1,3 +1,0 @@
-import { getLogger } from '@nangohq/utils';
-
-export const logger = getLogger('billing');

--- a/packages/billing/package.json
+++ b/packages/billing/package.json
@@ -14,6 +14,7 @@
     "dependencies": {
         "@nangohq/utils": "file:../utils",
         "@nangohq/types": "file:../types",
+        "dd-trace": "5.52.0",
         "orb-billing": "5.0.0",
         "uuidv7": "1.0.2"
     },


### PR DESCRIPTION
Tracing `billing.ingest` so we can have metrics/alerts on billing ingestion

<!-- Summary by @propel-code-bot -->

---

**Add Datadog Tracing to Billing Ingestion**

This PR introduces distributed tracing (via dd-trace) to the billing ingestion flow. The changes wrap the core billing ingest and shutdown operations in Datadog tracing spans, enabling detailed observability and the ability to set up metrics and alerts around these operations. In addition, logging responsibility is moved out of the billing library to conform to best practices for library code, removing the internal logger and its usages. Supporting updates to dependencies are included to add dd-trace.

<details>
<summary><strong>Key Changes</strong></summary>

• Added dd-trace (Datadog tracing) as a dependency in billing/package.json and package-lock.json.
• Wrapped Billing.ingest and Billing.shutdown methods in tracing spans (`billing.ingest` and `billing.shutdown`), including error tagging.
• Removed internal logging (logger usage and logger.ts) from the billing package, delegating all logging responsibilities to consumers of the library.
• Updated error handling in shutdown and ingest routines to record errors on the relevant tracing span.
• Cleaned up batcher callback to simplify failure flow (throw on batch ingest error without internal logging).

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/billing/lib/billing.ts
• packages/billing/package.json
• packages/billing/lib/logger.ts
• package-lock.json

</details>

---
*This summary was automatically generated by @propel-code-bot*