### PR TITLE
fix(reconnect-flow): attach end user id on reconnect flow

### DIFF
--- a/packages/server/lib/controllers/connect/postReconnect.ts
+++ b/packages/server/lib/controllers/connect/postReconnect.ts
@@ -107,6 +107,7 @@ export const postConnectSessionsReconnect = asyncWrapper<PostPublicConnectSessio
 
         // create connect session
         const createConnectSession = await connectSessionService.createConnectSession(trx, {
+            endUserId: endUser.id,
             endUser: body.end_user ? EndUserMapper.apiToEndUser(body.end_user, body.organization) : null,
             accountId: account.id,
             environmentId: environment.id,

--- a/packages/server/lib/controllers/connect/postSessions.ts
+++ b/packages/server/lib/controllers/connect/postSessions.ts
@@ -167,6 +167,7 @@ export async function generateSession(res: Response<any, Required<RequestLocals>
 
         // create connect session
         const createConnectSession = await connectSessionService.createConnectSession(trx, {
+            endUserId: null,
             accountId: account.id,
             environmentId: environment.id,
             allowedIntegrations: body.allowed_integrations && body.allowed_integrations.length > 0 ? body.allowed_integrations : null,

--- a/packages/server/lib/services/connectSession.service.ts
+++ b/packages/server/lib/services/connectSession.service.ts
@@ -22,7 +22,7 @@ export interface DBConnectSession {
     readonly overrides: Record<string, ConnectSessionOverrides> | null;
     readonly end_user: InternalEndUser | null;
 }
-type DbInsertConnectSession = Omit<DBConnectSession, 'id' | 'end_user_id' | 'created_at' | 'updated_at'>;
+type DbInsertConnectSession = Omit<DBConnectSession, 'id' | 'created_at' | 'updated_at'>;
 
 const ConnectSessionMapper = {
     to: (session: ConnectSession): DBConnectSession => {
@@ -77,6 +77,7 @@ export interface ConnectSessionAndEndUser {
 export async function createConnectSession(
     db: Knex,
     {
+        endUserId,
         accountId,
         environmentId,
         connectionId,
@@ -88,12 +89,21 @@ export async function createConnectSession(
     }: SetOptional<
         Pick<
             ConnectSession,
-            'allowedIntegrations' | 'connectionId' | 'integrationsConfigDefaults' | 'accountId' | 'environmentId' | 'operationId' | 'overrides' | 'endUser'
+            | 'allowedIntegrations'
+            | 'connectionId'
+            | 'integrationsConfigDefaults'
+            | 'accountId'
+            | 'environmentId'
+            | 'operationId'
+            | 'overrides'
+            | 'endUser'
+            | 'endUserId'
         >,
         'connectionId'
     >
 ): Promise<Result<ConnectSession, ConnectSessionError>> {
     const dbSession: DbInsertConnectSession = {
+        end_user_id: endUserId || null,
         account_id: accountId,
         environment_id: environmentId,
         connection_id: connectionId || null,


### PR DESCRIPTION
As described in the [thread](https://nangohq.slack.com/archives/C08PAUW3GKX/p1757557591749879) there is a problem with the reconnect flow which I was able to reproduce. It seems to have been introduced with https://github.com/NangoHQ/nango/pull/4564.  

I haven't touched the connect UI at all so I'm sure this isn't the right fix but it fixes the reconnect flow bug that is reported @bodinsamuel. I guess I could reason since this is a reconnect flow the `end_user_id` can already exist because it was previously created so we should attach the `end_user_id` primary id in this scenario. Otherwise we wouldn't. But again, shot in the dark really.

<!-- Summary by @propel-code-bot -->

---

**Attach `end_user_id` for Reconnect Flow in Connect Session Creation**

This PR addresses a reported bug in the reconnect flow by ensuring that the `end_user_id` is properly attached when creating a connect session during a reconnect operation. The change updates the relevant service and controller logic to accept and persist the `end_user_id` for reconnect flows, while initializing it to `null` for new connections. No UI changes are made, and the update is narrowly scoped to backend TypeScript files involved in session creation.

<details>
<summary><strong>Key Changes</strong></summary>

• Modified `createConnectSession` in `connectSession.service.ts` to accept an `endUserId` parameter for use in session creation.
• Updated type definitions (`DbInsertConnectSession`) and parameter typing to include `end_user_id`.
• Ensured `endUserId` is set from the existing user in the reconnect flow (`postReconnect.ts`), and explicitly set to `null` in first-time connect flow (`postSessions.ts`).

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/services/connectSession.service.ts`
• `packages/server/lib/controllers/connect/postReconnect.ts`
• `packages/server/lib/controllers/connect/postSessions.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*