### PR TITLE
fix(docs): actually write docupdates

### DIFF
--- a/docs-v2/snippets/generated/airtable-pat/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/airtable-pat/PreBuiltUseCases.mdx
@@ -7,24 +7,24 @@
 <Accordion title="Users">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /whoami` | Fetch current user information | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/airtable-pat/actions/whoami.md) |
+| `GET /whoami` | Fetch current user information | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/airtable/actions/whoami.md) |
 </Accordion>
 
 
 <Accordion title="Webhooks">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /webhooks` | Create a webhook for a particular base | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/airtable-pat/actions/create-webhook.md) |
-| `GET /webhooks` | List all the webhooks available for a base | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/airtable-pat/actions/list-webhooks.md) |
-| `DELETE /webhooks` | Delete a webhook | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/airtable-pat/actions/delete-webhook.md) |
+| `POST /webhooks` | Create a webhook for a particular base | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/airtable/actions/create-webhook.md) |
+| `GET /webhooks` | List all the webhooks available for a base | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/airtable/actions/list-webhooks.md) |
+| `DELETE /webhooks` | Delete a webhook | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/airtable/actions/delete-webhook.md) |
 </Accordion>
 
 
 <Accordion title="Others">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /tables` | Lists all tables with their schema for all bases with a reference to the base id that<br />the table belongs to | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/airtable-pat/syncs/tables.md) |
-| `GET /bases` | List all bases | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/airtable-pat/syncs/bases.md) |
+| `GET /tables` | Lists all tables with their schema for all bases with a reference to the base id that<br />the table belongs to | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/airtable/syncs/tables.md) |
+| `GET /bases` | List all bases | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/airtable/syncs/bases.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/avalara-sandbox/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/avalara-sandbox/PreBuiltUseCases.mdx
@@ -7,10 +7,10 @@
 <Accordion title="Transactions">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /transactions` | Creates a new transaction | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/avalara-sandbox/actions/create-transaction.md) |
-| `PUT /transactions` | Marks a transaction by changing its status to Committed | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/avalara-sandbox/actions/commit-transaction.md) |
-| `DELETE /transactions` | Voids the current transaction uniquely identified by the transactionCode | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/avalara-sandbox/actions/void-transaction.md) |
-| `GET /transactions` | List all transactions with a default backfill date of one year. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/avalara-sandbox/syncs/transactions.md) |
+| `POST /transactions` | Creates a new transaction | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/avalara/actions/create-transaction.md) |
+| `PUT /transactions` | Marks a transaction by changing its status to Committed | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/avalara/actions/commit-transaction.md) |
+| `DELETE /transactions` | Voids the current transaction uniquely identified by the transactionCode | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/avalara/actions/void-transaction.md) |
+| `GET /transactions` | List all transactions with a default backfill date of one year. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/avalara/syncs/transactions.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/bill-sandbox/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/bill-sandbox/PreBuiltUseCases.mdx
@@ -7,9 +7,9 @@
 <Accordion title="Users">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /users` | Creates a user in Bill. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/bill-sandbox/actions/create-user.md) |
-| `DELETE /users` | Archive an existing user in Bill | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/bill-sandbox/actions/disable-user.md) |
-| `GET /users` | Fetches a list of users from Bill sandbox | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/bill-sandbox/syncs/users.md) |
+| `POST /users` | Creates a user in Bill. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/bill/actions/create-user.md) |
+| `DELETE /users` | Archive an existing user in Bill | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/bill/actions/disable-user.md) |
+| `GET /users` | Fetches a list of users from Bill sandbox | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/bill/syncs/users.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/dialpad-sandbox/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/dialpad-sandbox/PreBuiltUseCases.mdx
@@ -7,9 +7,9 @@
 <Accordion title="Users">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /users` | Creates a user in Dialpad | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/dialpad-sandbox/actions/create-user.md) |
-| `DELETE /users/email` | Deletes a user in Dialpad by email | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/dialpad-sandbox/actions/delete-user.md) |
-| `GET /users` | Fetches a list of users from Dialpad | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/dialpad-sandbox/syncs/users.md) |
+| `POST /users` | Creates a user in Dialpad | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/dialpad/actions/create-user.md) |
+| `DELETE /users/email` | Deletes a user in Dialpad by email | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/dialpad/actions/delete-user.md) |
+| `GET /users` | Fetches a list of users from Dialpad | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/dialpad/syncs/users.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/docusign-sandbox/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/docusign-sandbox/PreBuiltUseCases.mdx
@@ -7,9 +7,9 @@
 <Accordion title="Users">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /users` | Creates a user in DocuSign | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/docusign-sandbox/actions/create-user.md) |
-| `DELETE /users` | Deletes a user in DocuSign | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/docusign-sandbox/actions/delete-user.md) |
-| `GET /users` | Fetches a list of users from DocuSign | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/docusign-sandbox/syncs/users.md) |
+| `POST /users` | Creates a user in DocuSign | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/docusign/actions/create-user.md) |
+| `DELETE /users` | Deletes a user in DocuSign | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/docusign/actions/delete-user.md) |
+| `GET /users` | Fetches a list of users from DocuSign | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/docusign/syncs/users.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/github-app-oauth/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/github-app-oauth/PreBuiltUseCases.mdx
@@ -7,21 +7,21 @@
 <Accordion title="Commits">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /commits` | Get all pull commits from a Github repository. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/github-app-oauth/syncs/commits.md) |
+| `GET /commits` | Get all pull commits from a Github repository. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/github-app/syncs/commits.md) |
 </Accordion>
 
 
 <Accordion title="Pull Requests">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /pull-requests` | Get all pull requests from a Github repository. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/github-app-oauth/syncs/pull-requests.md) |
+| `GET /pull-requests` | Get all pull requests from a Github repository. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/github-app/syncs/pull-requests.md) |
 </Accordion>
 
 
 <Accordion title="Repositories">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /repositories` | List all repositories accessible to this Github App | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/github-app-oauth/actions/repositories.md) |
+| `GET /repositories` | List all repositories accessible to this Github App | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/github-app/actions/repositories.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/gong-oauth/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/gong-oauth/PreBuiltUseCases.mdx
@@ -7,16 +7,16 @@
 <Accordion title="Calls">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /fetch-call-transcripts` | Fetches a list of call transcripts from Gong | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gong-oauth/actions/fetch-call-transcripts.md) |
-| `GET /calls` | Fetches a list of calls from Gong | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gong-oauth/syncs/calls.md) |
-| `GET /call-transcripts` | Fetches a list of call transcripts from Gong | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gong-oauth/syncs/call-transcripts.md) |
+| `GET /fetch-call-transcripts` | Fetches a list of call transcripts from Gong | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gong/actions/fetch-call-transcripts.md) |
+| `GET /calls` | Fetches a list of calls from Gong | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gong/syncs/calls.md) |
+| `GET /call-transcripts` | Fetches a list of call transcripts from Gong | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gong/syncs/call-transcripts.md) |
 </Accordion>
 
 
 <Accordion title="Users">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /users` | Fetches the list of gong users | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gong-oauth/syncs/users.md) |
+| `GET /users` | Fetches the list of gong users | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gong/syncs/users.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/gorgias-basic/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/gorgias-basic/PreBuiltUseCases.mdx
@@ -7,17 +7,17 @@
 <Accordion title="Tickets">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /ticket` | Creates a new ticket | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gorgias-basic/actions/create-ticket.md) |
-| `GET /tickets` | Fetches a list of tickets with their associated messages | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gorgias-basic/syncs/tickets.md) |
+| `POST /ticket` | Creates a new ticket | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gorgias/actions/create-ticket.md) |
+| `GET /tickets` | Fetches a list of tickets with their associated messages | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gorgias/syncs/tickets.md) |
 </Accordion>
 
 
 <Accordion title="Users">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /users` | Creates a new user with a role in Gorgias. Defaults to agent if a role is not provided | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gorgias-basic/actions/create-user.md) |
-| `DELETE /users` | Deletes a user in Gorgias | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gorgias-basic/actions/delete-user.md) |
-| `GET /users` | Fetches the list of users | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gorgias-basic/syncs/users.md) |
+| `POST /users` | Creates a new user with a role in Gorgias. Defaults to agent if a role is not provided | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gorgias/actions/create-user.md) |
+| `DELETE /users` | Deletes a user in Gorgias | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gorgias/actions/delete-user.md) |
+| `GET /users` | Fetches the list of users | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gorgias/syncs/users.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/greenhouse/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/greenhouse/PreBuiltUseCases.mdx
@@ -7,9 +7,9 @@
 <Accordion title="Others">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /greenhouse-basic/applications` | Fetches a list of all organization's applications from greenhouse | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/greenhouse/syncs/applications.md) |
-| `GET /greenhouse-basic/candidates` | Fetches a list of all organization's candidates from greenhouse | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/greenhouse/syncs/candidates.md) |
-| `GET /greenhouse-basic/jobs` | Fetches a list of all organization's jobs from greenhouse | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/greenhouse/syncs/jobs.md) |
+| `GET /greenhouse-basic/applications` | Fetches a list of all organization's applications from greenhouse | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/greenhouse-basic/syncs/applications.md) |
+| `GET /greenhouse-basic/candidates` | Fetches a list of all organization's candidates from greenhouse | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/greenhouse-basic/syncs/candidates.md) |
+| `GET /greenhouse-basic/jobs` | Fetches a list of all organization's jobs from greenhouse | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/greenhouse-basic/syncs/jobs.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/gusto-demo/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/gusto-demo/PreBuiltUseCases.mdx
@@ -7,17 +7,17 @@
 <Accordion title="Employees">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /employees` | Creates an employee in Gusto. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gusto-demo/actions/create-employee.md) |
-| `PUT /employees` | Updates an employee in Gusto. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gusto-demo/actions/update-employee.md) |
-| `DELETE /employees` | Terminates an employee in Gusto. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gusto-demo/actions/terminate-employee.md) |
-| `GET /employees` | Fetches all employees from Gusto | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gusto-demo/syncs/employees.md) |
+| `POST /employees` | Creates an employee in Gusto. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gusto/actions/create-employee.md) |
+| `PUT /employees` | Updates an employee in Gusto. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gusto/actions/update-employee.md) |
+| `DELETE /employees` | Terminates an employee in Gusto. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gusto/actions/terminate-employee.md) |
+| `GET /employees` | Fetches all employees from Gusto | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gusto/syncs/employees.md) |
 </Accordion>
 
 
 <Accordion title="Unified HRIS API">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /employees/unified` | Fetches all employees from Gusto and maps them to the standard HRIS model | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gusto-demo/syncs/unified-employees.md) |
+| `GET /employees/unified` | Fetches all employees from Gusto and maps them to the standard HRIS model | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/gusto/syncs/unified-employees.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/lever-basic-sandbox/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/lever-basic-sandbox/PreBuiltUseCases.mdx
@@ -7,77 +7,77 @@
 <Accordion title="Applications">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /applications` | Fetches a list of all applications for a candidate in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/syncs/opportunities-applications.md) |
+| `GET /applications` | Fetches a list of all applications for a candidate in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities-applications.md) |
 </Accordion>
 
 
 <Accordion title="Archived">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /archived/reasons` | Get all archived reasons | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/actions/get-archive-reasons.md) |
+| `GET /archived/reasons` | Get all archived reasons | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/get-archive-reasons.md) |
 </Accordion>
 
 
 <Accordion title="Notes">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /notes` | Action to create a note and add it to an opportunity. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/actions/create-note.md) |
-| `GET /notes` | Fetches a list of all notes for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/syncs/opportunities-notes.md) |
+| `POST /notes` | Action to create a note and add it to an opportunity. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/create-note.md) |
+| `GET /notes` | Fetches a list of all notes for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities-notes.md) |
 </Accordion>
 
 
 <Accordion title="Offers">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /offers` | Fetches a list of all offers for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/syncs/opportunities-offers.md) |
+| `GET /offers` | Fetches a list of all offers for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities-offers.md) |
 </Accordion>
 
 
 <Accordion title="Opportunities">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /opportunities` | Create an opportunity and optionally candidates associated with the opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/actions/create-opportunity.md) |
-| `POST /opportunities/links` | Update the links in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/actions/update-opportunity-links.md) |
-| `POST /opportunities/sources` | Update the sources in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/actions/update-opportunity-sources.md) |
-| `POST /opportunities/stages` | Update the stage in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/actions/update-opportunity-stage.md) |
-| `POST /opportunities/tags` | Update the tags in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/actions/update-opportunity-tags.md) |
-| `PUT /opportunities/archived` | Update the archived state of an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/actions/update-opportunity-archived.md) |
-| `PATCH /opportunities` | Update an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/actions/update-opportunity.md) |
-| `GET /opportunities` | Fetches all opportunities | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/syncs/opportunities.md) |
-| `GET /opportunities/feedback` | Fetches a list of all feedback forms for a candidate for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/syncs/opportunities-feedbacks.md) |
-| `GET /opportunities/interviews` | Fetches a list of all interviews for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/syncs/opportunities-interviews.md) |
+| `POST /opportunities` | Create an opportunity and optionally candidates associated with the opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/create-opportunity.md) |
+| `POST /opportunities/links` | Update the links in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity-links.md) |
+| `POST /opportunities/sources` | Update the sources in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity-sources.md) |
+| `POST /opportunities/stages` | Update the stage in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity-stage.md) |
+| `POST /opportunities/tags` | Update the tags in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity-tags.md) |
+| `PUT /opportunities/archived` | Update the archived state of an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity-archived.md) |
+| `PATCH /opportunities` | Update an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity.md) |
+| `GET /opportunities` | Fetches all opportunities | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities.md) |
+| `GET /opportunities/feedback` | Fetches a list of all feedback forms for a candidate for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities-feedbacks.md) |
+| `GET /opportunities/interviews` | Fetches a list of all interviews for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities-interviews.md) |
 </Accordion>
 
 
 <Accordion title="Postings">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /postings` | Fetches a list of all postings in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/syncs/postings.md) |
-| `GET /postings/questions` | Fetches a list of all questions included in a posting’s application form in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/syncs/postings-questions.md) |
+| `GET /postings` | Fetches a list of all postings in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/postings.md) |
+| `GET /postings/questions` | Fetches a list of all questions included in a posting’s application form in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/postings-questions.md) |
 </Accordion>
 
 
 <Accordion title="Posts">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /posts/limited` | Get all posts for your account. Note that this does<br />not paginate the response so it is possible that not all postings <br />are returned. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/actions/get-postings.md) |
-| `GET /posts/single` | Get single post for your account in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/actions/get-posting.md) |
-| `POST /posts/apply` | Submit an application on behalf of a candidate. This endpoint can only be used to submit applications to published or unlisted postings. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/actions/apply-posting.md) |
+| `GET /posts/limited` | Get all posts for your account. Note that this does<br />not paginate the response so it is possible that not all postings <br />are returned. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/get-postings.md) |
+| `GET /posts/single` | Get single post for your account in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/get-posting.md) |
+| `POST /posts/apply` | Submit an application on behalf of a candidate. This endpoint can only be used to submit applications to published or unlisted postings. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/apply-posting.md) |
 </Accordion>
 
 
 <Accordion title="Stages">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /stages/limited` | Action to get lists all pipeline stages. Note that this does <br />not paginate the response so it is possible that not all stages <br />are returned. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/actions/get-stages.md) |
-| `GET /stages` | Fetches a list of all pipeline stages in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/syncs/stages.md) |
+| `GET /stages/limited` | Action to get lists all pipeline stages. Note that this does <br />not paginate the response so it is possible that not all stages <br />are returned. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/get-stages.md) |
+| `GET /stages` | Fetches a list of all pipeline stages in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/stages.md) |
 </Accordion>
 
 
 <Accordion title="Users">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /users` | Lists all the users in your Lever account. Only active users are included by default. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic-sandbox/actions/users.md) |
+| `GET /users` | Lists all the users in your Lever account. Only active users are included by default. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/users.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/lever-basic/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/lever-basic/PreBuiltUseCases.mdx
@@ -7,77 +7,77 @@
 <Accordion title="Applications">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /applications` | Fetches a list of all applications for a candidate in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/syncs/opportunities-applications.md) |
+| `GET /applications` | Fetches a list of all applications for a candidate in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities-applications.md) |
 </Accordion>
 
 
 <Accordion title="Archived">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /archived/reasons` | Get all archived reasons | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/actions/get-archive-reasons.md) |
+| `GET /archived/reasons` | Get all archived reasons | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/get-archive-reasons.md) |
 </Accordion>
 
 
 <Accordion title="Notes">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /notes` | Action to create a note and add it to an opportunity. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/actions/create-note.md) |
-| `GET /notes` | Fetches a list of all notes for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/syncs/opportunities-notes.md) |
+| `POST /notes` | Action to create a note and add it to an opportunity. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/create-note.md) |
+| `GET /notes` | Fetches a list of all notes for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities-notes.md) |
 </Accordion>
 
 
 <Accordion title="Offers">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /offers` | Fetches a list of all offers for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/syncs/opportunities-offers.md) |
+| `GET /offers` | Fetches a list of all offers for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities-offers.md) |
 </Accordion>
 
 
 <Accordion title="Opportunities">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /opportunities` | Create an opportunity and optionally candidates associated with the opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/actions/create-opportunity.md) |
-| `POST /opportunities/links` | Update the links in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/actions/update-opportunity-links.md) |
-| `POST /opportunities/sources` | Update the sources in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/actions/update-opportunity-sources.md) |
-| `POST /opportunities/stages` | Update the stage in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/actions/update-opportunity-stage.md) |
-| `POST /opportunities/tags` | Update the tags in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/actions/update-opportunity-tags.md) |
-| `PUT /opportunities/archived` | Update the archived state of an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/actions/update-opportunity-archived.md) |
-| `PATCH /opportunities` | Update an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/actions/update-opportunity.md) |
-| `GET /opportunities` | Fetches all opportunities | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/syncs/opportunities.md) |
-| `GET /opportunities/feedback` | Fetches a list of all feedback forms for a candidate for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/syncs/opportunities-feedbacks.md) |
-| `GET /opportunities/interviews` | Fetches a list of all interviews for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/syncs/opportunities-interviews.md) |
+| `POST /opportunities` | Create an opportunity and optionally candidates associated with the opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/create-opportunity.md) |
+| `POST /opportunities/links` | Update the links in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity-links.md) |
+| `POST /opportunities/sources` | Update the sources in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity-sources.md) |
+| `POST /opportunities/stages` | Update the stage in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity-stage.md) |
+| `POST /opportunities/tags` | Update the tags in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity-tags.md) |
+| `PUT /opportunities/archived` | Update the archived state of an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity-archived.md) |
+| `PATCH /opportunities` | Update an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity.md) |
+| `GET /opportunities` | Fetches all opportunities | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities.md) |
+| `GET /opportunities/feedback` | Fetches a list of all feedback forms for a candidate for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities-feedbacks.md) |
+| `GET /opportunities/interviews` | Fetches a list of all interviews for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities-interviews.md) |
 </Accordion>
 
 
 <Accordion title="Postings">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /postings` | Fetches a list of all postings in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/syncs/postings.md) |
-| `GET /postings/questions` | Fetches a list of all questions included in a posting’s application form in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/syncs/postings-questions.md) |
+| `GET /postings` | Fetches a list of all postings in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/postings.md) |
+| `GET /postings/questions` | Fetches a list of all questions included in a posting’s application form in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/postings-questions.md) |
 </Accordion>
 
 
 <Accordion title="Posts">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /posts/limited` | Get all posts for your account. Note that this does<br />not paginate the response so it is possible that not all postings <br />are returned. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/actions/get-postings.md) |
-| `GET /posts/single` | Get single post for your account in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/actions/get-posting.md) |
-| `POST /posts/apply` | Submit an application on behalf of a candidate. This endpoint can only be used to submit applications to published or unlisted postings. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/actions/apply-posting.md) |
+| `GET /posts/limited` | Get all posts for your account. Note that this does<br />not paginate the response so it is possible that not all postings <br />are returned. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/get-postings.md) |
+| `GET /posts/single` | Get single post for your account in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/get-posting.md) |
+| `POST /posts/apply` | Submit an application on behalf of a candidate. This endpoint can only be used to submit applications to published or unlisted postings. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/apply-posting.md) |
 </Accordion>
 
 
 <Accordion title="Stages">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /stages/limited` | Action to get lists all pipeline stages. Note that this does <br />not paginate the response so it is possible that not all stages <br />are returned. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/actions/get-stages.md) |
-| `GET /stages` | Fetches a list of all pipeline stages in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/syncs/stages.md) |
+| `GET /stages/limited` | Action to get lists all pipeline stages. Note that this does <br />not paginate the response so it is possible that not all stages <br />are returned. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/get-stages.md) |
+| `GET /stages` | Fetches a list of all pipeline stages in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/stages.md) |
 </Accordion>
 
 
 <Accordion title="Users">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /users` | Lists all the users in your Lever account. Only active users are included by default. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-basic/actions/users.md) |
+| `GET /users` | Lists all the users in your Lever account. Only active users are included by default. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/users.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/lever-sandbox/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/lever-sandbox/PreBuiltUseCases.mdx
@@ -7,77 +7,77 @@
 <Accordion title="Applications">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /applications` | Fetches a list of all applications for a candidate in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/syncs/opportunities-applications.md) |
+| `GET /applications` | Fetches a list of all applications for a candidate in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities-applications.md) |
 </Accordion>
 
 
 <Accordion title="Archived">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /archived/reasons` | Get all archived reasons | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/actions/get-archive-reasons.md) |
+| `GET /archived/reasons` | Get all archived reasons | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/get-archive-reasons.md) |
 </Accordion>
 
 
 <Accordion title="Notes">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /notes` | Action to create a note and add it to an opportunity. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/actions/create-note.md) |
-| `GET /notes` | Fetches a list of all notes for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/syncs/opportunities-notes.md) |
+| `POST /notes` | Action to create a note and add it to an opportunity. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/create-note.md) |
+| `GET /notes` | Fetches a list of all notes for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities-notes.md) |
 </Accordion>
 
 
 <Accordion title="Offers">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /offers` | Fetches a list of all offers for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/syncs/opportunities-offers.md) |
+| `GET /offers` | Fetches a list of all offers for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities-offers.md) |
 </Accordion>
 
 
 <Accordion title="Opportunities">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /opportunities` | Create an opportunity and optionally candidates associated with the opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/actions/create-opportunity.md) |
-| `POST /opportunities/links` | Update the links in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/actions/update-opportunity-links.md) |
-| `POST /opportunities/sources` | Update the sources in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/actions/update-opportunity-sources.md) |
-| `POST /opportunities/stages` | Update the stage in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/actions/update-opportunity-stage.md) |
-| `POST /opportunities/tags` | Update the tags in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/actions/update-opportunity-tags.md) |
-| `PUT /opportunities/archived` | Update the archived state of an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/actions/update-opportunity-archived.md) |
-| `PATCH /opportunities` | Update an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/actions/update-opportunity.md) |
-| `GET /opportunities` | Fetches all opportunities | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/syncs/opportunities.md) |
-| `GET /opportunities/feedback` | Fetches a list of all feedback forms for a candidate for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/syncs/opportunities-feedbacks.md) |
-| `GET /opportunities/interviews` | Fetches a list of all interviews for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/syncs/opportunities-interviews.md) |
+| `POST /opportunities` | Create an opportunity and optionally candidates associated with the opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/create-opportunity.md) |
+| `POST /opportunities/links` | Update the links in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity-links.md) |
+| `POST /opportunities/sources` | Update the sources in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity-sources.md) |
+| `POST /opportunities/stages` | Update the stage in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity-stage.md) |
+| `POST /opportunities/tags` | Update the tags in an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity-tags.md) |
+| `PUT /opportunities/archived` | Update the archived state of an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity-archived.md) |
+| `PATCH /opportunities` | Update an opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/update-opportunity.md) |
+| `GET /opportunities` | Fetches all opportunities | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities.md) |
+| `GET /opportunities/feedback` | Fetches a list of all feedback forms for a candidate for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities-feedbacks.md) |
+| `GET /opportunities/interviews` | Fetches a list of all interviews for every single opportunity | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/opportunities-interviews.md) |
 </Accordion>
 
 
 <Accordion title="Postings">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /postings` | Fetches a list of all postings in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/syncs/postings.md) |
-| `GET /postings/questions` | Fetches a list of all questions included in a posting’s application form in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/syncs/postings-questions.md) |
+| `GET /postings` | Fetches a list of all postings in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/postings.md) |
+| `GET /postings/questions` | Fetches a list of all questions included in a posting’s application form in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/postings-questions.md) |
 </Accordion>
 
 
 <Accordion title="Posts">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /posts/limited` | Get all posts for your account. Note that this does<br />not paginate the response so it is possible that not all postings <br />are returned. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/actions/get-postings.md) |
-| `GET /posts/single` | Get single post for your account in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/actions/get-posting.md) |
-| `POST /posts/apply` | Submit an application on behalf of a candidate. This endpoint can only be used to submit applications to published or unlisted postings. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/actions/apply-posting.md) |
+| `GET /posts/limited` | Get all posts for your account. Note that this does<br />not paginate the response so it is possible that not all postings <br />are returned. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/get-postings.md) |
+| `GET /posts/single` | Get single post for your account in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/get-posting.md) |
+| `POST /posts/apply` | Submit an application on behalf of a candidate. This endpoint can only be used to submit applications to published or unlisted postings. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/apply-posting.md) |
 </Accordion>
 
 
 <Accordion title="Stages">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /stages/limited` | Action to get lists all pipeline stages. Note that this does <br />not paginate the response so it is possible that not all stages <br />are returned. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/actions/get-stages.md) |
-| `GET /stages` | Fetches a list of all pipeline stages in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/syncs/stages.md) |
+| `GET /stages/limited` | Action to get lists all pipeline stages. Note that this does <br />not paginate the response so it is possible that not all stages <br />are returned. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/get-stages.md) |
+| `GET /stages` | Fetches a list of all pipeline stages in Lever | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/syncs/stages.md) |
 </Accordion>
 
 
 <Accordion title="Users">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /users` | Lists all the users in your Lever account. Only active users are included by default. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever-sandbox/actions/users.md) |
+| `GET /users` | Lists all the users in your Lever account. Only active users are included by default. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/lever/actions/users.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/okta-preview/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/okta-preview/PreBuiltUseCases.mdx
@@ -7,23 +7,23 @@
 <Accordion title="User Groups">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `PUT /user-groups` | Assigns a user to a group with the OKTA_GROUP type | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/okta-preview/actions/add-user-group.md) |
-| `DELETE /user-groups` | Unassigns a user from a group with the OKTA_GROUP type | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/okta-preview/actions/remove-user-group.md) |
+| `PUT /user-groups` | Assigns a user to a group with the OKTA_GROUP type | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/okta/actions/add-user-group.md) |
+| `DELETE /user-groups` | Unassigns a user from a group with the OKTA_GROUP type | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/okta/actions/remove-user-group.md) |
 </Accordion>
 
 
 <Accordion title="Users">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /users` | Creates a new user in your Okta org without credentials. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/okta-preview/actions/create-user.md) |
-| `GET /users` | Fetches lists users in your org | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/okta-preview/syncs/users.md) |
+| `POST /users` | Creates a new user in your Okta org without credentials. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/okta/actions/create-user.md) |
+| `GET /users` | Fetches lists users in your org | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/okta/syncs/users.md) |
 </Accordion>
 
 
 <Accordion title="Others">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /group` | Adds a new group with the OKTA_GROUP type to your org | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/okta-preview/actions/add-group.md) |
+| `POST /group` | Adds a new group with the OKTA_GROUP type to your org | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/okta/actions/add-group.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/quickbooks-sandbox/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/quickbooks-sandbox/PreBuiltUseCases.mdx
@@ -7,105 +7,105 @@
 <Accordion title="Accounts">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /accounts` | Creates a single account in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/actions/create-account.md) |
-| `PUT /accounts` | Updates a single account in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/actions/update-account.md) |
-| `GET /accounts` | Fetches all accounts in QuickBooks. Handles both active and archived accounts, saving or deleting them based on their status. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/syncs/accounts.md) |
+| `POST /accounts` | Creates a single account in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/actions/create-account.md) |
+| `PUT /accounts` | Updates a single account in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/actions/update-account.md) |
+| `GET /accounts` | Fetches all accounts in QuickBooks. Handles both active and archived accounts, saving or deleting them based on their status. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/syncs/accounts.md) |
 </Accordion>
 
 
 <Accordion title="Bill Payments">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /bill-payments` | Fetches all QuickBooks bill payments | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/syncs/bill-payments.md) |
+| `GET /bill-payments` | Fetches all QuickBooks bill payments | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/syncs/bill-payments.md) |
 </Accordion>
 
 
 <Accordion title="Bills">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /bills` | Creates a single bill in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/actions/create-bill.md) |
-| `GET /bills` | Fetches all QuickBooks bills | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/syncs/bills.md) |
+| `POST /bills` | Creates a single bill in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/actions/create-bill.md) |
+| `GET /bills` | Fetches all QuickBooks bills | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/syncs/bills.md) |
 </Accordion>
 
 
 <Accordion title="Credit Memos">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /credit-memos` | Creates a single credit memo in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/actions/create-credit-memo.md) |
-| `PUT /credit-memos` | Updates a single credit memo in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/actions/update-credit-memo.md) |
-| `GET /credit-memos` | Fetches all QuickBooks credit memos | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/syncs/credit-memos.md) |
+| `POST /credit-memos` | Creates a single credit memo in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/actions/create-credit-memo.md) |
+| `PUT /credit-memos` | Updates a single credit memo in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/actions/update-credit-memo.md) |
+| `GET /credit-memos` | Fetches all QuickBooks credit memos | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/syncs/credit-memos.md) |
 </Accordion>
 
 
 <Accordion title="Customers">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /customers` | Creates a single customer in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/actions/create-customer.md) |
-| `PUT /customers` | Update a single customer in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/actions/update-customer.md) |
-| `GET /customers` | Fetches all QuickBooks customers. Handles both active and archived customers, saving or deleting them based on their status. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/syncs/customers.md) |
+| `POST /customers` | Creates a single customer in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/actions/create-customer.md) |
+| `PUT /customers` | Update a single customer in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/actions/update-customer.md) |
+| `GET /customers` | Fetches all QuickBooks customers. Handles both active and archived customers, saving or deleting them based on their status. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/syncs/customers.md) |
 </Accordion>
 
 
 <Accordion title="Deposits">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /deposits` | Fetches all QuickBooks deposits | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/syncs/deposits.md) |
+| `GET /deposits` | Fetches all QuickBooks deposits | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/syncs/deposits.md) |
 </Accordion>
 
 
 <Accordion title="Invoices">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /invoices` | Creates a single invoice in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/actions/create-invoice.md) |
-| `PUT /invoices` | Updates a single invoice in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/actions/update-invoice.md) |
-| `GET /invoices` | Fetches all invoices in QuickBooks. Handles both active and voided invoices, saving or deleting them based on their status. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/syncs/invoices.md) |
+| `POST /invoices` | Creates a single invoice in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/actions/create-invoice.md) |
+| `PUT /invoices` | Updates a single invoice in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/actions/update-invoice.md) |
+| `GET /invoices` | Fetches all invoices in QuickBooks. Handles both active and voided invoices, saving or deleting them based on their status. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/syncs/invoices.md) |
 </Accordion>
 
 
 <Accordion title="Items">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /items` | Creates a single item in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/actions/create-item.md) |
-| `PUT /items` | Update a single item in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/actions/update-item.md) |
-| `GET /items` | Fetches all items in QuickBooks. Handles both active and archived items, saving or deleting them based on their status. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/syncs/items.md) |
+| `POST /items` | Creates a single item in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/actions/create-item.md) |
+| `PUT /items` | Update a single item in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/actions/update-item.md) |
+| `GET /items` | Fetches all items in QuickBooks. Handles both active and archived items, saving or deleting them based on their status. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/syncs/items.md) |
 </Accordion>
 
 
 <Accordion title="Journal Entries">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /journal-entries` | Creates a single journal entry in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/actions/create-journal-entry.md) |
-| `PUT /journal-entries` | Update a single journal entry in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/actions/update-journal-entry.md) |
-| `GET /journal-entries` | Fetch all journal entries in QuickBooks | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/syncs/journal-entries.md) |
+| `POST /journal-entries` | Creates a single journal entry in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/actions/create-journal-entry.md) |
+| `PUT /journal-entries` | Update a single journal entry in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/actions/update-journal-entry.md) |
+| `GET /journal-entries` | Fetch all journal entries in QuickBooks | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/syncs/journal-entries.md) |
 </Accordion>
 
 
 <Accordion title="Payments">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /payments` | Creates a single payment in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/actions/create-payment.md) |
-| `GET /payments` | Fetches all payments in QuickBooks. Handles both active and voided payments, saving or deleting them based on their status. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/syncs/payments.md) |
+| `POST /payments` | Creates a single payment in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/actions/create-payment.md) |
+| `GET /payments` | Fetches all payments in QuickBooks. Handles both active and voided payments, saving or deleting them based on their status. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/syncs/payments.md) |
 </Accordion>
 
 
 <Accordion title="Purchase Orders">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /purchase-orders` | Creates a single purchase order in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/actions/create-purchase-order.md) |
+| `POST /purchase-orders` | Creates a single purchase order in QuickBooks. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/actions/create-purchase-order.md) |
 </Accordion>
 
 
 <Accordion title="Purchases">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /purchases` | Fetches all QuickBooks purchases | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/syncs/purchases.md) |
+| `GET /purchases` | Fetches all QuickBooks purchases | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/syncs/purchases.md) |
 </Accordion>
 
 
 <Accordion title="Transfers">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /transfers` | Fetches all QuickBooks transfers | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks-sandbox/syncs/transfers.md) |
+| `GET /transfers` | Fetches all QuickBooks transfers | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/quickbooks/syncs/transfers.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/ramp-sandbox/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/ramp-sandbox/PreBuiltUseCases.mdx
@@ -7,9 +7,9 @@
 <Accordion title="Users">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /users` | Creates a user in Ramp | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ramp-sandbox/actions/create-user.md) |
-| `DELETE /users` | Deletes a user in Ramp by id | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ramp-sandbox/actions/disable-user.md) |
-| `GET /users` | Fetches a list of users from Ramp | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ramp-sandbox/syncs/users.md) |
+| `POST /users` | Creates a user in Ramp | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ramp/actions/create-user.md) |
+| `DELETE /users` | Deletes a user in Ramp by id | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ramp/actions/disable-user.md) |
+| `GET /users` | Fetches a list of users from Ramp | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ramp/syncs/users.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/ring-central-sandbox/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/ring-central-sandbox/PreBuiltUseCases.mdx
@@ -7,24 +7,24 @@
 <Accordion title="Company">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /account/current` | Retrieves information about the current RingCentral account/company. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ring-central-sandbox/actions/get-company-info.md) |
+| `GET /account/current` | Retrieves information about the current RingCentral account/company. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ring-central/actions/get-company-info.md) |
 </Accordion>
 
 
 <Accordion title="Contacts">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /contacts` | Creates a new external contact in RingCentral. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ring-central-sandbox/actions/create-contact.md) |
-| `GET /contacts` | Fetches the list of external contacts from RingCentral | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ring-central-sandbox/syncs/contacts.md) |
+| `POST /contacts` | Creates a new external contact in RingCentral. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ring-central/actions/create-contact.md) |
+| `GET /contacts` | Fetches the list of external contacts from RingCentral | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ring-central/syncs/contacts.md) |
 </Accordion>
 
 
 <Accordion title="Users">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /users` | Creates a user in RingCentral | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ring-central-sandbox/actions/create-user.md) |
-| `DELETE /users` | Deletes a user in RingCentral | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ring-central-sandbox/actions/delete-user.md) |
-| `GET /users` | Fetches the list of users from RingCentral | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ring-central-sandbox/syncs/users.md) |
+| `POST /users` | Creates a user in RingCentral | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ring-central/actions/create-user.md) |
+| `DELETE /users` | Deletes a user in RingCentral | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ring-central/actions/delete-user.md) |
+| `GET /users` | Fetches the list of users from RingCentral | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/ring-central/syncs/users.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/salesforce-sandbox/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/salesforce-sandbox/PreBuiltUseCases.mdx
@@ -7,56 +7,56 @@
 <Accordion title="Accounts">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /accounts` | Create a single account in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/actions/create-account.md) |
-| `PATCH /accounts` | Update a single account in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/actions/update-account.md) |
-| `DELETE /accounts` | Delete a single account in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/actions/delete-account.md) |
-| `GET /accounts` | Fetches a list of accounts from salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/syncs/accounts.md) |
+| `POST /accounts` | Create a single account in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/actions/create-account.md) |
+| `PATCH /accounts` | Update a single account in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/actions/update-account.md) |
+| `DELETE /accounts` | Delete a single account in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/actions/delete-account.md) |
+| `GET /accounts` | Fetches a list of accounts from salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/syncs/accounts.md) |
 </Accordion>
 
 
 <Accordion title="Contacts">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /contacts` | Create a single contact in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/actions/create-contact.md) |
-| `PATCH /contacts` | Update a single contact in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/actions/update-contact.md) |
-| `DELETE /contacts` | Delete a single contact in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/actions/delete-contact.md) |
-| `GET /contacts` | Fetches a list of contacts from salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/syncs/contacts.md) |
+| `POST /contacts` | Create a single contact in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/actions/create-contact.md) |
+| `PATCH /contacts` | Update a single contact in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/actions/update-contact.md) |
+| `DELETE /contacts` | Delete a single contact in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/actions/delete-contact.md) |
+| `GET /contacts` | Fetches a list of contacts from salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/syncs/contacts.md) |
 </Accordion>
 
 
 <Accordion title="Leads">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /leads` | Create a single lead in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/actions/create-lead.md) |
-| `PATCH /leads` | Update a single lead in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/actions/update-lead.md) |
-| `DELETE /leads` | Delete a single lead in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/actions/delete-lead.md) |
-| `GET /leads` | Fetches a list of leads from salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/syncs/leads.md) |
+| `POST /leads` | Create a single lead in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/actions/create-lead.md) |
+| `PATCH /leads` | Update a single lead in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/actions/update-lead.md) |
+| `DELETE /leads` | Delete a single lead in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/actions/delete-lead.md) |
+| `GET /leads` | Fetches a list of leads from salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/syncs/leads.md) |
 </Accordion>
 
 
 <Accordion title="Opportunities">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `POST /opportunities` | Create a single opportunity in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/actions/create-opportunity.md) |
-| `PATCH /opportunities` | Update a single opportunity in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/actions/update-opportunity.md) |
-| `DELETE /opportunities` | Delete a single opportunity in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/actions/delete-opportunity.md) |
-| `GET /opportunities` | Fetches a list of opportunities from salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/syncs/opportunities.md) |
+| `POST /opportunities` | Create a single opportunity in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/actions/create-opportunity.md) |
+| `PATCH /opportunities` | Update a single opportunity in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/actions/update-opportunity.md) |
+| `DELETE /opportunities` | Delete a single opportunity in salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/actions/delete-opportunity.md) |
+| `GET /opportunities` | Fetches a list of opportunities from salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/syncs/opportunities.md) |
 </Accordion>
 
 
 <Accordion title="Users">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /whoami` | Fetch current user information | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/actions/whoami.md) |
+| `GET /whoami` | Fetch current user information | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/actions/whoami.md) |
 </Accordion>
 
 
 <Accordion title="Others">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /fields` | Fetch available task fields, child relationships and validation rules. If the input is not specified then it defaults back to "Task"<br />Data Validation: Parses all incoming data with Zod. Does not fail on parsing error will instead log parse error and return result. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/actions/fetch-fields.md) |
-| `GET /articles` | Fetches a list of articles from salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/syncs/articles.md) |
-| `GET /tickets` | Fetches a list of tickets from salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce-sandbox/syncs/tickets.md) |
+| `GET /fields` | Fetch available task fields, child relationships and validation rules. If the input is not specified then it defaults back to "Task"<br />Data Validation: Parses all incoming data with Zod. Does not fail on parsing error will instead log parse error and return result. | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/actions/fetch-fields.md) |
+| `GET /articles` | Fetches a list of articles from salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/syncs/articles.md) |
+| `GET /tickets` | Fetches a list of tickets from salesforce | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/salesforce/syncs/tickets.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/docs-v2/snippets/generated/stripe-app-sandbox/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/stripe-app-sandbox/PreBuiltUseCases.mdx
@@ -7,7 +7,7 @@
 <Accordion title="Subscriptions">
 | Endpoint | Description | Readme |
 | - | - | - |
-| `GET /subscriptions` | Fetches a list of subscriptions | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/stripe-app-sandbox/syncs/subscriptions.md) |
+| `GET /subscriptions` | Fetches a list of subscriptions | [🔗](https://github.com/NangoHQ/integration-templates/blob/main/integrations/stripe-app/syncs/subscriptions.md) |
 </Accordion>
 
 </AccordionGroup>

--- a/scripts/docs-gen-snippets.ts
+++ b/scripts/docs-gen-snippets.ts
@@ -233,7 +233,7 @@ function buildEndpoints(type: string, syncOrAction: any, integration: string, sy
                     path: endpoint?.path,
                     description: item?.description?.trim(),
                     group: endpoint?.group,
-                    script: `${integration}/${type}s/${symLinkTargetName || item.name}`
+                    script: `${symLinkTargetName || integration}/${type}s/${item.name}`
                 });
             }
         }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
With fix for path
<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the generated documentation snippets across multiple integration providers to fix the paths linking to readme and action/sync markdown files. The main goal is to ensure that documentation for pre-built use cases in MDX files correctly references the top-level, non-sandboxed integration directories after a directory structure or symlink change in the templates repository. Additionally, a small change in the docs-gen-snippets.ts script modifies how the script path is constructed when generating these docs, placing symLinkTargetName (if present) ahead of the integration name, which results in the correct underlying path references throughout all generated documentation.

*This summary was automatically generated by @propel-code-bot*