### PR TITLE
feat: add slack notification success/failure metrics

### DIFF
--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -89,6 +89,9 @@ export enum Types {
     AUTH_SUCCESS = 'nango.server.auth.success',
     AUTH_FAILURE = 'nango.server.auth.failure',
 
+    SLACK_NOTIFICATION_SUCCESS = 'nango.slack.notification.success',
+    SLACK_NOTIFICATION_FAILURE = 'nango.slack.notification.failure',
+
     GET_RECORDS_COUNT = 'nango.server.getRecords.count',
     GET_RECORDS_SIZE_IN_BYTES = 'nango.server.getRecords.sizeInBytes',
 


### PR DESCRIPTION
We lack visibility on slack notifications. This PR adds dd metrics for slack notification success/failures

<!-- Summary by @propel-code-bot -->

---

**Add Datadog Metrics for Slack Notification Success and Failure**

This pull request introduces new Datadog metrics to improve visibility over Slack notification delivery outcomes within the system. Specifically, it adds instrumentation in the `sendSlackNotification` logic to capture both successful and failed Slack notification attempts, incrementing new metric types in each scenario. The metric types for success and failure are defined in the `metrics.Types` enum. Minor improvements were also made to error propagation in Slack-related proxy functions.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `metrics.increment(metrics.Types.SLACK_NOTIFICATION_SUCCESS, ...)` and `metrics.increment(metrics.Types.SLACK_NOTIFICATION_FAILURE, ...)` calls in the `sendSlackNotification` function in `packages/shared/lib/services/notification/slack.service.ts`.
• Extended the `metrics.Types` enum in `packages/utils/lib/telemetry/metrics.ts` with `SLACK_NOTIFICATION_SUCCESS` and `SLACK_NOTIFICATION_FAILURE`.
• Improved error propagation in the `proxySlackMessage` method to include error causes when Slack API failures occur.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/services/notification/slack.service.ts`
• `packages/utils/lib/telemetry/metrics.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*