### PR TITLE
feat: decouple getting started closed state from progress

### DIFF
--- a/packages/database/lib/migrations/20250825190400_move_getting_started_closed_to_users.cjs
+++ b/packages/database/lib/migrations/20250825190400_move_getting_started_closed_to_users.cjs
@@ -1,0 +1,19 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE _nango_users ADD COLUMN closed_getting_started BOOLEAN NOT NULL DEFAULT FALSE`);
+    await knex.raw(`
+        UPDATE _nango_users
+        SET closed_getting_started = closed
+        FROM getting_started_progress
+        WHERE _nango_users.id = getting_started_progress.user_id`);
+    await knex.raw(`ALTER TABLE getting_started_progress DROP COLUMN closed`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};

--- a/packages/database/lib/migrations/20250825190400_move_getting_started_closed_to_users.cjs
+++ b/packages/database/lib/migrations/20250825190400_move_getting_started_closed_to_users.cjs
@@ -1,4 +1,4 @@
-exports.config = { transaction: false };
+exports.config = { transaction: true };
 
 /**
  * @param {import('knex').Knex} knex

--- a/packages/database/lib/migrations/20250825190400_move_getting_started_closed_to_users.cjs
+++ b/packages/database/lib/migrations/20250825190400_move_getting_started_closed_to_users.cjs
@@ -4,10 +4,10 @@ exports.config = { transaction: true };
  * @param {import('knex').Knex} knex
  */
 exports.up = async function (knex) {
-    await knex.raw(`ALTER TABLE _nango_users ADD COLUMN closed_getting_started BOOLEAN NOT NULL DEFAULT FALSE`);
+    await knex.raw(`ALTER TABLE _nango_users ADD COLUMN getting_started_closed BOOLEAN NOT NULL DEFAULT FALSE`);
     await knex.raw(`
         UPDATE _nango_users
-        SET closed_getting_started = closed
+        SET getting_started_closed = closed
         FROM getting_started_progress
         WHERE _nango_users.id = getting_started_progress.user_id`);
     await knex.raw(`ALTER TABLE getting_started_progress DROP COLUMN closed`);

--- a/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
@@ -116,8 +116,7 @@ describe(`GET ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             connection_id: connection.id,
-            step: 3,
-            closed: false
+            step: 3
         });
         expect(progress.isErr()).toBe(false);
 

--- a/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.integration.test.ts
@@ -80,8 +80,7 @@ describe(`PATCH ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 0,
-            connection_id: null,
-            closed: false
+            connection_id: null
         });
         expect(progress.isOk()).toBe(true);
 
@@ -89,7 +88,7 @@ describe(`PATCH ${endpoint}`, () => {
             method: 'PATCH',
             session,
             query: { env: env.name },
-            body: { step: 2, closed: true }
+            body: { step: 2 }
         });
 
         expect(res.res.status).toBe(204);
@@ -99,7 +98,6 @@ describe(`PATCH ${endpoint}`, () => {
         assert(!updatedProgress.isErr(), 'Failed to get progress');
 
         expect(updatedProgress.value?.step).toBe(2);
-        expect(updatedProgress.value?.closed).toBe(true);
     });
 
     it('should attach a connection', async () => {
@@ -121,8 +119,7 @@ describe(`PATCH ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 0,
-            connection_id: null,
-            closed: false
+            connection_id: null
         });
         expect(progress.isOk()).toBe(true);
 
@@ -173,8 +170,7 @@ describe(`PATCH ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 2,
-            connection_id: connection.id,
-            closed: false
+            connection_id: connection.id
         });
         expect(progress.isOk()).toBe(true);
 
@@ -213,8 +209,7 @@ describe(`PATCH ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 0,
-            connection_id: null,
-            closed: false
+            connection_id: null
         });
         expect(progress.isOk()).toBe(true);
 
@@ -254,8 +249,7 @@ describe(`PATCH ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 1,
-            connection_id: null,
-            closed: false
+            connection_id: null
         });
         expect(progress.isOk()).toBe(true);
 

--- a/packages/server/lib/controllers/v1/meta/getMeta.ts
+++ b/packages/server/lib/controllers/v1/meta/getMeta.ts
@@ -1,5 +1,4 @@
-import db from '@nangohq/database';
-import { environmentService, gettingStartedService } from '@nangohq/shared';
+import { environmentService } from '@nangohq/shared';
 import { NANGO_VERSION, baseUrl, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
@@ -16,7 +15,6 @@ export const getMeta = asyncWrapper<GetMeta>(async (req, res) => {
     const sessionUser = res.locals.user;
 
     const environments = await environmentService.getEnvironmentsByAccountId(sessionUser.account_id);
-    const gettingStartedProgress = await gettingStartedService.getProgressByUserId(db.knex, sessionUser.id);
     res.status(200).send({
         data: {
             environments: environments.map((env) => {
@@ -25,7 +23,7 @@ export const getMeta = asyncWrapper<GetMeta>(async (req, res) => {
             version: NANGO_VERSION,
             baseUrl,
             debugMode: req.session.debugMode === true,
-            gettingStartedClosed: (gettingStartedProgress.isOk() && gettingStartedProgress.value?.closed) ?? false
+            gettingStartedClosed: sessionUser.closed_getting_started
         }
     });
 });

--- a/packages/server/lib/controllers/v1/meta/getMeta.ts
+++ b/packages/server/lib/controllers/v1/meta/getMeta.ts
@@ -23,7 +23,7 @@ export const getMeta = asyncWrapper<GetMeta>(async (req, res) => {
             version: NANGO_VERSION,
             baseUrl,
             debugMode: req.session.debugMode === true,
-            gettingStartedClosed: sessionUser.closed_getting_started
+            gettingStartedClosed: sessionUser.getting_started_closed
         }
     });
 });

--- a/packages/server/lib/controllers/v1/team/getTeam.integration.test.ts
+++ b/packages/server/lib/controllers/v1/team/getTeam.integration.test.ts
@@ -60,7 +60,8 @@ describe(`GET ${route}`, () => {
                         email: user.email,
                         id: user.id,
                         name: user.name,
-                        uuid: user.uuid
+                        uuid: user.uuid,
+                        closedGettingStarted: user.closed_getting_started
                     }
                 ]
             }

--- a/packages/server/lib/controllers/v1/team/getTeam.integration.test.ts
+++ b/packages/server/lib/controllers/v1/team/getTeam.integration.test.ts
@@ -61,7 +61,7 @@ describe(`GET ${route}`, () => {
                         id: user.id,
                         name: user.name,
                         uuid: user.uuid,
-                        closedGettingStarted: user.closed_getting_started
+                        gettingStartedClosed: user.getting_started_closed
                     }
                 ]
             }

--- a/packages/server/lib/controllers/v1/user/patchUser.ts
+++ b/packages/server/lib/controllers/v1/user/patchUser.ts
@@ -41,8 +41,8 @@ export const patchUser = asyncWrapper<PatchUser, never>(async (req, res) => {
         update.name = body.name;
     }
 
-    if (body.closedGettingStarted !== undefined) {
-        update.closed_getting_started = body.closedGettingStarted;
+    if (body.gettingStartedClosed !== undefined) {
+        update.getting_started_closed = body.gettingStartedClosed;
     }
 
     const updated = await userService.update(update);

--- a/packages/server/lib/formatters/user.ts
+++ b/packages/server/lib/formatters/user.ts
@@ -1,11 +1,12 @@
 import type { ApiUser, DBUser } from '@nangohq/types';
 
-export function userToAPI(user: Pick<DBUser, 'id' | 'account_id' | 'email' | 'name' | 'uuid'>): ApiUser {
+export function userToAPI(user: Pick<DBUser, 'id' | 'account_id' | 'email' | 'name' | 'uuid' | 'closed_getting_started'>): ApiUser {
     return {
         id: user.id,
         accountId: user.account_id,
         email: user.email,
         name: user.name,
-        uuid: user.uuid
+        uuid: user.uuid,
+        closedGettingStarted: user.closed_getting_started
     };
 }

--- a/packages/server/lib/formatters/user.ts
+++ b/packages/server/lib/formatters/user.ts
@@ -1,12 +1,12 @@
 import type { ApiUser, DBUser } from '@nangohq/types';
 
-export function userToAPI(user: Pick<DBUser, 'id' | 'account_id' | 'email' | 'name' | 'uuid' | 'closed_getting_started'>): ApiUser {
+export function userToAPI(user: Pick<DBUser, 'id' | 'account_id' | 'email' | 'name' | 'uuid' | 'getting_started_closed'>): ApiUser {
     return {
         id: user.id,
         accountId: user.account_id,
         email: user.email,
         name: user.name,
         uuid: user.uuid,
-        closedGettingStarted: user.closed_getting_started
+        gettingStartedClosed: user.getting_started_closed
     };
 }

--- a/packages/shared/lib/services/getting-started.service.ts
+++ b/packages/shared/lib/services/getting-started.service.ts
@@ -76,8 +76,7 @@ export async function getProgressByUserId(db: Knex, userId: number): Promise<Res
                 environment: pick(result.environment, ['id', 'name'])
             },
             connection: result.connection ? pick(result.connection, ['id', 'connection_id']) : null,
-            step: result.progress.step,
-            closed: result.progress.closed
+            step: result.progress.step
         });
     } catch (err) {
         return Err(new Error('failed_to_get_getting_started_progress', { cause: err }));
@@ -129,8 +128,7 @@ export async function getOrCreateProgressByUser(db: Knex, user: DBUser, currentE
             user_id: user.id,
             getting_started_meta_id: gettingStartedMeta.value.id,
             step: 0,
-            connection_id: null,
-            closed: false
+            connection_id: null
         });
 
         if (createdResult.isErr()) {
@@ -169,10 +167,6 @@ export async function patchProgressByUser(db: Knex, user: DBUser, input: PatchGe
 
         if (typeof input.step !== 'undefined') {
             update.step = input.step;
-        }
-
-        if (typeof input.closed !== 'undefined') {
-            update.closed = input.closed;
         }
 
         if (typeof input.connection_id !== 'undefined') {

--- a/packages/types/lib/gettingStarted/db.ts
+++ b/packages/types/lib/gettingStarted/db.ts
@@ -19,5 +19,4 @@ export interface DBGettingStartedProgress extends Timestamps {
     user_id: number;
     connection_id: number | null;
     step: number;
-    closed: boolean;
 }

--- a/packages/types/lib/gettingStarted/dto.ts
+++ b/packages/types/lib/gettingStarted/dto.ts
@@ -10,13 +10,11 @@ export interface GettingStartedOutput {
     };
     connection: Pick<DBConnection, 'id' | 'connection_id'> | null;
     step: number;
-    closed: boolean;
 }
 
 export interface PatchGettingStartedInput {
     connection_id?: string | null | undefined;
     step?: number | undefined;
-    closed?: boolean | undefined;
 }
 
 export type CreateGettingStartedMeta = Omit<DBGettingStartedMeta, 'id' | 'created_at' | 'updated_at'>;

--- a/packages/types/lib/user/api.ts
+++ b/packages/types/lib/user/api.ts
@@ -11,7 +11,10 @@ export type GetUser = Endpoint<{
 export type PatchUser = Endpoint<{
     Method: 'PATCH';
     Path: `/api/v1/user`;
-    Body: { name: string };
+    Body: {
+        name?: string | undefined;
+        closedGettingStarted?: boolean | undefined;
+    };
     Success: {
         data: ApiUser;
     };
@@ -23,6 +26,7 @@ export interface ApiUser {
     email: string;
     name: string;
     uuid: string;
+    closedGettingStarted: boolean;
 }
 
 export type PutUserPassword = Endpoint<{

--- a/packages/types/lib/user/api.ts
+++ b/packages/types/lib/user/api.ts
@@ -13,7 +13,7 @@ export type PatchUser = Endpoint<{
     Path: `/api/v1/user`;
     Body: {
         name?: string | undefined;
-        closedGettingStarted?: boolean | undefined;
+        gettingStartedClosed?: boolean | undefined;
     };
     Success: {
         data: ApiUser;
@@ -26,7 +26,7 @@ export interface ApiUser {
     email: string;
     name: string;
     uuid: string;
-    closedGettingStarted: boolean;
+    gettingStartedClosed: boolean;
 }
 
 export type PutUserPassword = Endpoint<{

--- a/packages/types/lib/user/db.ts
+++ b/packages/types/lib/user/db.ts
@@ -14,5 +14,5 @@ export interface DBUser extends Timestamps {
     email_verification_token: string | null;
     email_verification_token_expires_at: Date | null;
     uuid: string;
-    closed_getting_started: boolean;
+    getting_started_closed: boolean;
 }

--- a/packages/types/lib/user/db.ts
+++ b/packages/types/lib/user/db.ts
@@ -14,4 +14,5 @@ export interface DBUser extends Timestamps {
     email_verification_token: string | null;
     email_verification_token_expires_at: Date | null;
     uuid: string;
+    closed_getting_started: boolean;
 }

--- a/packages/webapp/src/components/LeftNavBar.tsx
+++ b/packages/webapp/src/components/LeftNavBar.tsx
@@ -20,9 +20,8 @@ import { useClickAway } from 'react-use';
 import { EnvironmentPicker } from './EnvironmentPicker';
 import { useConnectionsCount } from '../hooks/useConnections';
 import { useEnvironment } from '../hooks/useEnvironment';
-import { patchGettingStarted } from '../hooks/useGettingStarted';
 import { useMeta } from '../hooks/useMeta';
-import { useUser } from '../hooks/useUser';
+import { apiPatchUser, useUser } from '../hooks/useUser';
 import { useStore } from '../store';
 import UsageCard from './UsageCard';
 import { globalEnv } from '../utils/env';
@@ -84,7 +83,9 @@ export default function LeftNavBar(props: LeftNavBarProps) {
                 value: LeftNavBarItems.GettingStarted,
                 link: `/${env}/getting-started`,
                 onClose: async () => {
-                    await patchGettingStarted(env, { closed: true });
+                    await apiPatchUser({
+                        closedGettingStarted: true
+                    });
                     void mutateMeta();
                 }
             });

--- a/packages/webapp/src/components/LeftNavBar.tsx
+++ b/packages/webapp/src/components/LeftNavBar.tsx
@@ -84,7 +84,7 @@ export default function LeftNavBar(props: LeftNavBarProps) {
                 link: `/${env}/getting-started`,
                 onClose: async () => {
                     await apiPatchUser({
-                        closedGettingStarted: true
+                        gettingStartedClosed: true
                     });
                     void mutateMeta();
                 }


### PR DESCRIPTION
As I'll be resetting the `getting_started_progress` for everyone when replacing `google-calendar` with `github`, I think it's better that we decouple the closed state from it, so the closed state is persisted independently.

I've added a column to the `_nango_users` table, but treat this as a proposal and feel free to suggest otherwise.

<!-- Summary by @propel-code-bot -->

---

**Decouple 'Getting Started' Closed State from Progress (User-Level, Not Progress-Level)**

This PR fundamentally changes how the 'Getting Started' onboarding closed state is persisted. The closed status, previously a property on 'getting_started_progress' (which is progress/environment-specific), is migrated to a new user-level boolean field, `getting_started_closed`, on the `_nango_users` table. This enables the system to independently manage whether onboarding has been closed, decoupling it from progress steps that may now be reset independently (as motivated by upcoming flow changes replacing Google Calendar with GitHub for onboarding). To achieve this, the PR adds a database migration that migrates any legacy 'closed' values to the new user column, adjusts the relevant TypeScript types, API contracts, validation, controllers, webapp logic, and associated tests, ensuring all external and internal user contracts provide and persist this new field where appropriate.

<details>
<summary><strong>Key Changes</strong></summary>

• Adds a ``getting_started_closed`` boolean column to the `_nango_users` table with a migration that transfers legacy state and drops the old field in `getting_started_progress`.
• Updates `TypeScript` types (`@nangohq/types`): removes `closed` from progress `DTOs`; adds ``gettingStartedClosed`` to user `DTOs`.
• Refactors backend: removes `closed` handling from progress logic, updates ```PATCH`` /api/v1/user` contract and implementation to support changing the closed state, modifies meta ``API`` and related controllers to serve the value from the user record.
• Updates webapp: `Getting Started` ``UI`` closure now calls ``PATCH`` /api/v1/user, not ``PATCH`` progress; adjusts hooks and navigation accordingly.
• Modifies and cleans up relevant tests (integration, ``API``, ``DTO``-related) to match new contracts and behaviors.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Database schema (user table, progress table, migration logic)
• User and onboarding ``API`` endpoints (/api/v1/user, /api/v1/meta, /api/v1/getting-started)
• Backend controller/service logic for onboarding progress and user updates
• Frontend onboarding ``UX``, navigation component
• `TypeScript` types/`DTOs` for users and onboarding progress
• Integration/acceptance tests

</details>

---
*This summary was automatically generated by @propel-code-bot*