### PR TITLE
fix: Revert "fix(paginate): throw error if `response_path` isn't present on the first page"

### DIFF
--- a/packages/runner-sdk/lib/paginate.service.ts
+++ b/packages/runner-sdk/lib/paginate.service.ts
@@ -59,7 +59,6 @@ class PaginationService {
         const cursorPagination: CursorPagination = paginationConfig;
 
         let nextCursor: string | number | undefined;
-        let isFirstPage = true;
 
         do {
             if (typeof nextCursor !== 'undefined') {
@@ -69,11 +68,6 @@ class PaginationService {
             this.updateConfigBodyOrParams(passPaginationParamsInBody, config, updatedBodyOrParams);
 
             const response = await proxy(config);
-
-            if (isFirstPage) {
-                this.validateFirstPageResponse(response, paginationConfig.response_path);
-                isFirstPage = false;
-            }
 
             const responseData: T[] = cursorPagination.response_path ? get(response.data, cursorPagination.response_path) : response.data;
 
@@ -114,15 +108,9 @@ class PaginationService {
         this.updateConfigBodyOrParams(passPaginationParamsInBody, config, updatedBodyOrParams);
 
         let previousPageLink: string | undefined;
-        let isFirstPage = true;
 
         while (true) {
             const response = await proxy(config);
-
-            if (isFirstPage) {
-                this.validateFirstPageResponse(response, paginationConfig.response_path);
-                isFirstPage = false;
-            }
 
             const responseData: T[] = paginationConfig.response_path ? get(response.data, paginationConfig.response_path) : response.data;
 
@@ -167,7 +155,6 @@ class PaginationService {
         const offsetParameterName: string = offsetPagination.offset_name_in_request;
         const offsetCalculationMethod: OffsetCalculationMethod = offsetPagination.offset_calculation_method || 'by-response-size';
         let offset = offsetPagination.offset_start_value || 0;
-        let isFirstPage = true;
 
         while (true) {
             updatedBodyOrParams[offsetParameterName] = passPaginationParamsInBody ? offset : String(offset);
@@ -175,11 +162,6 @@ class PaginationService {
             this.updateConfigBodyOrParams(passPaginationParamsInBody, config, updatedBodyOrParams);
 
             const response = await proxy(config);
-
-            if (isFirstPage) {
-                this.validateFirstPageResponse(response, paginationConfig.response_path);
-                isFirstPage = false;
-            }
 
             const responseData: T[] = paginationConfig.response_path ? get(response.data, paginationConfig.response_path) : response.data;
             if (!responseData || !responseData.length) {
@@ -246,22 +228,6 @@ class PaginationService {
         }
 
         return nextPageLink;
-    }
-
-    private validateFirstPageResponse(response: AxiosResponse, responsePath?: string): void {
-        if (responsePath) {
-            const resolvedAtPath = get(response.data, responsePath);
-            if (typeof resolvedAtPath === 'undefined') {
-                throw new Error(`Missing expected response_path '${responsePath}' on first page`);
-            }
-            if (!Array.isArray(resolvedAtPath)) {
-                throw new Error(`Expected an array at response_path '${responsePath}' on first page`);
-            }
-        } else {
-            if (!Array.isArray(response.data)) {
-                throw new Error('Expected response.data to be an array on first page');
-            }
-        }
     }
 }
 

--- a/packages/runner-sdk/lib/paginate.service.unit.test.ts
+++ b/packages/runner-sdk/lib/paginate.service.unit.test.ts
@@ -204,7 +204,6 @@ describe('PaginationService', () => {
             it('should handle undefined response data', async () => {
                 proxy.mockResolvedValueOnce({
                     data: {
-                        data: [],
                         pages: { next: null }
                     }
                 });
@@ -346,54 +345,6 @@ describe('PaginationService', () => {
                         endpoint: '/test'
                     })
                 );
-            });
-        });
-
-        describe('first-page validation', () => {
-            beforeEach(() => {
-                paginationConfig = {
-                    type: 'link',
-                    link_rel_in_response_header: 'next',
-                    response_path: 'data',
-                    limit_name_in_request: 'limit'
-                } as LinkPagination;
-            });
-
-            it('should throw if response_path is missing on first page', async () => {
-                proxy.mockResolvedValueOnce({
-                    headers: { link: undefined },
-                    data: {
-                        pagination: { next_url: null }
-                    }
-                });
-
-                const generator = PaginationService.link(config, paginationConfig, {}, false, proxy);
-                await expect(generator.next()).rejects.toThrow("Missing expected response_path 'data' on first page");
-            });
-
-            it('should throw if response_path resolves to non-array on first page', async () => {
-                proxy.mockResolvedValueOnce({
-                    headers: { link: undefined },
-                    data: {
-                        data: { id: 1 },
-                        pagination: { next_url: null }
-                    }
-                });
-
-                const generator = PaginationService.link(config, paginationConfig, {}, false, proxy);
-                await expect(generator.next()).rejects.toThrow("Expected an array at response_path 'data' on first page");
-            });
-
-            it('should throw if no response_path and response.data is not array', async () => {
-                const paginationConfigNoPath: any = { ...paginationConfig };
-                delete paginationConfigNoPath.response_path;
-                proxy.mockResolvedValueOnce({
-                    headers: { link: undefined },
-                    data: { message: 'not-an-array' }
-                });
-
-                const generator = PaginationService.link(config, paginationConfigNoPath, {}, false, proxy);
-                await expect(generator.next()).rejects.toThrow('Expected response.data to be an array on first page');
             });
         });
     });


### PR DESCRIPTION
Reverts NangoHQ/nango#4587