### PR TITLE
feat: add RUNNER_FLEET_ID

### DIFF
--- a/packages/fleet/lib/fleet.integration.test.ts
+++ b/packages/fleet/lib/fleet.integration.test.ts
@@ -10,7 +10,7 @@ import * as nodeConfigOverrides from './models/node_config_overrides.js';
 import { noopNodeProvider } from './node-providers/noop.js';
 
 describe('fleet', () => {
-    const fleetId = 'nango_runners';
+    const fleetId = 'test_runners';
     const dbClient = getTestDbClient(fleetId);
     const nodeProvider = noopNodeProvider;
     const fleet = new Fleet({

--- a/packages/fleet/lib/fleet.ts
+++ b/packages/fleet/lib/fleet.ts
@@ -13,7 +13,6 @@ import { FleetError } from './utils/errors.js';
 import { withPgLock } from './utils/locking.js';
 import { waitUntilHealthy } from './utils/url.js';
 
-import type { FleetId } from './instances.js';
 import type { NodeProvider } from './node-providers/node_provider.js';
 import type { Node, NodeConfigOverride } from './types.js';
 import type { Deployment, RoutingId } from '@nangohq/types';
@@ -30,7 +29,7 @@ export class Fleet {
     private supervisor: Supervisor | undefined = undefined;
     private nodeProvider: NodeProvider;
 
-    constructor({ fleetId, dbUrl = defaultDbUrl, nodeProvider }: { fleetId: FleetId; dbUrl?: string | undefined; nodeProvider?: NodeProvider }) {
+    constructor({ fleetId, dbUrl = defaultDbUrl, nodeProvider }: { fleetId: string; dbUrl?: string | undefined; nodeProvider?: NodeProvider }) {
         this.fleetId = fleetId;
         this.dbClient = new DatabaseClient({ url: dbUrl, schema: fleetId });
         if (nodeProvider) {

--- a/packages/fleet/lib/instances.ts
+++ b/packages/fleet/lib/instances.ts
@@ -1,1 +1,0 @@
-export type FleetId = 'nango_runners';

--- a/packages/jobs/lib/runner/fleet.ts
+++ b/packages/jobs/lib/runner/fleet.ts
@@ -5,7 +5,7 @@ import { kubernetesNodeProvider } from './kubernetes.js';
 import { localNodeProvider } from './local.js';
 import { renderNodeProvider } from './render.js';
 
-const fleetId = 'nango_runners';
+const fleetId = envs.RUNNER_FLEET_ID;
 export const runnersFleet = (() => {
     switch (envs.RUNNER_TYPE) {
         case 'LOCAL':

--- a/packages/server/lib/fleet.ts
+++ b/packages/server/lib/fleet.ts
@@ -1,3 +1,5 @@
 import { Fleet } from '@nangohq/fleet';
 
-export const runnersFleet = new Fleet({ fleetId: 'nango_runners' });
+import { envs } from './env.js';
+
+export const runnersFleet = new Fleet({ fleetId: envs.RUNNER_FLEET_ID });

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -78,6 +78,11 @@ export const ENVS = z.object({
 
     // Runner
     RUNNER_TYPE: z.enum(['LOCAL', 'REMOTE', 'RENDER', 'KUBERNETES']).default('LOCAL'),
+    RUNNER_FLEET_ID: z
+        .string()
+        .regex(/^[a-zA-Z0-9_-]+$/)
+        .optional()
+        .default('nango_runners'),
     RUNNER_SERVICE_URL: z.url().optional(),
     NANGO_RUNNER_PATH: z.string().optional(),
     RUNNER_OWNER_ID: z.string().optional(),


### PR DESCRIPTION
migration to k8s/aws requires to have 2 fleet of runners alongside each other, both managed by their own supervisor
This commit allows to set the fleetId dynamically via an env var

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Support for Configurable RUNNER_FLEET_ID via Environment Variable**

This PR introduces a new environment variable, RUNNER_FLEET_ID, enabling dynamic configuration of the Runner Fleet ID to support multiple concurrent runner fleets (e.g., for Kubernetes/AWS migrations where separate supervisors and parallel fleets are needed). It replaces the previously hardcoded fleetId ('nango_runners') with a value read dynamically from the environment, including appropriate validation and updates across the server, jobs, and fleet packages, associated tests, and schema parsing logic.

<details>
<summary><strong>Key Changes</strong></summary>

• Added ``RUNNER_FLEET_ID`` env var with regex validation and default value in environment schema (parse.ts)
• Refactored server and jobs runner fleet initialization to use envs.``RUNNER_FLEET_ID`` instead of hardcoded value
• Modified Fleet class to accept ``fleetId`` as string (removed usage of `FleetId` type and deleted associated type definition)
• Updated fleet integration tests to use non-default `fleetId` values for better isolation and demonstration
• Cleaned up code references to the static `FleetId`, removing now-unnecessary imports

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Environment variable schema and parsing
• Fleet initialization in jobs and server code
• Fleet class instantiation and typing
• Fleet integration tests
• Type definitions (removal of `FleetId` type)

</details>

---
*This summary was automatically generated by @propel-code-bot*