### PR TITLE
fix(billing): downgrading to free should not require a card

### DIFF
--- a/packages/server/lib/controllers/v1/plans/change/postChange.ts
+++ b/packages/server/lib/controllers/v1/plans/change/postChange.ts
@@ -50,8 +50,9 @@ export const postPlanChange = asyncWrapper<PostPlanChange>(async (req, res) => {
     }
 
     const newPlan = plansList.find((p) => p.orbId === body.orbId)!;
+    const isUpgrade = plansList.filter((p) => currentDef.nextPlan?.includes(p.code))?.find((p) => p.orbId === body.orbId);
 
-    if (!plan.stripe_payment_id || !plan.stripe_customer_id) {
+    if ((isUpgrade && (!plan.stripe_payment_id || !plan.stripe_customer_id)) || (!isUpgrade && newPlan.code !== 'free')) {
         res.status(400).send({ error: { code: 'invalid_body', message: 'team is not linked to stripe' } });
         return;
     }
@@ -73,8 +74,6 @@ export const postPlanChange = asyncWrapper<PostPlanChange>(async (req, res) => {
         report(err);
         return;
     }
-
-    const isUpgrade = plansList.filter((p) => currentDef.nextPlan?.includes(p.code))?.find((p) => p.orbId === body.orbId);
 
     // -- Upgrade
     if (isUpgrade) {

--- a/packages/webapp/src/pages/Team/Billing/components/PlanCard.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/PlanCard.tsx
@@ -198,7 +198,7 @@ export const PlanCard: React.FC<{
                     )}
                 </footer>
             </div>
-            {!hasPaymentMethod ? (
+            {!hasPaymentMethod && !def.isDowngrade && def.plan.code === 'free' ? (
                 <DialogContent className="w-[550px] max-h-[800px]">
                     <DialogTitle>Add a payment method first</DialogTitle>
                     <StripeForm onSuccess={() => {}} />

--- a/packages/webapp/src/pages/Team/Billing/components/PlanCard.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/PlanCard.tsx
@@ -198,7 +198,7 @@ export const PlanCard: React.FC<{
                     )}
                 </footer>
             </div>
-            {!hasPaymentMethod && !def.isDowngrade && def.plan.code === 'free' ? (
+            {(!hasPaymentMethod && def.isUpgrade) || (!hasPaymentMethod && def.isDowngrade && def.plan.code !== 'free') ? (
                 <DialogContent className="w-[550px] max-h-[800px]">
                     <DialogTitle>Add a payment method first</DialogTitle>
                     <StripeForm onSuccess={() => {}} />


### PR DESCRIPTION
## Changes

- fix(billing): downgrade to free should not require a card
Ideally, all paying customers have a card but sometimes they are manually upgraded

<!-- Summary by @propel-code-bot -->

---

**Allow Downgrades to Free Plan Without Requiring Payment Method**

This pull request modifies both the backend and frontend logic so that teams can downgrade their subscription to the free plan without needing to provide a payment method or Stripe customer information. Previously, the system enforced a payment card requirement for all plan changes, which prevented manually upgraded customers (without Stripe records) from downgrading to free. With these changes, upgrades and paid plan downgrades still require card verification, but downgrading to the free plan bypasses this requirement.

<details>
<summary><strong>Key Changes</strong></summary>

• Backend (``postChange`.ts`): Refactored logic to skip Stripe payment/customer checks when downgrading to the free plan; the checks are still enforced for upgrades or downgrades to paid plans.
• Frontend (``PlanCard`.tsx`): Changed the condition for displaying the Stripe payment dialog to only require a payment method when upgrading or downgrading to a paid plan, not for downgrades to free.
• Cleaned up redundant and misplaced Stripe validations to clarify upgrade/downgrade requirements.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Backend: Server plan change controller (``postChange`.ts`)
• Frontend: Billing plan change ``UI`` (``PlanCard`.tsx`)

</details>

---
*This summary was automatically generated by @propel-code-bot*