### PR TITLE
fix(fleet): always idle node when finishing timeout

### DIFF
--- a/packages/fleet/lib/supervisor/supervisor.ts
+++ b/packages/fleet/lib/supervisor/supervisor.ts
@@ -428,17 +428,14 @@ export class Supervisor {
     }
 
     private async finishingTimeout({ node }: { type: 'FINISHING_TIMEOUT'; node: Node }): Promise<Result<Node>> {
-        // Locally we assume the node is IDLE
-        // since the process is likely already killed
-        // and the node is not able to notify back that it is idle
-        if (envs.RUNNER_TYPE === 'LOCAL') {
-            return nodes.transitionTo(this.dbClient.db, {
-                nodeId: node.id,
-                newState: 'IDLE'
-            });
-        }
-        // TODO: find a better way to warn and alert
-        logger.warning('Node is taking too long to finish:', node);
-        return Promise.resolve(Ok(node));
+        logger.warning('Node is taking too long to finish. Idling it.', node);
+        // Locally, the runner process is likely already killed
+        // and it is not able to notify back that it is idle
+        // In prod/staging, the node might have crashed while in FINISHING state
+        // and never notified that it is idle
+        return nodes.transitionTo(this.dbClient.db, {
+            nodeId: node.id,
+            newState: 'IDLE'
+        });
     }
 }

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -99,7 +99,7 @@ export const ENVS = z.object({
     FLEET_TIMEOUT_FINISHING_MS: z.coerce
         .number()
         .optional()
-        .default(24 * 60 * 60 * 1000), // 24 hours
+        .default(25 * 60 * 60 * 1000), // 25 hours
     FLEET_TIMEOUT_IDLE_MS: z.coerce
         .number()
         .optional()


### PR DESCRIPTION
Once in a while I noticed a runner stuck in FINISHING state. I tracked to problem to runners crashing while finishing. They then never report their are idle and are therefore never terminated. This PR ensure that if FINISHING_TIMEOUT is reached the node is always marked as idle.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Ensure Nodes Are Idled on FINISHING Timeout & Extend Timeout**

This PR addresses a scenario where fleet runner nodes could become indefinitely stuck in the FINISHING state if their process crashes before reporting as IDLE. The supervisor logic has been unified so that on a FINISHING_TIMEOUT in any environment, the node is now always transitioned to IDLE using nodes.transitionTo(). Additionally, the default finishing timeout duration (FLEET_TIMEOUT_FINISHING_MS) is increased from 24 to 25 hours to provide a buffer and avoid premature idling during longer-than-expected operations.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaces environment-specific handling of ``FINISHING_TIMEOUT`` with unconditional transition of the node to ``IDLE``.
• Simplifies and clarifies the `finishingTimeout` handler and associated logging.
• Increases default ``FLEET_TIMEOUT_FINISHING_MS`` from 24 to 25 hours in environment variable parsing.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/fleet/lib/supervisor/supervisor.ts (supervisor logic for ``FINISHING_TIMEOUT``)
• packages/utils/lib/environment/parse.ts (environment config and default timeouts)

</details>

---
*This summary was automatically generated by @propel-code-bot*