### PR TITLE
feat: error message when 429s from nango API in scripts

### DIFF
--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -246,10 +246,19 @@ export async function exec({
                         errorResponse && typeof errorResponse === 'object' ? (errorResponse as Record<string, unknown>) : { message: errorResponse }
                     );
 
+                    let type = 'script_http_error';
+                    // If the error is a rate limit error from Nango API, we return a specific type/message
+                    if (err.response.status === 429 && err.response.config.url) {
+                        const url = new URL(err.response.config.url);
+                        if (url.hostname === 'api.nango.dev' || url.hostname === 'localhost') {
+                            type = 'script_api_rate_limit_error';
+                        }
+                    }
+
                     return {
                         success: false,
                         error: {
-                            type: 'script_http_error',
+                            type,
                             payload: responseBody,
                             status: err.response.status,
                             additional_properties: {

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -481,7 +481,7 @@ export class NangoError extends NangoInternalError {
 
             case 'script_api_rate_limit_error':
                 this.status = 424;
-                this.message = `Too many operations performed against the Nango API. Reduce the number of actions and/or the frequency of your syncs. Contact Nango support to increase your limits.`; //TODO
+                this.message = `Script API rate limit exceeded. Your Nango scripts made too many calls to the Nango API within the allowed window. Mitigation: reduce how often scripts run (e.g. lower sync frequency, fewer actions). Need higher limits? Contact Nango support.`;
                 break;
 
             case 'script_internal_error':

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -479,6 +479,11 @@ export class NangoError extends NangoInternalError {
                 this.message = `An error occurred during an HTTP call`;
                 break;
 
+            case 'script_api_rate_limit_error':
+                this.status = 424;
+                this.message = `Too many operations performed against the Nango API. Reduce the number of actions and/or the frequency of your syncs. Contact Nango support to increase your limits.`; //TODO
+                break;
+
             case 'script_internal_error':
                 this.status = 500;
                 this.message = `An internal error occurred during the script execution`;


### PR DESCRIPTION
More self-explanatory message in Nango logs when the Nango API rate-limit is hit

We currently show a message that says "An error occurred during an HTTP call" when a customer hit the rate-limit from a script. 
<!-- Summary by @propel-code-bot -->

---

**Add Specific Error Messaging for 429 Rate Limits from Nango API in Scripts**

This PR enhances error handling for scripts that interact with the Nango API. When a script receives an HTTP 429 (Too Many Requests) error from the Nango API, the system now issues a specific error type (`script_api_rate_limit_error`) with a clear, actionable message instructing users about mitigating rate limits and pointing them to support if necessary. The implementation ensures that users are not presented with ambiguous generic HTTP errors but are instead informed of the exact cause (Nango API rate limiting), improving troubleshooting and transparency in script logs. Updates are performed in both the script runner's error classification logic and the central error utility.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced logic in `packages/runner/lib/exec.ts` to specifically detect ``HTTP`` 429 errors from calls to the Nango ``API`` domains (`api.nango.dev`, `localhost`) during script execution.
• Assigned a new error type: ``script_api_rate_limit_error`` when such 429s are detected.
• Extended error message mapping in `packages/shared/lib/utils/error.ts` to give detailed user instructions for this new error, with status code 424.
• Old behavior (generic ``HTTP`` error message for 429s) is replaced with targeted, user-friendly instructions and mitigation suggestions.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Script execution error handling (packages/runner/lib/exec.ts)
• Central error messaging and type mapping (packages/shared/lib/utils/error.ts)

</details>

---
*This summary was automatically generated by @propel-code-bot*