### PR TITLE
fix(webhook): add proper user agent

### DIFF
--- a/packages/utils/lib/http.ts
+++ b/packages/utils/lib/http.ts
@@ -1,3 +1,7 @@
+import os from 'node:os';
+
+import { NANGO_VERSION } from './version.js';
+
 // Headers that are never relevant to the outcome of the call
 const IGNORED_HEADERS = new Set([
     'access-control-allow-credentials',
@@ -91,4 +95,19 @@ export function redactObjectOrString<TData extends string | Record<string, any>>
         return JSON.parse(redactURL({ url: JSON.stringify(data), valuesToFilter })) as TData;
     }
     return redactURL({ url: data, valuesToFilter }) as TData;
+}
+
+let userAgent: string | undefined;
+export function getUserAgent(): string {
+    if (userAgent) {
+        return userAgent;
+    }
+
+    const clientVersion = NANGO_VERSION;
+    const nodeVersion = process.versions.node;
+
+    const osName = os.platform().replace(' ', '_');
+    const osVersion = os.release().replace(' ', '_');
+    userAgent = `nango/${clientVersion} (${osName}/${osVersion}; node.js/${nodeVersion})`;
+    return userAgent;
 }

--- a/packages/utils/lib/http.ts
+++ b/packages/utils/lib/http.ts
@@ -97,17 +97,11 @@ export function redactObjectOrString<TData extends string | Record<string, any>>
     return redactURL({ url: data, valuesToFilter }) as TData;
 }
 
-let userAgent: string | undefined;
-export function getUserAgent(): string {
-    if (userAgent) {
-        return userAgent;
-    }
-
+export const userAgent = (() => {
     const clientVersion = NANGO_VERSION;
     const nodeVersion = process.versions.node;
 
     const osName = os.platform().replace(' ', '_');
     const osVersion = os.release().replace(' ', '_');
-    userAgent = `nango/${clientVersion} (${osName}/${osVersion}; node.js/${nodeVersion})`;
-    return userAgent;
-}
+    return `nango/${clientVersion} (${osName}/${osVersion}; node.js/${nodeVersion})`;
+})();

--- a/packages/webhooks/lib/asyncAction.unit.test.ts
+++ b/packages/webhooks/lib/asyncAction.unit.test.ts
@@ -81,10 +81,10 @@ describe('AsyncAction webhookds', () => {
         };
         const bodyString = stringifyStable(body).unwrap();
         expect(spy).toHaveBeenNthCalledWith(1, webhookSettings.primary_url, bodyString, {
-            headers: { 'X-Nango-Signature': expect.any(String), 'content-type': 'application/json' }
+            headers: { 'X-Nango-Signature': expect.any(String), 'content-type': 'application/json', 'user-agent': expect.stringContaining('nango/') }
         });
         expect(spy).toHaveBeenNthCalledWith(2, webhookSettings.secondary_url, bodyString, {
-            headers: { 'X-Nango-Signature': expect.any(String), 'content-type': 'application/json' }
+            headers: { 'X-Nango-Signature': expect.any(String), 'content-type': 'application/json', 'user-agent': expect.stringContaining('nango/') }
         });
     });
 });

--- a/packages/webhooks/lib/auth.unit.test.ts
+++ b/packages/webhooks/lib/auth.unit.test.ts
@@ -296,7 +296,8 @@ describe('Webhooks: auth notification tests', () => {
             expect.objectContaining({
                 headers: {
                     'X-Nango-Signature': expect.toBeSha256(),
-                    'content-type': 'application/json'
+                    'content-type': 'application/json',
+                    'user-agent': expect.stringContaining('nango/')
                 }
             })
         );
@@ -308,7 +309,8 @@ describe('Webhooks: auth notification tests', () => {
             expect.objectContaining({
                 headers: {
                     'X-Nango-Signature': expect.toBeSha256(),
-                    'content-type': 'application/json'
+                    'content-type': 'application/json',
+                    'user-agent': expect.stringContaining('nango/')
                 }
             })
         );

--- a/packages/webhooks/lib/sync.unit.test.ts
+++ b/packages/webhooks/lib/sync.unit.test.ts
@@ -293,7 +293,8 @@ describe('Webhooks: sync notification tests', () => {
             expect.objectContaining({
                 headers: {
                     'X-Nango-Signature': expect.toBeSha256(),
-                    'content-type': 'application/json'
+                    'content-type': 'application/json',
+                    'user-agent': expect.stringContaining('nango/')
                 }
             })
         );
@@ -305,7 +306,8 @@ describe('Webhooks: sync notification tests', () => {
             expect.objectContaining({
                 headers: {
                     'X-Nango-Signature': expect.toBeSha256(),
-                    'content-type': 'application/json'
+                    'content-type': 'application/json',
+                    'user-agent': expect.stringContaining('nango/')
                 }
             })
         );

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 
 import { isAxiosError } from 'axios';
 
-import { Err, Ok, axiosInstance as axios, getUserAgent, networkError, redactHeaders, retryFlexible, stringifyStable } from '@nangohq/utils';
+import { Err, Ok, axiosInstance as axios, networkError, redactHeaders, retryFlexible, stringifyStable, userAgent } from '@nangohq/utils';
 
 import type { LogContext } from '@nangohq/logs';
 import type { DBEnvironment, DBExternalWebhook, MessageHTTPResponse, MessageRow, WebhookTypes } from '@nangohq/types';
@@ -144,7 +144,7 @@ export const deliver = async ({
             ...filteredHeaders,
             'X-Nango-Signature': getSignatureHeader(environment.secret_key, bodyString.value),
             'content-type': 'application/json',
-            'user-agent': getUserAgent()
+            'user-agent': userAgent
         };
 
         const logRequest: MessageRow['request'] = {

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 
 import { isAxiosError } from 'axios';
 
-import { Err, Ok, axiosInstance as axios, networkError, redactHeaders, retryFlexible, stringifyStable } from '@nangohq/utils';
+import { Err, Ok, axiosInstance as axios, getUserAgent, networkError, redactHeaders, retryFlexible, stringifyStable } from '@nangohq/utils';
 
 import type { LogContext } from '@nangohq/logs';
 import type { DBEnvironment, DBExternalWebhook, MessageHTTPResponse, MessageRow, WebhookTypes } from '@nangohq/types';
@@ -143,7 +143,8 @@ export const deliver = async ({
         const headers = {
             ...filteredHeaders,
             'X-Nango-Signature': getSignatureHeader(environment.secret_key, bodyString.value),
-            'content-type': 'application/json'
+            'content-type': 'application/json',
+            'user-agent': getUserAgent()
         };
 
         const logRequest: MessageRow['request'] = {


### PR DESCRIPTION
## Changes

- Add proper user agent when sending webhook

<!-- Summary by @propel-code-bot -->

---

**Add Standardized User-Agent Header to Webhook Requests**

This pull request ensures all outgoing webhook HTTP requests include a standardized `user-agent` header. The header value is dynamically constructed at runtime to include `nango` client version, Node.js version, and operating system details. The update centralizes the header construction in a new `userAgent` constant and enforces its use across webhook delivery mechanisms. Associated unit tests are also updated to verify the new `user-agent` presence and correct formatting in webhook HTTP requests.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced `userAgent` constant in `packages/utils/lib/http.ts`, built using `NANGO_VERSION`, Node.js version, and OS info.
• Updated webhook delivery in `packages/webhooks/lib/utils.ts` to include the `user-agent` header on all outgoing webhook requests.
• Ensured all imports and header constructions in webhook paths now use the standardized `userAgent` constant.
• Extended and adjusted tests in `packages/webhooks/lib/auth.unit.test.ts`, `packages/webhooks/lib/sync.unit.test.ts`, and `packages/webhooks/lib/asyncAction.unit.test.ts` to assert inclusion and correct formatting of the `user-agent` header.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/utils/lib/http.ts`
• `packages/webhooks/lib/utils.ts`
• `packages/webhooks/lib/auth.unit.test.ts`
• `packages/webhooks/lib/sync.unit.test.ts`
• `packages/webhooks/lib/asyncAction.unit.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*