### PR TITLE
fix: deploy webapp to s3 with cloudfront

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,8 +25,38 @@ on:
                     - orchestrator
                     - metering
                     - connect_ui
+                    - app_ui
 
 jobs:
+    deploy_app_ui_aws:
+        if: inputs.stage == 'staging' && inputs.service == 'app_ui'
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write
+            contents: read
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Install dependencies
+              run: npm ci
+            - name: Build Webapp
+              run: npm run ts-build && npm run -w @nangohq/webapp build
+            - name: Replace env.js source with api path in dist/index.html
+              run: |
+                  FILE="packages/webapp/dist/index.html"
+                  sed -E -i 's#(src=")/env\.js\?hash=([^"]+)#\1https://api-staging.nango.dev/env.js?hash=\2#g' "$FILE"
+            - name: configure aws credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  role-to-assume: ${{ secrets.STAGING_DEPLOY_APP_UI_ROLE }}
+                  role-session-name: GitHub_to_AWS_via_FederatedOIDC
+                  aws-region: ${{ secrets.STAGING_AWS_REGION }}
+            - name: Deploy Connect UI to S3
+              run: |
+                  aws s3 sync packages/webapp/dist/ s3://${{ secrets.STAGING_APP_UI_BUCKET }} --delete
+            - name: Create invalidation
+              run: |
+                  aws cloudfront create-invalidation --distribution-id ${{ secrets.STAGING_APP_UI_DISTRIBUTION_ID }} --paths "/*"
     deploy_connect_ui_aws:
         if: inputs.stage == 'staging' && inputs.service == 'connect_ui'
         runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -51,7 +51,7 @@ jobs:
                   role-to-assume: ${{ secrets.STAGING_DEPLOY_APP_UI_ROLE }}
                   role-session-name: GitHub_to_AWS_via_FederatedOIDC
                   aws-region: ${{ secrets.STAGING_AWS_REGION }}
-            - name: Deploy Connect UI to S3
+            - name: Deploy Webapp to S3
               run: |
                   aws s3 sync packages/webapp/dist/ s3://${{ secrets.STAGING_APP_UI_BUCKET }} --delete
             - name: Create invalidation

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -42,9 +42,11 @@ jobs:
             - name: Build Webapp
               run: npm run ts-build && npm run -w @nangohq/webapp build
             - name: Replace env.js source with api path in dist/index.html
+              env:
+                  API_DOMAIN: 'https://api-staging.nango.dev'
               run: |
                   FILE="packages/webapp/dist/index.html"
-                  sed -E -i 's#(src=")/env\.js\?hash=([^"]+)#\1https://api-staging.nango.dev/env.js?hash=\2#g' "$FILE"
+                  sed -E -i 's#(src=")/env\.js\?hash=([^"]+)#\1${{ env.API_DOMAIN }}/env.js?hash=\2#g' "$FILE"
             - name: configure aws credentials
               uses: aws-actions/configure-aws-credentials@v4
               with:


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Deploy app_ui to AWS S3 with CloudFront Support in GitHub Actions**

This pull request expands the deployment workflow to support the deployment of the 'app_ui' frontend application to AWS S3 with CloudFront cache invalidation. A new GitHub Actions job ('deploy_app_ui_aws') is introduced for staging, automating the build, environment-specific rewrites in the output index.html, AWS credential configuration using OIDC, uploading assets to S3, and triggering CloudFront cache invalidation. The deployable services list is also updated to include 'app_ui'.

<details>
<summary><strong>Key Changes</strong></summary>

• Added ``app_ui`` as a deployable service option in the workflow dispatch inputs.
• Created a ``deploy_app_ui_aws`` job for deploying ``app_ui`` to `S3` and managing `CloudFront` cache in the staging environment.
• The job includes steps for repository checkout, installing dependencies, building the webapp, environment variable replacement in dist/index.html (for env.js path), ``AWS`` authentication/configuration, `S3` sync, and `CloudFront` invalidation.
• Best practices and naming clarifications have been raised in review comments.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• .github/workflows/deploy.yaml

</details>

---
*This summary was automatically generated by @propel-code-bot*