### PR TITLE
fix(api): block public key usage for new accounts 

### DIFF
--- a/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
@@ -17,40 +17,6 @@ describe(`GET ${endpoint}`, () => {
         api.server.close();
     });
 
-    it('should create one connection with connection_id', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
-        const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
-
-        const res = await api.fetch(endpoint, {
-            method: 'POST',
-            query: { connection_id: 'a', public_key: env.public_key },
-            params: { providerConfigKey: config.unique_key }
-        });
-
-        isSuccess(res.json);
-        expect(res.json).toStrictEqual<typeof res.json>({
-            connectionId: 'a',
-            providerConfigKey: 'unauthenticated'
-        });
-    });
-
-    it('should create one connection without connection_id', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
-        const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
-
-        const res = await api.fetch(endpoint, {
-            method: 'POST',
-            query: { public_key: env.public_key },
-            params: { providerConfigKey: config.unique_key }
-        });
-
-        isSuccess(res.json);
-        expect(res.json).toStrictEqual<typeof res.json>({
-            connectionId: expect.any(String),
-            providerConfigKey: 'unauthenticated'
-        });
-    });
-
     it('should create one connection with sessionToken', async () => {
         const { env } = await seeders.seedAccountEnvAndUser();
         const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -32,6 +32,8 @@ const logger = getLogger('AccessMiddleware');
 const keyRegex = /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
 const ignoreEnvPaths = ['/api/v1/environments', '/api/v1/meta', '/api/v1/user', '/api/v1/user/name', '/api/v1/signin', '/api/v1/invite/:id'];
 
+const deprecatedPublicAuthenticationCutoffDate = new Date('2025-08-25');
+
 export class AccessMiddleware {
     private async validateSecretKey(secret: string): Promise<
         Result<{
@@ -426,7 +428,7 @@ export class AccessMiddleware {
                     return;
                 }
 
-                if (result.value.account.created_at > new Date('2025-08-25')) {
+                if (result.value.account.created_at > deprecatedPublicAuthenticationCutoffDate) {
                     res.status(401).send({
                         error: {
                             code: 'deprecated_authentication',

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -430,7 +430,7 @@ export class AccessMiddleware {
                     res.status(401).send({
                         error: {
                             code: 'deprecated_authentication',
-                            message: 'Public key authentication is deprecated. Please connect session authentication instead.'
+                            message: 'Public key authentication is deprecated. Please use connect session authentication instead.'
                         }
                     });
                     return;

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -426,6 +426,16 @@ export class AccessMiddleware {
                     return;
                 }
 
+                if (result.value.account.created_at > new Date('2025-08-25')) {
+                    res.status(401).send({
+                        error: {
+                            code: 'deprecated_authentication',
+                            message: 'Public key authentication is deprecated. Please connect session authentication instead.'
+                        }
+                    });
+                    return;
+                }
+
                 res.locals['authType'] = 'publicKey';
                 res.locals['account'] = result.value.account;
                 res.locals['environment'] = result.value.environment;

--- a/packages/webapp/src/pages/Environment/Settings/Main.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Main.tsx
@@ -41,8 +41,8 @@ export const MainSettings: React.FC = () => {
                     />
                     {env !== PROD_ENVIRONMENT_NAME && (
                         <Info>
-                            If you’re using the CLI, make sure your .env file includes NANGO_SECRET_KEY_{env.toUpperCase()}={'<secret-key>'}. This variable name
-                            is based on your Nango environment name, update it if you rename the environment.
+                            If you&apos;re using the CLI, make sure your .env file includes NANGO_SECRET_KEY_{env.toUpperCase()}={'<secret-key>'}. This variable
+                            name is based on your Nango environment name, update it if you rename the environment.
                         </Info>
                     )}
                 </div>

--- a/packages/webapp/src/pages/Environment/Settings/Show.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Show.tsx
@@ -15,6 +15,7 @@ import { Skeleton } from '../../../components/ui/Skeleton';
 import { PROD_ENVIRONMENT_NAME } from '../../../constants';
 import { apiDeleteEnvironment, useEnvironment } from '../../../hooks/useEnvironment';
 import { useMeta } from '../../../hooks/useMeta';
+import { useTeam } from '../../../hooks/useTeam';
 import { useToast } from '../../../hooks/useToast';
 import DashboardLayout from '../../../layout/DashboardLayout';
 import { useStore } from '../../../store';
@@ -26,6 +27,7 @@ export const EnvironmentSettings: React.FC = () => {
     const { mutate: mutateMeta } = useMeta();
     const env = useStore((state) => state.env);
     const setEnv = useStore((state) => state.setEnv);
+    const { team } = useTeam(env);
 
     const { environmentAndAccount } = useEnvironment(env);
     const [scrolled, setScrolled] = useState(false);
@@ -70,7 +72,7 @@ export const EnvironmentSettings: React.FC = () => {
         }
     };
 
-    if (!environmentAndAccount) {
+    if (!environmentAndAccount || !team) {
         return (
             <DashboardLayout selectedItem={LeftNavBarItems.EnvironmentSettings} className="p-6">
                 <Helmet>
@@ -88,6 +90,7 @@ export const EnvironmentSettings: React.FC = () => {
         );
     }
 
+    const canSeeDeprecatedAuthorization = new Date(team.created_at) <= new Date('2025-08-25');
     return (
         <DashboardLayout selectedItem={LeftNavBarItems.EnvironmentSettings} className="p-6">
             <Helmet>
@@ -112,14 +115,16 @@ export const EnvironmentSettings: React.FC = () => {
                 <NotificationSettings />
                 <VariablesSettings />
                 <ExportSettings />
-                <Accordion type="single" collapsible>
-                    <AccordionItem value="item-1" id="authorization">
-                        <AccordionTrigger>Deprecated authorization settings</AccordionTrigger>
-                        <AccordionContent>
-                            <AuthorizationSettings />
-                        </AccordionContent>
-                    </AccordionItem>
-                </Accordion>
+                {canSeeDeprecatedAuthorization && (
+                    <Accordion type="single" collapsible>
+                        <AccordionItem value="item-1" id="authorization">
+                            <AccordionTrigger>Deprecated authorization settings</AccordionTrigger>
+                            <AccordionContent>
+                                <AuthorizationSettings />
+                            </AccordionContent>
+                        </AccordionItem>
+                    </Accordion>
+                )}
             </div>
         </DashboardLayout>
     );


### PR DESCRIPTION
## Changes

- Block public key usage for new accounts
This should be non controversial since it wasn't documented anymore 

<!-- Summary by @propel-code-bot -->

---

**Deprecate Public Key Authentication for New Accounts**

This pull request enforces the deprecation of public key authentication for new accounts created after August 25, 2025. The server-side middleware now blocks public key authentication attempts for such accounts, returning an explanatory 401 error. On the frontend, deprecated public key authorization UI is conditionally hidden for new teams, remaining accessible only to legacy teams. Related backend test cases that relied on public key flows for connections have been removed as obsolete, and some UI/UX improvements were made to environment settings logic and comments.

<details>
<summary><strong>Key Changes</strong></summary>

• Adds a hardcoded cutoff date (2025-08-25) in backend middleware to block public key authentication for accounts created after that date.
• Returns ``HTTP`` 401 with { error: { code: ``deprecated_authentication`` } } when blocked.
• Frontend settings page conditionally renders deprecated authorization ``UI`` based on team creation date.
• Removes backend test cases related to creating connections with public key for unauthenticated auth.
• Small improvements to environment settings: ensures team data is loaded, and clarifies or corrects some ``UI`` info.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Server authentication middleware (access.middleware.ts)
• ``UI``: Environment Settings page (Show.tsx and Main.tsx)
• Backend integration tests (`postUnauthenticated`.integration.test.ts)

</details>

---
*This summary was automatically generated by @propel-code-bot*