### PR TITLE
fix(billing): send the total connections count to Orb

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1541,10 +1541,10 @@ class ConnectionService {
 
     /**
      * Note:
-     * a billable connection is a connection that is not deleted and has not been deleted during the month
+     * a prorated connection is a connection that is not deleted and has not been deleted during the month
      * connections are pro-rated based on the number of seconds they were existing in the month
      */
-    async billableConnections(referenceDate: Date): Promise<
+    async proratedConnections(referenceDate: Date): Promise<
         Result<
             {
                 accountId: number;
@@ -1657,6 +1657,34 @@ class ConnectionService {
         } catch (err: unknown) {
             return Err(new NangoError('failed_to_track_execution', { id, error: err }));
         }
+    }
+
+    /**
+     * Total number of connections that are not deleted per account
+     * Note: The proration is done by Orb
+     */
+    async billableConnections(): Promise<
+        Result<
+            {
+                accountId: number;
+                count: number;
+            }[],
+            NangoError
+        >
+    > {
+        const res = await db.readOnly
+            .select('e.account_id as accountId')
+            .count('c.id as count')
+            .from('_nango_connections as c')
+            .join('_nango_environments as e', 'c.environment_id', 'e.id')
+            .where('c.deleted_at', null)
+            .groupBy('e.account_id')
+            .havingRaw('count(c.id) > 0');
+
+        if (res) {
+            return Ok(res);
+        }
+        return Err(new NangoError('failed_to_get_billable_active_connections'));
     }
 
     /**

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -47,7 +47,7 @@ export interface BillingPlan {
 }
 
 export interface BillingIngestEvent {
-    type: 'monthly_active_records' | 'billable_connections' | 'billable_actions' | 'billable_active_connections';
+    type: 'monthly_active_records' | 'billable_connections' | 'total_connections' | 'billable_actions' | 'billable_active_connections';
     idempotencyKey: string;
     accountId: number;
     timestamp: Date;


### PR DESCRIPTION
Let Orb handle the proration

cc @rguldener 
<!-- Summary by @propel-code-bot -->

---

**Refactor Billing Export: Use Total Connections Metric for Orb Proration**

This pull request refactors the billing logic to shift proration responsibility for connections from the internal Nango implementation to Orb. A new 'total_connections' billing metric is introduced, representing the total number of undeleted connections per account, and is now exported to Orb for proration. The existing prorated (time-weighted) connection metric and related export logic are retained for validation and backward compatibility, but are scheduled for removal pending confirmation of the updated process. Code comments and types have been updated to clarify this shift and assist future maintainability.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced a new `billableConnections`() method in connection.service.ts to compute the total undeleted connections per account, used for the new ``total_connections`` metric.
• Updated the billing cron usage export (usage.ts) to call `exportBillableConnections`() for ``total_connections`` and added `exportProratedConnections`() as a parallel/fallback exporter.
• Updated `BillingIngestEvent` types (types.ts) to include ``total_connections`` as a possible metric type.
• Renamed the existing proration logic in connection.service.ts from `billableConnections`() to `proratedConnections`(), and updated references.
• Enhanced comments and documentation to clarify Orb's new proration responsibility and the transitional nature of the dual-export.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/shared/lib/services/connection.service.ts (billing logic and methods)
• packages/server/lib/crons/usage.ts (cron job and export logic)
• packages/types/lib/billing/types.ts (type definitions for billing events/metrics)

</details>

---
*This summary was automatically generated by @propel-code-bot*