### PR TITLE
docs: change date for end user release

### DIFF
--- a/docs-v2/changelog/dev-updates.mdx
+++ b/docs-v2/changelog/dev-updates.mdx
@@ -8,7 +8,7 @@ description: "Updates and breaking changes for developers."
 [Full technical changelog on <Icon icon="github" />](https://github.com/NangoHQ/nango/releases)
 </Info>
 
-<Update label="August 27, 2025"  tags={["Breaking changes", "API"]}>
+<Update label="Sep 1, 2025"  tags={["Breaking changes", "API"]}>
 
   ## End-user info is no longer shared between connections
 
@@ -16,7 +16,7 @@ Currently, if multiple connections share the same `end_user_id`, they also share
 
   ### 🗓️ Timeline
 
-  - **September 5, 2025**: End user updates will stop being replicated across connections.
+  - **September 8, 2025**: End user updates will stop being replicated across connections.
 
   ### 🧐 Am I impacted?
 


### PR DESCRIPTION
## Changes

- change date for end user release
Since I wasn't able to merge it last week

<!-- Summary by @propel-code-bot -->

---

This PR updates the developer changelog documentation by changing the scheduled dates for a previously announced 'end user release'. The main reason for this modification is that the update could not be merged last week as originally planned, requiring the public-facing release and timeline dates to be shifted forward.

*This summary was automatically generated by @propel-code-bot*