### PR TITLE
fix: sync status after runner crash

### DIFF
--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -590,6 +590,8 @@ export async function abortSync(task: TaskSyncAbort): Promise<Result<void>> {
             throw new Error(`Sync is disabled: ${task.id}`);
         }
 
+        await updateSyncJobStatus(syncJob.id, SyncStatus.STOPPED);
+
         const getEndUser = await getEndUserByConnectionId(db.knex, { connectionId: task.connection.id });
 
         const isCancel = task.abortedTask.state === 'CANCELLED';

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -93,7 +93,7 @@ const syncSchema = z.object({
     ...commonSchemaFields,
     payload: syncArgsSchema
 });
-const syncAbortchema = z.object({
+const syncAbortschema = z.object({
     ...commonSchemaFields,
     payload: syncAbortArgsSchema
 });
@@ -133,7 +133,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
             })
         );
     }
-    const syncAbort = syncAbortchema.safeParse(task);
+    const syncAbort = syncAbortschema.safeParse(task);
     if (syncAbort.success) {
         return Ok(
             TaskSyncAbort({

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -93,7 +93,7 @@ const syncSchema = z.object({
     ...commonSchemaFields,
     payload: syncArgsSchema
 });
-const syncAbortschema = z.object({
+const syncAbortSchema = z.object({
     ...commonSchemaFields,
     payload: syncAbortArgsSchema
 });
@@ -133,7 +133,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
             })
         );
     }
-    const syncAbort = syncAbortschema.safeParse(task);
+    const syncAbort = syncAbortSchema.safeParse(task);
     if (syncAbort.success) {
         return Ok(
             TaskSyncAbort({


### PR DESCRIPTION
We were not updating the sync status when a sync was aborted. 
It does work correctly for manual cancellation because in this case the runner is actually returning a failed task but when a task is expired after a runner crash, there is no failed task returned by the runner and the syncJob status is never updated.
In all case we should update the syncJob status when a sync is aborted.

One day I will tackle a refactoring of the syncJob table so we don't have to keep the status in-sync, but for now I am just fixing the bug.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Ensure Sync Status Is Updated After Runner Crash or Aborted Sync**

This PR fixes a bug where the sync job status was not updated when a sync was aborted due to a runner crash or task expiration. Previously, only manual cancellations (where the runner returned a failed task) updated the syncJob status correctly; other abort scenarios resulted in stale job status. The core fix ensures the syncJob status is updated to 'STOPPED' in all abort cases, improving consistency. Additionally, error handling in task abortion logic was strengthened and a schema naming typo was corrected in the validation logic.

<details>
<summary><strong>Key Changes</strong></summary>

• Force update of `syncJob` status to ```STOPPED``` for all sync aborts (including those caused by runner crashes) in packages/jobs/lib/execution/sync.ts.
• Wrap abort runner operation in a try/catch block and improve error reporting in packages/jobs/lib/execution/operations/abort.ts.
• Correct typo in schema name: `syncAbortchema` → `syncAbortSchema` and update all related references in packages/orchestrator/lib/clients/validate.ts.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/jobs/lib/execution/sync.ts
• packages/jobs/lib/execution/operations/abort.ts
• packages/orchestrator/lib/clients/validate.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*