### PR TITLE
docs: Change number of APIs supported to 500+

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Ship integrations fast. Maintain full control.
     <br />
 
   <br/>
-    <a href="https://nango.dev/integrations">400+ pre-configured APIs</a>
+    <a href="https://nango.dev/integrations">500+ pre-configured APIs</a>
     ·
     <a href="https://nango.dev">Website</a>
     ·
@@ -59,9 +59,9 @@ Nango's flexibility ensures it supports any API integration:
 2. **Custom integrations**: Build your own integrations in code with limitless customization capabilities.
 3. **Managed integrations**: Leverage Nango experts to create and maintain your integrations end-to-end.
 
-# 🔌 400+ pre-built APIs & integrations, or build your own!
+# 🔌 500+ pre-built APIs & integrations, or build your own!
 
-[Over 400 APIs are pre-configured](https://nango.dev/integrations) to work right out of the box. We support 25+ categories such:
+[Over 500 APIs are pre-configured](https://nango.dev/integrations) to work right out of the box. We support 25+ categories such:
 
 - **Accounting**: Netsuite, Quickbooks, Xero, ...
 - **Communications**: Slack, Discord, Teams, ...

--- a/docs-v2/guides/ai-use-cases.mdx
+++ b/docs-v2/guides/ai-use-cases.mdx
@@ -5,7 +5,7 @@ description: 'Overview of how Nango powers AI integrations.'
 ---
 
 Nango helps AI applications access external data and APIs. It is commonly used to:
-- Ingest data from 400+ APIs for Retrieval-Augmented Generation (RAG)
+- Ingest data from 500+ APIs for Retrieval-Augmented Generation (RAG)
 - Enable AI agents to take actions via API calls
 
 # AI agent demo video
@@ -27,14 +27,14 @@ If you want to run the demo yourself or check the code, here is the demo's [GitH
 # Data ingestion for RAG
 
 For applications that require fresh external data:
-- Continuous polling across 400+ APIs
+- Continuous polling across 500+ APIs
 - Real-time ingestion via high-frequency syncing and webhooks
 - Full control over integration code for custom data processing
 
 # API access for AI agents
 
 For agents that interact with external APIs:
-- Instant access to 400+ APIs and 600+ use cases
+- Instant access to 500+ APIs and 600+ use cases
 - Managed authentication (OAuth, API keys, etc.)
 - API action introspection ([reference](/reference/api/scripts/config))
 - Action triggering ([reference](/reference/api/action/trigger))

--- a/docs-v2/guides/mcp.mdx
+++ b/docs-v2/guides/mcp.mdx
@@ -40,7 +40,7 @@ Nango's MCP server implementation allows your LLMs to interact with external API
 Nango gives you powerful building blocks out of the box to reliably connect LLMs to external APIs:
 - Simplified interface for agents: Nango actions can encapsulate complex multi-step API logic into a single tool. This allows agents to focus on intent rather than figuring out raw APIs, improving success rates and reducing hallucinations.
 - Standardized actions across providers: You can define consistent use cases across APIs (e.g., “create calendar event” for both Google Calendar and Microsoft Teams), giving LLMs a unified interface for tool calling.
-- Pre-built catalog of 400+ APIs: Instantly access a wide library of APIs with existing integrations and actions ready to use—no need to start from scratch.
+- Pre-built catalog of 500+ APIs: Instantly access a wide library of APIs with existing integrations and actions ready to use—no need to start from scratch.
 - Customizable and strongly typed actions: Extend pre-built actions or define your own from scratch using Nango’s custom integrations. All actions are strongly typed, making them safer and easier to consume from LLM clients.
 - Built-in authentication flows: Nango provides a ready-made UI to authorize your end users, supporting OAuth, API keys, Basic Auth, and Custom Auth. This means agents can operate on behalf of users securely without extra setup.
 - Deep observability: Each action execution is logged in detail, including external API calls and errors—making it easier to debug and monitor LLM behavior.

--- a/docs-v2/guides/self-hosting/free-self-hosting/overview.mdx
+++ b/docs-v2/guides/self-hosting/free-self-hosting/overview.mdx
@@ -12,7 +12,7 @@ The full integration platform is available on the [Enterprise self-hosting](/gui
 
 | **Feature**                                                                                 | Free self-hosted edition | Nango Cloud (any plan) & Enterprise self-hosted |   |
 | ------------------------------------------------------------------------------------------- | ------------------------ | ----------------------------------------------- | - |
-| [Authorization for 400+ APIs](/guides/api-authorization/overview)                           | ✅                        | ✅                                               |   |
+| [Authorization for 500+ APIs](/guides/api-authorization/overview)                           | ✅                        | ✅                                               |   |
 | [Fully white-label authorization flow](/guides/api-authorization/whitelabel-the-oauth-flow) | ✅                        | ✅                                               |   |
 | End-user guides                                                                             | ✅                        | ✅                                               |   |
 | Invalid credentials detection                                                               | ✅                        | ✅                                               |   |

--- a/docs-v2/integrations/overview.mdx
+++ b/docs-v2/integrations/overview.mdx
@@ -9,7 +9,7 @@ Nango is a product [integration platform for developers](/getting-started/intro-
 
 <CardGroup cols={1}>
 <Card title="All APIs & integrations" icon="list" href="https://www.nango.dev/api-integrations">
-400+ APIs & 600+ integrations.
+500+ APIs & 600+ integrations.
 </Card>
 <Card title="Request or contribute a new API" icon="circle-question" href="/guides/api-authorization/new-api-support">
 We deliver them in &lt;48h.


### PR DESCRIPTION
Update all references to number of supported APIs to 500+
<!-- Summary by @propel-code-bot -->

---

**Update Documentation to Reflect 500+ API Integrations**

This PR updates all public-facing documentation references to increase the stated number of supported APIs from '400+' to '500+' across various files. All modifications are strictly textual changes, ensuring documentation accurately reflects the current integration count without altering any functionality, code, or structural documentation content.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced all mentions of `400+` supported `APIs`/integrations with `500+` in documentation sources.
• Updated numerical references in ``README``.md, guides, and overview pages.
• Ensured consistency of ``API`` count in feature tables, marketing cards, and capability overviews.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• ``README``.md
• docs-v2/guides/ai-use-cases.mdx
• docs-v2/guides/mcp.mdx
• docs-v2/guides/self-hosting/free-self-hosting/overview.mdx
• docs-v2/integrations/overview.mdx

</details>

---
*This summary was automatically generated by @propel-code-bot*