### PR TITLE
fix(logs): add success dimension to metric

### DIFF
--- a/packages/logs/lib/transport.ts
+++ b/packages/logs/lib/transport.ts
@@ -37,14 +37,16 @@ export class ESTransport implements LogTransportAbstract {
         }
 
         const start = Date.now();
+        let success: boolean = false;
         try {
             await createMessage(getFormattedMessage({ ...data, parentId: operationId, accountId }));
+            success = true;
             return true;
         } catch (err) {
             report(new Error('failed_to_insert_in_es', { cause: err }));
             return false;
         } finally {
-            metrics.duration(metrics.Types.LOGS_LOG, Date.now() - start, { accountId });
+            metrics.duration(metrics.Types.LOGS_LOG, Date.now() - start, { accountId, success: String(success) });
         }
     }
 


### PR DESCRIPTION
so we can differentiate successes/failures in dashboards/alerts

<!-- Summary by @propel-code-bot -->

---

This PR enhances log metric reporting in the Elasticsearch (ESTransport) log transport by introducing a new 'success' dimension. The dimension indicates whether a log insertion operation succeeded or failed, allowing dashboards and alerts to differentiate between these outcomes for better operational observability.

*This summary was automatically generated by @propel-code-bot*