### PR TITLE
feat(emails): change from email for transactional emails

### DIFF
--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -193,7 +193,7 @@ export const ENVS = z.object({
 
     // SMTP
     SMTP_URL: z.url().optional(),
-    SMTP_FROM: z.string().default('Nango <support@nango.dev>'),
+    SMTP_FROM: z.string().default('Nango <noreply@email.nango.dev>'),
 
     // Postgres
     NANGO_DATABASE_URL: z.url().optional(),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the default value of the SMTP_FROM environment variable for transactional emails. The 'from' address has been changed from 'Nango <support@nango.dev>' to 'Nango <noreply@email.nango.dev>' in the environment parser configuration, reflecting a move from the root domain email to a subdomain specifically for transactional messaging.

*This summary was automatically generated by @propel-code-bot*