### PR TITLE
fix(managed-email): use authorized email

### DIFF
--- a/packages/server/lib/controllers/v1/account/managed/getCallback.ts
+++ b/packages/server/lib/controllers/v1/account/managed/getCallback.ts
@@ -97,7 +97,7 @@ export const getManagedCallback = asyncWrapper<GetManagedCallback>(async (req, r
             account = (await accountService.getAccountById(db.knex, invitation.account_id))!;
         } else {
             // Regular signup
-            const resAccount = await accountService.createAccount({ name });
+            const resAccount = await accountService.createAccount({ name, email: authorizedUser.email });
             if (!resAccount) {
                 res.status(500).send({ error: { code: 'error_creating_account', message: 'Failed to create account' } });
                 return;


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Use email from SSO to properly categorize the email address
<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Fix: Use SSO-Authorized Email in Account Creation**

This pull request updates the regular signup flow in the managed SSO callback handler to use the email address provided by the authorized SSO user when creating a new account. The change ensures proper categorization of accounts by explicitly specifying the email during account creation.

<details>
<summary><strong>Key Changes</strong></summary>

• Modified `accountService`.`createAccount` call to include { email: `authorizedUser`.email } during regular signups
• Previously, only the name was passed; now both name and ``SSO`` email are used

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/controllers/v1/account/managed/`getCallback`.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*