### PR TITLE
fix: remove dynamic environment variables

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,15 +43,15 @@ jobs:
             - name: configure aws credentials
               uses: aws-actions/configure-aws-credentials@v4
               with:
-                  role-to-assume: ${{ secrets[format('{0}_DEPLOY_CONNECT_UI_ROLE', upper(inputs.stage))] }}
+                  role-to-assume: ${{ secrets.STAGING_DEPLOY_CONNECT_UI_ROLE }}
                   role-session-name: GitHub_to_AWS_via_FederatedOIDC
-                  aws-region: ${{ secrets[format('{0}_AWS_REGION', upper(inputs.stage))] }}
+                  aws-region: ${{ secrets.STAGING_AWS_REGION }}
             - name: Deploy Connect UI to S3
               run: |
-                  aws s3 sync packages/connect-ui/dist/ s3://${{ secrets[format('{0}_CONNECT_UI_BUCKET', upper(inputs.stage))] }} --delete
+                  aws s3 sync packages/connect-ui/dist/ s3://${{ secrets.STAGING_CONNECT_UI_BUCKET }} --delete
             - name: Create invalidation
               run: |
-                  aws cloudfront create-invalidation --distribution-id ${{ secrets[format('{0}_CONNECT_UI_DISTRIBUTION_ID', upper(inputs.stage))] }} --paths "/*"
+                  aws cloudfront create-invalidation --distribution-id ${{ secrets.STAGING_CONNECT_UI_DISTRIBUTION_ID }} --paths "/*"
 
     deploy_aws:
         if: inputs.stage == 'staging' && inputs.service != 'runner' && inputs.service != 'connect_ui'


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This pull request modifies the .github/workflows/deploy.yaml workflow to replace dynamic environment variable expressions (using format and upper functions for secret selection) with static, explicit references for the staging deployment of the Connect UI. Instead of referencing secrets using expressions like ${{ secrets[format('{0}_DEPLOY_CONNECT_UI_ROLE', upper(inputs.stage))] }}, the workflow now references ${{ secrets.STAGING_DEPLOY_CONNECT_UI_ROLE }} directly. This simplifies secret access in the workflow and removes dependency on dynamic variable interpolation.

*This summary was automatically generated by @propel-code-bot*