### PR TITLE
fix(docs): fix symlinks for docs if the scripts are an alias

### DIFF
--- a/scripts/docs-gen-snippets.ts
+++ b/scripts/docs-gen-snippets.ts
@@ -33,7 +33,10 @@ for (const flow of flows) {
     const integration = flow.providerConfigKey;
     const actions = flow.actions;
     const syncs = flow.syncs;
-    useCases[integration] = buildEndpoints('action', actions, integration).concat(buildEndpoints('sync', syncs, integration));
+    const symLinkTargetName = flow.symLinkTargetName;
+    useCases[integration] = buildEndpoints('action', actions, integration, symLinkTargetName).concat(
+        buildEndpoints('sync', syncs, integration, symLinkTargetName)
+    );
 }
 
 const providersHandled: string[] = [];
@@ -214,7 +217,7 @@ interface Endpoint {
     script: string;
 }
 
-function buildEndpoints(type: string, syncOrAction: any, integration: string) {
+function buildEndpoints(type: string, syncOrAction: any, integration: string, symLinkTargetName: string | null) {
     const endpoints: Endpoint[] = [];
     if (syncOrAction) {
         for (const item of syncOrAction) {
@@ -230,7 +233,7 @@ function buildEndpoints(type: string, syncOrAction: any, integration: string) {
                     path: endpoint?.path,
                     description: item?.description?.trim(),
                     group: endpoint?.group,
-                    script: `${integration}/${type}s/${item.name}`
+                    script: `${integration}/${type}s/${symLinkTargetName || item.name}`
                 });
             }
         }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Depends on https://github.com/NangoHQ/integration-templates/pull/391

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the docs generation script to handle cases where script names are aliases, ensuring that symbolic link (symlink) targets are correctly referenced in generated documentation. The update modifies the path-building logic for script references in generated docs so that it considers an optional symLinkTargetName, allowing provider aliases to resolve to the correct integration script paths.

*This summary was automatically generated by @propel-code-bot*