### PR TITLE
fix(post-connection-script): check for correct provider name (gusto-demo)

### DIFF
--- a/packages/server/lib/hooks/connection/providers/gusto/post-connection.ts
+++ b/packages/server/lib/hooks/connection/providers/gusto/post-connection.ts
@@ -5,7 +5,7 @@ import type { InternalNango as Nango } from '../../internal-nango.js';
 
 export default async function execute(nango: Nango) {
     const connection = await nango.getConnection();
-    const rootUrl = connection.provider_config_key.includes('sandbox') ? 'api.gusto-demo.com' : 'api.gusto.com';
+    const rootUrl = connection.provider_config_key.includes('demo') ? 'api.gusto-demo.com' : 'api.gusto.com';
 
     const response = await nango.proxy<GustoTokenInfoResponse>({
         baseUrlOverride: `https://${rootUrl}`,


### PR DESCRIPTION
## Describe the problem and your solution
- Check for correct provider name.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Fix Gusto Post-Connection Script to Use Correct Provider Name**

This PR updates the Gusto provider's post-connection script to properly detect and assign the API endpoint for the demo environment. By changing the provider config key check from 'sandbox' to 'demo', API calls for demo environments will now use the correct 'api.gusto-demo.com' base URL.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced the `provider_config_key` check in post-connection.ts to look for `demo` instead of `sandbox`
• Ensures that the Gusto demo environment is correctly identified and the appropriate ``API`` ``URL`` is used

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/hooks/connection/providers/gusto/post-connection.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*