### PR TITLE
feat: getting started closed state

### DIFF
--- a/packages/database/lib/migrations/20250822171500_getting_started_progress_add_closed.cjs
+++ b/packages/database/lib/migrations/20250822171500_getting_started_progress_add_closed.cjs
@@ -1,0 +1,13 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE "getting_started_progress" ADD COLUMN "closed" BOOLEAN NOT NULL DEFAULT FALSE`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};

--- a/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
@@ -116,7 +116,8 @@ describe(`GET ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             connection_id: connection.id,
-            step: 3
+            step: 3,
+            closed: false
         });
         expect(progress.isErr()).toBe(false);
 

--- a/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.integration.test.ts
@@ -61,7 +61,7 @@ describe(`PATCH ${endpoint}`, () => {
         });
     });
 
-    it('should update step', async () => {
+    it('should update step and closed', async () => {
         const { env, user, account } = await seeders.seedAccountEnvAndUser();
         const session = await authenticateUser(api, user);
 
@@ -80,7 +80,8 @@ describe(`PATCH ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 0,
-            connection_id: null
+            connection_id: null,
+            closed: false
         });
         expect(progress.isOk()).toBe(true);
 
@@ -88,7 +89,7 @@ describe(`PATCH ${endpoint}`, () => {
             method: 'PATCH',
             session,
             query: { env: env.name },
-            body: { step: 2 }
+            body: { step: 2, closed: true }
         });
 
         expect(res.res.status).toBe(204);
@@ -98,6 +99,7 @@ describe(`PATCH ${endpoint}`, () => {
         assert(!updatedProgress.isErr(), 'Failed to get progress');
 
         expect(updatedProgress.value?.step).toBe(2);
+        expect(updatedProgress.value?.closed).toBe(true);
     });
 
     it('should attach a connection', async () => {
@@ -119,7 +121,8 @@ describe(`PATCH ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 0,
-            connection_id: null
+            connection_id: null,
+            closed: false
         });
         expect(progress.isOk()).toBe(true);
 
@@ -170,7 +173,8 @@ describe(`PATCH ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 2,
-            connection_id: connection.id
+            connection_id: connection.id,
+            closed: false
         });
         expect(progress.isOk()).toBe(true);
 
@@ -209,7 +213,8 @@ describe(`PATCH ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 0,
-            connection_id: null
+            connection_id: null,
+            closed: false
         });
         expect(progress.isOk()).toBe(true);
 
@@ -249,7 +254,8 @@ describe(`PATCH ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 1,
-            connection_id: null
+            connection_id: null,
+            closed: false
         });
         expect(progress.isOk()).toBe(true);
 

--- a/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.ts
@@ -12,7 +12,7 @@ const validationBody = z
     .object({
         connection_id: z.string().optional().nullable(),
         step: z.number().int().nonnegative().optional(),
-        complete: z.boolean().optional()
+        closed: z.boolean().optional()
     })
     .strict();
 

--- a/packages/server/lib/controllers/v1/meta/getMeta.ts
+++ b/packages/server/lib/controllers/v1/meta/getMeta.ts
@@ -1,4 +1,5 @@
-import { environmentService, getOnboarding } from '@nangohq/shared';
+import db from '@nangohq/database';
+import { environmentService, gettingStartedService } from '@nangohq/shared';
 import { NANGO_VERSION, baseUrl, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
@@ -15,7 +16,7 @@ export const getMeta = asyncWrapper<GetMeta>(async (req, res) => {
     const sessionUser = res.locals.user;
 
     const environments = await environmentService.getEnvironmentsByAccountId(sessionUser.account_id);
-    const onboarding = await getOnboarding(sessionUser.id);
+    const gettingStartedProgress = await gettingStartedService.getProgressByUserId(db.knex, sessionUser.id);
     res.status(200).send({
         data: {
             environments: environments.map((env) => {
@@ -24,7 +25,7 @@ export const getMeta = asyncWrapper<GetMeta>(async (req, res) => {
             version: NANGO_VERSION,
             baseUrl,
             debugMode: req.session.debugMode === true,
-            onboardingComplete: onboarding?.complete || false
+            gettingStartedClosed: (gettingStartedProgress.isOk() && gettingStartedProgress.value?.closed) ?? false
         }
     });
 });

--- a/packages/shared/lib/services/getting-started.service.ts
+++ b/packages/shared/lib/services/getting-started.service.ts
@@ -76,7 +76,8 @@ export async function getProgressByUserId(db: Knex, userId: number): Promise<Res
                 environment: pick(result.environment, ['id', 'name'])
             },
             connection: result.connection ? pick(result.connection, ['id', 'connection_id']) : null,
-            step: result.progress.step
+            step: result.progress.step,
+            closed: result.progress.closed
         });
     } catch (err) {
         return Err(new Error('failed_to_get_getting_started_progress', { cause: err }));
@@ -128,7 +129,8 @@ export async function getOrCreateProgressByUser(db: Knex, user: DBUser, currentE
             user_id: user.id,
             getting_started_meta_id: gettingStartedMeta.value.id,
             step: 0,
-            connection_id: null
+            connection_id: null,
+            closed: false
         });
 
         if (createdResult.isErr()) {
@@ -167,6 +169,10 @@ export async function patchProgressByUser(db: Knex, user: DBUser, input: PatchGe
 
         if (typeof input.step !== 'undefined') {
             update.step = input.step;
+        }
+
+        if (typeof input.closed !== 'undefined') {
+            update.closed = input.closed;
         }
 
         if (typeof input.connection_id !== 'undefined') {

--- a/packages/types/lib/gettingStarted/db.ts
+++ b/packages/types/lib/gettingStarted/db.ts
@@ -19,4 +19,5 @@ export interface DBGettingStartedProgress extends Timestamps {
     user_id: number;
     connection_id: number | null;
     step: number;
+    closed: boolean;
 }

--- a/packages/types/lib/gettingStarted/dto.ts
+++ b/packages/types/lib/gettingStarted/dto.ts
@@ -10,11 +10,13 @@ export interface GettingStartedOutput {
     };
     connection: Pick<DBConnection, 'id' | 'connection_id'> | null;
     step: number;
+    closed: boolean;
 }
 
 export interface PatchGettingStartedInput {
     connection_id?: string | null | undefined;
     step?: number | undefined;
+    closed?: boolean | undefined;
 }
 
 export type CreateGettingStartedMeta = Omit<DBGettingStartedMeta, 'id' | 'created_at' | 'updated_at'>;

--- a/packages/types/lib/meta/api.ts
+++ b/packages/types/lib/meta/api.ts
@@ -12,7 +12,7 @@ export type GetMeta = Endpoint<{
             version: string;
             baseUrl: string;
             debugMode: boolean;
-            onboardingComplete: boolean;
+            gettingStartedClosed: boolean;
         };
     };
 }>;

--- a/packages/webapp/src/components/LeftNavBar.tsx
+++ b/packages/webapp/src/components/LeftNavBar.tsx
@@ -20,8 +20,8 @@ import { useClickAway } from 'react-use';
 import { EnvironmentPicker } from './EnvironmentPicker';
 import { useConnectionsCount } from '../hooks/useConnections';
 import { useEnvironment } from '../hooks/useEnvironment';
+import { patchGettingStarted } from '../hooks/useGettingStarted';
 import { useMeta } from '../hooks/useMeta';
-import { apiPatchOnboarding } from '../hooks/useOnboarding';
 import { useUser } from '../hooks/useUser';
 import { useStore } from '../store';
 import UsageCard from './UsageCard';
@@ -77,14 +77,14 @@ export default function LeftNavBar(props: LeftNavBarProps) {
 
     const items = useMemo(() => {
         const list: MenuItem[] = [];
-        if (meta && showGettingStarted && !meta.onboardingComplete) {
+        if (meta && showGettingStarted && !meta.gettingStartedClosed) {
             list.push({
                 name: 'Getting Started',
                 icon: IconRocket,
                 value: LeftNavBarItems.GettingStarted,
                 link: `/${env}/getting-started`,
                 onClose: async () => {
-                    await apiPatchOnboarding(env);
+                    await patchGettingStarted(env, { closed: true });
                     void mutateMeta();
                 }
             });
@@ -114,7 +114,7 @@ export default function LeftNavBar(props: LeftNavBarProps) {
             { link: `/${env}/team-settings`, name: 'Team', icon: IconUsersGroup, value: LeftNavBarItems.TeamSettings }
         ];
 
-        if (showGettingStarted && meta.onboardingComplete) {
+        if (showGettingStarted && meta.gettingStartedClosed) {
             list.push({ link: `/dev/getting-started`, name: 'Getting Started', icon: IconRocket, value: LeftNavBarItems.GettingStarted });
         }
 

--- a/packages/webapp/src/pages/Root.tsx
+++ b/packages/webapp/src/pages/Root.tsx
@@ -17,7 +17,7 @@ export const Root: React.FC = () => {
             return;
         }
 
-        if (env === 'dev' && showGettingStarted && !meta.onboardingComplete) {
+        if (env === 'dev' && showGettingStarted && !meta.gettingStartedClosed) {
             navigate('/dev/getting-started');
             return;
         }


### PR DESCRIPTION
I was removing all references to `onboarding` and I realized we still depend on it's `completed` state to handle the ability to "close" the getting started in the UI, which is a detail I've missed.
<img width="242" height="57" alt="image" src="https://github.com/user-attachments/assets/ec95820d-3e63-40f5-8db8-1d30178ba962" />

So I'm adding a `closed` state to the progress. Chose `closed` because going through all the getting started steps won't trigger it automatically. It will only be hidden if the user explicitly closes it by clicking the little `x` button.

Next PR will remove everything related to the old `onboarding`.
<!-- Summary by @propel-code-bot -->

---

**Add Explicit 'Closed' State for Getting Started UI Flow**

This PR replaces the use of the legacy 'onboardingComplete' logic with a dedicated 'closed' boolean state for the Getting Started user flow. The new 'closed' state allows the Getting Started feature to be dismissed only by explicit user action (e.g., clicking the close 'x'), and no longer depends on completion of all onboarding steps. The change involves database schema updates, backend API adjustments, new and modified TypeScript types, webapp UI and logic changes, and updates to tests and data contracts to consistently utilize the new 'closed' property throughout the stack.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduces a migration adding a `closed` ``BOOLEAN`` ``NOT`` ``NULL`` ``DEFAULT`` ``FALSE`` column to the ``getting_started_progress`` table.
• Extends backend logic and `TypeScript` types (``DTO``, ``DB`` types) to include the new `closed` property.
• Updates backend ``GET``/``PATCH`` endpoints for Getting Started to support reading and writing the `closed` flag.
• Refactors Meta ``API`` and client-side data structures to expose ``gettingStartedClosed`` instead of ``onboardingComplete``.
• Updates frontend webapp logic (sidebar menu, root redirect) to use ``gettingStartedClosed`` for controlling Getting Started visibility and behavior.
• Replaces legacy onboarding code paths with logic built around the new `closed` state.
• Modifies and extends relevant tests to verify correct handling of the new `closed` property and overall endpoint behavior.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Database schema/migrations
• Backend controllers/handlers for getting started and meta (``API`` v1)
• Backend & shared `TypeScript` types (db, `DTOs`, ``API`` contracts)
• Getting started service functions
• Frontend React webapp navigation and components
• Integration and unit test suites for getting started endpoints

</details>

---
*This summary was automatically generated by @propel-code-bot*