### PR TITLE
feat(UI-scopes): add copy button for scopes to be comma delimited

### DIFF
--- a/packages/webapp/src/components/ui/input/TagsInput.tsx
+++ b/packages/webapp/src/components/ui/input/TagsInput.tsx
@@ -4,6 +4,7 @@ import { forwardRef, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Input } from './Input';
 import useSet from '../../../hooks/useSet';
+import { CopyButton } from '../button/CopyButton';
 
 import type { KeyboardEvent } from 'react';
 
@@ -13,6 +14,7 @@ type TagsInputProps = Omit<JSX.IntrinsicElements['input'], 'defaultValue'> & {
     onScopeChange?: (values: string) => void;
     addToScopesSet?: (scope: string) => void;
     removeFromSelectedSet?: (scope: string) => void;
+    clipboard?: boolean;
 };
 
 const TagsInput = forwardRef<HTMLInputElement, TagsInputProps>(function TagsInput(
@@ -23,6 +25,7 @@ const TagsInput = forwardRef<HTMLInputElement, TagsInputProps>(function TagsInpu
         onScopeChange,
         addToScopesSet: optionalAddToScopesSet,
         removeFromSelectedSet: optionalRemoveFromSelectedSet,
+        clipboard,
         ...props
     },
     ref
@@ -150,6 +153,7 @@ const TagsInput = forwardRef<HTMLInputElement, TagsInputProps>(function TagsInpu
                             onKeyDown={handleEnter}
                             placeholder={scopes.length ? '' : 'Find the list of scopes in the documentation of the external API provider.'}
                             variant={'flat'}
+                            after={clipboard ? <CopyButton text={scopes.join(',')} textPrompt="Copy scopes" /> : undefined}
                         />
                     </div>
                     {error && <p className="text-red-600 text-sm mt-3">{error}</p>}

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuth.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuth.tsx
@@ -136,6 +136,7 @@ export const SettingsOAuth: React.FC<{ data: GetIntegration['Success']['data']; 
                             onScopeChange={handleScopeChange}
                             minLength={1}
                             readOnly={!shouldShowCredentials}
+                            clipboard={true}
                         />
                     </InfoBloc>
                 )}


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
<img width="1010" height="223" alt="image" src="https://github.com/user-attachments/assets/c552005f-6892-47ba-982e-48db208f7492" />

Results in 
```
https://www.googleapis.com/auth/admin.directory.user,https://www.googleapis.com/auth/admin.directory.user.readonly,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/admin.reports.audit.readonly,https://www.googleapis.com/auth/admin.reports.usage.readonly,https://www.googleapis.com/auth/admin.directory.user.security
```

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR introduces a 'Copy' button to the scopes field in the OAuth integration settings UI. Users can now copy all scopes as a single comma-delimited string directly from the interface, streamlining scope sharing and configuration.

*This summary was automatically generated by @propel-code-bot*