### PR TITLE
fix(server): fix base url validation

### DIFF
--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -39,7 +39,7 @@ const schemaHeaders = z.object({
     'provider-config-key': providerConfigKeySchema,
     'connection-id': connectionIdSchema,
     retries: z.coerce.number().optional().default(0),
-    'base-url-override': z.url().optional(),
+    'base-url-override': z.url().or(z.literal('')).optional(),
     decompress: z.enum(['true', 'false']).optional(),
     'retry-on': z
         .string()


### PR DESCRIPTION
## Describe the problem and your solution

- fix base url validation

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Fix Base URL Validation for Proxy Controller**

This PR updates the validation schema for the 'base-url-override' header in the proxy controller. Previously, the schema only allowed valid URLs, excluding empty strings, which caused issues when clients intentionally sent an empty override value. The change enables the header to be either a valid URL or an empty string, improving header flexibility.

<details>
<summary><strong>Key Changes</strong></summary>

• Revised Zod validation schema for `base-url-override` to allow either a valid ``URL`` or an empty string using `.or(z.literal(''))`.
• No other logic or file changes; only a single schema line is affected.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/controllers/proxy/`allProxy`.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*