### PR TITLE
fix(cli): support multiple package managers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28749,7 +28749,9 @@
                 "@types/json-schema": "7.0.15",
                 "axios": "1.11.0",
                 "json-schema": "0.4.0",
-                "vitest": "3.2.4",
+                "vitest": "3.2.4"
+            },
+            "peerDependencies": {
                 "zod": "4.0.5"
             }
         },
@@ -28793,8 +28795,8 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
             "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
-            "dev": true,
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/packages/cli/lib/migrations/toZeroYaml.ts
+++ b/packages/cli/lib/migrations/toZeroYaml.ts
@@ -8,7 +8,7 @@ import jscodeshift from 'jscodeshift';
 import ora from 'ora';
 
 import { Err, Ok } from '../utils/result.js';
-import { printDebug } from '../utils.js';
+import { detectPackageManager, printDebug } from '../utils.js';
 import { NANGO_VERSION } from '../version.js';
 import { compileAll } from '../zeroYaml/compile.js';
 import { compileAllFiles } from '../services/compile.service.js';
@@ -133,8 +133,8 @@ export async function migrateToZeroYaml({ fullPath, debug }: { fullPath: string;
     }
 
     {
-        const spinner = ora({ text: 'Running npm install' }).start();
-        await runNpmInstall(fullPath);
+        const spinner = ora({ text: 'Installing dependencies' }).start();
+        await runPackageManagerInstall(fullPath);
         spinner.succeed();
     }
 
@@ -166,11 +166,12 @@ async function getContent({ targetFile }: { targetFile: string }): Promise<strin
 }
 
 /**
- * Runs npm install in the given directory
+ * Runs package manager install in the given directory
  */
-export async function runNpmInstall(fullPath: string): Promise<void> {
+export async function runPackageManagerInstall(fullPath: string): Promise<void> {
     await new Promise((resolve, reject) => {
-        const proc = spawn('npm', ['install', '--no-audit', '--no-fund', '--no-progress'], {
+        const packageManager = detectPackageManager({ fullPath });
+        const proc = spawn(packageManager, ['install', ...(packageManager === 'npm' ? ['--no-audit', '--no-fund', '--no-progress'] : [])], {
             cwd: fullPath,
             stdio: 'inherit',
             shell: true
@@ -179,7 +180,7 @@ export async function runNpmInstall(fullPath: string): Promise<void> {
             if (code === 0) {
                 resolve(undefined);
             } else {
-                reject(new Error(`npm install failed with exit code ${code}`));
+                reject(new Error(`"${packageManager} install" failed with exit code ${code}`));
             }
         });
     });

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -312,3 +312,16 @@ export function slash(path: string) {
     }
     return path.replace(/\\/g, '/');
 }
+
+export function detectPackageManager({ fullPath }: { fullPath: string }) {
+    const dir = fs.readdirSync(fullPath);
+    if (dir.includes('pnpm-lock.yaml')) {
+        return 'pnpm';
+    } else if (dir.includes('yarn.lock')) {
+        return 'yarn';
+    } else if (dir.includes('bun.lockb') || dir.includes('bun.lock')) {
+        return 'bun';
+    } else {
+        return 'npm';
+    }
+}

--- a/packages/cli/lib/zeroYaml/check.ts
+++ b/packages/cli/lib/zeroYaml/check.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import ora from 'ora';
 
 import { exampleFolder } from './constants.js';
-import { runNpmInstall } from '../migrations/toZeroYaml.js';
+import { runPackageManagerInstall } from '../migrations/toZeroYaml.js';
 import { Err, Ok } from '../utils/result.js';
 import { printDebug } from '../utils.js';
 import { NANGO_VERSION } from '../version.js';
@@ -51,7 +51,7 @@ export async function checkAndSyncPackageJson({ fullPath, debug }: { fullPath: s
         console.log(chalk.yellow('Your dependencies are out of date. Updating...'));
         const spinner = ora({ text: 'Updating package.json' }).start();
         await fs.promises.writeFile(packageJsonPath, JSON.stringify(newPkg, null, 2));
-        await runNpmInstall(fullPath);
+        await runPackageManagerInstall(fullPath);
         spinner.succeed();
     } else {
         printDebug('Package.json is up to date', debug);

--- a/packages/cli/lib/zeroYaml/init.ts
+++ b/packages/cli/lib/zeroYaml/init.ts
@@ -6,7 +6,7 @@ import { promisify } from 'node:util';
 import chalk from 'chalk';
 import ora from 'ora';
 
-import { printDebug } from '../utils.js';
+import { detectPackageManager, printDebug } from '../utils.js';
 import { NANGO_VERSION } from '../version.js';
 import { compileAll } from './compile.js';
 import { exampleFolder } from './constants.js';
@@ -79,17 +79,18 @@ export async function initZero({
         return true;
     }
 
-    // Run npm install
+    // Install dependencies
     {
-        const spinner = ora({ text: 'Install packages' }).start();
+        const spinner = ora({ text: 'Install dependencies' }).start();
         try {
-            printDebug(`Running npm install`, debug);
+            printDebug(`Running package manager install`, debug);
 
-            await execAsync('npm install', { cwd: absolutePath });
+            const packageManager = detectPackageManager({ fullPath: absolutePath });
+            await execAsync(`${packageManager} install`, { cwd: absolutePath });
             spinner.succeed();
         } catch (err) {
             spinner.fail();
-            console.log(chalk.red(`Failed to npm install: ${err instanceof Error ? err.message : 'unknown error'}`));
+            console.log(chalk.red(`Failed to install dependencies: ${err instanceof Error ? err.message : 'unknown error'}`));
             return false;
         }
     }

--- a/packages/runner-sdk/package.json
+++ b/packages/runner-sdk/package.json
@@ -17,7 +17,9 @@
         "@types/json-schema": "7.0.15",
         "axios": "1.11.0",
         "json-schema": "0.4.0",
-        "vitest": "3.2.4",
+        "vitest": "3.2.4"
+    },
+    "peerDependencies": {
         "zod": "4.0.5"
     },
     "files": [


### PR DESCRIPTION
## Changes

Fixes https://github.com/NangoHQ/nango/issues/4434

- Support multiple package managers
Use the appropriate one when installing dependencies, and fix pnpm workspaces

<!-- Summary by @propel-code-bot -->

---

**Support Multiple Package Managers in CLI and Improve Dependency Handling**

This PR refactors the CLI and related scripts to automatically detect and support multiple Node.js package managers (npm, pnpm, yarn, bun) based on lockfiles present in the project directory, enhancing compatibility for various development environments and monorepo/workspace setups. It introduces a new utility, replaces hardcoded 'npm install' calls with dynamic package manager detection, and updates dependency management by moving 'zod' from devDependencies to peerDependencies in the runner SDK package.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced a `detectPackageManager` utility in packages/cli/lib/utils.ts that infers the package manager from existing lockfiles (pnpm-lock.yaml, yarn.lock, bun.lockb/bun.lock).
• Replaced direct use of `npm install` with a unified `runPackageManagerInstall` abstraction, which invokes the detected package manager for dependency installation across ``CLI`` migration, initialization, and check logic.
• Modified ``CLI`` scripts (packages/cli/lib/migrations/`toZeroYaml`.ts, packages/cli/lib/`zeroYaml`/init.ts, packages/cli/lib/`zeroYaml`/check.ts) to utilize the new dynamic installation logic, ensuring compatibility in diverse setups.
• Updated @nangohq/runner-sdk/package.json: moved `zod` dependency from `devDependencies` to `peerDependencies` to reflect proper usage and ensure alignment across consuming projects.
• Updated package-lock.json to reflect the peer dependency change for `zod`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• ``CLI`` utilities and commands (packages/cli/lib/utils.ts, migrations/`toZeroYaml`.ts, `zeroYaml`/init.ts, `zeroYaml`/check.ts)
• Dependency installation and management logic
• runner-sdk's package metadata
• Monorepo package-lock.json

</details>

---
*This summary was automatically generated by @propel-code-bot*