### PR TITLE
fix: revert security headers

### DIFF
--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -43,7 +43,7 @@ staticSite.use(
     ...[
         helmet.crossOriginOpenerPolicy({ policy: 'same-origin' }),
         helmet.crossOriginEmbedderPolicy({ policy: 'require-corp' }),
-        helmet.crossOriginResourcePolicy({ policy: 'same-origin' })
+        helmet.crossOriginResourcePolicy({ policy: 'same-site' })
     ]
 );
 staticSite.use('/assets', express.static(path.join(dirname(), webappBuildPath), { immutable: true, maxAge: '1y' }));

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 
 import express from 'express';
-import helmet from 'helmet';
 
 import { errorManager } from '@nangohq/shared';
 
@@ -39,7 +38,6 @@ router.use('/', publicAPI);
 // Webapp assets, static files and build.
 const webappBuildPath = '../../../webapp/dist';
 const staticSite = express.Router();
-staticSite.use(...[helmet.crossOriginEmbedderPolicy({ policy: 'require-corp' }), helmet.crossOriginResourcePolicy({ policy: 'same-site' })]);
 staticSite.use('/assets', express.static(path.join(dirname(), webappBuildPath), { immutable: true, maxAge: '1y' }));
 staticSite.use(express.static(path.join(dirname(), webappBuildPath), { cacheControl: true, maxAge: '1h' }));
 staticSite.get('*splat', (_, res) => {

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -39,13 +39,7 @@ router.use('/', publicAPI);
 // Webapp assets, static files and build.
 const webappBuildPath = '../../../webapp/dist';
 const staticSite = express.Router();
-staticSite.use(
-    ...[
-        helmet.crossOriginOpenerPolicy({ policy: 'same-origin' }),
-        helmet.crossOriginEmbedderPolicy({ policy: 'require-corp' }),
-        helmet.crossOriginResourcePolicy({ policy: 'same-site' })
-    ]
-);
+staticSite.use(...[helmet.crossOriginEmbedderPolicy({ policy: 'require-corp' }), helmet.crossOriginResourcePolicy({ policy: 'same-site' })]);
 staticSite.use('/assets', express.static(path.join(dirname(), webappBuildPath), { immutable: true, maxAge: '1y' }));
 staticSite.use(express.static(path.join(dirname(), webappBuildPath), { cacheControl: true, maxAge: '1h' }));
 staticSite.get('*splat', (_, res) => {


### PR DESCRIPTION
## Changes

- It's breaking stripe and oauth pop-up
Should have been more thorough when testing staging 

<!-- Summary by @propel-code-bot -->

---

This PR removes a recent addition of specific Helmet-based security headers from the Express static route middleware within the server. The revert is necessary because the introduced headers interfere with Stripe integration and OAuth pop-up flows, causing functional regressions in these areas.

*This summary was automatically generated by @propel-code-bot*