### PR TITLE
fix: `patchUser` zod schema

### DIFF
--- a/packages/server/lib/controllers/v1/user/patchUser.ts
+++ b/packages/server/lib/controllers/v1/user/patchUser.ts
@@ -11,7 +11,7 @@ import type { DBUser, PatchUser } from '@nangohq/types';
 const validation = z
     .object({
         name: z.string().min(3).max(255).optional(),
-        closedGettingStarted: z.boolean().optional()
+        gettingStartedClosed: z.boolean().optional()
     })
     .strict();
 


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

This PR updates the zod schema used for validating PATCH requests to the user controller by renaming the field `closedGettingStarted` to `gettingStartedClosed`. This change ensures consistency between the request body schema and the corresponding database/user object fields.

*This summary was automatically generated by @propel-code-bot*