### PR TITLE
fix: move usage tracking to metering

### DIFF
--- a/packages/metering/package.json
+++ b/packages/metering/package.json
@@ -14,6 +14,8 @@
         "directory": "packages/metering"
     },
     "dependencies": {
+        "@nangohq/account-usage": "file:../account-usage",
+        "@nangohq/database": "file:../database",
         "@nangohq/utils": "file:../utils",
         "@nangohq/pubsub": "file:../pubsub",
         "@nangohq/billing": "file:../billing",

--- a/packages/metering/tsconfig.json
+++ b/packages/metering/tsconfig.json
@@ -16,6 +16,12 @@
         },
         {
             "path": "../billing"
+        },
+        {
+            "path": "../database"
+        },
+        {
+            "path": "../account-usage"
         }
     ],
     "include": ["lib/**/*"]

--- a/packages/persist/lib/records.ts
+++ b/packages/persist/lib/records.ts
@@ -1,16 +1,15 @@
 import tracer from 'dd-trace';
 
-import { getAccountUsageTracker, onUsageIncreased } from '@nangohq/account-usage';
 import { logContextGetter } from '@nangohq/logs';
 import { format as recordsFormatter, records as recordsService } from '@nangohq/records';
-import { ErrorSourceEnum, LogActionEnum, connectionService, errorManager, getSyncConfigByJobId, updateSyncJobResult } from '@nangohq/shared';
+import { ErrorSourceEnum, LogActionEnum, errorManager, getSyncConfigByJobId, updateSyncJobResult } from '@nangohq/shared';
 import { Err, Ok, metrics, stringifyError } from '@nangohq/utils';
 
 import { logger } from './logger.js';
 import { pubsub } from './pubsub.js';
 
 import type { FormattedRecord, UnencryptedRecordData, UpsertSummary } from '@nangohq/records';
-import type { DBPlan, MergingStrategy } from '@nangohq/types';
+import type { MergingStrategy } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { Span } from 'dd-trace';
 
@@ -22,7 +21,6 @@ export async function persistRecords({
     accountId,
     environmentId,
     connectionId,
-    plan,
     providerConfigKey,
     syncId,
     syncJobId,
@@ -35,7 +33,6 @@ export async function persistRecords({
     accountId: number;
     environmentId: number;
     connectionId: number;
-    plan: DBPlan | null;
     providerConfigKey: string;
     syncId: string;
     syncJobId: number;
@@ -50,7 +47,6 @@ export async function persistRecords({
         tags: {
             persistType,
             environmentId,
-            connectionId,
             providerConfigKey,
             syncId,
             syncJobId,
@@ -60,14 +56,6 @@ export async function persistRecords({
     });
 
     const logCtx = logContextGetter.getStateLess({ id: String(activityLogId), accountId });
-
-    const connection = await connectionService.getConnectionById(connectionId);
-    if (!connection) {
-        const err = new Error(`Connection ${connectionId} not found`);
-        void logCtx.error('Connection not found', { error: err, persistType });
-        span.setTag('error', err).finish();
-        return Err(err);
-    }
 
     let persistFunction: (records: FormattedRecord[]) => Promise<Result<UpsertSummary>>;
     let softDelete: boolean;
@@ -154,19 +142,7 @@ export async function persistRecords({
             }
         );
 
-        const thirtyDaysAgo = new Date();
-        thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-        const isConnectionOlderThan30Days = new Date(connection.created_at) < thirtyDaysAgo;
-        const shouldBillMonthlyActiveRecords = isConnectionOlderThan30Days;
-
         const mar = new Set(summary.activatedKeys).size;
-
-        if (shouldBillMonthlyActiveRecords) {
-            // Account usage tracking for capping
-            const accountUsageTracker = await getAccountUsageTracker();
-            void accountUsageTracker.incrementUsage({ accountId, metric: 'active_records', delta: mar });
-            void onUsageIncreased({ accountId, metric: 'active_records', delta: mar, plan: plan ?? undefined });
-        }
 
         if (mar > 0) {
             void pubsub.publisher.publish({

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteRecords.ts
@@ -36,9 +36,8 @@ const validate = validateRequest<DeleteRecords>(recordsRequestParser);
 const handler = async (_req: EndpointRequest, res: EndpointResponse<DeleteRecords, AuthLocals>) => {
     const { environmentId, nangoConnectionId, syncId, syncJobId }: DeleteRecords['Params'] = res.locals.parsedParams;
     const { model, records, providerConfigKey, activityLogId, merging }: DeleteRecords['Body'] = res.locals.parsedBody;
-    const { account, plan } = res.locals;
+    const { account } = res.locals;
     const result = await persistRecords({
-        plan,
         persistType: 'delete',
         environmentId,
         accountId: account.id,

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/postRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/postRecords.ts
@@ -36,9 +36,8 @@ const validate = validateRequest<PostRecords>(recordsRequestParser);
 const handler = async (_req: EndpointRequest, res: EndpointResponse<PostRecords, AuthLocals>) => {
     const { environmentId, nangoConnectionId, syncId, syncJobId }: PostRecords['Params'] = res.locals.parsedParams;
     const { model, records, providerConfigKey, activityLogId, merging }: PostRecords['Body'] = res.locals.parsedBody;
-    const { account, plan } = res.locals;
+    const { account } = res.locals;
     const result = await persistRecords({
-        plan,
         persistType: 'save',
         accountId: account.id,
         environmentId,

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/putRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/putRecords.ts
@@ -36,9 +36,8 @@ const validate = validateRequest<PutRecords>(recordsRequestParser);
 const handler = async (_req: EndpointRequest, res: EndpointResponse<PutRecords, AuthLocals>) => {
     const { environmentId, nangoConnectionId, syncId, syncJobId }: PutRecords['Params'] = res.locals.parsedParams;
     const { model, records, providerConfigKey, activityLogId, merging }: PutRecords['Body'] = res.locals.parsedBody;
-    const { account, plan } = res.locals;
+    const { account } = res.locals;
     const result = await persistRecords({
-        plan,
         persistType: 'update',
         accountId: account.id,
         environmentId,

--- a/packages/persist/package.json
+++ b/packages/persist/package.json
@@ -23,7 +23,6 @@
         "@nangohq/records": "file:../records",
         "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",
-        "@nangohq/account-usage": "file:../account-usage",
         "@nangohq/pubsub": "file:../pubsub",
         "dd-trace": "5.52.0",
         "express": "5.1.0",

--- a/packages/pubsub/lib/event.ts
+++ b/packages/pubsub/lib/event.ts
@@ -25,7 +25,7 @@ export type UserCreatedEvent = EventBase<
 
 export type UsageEvent = EventBase<
     'usage',
-    'usage.monthly_active_records' | 'usage.actions',
+    'usage.monthly_active_records' | 'usage.actions' | 'usage.connections',
     {
         value: number;
         properties: {

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -1,6 +1,6 @@
 import tracer from 'dd-trace';
 
-import { getAccountUsageTracker, onUsageIncreased } from '@nangohq/account-usage';
+import { getAccountUsageTracker } from '@nangohq/account-usage';
 import { OtlpSpan, defaultOperationExpiration, logContextGetter } from '@nangohq/logs';
 import { records as recordsService } from '@nangohq/records';
 import {
@@ -247,9 +247,6 @@ class SyncController {
                 span.finish();
                 return;
             }
-
-            void accountUsageTracker.incrementUsage({ accountId: account.id, metric: 'actions' });
-            void onUsageIncreased({ accountId: account.id, metric: 'actions', delta: 1, plan: plan ?? undefined });
 
             const actionResponse = await getOrchestrator().triggerAction({
                 accountId: account.id,


### PR DESCRIPTION
Incrementing/checking account usage metric is not inlined anymore.
instead same events used for biliing are being dispatched and processed by metering

Note: server/persist will be deployed before metering, which will cause the lost of some events. Since usage metrics are only used to show in the dashboard and send an email when reaching the caps, @kaposke and I have agreed that loosing a few events is ok and putting in place a more complicated rollout strategy was not worth the extra effort
<!-- Summary by @propel-code-bot -->

---

**Centralize Usage Tracking via Metering Events**

This PR refactors account usage tracking (covering monthly active records, actions, and connections) to remove inlined/in-service increment and cap-check logic from the persist and server packages. Instead, usage tracking is now achieved by dispatching standard `usage.*` events (previously mainly for billing) through pubsub, which the metering service processes centrally. The metering service now contains the unified usage metrics logic, updating usage statistics and performing cap checks in response to these events. Related code paths in persist and server have been simplified, with unused plan/usage-tracking fields and direct logic eliminated. Dependency references have been tidied to reflect these changes.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced inline account usage tracking logic in server and persist with event dispatch to metering via pubsub.
• Metering now handles all usage increment, cap check, and associated notifications based on standardized `usage.*` events.
• Added handling and publishing for a new `usage.connections` event type.
• Removed redundant plan/usage-tracking code and parameters from persist and corresponding ``API`` routes.
• Introduced a ``trackUsage`` helper in metering for usage/cap operations.
• Extended `UsageEvent` pubsub type to include `usage.connections`.
• Updated and cleaned up tsconfig and package.json references for proper dependency alignment.
• Improved error reporting (to Sentry/monitoring) in metering event processing as per code review feedback.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Metering service (billing event processor, dependencies, tsconfig)
• Persist service (records and routes for data mutation)
• Server service (action trigger logic and connection creation hooks)
• Pubsub/event system (event types, dispatch)
• Supporting package manifests and types

</details>

---
*This summary was automatically generated by @propel-code-bot*