### PR TITLE
fix(email): update sending domain

### DIFF
--- a/packages/email/lib/providers/mailgun.provider.ts
+++ b/packages/email/lib/providers/mailgun.provider.ts
@@ -19,7 +19,7 @@ export class MailgunEmailProvider implements EmailProvider<MessagesSendResult> {
     }
 
     async send(email: string, subject: string, html: string): Promise<MessagesSendResult> {
-        return this.client.messages.create(envs.SMTP_DOMAIN || 'email.nango.dev', {
+        return this.client.messages.create(envs.SMTP_DOMAIN, {
             from: envs.SMTP_FROM,
             to: [email],
             subject,

--- a/packages/email/lib/providers/mailgun.provider.ts
+++ b/packages/email/lib/providers/mailgun.provider.ts
@@ -19,7 +19,7 @@ export class MailgunEmailProvider implements EmailProvider<MessagesSendResult> {
     }
 
     async send(email: string, subject: string, html: string): Promise<MessagesSendResult> {
-        return this.client.messages.create(envs.MAILGUN_SENDING_DOMAIN || 'email.nango.dev', {
+        return this.client.messages.create(envs.SMTP_DOMAIN || 'email.nango.dev', {
             from: envs.SMTP_FROM,
             to: [email],
             subject,

--- a/packages/email/lib/providers/mailgun.provider.ts
+++ b/packages/email/lib/providers/mailgun.provider.ts
@@ -19,7 +19,7 @@ export class MailgunEmailProvider implements EmailProvider<MessagesSendResult> {
     }
 
     async send(email: string, subject: string, html: string): Promise<MessagesSendResult> {
-        return this.client.messages.create(envs.SMTP_DOMAIN, {
+        return this.client.messages.create('email.nango.dev', {
             from: envs.SMTP_FROM,
             to: [email],
             subject,

--- a/packages/email/lib/providers/mailgun.provider.ts
+++ b/packages/email/lib/providers/mailgun.provider.ts
@@ -19,7 +19,7 @@ export class MailgunEmailProvider implements EmailProvider<MessagesSendResult> {
     }
 
     async send(email: string, subject: string, html: string): Promise<MessagesSendResult> {
-        return this.client.messages.create('nango.dev', {
+        return this.client.messages.create(envs.MAILGUN_SENDING_DOMAIN, {
             from: envs.SMTP_FROM,
             to: [email],
             subject,

--- a/packages/email/lib/providers/mailgun.provider.ts
+++ b/packages/email/lib/providers/mailgun.provider.ts
@@ -19,7 +19,7 @@ export class MailgunEmailProvider implements EmailProvider<MessagesSendResult> {
     }
 
     async send(email: string, subject: string, html: string): Promise<MessagesSendResult> {
-        return this.client.messages.create('email.nango.dev', {
+        return this.client.messages.create(envs.SMTP_DOMAIN, {
             from: envs.SMTP_FROM,
             to: [email],
             subject,

--- a/packages/email/lib/providers/mailgun.provider.ts
+++ b/packages/email/lib/providers/mailgun.provider.ts
@@ -19,7 +19,7 @@ export class MailgunEmailProvider implements EmailProvider<MessagesSendResult> {
     }
 
     async send(email: string, subject: string, html: string): Promise<MessagesSendResult> {
-        return this.client.messages.create(envs.MAILGUN_SENDING_DOMAIN, {
+        return this.client.messages.create(envs.MAILGUN_SENDING_DOMAIN || 'email.nango.dev', {
             from: envs.SMTP_FROM,
             to: [email],
             subject,

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -195,6 +195,7 @@ export const ENVS = z.object({
     // SMTP
     SMTP_URL: z.url().optional(),
     SMTP_FROM: z.string().default('Nango <noreply@email.nango.dev>'),
+    SMTP_DOMAIN: z.string().default('email.nango.dev'),
 
     // Postgres
     NANGO_DATABASE_URL: z.url().optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -195,7 +195,6 @@ export const ENVS = z.object({
     // SMTP
     SMTP_URL: z.url().optional(),
     SMTP_FROM: z.string().default('Nango <noreply@email.nango.dev>'),
-    SMTP_DOMAIN: z.string().default('email.nango.dev'),
 
     // Postgres
     NANGO_DATABASE_URL: z.url().optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -191,11 +191,11 @@ export const ENVS = z.object({
     // Mailgun
     MAILGUN_API_KEY: z.string().optional(),
     MAILGUN_URL: z.url().optional(),
-    MAILGUN_SENDING_DOMAIN: z.string().default('email.nango.dev'),
 
     // SMTP
     SMTP_URL: z.url().optional(),
     SMTP_FROM: z.string().default('Nango <noreply@email.nango.dev>'),
+    SMTP_DOMAIN: z.string().default('email.nango.dev'),
 
     // Postgres
     NANGO_DATABASE_URL: z.url().optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -191,6 +191,7 @@ export const ENVS = z.object({
     // Mailgun
     MAILGUN_API_KEY: z.string().optional(),
     MAILGUN_URL: z.url().optional(),
+    MAILGUN_SENDING_DOMAIN: z.string().default('email.nango.dev'),
 
     // SMTP
     SMTP_URL: z.url().optional(),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Make Mailgun Sending Domain Configurable via SMTP_DOMAIN ENV**

This PR refactors the Mailgun email provider to use an environment-driven configuration for the sending domain. It introduces the SMTP_DOMAIN environment variable (defaulting to 'email.nango.dev') and updates the environment parsing schema accordingly. The previously hardcoded domain ('nango.dev') is replaced by the configurable value to increase deployment flexibility and maintainability.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced hardcoded domain (`nango.dev`) in Mailgun provider with envs.``SMTP_DOMAIN``.
• Added ```SMTP_DOMAIN``` to environment schema with default `email.nango.dev`.
• Provider now uses envs.``SMTP_DOMAIN`` to determine sending domain at runtime.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/email/lib/providers/mailgun.provider.ts
• packages/utils/lib/environment/parse.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*