### PR TITLE
feat(rate-limit): separate rate limit buckets for scripts and direct calls

### DIFF
--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -76,6 +76,7 @@ export class Nango {
     providerConfigKey?: string;
     isSync = false;
     dryRun = false;
+    isScript = false;
     activityLogId?: string | undefined;
     userAgent: string;
     http: AxiosInstance;
@@ -104,6 +105,10 @@ export class Nango {
 
         if (config.isSync) {
             this.isSync = config.isSync;
+        }
+
+        if (config.isScript) {
+            this.isScript = config.isScript;
         }
 
         if (config.dryRun) {
@@ -348,10 +353,7 @@ export class Nango {
             throw new Error('Connection Id is required');
         }
 
-        const response = await this.getConnectionDetails(providerConfigKey, connectionId, false, false, {
-            'Nango-Is-Sync': true,
-            'Nango-Is-Dry-Run': this.dryRun
-        });
+        const response = await this.getConnectionDetails(providerConfigKey, connectionId, false, false);
 
         return response.data.metadata as T;
     }
@@ -881,8 +883,6 @@ export class Nango {
             'Connection-Id': connectionId!,
             'Provider-Config-Key': providerConfigKey!,
             'Base-Url-Override': baseUrlOverride || '',
-            'Nango-Is-Sync': this.isSync,
-            'Nango-Is-Dry-Run': this.dryRun,
             'Nango-Activity-Log-Id': this.activityLogId || '',
             ...customPrefixedHeaders
         };
@@ -1063,9 +1063,7 @@ export class Nango {
         const url = `${this.serverUrl}/connection/${connectionId}`;
 
         const headers = {
-            'Content-Type': 'application/json',
-            'Nango-Is-Sync': this.isSync,
-            'Nango-Is-Dry-Run': this.dryRun
+            'Content-Type': 'application/json'
         };
 
         if (additionalHeader) {
@@ -1082,12 +1080,15 @@ export class Nango {
     }
 
     /**
-     * Enriches the headers with the Authorization token
+     * Enriches the headers with the Authorization token and internal flags
      * @param headers - Optional. The headers to enrich
      * @returns The enriched headers
      */
     private enrichHeaders(headers: Record<string, string | number | boolean> = {}): Record<string, string | number | boolean> {
         headers['Authorization'] = 'Bearer ' + this.secretKey;
+        headers['Nango-Is-Sync'] = this.isSync;
+        headers['Nango-Is-Script'] = this.isScript;
+        headers['Nango-Is-Dry-Run'] = this.dryRun;
 
         return headers;
     }

--- a/packages/node-client/lib/types.ts
+++ b/packages/node-client/lib/types.ts
@@ -106,6 +106,7 @@ export interface NangoProps {
     providerConfigKey?: string;
     isSync?: boolean;
     dryRun?: boolean;
+    isScript?: boolean;
     activityLogId?: string | undefined;
 }
 

--- a/packages/runner/lib/exec.unit.test.ts
+++ b/packages/runner/lib/exec.unit.test.ts
@@ -281,6 +281,7 @@ describe('Exec', () => {
                             'Content-Type': 'application/json',
                             'Nango-Is-Dry-Run': 'true',
                             'Nango-Is-Sync': 'true',
+                            'Nango-Is-Script': 'true',
                             'User-Agent': expect.any(String)
                         },
                         maxBodyLength: -1,

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -41,7 +41,12 @@ export class NangoActionRunner extends NangoActionBase<never, Record<string, str
         this.locking = new Locking({ locks: runnerProps.locks, owner: this.activityLogId });
 
         this.nango = new Nango(
-            { isSync: false, dryRun: isTest, ...props },
+            {
+                isScript: true,
+                isSync: false,
+                dryRun: isTest,
+                ...props
+            },
             {
                 interceptors: {
                     request: (config) => {
@@ -269,7 +274,12 @@ export class NangoSyncRunner extends NangoSyncBase {
         this.locking = new Locking({ locks: runnerProps.locks, owner: this.activityLogId });
 
         this.nango = new Nango(
-            { isSync: true, dryRun: isTest, ...props },
+            {
+                isScript: true,
+                isSync: true,
+                dryRun: isTest,
+                ...props
+            },
             {
                 interceptors: {
                     request: (config) => {


### PR DESCRIPTION
Add isScript flag to node client and use it to differentiate rate limiting buckets between script executions and regular customers API calls. 
The objective is to ensure direct requests to the API are not consuming the same rate-limit as scripts and disturbed each other. 
When it happens it is confusing to customers where the requests come from since some requests from the scripts are done by the sdk.

I went for the simplest solution, using a header. The system can be abused of course but there is still a limit which is the most important (no unbounded number of requests). 
Worse case scenario, with this commit we are allowing twice the number of requests.

Both rate-limit buckets have the same size for now. We can make them have different size in the future if needs arises

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Separate Rate Limit Buckets for Scripts and Direct API Calls**

This PR introduces differentiated rate limiting for API requests originating from scripts (via the SDK) and direct customer API calls. By incorporating a new `isScript` flag into the node client, SDK, and request headers, script-based traffic is identified and assigned to a separate rate-limit bucket on the server side. The server's rate-limiter middleware detects the `Nango-Is-Script` HTTP header and applies isolated quotas, preventing script traffic from consuming customer quotas and reducing customer confusion regarding quota consumption.

<details>
<summary><strong>Key Changes</strong></summary>

• Added ``isScript`` flag to node client configuration and `NangoProps` interface.
• Updated ``SDK`` initialization to always set ``isScript`` true for script/runner contexts.
• Centralized internal request flag and authentication header addition in ``enrichHeaders`` method.
• Node client automatically attaches the `Nango-Is-Script` header to relevant requests.
• Server-side rate-limiting middleware now checks `Nango-Is-Script` header to maintain separate rate-limiting buckets (one for scripts, one for direct customer/``SDK`` calls).
• Updated affected unit tests to expect and validate the presence of the new header.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/node-client/lib/index.ts (client header logic, flag propagation)
• packages/node-client/lib/types.ts (`NangoProps` definition)
• packages/runner/lib/sdk/sdk.ts (``SDK``/script context initialization)
• packages/server/lib/middleware/ratelimit.middleware.ts (rate-limit key derivation)
• packages/runner/lib/exec.unit.test.ts (header expectations)

</details>

---
*This summary was automatically generated by @propel-code-bot*