### PR TITLE
fix(jobs): fail quicker when runner is not available

### DIFF
--- a/packages/jobs/lib/runner/fleet.runner.ts
+++ b/packages/jobs/lib/runner/fleet.runner.ts
@@ -1,6 +1,6 @@
 import { getRunnerClient } from '@nangohq/nango-runner';
 
-import { RunnerType } from './runner.js';
+import { RunnerType, runnerHttpOpts } from './runner.js';
 
 import type { Runner } from './runner.js';
 
@@ -11,6 +11,6 @@ export class FleetRunner implements Runner {
         public readonly id: string,
         public readonly url: string
     ) {
-        this.client = getRunnerClient(this.url);
+        this.client = getRunnerClient(this.url, runnerHttpOpts);
     }
 }

--- a/packages/jobs/lib/runner/remote.runner.ts
+++ b/packages/jobs/lib/runner/remote.runner.ts
@@ -1,6 +1,6 @@
 import { getRunnerClient } from '@nangohq/nango-runner';
 
-import { RunnerType } from './runner.js';
+import { RunnerType, runnerHttpOpts } from './runner.js';
 
 import type { Runner } from './runner.js';
 
@@ -11,7 +11,7 @@ export class RemoteRunner implements Runner {
         public readonly id: string,
         public readonly url: string
     ) {
-        this.client = getRunnerClient(this.url);
+        this.client = getRunnerClient(this.url, runnerHttpOpts);
     }
 
     static async getOrStart(runnerId: string): Promise<RemoteRunner> {

--- a/packages/jobs/lib/runner/runner.ts
+++ b/packages/jobs/lib/runner/runner.ts
@@ -20,6 +20,12 @@ export interface Runner {
     url: string;
 }
 
+export const runnerHttpOpts = {
+    headersTimeoutMs: envs.RUNNER_CLIENT_HEADERS_TIMEOUT_MS,
+    connectTimeoutMs: envs.RUNNER_CLIENT_CONNECT_TIMEOUT_MS,
+    responseTimeoutMs: envs.RUNNER_CLIENT_RESPONSE_TIMEOUT_MS
+};
+
 function getRunnerId(suffix: string): string {
     if (envs.RUNNER_TYPE === 'KUBERNETES') {
         suffix = `${suffix}-k8s`;

--- a/packages/runner/lib/client.ts
+++ b/packages/runner/lib/client.ts
@@ -19,9 +19,9 @@ export function getRunnerClient(url: string): ProxyAppRouter {
                     return fetch(url, {
                         ...options,
                         dispatcher: new Agent({
-                            headersTimeout: 0,
-                            connectTimeout: 0,
-                            bodyTimeout: 0
+                            headersTimeout: 10_000,
+                            connectTimeout: 5_000,
+                            bodyTimeout: 15_000
                         })
                     });
                 }

--- a/packages/runner/lib/client.ts
+++ b/packages/runner/lib/client.ts
@@ -8,7 +8,14 @@ import type { RequestInit } from 'undici';
 
 export type ProxyAppRouter = CreateTRPCProxyClient<AppRouter>;
 
-export function getRunnerClient(url: string): ProxyAppRouter {
+export function getRunnerClient(
+    url: string,
+    httpOpts: {
+        headersTimeoutMs: number;
+        connectTimeoutMs: number;
+        responseTimeoutMs: number;
+    }
+): ProxyAppRouter {
     return createTRPCProxyClient<AppRouter>({
         transformer: superjson,
         links: [
@@ -19,9 +26,9 @@ export function getRunnerClient(url: string): ProxyAppRouter {
                     return fetch(url, {
                         ...options,
                         dispatcher: new Agent({
-                            headersTimeout: 10_000,
-                            connectTimeout: 5_000,
-                            bodyTimeout: 15_000
+                            headersTimeout: httpOpts.headersTimeoutMs,
+                            connectTimeout: httpOpts.connectTimeoutMs,
+                            bodyTimeout: httpOpts.responseTimeoutMs
                         })
                     });
                 }

--- a/packages/runner/lib/client.unit.test.ts
+++ b/packages/runner/lib/client.unit.test.ts
@@ -35,7 +35,11 @@ describe('Runner client', () => {
     };
 
     beforeAll(() => {
-        client = getRunnerClient(serverUrl);
+        client = getRunnerClient(serverUrl, {
+            headersTimeoutMs: 3_000,
+            connectTimeoutMs: 2_000,
+            responseTimeoutMs: 5_000
+        });
         server.listen(port);
     });
 

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -68,6 +68,7 @@ export const ENVS = z.object({
 
     // Jobs
     JOBS_SERVICE_URL: z.url().optional().default('http://localhost:3005'),
+    JOBS_NAMESPACE: z.string().optional().default('nango'),
     NANGO_JOBS_PORT: z.coerce.number().optional().default(3005),
     PROVIDERS_URL: z.url().optional(),
     PROVIDERS_RELOAD_INTERVAL: z.coerce.number().optional().default(60000),
@@ -94,7 +95,9 @@ export const ENVS = z.object({
     RUNNER_NAMESPACE: z.string().optional().default('nango'),
     RUNNER_HTTP_LOG_SAMPLE_PCT: z.coerce.number().optional(),
     NAMESPACE_PER_RUNNER: z.stringbool().optional().default(false),
-    JOBS_NAMESPACE: z.string().optional().default('nango'),
+    RUNNER_CLIENT_HEADERS_TIMEOUT_MS: z.coerce.number().optional().default(10_000),
+    RUNNER_CLIENT_CONNECT_TIMEOUT_MS: z.coerce.number().optional().default(5000),
+    RUNNER_CLIENT_RESPONSE_TIMEOUT_MS: z.coerce.number().optional().default(15_000),
 
     // FLEET
     RUNNERS_DATABASE_URL: z.url().optional(),


### PR DESCRIPTION
Back in the old days, the requests dispatching tasks to runner were inlined :O and timeouts were disabled so they could accomodate long running scripts. It has not been working like this for a while now but we kept the no timeouts which mean the requests from jobs to runner can take a long time to fail when runner is overwhelmed/not reachable. (I have seen 2+ mins in traces).
This commit adds timeouts for requests to runner so it fails quicker. This is one of the reason webhooks couldn't be processed quickly enough when we experienced some spikes in the past few days. Not that they would have been executed since the customer runner was not healthy but they would have failed fast

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add HTTP Timeouts to Runner Client for Faster Failure on Unavailability**

This PR introduces configurable HTTP timeouts to the runner client used by the jobs service when making requests to the runner. By replacing previously unlimited (0) timeouts with explicit (and now environment-driven) values for connect, headers, and response timeouts, the system ensures that job-to-runner requests fail faster if the runner is unavailable or unresponsive. Environmental variables are added (with sensible defaults) to control these timeout values, improving system responsiveness during runner overload or downtime scenarios. The changes also update all runner client instantiations and related test cases to support and validate the new timeout contract.

<details>
<summary><strong>Key Changes</strong></summary>

• Added environment variables ``RUNNER_CLIENT_HEADERS_TIMEOUT_MS``, ``RUNNER_CLIENT_CONNECT_TIMEOUT_MS``, and ``RUNNER_CLIENT_RESPONSE_TIMEOUT_MS`` (with defaults: 10s, 5s, 15s) to configure ``HTTP`` timeouts.
• Modified `getRunnerClient`() signature to accept a timeout config and applied it to undici.Agent in runner client requests.
• Refactored `FleetRunner` and `RemoteRunner` to inject timeouts via `runnerHttpOpts`.
• Defined and exported `runnerHttpOpts` as a central config in runner.ts.
• Updated environment parsing logic to support new timeout variables and defaults.
• Adjusted runner client unit test to use explicit timeout parameters.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/runner/lib/client.ts (runner ``HTTP`` client creation)
• packages/jobs/lib/runner/runner.ts (runner config)
• packages/jobs/lib/runner/fleet.runner.ts (`FleetRunner` construction)
• packages/jobs/lib/runner/remote.runner.ts (`RemoteRunner` construction)
• packages/utils/lib/environment/parse.ts (environment variable parsing/validation)
• packages/runner/lib/client.unit.test.ts (unit test for client)

</details>

---
*This summary was automatically generated by @propel-code-bot*