### PR TITLE
fix: lower records batch size

### DIFF
--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -6,6 +6,7 @@ import { Err, Ok, retry, stringToHash } from '@nangohq/utils';
 import { RECORDS_TABLE, RECORD_COUNTS_TABLE } from '../constants.js';
 import { Cursor } from '../cursor.js';
 import { db, dbRead } from '../db/client.js';
+import { envs } from '../env.js';
 import { deepMergeRecordData } from '../helpers/merge.js';
 import { getUniqueId, removeDuplicateKey } from '../helpers/uniqueKey.js';
 import { decryptRecordData, encryptRecords } from '../utils/encryption.js';
@@ -27,7 +28,7 @@ import type { Knex } from 'knex';
 
 dayjs.extend(utc);
 
-const BATCH_SIZE = 1000;
+const BATCH_SIZE = envs.RECORDS_BATCH_SIZE;
 
 interface UpsertResult {
     external_id: string;

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -216,6 +216,7 @@ export const ENVS = z.object({
     RECORDS_DATABASE_READ_URL: z.url().optional(),
     RECORDS_DATABASE_SCHEMA: z.string().optional().default('nango_records'),
     RECORDS_DATABASE_SSL: z.stringbool().optional().default(false),
+    RECORDS_BATCH_SIZE: z.coerce.number().optional().default(1000),
 
     // Redis
     NANGO_REDIS_URL: z.url().optional(),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the batch size used for records processing from a hardcoded value (1000) to a configurable environment variable, enabling flexibility via the new RECORDS_BATCH_SIZE env. It introduces this configuration to environment parsing, ensuring batch operations can now be tuned per-deployment without code changes.

*This summary was automatically generated by @propel-code-bot*