### PR TITLE
feat: max concurrency per environment for function executions

### DIFF
--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -259,7 +259,7 @@ export class OrchestratorClient {
             ...rest,
             retry: { count: 0, max: 0 },
             timeoutSettingsInSecs: {
-                createdToStarted: 30,
+                createdToStarted: 5 * 60,
                 startedToCompleted: 60 * 60,
                 heartbeat: 5 * 60
             },

--- a/packages/server/lib/controllers/action/postTriggerAction.ts
+++ b/packages/server/lib/controllers/action/postTriggerAction.ts
@@ -6,6 +6,7 @@ import { OtlpSpan, defaultOperationExpiration, logContextGetter } from '@nangohq
 import { configService, connectionService, errorManager, getSyncConfigRaw, productTracking } from '@nangohq/shared';
 import { getHeaders, isCloud, metrics, redactHeaders, requireEmptyQuery, truncateJson, zodErrorToHTTP } from '@nangohq/utils';
 
+import { envs } from '../../env.js';
 import { connectionIdSchema, providerConfigKeySchema, syncNameSchema } from '../../helpers/validation.js';
 import { pubsub } from '../../pubsub.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
@@ -129,6 +130,7 @@ export const postPublicTriggerAction = asyncWrapper<PostPublicTriggerAction>(asy
                 input,
                 async,
                 retryMax,
+                maxConcurrency: envs.ACTION_ENVIRONMENT_MAX_CONCURRENCY,
                 logCtx
             });
 

--- a/packages/server/lib/controllers/mcp/server.ts
+++ b/packages/server/lib/controllers/mcp/server.ts
@@ -6,6 +6,7 @@ import { OtlpSpan, defaultOperationExpiration, logContextGetter } from '@nangohq
 import { configService, getActionsByProviderConfigKey } from '@nangohq/shared';
 import { Err, Ok, truncateJson } from '@nangohq/utils';
 
+import { envs } from '../../env.js';
 import { getOrchestrator } from '../../utils/utils.js';
 
 import type { CallToolRequest, CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js';
@@ -131,6 +132,7 @@ function callToolRequestHandler(
             input,
             async: false,
             retryMax: 3,
+            maxConcurrency: envs.ACTION_ENVIRONMENT_MAX_CONCURRENCY,
             logCtx
         });
 

--- a/packages/server/lib/hooks/connection/on/post-connection-creation.ts
+++ b/packages/server/lib/hooks/connection/on/post-connection-creation.ts
@@ -1,6 +1,7 @@
 import { OtlpSpan, defaultOperationExpiration } from '@nangohq/logs';
 import { onEventScriptService } from '@nangohq/shared';
 
+import { envs } from '../../../env.js';
 import { getOrchestrator } from '../../../utils/utils.js';
 
 import type { LogContextGetter } from '@nangohq/logs';
@@ -53,6 +54,7 @@ export async function postConnectionCreation(
             fileLocation,
             sdkVersion: script.sdk_version,
             async: true,
+            maxConcurrency: envs.ON_EVENT_ENVIRONMENT_MAX_CONCURRENCY,
             logCtx
         });
 

--- a/packages/server/lib/hooks/connection/on/pre-connection-deletion.ts
+++ b/packages/server/lib/hooks/connection/on/pre-connection-deletion.ts
@@ -1,6 +1,7 @@
 import { defaultOperationExpiration } from '@nangohq/logs';
 import { configService, getProvider, onEventScriptService } from '@nangohq/shared';
 
+import { envs } from '../../../env.js';
 import { getOrchestrator } from '../../../utils/utils.js';
 import preConnectionExecute from '../pre-connection.js';
 
@@ -75,6 +76,7 @@ export async function preConnectionDeletion({
             fileLocation,
             sdkVersion: script.sdk_version,
             async: false,
+            maxConcurrency: envs.ON_EVENT_ENVIRONMENT_MAX_CONCURRENCY,
             logCtx
         });
         if (res.isErr()) {

--- a/packages/server/lib/hooks/connection/on/validate-connection.ts
+++ b/packages/server/lib/hooks/connection/on/validate-connection.ts
@@ -1,6 +1,7 @@
 import { onEventScriptService } from '@nangohq/shared';
 import { Err, Ok } from '@nangohq/utils';
 
+import { envs } from '../../../env.js';
 import { getOrchestrator } from '../../../utils/utils.js';
 
 import type { LogContext } from '@nangohq/logs';
@@ -46,6 +47,7 @@ export async function validateConnection({
             fileLocation,
             sdkVersion: script.sdk_version,
             async: false,
+            maxConcurrency: envs.ON_EVENT_ENVIRONMENT_MAX_CONCURRENCY,
             logCtx
         });
 

--- a/packages/server/lib/webhook/internal-nango.ts
+++ b/packages/server/lib/webhook/internal-nango.ts
@@ -2,6 +2,7 @@ import get from 'lodash-es/get.js';
 
 import { connectionService, getSyncConfigsByConfigIdForWebhook } from '@nangohq/shared';
 
+import { envs } from '../env.js';
 import { getOrchestrator } from '../utils/utils.js';
 
 import type { LogContextGetter } from '@nangohq/logs';
@@ -112,6 +113,7 @@ export class InternalNango {
                             webhookName: webhook,
                             syncConfig,
                             input: body,
+                            maxConcurrency: envs.WEBHOOK_ENVIRONMENT_MAX_CONCURRENCY,
                             logContextGetter: this.logContextGetter
                         });
                     }

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -76,6 +76,10 @@ export const ENVS = z.object({
     ACTION_PROCESSOR_MAX_CONCURRENCY: z.coerce.number().optional().default(200),
     WEBHOOK_PROCESSOR_MAX_CONCURRENCY: z.coerce.number().optional().default(200),
     ONEVENT_PROCESSOR_MAX_CONCURRENCY: z.coerce.number().optional().default(50),
+    SYNC_ENVIRONMENT_MAX_CONCURRENCY: z.coerce.number().optional().default(100),
+    ACTION_ENVIRONMENT_MAX_CONCURRENCY: z.coerce.number().optional().default(100),
+    WEBHOOK_ENVIRONMENT_MAX_CONCURRENCY: z.coerce.number().optional().default(50),
+    ON_EVENT_ENVIRONMENT_MAX_CONCURRENCY: z.coerce.number().optional().default(50),
 
     // Runner
     RUNNER_TYPE: z.enum(['LOCAL', 'REMOTE', 'RENDER', 'KUBERNETES']).default('LOCAL'),


### PR DESCRIPTION
We currently only have a global concurrency limit at the processor level that limit how many functions are executed at the same time. It is nice to protect our infra but if a large number of tasks is queued for the same environment they are all dispatched to a single runner that cannot handle the load.
The orchestrator has a mechanism to limit how many tasks for a specific group can be executed at the same time. We currently only use to to limit the concurrency of async actions per environment. I propose to set a upper-limit of how many functions can be executed per environment and type of functions to avoid dispatching tons of functions to a single runner at the same time.
This commit introduce global limit per environment and per function types but a possible improvement would be to have dedicated values in plan (the same way we are doing for the API rate-limit) so different customers can have different limits

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Per-Environment Max Concurrency Limits for Function Executions**

This PR introduces configurable maximum concurrency limits per environment and function type (action, webhook, on-event script, sync) for function executions. Previously, only a global processor-level concurrency limit was enforced, which could cause overloading of individual runners if many tasks from one environment were queued. The new mechanism adds environment-scoped caps and exposes configuration via new environment variables, ensuring that no environment can overwhelm processing resources. Relevant orchestrator, service, and handler logic is updated to utilize and forward the per-environment concurrency limit values. Some minor improvements, such as increasing timeouts for webhook execution scheduling, are included.

<details>
<summary><strong>Key Changes</strong></summary>

• Added environment variables: `ACTION_ENVIRONMENT_MAX_CONCURRENCY`, `WEBHOOK_ENVIRONMENT_MAX_CONCURRENCY`, `ON_EVENT_ENVIRONMENT_MAX_CONCURRENCY`, `SYNC_ENVIRONMENT_MAX_CONCURRENCY`, each with sensible default values
• Forwarded `maxConcurrency` values from orchestrator API entrypoints through to execution logic for all function types
• Updated group key generation logic for orchestrator tasks to ensure per-environment separation/limits
• Injected `maxConcurrency` into all relevant calls for actions, webhooks, and on-event scripts (including controller and hook logic)
• Increased the webhook execution `createdToStarted` timeout from 30 seconds to 5 minutes to avoid premature task expiration for queued webhooks
• Expanded the environment schema in `packages/utils/lib/environment/parse.ts` to validate and provide default values for the new variables

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/clients/orchestrator.ts`
• `packages/server/lib/controllers/action/postTriggerAction.ts`
• `packages/server/lib/controllers/mcp/server.ts`
• `packages/server/lib/hooks/connection/on/post-connection-creation.ts`
• `packages/server/lib/hooks/connection/on/pre-connection-deletion.ts`
• `packages/server/lib/hooks/connection/on/validate-connection.ts`
• `packages/server/lib/webhook/internal-nango.ts`
• `packages/orchestrator/lib/clients/client.ts`
• `packages/utils/lib/environment/parse.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*