### PR TITLE
feat: ConnectUI customization frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9062,6 +9062,29 @@
                 "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
             }
         },
+        "node_modules/@tanstack/form-core": {
+            "version": "1.19.3",
+            "resolved": "https://registry.npmjs.org/@tanstack/form-core/-/form-core-1.19.3.tgz",
+            "integrity": "sha512-VUDKpR24kfKHh43nGtDExZtwpq1MMNmN0mrYbqNOOjOoOUm9yZ0fPxWjPBfJQOdvmyncV2Svg9I5klUPjXqWzA==",
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/store": "^0.7.4"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/form-core/node_modules/@tanstack/store": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.7.4.tgz",
+            "integrity": "sha512-F1XqZQici1Aq6WigEfcxJSml92nW+85Om8ElBMokPNg5glCYVOmPkZGIQeieYFxcPiKTfwo0MTOQpUyJtwncrg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
         "node_modules/@tanstack/history": {
             "version": "1.98.1",
             "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.98.1.tgz",
@@ -9081,6 +9104,59 @@
             "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.65.0.tgz",
             "integrity": "sha512-Bnnq/1axf00r2grRT6gUyIkZRKzhHs+p4DijrCQ3wMlA3D3TTT71gtaSLtqnzGddj73/7X5JDGyjiSLdjvQN4w==",
             "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/react-form": {
+            "version": "1.19.3",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-form/-/react-form-1.19.3.tgz",
+            "integrity": "sha512-e9m/aAemSIfM9Qesk6xeXiBdXLRhZPnQp4QVp/epcaaA6peBCYS0rBL9fuLKGrL4LRyDIA4jA68XR0Mxq0yO4A==",
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/form-core": "1.19.3",
+                "@tanstack/react-store": "^0.7.4",
+                "decode-formdata": "^0.9.0",
+                "devalue": "^5.3.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "@tanstack/react-start": "^1.130.10",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@tanstack/react-start": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@tanstack/react-form/node_modules/@tanstack/react-store": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.7.4.tgz",
+            "integrity": "sha512-DyG1e5Qz/c1cNLt/NdFbCA7K1QGuFXQYT6EfUltYMJoQ4LzBOGnOl5IjuxepNcRtmIKkGpmdMzdFZEkevgU9bQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/store": "0.7.4",
+                "use-sync-external-store": "^1.5.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@tanstack/react-form/node_modules/@tanstack/store": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.7.4.tgz",
+            "integrity": "sha512-F1XqZQici1Aq6WigEfcxJSml92nW+85Om8ElBMokPNg5glCYVOmPkZGIQeieYFxcPiKTfwo0MTOQpUyJtwncrg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -14170,6 +14246,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/decode-formdata": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/decode-formdata/-/decode-formdata-0.9.0.tgz",
+            "integrity": "sha512-q5uwOjR3Um5YD+ZWPOF/1sGHVW9A5rCrRwITQChRXlmPkxDFBqCm4jNTIVdGHNH9OnR+V9MoZVgRhsFb+ARbUw==",
+            "license": "MIT"
+        },
         "node_modules/deep-eql": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -14375,6 +14457,12 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/dev-null/-/dev-null-0.1.1.tgz",
             "integrity": "sha512-nMNZG0zfMgmdv8S5O0TM5cpwNbGKRGPCxVsr0SmA3NZZy9CYBbuNLL0PD3Acx9e5LIUgwONXtM9kM6RlawPxEQ=="
+        },
+        "node_modules/devalue": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.3.2.tgz",
+            "integrity": "sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==",
+            "license": "MIT"
         },
         "node_modules/dezalgo": {
             "version": "1.0.4",
@@ -19952,7 +20040,6 @@
         },
         "node_modules/loose-envify": {
             "version": "1.4.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
@@ -22104,7 +22191,6 @@
         },
         "node_modules/react": {
             "version": "18.3.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
@@ -22128,7 +22214,6 @@
         },
         "node_modules/react-dom": {
             "version": "18.3.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
@@ -23181,7 +23266,6 @@
         },
         "node_modules/scheduler": {
             "version": "0.23.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
@@ -26078,10 +26162,9 @@
             }
         },
         "node_modules/use-sync-external-store": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
-            "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
-            "dev": true,
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+            "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
             "license": "MIT",
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -29289,6 +29372,9 @@
         "packages/webapp": {
             "name": "@nangohq/webapp",
             "version": "1.0.0",
+            "dependencies": {
+                "@tanstack/react-form": "^1.19.3"
+            },
             "devDependencies": {
                 "@geist-ui/core": "2.3.8",
                 "@geist-ui/icons": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9066,6 +9066,7 @@
             "version": "1.19.3",
             "resolved": "https://registry.npmjs.org/@tanstack/form-core/-/form-core-1.19.3.tgz",
             "integrity": "sha512-VUDKpR24kfKHh43nGtDExZtwpq1MMNmN0mrYbqNOOjOoOUm9yZ0fPxWjPBfJQOdvmyncV2Svg9I5klUPjXqWzA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@tanstack/store": "^0.7.4"
@@ -9079,6 +9080,7 @@
             "version": "0.7.4",
             "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.7.4.tgz",
             "integrity": "sha512-F1XqZQici1Aq6WigEfcxJSml92nW+85Om8ElBMokPNg5glCYVOmPkZGIQeieYFxcPiKTfwo0MTOQpUyJtwncrg==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -9114,6 +9116,7 @@
             "version": "1.19.3",
             "resolved": "https://registry.npmjs.org/@tanstack/react-form/-/react-form-1.19.3.tgz",
             "integrity": "sha512-e9m/aAemSIfM9Qesk6xeXiBdXLRhZPnQp4QVp/epcaaA6peBCYS0rBL9fuLKGrL4LRyDIA4jA68XR0Mxq0yO4A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@tanstack/form-core": "1.19.3",
@@ -9139,6 +9142,7 @@
             "version": "0.7.4",
             "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.7.4.tgz",
             "integrity": "sha512-DyG1e5Qz/c1cNLt/NdFbCA7K1QGuFXQYT6EfUltYMJoQ4LzBOGnOl5IjuxepNcRtmIKkGpmdMzdFZEkevgU9bQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@tanstack/store": "0.7.4",
@@ -9157,6 +9161,7 @@
             "version": "0.7.4",
             "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.7.4.tgz",
             "integrity": "sha512-F1XqZQici1Aq6WigEfcxJSml92nW+85Om8ElBMokPNg5glCYVOmPkZGIQeieYFxcPiKTfwo0MTOQpUyJtwncrg==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -14250,6 +14255,7 @@
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/decode-formdata/-/decode-formdata-0.9.0.tgz",
             "integrity": "sha512-q5uwOjR3Um5YD+ZWPOF/1sGHVW9A5rCrRwITQChRXlmPkxDFBqCm4jNTIVdGHNH9OnR+V9MoZVgRhsFb+ARbUw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/deep-eql": {
@@ -14462,6 +14468,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.3.2.tgz",
             "integrity": "sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/dezalgo": {
@@ -20040,6 +20047,7 @@
         },
         "node_modules/loose-envify": {
             "version": "1.4.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
@@ -22191,6 +22199,7 @@
         },
         "node_modules/react": {
             "version": "18.3.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
@@ -22214,6 +22223,7 @@
         },
         "node_modules/react-dom": {
             "version": "18.3.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
@@ -23266,6 +23276,7 @@
         },
         "node_modules/scheduler": {
             "version": "0.23.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
@@ -26165,6 +26176,7 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
             "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -29372,9 +29384,6 @@
         "packages/webapp": {
             "name": "@nangohq/webapp",
             "version": "1.0.0",
-            "dependencies": {
-                "@tanstack/react-form": "^1.19.3"
-            },
             "devDependencies": {
                 "@geist-ui/core": "2.3.8",
                 "@geist-ui/icons": "1.0.2",
@@ -29403,6 +29412,7 @@
                 "@stripe/stripe-js": "7.3.1",
                 "@tabler/icons-react": "3.21.0",
                 "@tailwindcss/forms": "0.5.10",
+                "@tanstack/react-form": "^1.19.3",
                 "@tanstack/react-query": "5.72.2",
                 "@tanstack/react-table": "8.21.2",
                 "@tanstack/react-virtual": "3.13.6",

--- a/packages/connect-ui/src/views/Go.tsx
+++ b/packages/connect-ui/src/views/Go.tsx
@@ -342,7 +342,7 @@ export const Go: React.FC = () => {
             <header className="relative m-10">
                 <div className="absolute top-0 left-0 w-full flex justify-between">
                     {!isSingleIntegration ? (
-                        <Link to="/" onClick={() => setIsDirty(false)}>
+                        <Link to="/integrations" onClick={() => setIsDirty(false)}>
                             <Button className="gap-1" title={t('go.backToList')} variant={'transparent'}>
                                 <IconArrowLeft stroke={1} /> {t('common.back')}
                             </Button>

--- a/packages/connect-ui/src/views/Home.tsx
+++ b/packages/connect-ui/src/views/Home.tsx
@@ -20,7 +20,7 @@ export const Home: React.FC = () => {
     const { data, error } = useQuery({ enabled: sessionToken !== null, queryKey: ['sessionToken'], queryFn: getConnectSession });
     const apiURL = useSearchParam('apiURL');
     const isEmbedded = useSearchParam('embedded');
-    const isPreview = useSearchParam('preview');
+    const isPreview = useSearchParam('preview') === 'true';
     const detectClosedAuthWindow = useSearchParam('detectClosedAuthWindow');
 
     useEffect(() => {
@@ -37,6 +37,10 @@ export const Home: React.FC = () => {
                     break;
                 }
                 case 'settings_changed': {
+                    // Only allow dynamic theme changing in preview mode
+                    if (!isPreview) {
+                        break;
+                    }
                     const data = evt.data as ConnectUIEventSettingsChanged;
                     setTheme(data.payload.theme);
                     break;
@@ -56,7 +60,7 @@ export const Home: React.FC = () => {
             setSessionToken(inUrl);
         }
 
-        if (isPreview === 'true') {
+        if (isPreview) {
             // Don't clear event listeners on preview
             return;
         }
@@ -71,12 +75,13 @@ export const Home: React.FC = () => {
         if (apiURL) setApiURL(apiURL);
         if (detectClosedAuthWindow) setDetectClosedAuthWindow(detectClosedAuthWindow === 'true');
         if (isEmbedded) setIsEmbedded(isEmbedded === 'true');
-        if (isPreview) setIsPreview(isPreview === 'true');
+        if (isPreview) setIsPreview(isPreview);
     }, [apiURL, detectClosedAuthWindow, isEmbedded, isPreview, setApiURL, setDetectClosedAuthWindow, setIsEmbedded, setIsPreview]);
 
     useEffect(() => {
         if (data) {
             setSession(data.data);
+            setTheme(data.data.connectUISettings.theme);
             void navigate({ to: '/integrations' });
         }
     }, [data]);

--- a/packages/frontend/lib/types.ts
+++ b/packages/frontend/lib/types.ts
@@ -1,4 +1,4 @@
-import type { ConnectionResponseSuccess } from '@nangohq/types';
+import type { ConnectUISettings, ConnectionResponseSuccess } from '@nangohq/types';
 
 export type AuthErrorType =
     | 'missing_auth_token'
@@ -114,4 +114,9 @@ export interface ConnectUIEventConnect {
     payload: AuthResult;
 }
 
-export type ConnectUIEvent = ConnectUIEventReady | ConnectUIEventClose | ConnectUIEventConnect;
+export interface ConnectUIEventSettingsChanged {
+    type: 'settings_changed';
+    payload: ConnectUISettings;
+}
+
+export type ConnectUIEvent = ConnectUIEventReady | ConnectUIEventClose | ConnectUIEventConnect | ConnectUIEventSettingsChanged;

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -94,5 +94,8 @@
         "web-vitals": "2.1.4",
         "zustand": "5.0.3"
     },
-    "proxy": "http://localhost:3003"
+    "proxy": "http://localhost:3003",
+    "dependencies": {
+        "@tanstack/react-form": "^1.19.3"
+    }
 }

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -49,6 +49,7 @@
         "@stripe/stripe-js": "7.3.1",
         "@tabler/icons-react": "3.21.0",
         "@tailwindcss/forms": "0.5.10",
+        "@tanstack/react-form": "^1.19.3",
         "@tanstack/react-query": "5.72.2",
         "@tanstack/react-table": "8.21.2",
         "@tanstack/react-virtual": "3.13.6",
@@ -94,8 +95,5 @@
         "web-vitals": "2.1.4",
         "zustand": "5.0.3"
     },
-    "proxy": "http://localhost:3003",
-    "dependencies": {
-        "@tanstack/react-form": "^1.19.3"
-    }
+    "proxy": "http://localhost:3003"
 }

--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -16,7 +16,7 @@ import Signin from './pages/Account/Signin';
 import { Signup } from './pages/Account/Signup';
 import { VerifyEmail } from './pages/Account/VerifyEmail';
 import { VerifyEmailByExpiredToken } from './pages/Account/VerifyEmailByExpiredToken';
-import { ConnectUISettings } from './pages/ConnectUI/Show';
+import { ConnectUISettingsPage } from './pages/ConnectUI/Show';
 import { ConnectionCreate } from './pages/Connection/Create';
 import { ConnectionCreateLegacy } from './pages/Connection/CreateLegacy';
 import { ConnectionList } from './pages/Connection/List';
@@ -99,7 +99,7 @@ const App = () => {
                             <Route path="/:env/connections/:providerConfigKey/:connectionId" element={<ConnectionShow />} />
                             <Route path="/:env/activity" element={<Navigate to={`/${env}/logs`} replace={true} />} />
                             <Route path="/:env/logs" element={<LogsShow />} />
-                            <Route path="/:env/connect-ui" element={<ConnectUISettings />} />
+                            <Route path="/:env/connect-ui" element={<ConnectUISettingsPage />} />
                             <Route path="/:env/environment-settings" element={<EnvironmentSettings />} />
                             <Route path="/:env/project-settings" element={<Navigate to="/environment-settings" />} />
                             <Route path="/:env/account-settings" element={<Navigate to="/team-settings" />} />

--- a/packages/webapp/src/hooks/useConnectUISettings.tsx
+++ b/packages/webapp/src/hooks/useConnectUISettings.tsx
@@ -1,0 +1,44 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { APIError, apiFetch } from '../utils/api';
+
+import type { GetConnectUISettings, PutConnectUISettings } from '@nangohq/types';
+
+export function useConnectUISettings(env: string) {
+    return useQuery<GetConnectUISettings['Success'], APIError>({
+        enabled: Boolean(env),
+        queryKey: [env, 'connect-ui-settings'],
+        queryFn: async () => {
+            const res = await apiFetch(`/api/v1/connect-ui-settings?env=${env}`);
+
+            const json = (await res.json()) as GetConnectUISettings['Reply'];
+            if (!res.ok || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+
+            return json;
+        }
+    });
+}
+
+export function useUpdateConnectUISettings(env: string) {
+    const queryClient = useQueryClient();
+    return useMutation<PutConnectUISettings['Success'], APIError, PutConnectUISettings['Body']>({
+        mutationFn: async (data: PutConnectUISettings['Body']) => {
+            const res = await apiFetch(`/api/v1/connect-ui-settings?env=${env}`, {
+                method: 'PUT',
+                body: JSON.stringify(data)
+            });
+
+            const json = (await res.json()) as PutConnectUISettings['Reply'];
+            if (!res.ok || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+
+            return json;
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: [env, 'connect-ui-settings'] });
+        }
+    });
+}

--- a/packages/webapp/src/pages/ConnectUI/Show.tsx
+++ b/packages/webapp/src/pages/ConnectUI/Show.tsx
@@ -99,7 +99,6 @@ export const ConnectUISettingsPage = () => {
                     {/** Form */}
                     <form
                         onSubmit={(e) => {
-                            console.log('onSubmit', e);
                             e.preventDefault();
                             e.stopPropagation();
                             void form.handleSubmit();

--- a/packages/webapp/src/pages/ConnectUI/Show.tsx
+++ b/packages/webapp/src/pages/ConnectUI/Show.tsx
@@ -23,13 +23,40 @@ type ThemePath = {
     [K in keyof ConnectUIColorPalette]: `theme.light.${K}` | `theme.dark.${K}`;
 }[keyof ConnectUIColorPalette];
 
+const lightThemeFields: { name: ThemePath; label: string }[] = [
+    {
+        name: 'theme.light.background',
+        label: 'Background'
+    },
+    {
+        name: 'theme.light.foreground',
+        label: 'Foreground'
+    },
+    {
+        name: 'theme.light.primary',
+        label: 'Primary'
+    },
+    {
+        name: 'theme.light.primaryForeground',
+        label: 'Primary Foreground'
+    },
+    {
+        name: 'theme.light.textPrimary',
+        label: 'Text Primary'
+    },
+    {
+        name: 'theme.light.textMuted',
+        label: 'Text Muted'
+    }
+];
+
 export const ConnectUISettingsPage = () => {
     const toast = useToast();
     const env = useStore((state) => state.env);
     const environment = useEnvironment(env);
 
     const { data: connectUISettings } = useConnectUISettings(env);
-    const { mutate: updateConnectUISettings } = useUpdateConnectUISettings(env);
+    const { mutate: updateConnectUISettings, isPending: isUpdatingConnectUISettings } = useUpdateConnectUISettings(env);
     const connectUIPreviewRef = useRef<ConnectUIPreviewRef>(null);
 
     const form = useForm({
@@ -60,33 +87,6 @@ export const ConnectUISettingsPage = () => {
             });
         }
     });
-
-    const lightThemeFields: { name: ThemePath; label: string }[] = [
-        {
-            name: 'theme.light.background',
-            label: 'Background'
-        },
-        {
-            name: 'theme.light.foreground',
-            label: 'Foreground'
-        },
-        {
-            name: 'theme.light.primary',
-            label: 'Primary'
-        },
-        {
-            name: 'theme.light.primaryForeground',
-            label: 'Primary Foreground'
-        },
-        {
-            name: 'theme.light.textPrimary',
-            label: 'Text Primary'
-        },
-        {
-            name: 'theme.light.textMuted',
-            label: 'Text Muted'
-        }
-    ];
 
     return (
         <DashboardLayout selectedItem={LeftNavBarItems.ConnectUI} className="p-6 w-full">
@@ -183,9 +183,15 @@ export const ConnectUISettingsPage = () => {
 
                         {/** Save Button */}
                         <form.Subscribe selector={(state) => [state.canSubmit, state.isDirty, state.isSubmitting]}>
-                            {([canSubmit, isDirty, isSubmitting]) => (
-                                <Button type="submit" variant="primary" size="md" className="self-end" disabled={!canSubmit || !isDirty || isSubmitting}>
-                                    {isSubmitting ? 'Saving...' : 'Save settings'}
+                            {([canSubmit, isDirty]) => (
+                                <Button
+                                    type="submit"
+                                    variant="primary"
+                                    size="md"
+                                    className="self-end"
+                                    disabled={!canSubmit || !isDirty || isUpdatingConnectUISettings}
+                                >
+                                    {isUpdatingConnectUISettings ? 'Saving...' : 'Save settings'}
                                 </Button>
                             )}
                         </form.Subscribe>

--- a/packages/webapp/src/pages/ConnectUI/Show.tsx
+++ b/packages/webapp/src/pages/ConnectUI/Show.tsx
@@ -1,78 +1,14 @@
-import { useQuery } from '@tanstack/react-query';
-import { useEffect, useRef } from 'react';
+import { IconMoon, IconSun } from '@tabler/icons-react';
 import { Helmet } from 'react-helmet';
 
+import { ColorInput } from './components/ColorInput';
+import { ConnectUIPreview } from './components/ConnectUIPreview';
 import { LeftNavBarItems } from '../../components/LeftNavBar';
-import { apiConnectSessions } from '../../hooks/useConnect';
-import { useEnvironment } from '../../hooks/useEnvironment';
-import { useToast } from '../../hooks/useToast';
+import { Checkbox } from '../../components/ui/Checkbox';
+import { Button } from '../../components/ui/button/Button';
 import DashboardLayout from '../../layout/DashboardLayout';
-import { useStore } from '../../store';
-import { APIError } from '../../utils/api';
-import { createConnectUIPreviewIFrame } from '../../utils/connect-ui';
-import { globalEnv } from '../../utils/env';
 
 export const ConnectUISettings = () => {
-    const toast = useToast();
-    const env = useStore((state) => state.env);
-    const { environmentAndAccount } = useEnvironment(env);
-
-    const connectUIContainer = useRef<HTMLDivElement>(null);
-    const connectUIIframe = useRef<HTMLIFrameElement>();
-
-    const { data: sessionToken } = useQuery<string>({
-        enabled: Boolean(env),
-        queryKey: [env, 'preview-session-token'],
-        queryFn: async () => {
-            const res = await apiConnectSessions(env, {
-                end_user: {
-                    id: 'previewUserId',
-                    email: 'preview@nango.dev',
-                    display_name: 'Preview User'
-                }
-            });
-
-            if (!res.res.ok || 'error' in res.json) {
-                throw new APIError({ res: res.res, json: res.json });
-            }
-
-            return res.json.data.token;
-        },
-        refetchInterval: 1000,
-        refetchIntervalInBackground: true,
-        staleTime: 0
-    });
-
-    useEffect(() => {
-        if (!sessionToken || !connectUIIframe.current) {
-            return;
-        }
-
-        const iframe = connectUIIframe.current;
-        iframe.contentWindow?.postMessage(
-            {
-                type: 'session_token',
-                sessionToken
-            },
-            '*'
-        );
-    }, [sessionToken, connectUIIframe]);
-
-    useEffect(() => {
-        if (!environmentAndAccount || !connectUIContainer.current || connectUIIframe.current) {
-            return;
-        }
-
-        const iframe = createConnectUIPreviewIFrame({
-            baseURL: globalEnv.connectUrl,
-            apiURL: globalEnv.apiUrl,
-            sessionToken
-        });
-
-        connectUIIframe.current = iframe;
-        connectUIContainer.current.appendChild(iframe);
-    }, [env, environmentAndAccount, sessionToken, toast]);
-
     return (
         <DashboardLayout selectedItem={LeftNavBarItems.ConnectUI} className="p-6 w-full h-full">
             <Helmet>
@@ -80,8 +16,60 @@ export const ConnectUISettings = () => {
             </Helmet>
             <div className="flex flex-col h-full">
                 <h2 className="mb-8 text-3xl font-semibold tracking-tight text-white">Connect UI Settings</h2>
-                <div className="h-full flex justify-end">
-                    <div ref={connectUIContainer} className="h-full w-[500px] overflow-hidden" />
+                {/** Form */}
+                <div className="flex justify-center gap-8">
+                    <div className="flex flex-col gap-8">
+                        {/** Other settings */}
+                        <div className="space-y-4">
+                            <h2 className="text-lg font-bold text-grayscale-100 flex gap-2">Settings</h2>
+                            <div className="flex gap-2 items-center">
+                                <Checkbox id="showWatermark" />
+                                <label htmlFor="showWatermark" className={`text-sm font-medium text-grayscale-300`}>
+                                    Show watermark
+                                </label>
+                            </div>
+                        </div>
+
+                        {/** Theme */}
+                        <div className="space-y-4">
+                            <h2 className="text-lg font-bold text-grayscale-100 flex gap-2">Theme</h2>
+                            <div className="flex gap-8 h-fit">
+                                <div className="flex flex-col gap-4">
+                                    <h3 className="text-md font-medium text-grayscale-100 flex gap-2">
+                                        <IconSun className="w-6 h-6" /> Light
+                                    </h3>
+
+                                    <ColorInput name="background" id="background" label="Background" />
+                                    <ColorInput name="foreground" id="foreground" label="Foreground" />
+                                    <ColorInput name="primary" id="primary" label="Primary" />
+                                    <ColorInput name="primaryForeground" id="primaryForeground" label="Primary Foreground" />
+                                    <ColorInput name="textPrimary" id="textPrimary" label="Text Primary" />
+                                    <ColorInput name="textMuted" id="textMuted" label="Text Muted" />
+                                </div>
+                                <div className="w-px bg-grayscale-4" />
+                                <div className="flex flex-col gap-4">
+                                    <h3 className="text-md font-medium text-grayscale-100 flex gap-2">
+                                        <IconMoon className="w-6 h-6" /> Dark
+                                    </h3>
+
+                                    <ColorInput name="background" id="background" label="Background" />
+                                    <ColorInput name="foreground" id="foreground" label="Foreground" />
+                                    <ColorInput name="primary" id="primary" label="Primary" />
+                                    <ColorInput name="primaryForeground" id="primaryForeground" label="Primary Foreground" />
+                                    <ColorInput name="textPrimary" id="textPrimary" label="Text Primary" />
+                                    <ColorInput name="textMuted" id="textMuted" label="Text Muted" />
+                                </div>
+                            </div>
+                        </div>
+
+                        {/** Save Button */}
+                        <Button variant="primary" size="md" className="self-end">
+                            Save settings
+                        </Button>
+                    </div>
+
+                    {/** Preview */}
+                    <ConnectUIPreview className="h-full w-[500px]" />
                 </div>
             </div>
         </DashboardLayout>

--- a/packages/webapp/src/pages/ConnectUI/Show.tsx
+++ b/packages/webapp/src/pages/ConnectUI/Show.tsx
@@ -1,75 +1,199 @@
-import { IconMoon, IconSun } from '@tabler/icons-react';
+import { useForm } from '@tanstack/react-form';
+import { useRef } from 'react';
 import { Helmet } from 'react-helmet';
 
-import { ColorInput } from './components/ColorInput';
+import { ColorInput, isValidCSSColor } from './components/ColorInput';
 import { ConnectUIPreview } from './components/ConnectUIPreview';
 import { LeftNavBarItems } from '../../components/LeftNavBar';
+import LinkWithIcon from '../../components/LinkWithIcon';
 import { Checkbox } from '../../components/ui/Checkbox';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../components/ui/Tooltip';
 import { Button } from '../../components/ui/button/Button';
+import { useConnectUISettings, useUpdateConnectUISettings } from '../../hooks/useConnectUISettings';
+import { useEnvironment } from '../../hooks/useEnvironment';
+import { useToast } from '../../hooks/useToast';
 import DashboardLayout from '../../layout/DashboardLayout';
+import { useStore } from '../../store';
 
-export const ConnectUISettings = () => {
+import type { ConnectUIPreviewRef } from './components/ConnectUIPreview';
+import type { ConnectUIColorPalette } from '@nangohq/types';
+
+// Utility type to generate all possible theme paths
+type ThemePath = {
+    [K in keyof ConnectUIColorPalette]: `theme.light.${K}` | `theme.dark.${K}`;
+}[keyof ConnectUIColorPalette];
+
+export const ConnectUISettingsPage = () => {
+    const toast = useToast();
+    const env = useStore((state) => state.env);
+    const environment = useEnvironment(env);
+
+    const { data: connectUISettings } = useConnectUISettings(env);
+    const { mutate: updateConnectUISettings } = useUpdateConnectUISettings(env);
+    const connectUIPreviewRef = useRef<ConnectUIPreviewRef>(null);
+
+    const form = useForm({
+        defaultValues: connectUISettings?.data,
+        listeners: {
+            onChange: (state) => {
+                // Send settings changed event to the iFrame
+                if (state.formApi.state.isValid && connectUIPreviewRef.current) {
+                    connectUIPreviewRef.current.sendSettingsChanged(state.formApi.state.values);
+                }
+            },
+            onChangeDebounceMs: 500
+        },
+        onSubmit: (state) => {
+            updateConnectUISettings(state.formApi.state.values, {
+                onSuccess: () => {
+                    toast.toast({
+                        title: 'Connect UI settings updated',
+                        variant: 'success'
+                    });
+                },
+                onError: () => {
+                    toast.toast({
+                        title: 'Failed to update Connect UI settings',
+                        variant: 'error'
+                    });
+                }
+            });
+        }
+    });
+
+    const lightThemeFields: { name: ThemePath; label: string }[] = [
+        {
+            name: 'theme.light.background',
+            label: 'Background'
+        },
+        {
+            name: 'theme.light.foreground',
+            label: 'Foreground'
+        },
+        {
+            name: 'theme.light.primary',
+            label: 'Primary'
+        },
+        {
+            name: 'theme.light.primaryForeground',
+            label: 'Primary Foreground'
+        },
+        {
+            name: 'theme.light.textPrimary',
+            label: 'Text Primary'
+        },
+        {
+            name: 'theme.light.textMuted',
+            label: 'Text Muted'
+        }
+    ];
+
     return (
-        <DashboardLayout selectedItem={LeftNavBarItems.ConnectUI} className="p-6 w-full h-full">
+        <DashboardLayout selectedItem={LeftNavBarItems.ConnectUI} className="p-6 w-full">
             <Helmet>
                 <title>Connect UI - Nango</title>
             </Helmet>
             <div className="flex flex-col h-full">
                 <h2 className="mb-8 text-3xl font-semibold tracking-tight text-white">Connect UI Settings</h2>
-                {/** Form */}
                 <div className="flex justify-center gap-8">
-                    <div className="flex flex-col gap-8">
+                    {/** Form */}
+                    <form
+                        onSubmit={(e) => {
+                            console.log('onSubmit', e);
+                            e.preventDefault();
+                            e.stopPropagation();
+                            void form.handleSubmit();
+                        }}
+                        className="flex flex-col gap-8 mr-24"
+                    >
                         {/** Other settings */}
                         <div className="space-y-4">
-                            <h2 className="text-lg font-bold text-grayscale-100 flex gap-2">Settings</h2>
-                            <div className="flex gap-2 items-center">
-                                <Checkbox id="showWatermark" />
-                                <label htmlFor="showWatermark" className={`text-sm font-medium text-grayscale-300`}>
-                                    Show watermark
-                                </label>
-                            </div>
+                            <h2 className="text-lg font-bold text-grayscale-100">Settings</h2>
+                            <form.Field name="showWatermark">
+                                {(field) => (
+                                    <Tooltip delayDuration={0}>
+                                        <TooltipTrigger asChild>
+                                            <div className="flex gap-2 items-center">
+                                                <Checkbox
+                                                    id={field.name}
+                                                    name={field.name}
+                                                    checked={field.state.value}
+                                                    onCheckedChange={(checked) => field.handleChange(checked === 'indeterminate' ? true : checked)}
+                                                    onBlur={field.handleBlur}
+                                                    disabled={!environment.plan?.can_disable_connect_ui_watermark}
+                                                />
+                                                <label htmlFor={field.name} className={`text-sm font-medium text-grayscale-300`}>
+                                                    Show watermark
+                                                </label>
+                                            </div>
+                                        </TooltipTrigger>
+                                        {!environment.plan?.can_disable_connect_ui_watermark && (
+                                            <TooltipContent className="text-grayscale-300">
+                                                Disabling the watermark is only available for Growth plans.{' '}
+                                                <LinkWithIcon to={`/${env}/team/billing`}>Upgrade your plan</LinkWithIcon>
+                                            </TooltipContent>
+                                        )}
+                                    </Tooltip>
+                                )}
+                            </form.Field>
                         </div>
 
                         {/** Theme */}
                         <div className="space-y-4">
-                            <h2 className="text-lg font-bold text-grayscale-100 flex gap-2">Theme</h2>
+                            <h2 className="text-lg font-bold text-grayscale-100">Theme</h2>
                             <div className="flex gap-8 h-fit">
                                 <div className="flex flex-col gap-4">
-                                    <h3 className="text-md font-medium text-grayscale-100 flex gap-2">
-                                        <IconSun className="w-6 h-6" /> Light
-                                    </h3>
-
-                                    <ColorInput name="background" id="background" label="Background" />
-                                    <ColorInput name="foreground" id="foreground" label="Foreground" />
-                                    <ColorInput name="primary" id="primary" label="Primary" />
-                                    <ColorInput name="primaryForeground" id="primaryForeground" label="Primary Foreground" />
-                                    <ColorInput name="textPrimary" id="textPrimary" label="Text Primary" />
-                                    <ColorInput name="textMuted" id="textMuted" label="Text Muted" />
-                                </div>
-                                <div className="w-px bg-grayscale-4" />
-                                <div className="flex flex-col gap-4">
-                                    <h3 className="text-md font-medium text-grayscale-100 flex gap-2">
-                                        <IconMoon className="w-6 h-6" /> Dark
-                                    </h3>
-
-                                    <ColorInput name="background" id="background" label="Background" />
-                                    <ColorInput name="foreground" id="foreground" label="Foreground" />
-                                    <ColorInput name="primary" id="primary" label="Primary" />
-                                    <ColorInput name="primaryForeground" id="primaryForeground" label="Primary Foreground" />
-                                    <ColorInput name="textPrimary" id="textPrimary" label="Text Primary" />
-                                    <ColorInput name="textMuted" id="textMuted" label="Text Muted" />
+                                    {lightThemeFields.map((themeField) => (
+                                        <Tooltip key={themeField.name} delayDuration={0}>
+                                            <TooltipTrigger asChild>
+                                                <form.Field
+                                                    name={themeField.name}
+                                                    validators={{
+                                                        onChange: ({ value }: { value: string }) => (!isValidCSSColor(value) ? 'Invalid CSS color' : undefined)
+                                                    }}
+                                                >
+                                                    {(field) => (
+                                                        <>
+                                                            <ColorInput
+                                                                value={field.state.value}
+                                                                label={themeField.label}
+                                                                onChange={(e) => field.handleChange(e.target.value)}
+                                                                onBlur={field.handleBlur}
+                                                                disabled={!environment.plan?.can_customize_connect_ui_theme}
+                                                            />
+                                                            {!field.state.meta.isValid && (
+                                                                <em role="alert" className="text-sm text-red-500">
+                                                                    {field.state.meta.errors.join(', ')}
+                                                                </em>
+                                                            )}
+                                                        </>
+                                                    )}
+                                                </form.Field>
+                                            </TooltipTrigger>
+                                            {!environment.plan?.can_customize_connect_ui_theme && (
+                                                <TooltipContent side="bottom" className="text-grayscale-300">
+                                                    Customizing the theme is only available for Growth plans.{' '}
+                                                    <LinkWithIcon to={`/${env}/team/billing`}>Upgrade your plan</LinkWithIcon>
+                                                </TooltipContent>
+                                            )}
+                                        </Tooltip>
+                                    ))}
                                 </div>
                             </div>
                         </div>
 
                         {/** Save Button */}
-                        <Button variant="primary" size="md" className="self-end">
-                            Save settings
-                        </Button>
-                    </div>
+                        <form.Subscribe selector={(state) => [state.canSubmit, state.isDirty, state.isSubmitting]}>
+                            {([canSubmit, isDirty, isSubmitting]) => (
+                                <Button type="submit" variant="primary" size="md" className="self-end" disabled={!canSubmit || !isDirty || isSubmitting}>
+                                    {isSubmitting ? 'Saving...' : 'Save settings'}
+                                </Button>
+                            )}
+                        </form.Subscribe>
+                    </form>
 
                     {/** Preview */}
-                    <ConnectUIPreview className="h-full w-[500px]" />
+                    <ConnectUIPreview ref={connectUIPreviewRef} className="h-auto w-[500px]" />
                 </div>
             </div>
         </DashboardLayout>

--- a/packages/webapp/src/pages/ConnectUI/Show.tsx
+++ b/packages/webapp/src/pages/ConnectUI/Show.tsx
@@ -152,7 +152,7 @@ export const ConnectUISettingsPage = () => {
                                                     }}
                                                 >
                                                     {(field) => (
-                                                        <>
+                                                        <div className="flex flex-col gap-1">
                                                             <ColorInput
                                                                 value={field.state.value}
                                                                 label={themeField.label}
@@ -165,7 +165,7 @@ export const ConnectUISettingsPage = () => {
                                                                     {field.state.meta.errors.join(', ')}
                                                                 </em>
                                                             )}
-                                                        </>
+                                                        </div>
                                                     )}
                                                 </form.Field>
                                             </TooltipTrigger>

--- a/packages/webapp/src/pages/ConnectUI/components/ColorInput.tsx
+++ b/packages/webapp/src/pages/ConnectUI/components/ColorInput.tsx
@@ -1,21 +1,11 @@
-import { forwardRef, useState } from 'react';
+import { forwardRef } from 'react';
 
 import { Input } from '../../../components/ui/input/Input';
 import { cn } from '../../../utils/utils';
 
 import type { InputHTMLAttributes } from 'react';
 
-export interface ColorInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'onChange'> {
-    value?: string;
-    onChange?: (value: string) => void;
-    onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
-    className?: string;
-    placeholder?: string;
-    disabled?: boolean;
-    label?: string;
-}
-
-const isValidCSSColor = (color: string): boolean => {
+export const isValidCSSColor = (color: string): boolean => {
     if (!color) return false;
 
     // Create a temporary element to test the color
@@ -26,39 +16,20 @@ const isValidCSSColor = (color: string): boolean => {
     return tempElement.style.color !== '';
 };
 
+export interface ColorInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'value'> {
+    value: string;
+    className?: string;
+    placeholder?: string;
+    label?: string;
+}
+
 export const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>(
-    ({ value = '', onChange, onBlur, className, placeholder = '#000000', disabled, label, ...props }, ref) => {
-        const [isValid, setIsValid] = useState(true);
-        const [displayValue, setDisplayValue] = useState(value);
-
-        const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-            const newValue = e.target.value;
-            setDisplayValue(newValue);
-
-            // Validate the color
-            const valid = newValue === '' || isValidCSSColor(newValue);
-            setIsValid(valid);
-
-            if (onChange) {
-                onChange(newValue);
-            }
-        };
-
-        const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-            // Final validation on blur
-            const valid = displayValue === '' || isValidCSSColor(displayValue);
-            setIsValid(valid);
-
-            if (onBlur) {
-                onBlur(e);
-            }
-        };
-
+    ({ value = '', className, placeholder = '#000000', disabled, label, ...props }, ref) => {
         // Use the display value for the preview, fallback to a default color if invalid
-        const previewColor = displayValue && isValidCSSColor(displayValue) ? displayValue : '#000000';
+        const previewColor = value && isValidCSSColor(value) ? value : '#000000';
 
         return (
-            <div className={cn('flex flex-col gap-2', className)}>
+            <div className={cn('flex flex-col items-start gap-2', className)}>
                 {label && (
                     <label htmlFor={props.id} className="text-sm font-medium text-grayscale-300">
                         {label}
@@ -68,14 +39,12 @@ export const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>(
                     ref={ref}
                     type="text"
                     variant="border"
-                    value={displayValue}
-                    onChange={handleChange}
-                    onBlur={handleBlur}
+                    value={value}
                     placeholder={placeholder}
                     disabled={disabled}
                     before={
                         <div
-                            className={cn('w-5 h-5 rounded border-2 border-grayscale-600', !isValid && 'border-red-500', disabled && 'opacity-50')}
+                            className={cn('w-5 h-5 rounded border-2 border-grayscale-600', disabled && 'opacity-50')}
                             style={{ backgroundColor: previewColor }}
                             title={`Color preview: ${previewColor}`}
                         />

--- a/packages/webapp/src/pages/ConnectUI/components/ColorInput.tsx
+++ b/packages/webapp/src/pages/ConnectUI/components/ColorInput.tsx
@@ -1,0 +1,90 @@
+import { forwardRef, useState } from 'react';
+
+import { Input } from '../../../components/ui/input/Input';
+import { cn } from '../../../utils/utils';
+
+import type { InputHTMLAttributes } from 'react';
+
+export interface ColorInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'onChange'> {
+    value?: string;
+    onChange?: (value: string) => void;
+    onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
+    className?: string;
+    placeholder?: string;
+    disabled?: boolean;
+    label?: string;
+}
+
+const isValidCSSColor = (color: string): boolean => {
+    if (!color) return false;
+
+    // Create a temporary element to test the color
+    const tempElement = document.createElement('div');
+    tempElement.style.color = color;
+
+    // If the color is invalid, the browser will ignore it and keep the default
+    return tempElement.style.color !== '';
+};
+
+export const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>(
+    ({ value = '', onChange, onBlur, className, placeholder = '#000000', disabled, label, ...props }, ref) => {
+        const [isValid, setIsValid] = useState(true);
+        const [displayValue, setDisplayValue] = useState(value);
+
+        const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+            const newValue = e.target.value;
+            setDisplayValue(newValue);
+
+            // Validate the color
+            const valid = newValue === '' || isValidCSSColor(newValue);
+            setIsValid(valid);
+
+            if (onChange) {
+                onChange(newValue);
+            }
+        };
+
+        const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+            // Final validation on blur
+            const valid = displayValue === '' || isValidCSSColor(displayValue);
+            setIsValid(valid);
+
+            if (onBlur) {
+                onBlur(e);
+            }
+        };
+
+        // Use the display value for the preview, fallback to a default color if invalid
+        const previewColor = displayValue && isValidCSSColor(displayValue) ? displayValue : '#000000';
+
+        return (
+            <div className={cn('flex flex-col gap-2', className)}>
+                {label && (
+                    <label htmlFor={props.id} className="text-sm font-medium text-grayscale-300">
+                        {label}
+                    </label>
+                )}
+                <Input
+                    ref={ref}
+                    type="text"
+                    variant="border"
+                    value={displayValue}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    placeholder={placeholder}
+                    disabled={disabled}
+                    before={
+                        <div
+                            className={cn('w-5 h-5 rounded border-2 border-grayscale-600', !isValid && 'border-red-500', disabled && 'opacity-50')}
+                            style={{ backgroundColor: previewColor }}
+                            title={`Color preview: ${previewColor}`}
+                        />
+                    }
+                    {...props}
+                />
+            </div>
+        );
+    }
+);
+
+ColorInput.displayName = 'ColorInput';

--- a/packages/webapp/src/pages/ConnectUI/components/ConnectUIPreview.tsx
+++ b/packages/webapp/src/pages/ConnectUI/components/ConnectUIPreview.tsx
@@ -52,7 +52,7 @@ export const ConnectUIPreview = forwardRef<ConnectUIPreviewRef, { className?: st
 
             return res.json.data.token;
         },
-        refetchInterval: 1000,
+        refetchInterval: 1000 * 60 * 5, // 5 minutes
         refetchIntervalInBackground: true,
         staleTime: 0
     });

--- a/packages/webapp/src/pages/ConnectUI/components/ConnectUIPreview.tsx
+++ b/packages/webapp/src/pages/ConnectUI/components/ConnectUIPreview.tsx
@@ -1,0 +1,73 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+
+import { apiConnectSessions } from '../../../hooks/useConnect';
+import { useEnvironment } from '../../../hooks/useEnvironment';
+import { useStore } from '../../../store';
+import { APIError } from '../../../utils/api';
+import { createConnectUIPreviewIFrame } from '../../../utils/connect-ui';
+import { globalEnv } from '../../../utils/env';
+import { cn } from '../../../utils/utils';
+
+export const ConnectUIPreview = ({ className }: { className?: string }) => {
+    const env = useStore((state) => state.env);
+    const { environmentAndAccount } = useEnvironment(env);
+
+    const connectUIContainer = useRef<HTMLDivElement>(null);
+    const connectUIIframe = useRef<HTMLIFrameElement>();
+
+    const { data: sessionToken } = useQuery<string>({
+        enabled: Boolean(env),
+        queryKey: [env, 'preview-session-token'],
+        queryFn: async () => {
+            const res = await apiConnectSessions(env, {
+                end_user: {
+                    id: 'previewUserId',
+                    email: 'preview@nango.dev',
+                    display_name: 'Preview User'
+                }
+            });
+
+            if (!res.res.ok || 'error' in res.json) {
+                throw new APIError({ res: res.res, json: res.json });
+            }
+
+            return res.json.data.token;
+        },
+        refetchInterval: 1000,
+        refetchIntervalInBackground: true,
+        staleTime: 0
+    });
+
+    useEffect(() => {
+        if (!sessionToken || !connectUIIframe.current) {
+            return;
+        }
+
+        const iframe = connectUIIframe.current;
+        iframe.contentWindow?.postMessage(
+            {
+                type: 'session_token',
+                sessionToken
+            },
+            '*'
+        );
+    }, [sessionToken, connectUIIframe]);
+
+    useEffect(() => {
+        if (!environmentAndAccount || !connectUIContainer.current || connectUIIframe.current) {
+            return;
+        }
+
+        const iframe = createConnectUIPreviewIFrame({
+            baseURL: globalEnv.connectUrl,
+            apiURL: globalEnv.apiUrl,
+            sessionToken
+        });
+
+        connectUIIframe.current = iframe;
+        connectUIContainer.current.appendChild(iframe);
+    }, [env, environmentAndAccount, sessionToken]);
+
+    return <div ref={connectUIContainer} className={cn('overflow-hidden', className)} />;
+};


### PR DESCRIPTION
This PR adds real functionality to the ConnectUI Settings page. The page is still hidden, but can be accessed on `/:env/connect-ui`. Please, checkout to the branch and test it, have some fun and try to break it.

Here's a visual preview (improvised UI, may improve with designer's help):
<img width="1509" height="806" alt="image" src="https://github.com/user-attachments/assets/4eead53e-c998-4f27-a54f-20f464657c82" />

### Expected behaviors:
- The ConnectUI preview correctly displays integrations from the current environment. Creating connections with it is not possible (`Connect` has no behavior).
- Editing anything in the form is blocked (until you toggle the flags), with working tooltips linking to plan upgrades.
- `can_disable_connect_ui_watermark` and `can_customize_connect_ui_theme` flags independently govern your ability to edit the form.
- Show watermark checkbox has no effect yet.
- Color inputs accept any valid CSS color. Invalid colors display an error message `Invalid CSS color`.
- ConnectUI preview updates live while you edit the color in the forms (debounced by 500ms, only updates on full form valid)
- Colors are not persisted until Save button is pressed (reloading without saving resets it)
- Colors are persisted if Save button is clicked.
- After saving, accessing ConnectUI from other places (like creating a test connection) uses the new settings.

### Some colors to play with
Amber minimal (dark)
```
background: #17171
foreground: #262626
primary: #f59e0b
primary-foreground: #000000
text-primary: #bca9a9
text-muted: #a3a3a3
```
Bubblegum (light)
```
background: #f6e6ee
foreground: #fdedc9
primary: #d04f99
primary-foreground: #ffffff
text-primary: #5b5b5b
text-muted: #7a7a7a
```
Catppuccin (dark)
```
background: #181825
foreground: #1e1e2e
primary: #cba6f7
primary-foreground: #1e1e2e
text-primary: #cdd6f4
text-muted: #a6adc8
```

<!-- Summary by @propel-code-bot -->

---

**ConnectUI Customization Frontend: Live Theme Editing and Preview**

This PR introduces a new, fully functional ConnectUI Settings page in the webapp that allows users to customize the appearance and theme of the ConnectUI component. The settings interface includes a live preview (via iframe) for theme changes, color palette selection with validation, form state management, and live updates using a new postMessage event. Most settings are availability-gated by the environment's plan features, and all changes are only persisted on explicit save. Saved settings propagate to all ConnectUI usages. Supporting changes involve splitting and refactoring components for modularity, enhancements to event/type protocols, new hooks for settings management, and frontend dependency updates.

<details>
<summary><strong>Key Changes</strong></summary>

• New `ConnectUI` Settings page at /:env/connect-ui with form-driven ``UI`` for customizing theme colors and watermark visibility.
• Live preview via `ConnectUIPreview` component, supporting real-time updates with debounced `postMessage` communication.
• Color input fields with dynamic validation for valid ``CSS`` colors; errors shown in real-time.
• Settings governed by plan-based feature flags (watermark and theme customization gated per account plan); tooltips link to plan upgrades.
• Theme changes are previewed instantly but only saved when users explicitly persist; unsaved changes are reverted on reload.
• Settings persist and are consumed by `ConnectUI` in all relevant contexts, including test connection flows.
• Modularized previous `ConnectUI` settings implementation and introduced new hooks (`useConnectUISettings`, `useUpdateConnectUISettings`).
• Introduced new reusable `ColorInput` component.
• Added and integrated @tanstack/react-form for managing complex forms.
• Updated event protocol (added ``settings_changed`` event) and type definitions across frontend and `ConnectUI` package.
• Minor ``UI``/``UX``/navigation improvements (Go.tsx, Home.tsx).
• Dependency update: added @tanstack/react-form as a (dev) dependency.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Webapp `ConnectUI` settings ``UI`` and form logic (packages/webapp/src/pages/`ConnectUI`/Show.tsx)
• Reusable components: `ColorInput`, `ConnectUIPreview`
• Custom React hooks for `ConnectUI` settings
• `ConnectUI` iframe runtime/event handling (packages/connect-ui/src/views/Home.tsx, types)
• Frontend shared event/type definitions
• Webapp routing and navigation (App.tsx, Go.tsx)
• Frontend dependency management (package.json, package-lock.json)

</details>

---
*This summary was automatically generated by @propel-code-bot*