### PR TITLE
feat: store records size in bytes

### DIFF
--- a/packages/records/lib/db/migrations/20250910200700_record_counts_size_bytes.ts
+++ b/packages/records/lib/db/migrations/20250910200700_record_counts_size_bytes.ts
@@ -1,0 +1,14 @@
+import type { Knex } from 'knex';
+
+const TABLE = 'record_counts';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.transaction(async (trx) => {
+        await trx.raw(`
+            ALTER TABLE "${TABLE}"
+            ADD COLUMN IF NOT EXISTS size_bytes bigint NOT NULL DEFAULT 0;
+        `);
+    });
+}
+
+export async function down(_knex: Knex): Promise<void> {}

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -35,6 +35,8 @@ interface UpsertResult {
     id: string;
     last_modified_at: string;
     previous_last_modified_at: string | null;
+    size_bytes: number;
+    previous_size_bytes: number | null;
     status: 'inserted' | 'changed' | 'undeleted' | 'deleted' | 'unchanged';
 }
 
@@ -53,7 +55,7 @@ function getInactiveThisMonth(records: UpsertResult[]): UpsertResult[] {
     });
 }
 
-export async function getRecordCountsByModel({
+export async function getRecordStatsByModel({
     connectionId,
     environmentId
 }: {
@@ -69,10 +71,19 @@ export async function getRecordCountsByModel({
             })
             .select<RecordCount[]>('*');
 
-        const countsByModel: Record<string, RecordCount> = results.reduce((acc, result) => ({ ...acc, [result.model]: result }), {});
-        return Ok(countsByModel);
+        const statsByModel: Record<string, RecordCount> = results.reduce(
+            (acc, result) => ({
+                ...acc,
+                [result.model]: {
+                    ...result,
+                    size_bytes: Number(result.size_bytes) // bigint is returned as string by pg
+                }
+            }),
+            {}
+        );
+        return Ok(statsByModel);
     } catch {
-        const e = new Error(`Count records error for connection ${connectionId} and environment ${environmentId}`);
+        const e = new Error(`Failed to fetch stats for connection ${connectionId} and environment ${environmentId}`);
         return Err(e);
     }
 }
@@ -335,6 +346,7 @@ export async function upsert({
         await db.transaction(async (trx) => {
             // Lock to prevent concurrent upserts
             await trx.raw(`SELECT pg_advisory_xact_lock(?) as lock_records_${softDelete ? 'delete' : 'upsert'}`, [newLockId(connectionId, model)]);
+            let deltaSizeInBytes = 0;
             for (let i = 0; i < recordsWithoutDuplicates.length; i += BATCH_SIZE) {
                 const chunk = recordsWithoutDuplicates.slice(i, i + BATCH_SIZE);
                 const encryptedRecords = encryptRecords(chunk);
@@ -360,7 +372,7 @@ export async function upsert({
                 const externalIds = chunk.map((r) => r.external_id);
                 const query = trx
                     .with('existing', (qb) => {
-                        qb.select('external_id', 'data_hash', 'deleted_at', 'updated_at')
+                        qb.select('external_id', 'data_hash', 'deleted_at', 'updated_at', trx.raw('pg_column_size(json) as size_bytes'))
                             .from(RECORDS_TABLE)
                             .where({
                                 connection_id: connectionId,
@@ -371,7 +383,7 @@ export async function upsert({
                     .with('upsert', (qb) => {
                         qb.insert(encryptedRecords)
                             .into(RECORDS_TABLE)
-                            .returning(['id', 'external_id', 'data_hash', 'deleted_at', 'updated_at'])
+                            .returning(['id', 'external_id', 'data_hash', 'deleted_at', 'updated_at', trx.raw('pg_column_size(json) as size_bytes')])
                             .onConflict(['connection_id', 'external_id', 'model'])
                             .merge();
                         if (merging.strategy === 'ignore_if_modified_after_cursor' && merging.cursor) {
@@ -389,6 +401,8 @@ export async function upsert({
                             upsert.id as id,
                             upsert.external_id as external_id,
                             to_json(upsert.updated_at) as last_modified_at,
+                            upsert.size_bytes as size_bytes,
+                            existing.size_bytes as previous_size_bytes,
                             CASE
                               WHEN existing.updated_at IS NULL THEN NULL
                               ELSE to_json(existing.updated_at)
@@ -457,20 +471,23 @@ export async function upsert({
                         };
                     }
                 }
+                deltaSizeInBytes += res.reduce((acc, r) => acc + (r.size_bytes - (r.previous_size_bytes || 0)), 0);
             }
             const delta = summary.addedKeys.length - (summary.deletedKeys?.length ?? 0);
-            if (delta !== 0) {
+            if (delta !== 0 || deltaSizeInBytes !== 0) {
                 await trx
                     .from(RECORD_COUNTS_TABLE)
                     .insert({
                         connection_id: connectionId,
                         model,
                         environment_id: environmentId,
-                        count: delta
+                        count: delta,
+                        size_bytes: deltaSizeInBytes
                     })
                     .onConflict(['connection_id', 'environment_id', 'model'])
                     .merge({
                         count: trx.raw(`${RECORD_COUNTS_TABLE}.count + EXCLUDED.count`),
+                        size_bytes: trx.raw(`${RECORD_COUNTS_TABLE}.size_bytes + EXCLUDED.size_bytes`),
                         updated_at: trx.fn.now()
                     });
             }
@@ -527,6 +544,7 @@ export async function update({
         await db.transaction(async (trx) => {
             // Lock to prevent concurrent updates
             await trx.raw(`SELECT pg_advisory_xact_lock(?) as lock_records_update`, [newLockId(connectionId, model)]);
+            let deltaSizeInBytes = 0;
             for (let i = 0; i < recordsWithoutDuplicates.length; i += BATCH_SIZE) {
                 const chunk = recordsWithoutDuplicates.slice(i, i + BATCH_SIZE);
 
@@ -557,10 +575,22 @@ export async function update({
                 if (recordsToUpdate.length > 0) {
                     const encryptedRecords = encryptRecords(recordsToUpdate);
                     const query = trx
+                        .with('existing', (qb) => {
+                            qb.select('external_id', 'id', trx.raw('pg_column_size(json) as previous_size_bytes'))
+                                .from(RECORDS_TABLE)
+                                .where({
+                                    connection_id: connectionId,
+                                    model
+                                })
+                                .whereIn(
+                                    'external_id',
+                                    encryptedRecords.map((r) => r.external_id)
+                                );
+                        })
                         .with('upsert', (qb) => {
                             qb.from<{ external_id: string; id: string; last_modified_at: string }>(RECORDS_TABLE)
                                 .insert(encryptedRecords)
-                                .returning(['external_id', 'id', 'updated_at'])
+                                .returning(['external_id', 'id', 'updated_at', trx.raw('pg_column_size(json) as size_bytes')])
                                 .onConflict(['connection_id', 'external_id', 'model'])
                                 .merge();
                             if (merging.strategy === 'ignore_if_modified_after_cursor' && merging.cursor) {
@@ -578,14 +608,19 @@ export async function update({
                                 external_id: string;
                                 id: string;
                                 last_modified_at: string;
+                                previous_size_bytes: number;
+                                size_bytes: number;
                             }[]
                         >(
                             trx.raw(`
                             upsert.id as id,
                             upsert.external_id as external_id,
-                            to_json(upsert.updated_at) as last_modified_at`)
+                            to_json(upsert.updated_at) as last_modified_at,
+                            existing.previous_size_bytes as previous_size_bytes,
+                            upsert.size_bytes as size_bytes`)
                         )
                         .from('upsert')
+                        .join('existing', 'upsert.external_id', 'existing.external_id')
                         .orderBy([
                             { column: 'updated_at', order: 'asc' },
                             { column: 'id', order: 'asc' }
@@ -610,7 +645,20 @@ export async function update({
                             cursor: Cursor.new(lastRecord)
                         };
                     }
+                    deltaSizeInBytes += updated.reduce((acc, r) => acc + (r.size_bytes - (r.previous_size_bytes || 0)), 0);
                 }
+            }
+            if (deltaSizeInBytes !== 0) {
+                await trx
+                    .from(RECORD_COUNTS_TABLE)
+                    .where({
+                        connection_id: connectionId,
+                        model
+                    })
+                    .update({
+                        size_bytes: trx.raw(`${RECORD_COUNTS_TABLE}.size_bytes + ?`, [deltaSizeInBytes]),
+                        updated_at: trx.fn.now()
+                    });
             }
         });
         return Ok({

--- a/packages/records/lib/types.ts
+++ b/packages/records/lib/types.ts
@@ -71,5 +71,6 @@ export interface RecordCount {
     connection_id: number;
     environment_id: number;
     count: number;
+    size_bytes: number;
     updated_at: string;
 }

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -60,7 +60,7 @@ class SyncController {
     }
 
     private async addRecordCount(syncs: (Sync & { models: string[] })[], connectionId: number, environmentId: number) {
-        const byModel = await recordsService.getRecordCountsByModel({ connectionId, environmentId });
+        const byModel = await recordsService.getRecordStatsByModel({ connectionId, environmentId });
         if (byModel.isOk()) {
             return syncs.map((sync) => ({
                 ...sync,

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -58,7 +58,7 @@ export interface RecordsServiceInterface {
         model: string;
         syncId: string;
     }): Promise<{ totalDeletedRecords: number }>;
-    getRecordCountsByModel({ connectionId, environmentId }: { connectionId: number; environmentId: number }): Promise<Result<Record<string, RecordCount>>>;
+    getRecordStatsByModel({ connectionId, environmentId }: { connectionId: number; environmentId: number }): Promise<Result<Record<string, RecordCount>>>;
 }
 
 // TODO: move to @nangohq/types (with the rest of the ochestrator public types)

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -514,7 +514,7 @@ export class SyncManagerService {
             throw new Error(`Schedule for sync ${sync.id} and environment ${environmentId} not found`);
         }
 
-        const countRes = await recordsService.getRecordCountsByModel({ connectionId: sync.nango_connection_id, environmentId }); // TODO: handle sync's variant
+        const countRes = await recordsService.getRecordStatsByModel({ connectionId: sync.nango_connection_id, environmentId }); // TODO: handle sync's variant
         if (countRes.isErr()) {
             throw new Error(`Failed to get records count for sync ${sync.id} in environment ${environmentId}: ${stringifyError(countRes.error)}`);
         }


### PR DESCRIPTION
Storing the size in bytes of the records for each connection/model in the `record_counts` table

Note: the reported size is the compressed size reported by pg of the encrypted payload (with iv and authTag). So not the size as seen by the customer but the size taken on disk from the db point of view
<!-- Summary by @propel-code-bot -->

---

**Store Record Size in Bytes per Connection/Model**

This PR introduces tracking and storage of the compressed size in bytes of records for each connection and model in the `record_counts` table. The change adapts all critical layers-model logic, API/service, types, and integration tests-to support and expose the new `size_bytes` field. Compressed size, as reported by PostgreSQL (`pg_column_size`), is now calculated for each upsert, update, and delete operation, and stored/update in the database alongside the existing record counts. All downstream consumers and statistics APIs are updated to work with this extended metric.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `size_bytes` column (bigint, NOT NULL, default 0) to `record_counts` via migration `packages/records/lib/db/migrations/20250910200700_record_counts_size_bytes.ts`
• Updated `RecordCount` type in `packages/records/lib/types.ts` to include `size_bytes`
• Implemented calculation of payload size using `pg_column_size(json)` during record upsert and update in `packages/records/lib/models/records.ts`
• Tracked `deltaSizeInBytes` changes in transactional operations, updating/incrementing `size_bytes` in `record_counts` accordingly
• Replaced `getRecordCountsByModel` APIs/usages with `getRecordStatsByModel`, now returning both `count` and `size_bytes`
• Updated orchestrator client, sync flow management, and controller to pass and utilize the new statistics signature (`packages/shared/lib/clients/orchestrator.ts`, `packages/shared/lib/services/sync/manager.service.ts`, `packages/server/lib/controllers/sync.controller.ts`)
• Extended integration tests in `packages/records/lib/models/records.integration.test.ts` to validate correctness of `size_bytes` in key scenarios (insert, update, delete, soft delete, batch/upsert concurrency)
• All API/service layers now expect and populate model statistics including size in bytes

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `record_counts` table and migration logic
• `RecordCount` type definitions in `packages/records/lib/types.ts`
• Upsert, update, and delete logic in `packages/records/lib/models/records.ts`
• Integration tests in `packages/records/lib/models/records.integration.test.ts`
• Service and controller code relying on model statistics
• Orchestrator client/service interface and consumers

</details>

---
*This summary was automatically generated by @propel-code-bot*