### PR TITLE
fix: append k8s to runner id if runner type is KUBERNETES

### DIFF
--- a/packages/jobs/lib/runner/runner.ts
+++ b/packages/jobs/lib/runner/runner.ts
@@ -21,6 +21,9 @@ export interface Runner {
 }
 
 function getRunnerId(suffix: string): string {
+    if (envs.RUNNER_TYPE === 'KUBERNETES') {
+        suffix = `${suffix}-k8s`;
+    }
     return `${env}-runner-account-${suffix}`;
 }
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Uniquely Name Runner Nodes by Appending '-k8s' Suffix for Kubernetes Runner Type**

This PR introduces a minor update to the runner ID generation logic in the runner.ts file. When the environment variable RUNNER_TYPE is set to 'KUBERNETES', the function getRunnerId now appends '-k8s' to the runner ID's suffix, making the naming of runner nodes unique for Kubernetes environments and helping to prevent naming collisions. No changes were made to runner ID generation for non-Kubernetes scenarios.

<details>
<summary><strong>Key Changes</strong></summary>

• Added conditional logic in `getRunnerId` to append `-k8s` to the suffix if ``RUNNER_TYPE`` is ```KUBERNETES```.
• No changes to runner ``ID`` construction for other runner types.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/jobs/lib/runner/runner.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*