### PR TITLE
feat(persist): add endpoint to delete outdated records

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -149,6 +149,7 @@ export default tseslint.config(
                 {
                     allowNumber: true,
                     allowBoolean: true,
+                    allowArray: true,
                     allowNever: true
                 }
             ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -149,7 +149,6 @@ export default tseslint.config(
                 {
                     allowNumber: true,
                     allowBoolean: true,
-                    allowArray: true,
                     allowNever: true
                 }
             ],

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -291,12 +291,16 @@ export async function handleSyncSuccess({ taskId, nangoProps }: { taskId: string
         for (const model of nangoProps.syncConfig.models || []) {
             let deletedKeys: string[] = [];
             if (nangoProps.syncConfig.track_deletes) {
-                deletedKeys = await records.markPreviousGenerationRecordsAsDeleted({
+                const res = await records.deleteOutdatedRecords({
                     connectionId: nangoProps.nangoConnectionId,
                     model,
                     syncId: nangoProps.syncId,
                     generation: nangoProps.syncJobId
                 });
+                if (res.isErr()) {
+                    throw res.error;
+                }
+                deletedKeys = res.value;
                 void logCtx.info(`${model}: "track_deletes" post deleted ${deletedKeys.length} records`);
             }
 

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getCursor.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getCursor.ts
@@ -22,7 +22,7 @@ type GetCursor = Endpoint<{
     Success: GetCursorSuccess;
 }>;
 
-export const path = '/environment/:environmentId/connection/:nangoConnectionId/cursor';
+const path = '/environment/:environmentId/connection/:nangoConnectionId/cursor';
 const method = 'GET';
 
 const validate = validateRequest<GetCursor>(getCursorRequestParser);

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getRecords.ts
@@ -28,7 +28,7 @@ type GetRecords = Endpoint<{
     Success: GetRecordsSuccess;
 }>;
 
-export const path = '/environment/:environmentId/connection/:nangoConnectionId/records';
+const path = '/environment/:environmentId/connection/:nangoConnectionId/records';
 const method = 'GET';
 
 const validate = validateRequest<GetRecords>(getRecordsRequestParser);

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts
@@ -61,6 +61,7 @@ const handler = async (_req: EndpointRequest, res: EndpointResponse<DeleteOutdat
     });
     const logCtx = logContextGetter.getStateLess({ id: String(activityLogId), accountId: account.id });
     if (result.isOk()) {
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         void logCtx.info(`${model}: "Deleted ${result.value} outdated records for model ${model}"`);
         res.status(200).json({ deletedKeys: result.value });
     } else {

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts
@@ -1,0 +1,80 @@
+import z from 'zod';
+
+import { logContextGetter, operationIdRegex } from '@nangohq/logs';
+import { records } from '@nangohq/records';
+import { validateRequest } from '@nangohq/utils';
+
+import type { AuthLocals } from '../../../../../../../../../middleware/auth.middleware.js';
+import type { ApiError, DeleteOutdatedRecordsSuccess, Endpoint } from '@nangohq/types';
+import type { EndpointRequest, EndpointResponse, Route, RouteHandler } from '@nangohq/utils';
+
+type DeleteOutdatedRecords = Endpoint<{
+    Method: typeof method;
+    Path: typeof path;
+    Params: {
+        environmentId: number;
+        nangoConnectionId: number;
+        syncId: string;
+        syncJobId: number;
+    };
+    Body: {
+        model: string;
+        activityLogId: string;
+    };
+    Error: ApiError<'delete_outdated_records_failed'>;
+    Success: DeleteOutdatedRecordsSuccess;
+}>;
+
+const path = '/environment/:environmentId/connection/:nangoConnectionId/sync/:syncId/job/:syncJobId/outdated';
+const method = 'DELETE';
+
+const validate = validateRequest<DeleteOutdatedRecords>({
+    parseBody: (data: unknown) =>
+        z
+            .object({
+                model: z.string(),
+                activityLogId: operationIdRegex
+            })
+            .strict()
+            .parse(data),
+    parseParams: (data: unknown) =>
+        z
+            .object({
+                environmentId: z.coerce.number().int().positive(),
+                nangoConnectionId: z.coerce.number().int().positive(),
+                syncId: z.string(),
+                syncJobId: z.coerce.number().int().positive()
+            })
+            .strict()
+            .parse(data)
+});
+
+const handler = async (_req: EndpointRequest, res: EndpointResponse<DeleteOutdatedRecords, AuthLocals>) => {
+    const { nangoConnectionId, syncId, syncJobId } = res.locals.parsedParams;
+    const { model, activityLogId } = res.locals.parsedBody;
+    const { account } = res.locals;
+    const result = await records.deleteOutdatedRecords({
+        connectionId: nangoConnectionId,
+        syncId,
+        generation: syncJobId,
+        model
+    });
+    const logCtx = logContextGetter.getStateLess({ id: String(activityLogId), accountId: account.id });
+    if (result.isOk()) {
+        void logCtx.info(`${model}: "Deleted ${result.value} outdated records for model ${model}"`);
+        res.status(200).json({ deletedKeys: result.value });
+    } else {
+        void logCtx.error(`Failed to delete outdated records for model ${model}`, { error: result.error });
+        res.status(500).json({ error: { code: 'delete_outdated_records_failed', message: `Failed to delete outdated records: ${result.error.message}` } });
+    }
+    return;
+};
+
+export const route: Route<DeleteOutdatedRecords> = { path, method };
+
+export const routeHandler: RouteHandler<DeleteOutdatedRecords, AuthLocals> = {
+    method,
+    path,
+    validate,
+    handler
+};

--- a/packages/persist/lib/server.ts
+++ b/packages/persist/lib/server.ts
@@ -5,8 +5,12 @@ import { createRoute, requestLoggerMiddleware } from '@nangohq/utils';
 import { logger } from './logger.js';
 import { authMiddleware } from './middleware/auth.middleware.js';
 import { recordsPath } from './records.js';
-import { path as cursorPath, routeHandler as getCursorHandler } from './routes/environment/environmentId/connection/connectionId/getCursor.js';
-import { path as getRecordsPath, routeHandler as getRecordsHandler } from './routes/environment/environmentId/connection/connectionId/getRecords.js';
+import { route as getCursorRoute, routeHandler as getCursorHandler } from './routes/environment/environmentId/connection/connectionId/getCursor.js';
+import { route as getRecordsRoute, routeHandler as getRecordsHandler } from './routes/environment/environmentId/connection/connectionId/getRecords.js';
+import {
+    route as deleteOutdatedRecordsRoute,
+    routeHandler as deleteOutdatedRecordsHandler
+} from './routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.js';
 import { routeHandler as deleteRecordsHandler } from './routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteRecords.js';
 import { routeHandler as postRecordsHandler } from './routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/postRecords.js';
 import { routeHandler as putRecordsHandler } from './routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/putRecords.js';
@@ -31,13 +35,15 @@ if (process.env['ENABLE_REQUEST_LOG'] !== 'false') {
 server.use('/environment/:environmentId/*splat', authMiddleware);
 server.use('/environment/:environmentId/log', express.json({ limit: maxSizeJsonLog }));
 server.use(recordsPath, express.json({ limit: maxSizeJsonRecords }));
-server.use(cursorPath, express.json());
-server.use(getRecordsPath, express.json());
+server.use(getCursorRoute.path, express.json());
+server.use(getRecordsRoute.path, express.json());
+server.use(deleteOutdatedRecordsRoute.path, express.json());
 
 createRoute(server, getHealthHandler);
 createRoute(server, postLogHandler);
 createRoute(server, postRecordsHandler);
 createRoute(server, deleteRecordsHandler);
+createRoute(server, deleteOutdatedRecordsHandler);
 createRoute(server, putRecordsHandler);
 createRoute(server, getCursorHandler);
 createRoute(server, getRecordsHandler);

--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -769,12 +769,14 @@ describe('Records service', () => {
             await upsertRecords({ records: recordsGen3, connectionId, environmentId, model, syncId, syncJobId: 3 });
 
             // Mark previous generations (1 and 2) as deleted
-            const deletedIds = await Records.markPreviousGenerationRecordsAsDeleted({
-                connectionId,
-                model,
-                syncId,
-                generation: 3
-            });
+            const deletedIds = (
+                await Records.deleteOutdatedRecords({
+                    connectionId,
+                    model,
+                    syncId,
+                    generation: 3
+                })
+            ).unwrap();
 
             expect(deletedIds).toHaveLength(4);
             expect(deletedIds).toEqual(expect.arrayContaining(['1', '2', '3', '4']));
@@ -804,12 +806,14 @@ describe('Records service', () => {
             await upsertRecords({ records: [rec1], connectionId, environmentId, model, syncId, syncJobId: 2, softDelete: true });
 
             // Mark previous generation as deleted
-            const deletedIds = await Records.markPreviousGenerationRecordsAsDeleted({
-                connectionId,
-                model,
-                syncId,
-                generation: 3
-            });
+            const deletedIds = (
+                await Records.deleteOutdatedRecords({
+                    connectionId,
+                    model,
+                    syncId,
+                    generation: 3
+                })
+            ).unwrap();
 
             // Only the non-deleted record should be marked as deleted
             expect(deletedIds).toEqual(['2']);
@@ -832,12 +836,14 @@ describe('Records service', () => {
             const otherModelRecords = [{ id: '3', name: 'Other Model Record' }];
             await upsertRecords({ records: otherModelRecords, connectionId, environmentId, model: otherModel, syncId, syncJobId: 1 });
 
-            const deletedIds = await Records.markPreviousGenerationRecordsAsDeleted({
-                connectionId,
-                model,
-                syncId,
-                generation: 2
-            });
+            const deletedIds = (
+                await Records.deleteOutdatedRecords({
+                    connectionId,
+                    model,
+                    syncId,
+                    generation: 2
+                })
+            ).unwrap();
             expect(deletedIds).toEqual(['1']);
         });
 
@@ -851,13 +857,15 @@ describe('Records service', () => {
             const records = Array.from({ length: count }, (_, i) => ({ id: `${i}`, name: `record ${i}` }));
             await upsertRecords({ records, connectionId, environmentId, model, syncId, syncJobId: 1 });
 
-            const deletedIds = await Records.markPreviousGenerationRecordsAsDeleted({
-                connectionId,
-                model,
-                syncId,
-                generation: 2,
-                batchSize: 3 // small batch size
-            });
+            const deletedIds = (
+                await Records.deleteOutdatedRecords({
+                    connectionId,
+                    model,
+                    syncId,
+                    generation: 2,
+                    batchSize: 3 // small batch size
+                })
+            ).unwrap();
             expect(deletedIds).toHaveLength(count);
         });
 
@@ -878,12 +886,14 @@ describe('Records service', () => {
             const initialCounts = (await Records.getRecordCountsByModel({ connectionId, environmentId })).unwrap();
             expect(initialCounts[model]?.count).toBe(3);
 
-            const deletedIds = await Records.markPreviousGenerationRecordsAsDeleted({
-                connectionId,
-                model,
-                syncId,
-                generation: 2
-            });
+            const deletedIds = (
+                await Records.deleteOutdatedRecords({
+                    connectionId,
+                    model,
+                    syncId,
+                    generation: 2
+                })
+            ).unwrap();
             expect(deletedIds).toHaveLength(3);
 
             const finalCounts = (await Records.getRecordCountsByModel({ connectionId, environmentId })).unwrap();

--- a/packages/types/lib/persist/api.ts
+++ b/packages/types/lib/persist/api.ts
@@ -30,6 +30,10 @@ export interface DeleteRecordsSuccess {
     nextMerging: MergingStrategy;
 }
 
+export interface DeleteOutdatedRecordsSuccess {
+    deletedKeys: string[];
+}
+
 export interface GetCursorSuccess {
     cursor?: string;
 }


### PR DESCRIPTION
The endpoint will be called by a new runner-sdk function that customers can call in their custom integrations to delete records from previous executions (equivalent to the track_deletes functionalities).
The endpoint is not used yet
<!-- Summary by @propel-code-bot -->

---

**Add API Endpoint and Service Logic to Delete Outdated Persist Records**

This PR adds a new DELETE REST API endpoint to the Persist module, allowing deletion of outdated (i.e., prior-generation) records for a given connection, sync, and sync job. The records service is refactored to provide a type-safe, result-oriented `deleteOutdatedRecords` method (superseding `markPreviousGenerationRecordsAsDeleted`), with all usages updated accordingly. Input/output validation and API response types are strengthened, and the new endpoint is fully covered by unit, integration, and end-to-end tests. Server wiring is updated to expose the new endpoint, but it is not yet used in production.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced ``DELETE`` endpoint at /environment/:`environmentId`/connection/:`nangoConnectionId`/sync/:`syncId`/job/:`syncJobId`/outdated, including Zod-based validation, error handling, and logging.
• Implemented and exported records service method ``deleteOutdatedRecords``, refactoring and deprecating ``markPreviousGenerationRecordsAsDeleted``; all internal usages updated.
• Updated the sync job execution flow to consume ``deleteOutdatedRecords`` using typed results (Ok/Err).
• Expanded ``API`` response and types in @nangohq/types, e.g., added `DeleteOutdatedRecordsSuccess`.
• Unit, integration, and end-to-end ``API`` tests added to cover deletion of outdated records, batch operation behavior, and record count updates.
• Server routing and middleware expanded to mount the new endpoint; minimal `ESLint` rule update/override for template string array logging.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• persist ``API`` server and routing
• records service/data layer (delete/mark outdated records logic)
• jobs sync execution flow (`track_deletes` logic)
• ``API``/type definitions in @nangohq/types
• records and server test suites
• minor `ESLint` rule exception

</details>

---
*This summary was automatically generated by @propel-code-bot*