### PR TITLE
fix(records): poll min and max, statement timeout moved to env vars

### DIFF
--- a/packages/records/lib/db/config.ts
+++ b/packages/records/lib/db/config.ts
@@ -14,12 +14,12 @@ const config: Knex.Config = {
     client: 'postgres',
     connection: {
         connectionString: databaseUrl,
-        statement_timeout: 60000,
+        statement_timeout: envs.RECORDS_DATABASE_STATEMENT_TIMEOUT_MS,
         ssl: envs.RECORDS_DATABASE_SSL ? { rejectUnauthorized: false } : false,
         application_name: process.env['NANGO_DB_APPLICATION_NAME'] || '[unknown]'
     },
     searchPath: schema,
-    pool: { min: 2, max: 50 },
+    pool: { min: envs.RECORDS_DATABASE_POOL_MIN, max: envs.RECORDS_DATABASE_POOL_MAX },
     migrations: {
         extension: isJS ? 'js' : 'ts',
         directory: 'migrations',

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -216,6 +216,9 @@ export const ENVS = z.object({
     RECORDS_DATABASE_READ_URL: z.url().optional(),
     RECORDS_DATABASE_SCHEMA: z.string().optional().default('nango_records'),
     RECORDS_DATABASE_SSL: z.stringbool().optional().default(false),
+    RECORDS_DATABASE_POOL_MIN: z.coerce.number().optional().default(2),
+    RECORDS_DATABASE_POOL_MAX: z.coerce.number().optional().default(50),
+    RECORDS_DATABASE_STATEMENT_TIMEOUT_MS: z.coerce.number().optional().default(60000),
 
     // Redis
     NANGO_REDIS_URL: z.url().optional(),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Make Records DB Pool and Timeout Configurable via Environment Variables**

This PR updates the records database configuration by making the connection pool size (min and max) and statement timeout parameters dynamically configurable using environment variables, instead of hardcoded values. It introduces new environment variables for these parameters, sets defaults via Zod schema validation in the environment parser utility, and adjusts the Knex config to read from the updated envs object. These changes allow deployments to tune database connection performance and timeout behavior without code changes.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaces hardcoded pool min/max size and statement timeout in `packages/records/lib/db/config.ts` with values from new environment variables (``RECORDS_DATABASE_POOL_MIN``, ``RECORDS_DATABASE_POOL_MAX``, ``RECORDS_DATABASE_STATEMENT_TIMEOUT_MS``).
• Extends `packages/utils/lib/environment/parse.ts` to add Zod schema entries and sensible defaults for the new environment variables controlling pool min/max and statement timeout.
• Ensures these env values are used in the primary records ``DB`` Knex config for connection setup.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Database configuration for the records package
• Environment parsing and validation logic

</details>

---
*This summary was automatically generated by @propel-code-bot*