### PR TITLE
fix: connections count metric

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1532,8 +1532,12 @@ class ConnectionService {
             >(
                 db.knex.raw(`_nango_environments.account_id as "accountId"`),
                 db.knex.raw(`count(DISTINCT _nango_connections.id) AS "count"`),
-                db.knex.raw(`count(DISTINCT CASE WHEN _nango_sync_configs.type = 'action' THEN _nango_connections.id ELSE NULL END) as "withActions"`),
-                db.knex.raw(`count(DISTINCT CASE WHEN _nango_sync_configs.type = 'sync' THEN _nango_connections.id ELSE NULL END) as "withSyncs"`),
+                db.knex.raw(
+                    `count(DISTINCT CASE WHEN _nango_sync_configs.type = 'action' AND _nango_sync_configs.enabled IS TRUE THEN _nango_connections.id ELSE NULL END) as "withActions"`
+                ),
+                db.knex.raw(
+                    `count(DISTINCT CASE WHEN _nango_sync_configs.type = 'sync' AND _nango_sync_configs.enabled IS TRUE THEN _nango_connections.id ELSE NULL END) as "withSyncs"`
+                ),
                 db.knex.raw(
                     `count(DISTINCT CASE WHEN _nango_sync_configs.webhook_subscriptions IS NOT NULL AND array_length(_nango_sync_configs.webhook_subscriptions, 1) > 0 THEN _nango_connections.id ELSE NULL END) as "withWebhooks"`
                 )
@@ -1542,9 +1546,6 @@ class ConnectionService {
             .whereNull('_nango_sync_configs.deleted_at')
             .where(function () {
                 this.where('_nango_sync_configs.active', true).orWhereNull('_nango_sync_configs.active');
-            })
-            .where(function () {
-                this.where('_nango_sync_configs.enabled', true).orWhereNull('_nango_sync_configs.enabled');
             })
             .groupBy('_nango_environments.account_id');
 


### PR DESCRIPTION
The query counting connections per account was filtering out connections without enabled sync configs (if sync configs existed) This commit fixes the count by not filtering on sync_config.enabled so all connections are accounted for

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Fix Connection Count Metric to Include All Connections**

This pull request updates the metric logic for counting connections per account to ensure all connections are included, not just those with enabled sync configs. Previously, the SQL query filtered out connections if they lacked any enabled sync configs, which led to an undercount; the new logic removes this filter for the total count, while still segmenting 'withActions' and 'withSyncs' by enabled config status only in those columns.

<details>
<summary><strong>Key Changes</strong></summary>

• Refactored the ``SQL`` aggregation in `countMetric`() to ensure total `count` includes connections regardless of their associated `sync_config`.enabled value.
• Updated the calculation of ``withActions`` and ``withSyncs`` to only include connections with enabled sync configs of type `action` and `sync`, respectively.
• Removed an extraneous filtering clause on `sync_config`.enabled from the ``WHERE`` conditions.
• Ensured existing filtering on `sync_config`.active remains unchanged for correct active status accounting.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/shared/lib/services/connection.service.ts (`countMetric` function and its ``SQL`` query)

</details>

---
*This summary was automatically generated by @propel-code-bot*