### PR TITLE
chore: track auth type usage

### DIFF
--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -97,7 +97,8 @@ export class AccessMiddleware {
         } catch (err) {
             logger.error(`failed_get_env_by_secret_key ${stringifyError(err)}`);
             span.setTag('error', err);
-            return errorManager.errRes(res, 'malformed_auth_header');
+            errorManager.errRes(res, 'malformed_auth_header');
+            return;
         } finally {
             metrics.duration(metrics.Types.AUTH_GET_ENV_BY_SECRET_KEY, Date.now() - start, { accountId: res.locals['account']?.id || 'unknown' });
             span.finish();
@@ -274,7 +275,8 @@ export class AccessMiddleware {
         } catch (err) {
             logger.error(`failed_get_env_by_connect_session ${stringifyError(err)}`);
             span.setTag('error', err);
-            return errorManager.errRes(res, 'unknown_account');
+            errorManager.errRes(res, 'unknown_account');
+            return;
         } finally {
             metrics.duration(metrics.Types.AUTH_GET_ENV_BY_CONNECT_SESSION, Date.now() - start);
             span.finish();
@@ -316,7 +318,8 @@ export class AccessMiddleware {
         } catch (err) {
             logger.error(`failed_get_env_by_connect_session ${stringifyError(err)}`);
             span.setTag('error', err);
-            return errorManager.errRes(res, 'unknown_account');
+            errorManager.errRes(res, 'unknown_account');
+            return;
         } finally {
             metrics.duration(metrics.Types.AUTH_GET_ENV_BY_CONNECT_SESSION, Date.now() - start);
             span.finish();
@@ -379,7 +382,8 @@ export class AccessMiddleware {
         } catch (err) {
             logger.error(`failed_get_env_by_connect_session_or_secret ${stringifyError(err)}`);
             span.setTag('error', err);
-            return errorManager.errRes(res, 'unknown_account');
+            errorManager.errRes(res, 'unknown_account');
+            return;
         } finally {
             metrics.duration(metrics.Types.AUTH_GET_ENV_BY_CONNECT_SESSION_OR_SECRET_KEY, Date.now() - start);
             span.finish();
@@ -409,15 +413,19 @@ export class AccessMiddleware {
                 res.locals['endUser'] = connectSessionResult.value.endUser;
                 res.locals['plan'] = connectSessionResult.value.plan;
                 tagTraceUser(connectSessionResult.value);
+
+                metrics.increment(metrics.Types.AUTH_WITH_CONNECT_SESSION);
             } else {
                 const publicKey = req.query['public_key'] as string;
 
                 if (!publicKey) {
-                    return errorManager.errRes(res, 'missing_public_key');
+                    errorManager.errRes(res, 'missing_public_key');
+                    return;
                 }
 
                 if (!keyRegex.test(publicKey)) {
-                    return errorManager.errRes(res, 'invalid_public_key');
+                    errorManager.errRes(res, 'invalid_public_key');
+                    return;
                 }
 
                 const result = await this.validatePublicKey(publicKey);
@@ -431,12 +439,15 @@ export class AccessMiddleware {
                 res.locals['environment'] = result.value.environment;
                 res.locals['plan'] = result.value.plan;
                 tagTraceUser(result.value);
+
+                metrics.increment(metrics.Types.AUTH_WITH_PUBLIC_KEY);
             }
             next();
         } catch (err) {
             errorManager.report(err, { source: ErrorSourceEnum.PLATFORM, operation: LogActionEnum.INTERNAL_AUTHORIZATION });
             span.setTag('error', err);
-            return errorManager.errRes(res, 'unknown_account');
+            errorManager.errRes(res, 'unknown_account');
+            return;
         } finally {
             metrics.duration(metrics.Types.AUTH_GET_ENV_BY_CONNECT_SESSION_OR_PUBLIC_KEY, Date.now() - start);
             span.finish();
@@ -495,24 +506,28 @@ export class AccessMiddleware {
 
     admin(req: Request, res: Response, next: NextFunction) {
         if (!isCloud) {
-            return errorManager.errRes(res, 'only_nango_cloud');
+            errorManager.errRes(res, 'only_nango_cloud');
+            return;
         }
 
         const adminKey = process.env['NANGO_ADMIN_KEY'];
 
         if (!adminKey) {
-            return errorManager.errRes(res, 'admin_key_configuration');
+            errorManager.errRes(res, 'admin_key_configuration');
+            return;
         }
 
         const authorizationHeader = req.get('authorization');
 
         if (!authorizationHeader) {
-            return errorManager.errRes(res, 'missing_auth_header');
+            errorManager.errRes(res, 'missing_auth_header');
+            return;
         }
 
         const candidateKey = authorizationHeader.split('Bearer ').pop();
         if (candidateKey !== adminKey) {
-            return errorManager.errRes(res, 'invalid_admin_key');
+            errorManager.errRes(res, 'invalid_admin_key');
+            return;
         }
 
         next();
@@ -522,18 +537,21 @@ export class AccessMiddleware {
         const key = envs.NANGO_INTERNAL_API_KEY;
 
         if (!key) {
-            return errorManager.errRes(res, 'internal_private_key_configuration');
+            errorManager.errRes(res, 'internal_private_key_configuration');
+            return;
         }
 
         const authorizationHeader = req.get('authorization');
 
         if (!authorizationHeader) {
-            return errorManager.errRes(res, 'missing_auth_header');
+            errorManager.errRes(res, 'missing_auth_header');
+            return;
         }
 
         const receivedKey = authorizationHeader.split('Bearer ').pop();
         if (!receivedKey || !stringTimingSafeEqual(receivedKey, key)) {
-            return errorManager.errRes(res, 'invalid_internal_private_key');
+            errorManager.errRes(res, 'invalid_internal_private_key');
+            return;
         }
 
         next();

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -10,6 +10,8 @@ export enum Types {
     AUTH_GET_ENV_BY_SECRET_KEY = 'nango.auth.getEnvBySecretKey',
     AUTH_GET_ENV_BY_CONNECT_SESSION_OR_SECRET_KEY = 'nango.auth.getEnvByConnectSessionOrSecretKey',
     AUTH_GET_ENV_BY_CONNECT_SESSION_OR_PUBLIC_KEY = 'nango.auth.getEnvByConnectSessionOrPublicKey',
+    AUTH_WITH_PUBLIC_KEY = 'nango.auth.publicKey',
+    AUTH_WITH_CONNECT_SESSION = 'nango.auth.connectSession',
     AUTH_SESSION = 'nango.auth.session',
     GET_CONNECTION = 'nango.server.getConnection',
     JOBS_DELETE_SYNCS_DATA = 'nango.jobs.cron.deleteSyncsData',


### PR DESCRIPTION
## Changes

Contributes to https://linear.app/nango/issue/NAN-3569/migrate-all-customers-to-connect-session-and-new-connection-format

- Track auth type usage (connect session or public key)
So we have a better view of the volume we still need to migrate

- Fix invalid void return warning

<!-- Summary by @propel-code-bot -->

---

**Add Metrics for Auth Type Usage & Standardize Void Returns in Middleware**

This PR introduces telemetry to track which authentication method (connect session or public key) is used within the system. To support this, new metrics are added, and the authentication middleware is updated to increment those metrics appropriately. Additionally, the middleware error handling is refactored for proper void function compliance, replacing instances of 'return errorManager.errRes(res, ...)' with explicit error responses followed by 'return;', addressing invalid void return warnings.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced two new metrics in the metrics enum: ``AUTH_WITH_PUBLIC_KEY`` and ``AUTH_WITH_CONNECT_SESSION``.
• Updated `connectSessionOrPublicKeyAuth` middleware to increment the respective metric based on the authentication method detected.
• Standardized error handling in several middleware functions by removing return value from `errorManager`.`errRes`() and following with explicit `return;` for void compliance.
• Refactored admin and internal authentication middlewares to use explicit error response and return pattern.
• No change to authentication logic-behavior remains the same except for side-effect of new metric incrementing.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/middleware/access.middleware.ts
• packages/utils/lib/telemetry/metrics.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*