### PR TITLE
fix(api): always send team update event

### DIFF
--- a/packages/server/lib/controllers/v1/team/putTeam.ts
+++ b/packages/server/lib/controllers/v1/team/putTeam.ts
@@ -30,14 +30,12 @@ export const putTeam = asyncWrapper<PutTeam>(async (req, res) => {
         return;
     }
 
-    const { account, plan } = res.locals;
+    const { account } = res.locals;
     const body: PutTeam['Body'] = val.data;
 
     await accountService.editAccount({ id: account.id, ...body });
 
-    if (plan?.stripe_customer_id && plan?.orb_customer_id) {
-        void pubsub.publisher.publish({ subject: 'team', type: 'team.updated', payload: { id: account.id } });
-    }
+    void pubsub.publisher.publish({ subject: 'team', type: 'team.updated', payload: { id: account.id } });
 
     res.status(200).send({
         data: teamToApi({


### PR DESCRIPTION
## Changes

- Always send team update event
It was supposed to be part of the previous PR, but the push didn't work, and I didn't notice before merging. It's not changing the current expectation in the metering system
<!-- Summary by @propel-code-bot -->

---

This pull request modifies the team update API handler to unconditionally emit a 'team.updated' event via the pubsub publisher every time a team is updated. Previously, this event was only published if the team account had both a Stripe and an Orb customer ID associated with its billing plan. The change simplifies the event logic so an event is always sent on update, ensuring downstream consumers consistently receive update notifications, independent of billing configuration.

*This summary was automatically generated by @propel-code-bot*