### PR TITLE
fix: per-fleet lock key and fix kubernetes runner management

### DIFF
--- a/packages/fleet/lib/fleet.ts
+++ b/packages/fleet/lib/fleet.ts
@@ -109,7 +109,7 @@ export class Fleet {
             if (!starting[0] && !pending[0]) {
                 await withPgLock({
                     db: this.dbClient.db,
-                    lockKey: `create_node_${routingId}`,
+                    lockKey: `fleet_${this.fleetId}_create_node_${routingId}`,
                     fn: async (trx): Promise<Result<Node>> => {
                         const deployment = await deployments.getActive(trx);
                         if (deployment.isErr()) {

--- a/packages/fleet/lib/supervisor/supervisor.ts
+++ b/packages/fleet/lib/supervisor/supervisor.ts
@@ -109,7 +109,7 @@ export class Supervisor {
         while (this.state === 'running') {
             const res = await withPgLock({
                 db: this.dbClient.db,
-                lockKey: `fleet_supervisor`,
+                lockKey: envs.FLEET_SUPERVISOR_LOCK_KEY,
                 fn: async () => this.tick(),
                 timeoutMs: envs.FLEET_SUPERVISOR_TIMEOUT_TICK_MS,
                 onTimeout: () => {

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -111,23 +111,22 @@ class Kubernetes {
 
     private async ensureNamespace(namespace: string): Promise<Result<void>> {
         const namespaceManifest: k8s.V1Namespace = {
-            apiVersion: 'v1',
-            kind: 'Namespace',
             metadata: {
                 name: namespace
             }
         };
 
         try {
-            await this.coreApi.patchNamespace(
-                {
-                    name: namespace,
-                    body: namespaceManifest,
-                    fieldManager: 'nango-supervisor'
-                },
-                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
-            );
+            await this.coreApi.createNamespace({
+                body: namespaceManifest
+            });
         } catch (err: any) {
+            if (err.body) {
+                const body = JSON.parse(err.body);
+                if (body.reason == 'AlreadyExists') {
+                    return Ok(undefined);
+                }
+            }
             return Err(new Error('Failed to create namespace', { cause: err }));
         }
 
@@ -136,12 +135,9 @@ class Kubernetes {
 
     private async createDeployment(node: Node, name: string, namespace: string, runnerUrl: string): Promise<Result<void>> {
         const deploymentManifest: k8s.V1Deployment = {
-            apiVersion: 'apps/v1',
-            kind: 'Deployment',
             metadata: {
                 name,
-                labels: { app: name },
-                namespace
+                labels: { app: name }
             },
             spec: {
                 replicas: 1,
@@ -170,29 +166,35 @@ class Kubernetes {
         };
 
         try {
-            await this.appsApi.patchNamespacedDeployment(
-                {
-                    name,
-                    namespace,
-                    body: deploymentManifest,
-                    fieldManager: 'nango-supervisor'
-                },
-                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
-            );
-            return Ok(undefined);
-        } catch (err) {
+            await this.appsApi.createNamespacedDeployment({
+                namespace,
+                body: deploymentManifest
+            });
+        } catch (err: any) {
+            if (err.body) {
+                const body = JSON.parse(err.body);
+                if (body.reason == 'AlreadyExists') {
+                    try {
+                        await this.appsApi.patchNamespacedDeployment({
+                            name,
+                            namespace,
+                            body: deploymentManifest
+                        });
+                    } catch (err: any) {
+                        return Err(new Error('Failed to patch deployment', { cause: err }));
+                    }
+                }
+            }
             return Err(new Error('Failed to create deployment', { cause: err }));
         }
+        return Ok(undefined);
     }
 
     private async createService(_node: Node, name: string, namespace: string): Promise<Result<void>> {
         const serviceManifest: k8s.V1Service = {
-            apiVersion: 'v1',
-            kind: 'Service',
             metadata: {
                 name,
-                labels: { app: name },
-                namespace
+                labels: { app: name }
             },
             spec: {
                 selector: { app: name },
@@ -208,119 +210,154 @@ class Kubernetes {
         };
 
         try {
-            await this.coreApi.patchNamespacedService(
-                {
-                    name,
-                    namespace,
-                    body: serviceManifest,
-                    fieldManager: 'nango-supervisor'
-                },
-                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
-            );
-            return Ok(undefined);
-        } catch (err) {
-            return Err(new Error('Failed to create service', { cause: err }));
+            await this.coreApi.createNamespacedService({
+                namespace,
+                body: serviceManifest
+            });
+        } catch (err: any) {
+            if (err.body) {
+                const body = JSON.parse(err.body);
+                if (body.reason == 'AlreadyExists') {
+                    try {
+                        await this.coreApi.patchNamespacedService(
+                            {
+                                name,
+                                namespace,
+                                body: serviceManifest
+                            },
+                            k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
+                        );
+                    } catch (err: any) {
+                        return Err(new Error('Failed to patch namespace', { cause: err }));
+                    }
+                } else {
+                    return Err(new Error('Failed to create namespace', { cause: err }));
+                }
+            } else {
+                return Err(new Error('Failed to create namespace', { cause: err }));
+            }
         }
+        return Ok(undefined);
     }
 
     private async createNetworkPolicies(namespace: string): Promise<Result<void>> {
+        const denyAll: k8s.V1NetworkPolicy = {
+            metadata: { name: 'default-deny' },
+            spec: {
+                podSelector: {},
+                policyTypes: ['Ingress']
+            }
+        };
         try {
-            // 1. Default deny all ingress
-            await this.networkingApi.patchNamespacedNetworkPolicy(
-                {
-                    name: 'default-deny',
-                    namespace,
-                    body: {
-                        apiVersion: 'networking.k8s.io/v1',
-                        kind: 'NetworkPolicy',
-                        metadata: { name: 'default-deny', namespace },
-                        spec: {
-                            podSelector: {},
-                            policyTypes: ['Ingress']
-                        }
-                    },
-                    fieldManager: 'nango-supervisor'
-                },
-                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
-            );
+            await this.networkingApi.createNamespacedNetworkPolicy({
+                namespace,
+                body: denyAll
+            });
         } catch (err: any) {
+            if (err.body) {
+                const body = JSON.parse(err.body);
+                if (body.reason == 'AlreadyExists') {
+                    try {
+                        await this.networkingApi.patchNamespacedNetworkPolicy({
+                            name: 'default-deny',
+                            namespace,
+                            body: denyAll
+                        });
+                    } catch (err: any) {
+                        return Err(new Error('Failed to patch default-deny network policy', { cause: err }));
+                    }
+                }
+            }
             return Err(new Error('Failed to create default-deny network policy', { cause: err }));
         }
-
-        try {
-            // 2. Allow ingress from nango
-            await this.networkingApi.patchNamespacedNetworkPolicy(
-                {
-                    name: 'allow-from-nango',
-                    namespace,
-                    body: {
-                        apiVersion: 'networking.k8s.io/v1',
-                        kind: 'NetworkPolicy',
-                        metadata: { name: 'allow-from-nango', namespace },
-                        spec: {
-                            podSelector: {},
-                            ingress: [
-                                {
-                                    _from: [
-                                        {
-                                            namespaceSelector: {
-                                                matchLabels: { name: this.jobsNamespace }
-                                            }
-                                        }
-                                    ]
+        const allowFromNango: k8s.V1NetworkPolicy = {
+            metadata: { name: 'allow-from-nango' },
+            spec: {
+                podSelector: {},
+                ingress: [
+                    {
+                        _from: [
+                            {
+                                namespaceSelector: {
+                                    matchLabels: { name: this.jobsNamespace }
                                 }
-                            ],
-                            policyTypes: ['Ingress']
-                        }
-                    },
-                    fieldManager: 'nango-supervisor'
-                },
-                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
-            );
+                            }
+                        ]
+                    }
+                ],
+                policyTypes: ['Ingress']
+            }
+        };
+        try {
+            await this.networkingApi.createNamespacedNetworkPolicy({
+                namespace,
+                body: allowFromNango
+            });
         } catch (err: any) {
+            if (err.body) {
+                const body = JSON.parse(err.body);
+                if (body.reason == 'AlreadyExists') {
+                    try {
+                        await this.networkingApi.patchNamespacedNetworkPolicy({
+                            name: 'allow-from-nango',
+                            namespace,
+                            body: allowFromNango
+                        });
+                    } catch (err: any) {
+                        return Err(new Error('Failed to patch allow-from-nango network policy', { cause: err }));
+                    }
+                }
+            }
             return Err(new Error('Failed to create allow-from-nango network policy', { cause: err }));
         }
 
-        try {
-            // 3. Allow egress to nango + internet
-            await this.networkingApi.patchNamespacedNetworkPolicy(
-                {
-                    name: 'allow-egress-to-nango-and-internet',
-                    namespace,
-                    body: {
-                        apiVersion: 'networking.k8s.io/v1',
-                        kind: 'NetworkPolicy',
-                        metadata: { name: 'allow-egress-to-nango-and-internet', namespace },
-                        spec: {
-                            podSelector: {},
-                            policyTypes: ['Egress'],
-                            egress: [
-                                {
-                                    to: [
-                                        {
-                                            namespaceSelector: {
-                                                matchLabels: { name: this.jobsNamespace }
-                                            }
-                                        }
-                                    ]
-                                },
-                                {
-                                    to: [
-                                        {
-                                            ipBlock: {
-                                                cidr: '0.0.0.0/0'
-                                            }
-                                        }
-                                    ]
+        const allowEgressToNangoAndInternet: k8s.V1NetworkPolicy = {
+            metadata: { name: 'allow-egress-to-nango-and-internet' },
+            spec: {
+                podSelector: {},
+                policyTypes: ['Egress'],
+                egress: [
+                    {
+                        to: [
+                            {
+                                namespaceSelector: {
+                                    matchLabels: { name: this.jobsNamespace }
                                 }
-                            ]
-                        }
+                            }
+                        ]
                     },
-                    fieldManager: 'nango-supervisor'
-                },
-                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
-            );
+                    {
+                        to: [
+                            {
+                                ipBlock: {
+                                    cidr: '0.0.0.0/0'
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+        try {
+            await this.networkingApi.createNamespacedNetworkPolicy({
+                namespace,
+                body: allowEgressToNangoAndInternet
+            });
         } catch (err: any) {
+            if (err.body) {
+                const body = JSON.parse(err.body);
+                if (body.reason == 'AlreadyExists') {
+                    try {
+                        await this.networkingApi.patchNamespacedNetworkPolicy({
+                            name: 'allow-egress-to-nango-and-internet',
+                            namespace,
+                            body: allowEgressToNangoAndInternet
+                        });
+                    } catch (err: any) {
+                        return Err(new Error('Failed to patch allow-egress-to-nango-and-internet network policy', { cause: err }));
+                    }
+                }
+            }
             return Err(new Error('Failed to create allow-egress-to-nango-and-internet network policy', { cause: err }));
         }
 

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -117,16 +117,14 @@ class Kubernetes {
         };
 
         try {
-            await this.coreApi.createNamespace({
-                body: namespaceManifest
-            });
+            await this.coreApi.patchNamespace(
+                {
+                    name: namespace,
+                    body: namespaceManifest
+                },
+                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
+            );
         } catch (err: any) {
-            if (err.body) {
-                const body = JSON.parse(err.body);
-                if (body.reason == 'AlreadyExists') {
-                    return Ok(undefined);
-                }
-            }
             return Err(new Error('Failed to create namespace', { cause: err }));
         }
 
@@ -166,28 +164,18 @@ class Kubernetes {
         };
 
         try {
-            await this.appsApi.createNamespacedDeployment({
-                namespace,
-                body: deploymentManifest
-            });
-        } catch (err: any) {
-            if (err.body) {
-                const body = JSON.parse(err.body);
-                if (body.reason == 'AlreadyExists') {
-                    try {
-                        await this.appsApi.patchNamespacedDeployment({
-                            name,
-                            namespace,
-                            body: deploymentManifest
-                        });
-                    } catch (err: any) {
-                        return Err(new Error('Failed to patch deployment', { cause: err }));
-                    }
-                }
-            }
+            await this.appsApi.patchNamespacedDeployment(
+                {
+                    name,
+                    namespace,
+                    body: deploymentManifest
+                },
+                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
+            );
+            return Ok(undefined);
+        } catch (err) {
             return Err(new Error('Failed to create deployment', { cause: err }));
         }
-        return Ok(undefined);
     }
 
     private async createService(_node: Node, name: string, namespace: string): Promise<Result<void>> {
@@ -210,154 +198,109 @@ class Kubernetes {
         };
 
         try {
-            await this.coreApi.createNamespacedService({
-                namespace,
-                body: serviceManifest
-            });
-        } catch (err: any) {
-            if (err.body) {
-                const body = JSON.parse(err.body);
-                if (body.reason == 'AlreadyExists') {
-                    try {
-                        await this.coreApi.patchNamespacedService(
-                            {
-                                name,
-                                namespace,
-                                body: serviceManifest
-                            },
-                            k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
-                        );
-                    } catch (err: any) {
-                        return Err(new Error('Failed to patch namespace', { cause: err }));
-                    }
-                } else {
-                    return Err(new Error('Failed to create namespace', { cause: err }));
-                }
-            } else {
-                return Err(new Error('Failed to create namespace', { cause: err }));
-            }
+            await this.coreApi.patchNamespacedService(
+                {
+                    name,
+                    namespace,
+                    body: serviceManifest
+                },
+                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
+            );
+            return Ok(undefined);
+        } catch (err) {
+            return Err(new Error('Failed to create service', { cause: err }));
         }
-        return Ok(undefined);
     }
 
     private async createNetworkPolicies(namespace: string): Promise<Result<void>> {
-        const denyAll: k8s.V1NetworkPolicy = {
-            metadata: { name: 'default-deny' },
-            spec: {
-                podSelector: {},
-                policyTypes: ['Ingress']
-            }
-        };
         try {
-            await this.networkingApi.createNamespacedNetworkPolicy({
-                namespace,
-                body: denyAll
-            });
-        } catch (err: any) {
-            if (err.body) {
-                const body = JSON.parse(err.body);
-                if (body.reason == 'AlreadyExists') {
-                    try {
-                        await this.networkingApi.patchNamespacedNetworkPolicy({
-                            name: 'default-deny',
-                            namespace,
-                            body: denyAll
-                        });
-                    } catch (err: any) {
-                        return Err(new Error('Failed to patch default-deny network policy', { cause: err }));
+            // 1. Default deny all ingress
+            await this.networkingApi.patchNamespacedNetworkPolicy(
+                {
+                    name: 'default-deny',
+                    namespace,
+                    body: {
+                        metadata: { name: 'default-deny' },
+                        spec: {
+                            podSelector: {},
+                            policyTypes: ['Ingress']
+                        }
                     }
-                }
-            }
+                },
+                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
+            );
+        } catch (err: any) {
             return Err(new Error('Failed to create default-deny network policy', { cause: err }));
         }
-        const allowFromNango: k8s.V1NetworkPolicy = {
-            metadata: { name: 'allow-from-nango' },
-            spec: {
-                podSelector: {},
-                ingress: [
-                    {
-                        _from: [
-                            {
-                                namespaceSelector: {
-                                    matchLabels: { name: this.jobsNamespace }
-                                }
-                            }
-                        ]
-                    }
-                ],
-                policyTypes: ['Ingress']
-            }
-        };
+
         try {
-            await this.networkingApi.createNamespacedNetworkPolicy({
-                namespace,
-                body: allowFromNango
-            });
-        } catch (err: any) {
-            if (err.body) {
-                const body = JSON.parse(err.body);
-                if (body.reason == 'AlreadyExists') {
-                    try {
-                        await this.networkingApi.patchNamespacedNetworkPolicy({
-                            name: 'allow-from-nango',
-                            namespace,
-                            body: allowFromNango
-                        });
-                    } catch (err: any) {
-                        return Err(new Error('Failed to patch allow-from-nango network policy', { cause: err }));
+            // 2. Allow ingress from nango
+            await this.networkingApi.patchNamespacedNetworkPolicy(
+                {
+                    name: 'allow-from-nango',
+                    namespace,
+                    body: {
+                        metadata: { name: 'allow-from-nango' },
+                        spec: {
+                            podSelector: {},
+                            ingress: [
+                                {
+                                    _from: [
+                                        {
+                                            namespaceSelector: {
+                                                matchLabels: { name: this.jobsNamespace }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            policyTypes: ['Ingress']
+                        }
                     }
-                }
-            }
+                },
+                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
+            );
+        } catch (err: any) {
             return Err(new Error('Failed to create allow-from-nango network policy', { cause: err }));
         }
 
-        const allowEgressToNangoAndInternet: k8s.V1NetworkPolicy = {
-            metadata: { name: 'allow-egress-to-nango-and-internet' },
-            spec: {
-                podSelector: {},
-                policyTypes: ['Egress'],
-                egress: [
-                    {
-                        to: [
-                            {
-                                namespaceSelector: {
-                                    matchLabels: { name: this.jobsNamespace }
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        to: [
-                            {
-                                ipBlock: {
-                                    cidr: '0.0.0.0/0'
-                                }
-                            }
-                        ]
-                    }
-                ]
-            }
-        };
         try {
-            await this.networkingApi.createNamespacedNetworkPolicy({
-                namespace,
-                body: allowEgressToNangoAndInternet
-            });
-        } catch (err: any) {
-            if (err.body) {
-                const body = JSON.parse(err.body);
-                if (body.reason == 'AlreadyExists') {
-                    try {
-                        await this.networkingApi.patchNamespacedNetworkPolicy({
-                            name: 'allow-egress-to-nango-and-internet',
-                            namespace,
-                            body: allowEgressToNangoAndInternet
-                        });
-                    } catch (err: any) {
-                        return Err(new Error('Failed to patch allow-egress-to-nango-and-internet network policy', { cause: err }));
+            // 3. Allow egress to nango + internet
+            await this.networkingApi.patchNamespacedNetworkPolicy(
+                {
+                    name: 'allow-egress-to-nango-and-internet',
+                    namespace,
+                    body: {
+                        metadata: { name: 'allow-egress-to-nango-and-internet' },
+                        spec: {
+                            podSelector: {},
+                            policyTypes: ['Egress'],
+                            egress: [
+                                {
+                                    to: [
+                                        {
+                                            namespaceSelector: {
+                                                matchLabels: { name: this.jobsNamespace }
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    to: [
+                                        {
+                                            ipBlock: {
+                                                cidr: '0.0.0.0/0'
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
                     }
-                }
-            }
+                },
+                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
+            );
+        } catch (err: any) {
             return Err(new Error('Failed to create allow-egress-to-nango-and-internet network policy', { cause: err }));
         }
 

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -111,6 +111,7 @@ class Kubernetes {
 
     private async ensureNamespace(namespace: string): Promise<Result<void>> {
         const namespaceManifest: k8s.V1Namespace = {
+            kind: 'Namespace',
             metadata: {
                 name: namespace
             }
@@ -134,6 +135,7 @@ class Kubernetes {
 
     private async createDeployment(node: Node, name: string, namespace: string, runnerUrl: string): Promise<Result<void>> {
         const deploymentManifest: k8s.V1Deployment = {
+            kind: 'Deployment',
             metadata: {
                 name,
                 labels: { app: name }
@@ -182,6 +184,7 @@ class Kubernetes {
 
     private async createService(_node: Node, name: string, namespace: string): Promise<Result<void>> {
         const serviceManifest: k8s.V1Service = {
+            kind: 'Service',
             metadata: {
                 name,
                 labels: { app: name }
@@ -223,6 +226,7 @@ class Kubernetes {
                     name: 'default-deny',
                     namespace,
                     body: {
+                        kind: 'NetworkPolicy',
                         metadata: { name: 'default-deny' },
                         spec: {
                             podSelector: {},
@@ -244,6 +248,7 @@ class Kubernetes {
                     name: 'allow-from-nango',
                     namespace,
                     body: {
+                        kind: 'NetworkPolicy',
                         metadata: { name: 'allow-from-nango' },
                         spec: {
                             podSelector: {},
@@ -276,6 +281,7 @@ class Kubernetes {
                     name: 'allow-egress-to-nango-and-internet',
                     namespace,
                     body: {
+                        kind: 'NetworkPolicy',
                         metadata: { name: 'allow-egress-to-nango-and-internet' },
                         spec: {
                             podSelector: {},

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -111,6 +111,7 @@ class Kubernetes {
 
     private async ensureNamespace(namespace: string): Promise<Result<void>> {
         const namespaceManifest: k8s.V1Namespace = {
+            apiVersion: 'v1',
             kind: 'Namespace',
             metadata: {
                 name: namespace
@@ -135,6 +136,7 @@ class Kubernetes {
 
     private async createDeployment(node: Node, name: string, namespace: string, runnerUrl: string): Promise<Result<void>> {
         const deploymentManifest: k8s.V1Deployment = {
+            apiVersion: 'apps/v1',
             kind: 'Deployment',
             metadata: {
                 name,
@@ -184,6 +186,7 @@ class Kubernetes {
 
     private async createService(_node: Node, name: string, namespace: string): Promise<Result<void>> {
         const serviceManifest: k8s.V1Service = {
+            apiVersion: 'v1',
             kind: 'Service',
             metadata: {
                 name,
@@ -226,6 +229,7 @@ class Kubernetes {
                     name: 'default-deny',
                     namespace,
                     body: {
+                        apiVersion: 'networking.k8s.io/v1',
                         kind: 'NetworkPolicy',
                         metadata: { name: 'default-deny' },
                         spec: {
@@ -248,6 +252,7 @@ class Kubernetes {
                     name: 'allow-from-nango',
                     namespace,
                     body: {
+                        apiVersion: 'networking.k8s.io/v1',
                         kind: 'NetworkPolicy',
                         metadata: { name: 'allow-from-nango' },
                         spec: {
@@ -281,6 +286,7 @@ class Kubernetes {
                     name: 'allow-egress-to-nango-and-internet',
                     namespace,
                     body: {
+                        apiVersion: 'networking.k8s.io/v1',
                         kind: 'NetworkPolicy',
                         metadata: { name: 'allow-egress-to-nango-and-internet' },
                         spec: {

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -114,7 +114,6 @@ class Kubernetes {
                 if (!this.notFound(err)) {
                     return Err(new Error('Failed to delete service', { cause: err }));
                 }
-                return Err(new Error('Failed to delete service', { cause: err }));
             }
 
             try {

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -140,7 +140,8 @@ class Kubernetes {
             kind: 'Deployment',
             metadata: {
                 name,
-                labels: { app: name }
+                labels: { app: name },
+                namespace
             },
             spec: {
                 replicas: 1,
@@ -190,7 +191,8 @@ class Kubernetes {
             kind: 'Service',
             metadata: {
                 name,
-                labels: { app: name }
+                labels: { app: name },
+                namespace
             },
             spec: {
                 selector: { app: name },
@@ -231,7 +233,7 @@ class Kubernetes {
                     body: {
                         apiVersion: 'networking.k8s.io/v1',
                         kind: 'NetworkPolicy',
-                        metadata: { name: 'default-deny' },
+                        metadata: { name: 'default-deny', namespace },
                         spec: {
                             podSelector: {},
                             policyTypes: ['Ingress']
@@ -254,7 +256,7 @@ class Kubernetes {
                     body: {
                         apiVersion: 'networking.k8s.io/v1',
                         kind: 'NetworkPolicy',
-                        metadata: { name: 'allow-from-nango' },
+                        metadata: { name: 'allow-from-nango', namespace },
                         spec: {
                             podSelector: {},
                             ingress: [
@@ -288,7 +290,7 @@ class Kubernetes {
                     body: {
                         apiVersion: 'networking.k8s.io/v1',
                         kind: 'NetworkPolicy',
-                        metadata: { name: 'allow-egress-to-nango-and-internet' },
+                        metadata: { name: 'allow-egress-to-nango-and-internet', namespace },
                         spec: {
                             podSelector: {},
                             policyTypes: ['Egress'],

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -65,7 +65,7 @@ class Kubernetes {
         }
 
         // Create network policies
-        const networkPoliciesResult = await this.createNetworkPolicies(namespace);
+        const networkPoliciesResult = await this.createNetworkPolicies(namespace, node.id);
         if (networkPoliciesResult.isErr()) {
             return networkPoliciesResult;
         }
@@ -91,7 +91,7 @@ class Kubernetes {
             });
 
             // Delete network policies
-            await this.deleteNetworkPolicies(namespace);
+            await this.deleteNetworkPolicies(namespace, node.id);
 
             return Ok(undefined);
         } catch (err) {
@@ -215,9 +215,9 @@ class Kubernetes {
         return Ok(undefined);
     }
 
-    private async createNetworkPolicies(namespace: string): Promise<Result<void>> {
+    private async createNetworkPolicies(namespace: string, nodeId: number): Promise<Result<void>> {
         const denyAll: k8s.V1NetworkPolicy = {
-            metadata: { name: 'default-deny' },
+            metadata: { name: `default-deny-${nodeId}` },
             spec: {
                 podSelector: {},
                 policyTypes: ['Ingress']
@@ -239,7 +239,7 @@ class Kubernetes {
             }
         }
         const allowFromNango: k8s.V1NetworkPolicy = {
-            metadata: { name: 'allow-from-nango' },
+            metadata: { name: `allow-from-nango-${nodeId}` },
             spec: {
                 podSelector: {},
                 ingress: [
@@ -273,7 +273,7 @@ class Kubernetes {
         }
 
         const allowEgressToNangoAndInternet: k8s.V1NetworkPolicy = {
-            metadata: { name: 'allow-egress-to-nango-and-internet' },
+            metadata: { name: `allow-egress-to-nango-and-internet-${nodeId}` },
             spec: {
                 podSelector: {},
                 policyTypes: ['Egress'],
@@ -318,19 +318,19 @@ class Kubernetes {
         return Ok(undefined);
     }
 
-    private async deleteNetworkPolicies(namespace: string): Promise<void> {
+    private async deleteNetworkPolicies(namespace: string, nodeId: number): Promise<void> {
         try {
             // Delete network policies
             await this.networkingApi.deleteNamespacedNetworkPolicy({
-                name: 'default-deny',
+                name: `default-deny-${nodeId}`,
                 namespace
             });
             await this.networkingApi.deleteNamespacedNetworkPolicy({
-                name: 'allow-from-nango',
+                name: `allow-from-nango-${nodeId}`,
                 namespace
             });
             await this.networkingApi.deleteNamespacedNetworkPolicy({
-                name: 'allow-egress-to-nango-and-internet',
+                name: `allow-egress-to-nango-and-internet-${nodeId}`,
                 namespace
             });
         } catch (err) {

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -175,11 +175,14 @@ class Kubernetes {
                 const body = JSON.parse(err.body);
                 if (body.reason == 'AlreadyExists') {
                     try {
-                        await this.appsApi.patchNamespacedDeployment({
-                            name,
-                            namespace,
-                            body: deploymentManifest
-                        });
+                        await this.appsApi.patchNamespacedDeployment(
+                            {
+                                name,
+                                namespace,
+                                body: deploymentManifest
+                            },
+                            k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.StrategicMergePatch)
+                        );
                     } catch (err: any) {
                         return Err(new Error('Failed to patch deployment', { cause: err }));
                     }
@@ -225,7 +228,7 @@ class Kubernetes {
                                 namespace,
                                 body: serviceManifest
                             },
-                            k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
+                            k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.StrategicMergePatch)
                         );
                     } catch (err: any) {
                         return Err(new Error('Failed to patch namespace', { cause: err }));
@@ -258,11 +261,14 @@ class Kubernetes {
                 const body = JSON.parse(err.body);
                 if (body.reason == 'AlreadyExists') {
                     try {
-                        await this.networkingApi.patchNamespacedNetworkPolicy({
-                            name: 'default-deny',
-                            namespace,
-                            body: denyAll
-                        });
+                        await this.networkingApi.patchNamespacedNetworkPolicy(
+                            {
+                                name: 'default-deny',
+                                namespace,
+                                body: denyAll
+                            },
+                            k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.StrategicMergePatch)
+                        );
                     } catch (err: any) {
                         return Err(new Error('Failed to patch default-deny network policy', { cause: err }));
                     }
@@ -298,11 +304,14 @@ class Kubernetes {
                 const body = JSON.parse(err.body);
                 if (body.reason == 'AlreadyExists') {
                     try {
-                        await this.networkingApi.patchNamespacedNetworkPolicy({
-                            name: 'allow-from-nango',
-                            namespace,
-                            body: allowFromNango
-                        });
+                        await this.networkingApi.patchNamespacedNetworkPolicy(
+                            {
+                                name: 'allow-from-nango',
+                                namespace,
+                                body: allowFromNango
+                            },
+                            k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.StrategicMergePatch)
+                        );
                     } catch (err: any) {
                         return Err(new Error('Failed to patch allow-from-nango network policy', { cause: err }));
                     }
@@ -348,11 +357,14 @@ class Kubernetes {
                 const body = JSON.parse(err.body);
                 if (body.reason == 'AlreadyExists') {
                     try {
-                        await this.networkingApi.patchNamespacedNetworkPolicy({
-                            name: 'allow-egress-to-nango-and-internet',
-                            namespace,
-                            body: allowEgressToNangoAndInternet
-                        });
+                        await this.networkingApi.patchNamespacedNetworkPolicy(
+                            {
+                                name: 'allow-egress-to-nango-and-internet',
+                                namespace,
+                                body: allowEgressToNangoAndInternet
+                            },
+                            k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.StrategicMergePatch)
+                        );
                     } catch (err: any) {
                         return Err(new Error('Failed to patch allow-egress-to-nango-and-internet network policy', { cause: err }));
                     }

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -127,7 +127,7 @@ class Kubernetes {
                     name: namespace,
                     body: namespaceManifest
                 },
-                this.apiOptions
+                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
             );
         } catch (err: any) {
             return Err(new Error('Failed to create namespace', { cause: err }));
@@ -175,7 +175,7 @@ class Kubernetes {
                     namespace,
                     body: deploymentManifest
                 },
-                this.apiOptions
+                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
             );
             return Ok(undefined);
         } catch (err) {
@@ -209,7 +209,7 @@ class Kubernetes {
                     namespace,
                     body: serviceManifest
                 },
-                this.apiOptions
+                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
             );
             return Ok(undefined);
         } catch (err) {
@@ -232,7 +232,7 @@ class Kubernetes {
                         }
                     }
                 },
-                this.apiOptions
+                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
             );
         } catch (err: any) {
             return Err(new Error('Failed to create default-deny network policy', { cause: err }));
@@ -263,7 +263,7 @@ class Kubernetes {
                         }
                     }
                 },
-                this.apiOptions
+                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
             );
         } catch (err: any) {
             return Err(new Error('Failed to create allow-from-nango network policy', { cause: err }));
@@ -303,7 +303,7 @@ class Kubernetes {
                         }
                     }
                 },
-                this.apiOptions
+                k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
             );
         } catch (err: any) {
             return Err(new Error('Failed to create allow-egress-to-nango-and-internet network policy', { cause: err }));

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -120,7 +120,8 @@ class Kubernetes {
             await this.coreApi.patchNamespace(
                 {
                     name: namespace,
-                    body: namespaceManifest
+                    body: namespaceManifest,
+                    fieldManager: 'nango-supervisor'
                 },
                 k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
             );
@@ -168,7 +169,8 @@ class Kubernetes {
                 {
                     name,
                     namespace,
-                    body: deploymentManifest
+                    body: deploymentManifest,
+                    fieldManager: 'nango-supervisor'
                 },
                 k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
             );
@@ -202,7 +204,8 @@ class Kubernetes {
                 {
                     name,
                     namespace,
-                    body: serviceManifest
+                    body: serviceManifest,
+                    fieldManager: 'nango-supervisor'
                 },
                 k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
             );
@@ -225,7 +228,8 @@ class Kubernetes {
                             podSelector: {},
                             policyTypes: ['Ingress']
                         }
-                    }
+                    },
+                    fieldManager: 'nango-supervisor'
                 },
                 k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
             );
@@ -256,7 +260,8 @@ class Kubernetes {
                             ],
                             policyTypes: ['Ingress']
                         }
-                    }
+                    },
+                    fieldManager: 'nango-supervisor'
                 },
                 k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
             );
@@ -296,7 +301,8 @@ class Kubernetes {
                                 }
                             ]
                         }
-                    }
+                    },
+                    fieldManager: 'nango-supervisor'
                 },
                 k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.ServerSideApply)
             );

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -186,9 +186,12 @@ class Kubernetes {
                     } catch (err: any) {
                         return Err(new Error('Failed to patch deployment', { cause: err }));
                     }
+                } else {
+                    return Err(new Error('Failed to create deployment', { cause: err }));
                 }
+            } else {
+                return Err(new Error('Failed to create deployment', { cause: err }));
             }
-            return Err(new Error('Failed to create deployment', { cause: err }));
         }
         return Ok(undefined);
     }
@@ -231,13 +234,13 @@ class Kubernetes {
                             k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.StrategicMergePatch)
                         );
                     } catch (err: any) {
-                        return Err(new Error('Failed to patch namespace', { cause: err }));
+                        return Err(new Error('Failed to patch service', { cause: err }));
                     }
                 } else {
-                    return Err(new Error('Failed to create namespace', { cause: err }));
+                    return Err(new Error('Failed to create service', { cause: err }));
                 }
             } else {
-                return Err(new Error('Failed to create namespace', { cause: err }));
+                return Err(new Error('Failed to create service', { cause: err }));
             }
         }
         return Ok(undefined);
@@ -272,9 +275,12 @@ class Kubernetes {
                     } catch (err: any) {
                         return Err(new Error('Failed to patch default-deny network policy', { cause: err }));
                     }
+                } else {
+                    return Err(new Error('Failed to create default-deny network policy', { cause: err }));
                 }
+            } else {
+                return Err(new Error('Failed to create default-deny network policy', { cause: err }));
             }
-            return Err(new Error('Failed to create default-deny network policy', { cause: err }));
         }
         const allowFromNango: k8s.V1NetworkPolicy = {
             metadata: { name: 'allow-from-nango' },
@@ -315,9 +321,12 @@ class Kubernetes {
                     } catch (err: any) {
                         return Err(new Error('Failed to patch allow-from-nango network policy', { cause: err }));
                     }
+                } else {
+                    return Err(new Error('Failed to create allow-from-nango network policy', { cause: err }));
                 }
+            } else {
+                return Err(new Error('Failed to create allow-from-nango network policy', { cause: err }));
             }
-            return Err(new Error('Failed to create allow-from-nango network policy', { cause: err }));
         }
 
         const allowEgressToNangoAndInternet: k8s.V1NetworkPolicy = {
@@ -368,9 +377,12 @@ class Kubernetes {
                     } catch (err: any) {
                         return Err(new Error('Failed to patch allow-egress-to-nango-and-internet network policy', { cause: err }));
                     }
+                } else {
+                    return Err(new Error('Failed to create allow-egress-to-nango-and-internet network policy', { cause: err }));
                 }
+            } else {
+                return Err(new Error('Failed to create allow-egress-to-nango-and-internet network policy', { cause: err }));
             }
-            return Err(new Error('Failed to create allow-egress-to-nango-and-internet network policy', { cause: err }));
         }
 
         return Ok(undefined);

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -144,10 +144,7 @@ class Kubernetes {
                 selector: { matchLabels: { app: name } },
                 template: {
                     metadata: {
-                        labels: { app: name },
-                        annotations: {
-                            'supervisor.nango.dev/restartedAt': new Date().toISOString()
-                        }
+                        labels: { app: name }
                     },
                     spec: {
                         containers: [
@@ -170,30 +167,16 @@ class Kubernetes {
                 namespace,
                 body: deploymentManifest
             });
+            return Ok(undefined);
         } catch (err: any) {
             if (err.body) {
                 const body = JSON.parse(err.body);
                 if (body.reason == 'AlreadyExists') {
-                    try {
-                        await this.appsApi.patchNamespacedDeployment(
-                            {
-                                name,
-                                namespace,
-                                body: deploymentManifest
-                            },
-                            k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.StrategicMergePatch)
-                        );
-                    } catch (err: any) {
-                        return Err(new Error('Failed to patch deployment', { cause: err }));
-                    }
-                } else {
-                    return Err(new Error('Failed to create deployment', { cause: err }));
+                    return Ok(undefined);
                 }
-            } else {
-                return Err(new Error('Failed to create deployment', { cause: err }));
             }
+            return Err(new Error('Failed to create deployment', { cause: err }));
         }
-        return Ok(undefined);
     }
 
     private async createService(_node: Node, name: string, namespace: string): Promise<Result<void>> {
@@ -224,24 +207,10 @@ class Kubernetes {
             if (err.body) {
                 const body = JSON.parse(err.body);
                 if (body.reason == 'AlreadyExists') {
-                    try {
-                        await this.coreApi.patchNamespacedService(
-                            {
-                                name,
-                                namespace,
-                                body: serviceManifest
-                            },
-                            k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.StrategicMergePatch)
-                        );
-                    } catch (err: any) {
-                        return Err(new Error('Failed to patch service', { cause: err }));
-                    }
-                } else {
-                    return Err(new Error('Failed to create service', { cause: err }));
+                    return Ok(undefined);
                 }
-            } else {
-                return Err(new Error('Failed to create service', { cause: err }));
             }
+            return Err(new Error('Failed to create service', { cause: err }));
         }
         return Ok(undefined);
     }
@@ -262,20 +231,7 @@ class Kubernetes {
         } catch (err: any) {
             if (err.body) {
                 const body = JSON.parse(err.body);
-                if (body.reason == 'AlreadyExists') {
-                    try {
-                        await this.networkingApi.patchNamespacedNetworkPolicy(
-                            {
-                                name: 'default-deny',
-                                namespace,
-                                body: denyAll
-                            },
-                            k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.StrategicMergePatch)
-                        );
-                    } catch (err: any) {
-                        return Err(new Error('Failed to patch default-deny network policy', { cause: err }));
-                    }
-                } else {
+                if (body.reason !== 'AlreadyExists') {
                     return Err(new Error('Failed to create default-deny network policy', { cause: err }));
                 }
             } else {
@@ -308,20 +264,7 @@ class Kubernetes {
         } catch (err: any) {
             if (err.body) {
                 const body = JSON.parse(err.body);
-                if (body.reason == 'AlreadyExists') {
-                    try {
-                        await this.networkingApi.patchNamespacedNetworkPolicy(
-                            {
-                                name: 'allow-from-nango',
-                                namespace,
-                                body: allowFromNango
-                            },
-                            k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.StrategicMergePatch)
-                        );
-                    } catch (err: any) {
-                        return Err(new Error('Failed to patch allow-from-nango network policy', { cause: err }));
-                    }
-                } else {
+                if (body.reason !== 'AlreadyExists') {
                     return Err(new Error('Failed to create allow-from-nango network policy', { cause: err }));
                 }
             } else {
@@ -364,20 +307,7 @@ class Kubernetes {
         } catch (err: any) {
             if (err.body) {
                 const body = JSON.parse(err.body);
-                if (body.reason == 'AlreadyExists') {
-                    try {
-                        await this.networkingApi.patchNamespacedNetworkPolicy(
-                            {
-                                name: 'allow-egress-to-nango-and-internet',
-                                namespace,
-                                body: allowEgressToNangoAndInternet
-                            },
-                            k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.StrategicMergePatch)
-                        );
-                    } catch (err: any) {
-                        return Err(new Error('Failed to patch allow-egress-to-nango-and-internet network policy', { cause: err }));
-                    }
-                } else {
+                if (body.reason !== 'AlreadyExists') {
                     return Err(new Error('Failed to create allow-egress-to-nango-and-internet network policy', { cause: err }));
                 }
             } else {

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -11,11 +11,6 @@ import type { Result } from '@nangohq/utils';
 export const logger = getLogger('Kubernetes');
 
 class Kubernetes {
-    //Using these API options allows us to use server-side apply to create or patch the resources
-    //More information: https://kubernetes.io/docs/reference/using-api/server-side-apply/
-    private readonly apiOptions: k8s.ConfigurationOptions = {
-        middleware: [k8s.setHeaderMiddleware('Content-Type', 'application/apply-patch+yaml')]
-    };
     private static instance: Kubernetes | null = null;
     private readonly kc: k8s.KubeConfig;
     private readonly appsApi: k8s.AppsV1Api;

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -98,6 +98,7 @@ export const ENVS = z.object({
 
     // FLEET
     RUNNERS_DATABASE_URL: z.url().optional(),
+    FLEET_SUPERVISOR_LOCK_KEY: z.string().default('fleet_supervisor'),
     FLEET_TIMEOUT_PENDING_MS: z.coerce
         .number()
         .optional()


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Refactor Kubernetes Runner Management and Add Configurable Supervisor Lock Key**

This PR significantly refactors the Kubernetes runner provider and fleet supervisor locking logic. It removes the use of Kubernetes server-side apply (SSA) and patch-based updates for Deployments, Services, and NetworkPolicies, replacing them with explicit resource creation calls that gracefully handle 'AlreadyExists' and 'NotFound' errors. NetworkPolicies are now named per node instance (via node id) for better resource isolation and cleanup. The PR also introduces a configurable Postgres advisory lock key (FLEET_SUPERVISOR_LOCK_KEY) for the fleet supervisor process, moving from hardcoded values to environment-driven configuration, and ensures the per-fleet uniqueness of node creation locks. All environment and config schemas are updated to support these changes.

<details>
<summary><strong>Key Changes</strong></summary>

• Switched Kubernetes runner logic from server-side apply/patch to explicit resource creation with existence/error checks for Deployments, Services, and `NetworkPolicies`.
• `NetworkPolicies` now use per-node-instance names incorporating node id, improving cleanup and preventing naming conflicts.
• Enhanced error handling on creation and deletion of Kubernetes resources, directly handling `AlreadyExists` and `NotFound` scenarios.
• Cleaned up the node deletion flow to ignore `NotFound` errors for Deployments, Services, and `NetworkPolicies`.
• Added ``FLEET_SUPERVISOR_LOCK_KEY`` environment/config variable to allow the supervisor advisory Postgres lock key to be runtime-configured.
• Updated all code paths, schemas, and usages to honor the new configuration for lock keys (now with per-fleet uniqueness for node creation locks).

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/jobs/lib/runner/kubernetes.ts
• packages/fleet/lib/fleet.ts
• packages/fleet/lib/supervisor/supervisor.ts
• packages/utils/lib/environment/parse.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*