### PR TITLE
fix(webapp): use `isLoading`  instead of disabled prop

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -10443,6 +10443,7 @@ snowflake-jwt:
             title: User Name
             description: The username for your Snowflake account used for authentication
             example: MYUSER
+            pattern: ^[A-Z0-9]+$
             doc_section: '#step-3-finding-your-user-name'
         privateKey:
             type: string

--- a/packages/webapp/src/pages/Integrations/Create.tsx
+++ b/packages/webapp/src/pages/Integrations/Create.tsx
@@ -221,14 +221,19 @@ export default function Create() {
                                 </div>
                             </div>
                             <div className="flex justify-between">
-                                <Button type="button" onClick={() => handleIntegrationCreation(env !== 'prod')} disabled={isCreatingShared} variant="primary">
+                                <Button type="button" onClick={() => handleIntegrationCreation(env !== 'prod')} isLoading={isCreatingShared} variant="primary">
                                     {isCreatingShared && env !== 'prod'
                                         ? 'Creating...'
                                         : env !== 'prod'
                                           ? "Use Nango's developer app"
                                           : 'Use your own developer app'}
                                 </Button>
-                                <Button type="button" onClick={() => handleIntegrationCreation(env === 'prod')} disabled={isCreatingShared} variant="secondary">
+                                <Button
+                                    type="button"
+                                    onClick={() => handleIntegrationCreation(env === 'prod')}
+                                    isLoading={isCreatingShared}
+                                    variant="secondary"
+                                >
                                     {isCreatingShared && env === 'prod'
                                         ? 'Creating...'
                                         : env === 'prod'


### PR DESCRIPTION
## Describe the problem and your solution

- Use `isLoading` prop instead of `disabled`
- Snowflake allows both letters and numbers only when creating an account, but after the account is created, it automatically converts the username to uppercase. 

<img width="295" height="89" alt="Screenshot 2025-08-28 at 16 58 38" src="https://github.com/user-attachments/assets/7924296f-7195-4cd2-b5e8-04ee4764859f" />

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR makes two targeted changes. First, it updates the integration creation flow in the webapp to use the Button component's `isLoading` prop instead of `disabled` for shared integration creation, providing more accurate loading state feedback to users. Second, it updates the Snowflake provider configuration in `providers.yaml` by adding a regex pattern (`^[A-Z0-9]+$`) to the username field, enforcing uppercase alphanumeric input at configuration time, in line with Snowflake's normalization of usernames.

*This summary was automatically generated by @propel-code-bot*