### PR TITLE
fix: better index for scheduler scheduling query

### DIFF
--- a/packages/scheduler/lib/db/migrations/20250814191100_better_scheduling_query_index.ts
+++ b/packages/scheduler/lib/db/migrations/20250814191100_better_scheduling_query_index.ts
@@ -1,0 +1,18 @@
+import type { Knex } from 'knex';
+
+import { SCHEDULES_TABLE } from '../../models/schedules.js';
+
+export const config = {
+    transaction: false
+};
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`DROP INDEX IF EXISTS "idx_schedules_scheduling";`);
+    await knex.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_schedules_ready_for_execution
+        ON ${SCHEDULES_TABLE} (next_execution_at)
+        WHERE state = 'STARTED';`
+    );
+}
+
+export async function down(): Promise<void> {}


### PR DESCRIPTION
Current index idx_schedules_scheduling is not being used by pg.
```
LockRows  (cost=0.00..11972.65 rows=18370 width=442)
  Output: id, name, state, starts_at, frequency, payload, created_at, updated_at, deleted_at, group_key, retry_max, created_to_started_timeout_secs, started_to_completed_timeout_secs, heartbeat_timeout_secs, last_scheduled_task_id, last_scheduled_task_state, next_execution_at, ctid
  ->  Seq Scan on nango_scheduler.schedules  (cost=0.00..11788.95 rows=18370 width=442)
        Output: id, name, state, starts_at, frequency, payload, created_at, updated_at, deleted_at, group_key, retry_max, created_to_started_timeout_secs, started_to_completed_timeout_secs, heartbeat_timeout_secs, last_scheduled_task_id, last_scheduled_task_state, next_execution_at, ctid
        Filter: (((schedules.last_scheduled_task_state <> ALL ('{CREATED,STARTED}'::nango_scheduler.task_states[])) OR (schedules.last_scheduled_task_state IS NULL)) AND (schedules.state = 'STARTED'::nango_scheduler.schedule_states) AND (schedules.starts_at <= CURRENT_TIMESTAMP) AND (schedules.next_execution_at <= CURRENT_TIMESTAMP))
Query Identifier: -4104018019564563248
```

Removing the index and adding a simpler one that is being picked up by pg It results in a 3x decrease of the tup_returned metric

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Optimize Scheduling Query Index for Scheduler**

This pull request introduces a database migration that drops the existing, ineffective 'idx_schedules_scheduling' index on the schedules table and creates a new partial index ('idx_schedules_ready_for_execution') on the 'next_execution_at' column where the schedule state is 'STARTED'. The change ensures PostgreSQL utilizes the index for relevant scheduling queries, significantly improving performance, as shown by a reported reduction in 'tup_returned' by a factor of three. The migration currently lacks a rollback implementation in the `down` function and uses raw SQL with template literals.

<details>
<summary><strong>Key Changes</strong></summary>

• Drops the unused ``idx_schedules_scheduling`` index from the schedules table.
• Creates a new partial index ``idx_schedules_ready_for_execution`` on ``next_execution_at`` for rows where state = ```STARTED```.
• Implements the index creation with ```CREATE`` ``INDEX`` ``CONCURRENTLY`` ``IF`` ``NOT`` ``EXISTS``` to reduce table lock risk during migration.
• Leaves the migration rollback (down) function empty.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Database migrations for the scheduler service
• schedules table indexes

</details>

---
*This summary was automatically generated by @propel-code-bot*