### PR TITLE
chore: Revert "fix(billing): send the total connections count to Orb (#4458)"

### DIFF
--- a/packages/server/lib/crons/usage.ts
+++ b/packages/server/lib/crons/usage.ts
@@ -46,7 +46,6 @@ export async function exec(): Promise<void> {
 
         try {
             await billing.exportBillableConnections();
-            await billing.exportProratedConnections();
             await billing.exportActiveConnections();
             await observability.exportConnectionsMetrics();
             await observability.exportRecordsMetrics();
@@ -99,31 +98,8 @@ const billing = {
     exportBillableConnections: async (): Promise<void> => {
         await tracer.trace<Promise<void>>('nango.cron.exportUsage.billing.connections', async (span) => {
             try {
-                const res = await connectionService.billableConnections();
-                if (res.isErr()) {
-                    throw res.error;
-                }
-
-                const events = res.value.map<BillingMetric>(({ accountId, count }) => {
-                    return { type: 'total_connections', value: count, properties: { accountId } };
-                });
-
-                const sendRes = usageBilling.addAll(events);
-                if (sendRes.isErr()) {
-                    throw sendRes.error;
-                }
-            } catch (err) {
-                span.setTag('error', err);
-                report(new Error('cron_failed_to_export_billable_connections', { cause: err }));
-            }
-        });
-    },
-    // TODO: remove once we confirmed the total connections metric (proration done by Orb) above is correct
-    exportProratedConnections: async (): Promise<void> => {
-        await tracer.trace<Promise<void>>('nango.cron.exportUsage.billing.proratedconnections', async (span) => {
-            try {
                 const now = new Date();
-                const res = await connectionService.proratedConnections(now);
+                const res = await connectionService.billableConnections(now);
                 if (res.isErr()) {
                     throw res.error;
                 }
@@ -138,7 +114,7 @@ const billing = {
                 }
             } catch (err) {
                 span.setTag('error', err);
-                report(new Error('cron_failed_to_export_prorated_connections', { cause: err }));
+                report(new Error('cron_failed_to_export_billable_connections', { cause: err }));
             }
         });
     },

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1541,10 +1541,10 @@ class ConnectionService {
 
     /**
      * Note:
-     * a prorated connection is a connection that is not deleted and has not been deleted during the month
+     * a billable connection is a connection that is not deleted and has not been deleted during the month
      * connections are pro-rated based on the number of seconds they were existing in the month
      */
-    async proratedConnections(referenceDate: Date): Promise<
+    async billableConnections(referenceDate: Date): Promise<
         Result<
             {
                 accountId: number;
@@ -1657,34 +1657,6 @@ class ConnectionService {
         } catch (err: unknown) {
             return Err(new NangoError('failed_to_track_execution', { id, error: err }));
         }
-    }
-
-    /**
-     * Total number of connections that are not deleted per account
-     * Note: The proration is done by Orb
-     */
-    async billableConnections(): Promise<
-        Result<
-            {
-                accountId: number;
-                count: number;
-            }[],
-            NangoError
-        >
-    > {
-        const res = await db.readOnly
-            .select('e.account_id as accountId')
-            .count('c.id as count')
-            .from('_nango_connections as c')
-            .join('_nango_environments as e', 'c.environment_id', 'e.id')
-            .where('c.deleted_at', null)
-            .groupBy('e.account_id')
-            .havingRaw('count(c.id) > 0');
-
-        if (res) {
-            return Ok(res);
-        }
-        return Err(new NangoError('failed_to_get_billable_active_connections'));
     }
 
     /**

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -47,7 +47,7 @@ export interface BillingPlan {
 }
 
 export interface BillingIngestEvent {
-    type: 'monthly_active_records' | 'billable_connections' | 'total_connections' | 'billable_actions' | 'billable_active_connections';
+    type: 'monthly_active_records' | 'billable_connections' | 'billable_actions' | 'billable_active_connections';
     idempotencyKey: string;
     accountId: number;
     timestamp: Date;


### PR DESCRIPTION
This reverts commit 904d1807cdf8ab28638ceb49731030598e554a4c.

Our calculation to prorate connections was correct. We found the issue was in the billing metric in Orb. Reverting and removing the total connections metric which is not necessary anymore

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Revert Removal of Prorated Connections Logic & Remove Unneeded Total Connections Metric**

This pull request reverts the earlier change introduced in commit 904d1807cdf8ab28638ceb49731030598e554a4c that had modified billing metrics to send the total connections count to Orb. The previous logic for prorated 'billable connections' is restored, and the paths and types used to report the now-unneeded 'total connections' metric are removed. The change is motivated by confirmation that proration logic was already correct and the underlying discrepancy lay with billing metric configuration in Orb, rather than in the codebase.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed `billableConnections` (total connections) metric logic from packages/shared/lib/services/connection.service.ts.
• Restored and renamed ``proratedConnections`` method to ``billableConnections`(`referenceDate`: Date)`, returning prorated results; removed old total count-style `billableConnections`() signature.
• Adjusted billing cron in packages/server/lib/crons/usage.ts to call only the prorated ``billableConnections`(`referenceDate`: Date)`, no longer exporting ``proratedConnections`` or the obsolete metric.
• Removed references to the ``total_connections`` metric in the billing event types definition (packages/types/lib/billing/types.ts), restricting valid metric types.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Billing/proration logic in connection.service.ts
• Billing/usage cron jobs
• Billing metric event typings

</details>

---
*This summary was automatically generated by @propel-code-bot*