### PR TITLE
fix: do not join Slack channel on every message

### DIFF
--- a/packages/shared/lib/services/notification/slack.service.ts
+++ b/packages/shared/lib/services/notification/slack.service.ts
@@ -694,97 +694,126 @@ export class SlackService {
             return Err('slack_hook_channel_id_not_configured');
         }
 
-        // Join the Slack channel
-        let proxyConfig = getProxyConfiguration({
-            externalConfig: {
-                method: 'POST',
-                endpoint: 'conversations.join',
-                headers: { 'Content-Type': 'application/json; charset=utf-8' },
-                data: { channel },
-                decompress: false,
-                providerConfigKey: integration.unique_key
-            },
-            internalConfig: {
-                providerName: integration.provider
-            }
-        });
-        if (proxyConfig.isErr()) {
-            return Err('failed_to_get_proxy_config');
-        }
-        let proxy = new ProxyRequest({
-            logger: () => {},
-            proxyConfig: proxyConfig.value,
-            getConnection: () => slackConnection
-        });
-        const join = await proxy.request();
-        if (join.isErr()) {
-            return Err(new Error('slack_join_channel_failed', { cause: join.error }));
-        }
-        if (!join.value.data.ok) {
-            return Err(join.value.data.error);
-        }
-
-        // Send/update chat message
-        const data = {
-            channel,
-            ts: payload.ts || '',
-            attachments: [
-                {
-                    color: color,
-                    blocks: [
-                        {
-                            type: 'section',
-                            text: {
-                                type: 'mrkdwn',
-                                text: payload.content
-                            }
-                        },
-                        ...(payload.meta
-                            ? [
-                                  {
-                                      type: 'context',
-                                      elements: [
-                                          {
-                                              type: 'mrkdwn',
-                                              text: `${payload.meta.accountName} (uuid: ${payload.meta.accountUuid})`
-                                          }
-                                      ]
-                                  }
-                              ]
-                            : [])
-                    ]
+        const joinChannel = async (): Promise<Result<void>> => {
+            const proxyConfig = getProxyConfiguration({
+                externalConfig: {
+                    method: 'POST',
+                    endpoint: 'conversations.join',
+                    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+                    data: { channel },
+                    decompress: false,
+                    providerConfigKey: integration.unique_key
+                },
+                internalConfig: {
+                    providerName: integration.provider
                 }
-            ]
+            });
+            if (proxyConfig.isErr()) {
+                return Err('failed_to_get_proxy_config');
+            }
+            const proxy = new ProxyRequest({
+                logger: () => {},
+                proxyConfig: proxyConfig.value,
+                getConnection: () => slackConnection
+            });
+            const join = await proxy.request();
+            if (join.isErr()) {
+                return Err(new Error('slack_join_channel_failed', { cause: join.error }));
+            }
+            if (!join.value.data.ok) {
+                return Err(join.value.data.error);
+            }
+            return Ok(undefined);
         };
 
-        proxyConfig = getProxyConfiguration({
-            externalConfig: {
-                method: 'POST',
-                endpoint: data.ts ? 'chat.update' : 'chat.postMessage',
-                headers: { 'Content-Type': 'application/json; charset=utf-8' },
-                data,
-                decompress: false,
-                providerConfigKey: integration.unique_key,
-                retries: 10
-            },
-            internalConfig: {
-                providerName: integration.provider
-            }
-        });
-        if (proxyConfig.isErr()) {
-            return Err('failed_to_get_proxy_config');
-        }
-        proxy = new ProxyRequest({
-            logger: () => {},
-            proxyConfig: proxyConfig.value,
-            getConnection: () => slackConnection
-        });
-        const slackMessage = await proxy.request();
-        if (slackMessage.isErr()) {
-            return Err(new Error('slack_post_failed', { cause: slackMessage.error }));
-        }
+        const sendMessage = async (): Promise<Result<PostSlackMessageResponse>> => {
+            // Send/update chat message
+            const data = {
+                channel,
+                ts: payload.ts || '',
+                attachments: [
+                    {
+                        color: color,
+                        blocks: [
+                            {
+                                type: 'section',
+                                text: {
+                                    type: 'mrkdwn',
+                                    text: payload.content
+                                }
+                            },
+                            ...(payload.meta
+                                ? [
+                                      {
+                                          type: 'context',
+                                          elements: [
+                                              {
+                                                  type: 'mrkdwn',
+                                                  text: `${payload.meta.accountName} (uuid: ${payload.meta.accountUuid})`
+                                              }
+                                          ]
+                                      }
+                                  ]
+                                : [])
+                        ]
+                    }
+                ]
+            };
 
-        return Ok(slackMessage.value.data as PostSlackMessageResponse);
+            const proxyConfig = getProxyConfiguration({
+                externalConfig: {
+                    method: 'POST',
+                    endpoint: data.ts ? 'chat.update' : 'chat.postMessage',
+                    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+                    data,
+                    decompress: false,
+                    providerConfigKey: integration.unique_key,
+                    retries: 10
+                },
+                internalConfig: {
+                    providerName: integration.provider
+                }
+            });
+            if (proxyConfig.isErr()) {
+                return Err('failed_to_get_proxy_config');
+            }
+            const proxy = new ProxyRequest({
+                logger: () => {},
+                proxyConfig: proxyConfig.value,
+                getConnection: () => slackConnection
+            });
+            const slackMessage = await proxy.request();
+
+            if (slackMessage.isErr()) {
+                return Err(new Error('slack_post_failed', { cause: slackMessage.error }));
+            }
+
+            // https://docs.slack.dev/reference/methods/chat.postMessage/
+            if (slackMessage.value.data?.error === 'not_in_channel') {
+                return Err('not_in_channel');
+            }
+
+            return Ok(slackMessage.value.data as PostSlackMessageResponse);
+        };
+
+        const send = await sendMessage();
+
+        if (send.isErr()) {
+            // if we get `not_in_channel` error we try to join the channel and resend the message
+            if (send.error.message === 'not_in_channel') {
+                const join = await joinChannel();
+                if (join.isErr()) {
+                    return Err(join.error);
+                }
+                const resend = await sendMessage();
+                if (resend.isErr()) {
+                    return Err(resend.error);
+                }
+                return resend;
+            }
+            return Err(send.error);
+        }
+        return send;
     }
 
     public async closeOpenNotificationForConnection({ connectionId, environmentId }: { connectionId: number; environmentId: number }) {


### PR DESCRIPTION
Slack notification: we currently join the channel every time a Slack
notification is sent, even if it is not necessary.
This commit modifies the flow, first trying the send the message and
only joining if we get a `not_in_channel` error. That's an extra call
for the first notification but all the following ones will be one request
instead of two.
<!-- Summary by @propel-code-bot -->

---

**Optimize Slack Channel Join Logic for Notifications**

This PR refactors the `proxySlackMessage()` method in `packages/shared/lib/services/notification/slack.service.ts` to improve efficiency of sending Slack notifications. Previously, the system attempted to join a Slack channel before every notification, causing unnecessary API calls even when the user was already a member. With this change, the message is sent first; if Slack returns a `not_in_channel` error, the implementation then joins the channel and reattempts the message. This reduces the number of requests per notification from two to one in most cases after the first message.

<details>
<summary><strong>Key Changes</strong></summary>

• Refactored the `proxySlackMessage()` method to send messages before attempting to join the channel
• Added local async functions `sendMessage` and `joinChannel` within `proxySlackMessage()` for improved logic encapsulation
• Error handling updated to resend the message only after a `not_in_channel` error is detected
• Eliminated redundant requests to Slack's `conversations.join` API when already in the channel

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/services/notification/slack.service.ts`
• `proxySlackMessage()` logic

</details>

---
*This summary was automatically generated by @propel-code-bot*