### PR TITLE
feat(tracking): track prod usage threshold

### DIFF
--- a/packages/metering/lib/processors/billing.ts
+++ b/packages/metering/lib/processors/billing.ts
@@ -139,7 +139,7 @@ async function notifyOnProdUsageThreshold({ accountId, environmentId }: { accoun
                     productTracking.track({
                         name: 'prod:connections:threshold_hit',
                         team,
-                        eventProperties: { connectionCount: threshold }
+                        userProperties: { connectionCount: threshold }
                     });
                 }
             }

--- a/packages/metering/lib/processors/billing.ts
+++ b/packages/metering/lib/processors/billing.ts
@@ -2,7 +2,7 @@ import { getAccountUsageTracker, onUsageIncreased } from '@nangohq/account-usage
 import { billing } from '@nangohq/billing';
 import db from '@nangohq/database';
 import { Subscriber } from '@nangohq/pubsub';
-import { connectionService, getPlan } from '@nangohq/shared';
+import { accountService, connectionService, environmentService, getPlan, productTracking } from '@nangohq/shared';
 import { Err, Ok, metrics, report, stringifyError } from '@nangohq/utils';
 
 import { logger } from '../utils.js';
@@ -82,6 +82,12 @@ async function process(event: UsageEvent): Promise<Result<void>> {
                     metric: 'connections',
                     delta: event.payload.value
                 });
+                if (typeof event.payload.properties['environmentId'] === 'number') {
+                    await notifyOnProdUsageThreshold({
+                        accountId: event.payload.properties.accountId,
+                        environmentId: event.payload.properties['environmentId']
+                    });
+                }
                 // No billing action for connections, just tracking usage
                 return Ok(undefined);
             }
@@ -116,5 +122,29 @@ async function trackUsage({ accountId, metric, delta }: { accountId: number; met
         });
     } catch (err) {
         report(new Error('Failed to track usage', { cause: err }), { accountId, metric, delta });
+    }
+}
+
+async function notifyOnProdUsageThreshold({ accountId, environmentId }: { accountId: number; environmentId: number }): Promise<void> {
+    const threshold = 3;
+    try {
+        const environment = await environmentService.getRawById(environmentId);
+
+        if (environment && environment.name === 'prod') {
+            const connections = await connectionService.countConnectionsByEnvironment({ environmentId });
+
+            if (connections === threshold) {
+                const team = await accountService.getAccountById(db.knex, accountId);
+                if (team) {
+                    productTracking.track({
+                        name: 'prod:connections:threshold_hit',
+                        team,
+                        eventProperties: { connectionCount: threshold }
+                    });
+                }
+            }
+        }
+    } catch (err) {
+        report(new Error('Failed to notify on usage threshold', { cause: err }), { accountId });
     }
 }

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -503,6 +503,16 @@ class ConnectionService {
         return res?.count ? Number(res.count) : 0;
     }
 
+    public async countConnectionsByEnvironment({ environmentId }: { environmentId: number }): Promise<number> {
+        const res = await db.knex
+            .from<DBConnection>(`_nango_connections`)
+            .where({ environment_id: environmentId, deleted: false })
+            .count<{ count: string }>('*')
+            .first();
+
+        return res?.count ? Number(res.count) : 0;
+    }
+
     public async getConnectionsByEnvironmentAndConfig(environment_id: number, providerConfigKey: string): Promise<ConnectionInternal[]> {
         const result = await db.knex
             .from<DBConnection>(`_nango_connections`)

--- a/packages/shared/lib/utils/productTracking.ts
+++ b/packages/shared/lib/utils/productTracking.ts
@@ -10,13 +10,14 @@ export type ProductTrackingTypes =
     | 'account:billing:plan_changed'
     | 'account:billing:downgraded'
     | 'account:billing:upgraded'
+    | 'deploy:success'
+    | 'prod:connections:threshold_hit'
     | 'server:resource_capped:connection_creation'
     | 'server:resource_capped:connection_imported'
     | 'server:resource_capped:script_activate'
     | 'server:resource_capped:script_deploy_is_disabled'
     | 'server:resource_capped:action_triggered'
-    | 'server:resource_capped:active_records'
-    | 'deploy:success';
+    | 'server:resource_capped:active_records';
 
 class ProductTracking {
     client: PostHog | undefined;


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Notify in posthog when prod connections reach 3. Debatable if this is the best location to do it but it felt closest to being correct.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Track Production Environment Connection Usage Threshold Events**

This PR introduces new instrumentation to detect when a customer reaches exactly three active connections in their 'prod' environment and emits a corresponding tracking event ('prod:connections:threshold_hit') to PostHog. The core logic is added to the billing connection usage flow, with supporting utility methods to efficiently count connections by environment and a small change to product tracking types to support the new event.

<details>
<summary><strong>Key Changes</strong></summary>

• New `notifyOnProdUsageThreshold` function in billing processor: triggers a `PostHog` tracking event when a `prod` environment reaches 3 active connections.
• Addition of `ConnectionService`.`countConnectionsByEnvironment` utility to count non-deleted connections for a specified environment.
• Billing processor updated to invoke threshold tracking logic after connection usage events (if `environmentId` is present).
• Update to `productTracking`.ts to include the new `prod:connections:`threshold_hit`` event in the allowed tracking event types.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/metering/lib/processors/billing.ts (main billing event logic)
• packages/shared/lib/services/connection.service.ts (connection counting utility)
• packages/shared/lib/utils/`productTracking`.ts (event types for product tracking)

</details>

---
*This summary was automatically generated by @propel-code-bot*