### PR TITLE
fix(cli-generate-docs): handle optional props

### DIFF
--- a/packages/cli/lib/services/docs.service.unit.test.ts
+++ b/packages/cli/lib/services/docs.service.unit.test.ts
@@ -21,7 +21,8 @@ describe('modelToJson', () => {
                         enum: { type: 'string', enum: ['a', true, 'c'] },
                         union: { anyOf: [{ type: 'string' }, { type: 'number' }] },
                         width: { type: ['number', 'null'] }
-                    }
+                    },
+                    required: ['id', 'name', 'arr', 'arr2', 'ref', 'obj', 'enum', 'union']
                 }
             },
             {
@@ -30,7 +31,8 @@ describe('modelToJson', () => {
                     type: 'object',
                     properties: {
                         bio: { type: 'string' }
-                    }
+                    },
+                    required: ['bio']
                 }
             }
         ];
@@ -38,15 +40,15 @@ describe('modelToJson', () => {
         expect(result).toEqual({
             id: '<string>',
             arr: '<string[]>',
-            arr2: [{ name: '<string>' }],
+            arr2: [{ ['name?']: '<string>' }],
             name: '<string>',
             enum: "<enum: 'a' | 'true' | 'c'>",
             union: '<<string> | <number>>',
             ref: { bio: '<string>' },
             obj: {
-                name: '<string>'
+                ['name?']: '<string>'
             },
-            width: '<number | null>'
+            ['width?']: '<number | null>'
         });
     });
 });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**cli-generate-docs: Properly Handles Optional Properties in modelToJson**

This PR updates the modelToJson function within docs.service.ts to correctly distinguish between required and optional properties when generating JSON schema examples for documentation. Optional properties in object schemas are now suffixed with a '?' in the output, and the logic for tracking and propagating 'required' fields through nested schemas (, arrays, unions) has been refactored. Test coverage was also updated to assert correct handling of required vs. optional properties.

<details>
<summary><strong>Key Changes</strong></summary>

• Added the optional `required` argument to `modelToJson`, defaulting to [].
• Object properties that are not required are now displayed with a `?` suffix in output.
• Recursive invocations of `modelToJson` (for , arrays, unions) now accept and pass the `required` array appropriately.
• Updated handling of object properties in `modelToJson` to respect `required` from the ``JSON`` schema.
• Unit tests updated to expect optional properties (and nested ones) to have correct `?` key notation.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/cli/lib/services/docs.service.ts (`modelToJson` function)
• packages/cli/lib/services/docs.service.unit.test.ts (tests for `modelToJson`)

</details>

---
*This summary was automatically generated by @propel-code-bot*