### PR TITLE
docs: fix typo in changelog

### DIFF
--- a/docs-v2/changelog/dev-updates.mdx
+++ b/docs-v2/changelog/dev-updates.mdx
@@ -84,7 +84,7 @@ Currently, if multiple connections share the same `end_user_id`, they also share
 
 <Update label="August 20, 2025" description="v0.66.2" tags={["Breaking changes", "API", "CLI"]}>
 
-  ## Deprecation of `/connections` endpoints
+  ## Deprecation of `/connection` endpoints
 
   In this release, we've made some changes to the API that are breaking for some users.
 


### PR DESCRIPTION
`/connection` is deprecated (not `/connections`)

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->
https://docs.nango.dev/changelog/dev-updates#deprecation-of-%2Fconnections-endpoints

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This pull request corrects a documentation typo in the changelog. The section title is updated to reflect that the `/connection` endpoints-not `/connections`-are deprecated, aligning it with the referenced documentation and intended messaging.

*This summary was automatically generated by @propel-code-bot*