### PR TITLE
fix: Revert "fix(github): refresh a jwt for github app and github app…

### DIFF
--- a/packages/server/lib/controllers/appAuth.controller.ts
+++ b/packages/server/lib/controllers/appAuth.controller.ts
@@ -105,7 +105,7 @@ class AppAuthController {
                 return;
             }
 
-            const connectionConfig: Record<string, string | undefined | Record<string, string | number>> = {
+            const connectionConfig: Record<string, string | undefined> = {
                 installation_id,
                 app_id: config.oauth_client_id
             };

--- a/packages/shared/lib/auth/githubApp.ts
+++ b/packages/shared/lib/auth/githubApp.ts
@@ -1,23 +1,20 @@
 import { Err, Ok } from '@nangohq/utils';
 
 import * as jwtClient from './jwt.js';
-import { REFRESH_MARGIN_TEN } from '../services/connections/utils.js';
 import { AuthCredentialsError } from '../utils/error.js';
-import { interpolateStringFromObject, isTokenExpired } from '../utils/utils.js';
+import { interpolateStringFromObject } from '../utils/utils.js';
 
-import type { AppCredentials, ConnectionConfig, DBConnectionDecrypted, IntegrationConfig, ProviderCustom, ProviderGithubApp } from '@nangohq/types';
+import type { AppCredentials, ConnectionConfig, IntegrationConfig, ProviderCustom, ProviderGithubApp } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 /**
  * Create Github APP credentials
  */
 export async function createCredentials({
-    connection,
     provider,
     integration,
     connectionConfig
 }: {
-    connection?: DBConnectionDecrypted;
     provider: ProviderGithubApp | ProviderCustom;
     integration: IntegrationConfig;
     connectionConfig: ConnectionConfig;
@@ -46,38 +43,6 @@ export async function createCredentials({
             payload['iss'] = connectionConfig['app_id'];
         }
 
-        if (
-            connection &&
-            connection.credentials &&
-            'expires_at' in connection.credentials &&
-            'access_token' in connection.credentials &&
-            !isTokenExpired(connection.credentials.expires_at, REFRESH_MARGIN_TEN)
-        ) {
-            const createdJwtToken = jwtClient.fetchJwtToken({
-                privateKey,
-                payload,
-                options: { algorithm: 'RS256' }
-            });
-            if (createdJwtToken.isErr()) {
-                return Err(createdJwtToken.error);
-            }
-            const { jwtToken } = createdJwtToken.value;
-            const decodedJwt = jwtClient.decode(jwtToken);
-            const expirationFromJwt = decodedJwt?.['exp'];
-
-            return Ok({
-                type: 'APP',
-                access_token: connection.credentials['access_token'],
-                expires_at: connection.credentials['expires_at'],
-                raw: connection.credentials,
-                jwtToken: {
-                    token: jwtToken,
-                    expires_at: expirationFromJwt ? expirationFromJwt * 1000 : 0
-                },
-                app: connection.credentials
-            });
-        }
-
         const create = await jwtClient.createCredentialsFromURL({
             privateKey,
             url: tokenUrl,
@@ -92,18 +57,12 @@ export async function createCredentials({
 
         const { tokenResponse, jwtToken } = create.value;
 
-        const decodedJwt = jwtClient.decode(jwtToken);
-        const expirationFromJwt = decodedJwt?.['exp'];
-
         const credentials: AppCredentials = {
             type: 'APP',
             access_token: tokenResponse.token!,
             expires_at: tokenResponse.expires_at,
             raw: tokenResponse,
-            jwtToken: {
-                token: jwtToken,
-                expires_at: expirationFromJwt ? expirationFromJwt * 1000 : 0
-            }
+            jwtToken
         };
 
         return Ok(credentials);

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1016,7 +1016,6 @@ class ConnectionService {
     ): Promise<Result<CombinedOauth2AppCredentials | AppCredentials, AuthCredentialsError>> {
         if (provider.auth_mode === 'APP') {
             const appResult = await githubAppClient.createCredentials({
-                connection,
                 integration: config,
                 provider: provider as ProviderGithubApp,
                 connectionConfig: connection.connection_config
@@ -1037,7 +1036,6 @@ class ConnectionService {
                 logCtx
             }),
             githubAppClient.createCredentials({
-                connection,
                 integration: config,
                 provider: provider as ProviderGithubApp,
                 connectionConfig: connection.connection_config

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -414,15 +414,6 @@ export async function refreshCredentialsIfNeeded({
             // Use newCredentials as fallback when neither user nor app are specifically present
             connectionToRefresh.credentials = newCredentials;
         }
-
-        // for github app and github-app oauth we also store the jwt token in the connection config
-        if (newCredentials.type === 'APP' && 'jwtToken' in newCredentials) {
-            connectionToRefresh['connection_config']['jwtToken'] = newCredentials['jwtToken'];
-        }
-        if (newCredentials.type === 'CUSTOM' && 'app' in newCredentials && 'jwtToken' in newCredentials.app && newCredentials.app.jwtToken) {
-            connectionToRefresh['connection_config']['jwtToken'] = newCredentials['app']['jwtToken'];
-        }
-
         connectionToRefresh = await connectionService.updateConnection({
             ...connectionToRefresh,
             last_fetched_at: new Date(),
@@ -472,18 +463,6 @@ export async function shouldRefreshCredentials({
                 return { should: true, reason: 'expired_introspected_token' };
             }
             return { should: false, reason: 'fresh_introspected_token' };
-        }
-
-        if (credentials.type === 'APP' || credentials.type === 'CUSTOM') {
-            // A Github App or Custom (Github App OAuth) have a jwt expiration and
-            // an access token expiration
-            const connection_config = connection.connection_config;
-            if (connection_config['jwtToken']) {
-                const jwtTokenExpiration = connection_config['jwtToken']['expires_at'];
-                if (jwtTokenExpiration && isTokenExpired(new Date(jwtTokenExpiration), REFRESH_MARGIN_S)) {
-                    return { should: true, reason: 'expired_jwt_token' };
-                }
-            }
         }
 
         if (!credentials.expires_at) {

--- a/packages/shared/lib/services/connections/utils.ts
+++ b/packages/shared/lib/services/connections/utils.ts
@@ -7,7 +7,6 @@ export const DEFAULT_OAUTHCC_EXPIRES_AT_MS = ms('55minutes'); // This ensures we
 export const DEFAULT_INFINITE_EXPIRES_AT_MS = ms('99years');
 export const MAX_CONSECUTIVE_DAYS_FAILED_REFRESH = 4;
 export const REFRESH_MARGIN_S = ms('15minutes') / 1000;
-export const REFRESH_MARGIN_TEN = ms('10minutes') / 1000;
 
 export function getExpiresAtFromCredentials(credentials: AllAuthCredentials): Date | null {
     if (credentials.type === 'CUSTOM' && 'app' in credentials) {

--- a/packages/shared/lib/services/connections/utils.unit.test.ts
+++ b/packages/shared/lib/services/connections/utils.unit.test.ts
@@ -16,8 +16,8 @@ describe('getExpiresAtFromCredentials', () => {
         const credentials = {
             type: 'CUSTOM',
             raw: {},
-            app: { type: 'APP', access_token: 'app_token', raw: {}, expires_at: new Date('2025-07-20T10:00:00Z') },
-            user: { type: 'OAUTH2', access_token: 'user_token', raw: {}, expires_at: new Date('2025-07-18T10:00:00Z') }
+            app: { type: 'APP', access_token: 'app_token', raw: {}, expires_at: new Date('2025-07-20T10:00:00Z').toISOString() },
+            user: { type: 'OAUTH2', access_token: 'user_token', raw: {}, expires_at: new Date('2025-07-18T10:00:00Z').toISOString() }
         } as AllAuthCredentials;
 
         const result = getExpiresAtFromCredentials(credentials);
@@ -28,7 +28,7 @@ describe('getExpiresAtFromCredentials', () => {
         const credentials = {
             type: 'CUSTOM',
             raw: {},
-            app: { type: 'APP', access_token: 'app_token', raw: {}, expires_at: new Date('2025-07-20T10:00:00Z') }
+            app: { type: 'APP', access_token: 'app_token', raw: {}, expires_at: new Date('2025-07-20T10:00:00Z').toISOString() }
         } as AllAuthCredentials;
 
         const result = getExpiresAtFromCredentials(credentials);
@@ -39,8 +39,8 @@ describe('getExpiresAtFromCredentials', () => {
         const credentials = {
             type: 'CUSTOM',
             raw: {},
-            app: { type: 'APP', access_token: 'app_token', raw: {}, expires_at: new Date('2025-07-18T09:00:00Z') },
-            user: { type: 'OAUTH2', access_token: 'user_token', raw: {}, expires_at: new Date('2025-07-20T10:00:00Z') }
+            app: { type: 'APP', access_token: 'app_token', raw: {}, expires_at: new Date('2025-07-18T09:00:00Z').toISOString() },
+            user: { type: 'OAUTH2', access_token: 'user_token', raw: {}, expires_at: new Date('2025-07-20T10:00:00Z').toISOString() }
         } as AllAuthCredentials;
 
         const result = getExpiresAtFromCredentials(credentials);

--- a/packages/types/lib/auth/api.ts
+++ b/packages/types/lib/auth/api.ts
@@ -72,10 +72,7 @@ export interface AppCredentials {
     access_token: string;
     expires_at?: Date | undefined;
     raw: Record<string, any>;
-    jwtToken?: {
-        token: string;
-        expires_at?: number;
-    };
+    jwtToken?: string;
 }
 
 export interface AppStoreCredentials {
@@ -103,11 +100,6 @@ export interface OAuth2Credentials extends CredentialsCommon {
 
 export interface CustomCredentials extends CredentialsCommon {
     type: AuthModes['Custom'];
-    expires_at?: Date | undefined;
-    jwtToken?: {
-        token: string;
-        expires_at?: number;
-    };
 }
 
 export interface OAuth2ClientCredentials extends CredentialsCommon {
@@ -198,7 +190,6 @@ export type TestableCredentials = ApiKeyCredentials | BasicApiCredentials | TbaC
 export type RefreshableCredentials =
     | OAuth2Credentials
     | AppCredentials
-    | CustomCredentials
     | AppStoreCredentials
     | OAuth2ClientCredentials
     | JwtCredentials


### PR DESCRIPTION
… oauth (#4538)"

This reverts commit 4b2b17c8a1b31f882bde49bbd9fd0acf6644655e.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Revert "fix(github): refresh a jwt for github app and github app oauth (#4538)"**

This PR reverts the changes introduced in commit 4b2b17c8a1b31f882bde49bbd9fd0acf6644655e, which previously updated the logic for refreshing JWT tokens for GitHub Apps and GitHub App OAuth flows. The reverted changes affect the structure and storage of JWT tokens within 'AppCredentials', related utility functions, type definitions, and some test logic. The codebase reverts to the older model where JWT tokens are handled and stored as plain strings (rather than as objects containing token and expiration), and dependent code is updated accordingly.

<details>
<summary><strong>Key Changes</strong></summary>

• Reverts helper function (``fetchJwtToken``) and related ``JWT`` decode logic in `jwt.ts`; restores older, simplified ``JWT``-handling approach.
• Modifies ``AppCredentials`` and ``CustomCredentials`` typings to store `JWTs` as strings instead of objects.
• Removes logic that separately tracks and refreshes ``JWT`` token expirations in connection configs and in ``shouldRefreshCredentials``.
• Updates how ``JWT`` tokens are set and used in ``githubApp`.ts` and associated controller/services (including removing specific expiration tracking).
• Adjusts unit tests to match the reverted credentials structures (notably, date serialization details).
• Removes ``REFRESH_MARGIN_TEN`` constant and related logic.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/shared/lib/auth/jwt.ts
• packages/shared/lib/auth/`githubApp`.ts
• packages/shared/lib/services/connections/credentials/refresh.ts
• packages/shared/lib/services/connections/utils.ts
• packages/types/lib/auth/api.ts
• packages/shared/lib/services/connection.service.ts
• packages/server/lib/controllers/`appAuth`.controller.ts
• packages/shared/lib/services/connections/utils.unit.test.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*