### PR TITLE
feat(runner-sdk): add deleteRecordsFromPreviousExecution function

### DIFF
--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -453,6 +453,7 @@ export declare class NangoSync extends NangoAction {
     batchUpdate<T extends object>(results: T[], model: string): Promise<boolean | null>;
     getMetadata<T = Metadata>(): Promise<T>;
     setMergingStrategy(merging: { strategy: 'ignore_if_modified_after' | 'override' }, model: string): Promise<void>;
+    deleteRecordsFromPreviousExecution(model: TModelName): MaybePromise<{ deletedKeys: string[] }>;
     getRecordsByIds<K = string | number, T = any>(ids: K[], model: string): Promise<Map<K, T>>;
 }
 /**

--- a/packages/cli/lib/services/parser.service.ts
+++ b/packages/cli/lib/services/parser.service.ts
@@ -254,7 +254,7 @@ class ParserService {
         if (
             batchingRecordsLines.length > 0 &&
             deleteRecordsFromPreviousExecutionLines.length > 0 &&
-            batchingRecordsLines.some((line) => line > Math.min(...batchingRecordsLines))
+            batchingRecordsLines.some((line) => line > Math.min(...deleteRecordsFromPreviousExecutionLines))
         ) {
             console.log(
                 chalk.red(

--- a/packages/cli/lib/services/sdk.ts
+++ b/packages/cli/lib/services/sdk.ts
@@ -307,6 +307,11 @@ export class NangoSyncCLI extends NangoSyncBase {
         // Not applicable to CLI
         return Promise.resolve();
     }
+
+    public override async deleteRecordsFromPreviousExecution(_model: string): Promise<{ deletedKeys: string[] }> {
+        this.log(`This has no effect but on a remote Nango instance would delete records that were not added or updated during the current execution.`);
+        return Promise.resolve({ deletedKeys: [] });
+    }
 }
 
 function getAxiosSettings(props: NangoProps) {

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts
@@ -61,8 +61,7 @@ const handler = async (_req: EndpointRequest, res: EndpointResponse<DeleteOutdat
     });
     const logCtx = logContextGetter.getStateLess({ id: String(activityLogId), accountId: account.id });
     if (result.isOk()) {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        void logCtx.info(`${model}: "Deleted ${result.value} outdated records for model ${model}"`);
+        void logCtx.info(`Deleted ${result.value.length} outdated records for model ${model}`, { deletedKeys: result.value });
         res.status(200).json({ deletedKeys: result.value });
     } else {
         void logCtx.error(`Failed to delete outdated records for model ${model}`, { error: result.error });

--- a/packages/runner-sdk/lib/sync.ts
+++ b/packages/runner-sdk/lib/sync.ts
@@ -65,6 +65,8 @@ export abstract class NangoSyncBase<
         model: TModelName
     ): MaybePromise<Map<TKey, TModel>>;
 
+    public abstract deleteRecordsFromPreviousExecution(model: TModelName): MaybePromise<{ deletedKeys: string[] }>;
+
     public abstract setMergingStrategy(merging: { strategy: 'ignore_if_modified_after' | 'override' }, model: TModelName): Promise<void>;
 
     protected validateRecords(model: string, records: unknown[]): { data: any; validation: ValidateDataError[] }[] {

--- a/packages/runner-sdk/models.d.ts
+++ b/packages/runner-sdk/models.d.ts
@@ -410,6 +410,7 @@ export declare class NangoSync extends NangoAction {
     batchUpdate<T extends object>(results: T[], model: string): Promise<boolean | null>;
     getMetadata<T = Metadata>(): Promise<T>;
     setMergingStrategy(merging: { strategy: 'ignore_if_modified_after' | 'override' }, model: string): Promise<void>;
+    deleteRecordsFromPreviousExecution(model: TModelName): MaybePromise<{ deletedKeys: string[] }>;
     getRecordsByIds<K = string | number, T = any>(ids: K[], model: string): Promise<Map<K, T>>;
 }
 /**

--- a/packages/runner/lib/sdk/persist.ts
+++ b/packages/runner/lib/sdk/persist.ts
@@ -266,6 +266,35 @@ export class PersistClient {
         return res;
     }
 
+    public async deleteOutdatedRecords({
+        model,
+        environmentId,
+        nangoConnectionId,
+        syncId,
+        syncJobId,
+        activityLogId
+    }: {
+        model: string;
+        environmentId: number;
+        nangoConnectionId: number;
+        syncId: string;
+        syncJobId: number;
+        activityLogId: string;
+    }): Promise<Result<{ deletedKeys: string[] }>> {
+        const res = await this.makeRequest<{ deletedKeys: string[] }>({
+            method: 'DELETE',
+            url: `/environment/${environmentId}/connection/${nangoConnectionId}/sync/${syncId}/job/${syncJobId}/outdated`,
+            data: {
+                model,
+                activityLogId
+            }
+        });
+        if (res.isErr()) {
+            return Err(new Error(`Failed to delete outdated records: ${res.error.message}`));
+        }
+        return res;
+    }
+
     public async getCursor({
         environmentId,
         nangoConnectionId,

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -482,6 +482,22 @@ export class NangoSyncRunner extends NangoSyncBase {
         return true;
     }
 
+    public async deleteRecordsFromPreviousExecution(model: string): Promise<{ deletedKeys: string[] }> {
+        this.throwIfAborted();
+        const res = await this.persistClient.deleteOutdatedRecords({
+            model: this.modelFullName(model),
+            environmentId: this.environmentId,
+            nangoConnectionId: this.nangoConnectionId!,
+            syncId: this.syncId!,
+            syncJobId: this.syncJobId!,
+            activityLogId: this.activityLogId
+        });
+        if (res.isErr()) {
+            throw res.error;
+        }
+        return res.value;
+    }
+
     public async getRecordsByIds<K = string | number, T = any>(ids: K[], model: string): Promise<Map<K, T>> {
         this.throwIfAborted();
 


### PR DESCRIPTION
track_deletes will be depracated in favor of explicitely calling this function in custom syncs.

Added some compile time checks for deleteRecordsFromPreviousExecution:
- must be called after all batch operations
- cannot be called more than once (not strictly necessary) 

I haven't touched the current `track_deletes` configuration for now. If `deleteRecordsFromPreviousExecution` is called and `track_deletes` set to true, it would result in attempting at marking old records as deleted again (which will be a no op). I don't know if it is possible but if it is we could dissallow `track_deletes=true` and usage of `deleteRecordsFromPreviousExecution` at compile time. Maybe @bodinsamuel you know

<!-- Summary by @propel-code-bot -->

---

**Add deleteRecordsFromPreviousExecution Function to Runner SDK (Deprecate track_deletes)**

This PR introduces the new deleteRecordsFromPreviousExecution method to the Runner SDK, enabling explicit deletion of outdated records from previous sync executions in custom sync workflows. The method is added to the abstract NangoSyncBase interface and implemented in the runner, CLI, and test SDKs, with supporting changes throughout the SDK, persist client, and validation/compilation layers. Compile-time and static analysis checks enforce correct usage: the method must be called only once per sync and after all batch save/update/delete operations. The previous configuration property track_deletes is being deprecated in favor of this explicit API, though both currently coexist for compatibility. Associated changes are reflected in the SDK type definitions, CLI tooling, parser/validation code, backend route, and snapshot tests.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced abstract `deleteRecordsFromPreviousExecution` method in `NangoSyncBase`; method is implemented in runner, ``CLI``, and test `SDKs`.
• `PersistClient` now exposes `deleteOutdatedRecords` to back the new ``SDK`` method and makes the appropriate ``DELETE`` ``API`` call on the backend.
• Added validation and compile-time/static checks to enforce correct call order (after all batch ops, only once per sync).
• Parser/service/compile.ts files updated to recognize and verify correct usage of the new function in user sync scripts.
• Backend ``API`` route for deleting outdated records adjusted for better logging and ``JSON`` response.
• ``SDK`` and types (d.ts/snapshots) updated to surface the new function.
• ``CLI`` and test `SDKs` implement a no-op stub for this method for local/testing environments.
• No changes yet to the legacy `track_deletes` config; coexistence is supported with no functional overlap.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• runner-sdk/lib/sync.ts (``API`` interface)
• runner/lib/sdk/sdk.ts, cli/lib/services/sdk.ts (method implementation)
• runner/lib/sdk/persist.ts (persist client ``API``)
• cli/lib/`zeroYaml`/compile.ts, cli/lib/services/parser.service.ts (static/compile time checks, code analysis)
• persist/lib/routes/…/`deleteOutdatedRecords`.ts (backend endpoint)
• types/snapshots (``SDK`` d.ts, snapshot tests)

</details>

---
*This summary was automatically generated by @propel-code-bot*