### PR TITLE
fix(deploy): deploy to AWS for staging environments

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,6 +27,36 @@ on:
                     - connect_ui
 
 jobs:
+    deploy_aws:
+        if: inputs.stage == 'staging'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            actions: write
+        steps:
+            - name: Checkout nango-environments
+              uses: actions/checkout@v4
+              with:
+                  repository: NangoHQ/nango-environments
+                  token: ${{ secrets.NANGO_ENVIRONMENTS_PAT }}
+                  path: nango-environments
+
+            - name: Deploy ${{ inputs.service }} (AWS)
+              run: |
+                  cd nango-environments
+
+                  # Configure git for the commit
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+                  # Update the nango-values.yaml file for the current stage and service
+                  yq eval '.spec.values.${{ inputs.service }}.image.tag = "${{ github.sha }}"' -i apps/${{ inputs.stage }}/nango-values.yaml
+
+                  # Commit and push the changes
+                  git add apps/${{ inputs.stage }}/nango-values.yaml
+                  git commit -m "Update ${{ inputs.service }} image tag to ${{ github.sha }} in ${{ inputs.stage }}"
+                  git push origin main
+
     deploy_server:
         if: inputs.service == 'server'
         runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,7 +28,7 @@ on:
 
 jobs:
     deploy_aws:
-        if: inputs.stage == 'staging'
+        if: inputs.stage == 'staging' && inputs.service != 'runner' && inputs.service != 'connect_ui'
         runs-on: ubuntu-latest
         permissions:
             contents: write


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add AWS Deployment Job for Staging Environments in CI Workflow**

This PR modifies the deployment workflow by introducing a new job called 'deploy_aws' to support deployments to AWS, specifically targeting staging environments. The job checks out a separate 'nango-environments' repository, updates the image tag for the deployed service in the appropriate YAML file using 'yq', and commits and pushes these changes back to the repository. The deploy_aws job only runs when the deployment target is the staging stage and excludes the 'runner' and 'connect_ui' services, which continue to use the existing Render-based deployment jobs. No changes are made to production deployments or to the Render-based jobs for other environments.

<details>
<summary><strong>Key Changes</strong></summary>

• Added ``deploy_aws`` job in .github/workflows/deploy.yaml for staging environment deployments.
• The `deploy_aws` job conditionally runs only for `staging` stage and excludes `runner` and ``connect_ui`` services.
• Implements checkout of the `nango-environments` repository using a `GitHub` Actions Personal Access Token.
• Uses `yq` to update the image tag in the relevant service's ``YAML`` config for the staging environment.
• Commits and pushes configuration updates to the main branch of the `nango-environments` repo.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• .github/workflows/deploy.yaml (``CI``/``CD`` workflow logic)

</details>

---
*This summary was automatically generated by @propel-code-bot*