### PR TITLE
fix(plan): prevent deleting payment method if they have an active sub

### DIFF
--- a/packages/server/lib/controllers/v1/stripe/payment_methods/deletePaymentMethod.ts
+++ b/packages/server/lib/controllers/v1/stripe/payment_methods/deletePaymentMethod.ts
@@ -38,7 +38,7 @@ export const deleteStripePaymentMethod = asyncWrapper<DeleteStripePayment>(async
         res.status(400).send({
             error: {
                 code: 'invalid_body',
-                message: 'Cannot delete payment method when not on free plan. Reach out to support if you need to delete or change your payment method.'
+                message: 'Cannot delete payment method with an active subscription. Reach out to support if you need to delete or change your payment method.'
             }
         });
         return;

--- a/packages/server/lib/controllers/v1/stripe/payment_methods/deletePaymentMethod.ts
+++ b/packages/server/lib/controllers/v1/stripe/payment_methods/deletePaymentMethod.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 
 import { getStripe } from '@nangohq/billing';
 import db from '@nangohq/database';
-import { updatePlan } from '@nangohq/shared';
+import { freePlan, updatePlan } from '@nangohq/shared';
 import { report, zodErrorToHTTP } from '@nangohq/utils';
 
 import { envs } from '../../../../env.js';
@@ -31,6 +31,16 @@ export const deleteStripePaymentMethod = asyncWrapper<DeleteStripePayment>(async
     const valQuery = schemaQuery.safeParse(req.query);
     if (!valQuery.success) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valQuery.error) } });
+        return;
+    }
+
+    if (plan.name !== freePlan.code) {
+        res.status(400).send({
+            error: {
+                code: 'invalid_body',
+                message: 'Cannot delete payment method when not on free plan. Reach out to support if you need to delete or change your payment method.'
+            }
+        });
         return;
     }
 


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-3872/prevent-removing-payment-method-in-nango-ui

- prevent deleting payment method if has upgrade

<!-- Summary by @propel-code-bot -->

---

**Prevent Deletion of Payment Method for Active Subscriptions**

This pull request updates the deletion logic for Stripe payment methods to prevent users from removing their payment method if their account is associated with an active (non-free) subscription plan. If such a removal is attempted, a `400 Bad Request` response is returned, along with a descriptive error message instructing the user to contact support. The primary modification is an additional conditional check in the `deleteStripePaymentMethod` controller, ensuring alignment with the intent to block deletion except for accounts on the free plan.

<details>
<summary><strong>Key Changes</strong></summary>

• Added a check in `deleteStripePaymentMethod` to prevent payment method deletion when the user's plan is not the free tier (`freePlan.code`).
• Updated import statement to include `freePlan` from `@nangohq/shared`.
• Returns a standardized error response when deletion is blocked.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/v1/stripe/payment_methods/deletePaymentMethod.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*