### PR TITLE
fix(docs): documentation fixes

### DIFF
--- a/docs-v2/guides/custom-integrations/extend-a-pre-built-integration.mdx
+++ b/docs-v2/guides/custom-integrations/extend-a-pre-built-integration.mdx
@@ -16,9 +16,9 @@ Pre-requisite: set up [the CLI and integration folder](/guides/custom-integratio
 
 # Download the template code
 
-Typescript templates: The code is available on [GitHub](https://github.com/NangoHQ/integration-templates/tree/main/templates)
+Typescript templates: The code is available on [GitHub](https://github.com/NangoHQ/integration-templates/tree/main/integrations)
 
-nango.yaml templates: The code is available on [GitHub](https://www.nango.dev/templates) or directly in the Nango UI in the _Endpoints_ tab of an integration.
+nango.yaml templates: The code is available directly in the Nango UI in the _Endpoints_ tab of an integration if you're using an older version of a template.
 
 
 ## Typescript templates


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Fix Documentation Links and Clarify Template Access**

This pull request addresses minor documentation issues in the guide for extending pre-built integrations. It updates and corrects links to the TypeScript and nango.yaml template sources, and clarifies the process for accessing these templates through GitHub or the Nango UI. There are minor text clarifications and one formatting fix, but no code or functional changes.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `GitHub` link for `TypeScript` templates to point to the correct integrations directory.
• Clarified instructions for retrieving nango.yaml templates, specifying availability in the Nango ``UI`` for older versions.
• Corrected a formatting issue with the <Tip> component closure.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• docs-v2/guides/custom-integrations/extend-a-pre-built-integration.mdx

</details>

---
*This summary was automatically generated by @propel-code-bot*