### PR TITLE
fix: ignore the app_ui for aws deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -86,7 +86,7 @@ jobs:
                   aws cloudfront create-invalidation --distribution-id ${{ secrets.STAGING_CONNECT_UI_DISTRIBUTION_ID }} --paths "/*"
 
     deploy_aws:
-        if: inputs.stage == 'staging' && inputs.service != 'runner' && inputs.service != 'connect_ui'
+        if: inputs.stage == 'staging' && inputs.service != 'runner' && inputs.service != 'connect_ui' && inputs.service != 'app_ui'
         runs-on: ubuntu-latest
         permissions:
             contents: write


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR modifies the deployment workflow YAML to exclude the 'app_ui' service from the generic 'deploy_aws' job. Now, when staging deployments are triggered, 'app_ui' joins the list of services ('runner', 'connect_ui') that are not handled by the more generic AWS deployment job and are instead handled by their own dedicated jobs. Only a single line in the workflow file is updated.

*This summary was automatically generated by @propel-code-bot*