### PR TITLE
feat: swap getting started with GitHub

### DIFF
--- a/packages/database/lib/migrations/20250825190400_move_getting_started_closed_to_users.cjs
+++ b/packages/database/lib/migrations/20250825190400_move_getting_started_closed_to_users.cjs
@@ -1,0 +1,19 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE _nango_users ADD COLUMN closed_getting_started BOOLEAN NOT NULL DEFAULT FALSE`);
+    await knex.raw(`
+        UPDATE _nango_users
+        SET closed_getting_started = closed
+        FROM getting_started_progress
+        WHERE _nango_users.id = getting_started_progress.user_id`);
+    await knex.raw(`ALTER TABLE getting_started_progress DROP COLUMN closed`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};

--- a/packages/database/lib/migrations/20250825190400_move_getting_started_closed_to_users.cjs
+++ b/packages/database/lib/migrations/20250825190400_move_getting_started_closed_to_users.cjs
@@ -1,4 +1,4 @@
-exports.config = { transaction: false };
+exports.config = { transaction: true };
 
 /**
  * @param {import('knex').Knex} knex

--- a/packages/database/lib/migrations/20250825230800_reset_getting_started.cjs
+++ b/packages/database/lib/migrations/20250825230800_reset_getting_started.cjs
@@ -1,0 +1,37 @@
+exports.config = { transaction: true };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    // Soft-delete all connections referenced in getting_started_progress
+    await knex('_nango_connections')
+        .whereIn('id', function () {
+            this.select('connection_id').from('getting_started_progress').whereNotNull('connection_id');
+        })
+        .update({
+            deleted: true,
+            deleted_at: knex.fn.now()
+        });
+
+    // Hard-delete all getting_started_progress records
+    await knex('getting_started_progress').del();
+
+    // Soft-delete all configs referenced in getting_started_meta
+    await knex('_nango_configs')
+        .whereIn('id', function () {
+            this.select('integration_id').from('getting_started_meta');
+        })
+        .update({
+            deleted: true,
+            deleted_at: knex.fn.now()
+        });
+
+    // Hard-delete all getting_started_meta records
+    await knex('getting_started_meta').del();
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};

--- a/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
@@ -116,8 +116,7 @@ describe(`GET ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             connection_id: connection.id,
-            step: 3,
-            closed: false
+            step: 3
         });
         expect(progress.isErr()).toBe(false);
 

--- a/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
@@ -37,9 +37,9 @@ describe(`GET ${endpoint}`, () => {
                     environment: { id: env.id, name: env.name },
                     integration: {
                         id: expect.any(Number),
-                        unique_key: 'google-calendar-getting-started',
-                        provider: 'google-calendar',
-                        display_name: 'Google Calendar (Getting Started)'
+                        unique_key: 'github-getting-started',
+                        provider: 'github',
+                        display_name: 'GitHub OAuth (Getting Started)'
                     }
                 },
                 connection: null,
@@ -55,8 +55,8 @@ describe(`GET ${endpoint}`, () => {
         // Ensure pre-provisioned integration exists
         const provider = getProvider('google-calendar');
         expect(provider).toBeTruthy();
-        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar', {
-            display_name: 'Google Calendar (Getting Started)'
+        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'github-getting-started', 'github', {
+            display_name: 'GitHub OAuth (Getting Started)'
         });
 
         // Create meta without progress
@@ -93,8 +93,8 @@ describe(`GET ${endpoint}`, () => {
         const session = await authenticateUser(api, user);
 
         // Create integration
-        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar', {
-            display_name: 'Google Calendar (Getting Started)'
+        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'github-getting-started', 'github', {
+            display_name: 'GitHub OAuth (Getting Started)'
         });
 
         // Create meta and and progress
@@ -108,7 +108,7 @@ describe(`GET ${endpoint}`, () => {
         // Connection to link to progress
         const connection = await seeders.createConnectionSeed({
             env,
-            provider: 'google-calendar-getting-started',
+            provider: 'github-getting-started',
             connectionId: 'demo-conn-id'
         });
 
@@ -150,7 +150,7 @@ describe(`GET ${endpoint}`, () => {
         // Create a connection and link it to the progress
         const connection = await seeders.createConnectionSeed({
             env,
-            provider: 'google-calendar-getting-started',
+            provider: 'github-getting-started',
             connectionId: 'test-conn-id'
         });
 

--- a/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.integration.test.ts
@@ -80,8 +80,7 @@ describe(`PATCH ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 0,
-            connection_id: null,
-            closed: false
+            connection_id: null
         });
         expect(progress.isOk()).toBe(true);
 
@@ -89,7 +88,7 @@ describe(`PATCH ${endpoint}`, () => {
             method: 'PATCH',
             session,
             query: { env: env.name },
-            body: { step: 2, closed: true }
+            body: { step: 2 }
         });
 
         expect(res.res.status).toBe(204);
@@ -99,7 +98,6 @@ describe(`PATCH ${endpoint}`, () => {
         assert(!updatedProgress.isErr(), 'Failed to get progress');
 
         expect(updatedProgress.value?.step).toBe(2);
-        expect(updatedProgress.value?.closed).toBe(true);
     });
 
     it('should attach a connection', async () => {
@@ -121,8 +119,7 @@ describe(`PATCH ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 0,
-            connection_id: null,
-            closed: false
+            connection_id: null
         });
         expect(progress.isOk()).toBe(true);
 
@@ -173,8 +170,7 @@ describe(`PATCH ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 2,
-            connection_id: connection.id,
-            closed: false
+            connection_id: connection.id
         });
         expect(progress.isOk()).toBe(true);
 
@@ -213,8 +209,7 @@ describe(`PATCH ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 0,
-            connection_id: null,
-            closed: false
+            connection_id: null
         });
         expect(progress.isOk()).toBe(true);
 
@@ -254,8 +249,7 @@ describe(`PATCH ${endpoint}`, () => {
             user_id: user.id,
             getting_started_meta_id: meta.value.id,
             step: 1,
-            connection_id: null,
-            closed: false
+            connection_id: null
         });
         expect(progress.isOk()).toBe(true);
 

--- a/packages/server/lib/controllers/v1/meta/getMeta.ts
+++ b/packages/server/lib/controllers/v1/meta/getMeta.ts
@@ -1,5 +1,4 @@
-import db from '@nangohq/database';
-import { environmentService, gettingStartedService } from '@nangohq/shared';
+import { environmentService } from '@nangohq/shared';
 import { NANGO_VERSION, baseUrl, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
@@ -16,7 +15,6 @@ export const getMeta = asyncWrapper<GetMeta>(async (req, res) => {
     const sessionUser = res.locals.user;
 
     const environments = await environmentService.getEnvironmentsByAccountId(sessionUser.account_id);
-    const gettingStartedProgress = await gettingStartedService.getProgressByUserId(db.knex, sessionUser.id);
     res.status(200).send({
         data: {
             environments: environments.map((env) => {
@@ -25,7 +23,7 @@ export const getMeta = asyncWrapper<GetMeta>(async (req, res) => {
             version: NANGO_VERSION,
             baseUrl,
             debugMode: req.session.debugMode === true,
-            gettingStartedClosed: (gettingStartedProgress.isOk() && gettingStartedProgress.value?.closed) ?? false
+            gettingStartedClosed: sessionUser.closed_getting_started
         }
     });
 });

--- a/packages/server/lib/controllers/v1/team/getTeam.integration.test.ts
+++ b/packages/server/lib/controllers/v1/team/getTeam.integration.test.ts
@@ -60,7 +60,8 @@ describe(`GET ${route}`, () => {
                         email: user.email,
                         id: user.id,
                         name: user.name,
-                        uuid: user.uuid
+                        uuid: user.uuid,
+                        closedGettingStarted: user.closed_getting_started
                     }
                 ]
             }

--- a/packages/server/lib/formatters/user.ts
+++ b/packages/server/lib/formatters/user.ts
@@ -1,11 +1,12 @@
 import type { ApiUser, DBUser } from '@nangohq/types';
 
-export function userToAPI(user: Pick<DBUser, 'id' | 'account_id' | 'email' | 'name' | 'uuid'>): ApiUser {
+export function userToAPI(user: Pick<DBUser, 'id' | 'account_id' | 'email' | 'name' | 'uuid' | 'closed_getting_started'>): ApiUser {
     return {
         id: user.id,
         accountId: user.account_id,
         email: user.email,
         name: user.name,
-        uuid: user.uuid
+        uuid: user.uuid,
+        closedGettingStarted: user.closed_getting_started
     };
 }

--- a/packages/shared/lib/services/getting-started.service.ts
+++ b/packages/shared/lib/services/getting-started.service.ts
@@ -76,8 +76,7 @@ export async function getProgressByUserId(db: Knex, userId: number): Promise<Res
                 environment: pick(result.environment, ['id', 'name'])
             },
             connection: result.connection ? pick(result.connection, ['id', 'connection_id']) : null,
-            step: result.progress.step,
-            closed: result.progress.closed
+            step: result.progress.step
         });
     } catch (err) {
         return Err(new Error('failed_to_get_getting_started_progress', { cause: err }));
@@ -129,8 +128,7 @@ export async function getOrCreateProgressByUser(db: Knex, user: DBUser, currentE
             user_id: user.id,
             getting_started_meta_id: gettingStartedMeta.value.id,
             step: 0,
-            connection_id: null,
-            closed: false
+            connection_id: null
         });
 
         if (createdResult.isErr()) {
@@ -169,10 +167,6 @@ export async function patchProgressByUser(db: Knex, user: DBUser, input: PatchGe
 
         if (typeof input.step !== 'undefined') {
             update.step = input.step;
-        }
-
-        if (typeof input.closed !== 'undefined') {
-            update.closed = input.closed;
         }
 
         if (typeof input.connection_id !== 'undefined') {

--- a/packages/types/lib/gettingStarted/db.ts
+++ b/packages/types/lib/gettingStarted/db.ts
@@ -19,5 +19,4 @@ export interface DBGettingStartedProgress extends Timestamps {
     user_id: number;
     connection_id: number | null;
     step: number;
-    closed: boolean;
 }

--- a/packages/types/lib/gettingStarted/dto.ts
+++ b/packages/types/lib/gettingStarted/dto.ts
@@ -10,13 +10,11 @@ export interface GettingStartedOutput {
     };
     connection: Pick<DBConnection, 'id' | 'connection_id'> | null;
     step: number;
-    closed: boolean;
 }
 
 export interface PatchGettingStartedInput {
     connection_id?: string | null | undefined;
     step?: number | undefined;
-    closed?: boolean | undefined;
 }
 
 export type CreateGettingStartedMeta = Omit<DBGettingStartedMeta, 'id' | 'created_at' | 'updated_at'>;

--- a/packages/types/lib/user/api.ts
+++ b/packages/types/lib/user/api.ts
@@ -11,7 +11,10 @@ export type GetUser = Endpoint<{
 export type PatchUser = Endpoint<{
     Method: 'PATCH';
     Path: `/api/v1/user`;
-    Body: { name: string };
+    Body: {
+        name?: string | undefined;
+        closedGettingStarted?: boolean | undefined;
+    };
     Success: {
         data: ApiUser;
     };
@@ -23,6 +26,7 @@ export interface ApiUser {
     email: string;
     name: string;
     uuid: string;
+    closedGettingStarted: boolean;
 }
 
 export type PutUserPassword = Endpoint<{

--- a/packages/types/lib/user/db.ts
+++ b/packages/types/lib/user/db.ts
@@ -14,4 +14,5 @@ export interface DBUser extends Timestamps {
     email_verification_token: string | null;
     email_verification_token_expires_at: Date | null;
     uuid: string;
+    closed_getting_started: boolean;
 }

--- a/packages/webapp/src/components/LeftNavBar.tsx
+++ b/packages/webapp/src/components/LeftNavBar.tsx
@@ -20,9 +20,8 @@ import { useClickAway } from 'react-use';
 import { EnvironmentPicker } from './EnvironmentPicker';
 import { useConnectionsCount } from '../hooks/useConnections';
 import { useEnvironment } from '../hooks/useEnvironment';
-import { patchGettingStarted } from '../hooks/useGettingStarted';
 import { useMeta } from '../hooks/useMeta';
-import { useUser } from '../hooks/useUser';
+import { apiPatchUser, useUser } from '../hooks/useUser';
 import { useStore } from '../store';
 import UsageCard from './UsageCard';
 import { globalEnv } from '../utils/env';
@@ -84,7 +83,9 @@ export default function LeftNavBar(props: LeftNavBarProps) {
                 value: LeftNavBarItems.GettingStarted,
                 link: `/${env}/getting-started`,
                 onClose: async () => {
-                    await patchGettingStarted(env, { closed: true });
+                    await apiPatchUser({
+                        closedGettingStarted: true
+                    });
                     void mutateMeta();
                 }
             });

--- a/packages/webapp/src/pages/GettingStarted/FirstStep.tsx
+++ b/packages/webapp/src/pages/GettingStarted/FirstStep.tsx
@@ -1,4 +1,4 @@
-import { IconBrandGoogleFilled, IconX } from '@tabler/icons-react';
+import { IconBrandGithub, IconX } from '@tabler/icons-react';
 import { useCallback, useRef } from 'react';
 import { useUnmount } from 'react-use';
 
@@ -112,7 +112,7 @@ export const FirstStep: React.FC<FirstStepProps> = ({ connection, integration, o
             <div className="text-text-secondary text-sm">
                 <Button variant="primary" onClick={onClickDisconnect}>
                     <IconX className="w-4 h-4 mr-2" />
-                    Disconnect from Google Calendar
+                    Disconnect from GitHub
                 </Button>
                 <p className="mt-5 text-text-primary text-sm flex flex-row gap-1">
                     A connection was created with the connection id:{' '}
@@ -126,12 +126,12 @@ export const FirstStep: React.FC<FirstStepProps> = ({ connection, integration, o
         <div className="flex flex-col gap-5">
             <p className="text-text-secondary text-sm">Connect your account just like your users would in your app.</p>
             <Button variant="primary" className="w-fit" onClick={onClickConnect}>
-                <IconBrandGoogleFilled className="w-4 h-4 mr-2" />
-                Connect to Google Calendar
+                <IconBrandGithub className="w-4 h-4 mr-2" />
+                Connect to GitHub
             </Button>
             <p className="text-text-secondary text-sm">
                 This will create a connection for your{' '}
-                <LinkWithIcon to={`/${env}/integrations/${integration?.unique_key}`}>Google Calendar integration</LinkWithIcon>, which we have set up for you.
+                <LinkWithIcon to={`/${env}/integrations/${integration?.unique_key}`}>GitHub OAuth integration</LinkWithIcon>, which we have set up for you.
             </p>
         </div>
     );

--- a/packages/webapp/src/pages/GettingStarted/Show.tsx
+++ b/packages/webapp/src/pages/GettingStarted/Show.tsx
@@ -42,17 +42,17 @@ export const GettingStarted: React.FC = () => {
                 <title>Getting Started - Nango</title>
             </Helmet>
             <header className="flex items-center mb-8">
-                <h2 className="flex text-left text-3xl font-semibold tracking-tight text-text-primary">Try Nango with Google Calendar</h2>
+                <h2 className="flex text-left text-3xl font-semibold tracking-tight text-text-primary">Demo: try Nango with GitHub</h2>
             </header>
             <VerticalSteps
                 className="w-full"
                 currentStep={currentStep}
                 steps={[
                     {
-                        id: 'authorize-google-calendar',
+                        id: 'authorize-github',
                         renderTitle: (status) => {
                             if (status === 'completed') {
-                                return <h3 className="text-success-4 text-lg font-semibold">Google Calendar Authorized!</h3>;
+                                return <h3 className="text-success-4 text-lg font-semibold">GitHub Authorized!</h3>;
                             }
                             return <h3 className="text-text-primary text-lg font-semibold">Experience the user&apos;s auth flow</h3>;
                         },
@@ -88,7 +88,7 @@ export const GettingStarted: React.FC = () => {
                     {
                         id: 'access-google-calendar-api',
                         renderTitle: () => {
-                            return <h3 className="text-text-primary text-lg font-semibold">Use Nango as a proxy to make requests to Google Calendar</h3>;
+                            return <h3 className="text-text-primary text-lg font-semibold">Use Nango as a proxy to make requests to GitHub</h3>;
                         },
                         content: (
                             <SecondStep


### PR DESCRIPTION
We're swapping the getting started flow from creating a google calendar event, to starring Nango's github repo.

#### Backend
- Creates a db migration that deletes:
  - `getting_started_progress` for every user.
  - Every connection created in the getting started flow.
  - `getting_started_meta` for every account.
  - Every integration (`google-calendar-getting-started`) used in the getting started flow
- Replaces `google-calendar` integration by `github`

#### Frontend
- Replaces copy
- Replaces code-snippets
- Replaces proxy request to now star nango's github repo
- Experimental (feedback?) Added title to code-block to describe code intention.
  <img width="1022" height="493" alt="image" src="https://github.com/user-attachments/assets/44cd27b9-788c-4a08-a486-a051602deba2" />
<!-- Summary by @propel-code-bot -->

---

**Overhaul: Replace Getting Started Google Calendar Flow with GitHub Star**

This PR fully transitions the 'getting started' flow throughout the Nango application from a Google Calendar-centric demo to a GitHub-centric experience, where users connect their GitHub account and star the Nango GitHub repository. The migration touches backend services, database migrations, frontend UI/copy, test cases, and integration logic. All code, configuration, interface texts, and test seeds relating to Google Calendar in the onboarding have been replaced with GitHub equivalents. Additionally, a database migration resets any persisted getting started state and removes obsolete Google Calendar integration artifacts.

<details>
<summary><strong>Key Changes</strong></summary>

• Adds database migration to remove all `getting started` data tied to Google Calendar, including users' progress, meta records, connections, and integration configs.
• Backend updated: `getting-started` service and related logic now provision and reference a pre-configured `github-getting-started` integration instead of Google Calendar.
• Frontend onboarding pages and all related code/copy updated from Google Calendar to `GitHub`; `OAuth` connect flow, connection/disconnect buttons, and illustrative text updated.
• Demo code snippets (Node.js & `cURL`) replaced to show `GitHub` ``API`` `star repo` operations instead of Google Calendar event creation.
• Proxy request used in the interactive demo refactored to use `GitHub``s `star a repo' endpoint; relevant ``API`` ``HTTP`` verb and routing aligned (``PUT`` /user/starred/{owner}/{repo}).
• All onboarding and getting started test seeds, test logic, and expectations refactored to expect `GitHub` metadata and integration keys.
• Experimental ``UX`` addition: code block examples in the onboarding flow now display an optional title describing their action.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Frontend: `GettingStarted`/`FirstStep`.tsx, `GettingStarted`/`SecondStep`.tsx, `GettingStarted`/Show.tsx, step flows, ``UI`` copy and ``CTA`` buttons.
• Backend: shared/lib/services/getting-started.service.ts, onboarding logic, provider config provision.
• Database: migrations (reset, cleanup of onboarding state and Google Calendar records).
• Integration/feature tests: server/lib/controllers/v1/`gettingStarted`/`getGettingStarted`.integration.test.ts and seeding routines.

</details>

---
*This summary was automatically generated by @propel-code-bot*