### PR TITLE
chore(records): better index for track delete query

### DIFF
--- a/packages/records/lib/db/migrations/20250823172055_mark_as_deleted_index.ts
+++ b/packages/records/lib/db/migrations/20250823172055_mark_as_deleted_index.ts
@@ -1,0 +1,23 @@
+import type { Knex } from 'knex';
+
+export const config = {
+    transaction: false
+};
+
+export async function up(knex: Knex): Promise<void> {
+    // dropping existing indexes that are not being used by pg
+    // replacing with a more specific index below used by the "mark previous generation as deleted" query
+    await knex.raw(`DROP INDEX IF EXISTS records_sync_id_index;`);
+    await knex.raw(`DROP INDEX IF EXISTS records_sync_job_id_index;`);
+
+    // pg prevents adding index to parent table concurrently - must be done on each partition
+    for (let p = 0; p < 256; p++) {
+        await knex.raw(
+            `CREATE INDEX CONCURRENTLY IF NOT EXISTS records_p${p}_mark_previous_generation_as_deleted
+                   ON records_p${p}(connection_id, model, sync_id, sync_job_id)
+                   WHERE deleted_at IS NULL;`
+        );
+    }
+}
+
+export async function down(): Promise<void> {}


### PR DESCRIPTION
Indexes on `sync_id` and `sync_job_id` are currently not used by pg.
Replacing them with a more specific index just for the track deletes query. 

I have confirmed that those indexes are not used:
```
SELECT schemaname, relname, indexrelname, idx_scan, idx_tup_read
FROM pg_stat_user_indexes
WHERE indexrelname LIKE '%sync%'

nango_records	records_p0	records_p0_sync_id_idx	0	0
nango_records	records_p1	records_p1_sync_id_idx	0	0
nango_records	records_p2	records_p2_sync_id_idx	0	0
nango_records	records_p3	records_p3_sync_id_idx	0	0
nango_records	records_p4	records_p4_sync_id_idx	0	0
nango_records	records_p5	records_p5_sync_id_idx	0	0
nango_records	records_p6	records_p6_sync_id_idx	0	0
nango_records	records_p7	records_p7_sync_id_idx	0	0
nango_records	records_p8	records_p8_sync_id_idx	0	0
nango_records	records_p9	records_p9_sync_id_idx	0	0
nango_records	records_p10	records_p10_sync_id_idx	0	0
nango_records	records_p11	records_p11_sync_id_idx	0	0
nango_records	records_p12	records_p12_sync_id_idx	1	3
nango_records	records_p13	records_p13_sync_id_idx	0	0
nango_records	records_p14	records_p14_sync_id_idx	0	0
...
```

Indexes have already been added/removed in prod yesterday.
```
schemaname          relname           indexrelname                          idx_scan  idx_tup_read
nango_records	records_p0	records_p0_mark_previous_generation_as_deleted	18558	250044085
nango_records	records_p1	records_p1_mark_previous_generation_as_deleted	3363	1339391
nango_records	records_p2	records_p2_mark_previous_generation_as_deleted	16825	840912535
nango_records	records_p3	records_p3_mark_previous_generation_as_deleted	5555	5027702
nango_records	records_p4	records_p4_mark_previous_generation_as_deleted	1410	1931051
nango_records	records_p5	records_p5_mark_previous_generation_as_deleted	5893	4425735
nango_records	records_p6	records_p6_mark_previous_generation_as_deleted	4042	6664114
nango_records	records_p7	records_p7_mark_previous_generation_as_deleted	298     16464
nango_records	records_p8	records_p8_mark_previous_generation_as_deleted	5429	6273005
nango_records	records_p9	records_p9_mark_previous_generation_as_deleted	20033	79423284
....
```
<!-- Summary by @propel-code-bot -->

---

**Optimize Indexes for Track Delete Query in Records Partitioned Tables**

This PR introduces a database migration that refines the indexing strategy for the partitioned 'records' tables. It drops the underutilized indexes on sync_id and sync_job_id and replaces them with a more specific partial composite index to improve the performance of the 'mark previous generation as deleted' query. The new indexes are added individually to each of the 256 partitions with a WHERE clause filtering deleted_at IS NULL. These changes were already applied in production prior to this code migration.

<details>
<summary><strong>Key Changes</strong></summary>

• Drops existing indexes: `records_sync_id_index` and `records_sync_job_id_index` across all partitions.
• Creates a new partial composite index (`connection_id`, model, `sync_id`, `sync_job_id`) ``WHERE`` `deleted_at` ``IS`` ``NULL`` for each partition (`records_p0` to `records_p255`).
• Uses ``CREATE`` ``INDEX`` ``CONCURRENTLY`` to avoid locking during index creation.
• Configures migration to run without an explicit transaction (transaction: false).
• Down migration is stubbed and provides no rollback logic.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Database/schema migrations for partitioned records tables
• Index definitions and indexing strategy for records table

</details>

---
*This summary was automatically generated by @propel-code-bot*