### PR TITLE
feat(server): new getting started backend

### DIFF
--- a/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, assert, beforeAll, describe, expect, it } from 'vitest';
 
 import { gettingStartedService, seeders } from '@nangohq/shared';
 
@@ -52,6 +52,7 @@ describe(`DELETE ${endpoint}`, () => {
         isSuccess(res.json);
 
         const metaAfter = await gettingStartedService.getMetaByAccountId(account.id);
-        expect(metaAfter).toBeNull();
+        assert(!metaAfter.isErr(), 'Meta should be deleted');
+        expect(metaAfter.value).toBeNull();
     });
 });

--- a/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.integration.test.ts
@@ -48,7 +48,7 @@ describe(`DELETE ${endpoint}`, () => {
             oauth_scopes: 'hello, world'
         });
 
-        const metaResult = await gettingStartedService.getOrCreateGettingStartedMeta(account.id, env.id);
+        const metaResult = await gettingStartedService.getOrCreateMeta(account.id, env.id);
         expect(metaResult.isOk()).toBe(true);
         const meta = metaResult.unwrap();
 

--- a/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.integration.test.ts
@@ -1,8 +1,11 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { seeders } from '@nangohq/shared';
+import db from '@nangohq/database';
+import { gettingStartedService, seeders } from '@nangohq/shared';
 
 import { isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
+
+import type { DBGettingStartedMeta } from '@nangohq/types';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 
@@ -33,5 +36,29 @@ describe(`DELETE ${endpoint}`, () => {
         expect(res.json).toStrictEqual<typeof res.json>({
             success: true
         });
+    });
+
+    it('should delete getting started meta', async () => {
+        const { env, account } = await seeders.seedAccountEnvAndUser();
+
+        // Getting started meta expects a preprovisioned provider config
+        await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar', {
+            oauth_client_id: 'foo',
+            oauth_client_secret: 'bar',
+            oauth_scopes: 'hello, world'
+        });
+
+        const metaResult = await gettingStartedService.getOrCreateGettingStartedMeta(account.id, env.id);
+        expect(metaResult.isOk()).toBe(true);
+        const meta = metaResult.unwrap();
+
+        const res = await api.fetch(endpoint, { method: 'DELETE', token: env.secret_key, params: { uniqueKey: 'google-calendar-getting-started' } });
+        isSuccess(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            success: true
+        });
+
+        const metaAfter = await db.knex.from<DBGettingStartedMeta>('getting_started_meta').where({ id: meta.id }).first();
+        expect(metaAfter).toBeUndefined();
     });
 });

--- a/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.integration.test.ts
@@ -1,11 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import db from '@nangohq/database';
 import { gettingStartedService, seeders } from '@nangohq/shared';
 
 import { isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
-
-import type { DBGettingStartedMeta } from '@nangohq/types';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 
@@ -50,15 +47,11 @@ describe(`DELETE ${endpoint}`, () => {
 
         const metaResult = await gettingStartedService.getOrCreateMeta(account.id, env.id);
         expect(metaResult.isOk()).toBe(true);
-        const meta = metaResult.unwrap();
 
         const res = await api.fetch(endpoint, { method: 'DELETE', token: env.secret_key, params: { uniqueKey: 'google-calendar-getting-started' } });
         isSuccess(res.json);
-        expect(res.json).toStrictEqual<typeof res.json>({
-            success: true
-        });
 
-        const metaAfter = await db.knex.from<DBGettingStartedMeta>('getting_started_meta').where({ id: meta.id }).first();
-        expect(metaAfter).toBeUndefined();
+        const metaAfter = await gettingStartedService.getMetaByAccountId(account.id);
+        expect(metaAfter).toBeNull();
     });
 });

--- a/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.integration.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, assert, beforeAll, describe, expect, it } from 'vitest';
 
+import db from '@nangohq/database';
 import { gettingStartedService, seeders } from '@nangohq/shared';
 
 import { isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
@@ -45,13 +46,13 @@ describe(`DELETE ${endpoint}`, () => {
             oauth_scopes: 'hello, world'
         });
 
-        const metaResult = await gettingStartedService.getOrCreateMeta(account.id, env.id);
+        const metaResult = await gettingStartedService.getOrCreateMeta(db.knex, account.id, env.id);
         expect(metaResult.isOk()).toBe(true);
 
         const res = await api.fetch(endpoint, { method: 'DELETE', token: env.secret_key, params: { uniqueKey: 'google-calendar-getting-started' } });
         isSuccess(res.json);
 
-        const metaAfter = await gettingStartedService.getMetaByAccountId(account.id);
+        const metaAfter = await gettingStartedService.getMetaByAccountId(db.knex, account.id);
         assert(!metaAfter.isErr(), 'Meta should be deleted');
         expect(metaAfter.value).toBeNull();
     });

--- a/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
@@ -1,9 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import db from '@nangohq/database';
-import { getProvider, seeders } from '@nangohq/shared';
+import { configService, getProvider, gettingStartedService, seeders } from '@nangohq/shared';
 
 import { authenticateUser, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
+import { getOrchestrator } from '../../../utils/utils.js';
 
 import type { DBGettingStartedMeta, DBGettingStartedProgress } from '@nangohq/types';
 
@@ -151,18 +152,12 @@ describe(`GET ${endpoint}`, () => {
         expect(fresh?.connection_id).toBe(connection.id);
     });
 
-    it('returns connection as null when the linked connection is deleted', async () => {
-        const { env, user, account } = await seeders.seedAccountEnvAndUser();
+    it('returns connection as null when the linked connection is soft deleted', async () => {
+        const { env, user } = await seeders.seedAccountEnvAndUser();
         const session = await authenticateUser(api, user);
 
-        // Ensure integration exists
-        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar');
-
-        // Create meta and a progress row with a connection
-        const [meta] = await db.knex
-            .from<DBGettingStartedMeta>('getting_started_meta')
-            .insert({ account_id: account.id, environment_id: env.id, integration_id: integration.id! })
-            .returning('*');
+        const gettingStartedProgress = await gettingStartedService.getOrCreateProgressByUser(user, env.id);
+        expect(gettingStartedProgress.isOk()).toBe(true);
 
         // Create a connection and link it to the progress
         const connection = await seeders.createConnectionSeed({
@@ -171,19 +166,11 @@ describe(`GET ${endpoint}`, () => {
             connectionId: 'test-conn-id'
         });
 
-        const [progress] = await db.knex
-            .from<DBGettingStartedProgress>('getting_started_progress')
-            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 2, complete: false, connection_id: connection.id })
-            .returning('*');
-        if (!progress) throw new Error('Failed to create progress');
+        // Attach the connection to the progress
+        await gettingStartedService.updateByUserId(user.id, { connection_id: connection.id });
 
-        // Verify the connection is initially linked
-        const initialRes = await api.fetch(endpoint, { method: 'GET', query: { env: 'dev' }, session });
-        isSuccess(initialRes.json);
-        expect(initialRes.json.data.connection).toMatchObject({ id: connection.id, connection_id: 'test-conn-id' });
-
-        // Delete the connection
-        await db.knex.from('_nango_connections').where({ id: connection.id }).delete();
+        // Soft delete the connection (not using service because it has lots of dependencies)
+        await db.knex.from('_nango_connections').where({ id: connection.id }).update({ deleted: true, deleted_at: new Date() });
 
         // Verify the connection is now null in the response
         const res = await api.fetch(endpoint, { method: 'GET', query: { env: 'dev' }, session });
@@ -193,14 +180,9 @@ describe(`GET ${endpoint}`, () => {
             data: {
                 meta: { environment: { id: env.id }, integration: { unique_key: 'google-calendar-getting-started' } },
                 connection: null,
-                step: 2,
+                step: 0,
                 complete: false
             }
         });
-
-        // Verify the progress row still exists but connection_id is null
-        const freshProgress = await db.knex.from<DBGettingStartedProgress>('getting_started_progress').where({ id: progress.id }).first();
-        expect(freshProgress).toBeTruthy();
-        expect(freshProgress?.connection_id).toBeNull();
     });
 });

--- a/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
@@ -60,7 +60,7 @@ describe(`GET ${endpoint}`, () => {
         });
 
         // Create meta without progress
-        const meta = await gettingStartedService.createMeta({
+        const meta = await gettingStartedService.createMeta(db.knex, {
             account_id: account.id,
             environment_id: env.id,
             integration_id: integration.id!
@@ -68,7 +68,7 @@ describe(`GET ${endpoint}`, () => {
         expect(meta.isOk()).toBe(true);
 
         // Sanity: no progress for this user
-        const existingProgress = await gettingStartedService.getProgressByUserId(user.id);
+        const existingProgress = await gettingStartedService.getProgressByUserId(db.knex, user.id);
         assert(!existingProgress.isErr());
         expect(existingProgress.value).toBeNull();
 
@@ -98,7 +98,7 @@ describe(`GET ${endpoint}`, () => {
         });
 
         // Create meta and and progress
-        const meta = await gettingStartedService.createMeta({
+        const meta = await gettingStartedService.createMeta(db.knex, {
             account_id: account.id,
             environment_id: env.id,
             integration_id: integration.id!
@@ -112,7 +112,7 @@ describe(`GET ${endpoint}`, () => {
             connectionId: 'demo-conn-id'
         });
 
-        const progress = await gettingStartedService.createProgress({
+        const progress = await gettingStartedService.createProgress(db.knex, {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             connection_id: connection.id,
@@ -144,7 +144,7 @@ describe(`GET ${endpoint}`, () => {
         const { env, user } = await seeders.seedAccountEnvAndUser();
         const session = await authenticateUser(api, user);
 
-        const gettingStartedProgress = await gettingStartedService.getOrCreateProgressByUser(user, env.id);
+        const gettingStartedProgress = await gettingStartedService.getOrCreateProgressByUser(db.knex, user, env.id);
         expect(gettingStartedProgress.isOk()).toBe(true);
 
         // Create a connection and link it to the progress
@@ -155,7 +155,7 @@ describe(`GET ${endpoint}`, () => {
         });
 
         // Attach the connection to the progress
-        await gettingStartedService.updateByUserId(user.id, { connection_id: connection.id });
+        await gettingStartedService.updateByUserId(db.knex, user.id, { connection_id: connection.id });
 
         // Soft delete the connection (not using service because it has lots of dependencies)
         await db.knex.from('_nango_connections').where({ id: connection.id }).update({ deleted: true, deleted_at: new Date() });

--- a/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
@@ -1,0 +1,153 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { getProvider, seeders } from '@nangohq/shared';
+
+import { authenticateUser, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
+
+import type { DBGettingStartedMeta, DBGettingStartedProgress } from '@nangohq/types';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+const endpoint = '/api/v1/getting-started';
+
+describe(`GET ${endpoint}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(endpoint, { method: 'GET', query: { env: 'dev' } });
+        shouldBeProtected(res);
+    });
+
+    it("creates meta+integration when they don't exist", async () => {
+        const { env, user, account } = await seeders.seedAccountEnvAndUser();
+        await seeders.createSharedCredentialsSeed('google-calendar');
+        const session = await authenticateUser(api, user);
+
+        // Ensure no getting_started_meta exists for this account
+        await db.knex.from<DBGettingStartedMeta>('getting_started_meta').where({ account_id: account.id }).delete();
+
+        const res = await api.fetch(endpoint, { method: 'GET', query: { env: 'dev' }, session });
+
+        isSuccess(res.json);
+        expect(res.res.status).toBe(200);
+        expect(res.json).toMatchObject({
+            data: {
+                meta: {
+                    environment: { id: env.id },
+                    integration: { unique_key: 'google-calendar-getting-started', environment_id: env.id }
+                },
+                connection: null,
+                step: 0,
+                complete: false
+            }
+        });
+
+        // Validate DB state: meta and progress exist
+        const meta = await db.knex.from<DBGettingStartedMeta>('getting_started_meta').where({ account_id: account.id }).first();
+        if (!meta) {
+            throw new Error('Failed to create getting_started_meta');
+        }
+        const progress = await db.knex
+            .from<DBGettingStartedProgress>('getting_started_progress')
+            .where({ user_id: user.id, getting_started_meta_id: meta.id })
+            .first();
+        expect(progress).toBeTruthy();
+    });
+
+    it('creates progress when meta exists without progress', async () => {
+        const { env, user, account } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        // Ensure pre-provisioned integration exists
+        const provider = getProvider('google-calendar');
+        expect(provider).toBeTruthy();
+        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar');
+
+        // Create meta without progress
+        const [meta] = await db.knex
+            .from<DBGettingStartedMeta>('getting_started_meta')
+            .insert({ account_id: account.id, environment_id: env.id, integration_id: integration.id! })
+            .returning('*');
+        if (!meta) throw new Error('Failed to create getting_started_meta');
+
+        // Sanity: no progress for this user
+        const existingProgress = await db.knex
+            .from<DBGettingStartedProgress>('getting_started_progress')
+            .where({ user_id: user.id, getting_started_meta_id: meta.id })
+            .first();
+        expect(existingProgress).toBeFalsy();
+
+        const res = await api.fetch(endpoint, { method: 'GET', query: { env: 'dev' }, session });
+
+        isSuccess(res.json);
+        expect(res.res.status).toBe(200);
+        expect(res.json).toMatchObject({
+            data: {
+                meta: { environment: { id: env.id }, integration: { environment_id: env.id } },
+                connection: null,
+                step: 0,
+                complete: false
+            }
+        });
+
+        const progress = await db.knex
+            .from<DBGettingStartedProgress>('getting_started_progress')
+            .where({ user_id: user.id, getting_started_meta_id: meta.id })
+            .first();
+        expect(progress).toBeTruthy();
+    });
+
+    it('returns existing meta+progress when both exist', async () => {
+        const { env, user, account } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        // Ensure integration exists
+        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar');
+
+        // Create meta and a progress row with some data
+        const [meta] = await db.knex
+            .from<DBGettingStartedMeta>('getting_started_meta')
+            .insert({ account_id: account.id, environment_id: env.id, integration_id: integration.id! })
+            .returning('*');
+
+        // Also create a fake connection and link it
+        const connection = await seeders.createConnectionSeed({
+            env,
+            provider: 'google-calendar-getting-started',
+            connectionId: 'demo-conn-id'
+        });
+
+        const [progress] = await db.knex
+            .from<DBGettingStartedProgress>('getting_started_progress')
+            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 3, complete: true, connection_id: connection.id })
+            .returning('*');
+        if (!progress) throw new Error('Failed to create progress');
+        const progressId = progress.id;
+
+        const res = await api.fetch(endpoint, { method: 'GET', query: { env: 'dev' }, session });
+        isSuccess(res.json);
+        expect(res.res.status).toBe(200);
+        expect(res.json).toMatchObject({
+            data: {
+                meta: { environment: { id: env.id }, integration: { unique_key: 'google-calendar-getting-started' } },
+                connection: { id: connection.id, connection_id: 'demo-conn-id' },
+                step: 3,
+                complete: true
+            }
+        });
+
+        // Ensure existing row was not altered unexpectedly
+        const fresh = (await db.knex.from<DBGettingStartedProgress>('getting_started_progress').where({ id: progressId }).first()) as
+            | DBGettingStartedProgress
+            | undefined;
+        expect(fresh?.step).toBe(3);
+        expect(fresh?.complete).toBe(true);
+        expect(fresh?.connection_id).toBe(connection.id);
+    });
+});

--- a/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
@@ -1,10 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import db from '@nangohq/database';
-import { configService, getProvider, gettingStartedService, seeders } from '@nangohq/shared';
+import { getProvider, gettingStartedService, seeders } from '@nangohq/shared';
 
 import { authenticateUser, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
-import { getOrchestrator } from '../../../utils/utils.js';
 
 import type { DBGettingStartedMeta, DBGettingStartedProgress } from '@nangohq/types';
 
@@ -44,8 +43,7 @@ describe(`GET ${endpoint}`, () => {
                     integration: { unique_key: 'google-calendar-getting-started', environment_id: env.id }
                 },
                 connection: null,
-                step: 0,
-                complete: false
+                step: 0
             }
         });
 
@@ -92,8 +90,7 @@ describe(`GET ${endpoint}`, () => {
             data: {
                 meta: { environment: { id: env.id }, integration: { environment_id: env.id } },
                 connection: null,
-                step: 0,
-                complete: false
+                step: 0
             }
         });
 
@@ -126,7 +123,7 @@ describe(`GET ${endpoint}`, () => {
 
         const [progress] = await db.knex
             .from<DBGettingStartedProgress>('getting_started_progress')
-            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 3, complete: true, connection_id: connection.id })
+            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 3, connection_id: connection.id })
             .returning('*');
         if (!progress) throw new Error('Failed to create progress');
         const progressId = progress.id;
@@ -138,8 +135,7 @@ describe(`GET ${endpoint}`, () => {
             data: {
                 meta: { environment: { id: env.id }, integration: { unique_key: 'google-calendar-getting-started' } },
                 connection: { id: connection.id, connection_id: 'demo-conn-id' },
-                step: 3,
-                complete: true
+                step: 3
             }
         });
 
@@ -148,7 +144,6 @@ describe(`GET ${endpoint}`, () => {
             | DBGettingStartedProgress
             | undefined;
         expect(fresh?.step).toBe(3);
-        expect(fresh?.complete).toBe(true);
         expect(fresh?.connection_id).toBe(connection.id);
     });
 
@@ -180,8 +175,7 @@ describe(`GET ${endpoint}`, () => {
             data: {
                 meta: { environment: { id: env.id }, integration: { unique_key: 'google-calendar-getting-started' } },
                 connection: null,
-                step: 0,
-                complete: false
+                step: 0
             }
         });
     });

--- a/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
@@ -145,7 +145,6 @@ describe(`GET ${endpoint}`, () => {
         const session = await authenticateUser(api, user);
 
         const gettingStartedProgress = await gettingStartedService.getOrCreateProgressByUser(user, env.id);
-        console.log(gettingStartedProgress.isErr() && gettingStartedProgress.error);
         expect(gettingStartedProgress.isOk()).toBe(true);
 
         // Create a connection and link it to the progress

--- a/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.ts
@@ -12,7 +12,7 @@ import type { GetGettingStarted } from '@nangohq/types';
 export const getGettingStarted = asyncWrapper<GetGettingStarted>(async (_, res) => {
     const { user, environment } = res.locals;
 
-    const gettingStartedProgressResult = await gettingStartedService.getOrCreateByUser(user, environment.id);
+    const gettingStartedProgressResult = await gettingStartedService.getOrCreateProgressByUser(user, environment.id);
 
     if (gettingStartedProgressResult.isErr()) {
         report(gettingStartedProgressResult.error);

--- a/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.ts
@@ -1,5 +1,5 @@
 import { gettingStartedService } from '@nangohq/shared';
-import { report } from '@nangohq/utils';
+import { report, requireEmptyBody, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 
@@ -9,7 +9,19 @@ import type { GetGettingStarted } from '@nangohq/types';
  * Getting started should always be available, so if it doesn't already exist, we create it,
  * including setting up a new google-calendar-getting-started integration using the preprovisioned provider if needed.
  */
-export const getGettingStarted = asyncWrapper<GetGettingStarted>(async (_, res) => {
+export const getGettingStarted = asyncWrapper<GetGettingStarted>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req, { withEnv: true });
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const emptyBody = requireEmptyBody(req);
+    if (emptyBody) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(emptyBody.error) } });
+        return;
+    }
+
     const { user, environment } = res.locals;
 
     const gettingStartedProgressResult = await gettingStartedService.getOrCreateProgressByUser(user, environment.id);

--- a/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.ts
@@ -1,3 +1,4 @@
+import db from '@nangohq/database';
 import { gettingStartedService } from '@nangohq/shared';
 import { report, requireEmptyBody, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
@@ -24,7 +25,7 @@ export const getGettingStarted = asyncWrapper<GetGettingStarted>(async (req, res
 
     const { user, environment } = res.locals;
 
-    const gettingStartedProgressResult = await gettingStartedService.getOrCreateProgressByUser(user, environment.id);
+    const gettingStartedProgressResult = await gettingStartedService.getOrCreateProgressByUser(db.knex, user, environment.id);
 
     if (gettingStartedProgressResult.isErr()) {
         report(gettingStartedProgressResult.error);

--- a/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.ts
@@ -1,0 +1,31 @@
+import { gettingStartedService } from '@nangohq/shared';
+import { report } from '@nangohq/utils';
+
+import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+
+import type { GetGettingStarted } from '@nangohq/types';
+
+/**
+ * Getting started should always be available, so if it doesn't already exist, we create it,
+ * including setting up a new google-calendar-getting-started integration using the preprovisioned provider if needed.
+ */
+export const getGettingStarted = asyncWrapper<GetGettingStarted>(async (_, res) => {
+    const { user, environment } = res.locals;
+
+    const gettingStartedProgressResult = await gettingStartedService.getOrCreateByUser(user, environment.id);
+
+    if (gettingStartedProgressResult.isErr()) {
+        report(gettingStartedProgressResult.error);
+        res.status(500).send({
+            error: {
+                code: 'failed_to_get_or_create_getting_started_progress',
+                message: gettingStartedProgressResult.error.message
+            }
+        });
+        return;
+    }
+
+    res.status(200).send({
+        data: gettingStartedProgressResult.value
+    });
+});

--- a/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.integration.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, assert, beforeAll, describe, expect, it } from 'vitest';
 
+import db from '@nangohq/database';
 import { gettingStartedService, seeders } from '@nangohq/shared';
 
 import { authenticateUser, isError, runServer, shouldBeProtected } from '../../../utils/tests.js';
@@ -68,14 +69,14 @@ describe(`PATCH ${endpoint}`, () => {
         const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar');
 
         // Create meta and progress
-        const meta = await gettingStartedService.createMeta({
+        const meta = await gettingStartedService.createMeta(db.knex, {
             account_id: account.id,
             environment_id: env.id,
             integration_id: integration.id!
         });
         assert(!meta.isErr(), 'Failed to create meta');
 
-        const progress = await gettingStartedService.createProgress({
+        const progress = await gettingStartedService.createProgress(db.knex, {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 0,
@@ -93,7 +94,7 @@ describe(`PATCH ${endpoint}`, () => {
         expect(res.res.status).toBe(204);
 
         // Verify the step was updated in the database
-        const updatedProgress = await gettingStartedService.getProgressByUserId(user.id);
+        const updatedProgress = await gettingStartedService.getProgressByUserId(db.knex, user.id);
         assert(!updatedProgress.isErr(), 'Failed to get progress');
 
         expect(updatedProgress.value?.step).toBe(2);
@@ -107,14 +108,14 @@ describe(`PATCH ${endpoint}`, () => {
         const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar');
 
         // Create meta and progress
-        const meta = await gettingStartedService.createMeta({
+        const meta = await gettingStartedService.createMeta(db.knex, {
             account_id: account.id,
             environment_id: env.id,
             integration_id: integration.id!
         });
         assert(!meta.isErr(), 'Failed to create meta');
 
-        const progress = await gettingStartedService.createProgress({
+        const progress = await gettingStartedService.createProgress(db.knex, {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 0,
@@ -138,7 +139,7 @@ describe(`PATCH ${endpoint}`, () => {
         expect(res.res.status).toBe(204);
 
         // Verify the connection was attached in the database
-        const updatedProgress = await gettingStartedService.getProgressByUserId(user.id);
+        const updatedProgress = await gettingStartedService.getProgressByUserId(db.knex, user.id);
         assert(!updatedProgress.isErr(), 'Failed to get progress');
 
         expect(updatedProgress.value?.connection?.id).toBe(connection.id);
@@ -158,14 +159,14 @@ describe(`PATCH ${endpoint}`, () => {
         });
 
         // Create meta and progress with connection already attached
-        const meta = await gettingStartedService.createMeta({
+        const meta = await gettingStartedService.createMeta(db.knex, {
             account_id: account.id,
             environment_id: env.id,
             integration_id: integration.id!
         });
         assert(!meta.isErr(), 'Failed to create meta');
 
-        const progress = await gettingStartedService.createProgress({
+        const progress = await gettingStartedService.createProgress(db.knex, {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 2,
@@ -183,7 +184,7 @@ describe(`PATCH ${endpoint}`, () => {
         expect(res.res.status).toBe(204);
 
         // Verify the connection was detached in the database
-        const updatedProgress = await gettingStartedService.getProgressByUserId(user.id);
+        const updatedProgress = await gettingStartedService.getProgressByUserId(db.knex, user.id);
         assert(!updatedProgress.isErr(), 'Failed to get progress');
 
         expect(updatedProgress.value?.connection).toBeNull();
@@ -197,14 +198,14 @@ describe(`PATCH ${endpoint}`, () => {
         const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar');
 
         // Create meta and progress
-        const meta = await gettingStartedService.createMeta({
+        const meta = await gettingStartedService.createMeta(db.knex, {
             account_id: account.id,
             environment_id: env.id,
             integration_id: integration.id!
         });
         assert(!meta.isErr(), 'Failed to create meta');
 
-        const progress = await gettingStartedService.createProgress({
+        const progress = await gettingStartedService.createProgress(db.knex, {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 0,
@@ -237,14 +238,14 @@ describe(`PATCH ${endpoint}`, () => {
         const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar');
 
         // Create meta and progress
-        const meta = await gettingStartedService.createMeta({
+        const meta = await gettingStartedService.createMeta(db.knex, {
             account_id: account.id,
             environment_id: env.id,
             integration_id: integration.id!
         });
         assert(!meta.isErr(), 'Failed to create meta');
 
-        const progress = await gettingStartedService.createProgress({
+        const progress = await gettingStartedService.createProgress(db.knex, {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 1,
@@ -263,7 +264,7 @@ describe(`PATCH ${endpoint}`, () => {
         expect(res.res.status).toBe(204);
 
         // Verify nothing changed in the database
-        const updatedProgress = await gettingStartedService.getProgressByUserId(user.id);
+        const updatedProgress = await gettingStartedService.getProgressByUserId(db.knex, user.id);
         assert(!updatedProgress.isErr(), 'Failed to get progress');
 
         expect(updatedProgress.value?.step).toBe(1);

--- a/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.integration.test.ts
@@ -1,0 +1,377 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { seeders } from '@nangohq/shared';
+
+import { authenticateUser, isError, runServer, shouldBeProtected } from '../../../utils/tests.js';
+
+import type { DBGettingStartedMeta, DBGettingStartedProgress } from '@nangohq/types';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+const endpoint = '/api/v1/getting-started';
+
+describe(`PATCH ${endpoint}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(endpoint, { method: 'PATCH', query: { env: 'dev' }, body: { step: 1 } });
+        shouldBeProtected(res);
+    });
+
+    it('should validate body schema', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            token: env.secret_key,
+            query: { env: env.name },
+            // @ts-expect-error on purpose
+            body: { step: 'invalid' }
+        });
+
+        expect(res.res.status).toBe(400);
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'invalid_body',
+                errors: [{ code: 'invalid_type', message: 'Invalid input: expected number, received string', path: ['step'] }]
+            }
+        });
+    });
+
+    it('should validate step is non-negative integer', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            token: env.secret_key,
+            query: { env: 'dev' },
+            body: { step: -1 }
+        });
+
+        expect(res.res.status).toBe(400);
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'invalid_body',
+                errors: [{ code: 'too_small', message: 'Too small: expected number to be >=0', path: ['step'] }]
+            }
+        });
+    });
+
+    it('should update step', async () => {
+        const { env, user, account } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        // Ensure integration exists
+        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar');
+
+        // Create meta and progress
+        const [meta] = await db.knex
+            .from<DBGettingStartedMeta>('getting_started_meta')
+            .insert({ account_id: account.id, environment_id: env.id, integration_id: integration.id! })
+            .returning('*');
+
+        const [progress] = await db.knex
+            .from<DBGettingStartedProgress>('getting_started_progress')
+            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 0, complete: false })
+            .returning('*');
+
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            session,
+            query: { env: env.name },
+            body: { step: 2 }
+        });
+
+        expect(res.res.status).toBe(204);
+
+        // Verify the step was updated in the database
+        const updatedProgress = await db.knex.from<DBGettingStartedProgress>('getting_started_progress').where({ id: progress!.id }).first();
+
+        expect(updatedProgress?.step).toBe(2);
+        expect(updatedProgress?.complete).toBe(false); // Should remain unchanged
+    });
+
+    it('should update completed status', async () => {
+        const { env, user, account } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        // Ensure integration exists
+        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar');
+
+        // Create meta and progress
+        const [meta] = await db.knex
+            .from<DBGettingStartedMeta>('getting_started_meta')
+            .insert({ account_id: account.id, environment_id: env.id, integration_id: integration.id! })
+            .returning('*');
+
+        const [progress] = await db.knex
+            .from<DBGettingStartedProgress>('getting_started_progress')
+            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 1, complete: false })
+            .returning('*');
+
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            session,
+            query: { env: env.name },
+            body: { complete: true }
+        });
+
+        expect(res.res.status).toBe(204);
+
+        // Verify the complete status was updated in the database
+        const updatedProgress = await db.knex.from<DBGettingStartedProgress>('getting_started_progress').where({ id: progress!.id }).first();
+
+        expect(updatedProgress?.complete).toBe(true);
+        expect(updatedProgress?.step).toBe(1); // Should remain unchanged
+    });
+
+    it('should update multiple fields at once', async () => {
+        const { env, user, account } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        // Ensure integration exists
+        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar');
+
+        // Create meta and progress
+        const [meta] = await db.knex
+            .from<DBGettingStartedMeta>('getting_started_meta')
+            .insert({ account_id: account.id, environment_id: env.id, integration_id: integration.id! })
+            .returning('*');
+
+        const [progress] = await db.knex
+            .from<DBGettingStartedProgress>('getting_started_progress')
+            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 0, complete: false })
+            .returning('*');
+
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            session,
+            query: { env: env.name },
+            body: { step: 3, complete: true }
+        });
+
+        expect(res.res.status).toBe(204);
+
+        // Verify both fields were updated in the database
+        const updatedProgress = await db.knex.from<DBGettingStartedProgress>('getting_started_progress').where({ id: progress!.id }).first();
+
+        expect(updatedProgress?.step).toBe(3);
+        expect(updatedProgress?.complete).toBe(true);
+    });
+
+    it('should attach a connection', async () => {
+        const { env, user, account } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        // Ensure integration exists
+        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar');
+
+        // Create meta and progress
+        const [meta] = await db.knex
+            .from<DBGettingStartedMeta>('getting_started_meta')
+            .insert({ account_id: account.id, environment_id: env.id, integration_id: integration.id! })
+            .returning('*');
+
+        const [progress] = await db.knex
+            .from<DBGettingStartedProgress>('getting_started_progress')
+            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 0, complete: false })
+            .returning('*');
+
+        // Create a connection to attach
+        const connection = await seeders.createConnectionSeed({
+            env,
+            provider: 'google-calendar-getting-started'
+        });
+
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            session,
+            query: { env: env.name },
+            body: { connection_id: connection.connection_id }
+        });
+
+        expect(res.res.status).toBe(204);
+
+        // Verify the connection was attached in the database
+        const updatedProgress = await db.knex.from<DBGettingStartedProgress>('getting_started_progress').where({ id: progress!.id }).first();
+
+        expect(updatedProgress?.connection_id).toBe(connection.id);
+    });
+
+    it('should detach a connection when connection_id is empty string', async () => {
+        const { env, user, account } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        // Ensure integration exists
+        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar');
+
+        // Create a connection to initially attach
+        const connection = await seeders.createConnectionSeed({
+            env,
+            provider: 'google-calendar-getting-started'
+        });
+
+        // Create meta and progress with connection already attached
+        const [meta] = await db.knex
+            .from<DBGettingStartedMeta>('getting_started_meta')
+            .insert({ account_id: account.id, environment_id: env.id, integration_id: integration.id! })
+            .returning('*');
+
+        const [progress] = await db.knex
+            .from<DBGettingStartedProgress>('getting_started_progress')
+            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 1, complete: false, connection_id: connection.id })
+            .returning('*');
+
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            session,
+            query: { env: env.name },
+            body: { connection_id: '' }
+        });
+
+        expect(res.res.status).toBe(204);
+
+        // Verify the connection was detached in the database
+        const updatedProgress = await db.knex.from<DBGettingStartedProgress>('getting_started_progress').where({ id: progress!.id }).first();
+
+        expect(updatedProgress?.connection_id).toBeNull();
+    });
+
+    it('should detach a connection when connection_id is null', async () => {
+        const { env, user, account } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        // Ensure integration exists
+        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar');
+
+        // Create a connection to initially attach
+        const connection = await seeders.createConnectionSeed({
+            env,
+            provider: 'google-calendar-getting-started'
+        });
+
+        // Create meta and progress with connection already attached
+        const [meta] = await db.knex
+            .from<DBGettingStartedMeta>('getting_started_meta')
+            .insert({ account_id: account.id, environment_id: env.id, integration_id: integration.id! })
+            .returning('*');
+
+        const [progress] = await db.knex
+            .from<DBGettingStartedProgress>('getting_started_progress')
+            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 2, complete: false, connection_id: connection.id })
+            .returning('*');
+
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            session,
+            query: { env: env.name },
+            body: { connection_id: null }
+        });
+
+        expect(res.res.status).toBe(204);
+
+        // Verify the connection was detached in the database
+        const updatedProgress = await db.knex.from<DBGettingStartedProgress>('getting_started_progress').where({ id: progress!.id }).first();
+
+        expect(updatedProgress?.connection_id).toBeNull();
+    });
+
+    it('should return 404 when connection_id does not exist', async () => {
+        const { env, user, account } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        // Ensure integration exists
+        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar');
+
+        // Create meta and progress
+        const [meta] = await db.knex
+            .from<DBGettingStartedMeta>('getting_started_meta')
+            .insert({ account_id: account.id, environment_id: env.id, integration_id: integration.id! })
+            .returning('*');
+
+        await db.knex
+            .from<DBGettingStartedProgress>('getting_started_progress')
+            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 0, complete: false });
+
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            session,
+            query: { env: env.name },
+            body: { connection_id: 'non-existent-connection' }
+        });
+
+        expect(res.res.status).toBe(404);
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'connection_not_found',
+                message: 'connection_not_found'
+            }
+        });
+    });
+
+    it('should handle no-op updates gracefully', async () => {
+        const { env, user, account } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        // Ensure integration exists
+        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar');
+
+        // Create meta and progress
+        const [meta] = await db.knex
+            .from<DBGettingStartedMeta>('getting_started_meta')
+            .insert({ account_id: account.id, environment_id: env.id, integration_id: integration.id! })
+            .returning('*');
+
+        const [progress] = await db.knex
+            .from<DBGettingStartedProgress>('getting_started_progress')
+            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 1, complete: false })
+            .returning('*');
+
+        // Send request with no actual changes
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            session,
+            query: { env: env.name },
+            body: {}
+        });
+
+        expect(res.res.status).toBe(204);
+
+        // Verify nothing changed in the database
+        const updatedProgress = await db.knex.from<DBGettingStartedProgress>('getting_started_progress').where({ id: progress!.id }).first();
+
+        expect(updatedProgress?.step).toBe(1);
+        expect(updatedProgress?.complete).toBe(false);
+    });
+
+    it('should fail if getting_started_progress does not exist', async () => {
+        const { env, user, account } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        // Ensure no getting_started_meta exists for this account
+        await db.knex.from<DBGettingStartedMeta>('getting_started_meta').where({ account_id: account.id }).delete();
+
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            session,
+            query: { env: env.name },
+            body: { step: 1 }
+        });
+
+        expect(res.res.status).toBe(404);
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'getting_started_progress_not_found',
+                message: 'getting_started_progress_not_found'
+            }
+        });
+    });
+});

--- a/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.integration.test.ts
@@ -78,7 +78,7 @@ describe(`PATCH ${endpoint}`, () => {
 
         const [progress] = await db.knex
             .from<DBGettingStartedProgress>('getting_started_progress')
-            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 0, complete: false })
+            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 0 })
             .returning('*');
 
         const res = await api.fetch(endpoint, {
@@ -94,41 +94,6 @@ describe(`PATCH ${endpoint}`, () => {
         const updatedProgress = await db.knex.from<DBGettingStartedProgress>('getting_started_progress').where({ id: progress!.id }).first();
 
         expect(updatedProgress?.step).toBe(2);
-        expect(updatedProgress?.complete).toBe(false); // Should remain unchanged
-    });
-
-    it('should update completed status', async () => {
-        const { env, user, account } = await seeders.seedAccountEnvAndUser();
-        const session = await authenticateUser(api, user);
-
-        // Ensure integration exists
-        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar');
-
-        // Create meta and progress
-        const [meta] = await db.knex
-            .from<DBGettingStartedMeta>('getting_started_meta')
-            .insert({ account_id: account.id, environment_id: env.id, integration_id: integration.id! })
-            .returning('*');
-
-        const [progress] = await db.knex
-            .from<DBGettingStartedProgress>('getting_started_progress')
-            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 1, complete: false })
-            .returning('*');
-
-        const res = await api.fetch(endpoint, {
-            method: 'PATCH',
-            session,
-            query: { env: env.name },
-            body: { complete: true }
-        });
-
-        expect(res.res.status).toBe(204);
-
-        // Verify the complete status was updated in the database
-        const updatedProgress = await db.knex.from<DBGettingStartedProgress>('getting_started_progress').where({ id: progress!.id }).first();
-
-        expect(updatedProgress?.complete).toBe(true);
-        expect(updatedProgress?.step).toBe(1); // Should remain unchanged
     });
 
     it('should update multiple fields at once', async () => {
@@ -146,14 +111,14 @@ describe(`PATCH ${endpoint}`, () => {
 
         const [progress] = await db.knex
             .from<DBGettingStartedProgress>('getting_started_progress')
-            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 0, complete: false })
+            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 0 })
             .returning('*');
 
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
             session,
             query: { env: env.name },
-            body: { step: 3, complete: true }
+            body: { step: 3 }
         });
 
         expect(res.res.status).toBe(204);
@@ -162,7 +127,6 @@ describe(`PATCH ${endpoint}`, () => {
         const updatedProgress = await db.knex.from<DBGettingStartedProgress>('getting_started_progress').where({ id: progress!.id }).first();
 
         expect(updatedProgress?.step).toBe(3);
-        expect(updatedProgress?.complete).toBe(true);
     });
 
     it('should attach a connection', async () => {
@@ -180,7 +144,7 @@ describe(`PATCH ${endpoint}`, () => {
 
         const [progress] = await db.knex
             .from<DBGettingStartedProgress>('getting_started_progress')
-            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 0, complete: false })
+            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 0 })
             .returning('*');
 
         // Create a connection to attach
@@ -225,7 +189,7 @@ describe(`PATCH ${endpoint}`, () => {
 
         const [progress] = await db.knex
             .from<DBGettingStartedProgress>('getting_started_progress')
-            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 1, complete: false, connection_id: connection.id })
+            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 1, connection_id: connection.id })
             .returning('*');
 
         const res = await api.fetch(endpoint, {
@@ -264,7 +228,7 @@ describe(`PATCH ${endpoint}`, () => {
 
         const [progress] = await db.knex
             .from<DBGettingStartedProgress>('getting_started_progress')
-            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 2, complete: false, connection_id: connection.id })
+            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 2, connection_id: connection.id })
             .returning('*');
 
         const res = await api.fetch(endpoint, {
@@ -295,9 +259,7 @@ describe(`PATCH ${endpoint}`, () => {
             .insert({ account_id: account.id, environment_id: env.id, integration_id: integration.id! })
             .returning('*');
 
-        await db.knex
-            .from<DBGettingStartedProgress>('getting_started_progress')
-            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 0, complete: false });
+        await db.knex.from<DBGettingStartedProgress>('getting_started_progress').insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 0 });
 
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
@@ -331,7 +293,7 @@ describe(`PATCH ${endpoint}`, () => {
 
         const [progress] = await db.knex
             .from<DBGettingStartedProgress>('getting_started_progress')
-            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 1, complete: false })
+            .insert({ user_id: user.id, getting_started_meta_id: meta!.id, step: 1 })
             .returning('*');
 
         // Send request with no actual changes
@@ -348,7 +310,6 @@ describe(`PATCH ${endpoint}`, () => {
         const updatedProgress = await db.knex.from<DBGettingStartedProgress>('getting_started_progress').where({ id: progress!.id }).first();
 
         expect(updatedProgress?.step).toBe(1);
-        expect(updatedProgress?.complete).toBe(false);
     });
 
     it('should fail if getting_started_progress does not exist', async () => {

--- a/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.ts
@@ -1,0 +1,47 @@
+import * as z from 'zod';
+
+import { gettingStartedService } from '@nangohq/shared';
+import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+
+import type { PatchGettingStarted } from '@nangohq/types';
+
+const validationBody = z
+    .object({
+        connection_id: z.string().optional(),
+        step: z.number().int().nonnegative().optional(),
+        complete: z.boolean().optional()
+    })
+    .strict();
+
+export const patchGettingStarted = asyncWrapper<PatchGettingStarted>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req, { withEnv: true });
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valBody = validationBody.safeParse(req.body);
+    if (!valBody.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+        return;
+    }
+
+    const body: PatchGettingStarted['Body'] = valBody.data;
+    const { user, environment } = res.locals;
+
+    const updated = await gettingStartedService.patchProgressByUser(user, environment.id, body);
+    if (updated.isErr()) {
+        const isNotFound = updated.error.message === 'connection_not_found';
+        if (isNotFound) {
+            res.status(404).send({ error: { code: 'connection_not_found', message: updated.error.message } });
+            return;
+        }
+        report(updated.error);
+        res.status(500).send({ error: { code: 'failed_to_update_getting_started_progress', message: updated.error.message } });
+        return;
+    }
+
+    res.status(204).send();
+});

--- a/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.ts
@@ -1,5 +1,6 @@
 import * as z from 'zod';
 
+import db from '@nangohq/database';
 import { gettingStartedService } from '@nangohq/shared';
 import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
@@ -31,7 +32,7 @@ export const patchGettingStarted = asyncWrapper<PatchGettingStarted>(async (req,
     const body: PatchGettingStarted['Body'] = valBody.data;
     const { user } = res.locals;
 
-    const updated = await gettingStartedService.patchProgressByUser(user, body);
+    const updated = await gettingStartedService.patchProgressByUser(db.knex, user, body);
     if (updated.isErr()) {
         if (updated.error.message === 'connection_not_found' || updated.error.message === 'getting_started_progress_not_found') {
             res.status(404).send({ error: { code: updated.error.message, message: updated.error.message } });

--- a/packages/server/lib/controllers/v1/integrations/postIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/postIntegration.ts
@@ -44,7 +44,7 @@ export const postIntegration = asyncWrapper<PostIntegration>(async (req, res) =>
 
     let integration: IntegrationConfig;
     if (body.useSharedCredentials) {
-        const result = await sharedCredentialsService.createPreprovisionedProvider(body.provider, environment.id, provider);
+        const result = await sharedCredentialsService.createPreprovisionedProvider({ providerName: body.provider, environment_id: environment.id, provider });
         if (result.isErr()) {
             res.status(400).send({
                 error: { code: 'invalid_body', message: result.error.message }

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -43,6 +43,8 @@ import { patchFlowEnable } from './controllers/v1/flows/id/patchEnable.js';
 import { patchFlowFrequency } from './controllers/v1/flows/id/patchFrequency.js';
 import { postPreBuiltDeploy } from './controllers/v1/flows/preBuilt/postDeploy.js';
 import { putUpgradePreBuilt } from './controllers/v1/flows/preBuilt/putUpgrade.js';
+import { getGettingStarted } from './controllers/v1/gettingStarted/getGettingStarted.js';
+import { patchGettingStarted } from './controllers/v1/gettingStarted/patchGettingStarted.js';
 import { getIntegrations } from './controllers/v1/integrations/getIntegrations.js';
 import { postIntegration } from './controllers/v1/integrations/postIntegration.js';
 import { deleteIntegration } from './controllers/v1/integrations/providerConfigKey/deleteIntegration.js';
@@ -208,6 +210,10 @@ web.route('/flows/:id/frequency').patch(webAuth, patchFlowFrequency);
 web.route('/flow/:flowName').get(webAuth, flowController.getFlow.bind(syncController));
 
 web.route('/onboarding').patch(webAuth, patchOnboarding);
+
+// Getting Started
+web.route('/getting-started').get(webAuth, getGettingStarted);
+web.route('/getting-started').patch(webAuth, patchGettingStarted);
 
 web.route('/logs/operations').post(webAuth, searchOperations);
 web.route('/logs/messages').post(webAuth, searchMessages);

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -33,6 +33,7 @@ export * from './services/sync/config/endpoint.service.js';
 export * from './services/sync/config/deploy.service.js';
 export * from './services/endUser.service.js';
 export * from './services/onboarding.service.js';
+export * as gettingStartedService from './services/getting-started.service.js';
 export * from './services/invitations.js';
 export * from './services/providers.js';
 export * from './services/proxy/utils.js';

--- a/packages/shared/lib/seeders/config.seeder.ts
+++ b/packages/shared/lib/seeders/config.seeder.ts
@@ -1,8 +1,10 @@
+import db from '@nangohq/database';
+
 import configService from '../services/config.service.js';
 import { getProvider } from '../services/providers.js';
 
 import type { Config as ProviderConfig } from '../models/Provider.js';
-import type { DBEnvironment, IntegrationConfig } from '@nangohq/types';
+import type { DBEnvironment, DBSharedCredentials, IntegrationConfig } from '@nangohq/types';
 
 export const createConfigSeeds = async (env: DBEnvironment): Promise<void> => {
     const googleProvider = getProvider('google');
@@ -75,6 +77,64 @@ export async function createConfigSeed(
         throw new Error('failed to created to provider config');
     }
     return created;
+}
+
+export async function createPreprovisionedProviderConfigSeed(
+    env: DBEnvironment,
+    unique_key: string,
+    providerName: string,
+    rest?: Partial<IntegrationConfig>
+): Promise<IntegrationConfig> {
+    const provider = getProvider(providerName);
+    if (!provider) {
+        throw new Error(`createPreprovisionedProviderSeed: ${providerName} provider not found`);
+    }
+
+    const sharedCredentials = await createSharedCredentialsSeed(providerName);
+
+    const created = await configService.createProviderConfig(
+        {
+            unique_key,
+            provider: providerName,
+            environment_id: env.id,
+            ...rest,
+            forward_webhooks: true,
+            shared_credentials_id: sharedCredentials.id
+        },
+        provider
+    );
+    if (!created) {
+        throw new Error('failed to created to preprovisioned provider config');
+    }
+    return created;
+}
+
+export async function createSharedCredentialsSeed(providerName: string): Promise<DBSharedCredentials> {
+    const credentials = {
+        oauth_client_id: 'test',
+        oauth_client_secret: 'test',
+        oauth_scopes: 'test'
+    };
+
+    // Create shared credentials
+    const sharedCredentialsResult = await db.knex
+        .insert<DBSharedCredentials>({
+            name: providerName,
+            credentials
+        })
+        .into('providers_shared_credentials')
+        .onConflict('name')
+        .merge({
+            credentials
+        })
+        .returning('*');
+
+    const sharedCredentials = sharedCredentialsResult[0];
+    if (!sharedCredentials) {
+        throw new Error('failed to create shared credentials');
+    }
+
+    return sharedCredentials;
 }
 
 export function getTestConfig(data?: Partial<IntegrationConfig>): IntegrationConfig {

--- a/packages/shared/lib/services/config.service.ts
+++ b/packages/shared/lib/services/config.service.ts
@@ -158,7 +158,7 @@ class ConfigService {
         // TODO: might be useless since we are dropping the data after a while
         await deleteSyncConfigByConfigId(id);
 
-        await gettingStartedService.deleteMetaByIntegrationId(id);
+        await gettingStartedService.deleteMetaByIntegrationId(db.knex, id);
 
         const updated = await db.knex.from<ProviderConfig>(`_nango_configs`).where({ id, deleted: false }).update({ deleted: true, deleted_at: new Date() });
         if (updated <= 0) {

--- a/packages/shared/lib/services/config.service.ts
+++ b/packages/shared/lib/services/config.service.ts
@@ -2,6 +2,7 @@ import db from '@nangohq/database';
 import { isCloud, nanoid } from '@nangohq/utils';
 
 import { getProvider } from './providers.js';
+import { gettingStartedService } from '../index.js';
 import encryptionManager from '../utils/encryption.manager.js';
 import { NangoError } from '../utils/error.js';
 import syncManager from './sync/manager.service.js';
@@ -156,6 +157,8 @@ class ConfigService {
 
         // TODO: might be useless since we are dropping the data after a while
         await deleteSyncConfigByConfigId(id);
+
+        await gettingStartedService.deleteMetaByIntegrationId(id);
 
         const updated = await db.knex.from<ProviderConfig>(`_nango_configs`).where({ id, deleted: false }).update({ deleted: true, deleted_at: new Date() });
         if (updated <= 0) {

--- a/packages/shared/lib/services/getting-started.service.ts
+++ b/packages/shared/lib/services/getting-started.service.ts
@@ -87,8 +87,7 @@ export async function getProgressByUserId(userId: number): Promise<Result<Gettin
                 environment: result.environment
             },
             connection: result.connection ?? null,
-            step: result.progress.step,
-            complete: result.progress.complete
+            step: result.progress.step
         });
     } catch (err) {
         console.error('failed_to_get_getting_started_progress', err);
@@ -156,9 +155,6 @@ export async function patchProgressByUser(user: DBUser, input: PatchGettingStart
 
     if (typeof input.step !== 'undefined') {
         update.step = input.step;
-    }
-    if (typeof input.complete !== 'undefined') {
-        update.complete = input.complete;
     }
 
     if (typeof input.connection_id !== 'undefined') {

--- a/packages/shared/lib/services/getting-started.service.ts
+++ b/packages/shared/lib/services/getting-started.service.ts
@@ -1,0 +1,173 @@
+import db from '@nangohq/database';
+import { getProvider } from '@nangohq/providers';
+import { Err, Ok } from '@nangohq/utils';
+
+import configService from './config.service.js';
+import sharedCredentialsService from './shared-credentials.service.js';
+
+import type {
+    DBConnection,
+    DBEnvironment,
+    DBGettingStartedMeta,
+    DBGettingStartedProgress,
+    DBUser,
+    GettingStartedOutput,
+    IntegrationConfig
+} from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+export async function createGettingStartedMeta(accountId: number, environmentId: number): Promise<Result<DBGettingStartedMeta>> {
+    try {
+        const result = await db.knex
+            .from<DBGettingStartedMeta>('getting_started_meta')
+            .insert({ account_id: accountId, environment_id: environmentId })
+            .returning('*');
+
+        if (!result[0]) {
+            return Err(new Error('failed_to_create_getting_started_meta'));
+        }
+
+        return Ok(result[0]);
+    } catch (err) {
+        return Err(new Error('failed_to_create_getting_started_meta', { cause: err }));
+    }
+}
+
+export async function createGettingStartedProgress(userId: number, metaId: number): Promise<Result<DBGettingStartedProgress>> {
+    try {
+        const result = await db.knex
+            .from<DBGettingStartedProgress>('getting_started_progress')
+            .insert({ user_id: userId, getting_started_meta_id: metaId })
+            .returning('*');
+
+        const gettingStartedProgress = result[0];
+
+        if (!gettingStartedProgress) {
+            return Err(new Error('failed_to_create_getting_started_progress'));
+        }
+
+        return Ok(gettingStartedProgress);
+    } catch (err) {
+        return Err(new Error('failed_to_create_getting_started_progress', { cause: err }));
+    }
+}
+
+export async function getByUserId(userId: number): Promise<Result<GettingStartedOutput>> {
+    const result = await db.knex
+        .select<{
+            getting_started_progress: DBGettingStartedProgress;
+            environment: DBEnvironment;
+            integration: IntegrationConfig;
+            connection: DBConnection | null;
+        }>('progress.* as progress', 'env.* as environment', 'config.* as integration', 'conn.* as connection')
+        .from('getting_started_progress as progress')
+        .leftJoin('getting_started_meta as meta', 'meta.id', 'progress.getting_started_meta_id')
+        .leftJoin('_nango_environments as env', 'env.id', 'meta.environment_id')
+        .leftJoin('_nango_configs as config', 'config.id', 'meta.integration_id')
+        .leftJoin('_nango_connections as conn', 'conn.id', 'progress.connection_id')
+        .where({ user_id: userId })
+        .first();
+
+    if (!result) {
+        return Err(new Error('getting_started_progress_not_found'));
+    }
+
+    return Ok({
+        meta: {
+            integration: result.integration,
+            environment: result.environment
+        },
+        connection: result.connection ?? null,
+        step: result.getting_started_progress.step
+    });
+}
+
+export function updateByUserId(userId: number, data: Partial<DBGettingStartedProgress>) {
+    return db.knex.from<DBGettingStartedProgress>('getting_started_progress').where({ user_id: userId }).update(data);
+}
+
+/**
+ * Gets getting started progress for the user, or creates it if it doesn't exist.
+ */
+export async function getOrCreateByUser(user: DBUser, currentEnvironmentId: number): Promise<Result<GettingStartedOutput>> {
+    const existingResult = await getByUserId(user.id);
+
+    if (existingResult.isOk()) {
+        return Ok(existingResult.value);
+    }
+
+    const gettingStartedMeta = await getOrCreateGettingStartedMeta(user.account_id, currentEnvironmentId);
+
+    if (gettingStartedMeta.isErr()) {
+        return Err(gettingStartedMeta.error);
+    }
+
+    const createdResult = await createGettingStartedProgress(user.id, gettingStartedMeta.value.id);
+
+    if (createdResult.isErr()) {
+        return Err(createdResult.error);
+    }
+
+    return getByUserId(createdResult.value.user_id);
+}
+
+async function getOrCreateGettingStartedMeta(accountId: number, currentEnvironmentId: number): Promise<Result<DBGettingStartedMeta>> {
+    const existingMeta = await db.knex.from<DBGettingStartedMeta>('getting_started_meta').where({ account_id: accountId }).first();
+
+    if (existingMeta) {
+        return Ok(existingMeta);
+    }
+
+    const googleCalendarIntegrationId = await getOrCreateGoogleCalendarIntegration(currentEnvironmentId);
+
+    if (googleCalendarIntegrationId.isErr()) {
+        return Err(googleCalendarIntegrationId.error);
+    }
+
+    try {
+        const newMeta = await createGettingStartedMeta(accountId, currentEnvironmentId);
+
+        if (newMeta.isErr()) {
+            return Err(new Error('failed_to_create_getting_started_meta'));
+        }
+
+        return Ok(newMeta.value);
+    } catch (err) {
+        return Err(new Error('failed_to_create_getting_started_meta', { cause: err }));
+    }
+}
+
+async function getOrCreateGoogleCalendarIntegration(environmentId: number): Promise<Result<number>> {
+    const existingIntegrationId = await configService.getIdByProviderConfigKey(environmentId, 'google-calendar-getting-started');
+
+    if (existingIntegrationId) {
+        return Ok(existingIntegrationId);
+    }
+
+    const PROVIDER_NAME = 'google-calendar';
+
+    const provider = getProvider(PROVIDER_NAME);
+    if (!provider) {
+        return Err(new Error('google_calendar_provider_not_found'));
+    }
+
+    const newIntegration = await sharedCredentialsService.createPreprovisionedProvider({
+        providerName: PROVIDER_NAME,
+        environment_id: environmentId,
+        provider,
+        display_name: 'Google Calendar (Getting Started)',
+        unique_key: 'google-calendar-getting-started'
+    });
+
+    if (newIntegration.isErr()) {
+        return Err(newIntegration.error);
+    }
+
+    const id = newIntegration.value.id ?? null;
+
+    if (!id) {
+        return Err(new Error('failed_to_create_google_calendar_integration'));
+    }
+
+    return Ok(id);
+}

--- a/packages/shared/lib/services/getting-started.service.ts
+++ b/packages/shared/lib/services/getting-started.service.ts
@@ -1,3 +1,5 @@
+import { pick } from 'lodash-es';
+
 import db from '@nangohq/database';
 import { getProvider } from '@nangohq/providers';
 import { Err, Ok } from '@nangohq/utils';
@@ -83,10 +85,10 @@ export async function getProgressByUserId(userId: number): Promise<Result<Gettin
 
         return Ok({
             meta: {
-                integration: result.integration,
-                environment: result.environment
+                integration: pick(result.integration, ['id', 'unique_key', 'provider', 'display_name']),
+                environment: pick(result.environment, ['id', 'name'])
             },
-            connection: result.connection ?? null,
+            connection: result.connection ? pick(result.connection, ['id', 'connection_id']) : null,
             step: result.progress.step
         });
     } catch (err) {

--- a/packages/shared/lib/services/getting-started.service.ts
+++ b/packages/shared/lib/services/getting-started.service.ts
@@ -91,7 +91,7 @@ export async function getProgressByUserId(userId: number): Promise<Result<Gettin
     }
 }
 
-async function getMetaByAccountId(accountId: number): Promise<Result<DBGettingStartedMeta | null>> {
+export async function getMetaByAccountId(accountId: number): Promise<Result<DBGettingStartedMeta | null>> {
     try {
         const gettingStartedMeta = await db.knex.from<DBGettingStartedMeta>('getting_started_meta').where({ account_id: accountId }).first();
 

--- a/packages/shared/lib/services/getting-started.service.ts
+++ b/packages/shared/lib/services/getting-started.service.ts
@@ -26,11 +26,7 @@ export async function createMeta(input: CreateGettingStartedMeta): Promise<Resul
     try {
         const [gettingStartedMeta] = await db.knex.from<DBGettingStartedMeta>('getting_started_meta').insert(input).returning('*');
 
-        if (!gettingStartedMeta) {
-            return Err(new Error('failed_to_create_getting_started_meta'));
-        }
-
-        return Ok(gettingStartedMeta);
+        return gettingStartedMeta ? Ok(gettingStartedMeta) : Err('failed_to_create_getting_started_meta');
     } catch (err) {
         return Err(new Error('failed_to_create_getting_started_meta', { cause: err }));
     }
@@ -40,11 +36,7 @@ export async function createProgress(input: CreateGettingStartedProgress): Promi
     try {
         const [gettingStartedProgress] = await db.knex.from<DBGettingStartedProgress>('getting_started_progress').insert(input).returning('*');
 
-        if (!gettingStartedProgress) {
-            return Err(new Error('failed_to_create_getting_started_progress'));
-        }
-
-        return Ok(gettingStartedProgress);
+        return gettingStartedProgress ? Ok(gettingStartedProgress) : Err('failed_to_create_getting_started_progress');
     } catch (err) {
         return Err(new Error('failed_to_create_getting_started_progress', { cause: err }));
     }
@@ -95,11 +87,7 @@ export async function getMetaByAccountId(accountId: number): Promise<Result<DBGe
     try {
         const gettingStartedMeta = await db.knex.from<DBGettingStartedMeta>('getting_started_meta').where({ account_id: accountId }).first();
 
-        if (!gettingStartedMeta) {
-            return Ok(null);
-        }
-
-        return Ok(gettingStartedMeta);
+        return gettingStartedMeta ? Ok(gettingStartedMeta) : Ok(null);
     } catch (err) {
         return Err(new Error('failed_to_get_getting_started_meta', { cause: err }));
     }
@@ -109,10 +97,7 @@ export async function updateByUserId(userId: number, data: Partial<DBGettingStar
     try {
         const [updated] = await db.knex.from<DBGettingStartedProgress>('getting_started_progress').where({ user_id: userId }).update(data).returning('*');
 
-        if (!updated) {
-            return Err(new Error('failed_to_update_getting_started_progress'));
-        }
-        return Ok(updated);
+        return updated ? Ok(updated) : Err('failed_to_update_getting_started_progress');
     } catch (err) {
         return Err(new Error('failed_to_update_getting_started_progress', { cause: err }));
     }
@@ -155,7 +140,7 @@ export async function getOrCreateProgressByUser(user: DBUser, currentEnvironment
     }
 
     if (newProgress.value === null) {
-        return Err(new Error('failed_to_get_getting_started_progress'));
+        return Err('failed_to_get_getting_started_progress');
     }
 
     return Ok(newProgress.value);
@@ -172,7 +157,7 @@ export async function patchProgressByUser(user: DBUser, input: PatchGettingStart
     }
 
     if (existing.value === null) {
-        return Err(new Error('getting_started_progress_not_found'));
+        return Err('getting_started_progress_not_found');
     }
 
     const update: Partial<DBGettingStartedProgress> = {};
@@ -234,7 +219,7 @@ export async function getOrCreateMeta(accountId: number, currentEnvironmentId: n
     const newMeta = await createMeta({ account_id: accountId, environment_id: currentEnvironmentId, integration_id: googleCalendarIntegrationId.value });
 
     if (newMeta.isErr()) {
-        return Err(new Error('failed_to_create_getting_started_meta'));
+        return Err('failed_to_create_getting_started_meta');
     }
 
     return Ok(newMeta.value);
@@ -251,7 +236,7 @@ async function getOrCreateGoogleCalendarIntegration(environmentId: number): Prom
 
     const provider = getProvider(PROVIDER_NAME);
     if (!provider) {
-        return Err(new Error('google_calendar_provider_not_found'));
+        return Err('google_calendar_provider_not_found');
     }
 
     const newIntegration = await sharedCredentialsService.createPreprovisionedProvider({
@@ -269,7 +254,7 @@ async function getOrCreateGoogleCalendarIntegration(environmentId: number): Prom
     const id = newIntegration.value.id ?? null;
 
     if (!id) {
-        return Err(new Error('failed_to_create_google_calendar_integration'));
+        return Err('failed_to_create_google_calendar_integration');
     }
 
     return Ok(id);
@@ -279,11 +264,7 @@ export async function deleteMetaByIntegrationId(integrationId: number): Promise<
     try {
         const result = await db.knex.from<DBGettingStartedMeta>('getting_started_meta').where({ integration_id: integrationId }).delete();
 
-        if (result === 0) {
-            return Err(new Error('failed_to_delete_getting_started_meta'));
-        }
-
-        return Ok(undefined);
+        return result && result > 0 ? Ok(undefined) : Err('failed_to_delete_getting_started_meta');
     } catch (err) {
         return Err(new Error('failed_to_delete_getting_started_meta', { cause: err }));
     }

--- a/packages/shared/lib/services/getting-started.service.ts
+++ b/packages/shared/lib/services/getting-started.service.ts
@@ -17,11 +17,11 @@ import type {
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
-export async function createGettingStartedMeta(accountId: number, environmentId: number): Promise<Result<DBGettingStartedMeta>> {
+export async function createGettingStartedMeta(accountId: number, environmentId: number, integrationId: number): Promise<Result<DBGettingStartedMeta>> {
     try {
         const result = await db.knex
             .from<DBGettingStartedMeta>('getting_started_meta')
-            .insert({ account_id: accountId, environment_id: environmentId })
+            .insert({ account_id: accountId, environment_id: environmentId, integration_id: integrationId })
             .returning('*');
 
         if (!result[0]) {
@@ -53,34 +53,45 @@ export async function createGettingStartedProgress(userId: number, metaId: numbe
     }
 }
 
-export async function getByUserId(userId: number): Promise<Result<GettingStartedProgressOutput>> {
-    const result = await db.knex
-        .select<{
-            getting_started_progress: DBGettingStartedProgress;
-            environment: DBEnvironment;
-            integration: IntegrationConfig;
-            connection: DBConnection | null;
-        }>('progress.* as progress', 'env.* as environment', 'config.* as integration', 'conn.* as connection')
-        .from('getting_started_progress as progress')
-        .leftJoin('getting_started_meta as meta', 'meta.id', 'progress.getting_started_meta_id')
-        .leftJoin('_nango_environments as env', 'env.id', 'meta.environment_id')
-        .leftJoin('_nango_configs as config', 'config.id', 'meta.integration_id')
-        .leftJoin('_nango_connections as conn', 'conn.id', 'progress.connection_id')
-        .where({ user_id: userId })
-        .first();
+export async function getProgressByUserId(userId: number): Promise<Result<GettingStartedProgressOutput | null>> {
+    try {
+        const result = await db.knex
+            .from<DBGettingStartedProgress>('getting_started_progress as progress')
+            .select<{
+                progress: DBGettingStartedProgress;
+                environment: DBEnvironment;
+                integration: IntegrationConfig;
+                connection: DBConnection | null;
+            }>(
+                db.knex.raw('row_to_json(progress.*) as progress'),
+                db.knex.raw('row_to_json(env.*) as environment'),
+                db.knex.raw('row_to_json(config.*) as integration'),
+                db.knex.raw('row_to_json(conn.*) as connection')
+            )
+            .leftJoin('getting_started_meta as meta', 'meta.id', 'progress.getting_started_meta_id')
+            .leftJoin('_nango_environments as env', 'env.id', 'meta.environment_id')
+            .leftJoin('_nango_configs as config', 'config.id', 'meta.integration_id')
+            .leftJoin('_nango_connections as conn', 'conn.id', 'progress.connection_id')
+            .where({ user_id: userId })
+            .first();
 
-    if (!result) {
-        return Err(new Error('getting_started_progress_not_found'));
+        if (!result) {
+            return Ok(null);
+        }
+
+        return Ok({
+            meta: {
+                integration: result.integration,
+                environment: result.environment
+            },
+            connection: result.connection ?? null,
+            step: result.progress.step,
+            complete: result.progress.complete
+        });
+    } catch (err) {
+        console.error('failed_to_get_getting_started_progress', err);
+        return Err(new Error('failed_to_get_getting_started_progress', { cause: err }));
     }
-
-    return Ok({
-        meta: {
-            integration: result.integration,
-            environment: result.environment
-        },
-        connection: result.connection ?? null,
-        step: result.getting_started_progress.step
-    });
 }
 
 export function updateByUserId(userId: number, data: Partial<DBGettingStartedProgress>) {
@@ -91,9 +102,13 @@ export function updateByUserId(userId: number, data: Partial<DBGettingStartedPro
  * Gets getting started progress for the user, or creates it if it doesn't exist.
  */
 export async function getOrCreateProgressByUser(user: DBUser, currentEnvironmentId: number): Promise<Result<GettingStartedProgressOutput>> {
-    const existingResult = await getByUserId(user.id);
+    const existingResult = await getProgressByUserId(user.id);
 
-    if (existingResult.isOk()) {
+    if (existingResult.isErr()) {
+        return Err(existingResult.error);
+    }
+
+    if (existingResult.value !== null) {
         return Ok(existingResult.value);
     }
 
@@ -109,20 +124,31 @@ export async function getOrCreateProgressByUser(user: DBUser, currentEnvironment
         return Err(createdResult.error);
     }
 
-    return getByUserId(createdResult.value.user_id);
+    const newProgress = await getProgressByUserId(createdResult.value.user_id);
+    if (newProgress.isErr()) {
+        return Err(newProgress.error);
+    }
+
+    if (newProgress.value === null) {
+        return Err(new Error('failed_to_get_getting_started_progress'));
+    }
+
+    return Ok(newProgress.value);
 }
 
 /**
  * Update getting started progress for a user and return the updated object.
  */
-export async function patchProgressByUser(user: DBUser, currentEnvironmentId: number, input: PatchGettingStartedInput): Promise<Result<void>> {
+export async function patchProgressByUser(user: DBUser, input: PatchGettingStartedInput): Promise<Result<void>> {
     // Ensure meta/progress exist and fetch meta information (environment, integration)
-    const existing = await getOrCreateProgressByUser(user, currentEnvironmentId);
+    const existing = await getProgressByUserId(user.id);
     if (existing.isErr()) {
         return Err(existing.error);
     }
 
-    const { meta } = existing.value;
+    if (existing.value === null) {
+        return Err(new Error('getting_started_progress_not_found'));
+    }
 
     const update: Partial<DBGettingStartedProgress> = {};
 
@@ -138,12 +164,6 @@ export async function patchProgressByUser(user: DBUser, currentEnvironmentId: nu
             update.connection_id = null;
         } else {
             try {
-                const configId = meta.integration.id;
-                if (!configId) {
-                    // Should never happen
-                    return Err(new Error('invalid_integration_id'));
-                }
-
                 const connection = await db.knex
                     .from<DBConnection>('_nango_connections')
                     .select<{ id: number }[]>('id')
@@ -189,7 +209,7 @@ async function getOrCreateGettingStartedMeta(accountId: number, currentEnvironme
     }
 
     try {
-        const newMeta = await createGettingStartedMeta(accountId, currentEnvironmentId);
+        const newMeta = await createGettingStartedMeta(accountId, currentEnvironmentId, googleCalendarIntegrationId.value);
 
         if (newMeta.isErr()) {
             return Err(new Error('failed_to_create_getting_started_meta'));

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -47,6 +47,7 @@ import type { DeleteEnvironment, PatchEnvironment, PostEnvironment } from './env
 import type { PatchWebhook } from './environment/api/webhook.js';
 import type { PostEnvironmentVariables } from './environment/variable/api.js';
 import type { PatchFlowDisable, PatchFlowEnable, PatchFlowFrequency, PostPreBuiltDeploy, PutUpgradePreBuiltFlow } from './flow/http.api.js';
+import type { GetGettingStarted, PatchGettingStarted } from './gettingStarted/api.js';
 import type {
     DeleteIntegration,
     DeletePublicIntegration,
@@ -166,7 +167,9 @@ export type PrivateApiEndpoints =
     | GetSharedCredentialsProviders
     | GetSharedCredentialsProvider
     | PostSharedCredentialsProvider
-    | PatchSharedCredentialsProvider;
+    | PatchSharedCredentialsProvider
+    | GetGettingStarted
+    | PatchGettingStarted;
 
 export type APIEndpoints = PrivateApiEndpoints | PublicApiEndpoints;
 

--- a/packages/types/lib/gettingStarted/api.ts
+++ b/packages/types/lib/gettingStarted/api.ts
@@ -17,4 +17,5 @@ export type PatchGettingStarted = Endpoint<{
         data: GettingStartedOutput;
     };
     Body: PatchGettingStartedInput;
+    Error: ApiError<'connection_not_found'> | ApiError<'failed_to_update_getting_started_progress'>;
 }>;

--- a/packages/types/lib/gettingStarted/api.ts
+++ b/packages/types/lib/gettingStarted/api.ts
@@ -1,4 +1,4 @@
-import type { GettingStartedOutput, PatchGettingStartedInput } from './dto.js';
+import type { GettingStartedOutput as GettingStartedProgressOutput, PatchGettingStartedInput as PatchGettingStartedProgressInput } from './dto.js';
 import type { ApiError, Endpoint } from '../api.js';
 
 export type GetGettingStarted = Endpoint<{
@@ -6,7 +6,7 @@ export type GetGettingStarted = Endpoint<{
     Path: '/api/v1/getting-started';
     Querystring: { env: string };
     Success: {
-        data: GettingStartedOutput;
+        data: GettingStartedProgressOutput;
     };
     Error: ApiError<'failed_to_get_or_create_getting_started_progress'>;
 }>;
@@ -16,6 +16,6 @@ export type PatchGettingStarted = Endpoint<{
     Path: '/api/v1/getting-started';
     Querystring: { env: string };
     Success: never;
-    Body: PatchGettingStartedInput;
+    Body: PatchGettingStartedProgressInput;
     Error: ApiError<'connection_not_found' | 'getting_started_progress_not_found' | 'failed_to_update_getting_started_progress'>;
 }>;

--- a/packages/types/lib/gettingStarted/api.ts
+++ b/packages/types/lib/gettingStarted/api.ts
@@ -1,0 +1,20 @@
+import type { GettingStartedOutput, PatchGettingStartedInput } from './dto.js';
+import type { ApiError, Endpoint } from '../api.js';
+
+export type GetGettingStarted = Endpoint<{
+    Method: 'GET';
+    Path: '/api/v1/getting-started';
+    Success: {
+        data: GettingStartedOutput;
+    };
+    Error: ApiError<'failed_to_get_or_create_getting_started_progress'>;
+}>;
+
+export type PatchGettingStarted = Endpoint<{
+    Method: 'PATCH';
+    Path: '/api/v1/getting-started';
+    Success: {
+        data: GettingStartedOutput;
+    };
+    Body: PatchGettingStartedInput;
+}>;

--- a/packages/types/lib/gettingStarted/api.ts
+++ b/packages/types/lib/gettingStarted/api.ts
@@ -15,9 +15,7 @@ export type PatchGettingStarted = Endpoint<{
     Method: 'PATCH';
     Path: '/api/v1/getting-started';
     Querystring: { env: string };
-    Success: {
-        data: GettingStartedOutput;
-    };
+    Success: never;
     Body: PatchGettingStartedInput;
     Error: ApiError<'connection_not_found' | 'getting_started_progress_not_found' | 'failed_to_update_getting_started_progress'>;
 }>;

--- a/packages/types/lib/gettingStarted/api.ts
+++ b/packages/types/lib/gettingStarted/api.ts
@@ -4,6 +4,7 @@ import type { ApiError, Endpoint } from '../api.js';
 export type GetGettingStarted = Endpoint<{
     Method: 'GET';
     Path: '/api/v1/getting-started';
+    Querystring: { env: string };
     Success: {
         data: GettingStartedOutput;
     };
@@ -13,9 +14,10 @@ export type GetGettingStarted = Endpoint<{
 export type PatchGettingStarted = Endpoint<{
     Method: 'PATCH';
     Path: '/api/v1/getting-started';
+    Querystring: { env: string };
     Success: {
         data: GettingStartedOutput;
     };
     Body: PatchGettingStartedInput;
-    Error: ApiError<'connection_not_found'> | ApiError<'failed_to_update_getting_started_progress'>;
+    Error: ApiError<'connection_not_found' | 'getting_started_progress_not_found' | 'failed_to_update_getting_started_progress'>;
 }>;

--- a/packages/types/lib/gettingStarted/dto.ts
+++ b/packages/types/lib/gettingStarted/dto.ts
@@ -1,3 +1,4 @@
+import type { DBGettingStartedMeta, DBGettingStartedProgress } from './db.js';
 import type { DBConnection } from '../connection/db.js';
 import type { DBEnvironment } from '../environment/db.js';
 import type { IntegrationConfig } from '../integration/db.js';
@@ -15,3 +16,6 @@ export interface PatchGettingStartedInput {
     connection_id?: string | null | undefined;
     step?: number | undefined;
 }
+
+export type CreateGettingStartedMeta = Omit<DBGettingStartedMeta, 'id' | 'created_at' | 'updated_at'>;
+export type CreateGettingStartedProgress = Omit<DBGettingStartedProgress, 'id' | 'created_at' | 'updated_at'>;

--- a/packages/types/lib/gettingStarted/dto.ts
+++ b/packages/types/lib/gettingStarted/dto.ts
@@ -4,10 +4,10 @@ import type { IntegrationConfig } from '../integration/db.js';
 
 export interface GettingStartedOutput {
     meta: {
-        environment: DBEnvironment;
-        integration: IntegrationConfig;
+        environment: Pick<DBEnvironment, 'id' | 'name'>;
+        integration: Pick<IntegrationConfig, 'id' | 'unique_key' | 'provider' | 'display_name'>;
     };
-    connection: DBConnection | null;
+    connection: Pick<DBConnection, 'id' | 'connection_id'> | null;
     step: number;
 }
 

--- a/packages/types/lib/gettingStarted/dto.ts
+++ b/packages/types/lib/gettingStarted/dto.ts
@@ -12,7 +12,7 @@ export interface GettingStartedOutput {
 }
 
 export interface PatchGettingStartedInput {
-    demo_connection_id?: string | undefined;
+    connection_id?: string | undefined;
     step?: number | undefined;
     complete?: boolean | undefined;
 }

--- a/packages/types/lib/gettingStarted/dto.ts
+++ b/packages/types/lib/gettingStarted/dto.ts
@@ -12,7 +12,7 @@ export interface GettingStartedOutput {
 }
 
 export interface PatchGettingStartedInput {
-    connection_id?: string | undefined;
+    connection_id?: string | null | undefined;
     step?: number | undefined;
     complete?: boolean | undefined;
 }

--- a/packages/types/lib/gettingStarted/dto.ts
+++ b/packages/types/lib/gettingStarted/dto.ts
@@ -14,5 +14,4 @@ export interface GettingStartedOutput {
 export interface PatchGettingStartedInput {
     connection_id?: string | null | undefined;
     step?: number | undefined;
-    complete?: boolean | undefined;
 }

--- a/packages/types/lib/gettingStarted/dto.ts
+++ b/packages/types/lib/gettingStarted/dto.ts
@@ -1,0 +1,18 @@
+import type { DBConnection } from '../connection/db.js';
+import type { DBEnvironment } from '../environment/db.js';
+import type { IntegrationConfig } from '../integration/db.js';
+
+export interface GettingStartedOutput {
+    meta: {
+        environment: DBEnvironment;
+        integration: IntegrationConfig;
+    };
+    connection: DBConnection | null;
+    step: number;
+}
+
+export interface PatchGettingStartedInput {
+    demo_connection_id?: string | undefined;
+    step?: number | undefined;
+    complete?: boolean | undefined;
+}

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -4,6 +4,9 @@ export type * from './api.endpoints.js';
 
 export type * from './onboarding/db.js';
 export type * from './onboarding/api.js';
+export type * from './gettingStarted/db.js';
+export type * from './gettingStarted/dto.js';
+export type * from './gettingStarted/api.js';
 export type * from './record/api.js';
 export type * from './logs/api.js';
 export type * from './logs/messages.js';

--- a/vite.integration.config.ts
+++ b/vite.integration.config.ts
@@ -17,7 +17,8 @@ export default defineConfig({
             NANGO_LOGS_ES_PREFIX: 'test',
             FLAG_PLAN_ENABLED: 'true',
             ORCHESTRATOR_SERVICE_URL: 'http://orchestrator',
-            RUNNER_NODE_ID: '1'
+            RUNNER_NODE_ID: '1',
+            FLAG_API_RATE_LIMIT_ENABLED: 'false'
         },
         fileParallelism: false,
         pool: 'forks',


### PR DESCRIPTION
> PR for Migrations: #4487 

> Long PR but a lot of it is long tests

This adds the necessary endpoints and behavior for the new getting started flow.

### The final desired flow of the getting started page
User can authenticate with Google Calendar via ConnectUI and make a proxy request with it. The integration used should belong to the account and be created automatically by default.

### What should happen behind the schemes
We create an integration with the unique key `google-calendar-getting-started`, using the `google-calendar` pre-provisioned provider (new shared credentials feature). This integration is tied to the user's account. Connections from the demo will be created in this integration. The user can navigate and see both the integration and created connections normally.

As such, we have to handle both the integration and the connection being deleted by the user. The flow needs to be ready for the scenario where the integration ceases to exist.

### My Approach
It basically all revolves around `getOrCreateX` happening to the whole dependency tree:
```
getOrCreate `getting_started_progress`
└── getOrCreate `getting_started_meta`
    └── getOrCreate `google-calendar-getting-started` integration
``` 

- User deleted the connection? That's low impact, it means we detach the connection from his `getting_started_progress`.
- User deleted the integration? In this case, both the `getting_started_meta` and `getting_started_progress`(es) attached to it are also deleted. It should all be created again if someone wants to go through the getting started flow.

### The fiddly details
Both connection and integration are deleted by soft-deletion. How I went around it:
- `getting_started_meta` shouldn't exist without an integration, so when an integration is soft-deleted, I hard delete `getting_started_meta` (which cascades to all related `getting_started_progress`(es)). I don't think it's worth adding soft-deletion to it, as it's a pain to maintain and it's not important.
- When fetching `getting-started-progress` I filter out soft-deleted `connections` when joining.

<!-- Summary by @propel-code-bot -->

---

**Implement New Backend/API Endpoints for Getting Started Onboarding Flow**

This major pull request introduces the full backend and type support for a new 'Getting Started' onboarding flow, including API endpoints, service logic, supporting migrations (requires PR #4487), and comprehensive tests. It centers around creating and managing a special onboarding integration ('google-calendar-getting-started') using preprovisioned shared credentials, tracking user onboarding progress, and handling robust lifecycle management for onboarding resources (integration, meta, progress, and associated connections).

The implementation ensures the onboarding experience is always available: if onboarding meta, progress records, or the dedicated Google Calendar integration do not exist, they will be (re)created on demand. The PR includes endpoints for fetching and updating onboarding progress, sophisticated lifecycle rules for resource deletion (including cascading cleanup for soft-deleted integrations), and extensive integration tests for all critical flows and edge cases. All API contracts, DB types, and seeding/test utilities required for this flow are included.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduces /api/v1/getting-started ``GET`` and ``PATCH`` endpoints for onboarding state
• Implements new onboarding service layer and supporting ``DB`` logic (with transactional safety and idempotency)
• Adds new tables: `getting_started_meta` and `getting_started_progress` (migrations are in a separate ``PR``)
• Automates provisioning and tying of a special `google-calendar-getting-started` integration using shared credentials
• Handles both soft and hard deletion of associated onboarding meta/progress when integration is deleted
• Ensures soft-deleted connections are filtered from onboarding progress, and detachment occurs on deletion
• Expands shared credentials service/utilities for preprovisioned provider/integration setup
• Adds and exposes all contract types, `DTOs`, and ``API`` types for new onboarding endpoints
• Includes 600+ lines of integration tests covering all onboarding scenarios and edge cases
• Updates seed utilities to streamline creation/testing of shared credentials and onboarding flows

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Server ``API`` controllers (new /getting-started endpoints, logic, and types)
• Service layer: new `gettingStartedService` and supporting `sharedCredentialsService` changes
• Database access layer: onboarding meta/progress, soft/hard deletion logic
• Types: types/lib/`gettingStarted`/*, api endpoints, integration with shared credentials
• Seeder/utilities: config and credentials creation helpers
• Test suite: new integration/controller tests for onboarding flows
• Integration deletion logic (now cascades to onboarding meta/progress)

</details>

---
*This summary was automatically generated by @propel-code-bot*