### PR TITLE
fix(webapp): use non-null assertion for runs 

### DIFF
--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Endpoints/components/ScriptSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Endpoints/components/ScriptSettings.tsx
@@ -242,7 +242,7 @@ export const ScriptSettings: React.FC<{
                                 <Dialog
                                     open={openFrequency}
                                     onOpenChange={(v) => {
-                                        if (v) onFrequencyChange(flow.runs);
+                                        if (v) onFrequencyChange(flow.runs!);
                                         setOpenFrequency(v);
                                     }}
                                 >


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Use Non-Null Assertion for `flow.runs` in Frequency Dialog Handler**

This pull request introduces a single-line change in the `ScriptSettings.tsx` component to use a non-null assertion (`!`) on the `flow.runs` property within the `onOpenChange` event handler for the frequency dialog. The update reflects a TypeScript change that explicitly asserts `flow.runs` will not be `null` or `undefined` when passed to the `onFrequencyChange` function, likely to resolve a type error or prevent unwanted warnings.

<details>
<summary><strong>Key Changes</strong></summary>

• Added a non-null assertion (`flow.runs!`) in the frequency dialog's `onOpenChange` handler in `ScriptSettings.tsx`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/pages/Integrations/providerConfigKey/Endpoints/components/ScriptSettings.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*