### PR TITLE
fix(zero): support more zod primitives

### DIFF
--- a/packages/cli/lib/zeroYaml/zodToNango.ts
+++ b/packages/cli/lib/zeroYaml/zodToNango.ts
@@ -50,7 +50,7 @@ export function zodToNangoModelField(name: string, schema: z.core.$ZodType): Nan
             return { name, value: [value], array: true, optional };
         }
         return { name, value: value.value, tsType: true, array: true, optional };
-    } else if (isZodUnion(schema)) {
+    } else if (isZodUnion(schema) || isZodDiscriminatedUnion(schema)) {
         const values: NangoModelField['value'] = [];
 
         for (const [key, value] of Object.entries(schema._zod.def.options)) {
@@ -67,6 +67,25 @@ export function zodToNangoModelField(name: string, schema: z.core.$ZodType): Nan
         throw new Error('z.undefined() is not supported, please use z.null() or z.optional() instead');
     } else if (isZodUnknown(schema)) {
         return { name, value: 'unknown', tsType: true, optional };
+    } else if (isZodBigInt(schema)) {
+        return { name, value: 'bigint', tsType: true, optional };
+    } else if (isZodEmail(schema)) {
+        // Not supported yet by "ts-json-schema-generator" (2.4.0)
+        // return { name, value: 'email', tsType: true, optional };
+        throw new Error(`z.email() is not supported, please use z.string() instead`);
+    } else if (isZodUrl(schema)) {
+        // Not supported yet by "ts-json-schema-generator" (2.4.0)
+        // return { name, value: 'url', tsType: true, optional };
+        throw new Error(`z.url() is not supported, please use z.string() instead`);
+    } else if (isZodTuple(schema)) {
+        // const values: NangoModelField['value'] = [];
+
+        // for (const [key, value] of Object.entries(schema._zod.def.items)) {
+        //     values.push(zodToNangoModelField(key, value));
+        // }
+        // return { name, value: values, tsType: true, array: true, optional };
+
+        throw new Error(`z.tuple() is not supported, please use z.array() instead`);
     } else {
         throw new Error(`field "${name}" contains an unsupported Zod type, please change or reach out to Nango support, ${JSON.stringify(schema)}`);
     }
@@ -146,4 +165,24 @@ function isZodUndefined(schema: z.core.$ZodType): schema is z.ZodUndefined {
 
 function isZodUnknown(schema: z.core.$ZodType): schema is z.ZodUnknown {
     return schema.constructor.name === 'ZodUnknown';
+}
+
+function isZodDiscriminatedUnion(schema: z.core.$ZodType): schema is z.ZodDiscriminatedUnion {
+    return schema.constructor.name === 'ZodDiscriminatedUnion';
+}
+
+function isZodBigInt(schema: z.core.$ZodType): schema is z.ZodBigInt {
+    return schema.constructor.name === 'ZodBigInt';
+}
+
+function isZodEmail(schema: z.core.$ZodType): schema is z.ZodEmail {
+    return schema.constructor.name === 'ZodEmail';
+}
+
+function isZodUrl(schema: z.core.$ZodType): schema is z.ZodURL {
+    return schema.constructor.name === 'ZodURL';
+}
+
+function isZodTuple(schema: z.core.$ZodType): schema is z.ZodTuple {
+    return schema.constructor.name === 'ZodTuple';
 }

--- a/packages/cli/lib/zeroYaml/zodToNango.unit.test.ts
+++ b/packages/cli/lib/zeroYaml/zodToNango.unit.test.ts
@@ -13,6 +13,7 @@ describe('zodToNango', () => {
                     foo: z.literal('bar'),
                     literalArray: z.literal(['bar', 'baz']),
                     num: z.number(),
+                    bigint: z.bigint(),
                     bool: z.boolean(),
                     null: z.null(),
                     enum: z.enum(['tip', 'top']),
@@ -29,10 +30,22 @@ describe('zodToNango', () => {
                     never: z.never(),
                     date: z.date(),
                     emptyObject: z.object({}),
-                    unknown: z.unknown()
+                    unknown: z.unknown(),
+                    discriminatedUnion: z.discriminatedUnion('type', [
+                        z.object({ type: z.literal('a'), foo: z.string() }),
+                        z.object({ type: z.literal('b'), bar: z.string() })
+                    ]),
+                    coerce: z.coerce.string()
+
+                    // Not supported yet
+                    // email: z.email(), // Not supported yet by "ts-json-schema-generator" (2.4.0)
+                    // url: z.url() // Not supported yet by "ts-json-schema-generator" (2.4.0)
+                    // tuple: z.tuple([z.string(), z.number()]) // legacy model shape is blocking us
+
                     // Not supported on purpose
                     // undefined: z.undefined()
                     // lazy: z.lazy(() => ref)
+                    // default: z.string().default(z.string())
                 })
             )
         ).toStrictEqual({
@@ -50,6 +63,7 @@ describe('zodToNango', () => {
                     ]
                 },
                 { name: 'num', optional: false, tsType: true, value: 'number' },
+                { name: 'bigint', optional: false, tsType: true, value: 'bigint' },
                 { name: 'bool', optional: false, tsType: true, value: 'boolean' },
                 { name: 'null', optional: false, tsType: true, value: null },
                 {
@@ -95,7 +109,43 @@ describe('zodToNango', () => {
                 { name: 'never', optional: false, tsType: true, value: 'never' },
                 { name: 'date', optional: false, tsType: true, value: 'Date' },
                 { name: 'emptyObject', optional: false, value: [] },
-                { name: 'unknown', optional: true, tsType: true, value: 'unknown' }
+                { name: 'unknown', optional: true, tsType: true, value: 'unknown' },
+                {
+                    name: 'discriminatedUnion',
+                    optional: false,
+                    tsType: true,
+                    union: true,
+                    value: [
+                        {
+                            name: '0',
+                            optional: false,
+                            value: [
+                                { name: 'type', optional: false, value: 'a' },
+                                { name: 'foo', optional: false, tsType: true, value: 'string' }
+                            ]
+                        },
+                        {
+                            name: '1',
+                            optional: false,
+                            value: [
+                                { name: 'type', optional: false, value: 'b' },
+                                { name: 'bar', optional: false, tsType: true, value: 'string' }
+                            ]
+                        }
+                    ]
+                },
+                { name: 'coerce', optional: true, tsType: true, value: 'string' }
+
+                // {
+                //     name: 'tuple',
+                //     optional: false,
+                //     tsType: true,
+                //     array: true,
+                //     value: [
+                //         { name: '0', optional: false, tsType: true, value: 'string' },
+                //         { name: '1', optional: false, tsType: true, value: 'number' }
+                //     ]
+                // }
             ]
         });
     });


### PR DESCRIPTION
## Changes

- Zero: support more Zod primitives
bigint, discriminated union. Document non-supported for new primitives (mostly because the underlying tools are not compatible)

<!-- Summary by @propel-code-bot -->

---

**Expand Zero Zod Primitives Support and Improved Error Handling**

This pull request enhances the `zodToNangoModelField` utility in the Zero YAML integration layer of the Nango CLI by adding support for more Zod schema primitives, specifically `bigint` and discriminated unions. It also introduces explicit error handling and in-code documentation for unsupported primitives like `email`, `url`, and `tuple`, generally due to upstream tool incompatibilities. The test suite has been expanded to validate the handling of these new and unsupported cases, improving resilience and developer feedback when encountering unsupported Zod features.

<details>
<summary><strong>Key Changes</strong></summary>

• Added support for Zod ``BigInt`` and ``DiscriminatedUnion`` types in field conversion logic.
• Implemented new type guards: ``isZodBigInt``, ``isZodDiscriminatedUnion``, ``isZodEmail``, ``isZodUrl``, ``isZodTuple``.
• Improved error handling with descriptive messages for unsupported primitives (e.g., `z.email()`, `z.url()`, `z.tuple()`), including comments explaining reasons for lack of support.
• Expanded and updated unit tests to cover added primitives, unsupported types, and nuanced behaviors.
• Updated mapping logic to check both union and discriminated union types for option extraction.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/cli/lib/`zeroYaml`/`zodToNango`.ts
• packages/cli/lib/`zeroYaml`/`zodToNango`.unit.test.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*