### PR TITLE
fix(cli): deploy by integration should filter integration

### DIFF
--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -152,7 +152,7 @@ async function createPackage({
 
     const postData: CLIDeployFlowConfig[] = [];
     const onEventScriptsByProvider: OnEventScriptsByProvider[] | undefined = optionalActionName || optionalSyncName ? undefined : []; // only load on-event scripts if we're not deploying a single sync or action
-    const singleDeployMode = Boolean(optionalSyncName || optionalActionName);
+    const singleDeployMode = Boolean(optionalSyncName || optionalActionName || optionalIntegrationId);
 
     for (const integration of parsed.integrations) {
         const { providerConfigKey, onEventScripts } = integration;


### PR DESCRIPTION
## Changes

- deploy by integration should filter integration
Just a little if missing

<!-- Summary by @propel-code-bot -->

---

**CLI: Fix Integration Filtering in Deploy Logic**

This PR corrects the CLI deploy behavior to properly filter by integration when deploying scripts. Specifically, the logic determining 'singleDeployMode' is updated to account for deployments targeted at a specific integration via the optionalIntegrationId argument. This change ensures the CLI only deploys scripts associated with the requested integration when that parameter is provided.

<details>
<summary><strong>Key Changes</strong></summary>

• `singleDeployMode` Boolean updated to also check for `optionalIntegrationId`, alongside `optionalSyncName` and `optionalActionName`.
• Ensures that when deploying by integration, only the relevant integration's scripts are considered.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/cli/lib/`zeroYaml`/deploy.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*