### PR TITLE
feat: deleteRecordsFromPreviousExecution docs  and deprecate trackDeletes

### DIFF
--- a/docs-v2/guides/custom-integrations/build-a-custom-integration.mdx
+++ b/docs-v2/guides/custom-integrations/build-a-custom-integration.mdx
@@ -130,7 +130,7 @@ async function fetchAndSaveRecords(nango: NangoSyncLocal, query: string) {
 
         endpoint = response.data.nextRecordsUrl;
     }
-    await nango.deleteRecordsFromPreviousExecution('SalesforceContact')
+    await nango.deleteRecordsFromPreviousExecutions('SalesforceContact')
 }
 
 function mapContacts(records: any[]): SalesforceContact[] {

--- a/docs-v2/guides/custom-integrations/build-a-custom-integration.mdx
+++ b/docs-v2/guides/custom-integrations/build-a-custom-integration.mdx
@@ -90,7 +90,6 @@ export default createSync({
   frequency: 'every hour',
   autoStart: true,
   syncType: 'full',
-  trackDeletes: true,
   models: {
     SalesforceContact: SalesforceContact,
   },
@@ -131,6 +130,7 @@ async function fetchAndSaveRecords(nango: NangoSyncLocal, query: string) {
 
         endpoint = response.data.nextRecordsUrl;
     }
+    await nango.deleteRecordsFromPreviousExecution('SalesforceContact')
 }
 
 function mapContacts(records: any[]): SalesforceContact[] {

--- a/docs-v2/guides/syncs/detecting-deletes.mdx
+++ b/docs-v2/guides/syncs/detecting-deletes.mdx
@@ -120,10 +120,8 @@ export default createSync({
 <Warning>
 **Be careful with exception handling when using** `deleteRecordsFromPreviousExecutions`
 
-Nango only performs deletion detection (the “diff”) if a sync run completes successfully without any uncaught exceptions.
-
 If you’re using `deleteRecordsFromPreviousExecutions`, exception handling becomes critical:
-- If your sync doesn’t fetch the full dataset, but still completes (e.g. you catch and swallow an exception), Nango will attempt the diff on an incomplete dataset.
+- If your sync doesn’t fetch the full dataset, but still call `deleteRecordsFromPreviousExecutions` (e.g. you catch and swallow an exception), Nango will attempt the diff on an incomplete dataset.
 - This leads to false positives, where valid records are mistakenly considered deleted.
 
 ✅ What You Should Do

--- a/docs-v2/guides/syncs/detecting-deletes.mdx
+++ b/docs-v2/guides/syncs/detecting-deletes.mdx
@@ -69,15 +69,10 @@ export default createSync({
 });
 ```
 
-## Detecting deletes in full refresh syncs
+## Detecting deletes in syncs
 
-Full refresh syncs download all records on every run.
-
-Nango can therefore detect removals by computing the diff between two consecutive result sets. Enable this behaviour with the `trackDeletes` flag ([full reference](/reference/integration-configuration#param-track-deletes)).
-
-<Note>
-  `trackDeletes` does not work with incremental syncs because fetching the data incrementally prevents performing a diff and automatically detecting deletions.
-</Note>
+Nango can detect removals by computing the diff between two consecutive result sets.
+Enable this behaviour by calling the `deleteRecordsFromPreviousExecution` function. ([full reference](/reference/scripts#detect-deletions-automatically)).
 
 ### Example full refresh sync with deletion detection
 
@@ -95,7 +90,6 @@ export default createSync({
   description: 'Fetch all help-desk tickets',
   frequency: 'every day',
   syncType: 'full',
-  trackDeletes: true,       // Enables deletion detection for the sync
   endpoints: [{ method: 'GET', path: '/tickets', group: 'Tickets' }],
   models: { Ticket: TicketSchema },
 
@@ -110,44 +104,47 @@ export default createSync({
     for await (const page of tickets) {
       await nango.batchSave(page, 'Ticket');
     }
+
+    // Delete records that don't exist anymore
+    await nango.deleteRecordsFromPreviousExecution('Ticket');
   }
 });
 ```
 
 ### How the algorithm works
 
-1. After a successful run, Nango stores the list of record IDs.
-2. On the next run, Nango compares the new list with the old one.
+1. During each execution, Nango stores the list of record IDs.
+2. When calling `deleteRecordsFromPreviousExecution`, Nango compares the new list with the old one.
 3. Any records missing in the new list are marked as deleted (soft delete). They remain accessible from the Nango cache, but with `record._metadata.deleted === true`.
 
 <Warning>
-**Be careful with exception handling when using** `trackDelete`
+**Be careful with exception handling when using** `deleteRecordsFromPreviousExecution`
 
 Nango only performs deletion detection (the “diff”) if a sync run completes successfully without any uncaught exceptions.
 
-If you’re using `trackDelete`, exception handling becomes critical:
+If you’re using `deleteRecordsFromPreviousExecution`, exception handling becomes critical:
 - If your sync doesn’t fetch the full dataset, but still completes (e.g. you catch and swallow an exception), Nango will attempt the diff on an incomplete dataset.
 - This leads to false positives, where valid records are mistakenly considered deleted.
 
-  ✅ What You Should Do
+✅ What You Should Do
 
-If a failure prevents full data retrieval, make sure the sync run fails so Nango skips deletion detection:
+If a failure prevents full data retrieval, make sure the sync run fails and `deleteRecordsFromPreviousExecution` is not being called:
 - Let exceptions bubble up and interrupt the run.
 - If you’re using `try/catch`, re-throw exceptions that indicate incomplete data.
 </Warning>
 <Warning>
-**How to use** `trackDeletes` **safely**
-If some records are incorrectly marked as deleted due to the `trackDeletes` feature, you can trigger a full resync (via the UI or API) to restore the correct data state.
+**How to use** `deleteRecordsFromPreviousExecution` **safely**
+If some records are incorrectly marked as deleted due to calling `deleteRecordsFromPreviousExecution` improperly, you can trigger a full resync (via the UI or API) to restore the correct data state.
 
-However, because `trackDeletes` relies on logic in your sync scripts—and mistakes there can lead to false deletions—we strongly recommend not performing irreversible destructive actions (like hard-deleting records in your system) based solely on deletions reported by Nango. A full resync should always be able to recover from issues.
+However, because `deleteRecordsFromPreviousExecution` relies on logic in your sync scripts—and mistakes there can lead to false deletions—we strongly recommend not performing irreversible destructive actions (like hard-deleting records in your system) based solely on deletions reported by Nango. A full resync should always be able to recover from issues.
 </Warning>
 
 ## Troubleshooting deletion detection issues
 
 | Symptom                                                                    | Likely cause                                                                             |
 | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Records that still exist in the source API are shown as `deleted` in Nango | `trackDeletes` was enabled on an incremental sync, or a full refresh run silently failed |
-| You never see deleted records                                              | Check if deletion detection is implemented for the sync.                                 |
+| Records that still exist in the source API are shown as `deleted` in Nango | sync didn't save all records (silent failures) before calling `deleteRecordsFromPreviousExecution` |
+| You never see deleted records                                              | Check if deleteRecordsFromPreviousExecution is correctly called by the sync                        |
 
 <Tip>
   **Questions, problems, feedback?** Please reach out in the [Slack community](https://nango.dev/slack).

--- a/docs-v2/guides/syncs/detecting-deletes.mdx
+++ b/docs-v2/guides/syncs/detecting-deletes.mdx
@@ -72,7 +72,7 @@ export default createSync({
 ## Detecting deletes in syncs
 
 Nango can detect removals by computing the diff between two consecutive result sets.
-Enable this behaviour by calling the `deleteRecordsFromPreviousExecution` function. ([full reference](/reference/scripts#detect-deletions-automatically)).
+Enable this behaviour by calling the `deleteRecordsFromPreviousExecutions` function. ([full reference](/reference/scripts#detect-deletions-automatically)).
 
 ### Example full refresh sync with deletion detection
 
@@ -106,7 +106,7 @@ export default createSync({
     }
 
     // Delete records that don't exist anymore
-    await nango.deleteRecordsFromPreviousExecution('Ticket');
+    await nango.deleteRecordsFromPreviousExecutions('Ticket');
   }
 });
 ```
@@ -114,37 +114,37 @@ export default createSync({
 ### How the algorithm works
 
 1. During each execution, Nango stores the list of record IDs.
-2. When calling `deleteRecordsFromPreviousExecution`, Nango compares the new list with the old one.
+2. When calling `deleteRecordsFromPreviousExecutions`, Nango compares the new list with the old one.
 3. Any records missing in the new list are marked as deleted (soft delete). They remain accessible from the Nango cache, but with `record._metadata.deleted === true`.
 
 <Warning>
-**Be careful with exception handling when using** `deleteRecordsFromPreviousExecution`
+**Be careful with exception handling when using** `deleteRecordsFromPreviousExecutions`
 
 Nango only performs deletion detection (the “diff”) if a sync run completes successfully without any uncaught exceptions.
 
-If you’re using `deleteRecordsFromPreviousExecution`, exception handling becomes critical:
+If you’re using `deleteRecordsFromPreviousExecutions`, exception handling becomes critical:
 - If your sync doesn’t fetch the full dataset, but still completes (e.g. you catch and swallow an exception), Nango will attempt the diff on an incomplete dataset.
 - This leads to false positives, where valid records are mistakenly considered deleted.
 
 ✅ What You Should Do
 
-If a failure prevents full data retrieval, make sure the sync run fails and `deleteRecordsFromPreviousExecution` is not being called:
+If a failure prevents full data retrieval, make sure the sync run fails and `deleteRecordsFromPreviousExecutions` is not being called:
 - Let exceptions bubble up and interrupt the run.
 - If you’re using `try/catch`, re-throw exceptions that indicate incomplete data.
 </Warning>
 <Warning>
-**How to use** `deleteRecordsFromPreviousExecution` **safely**
-If some records are incorrectly marked as deleted due to calling `deleteRecordsFromPreviousExecution` improperly, you can trigger a full resync (via the UI or API) to restore the correct data state.
+**How to use** `deleteRecordsFromPreviousExecutions` **safely**
+If some records are incorrectly marked as deleted due to calling `deleteRecordsFromPreviousExecutions` improperly, you can trigger a full resync (via the UI or API) to restore the correct data state.
 
-However, because `deleteRecordsFromPreviousExecution` relies on logic in your sync scripts—and mistakes there can lead to false deletions—we strongly recommend not performing irreversible destructive actions (like hard-deleting records in your system) based solely on deletions reported by Nango. A full resync should always be able to recover from issues.
+However, because `deleteRecordsFromPreviousExecutions` relies on logic in your sync scripts—and mistakes there can lead to false deletions—we strongly recommend not performing irreversible destructive actions (like hard-deleting records in your system) based solely on deletions reported by Nango. A full resync should always be able to recover from issues.
 </Warning>
 
 ## Troubleshooting deletion detection issues
 
 | Symptom                                                                    | Likely cause                                                                             |
 | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Records that still exist in the source API are shown as `deleted` in Nango | sync didn't save all records (silent failures) before calling `deleteRecordsFromPreviousExecution` |
-| You never see deleted records                                              | Check if deleteRecordsFromPreviousExecution is correctly called by the sync                        |
+| Records that still exist in the source API are shown as `deleted` in Nango | sync didn't save all records (silent failures) before calling `deleteRecordsFromPreviousExecutions` |
+| You never see deleted records                                              | Check if deleteRecordsFromPreviousExecutions is correctly called by the sync                        |
 
 <Tip>
   **Questions, problems, feedback?** Please reach out in the [Slack community](https://nango.dev/slack).

--- a/docs-v2/reference/scripts.mdx
+++ b/docs-v2/reference/scripts.mdx
@@ -42,7 +42,7 @@ icon: "code"
         await nango.batchSave(issues, 'GithubIssueDemo');
 
         // Delete records that don't exist anymore
-        await nango.deleteRecordsFromPreviousExecution('GithubIssueDemo')
+        await nango.deleteRecordsFromPreviousExecutions('GithubIssueDemo')
       },
     });
     ```
@@ -166,7 +166,7 @@ Read more about [integration scripts](/guides/custom-integrations/overview) to u
 </ResponseField>
 
 <ResponseField name="trackDeletes" type="boolean" deprecated>
-  [DEPRECATED] Instead use `await nango.deleteRecordsFromPreviousExecution('modelName')` inside the sync `exec` function.
+  [DEPRECATED] Instead use `await nango.deleteRecordsFromPreviousExecutions('modelName')` inside the sync `exec` function.
 
   When `trackDeletes` is set to `true`, Nango automatically detects deleted records **during full syncs only** and marks them as deleted in each record’s metadata (soft delete). These records remain stored in the cache.
 
@@ -783,7 +783,7 @@ await nango.batchDelete(githubIssuesToDelete, 'GitHubIssue');
 Automatically detects and marks records as deleted by comparing the current sync execution with the previous one.
 
 ```js
-await nango.deleteRecordsFromPreviousExecution('ModelName');
+await nango.deleteRecordsFromPreviousExecutions('ModelName');
 ```
 
 This function should be called at the end of your sync execution, after all records have been saved with `batchSave`. Nango will compare the records saved in the current execution with those from the previous execution and mark any missing records as deleted.

--- a/docs-v2/reference/scripts.mdx
+++ b/docs-v2/reference/scripts.mdx
@@ -21,7 +21,6 @@ icon: "code"
       frequency: 'every hour',
       autoStart: true,
       syncType: 'full',
-      trackDeletes: true,
 
       metadata: z.void(),
       models: {
@@ -41,6 +40,9 @@ icon: "code"
 
         // Persist issues to the Nango cache.
         await nango.batchSave(issues, 'GithubIssueDemo');
+
+        // Delete records that don't exist anymore
+        await nango.deleteRecordsFromPreviousExecution('GithubIssueDemo')
       },
     });
     ```
@@ -163,7 +165,9 @@ Read more about [integration scripts](/guides/custom-integrations/overview) to u
   ```
 </ResponseField>
 
-<ResponseField name="trackDeletes" type="boolean">
+<ResponseField name="trackDeletes" type="boolean" deprecated>
+  [DEPRECATED] Instead use `await nango.deleteRecordsFromPreviousExecution('modelName')` inside the sync `exec` function.
+
   When `trackDeletes` is set to `true`, Nango automatically detects deleted records **during full syncs only** and marks them as deleted in each record’s metadata (soft delete). These records remain stored in the cache.
 
   When set to `false`, Nango does not mark missing records as deleted, even if they weren’t returned in the latest full sync—they simply remain in the cache unchanged.
@@ -773,6 +777,33 @@ await nango.batchDelete(githubIssuesToDelete, 'GitHubIssue');
     The model type of the records to delete.
   </ResponseField>
 </Expandable>
+
+### Detect deletions automatically
+
+Automatically detects and marks records as deleted by comparing the current sync execution with the previous one.
+
+```js
+await nango.deleteRecordsFromPreviousExecution('ModelName');
+```
+
+This function should be called at the end of your sync execution, after all records have been saved with `batchSave`. Nango will compare the records saved in the current execution with those from the previous execution and mark any missing records as deleted.
+
+**Parameters**
+
+<Expandable>
+  <ResponseField name="modelType" type="string" required>
+    The model type to detect deletions for.
+  </ResponseField>
+</Expandable>
+
+**Important considerations:**
+
+- Only use within syncs that fetch the complete dataset
+- Call this function only after successfully saving all records
+- If your sync fails or doesn't fetch the complete dataset, avoid calling this function as it may cause false deletions
+- Records are soft deleted (marked with `_metadata.deleted = true`) and remain in the cache
+
+For more details on deletion detection strategies, see the [detecting deletes guide](/guides/syncs/detecting-deletes).
 
 ### Update records
 

--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -453,7 +453,7 @@ export declare class NangoSync extends NangoAction {
     batchUpdate<T extends object>(results: T[], model: string): Promise<boolean | null>;
     getMetadata<T = Metadata>(): Promise<T>;
     setMergingStrategy(merging: { strategy: 'ignore_if_modified_after' | 'override' }, model: string): Promise<void>;
-    deleteRecordsFromPreviousExecution(model: TModelName): MaybePromise<{ deletedKeys: string[] }>;
+    deleteRecordsFromPreviousExecutions(model: TModelName): MaybePromise<{ deletedKeys: string[] }>;
     getRecordsByIds<K = string | number, T = any>(ids: K[], model: string): Promise<Map<K, T>>;
 }
 /**

--- a/packages/cli/lib/services/parser.service.ts
+++ b/packages/cli/lib/services/parser.service.ts
@@ -72,7 +72,7 @@ class ParserService {
             'getEnvironmentVariables',
             'triggerAction',
             'setMergingStrategy',
-            'deleteRecordsFromPreviousExecution'
+            'deleteRecordsFromPreviousExecutions'
         ];
 
         const disallowedActionCalls = ['batchSend', 'batchSave', 'batchDelete', 'batchUpdate'];
@@ -85,11 +85,11 @@ class ParserService {
 
         const callsProxy = ['proxy', 'get', 'post', 'put', 'patch', 'delete'];
         const callsBatchingRecords = ['batchSave', 'batchDelete', 'batchUpdate'];
-        const callsReferencingModelsToCheck = callsBatchingRecords.concat('setMergingStrategy', 'deleteRecordsFromPreviousExecution', 'getRecordsByIds');
+        const callsReferencingModelsToCheck = callsBatchingRecords.concat('setMergingStrategy', 'deleteRecordsFromPreviousExecutions', 'getRecordsByIds');
         const proxyLines: number[] = [];
         const batchingRecordsLines: number[] = [];
         const setMergingStrategyLines: number[] = [];
-        const deleteRecordsFromPreviousExecutionLines: number[] = [];
+        const deleteRecordsFromPreviousExecutionsLines: number[] = [];
 
         traverseFn(ast, {
             CallExpression(path: NodePath<t.CallExpression>) {
@@ -181,8 +181,8 @@ class ParserService {
                         setMergingStrategyLines.push(lineNumber);
                     }
 
-                    if (callee.property.name === 'deleteRecordsFromPreviousExecution') {
-                        deleteRecordsFromPreviousExecutionLines.push(lineNumber);
+                    if (callee.property.name === 'deleteRecordsFromPreviousExecutions') {
+                        deleteRecordsFromPreviousExecutionsLines.push(lineNumber);
                     }
                 }
             },
@@ -242,10 +242,10 @@ class ParserService {
             usedCorrectly = false;
         }
 
-        if (deleteRecordsFromPreviousExecutionLines.length > 1) {
+        if (deleteRecordsFromPreviousExecutionsLines.length > 1) {
             console.log(
                 chalk.red(
-                    `deleteRecordsFromPreviousExecution should be called only once in "${filePath}:${Math.max(...deleteRecordsFromPreviousExecutionLines)}".`
+                    `deleteRecordsFromPreviousExecutions should be called only once in "${filePath}:${Math.max(...deleteRecordsFromPreviousExecutionsLines)}".`
                 )
             );
             usedCorrectly = false;
@@ -253,12 +253,12 @@ class ParserService {
 
         if (
             batchingRecordsLines.length > 0 &&
-            deleteRecordsFromPreviousExecutionLines.length > 0 &&
-            batchingRecordsLines.some((line) => line > Math.min(...deleteRecordsFromPreviousExecutionLines))
+            deleteRecordsFromPreviousExecutionsLines.length > 0 &&
+            batchingRecordsLines.some((line) => line > Math.min(...deleteRecordsFromPreviousExecutionsLines))
         ) {
             console.log(
                 chalk.red(
-                    `deleteRecordsFromPreviousExecution should be called after all batching records functions in "${filePath}:${Math.max(...deleteRecordsFromPreviousExecutionLines)}".`
+                    `deleteRecordsFromPreviousExecutions should be called after all batching records functions in "${filePath}:${Math.max(...deleteRecordsFromPreviousExecutionsLines)}".`
                 )
             );
             usedCorrectly = false;

--- a/packages/cli/lib/services/sdk.ts
+++ b/packages/cli/lib/services/sdk.ts
@@ -308,7 +308,7 @@ export class NangoSyncCLI extends NangoSyncBase {
         return Promise.resolve();
     }
 
-    public override async deleteRecordsFromPreviousExecution(_model: string): Promise<{ deletedKeys: string[] }> {
+    public override async deleteRecordsFromPreviousExecutions(_model: string): Promise<{ deletedKeys: string[] }> {
         this.log(`This has no effect but on a remote Nango instance would delete records that were not added or updated during the current execution.`);
         return Promise.resolve({ deletedKeys: [] });
     }

--- a/packages/cli/lib/zeroYaml/compile.ts
+++ b/packages/cli/lib/zeroYaml/compile.ts
@@ -94,7 +94,7 @@ export async function compileAll({ fullPath, debug }: { fullPath: string; debug:
                 if (sync.track_deletes) {
                     console.warn(
                         chalk.yellow(
-                            `\nWarning: Sync '${sync.name}' for integration '${integration.providerConfigKey}' has 'track_deletes' enabled. This feature is deprecated and will be removed in future versions. Please call 'nango.deleteRecordsFromPreviousExecution()' in your sync script to automatically detect deletions.`
+                            `\nWarning: Sync '${sync.name}' for integration '${integration.providerConfigKey}' has 'track_deletes' enabled. This feature is deprecated and will be removed in future versions. Please call 'nango.deleteRecordsFromPreviousExecutions()' in your sync script to automatically detect deletions.`
                         )
                     );
                 }
@@ -249,25 +249,25 @@ export async function bundleFile({ entryPoint, projectRootPath }: { entryPoint: 
                 })
             );
         }
-        if (bag.deleteRecordsFromPreviousExecutionLines.length > 1) {
+        if (bag.deleteRecordsFromPreviousExecutionsLines.length > 1) {
             return Err(
                 fileErrorToText({
                     filePath: friendlyPath,
-                    msg: `deleteRecordsFromPreviousExecution should be called only once per sync`,
-                    line: Math.max(...bag.deleteRecordsFromPreviousExecutionLines)
+                    msg: `deleteRecordsFromPreviousExecutions should be called only once per sync`,
+                    line: Math.max(...bag.deleteRecordsFromPreviousExecutionsLines)
                 })
             );
         }
         if (
-            bag.deleteRecordsFromPreviousExecutionLines.length > 0 &&
+            bag.deleteRecordsFromPreviousExecutionsLines.length > 0 &&
             bag.batchingRecordsLines.length > 0 &&
-            bag.batchingRecordsLines.some((line) => line > Math.min(...bag.deleteRecordsFromPreviousExecutionLines))
+            bag.batchingRecordsLines.some((line) => line > Math.min(...bag.deleteRecordsFromPreviousExecutionsLines))
         ) {
             return Err(
                 fileErrorToText({
                     filePath: friendlyPath,
-                    msg: `deleteRecordsFromPreviousExecution should be called after any batching records function`,
-                    line: Math.min(...bag.deleteRecordsFromPreviousExecutionLines)
+                    msg: `deleteRecordsFromPreviousExecutions should be called after any batching records function`,
+                    line: Math.min(...bag.deleteRecordsFromPreviousExecutionsLines)
                 })
             );
         }
@@ -332,12 +332,12 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
     const proxyLines: number[] = [];
     const batchingRecordsLines: number[] = [];
     const setMergingStrategyLines: number[] = [];
-    const deleteRecordsFromPreviousExecutionLines: number[] = [];
+    const deleteRecordsFromPreviousExecutionsLines: number[] = [];
     const bag = {
         proxyLines,
         batchingRecordsLines,
         setMergingStrategyLines,
-        deleteRecordsFromPreviousExecutionLines
+        deleteRecordsFromPreviousExecutionsLines
     };
 
     const normalizedEntryPoint = path.resolve(entryPoint);
@@ -364,7 +364,7 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
         'getEnvironmentVariables',
         'triggerAction',
         'setMergingStrategy',
-        'deleteRecordsFromPreviousExecution'
+        'deleteRecordsFromPreviousExecutions'
     ];
     const callsProxy = ['proxy', 'get', 'post', 'put', 'patch', 'delete'];
     const callsBatchingRecords = ['batchSave', 'batchDelete', 'batchUpdate'];
@@ -470,8 +470,8 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
                                         setMergingStrategyLines.push(lineNumber);
                                     }
 
-                                    if (callee.property.name === 'deleteRecordsFromPreviousExecution') {
-                                        deleteRecordsFromPreviousExecutionLines.push(lineNumber);
+                                    if (callee.property.name === 'deleteRecordsFromPreviousExecutions') {
+                                        deleteRecordsFromPreviousExecutionsLines.push(lineNumber);
                                     }
                                 }
                             }

--- a/packages/cli/lib/zeroYaml/compile.ts
+++ b/packages/cli/lib/zeroYaml/compile.ts
@@ -89,6 +89,18 @@ export async function compileAll({ fullPath, debug }: { fullPath: string; debug:
             return Err(def.error);
         }
 
+        for (const integration of def.value.integrations) {
+            for (const sync of integration.syncs) {
+                if (sync.track_deletes) {
+                    console.warn(
+                        chalk.yellow(
+                            `\nWarning: Sync '${sync.name}' for integration '${integration.providerConfigKey}' has 'track_deletes' enabled. This feature is deprecated and will be removed in future versions. Please call 'nango.deleteRecordsFromPreviousExecution()' in your sync script to automatically detect deletions.`
+                        )
+                    );
+                }
+            }
+        }
+
         generateAdditionalExports({ parsed: def.value, fullPath, debug });
 
         spinner.succeed();

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -292,7 +292,7 @@ export async function handleSyncSuccess({ taskId, nangoProps }: { taskId: string
             let deletedKeys: string[] = [];
             if (nangoProps.syncConfig.track_deletes) {
                 void logCtx.warn(
-                    `'track_deletes' is deprecated and will be removed in future versions. To detect deletions please call 'nango.deleteRecordsFromPreviousExecution()' in your sync script.`
+                    `'track_deletes' is deprecated and will be removed in future versions. To detect deletions please call 'nango.deleteRecordsFromPreviousExecutions()' in your sync script.`
                 );
                 const res = await records.deleteOutdatedRecords({
                     connectionId: nangoProps.nangoConnectionId,

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -291,6 +291,9 @@ export async function handleSyncSuccess({ taskId, nangoProps }: { taskId: string
         for (const model of nangoProps.syncConfig.models || []) {
             let deletedKeys: string[] = [];
             if (nangoProps.syncConfig.track_deletes) {
+                void logCtx.warn(
+                    `'track_deletes' is deprecated and will be removed in future versions. To detect deletions please call 'nango.deleteRecordsFromPreviousExecution()' in your sync script.`
+                );
                 const res = await records.deleteOutdatedRecords({
                     connectionId: nangoProps.nangoConnectionId,
                     model,

--- a/packages/runner-sdk/lib/scripts.ts
+++ b/packages/runner-sdk/lib/scripts.ts
@@ -75,6 +75,7 @@ export interface CreateSyncProps<TModels extends Record<string, ZodModel>, TMeta
     /**
      * If `true`, automatically detects deleted records and removes them when you fetch the latest data.
      *
+     * @deprecated This option will be removed in future versions. Please automatically detect deletions by calling `nango.deleteRecordsFromPreviousExecution()` in your sync script.
      * @default false
      */
     trackDeletes?: boolean;

--- a/packages/runner-sdk/lib/scripts.ts
+++ b/packages/runner-sdk/lib/scripts.ts
@@ -75,7 +75,7 @@ export interface CreateSyncProps<TModels extends Record<string, ZodModel>, TMeta
     /**
      * If `true`, automatically detects deleted records and removes them when you fetch the latest data.
      *
-     * @deprecated This option will be removed in future versions. Please automatically detect deletions by calling `nango.deleteRecordsFromPreviousExecution()` in your sync script.
+     * @deprecated This option will be removed in future versions. Please automatically detect deletions by calling `nango.deleteRecordsFromPreviousExecutions()` in your sync script.
      * @default false
      */
     trackDeletes?: boolean;

--- a/packages/runner-sdk/lib/sync.ts
+++ b/packages/runner-sdk/lib/sync.ts
@@ -65,7 +65,7 @@ export abstract class NangoSyncBase<
         model: TModelName
     ): MaybePromise<Map<TKey, TModel>>;
 
-    public abstract deleteRecordsFromPreviousExecution(model: TModelName): MaybePromise<{ deletedKeys: string[] }>;
+    public abstract deleteRecordsFromPreviousExecutions(model: TModelName): MaybePromise<{ deletedKeys: string[] }>;
 
     public abstract setMergingStrategy(merging: { strategy: 'ignore_if_modified_after' | 'override' }, model: TModelName): Promise<void>;
 

--- a/packages/runner-sdk/models.d.ts
+++ b/packages/runner-sdk/models.d.ts
@@ -410,7 +410,7 @@ export declare class NangoSync extends NangoAction {
     batchUpdate<T extends object>(results: T[], model: string): Promise<boolean | null>;
     getMetadata<T = Metadata>(): Promise<T>;
     setMergingStrategy(merging: { strategy: 'ignore_if_modified_after' | 'override' }, model: string): Promise<void>;
-    deleteRecordsFromPreviousExecution(model: TModelName): MaybePromise<{ deletedKeys: string[] }>;
+    deleteRecordsFromPreviousExecutions(model: TModelName): MaybePromise<{ deletedKeys: string[] }>;
     getRecordsByIds<K = string | number, T = any>(ids: K[], model: string): Promise<Map<K, T>>;
 }
 /**

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -485,7 +485,7 @@ export class NangoSyncRunner extends NangoSyncBase {
         return true;
     }
 
-    public async deleteRecordsFromPreviousExecution(model: string): Promise<{ deletedKeys: string[] }> {
+    public async deleteRecordsFromPreviousExecutions(model: string): Promise<{ deletedKeys: string[] }> {
         this.throwIfAborted();
         const res = await this.persistClient.deleteOutdatedRecords({
             model: this.modelFullName(model),


### PR DESCRIPTION
track_deletes is being deprecated:
- marked as @deprecated in zero yaml
- nango compile warning when set to true
- logs warning when set to true

Note: we don't deprecate it explicitly in legacy nango.yaml since it is EOL in december

This commit replace trackDeletes documentation by documentation about the `deleteRecordsFromPreviousExecution` runner-sdk function.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Deprecate `trackDeletes` and Transition to `deleteRecordsFromPreviousExecutions` for Deletion Detection**

This PR deprecates the `trackDeletes` flag in favor of the new `deleteRecordsFromPreviousExecutions` function for handling automatic deletion detection in sync integrations. The documentation, SDK API, CLI behavior, and associated type definitions have been updated throughout the codebase to both discourage the use of `trackDeletes` and encourage correct, explicit usage of the new function via scripts. Compiler- and runtime-level warnings now signal deprecated usage, and additional static and runtime checks enforce correct sequence and count of `deleteRecordsFromPreviousExecutions` calls. All public and internal documentation, including guides, SDK reference, and code comments, have been updated to reflect this new approach, with details on expected usage patterns and possible error scenarios.

<details>
<summary><strong>Key Changes</strong></summary>

• Marked `trackDeletes` as `@deprecated` in documentation, SDK type definitions, and zero YAML schemas.
• Added compile-time and runtime warnings in `packages/cli/lib/zeroYaml/compile.ts` and job execution logic if `trackDeletes` is set to `true`.
• Updated all documentation (`docs-v2/guides/syncs/detecting-deletes.mdx`, `docs-v2/reference/scripts.mdx`, `docs-v2/guides/custom-integrations/build-a-custom-integration.mdx`) to remove or rewrite `trackDeletes` sections in favor of `deleteRecordsFromPreviousExecutions`.
• Refactored CLI, SDK, runtime jobs, and parser logic to use pluralized `deleteRecordsFromPreviousExecutions` instead of singular/interim forms, ensuring API consistency.
• Enforced usage restrictions: `deleteRecordsFromPreviousExecutions` can only be called once per sync and only after all `batchSave` calls; violations emit compile-time errors.
• Amended and added tests, code snapshots, and type declarations to ensure correct name and enforcement patterns.
• Added explicit warnings in logs and docs about potential error scenarios and safe usage of deletion detection.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs-v2/guides/syncs/detecting-deletes.mdx`
• `docs-v2/reference/scripts.mdx`
• `docs-v2/guides/custom-integrations/build-a-custom-integration.mdx`
• `packages/cli/lib/zeroYaml/compile.ts`
• `packages/cli/lib/services/parser.service.ts`
• `packages/cli/lib/services/sdk.ts`
• `packages/jobs/lib/execution/sync.ts`
• `packages/runner-sdk/models.d.ts`
• `packages/runner-sdk/lib/scripts.ts`
• `packages/runner-sdk/lib/sync.ts`
• `packages/runner/lib/sdk/sdk.ts`
• `packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap`

</details>

---
*This summary was automatically generated by @propel-code-bot*