### PR TITLE
fix(api): start/pause connection_id is optional

### DIFF
--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -1455,7 +1455,7 @@ paths:
                                 syncs:
                                     oneOf:
                                         - type: array
-                                          description: A list of sync names that you wish to start.
+                                          description: A list of sync names that you wish to start. If empty, all syncs are triggered
                                           items:
                                               type: string
                                               description: Sync name
@@ -1516,7 +1516,7 @@ paths:
                                 syncs:
                                     oneOf:
                                         - type: array
-                                          description: A list of sync names that you wish to pause.
+                                          description: A list of sync names that you wish to pause. If empty, all syncs are triggered
                                           items:
                                               type: string
                                               description: Sync name

--- a/packages/server/lib/controllers/sync/postSyncPause.integration.test.ts
+++ b/packages/server/lib/controllers/sync/postSyncPause.integration.test.ts
@@ -54,8 +54,7 @@ describe(`POST ${endpoint}`, () => {
                 errors: [
                     { code: 'invalid_union', message: 'Invalid input', path: ['syncs', '0'] },
                     { code: 'invalid_union', message: 'Invalid input', path: ['syncs', '2'] },
-                    { code: 'invalid_type', message: 'Invalid input: expected string, received undefined', path: ['provider_config_key'] },
-                    { code: 'invalid_type', message: 'Invalid input: expected string, received undefined', path: ['connection_id'] }
+                    { code: 'invalid_type', message: 'Invalid input: expected string, received undefined', path: ['provider_config_key'] }
                 ]
             }
         });

--- a/packages/server/lib/controllers/sync/postSyncPause.ts
+++ b/packages/server/lib/controllers/sync/postSyncPause.ts
@@ -19,7 +19,7 @@ const bodySchema = z.strictObject({
         .min(0)
         .max(256),
     provider_config_key: providerConfigKeySchema,
-    connection_id: connectionIdSchema
+    connection_id: connectionIdSchema.optional()
 });
 
 export const postPublicSyncPause = asyncWrapper<PostPublicSyncPause>(async (req, res) => {

--- a/packages/server/lib/controllers/sync/postSyncStart.integration.test.ts
+++ b/packages/server/lib/controllers/sync/postSyncStart.integration.test.ts
@@ -54,8 +54,7 @@ describe(`POST ${endpoint}`, () => {
                 errors: [
                     { code: 'invalid_union', message: 'Invalid input', path: ['syncs', '0'] },
                     { code: 'invalid_union', message: 'Invalid input', path: ['syncs', '2'] },
-                    { code: 'invalid_type', message: 'Invalid input: expected string, received undefined', path: ['provider_config_key'] },
-                    { code: 'invalid_type', message: 'Invalid input: expected string, received undefined', path: ['connection_id'] }
+                    { code: 'invalid_type', message: 'Invalid input: expected string, received undefined', path: ['provider_config_key'] }
                 ]
             }
         });

--- a/packages/server/lib/controllers/sync/postSyncStart.ts
+++ b/packages/server/lib/controllers/sync/postSyncStart.ts
@@ -19,7 +19,7 @@ const bodySchema = z.strictObject({
         .min(0)
         .max(256),
     provider_config_key: providerConfigKeySchema,
-    connection_id: connectionIdSchema
+    connection_id: connectionIdSchema.optional()
 });
 
 export const postPublicSyncStart = asyncWrapper<PostPublicSyncStart>(async (req, res) => {

--- a/packages/types/lib/sync/api.ts
+++ b/packages/types/lib/sync/api.ts
@@ -71,7 +71,7 @@ export type PostPublicSyncPause = Endpoint<{
     Body: {
         syncs: (string | { name: string; variant: string })[];
         provider_config_key: string;
-        connection_id: string;
+        connection_id?: string | undefined;
     };
     Success: { success: boolean };
 }>;
@@ -82,7 +82,7 @@ export type PostPublicSyncStart = Endpoint<{
     Body: {
         syncs: (string | { name: string; variant: string })[];
         provider_config_key: string;
-        connection_id: string;
+        connection_id?: string | undefined;
     };
     Success: { success: boolean };
 }>;


### PR DESCRIPTION
## Changes

- fix(api): start/pause connection_id is optional
Third time the charm

- Documentation fix missing note about empty
<!-- Summary by @propel-code-bot -->

---

This PR updates the /sync/start and /sync/pause endpoints to make the 'connection_id' parameter optional in both the runtime validation and TypeScript API types. It also corrects and clarifies documentation, specifying that providing an empty syncs array targets all syncs. Related integration tests are updated accordingly to reflect the new request schema and validation logic.

*This summary was automatically generated by @propel-code-bot*