### PR TITLE
fix(types): update sdk types with updated getConnection signature

### DIFF
--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -357,7 +357,11 @@ export declare class NangoAction {
      * Get current integration
      */
     getIntegration(queries?: GetPublicIntegration['Querystring']): Promise<GetPublicIntegration['Success']['data']>;
-    getConnection(providerConfigKeyOverride?: string, connectionIdOverride?: string): Promise<Connection>;
+    getConnection(
+        providerConfigKeyOverride?: string,
+        connectionIdOverride?: string,
+        options?: { refreshToken?: boolean; refreshGithubAppJwtToken?: boolean; forceRefresh?: boolean }
+    ): Promise<GetPublicConnection['Success']>;
     setMetadata(metadata: Metadata): Promise<AxiosResponse<MetadataChangeResponse>>;
     updateMetadata(metadata: Metadata): Promise<AxiosResponse<MetadataChangeResponse>>;
     /**

--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -43,7 +43,7 @@ exports[`buildModelTs > should return empty (with sdk) 1`] = `
 
 import type { Nango } from '@nangohq/node';
 import type { AxiosInstance, AxiosInterceptorManager, AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
-import type { ApiEndUser, DBSyncConfig, DBTeam, GetPublicIntegration, HTTP_METHOD, RunnerFlags, PostPublicTrigger } from '@nangohq/types';
+import type { ApiEndUser, DBSyncConfig, DBTeam, GetPublicConnection, GetPublicIntegration, HTTP_METHOD, RunnerFlags, PostPublicTrigger } from '@nangohq/types';
 import type { ZodSchema, SafeParseSuccess } from 'zod';
 
 export declare const oldLevelToNewLevel: {

--- a/packages/runner-sdk/lib/action.ts
+++ b/packages/runner-sdk/lib/action.ts
@@ -208,7 +208,7 @@ export abstract class NangoActionBase<
     public async getConnection(
         providerConfigKeyOverride?: string,
         connectionIdOverride?: string,
-        options: { refreshToken?: boolean; refreshGithubAppJwtToken?: boolean; forceRefresh?: boolean } = {}
+        options?: { refreshToken?: boolean; refreshGithubAppJwtToken?: boolean; forceRefresh?: boolean }
     ): Promise<GetPublicConnection['Success']> {
         this.throwIfAborted();
 
@@ -219,9 +219,9 @@ export abstract class NangoActionBase<
         const cached = this.memoizedConnections.get(credentialsPair);
 
         const shouldRefresh =
-            options.forceRefresh ||
-            options.refreshToken ||
-            options.refreshGithubAppJwtToken ||
+            options?.forceRefresh ||
+            options?.refreshToken ||
+            options?.refreshGithubAppJwtToken ||
             !cached ||
             Date.now() - cached.timestamp > MEMOIZED_CONNECTION_TTL;
 
@@ -229,9 +229,9 @@ export abstract class NangoActionBase<
             const connection = await this.nango.getConnection(
                 providerConfigKey,
                 connectionId,
-                options.forceRefresh ?? false,
-                options.refreshToken ?? false,
-                options.refreshGithubAppJwtToken ?? false
+                options?.forceRefresh ?? false,
+                options?.refreshToken ?? false,
+                options?.refreshGithubAppJwtToken ?? false
             );
             this.memoizedConnections.set(credentialsPair, { connection, timestamp: Date.now() });
             return connection;

--- a/packages/runner-sdk/models.d.ts
+++ b/packages/runner-sdk/models.d.ts
@@ -1,6 +1,6 @@
 import type { Nango } from '@nangohq/node';
 import type { AxiosInstance, AxiosInterceptorManager, AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
-import type { ApiEndUser, DBSyncConfig, DBTeam, GetPublicIntegration, HTTP_METHOD, RunnerFlags, PostPublicTrigger } from '@nangohq/types';
+import type { ApiEndUser, DBSyncConfig, DBTeam, GetPublicConnection, GetPublicIntegration, HTTP_METHOD, RunnerFlags, PostPublicTrigger } from '@nangohq/types';
 import type { ZodSchema, SafeParseSuccess } from 'zod';
 
 export declare const oldLevelToNewLevel: {
@@ -314,7 +314,11 @@ export declare class NangoAction {
      * Get current integration
      */
     getIntegration(queries?: GetPublicIntegration['Querystring']): Promise<GetPublicIntegration['Success']['data']>;
-    getConnection(providerConfigKeyOverride?: string, connectionIdOverride?: string): Promise<Connection>;
+    getConnection(
+        providerConfigKeyOverride?: string,
+        connectionIdOverride?: string,
+        options?: { refreshToken?: boolean; refreshGithubAppJwtToken?: boolean; forceRefresh?: boolean }
+    ): Promise<GetPublicConnection['Success']>;
     setMetadata(metadata: Metadata): Promise<AxiosResponse<MetadataChangeResponse>>;
     updateMetadata(metadata: Metadata): Promise<AxiosResponse<MetadataChangeResponse>>;
     /**


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Update SDK Types: Align getConnection Signature and Types**

This PR updates the TypeScript SDK's type definitions and implementation to match a new signature for the getConnection method. The primary change is making the 'options' parameter optional and adjusting internal type references and method logic to reflect this, improving type safety and flexibility. Related snapshot files and model type imports are also updated for consistency.

<details>
<summary><strong>Key Changes</strong></summary>

• Changed `getConnection` signature in action.ts and models.d.ts: `options` parameter is now optional.
• Updated internal usage of `options` within `getConnection` to use optional chaining (options?.property).
• Adjusted model and snapshot files to import and use ``GetPublicConnection`[`Success`]` instead of the deprecated `Connection` type.
• Replaced all references to the old type and signature in affected files to match the new ``API``.
• Synchronized type changes between implementation and test snapshot declarations to maintain alignment.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/runner-sdk/lib/action.ts
• packages/runner-sdk/models.d.ts
• packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap

</details>

---
*This summary was automatically generated by @propel-code-bot*