### PR TITLE
feat(pre-connection-script): add pre-connection-creation script

### DIFF
--- a/packages/logs/lib/models/helpers.ts
+++ b/packages/logs/lib/models/helpers.ts
@@ -127,5 +127,6 @@ export const operationTypeToMessage: Record<ConcatOperationList, string> = {
     'webhook:connection_refresh': 'Token refresh webhooks',
     'events:post_connection_creation': 'Event-based executions',
     'events:pre_connection_deletion': 'Event-based executions',
-    'events:validate_connection': 'Event-based executions'
+    'events:validate_connection': 'Event-based executions',
+    'events:pre_connection_creation': 'Event-based executions'
 };

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -1210,8 +1210,7 @@ class OAuthController {
                     interpolatedTokenUrl.href,
                     authorizationCode,
                     session.callbackUrl,
-                    session.codeVerifier,
-                    connectionConfig
+                    session.codeVerifier
                 );
             } else {
                 const accessToken = await simpleOAuthClient.getToken(

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -192,7 +192,7 @@ class OAuthController {
             );
 
             if (preConnection.isOk() && preConnection.value) {
-                connectionConfig = { ...connectionConfig, ...preConnection.value };
+                connectionConfig = preConnection.value;
             }
 
             const session: OAuthSession = {

--- a/packages/server/lib/hooks/connection/internal-nango.ts
+++ b/packages/server/lib/hooks/connection/internal-nango.ts
@@ -59,7 +59,7 @@ export function getHandler({
     handlers
 }: {
     provider: Provider | null;
-    providerScriptPropertyName: 'pre_connection_deletion_script' | 'post_connection_script';
+    providerScriptPropertyName: 'pre_connection_deletion_script' | 'post_connection_script' | 'pre_connection_creation_script';
     handlers: Record<string, (internalNango: InternalNango) => Promise<void>>;
 }): ((internalNango: InternalNango) => Promise<void>) | undefined {
     if (!provider || !provider[providerScriptPropertyName]) {

--- a/packages/server/lib/hooks/connection/pre-connection-creation.ts
+++ b/packages/server/lib/hooks/connection/pre-connection-creation.ts
@@ -59,7 +59,7 @@ async function execute(
     try {
         if (handler) {
             logCtx = await logContextGetter.create(
-                { operation: { type: 'events', action: 'pre_connection_creation_script' } },
+                { operation: { type: 'events', action: 'pre_connection_creation' } },
                 {
                     account,
                     environment,

--- a/packages/server/lib/hooks/connection/pre-connection-creation.ts
+++ b/packages/server/lib/hooks/connection/pre-connection-creation.ts
@@ -73,7 +73,10 @@ async function execute(
             const internalNango = {
                 getConnection: baseInternalNango.getConnection,
                 proxy: baseInternalNango.proxy,
-                updateConnectionConfig: (config: ConnectionConfig) => Promise.resolve(config),
+                updateConnectionConfig: (config: ConnectionConfig) => {
+                    connection.connection_config = { ...connection.connection_config, ...config };
+                    return Promise.resolve(connection.connection_config);
+                },
                 unsetConnectionConfigAttributes: (...keys: string[]) => {
                     const updatedConfig = Object.fromEntries(Object.entries(connection.connection_config).filter(([key]) => !keys.includes(key)));
                     return Promise.resolve(updatedConfig);

--- a/packages/server/lib/hooks/connection/pre-connection-creation.ts
+++ b/packages/server/lib/hooks/connection/pre-connection-creation.ts
@@ -1,0 +1,109 @@
+import { getProvider } from '@nangohq/shared';
+import { metrics } from '@nangohq/utils';
+
+import * as preConnectionHandlers from './index.js';
+import { getHandler, getInternalNango } from './internal-nango.js';
+
+import type { InternalNango } from './internal-nango.js';
+import type { LogContextGetter, LogContextOrigin } from '@nangohq/logs';
+import type { Config } from '@nangohq/shared';
+import type { ConnectionConfig, DBConnectionDecrypted, DBEnvironment, DBTeam } from '@nangohq/types';
+
+let updatedConnectionConfig: ConnectionConfig | null = null;
+
+type PreConnectionHandler = (internalNango: InternalNango) => Promise<void>;
+
+type PreConnectionHandlersMap = Record<string, PreConnectionHandler>;
+const handlers: PreConnectionHandlersMap = preConnectionHandlers as unknown as PreConnectionHandlersMap;
+
+async function execute(
+    connectionId: string,
+    connectionConfig: ConnectionConfig,
+    logContextGetter: LogContextGetter,
+    account: DBTeam,
+    environment: DBEnvironment,
+    config: Config
+): Promise<ConnectionConfig | void> {
+    let logCtx: LogContextOrigin | undefined = undefined;
+
+    updatedConnectionConfig = null;
+
+    const { provider: providerName, unique_key: providerConfigKey } = config;
+    const provider = getProvider(providerName);
+    const handler = getHandler({
+        provider,
+        providerScriptPropertyName: 'pre_connection_creation_script',
+        handlers
+    });
+
+    const connection: DBConnectionDecrypted = {
+        id: -1,
+        end_user_id: null,
+        provider_config_key: providerConfigKey,
+        connection_id: connectionId,
+        credentials: {},
+        connection_config: connectionConfig,
+        environment_id: environment.id,
+        created_at: new Date(),
+        updated_at: new Date(),
+        config_id: -1,
+        credentials_iv: null,
+        credentials_tag: null,
+        deleted: false,
+        deleted_at: null,
+        last_fetched_at: null,
+        metadata: null,
+        credentials_expires_at: null,
+        last_refresh_failure: null,
+        last_refresh_success: null,
+        refresh_attempts: null,
+        refresh_exhausted: false
+    };
+
+    try {
+        if (handler) {
+            logCtx = await logContextGetter.create(
+                { operation: { type: 'events', action: 'post_connection_creation' } },
+                {
+                    account,
+                    environment,
+                    integration: { id: connection.config_id, name: connection.provider_config_key, provider: providerName },
+                    connection: { id: connection.id, name: connection.connection_id }
+                }
+            );
+
+            const baseInternalNango = getInternalNango(connection, providerName);
+
+            const internalNango = {
+                getConnection: baseInternalNango.getConnection,
+                proxy: baseInternalNango.proxy,
+                updateConnectionConfig: (config: ConnectionConfig) => {
+                    updatedConnectionConfig = config;
+                    return Promise.resolve(config);
+                },
+                unsetConnectionConfigAttributes: (...keys: string[]) => {
+                    const currentConfig = updatedConnectionConfig || connection.connection_config;
+                    const updatedConfig = Object.fromEntries(Object.entries(currentConfig).filter(([key]) => !keys.includes(key)));
+
+                    updatedConnectionConfig = updatedConfig;
+                    return Promise.resolve(updatedConfig);
+                }
+            };
+
+            await handler(internalNango);
+            void logCtx.info(`pre-connection-creation script succeeded`);
+            await logCtx.success();
+            metrics.increment(metrics.Types.PRE_CONNECTION__CREATION_SUCCESS);
+
+            return updatedConnectionConfig ?? undefined;
+        }
+
+        return undefined;
+    } catch (err) {
+        metrics.increment(metrics.Types.PRE_CONNECTION__CREATION_FAILURE);
+        void logCtx?.error('pre-connection-creation script failed', { error: err });
+        await logCtx?.failed();
+    }
+}
+
+export default execute;

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -98,7 +98,7 @@ export const connectionPreCreation = async (
         return Ok(undefined);
     } catch (err) {
         void logCtx.error('Pre Connection creation failed');
-        return Err(new Error('pre_connection_creation_failed', { err }));
+        return Err(new Error('pre_connection_creation_failed', { cause: err }));
     }
 };
 

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -88,7 +88,7 @@ export const connectionPreCreation = async (
     logCtx: LogContextStateless,
     account: DBTeam,
     environment: DBEnvironment
-): Promise<Result<ConnectionConfig | void, NangoError>> => {
+): Promise<Result<ConnectionConfig | void>> => {
     try {
         if (provider.pre_connection_creation_script) {
             void logCtx.info('Running pre-connection creation script');
@@ -98,7 +98,7 @@ export const connectionPreCreation = async (
         return Ok(undefined);
     } catch (err) {
         void logCtx.error('Pre Connection creation failed');
-        return Err(new NangoError('pre_connection_creation_failed', { err }));
+        return Err(new Error('pre_connection_creation_failed', { err }));
     }
 };
 

--- a/packages/shared/lib/utils/utils.ts
+++ b/packages/shared/lib/utils/utils.ts
@@ -391,7 +391,7 @@ export function encodeParameters(params: Record<string, any>): Record<string, st
 export function getConnectionMetadata(
     params: any,
     provider: Provider,
-    metadataField: 'webhook_response_metadata' | 'token_response_metadata'
+    metadataField: 'webhook_response_metadata' | 'token_response_metadata' | 'refresh_token_response_metadata'
 ): Record<string, any> {
     if (!params || !provider[metadataField]) {
         return {};

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -40,7 +40,7 @@ export interface OperationAction {
 
 export interface OperationOnEvents {
     type: 'events';
-    action: 'post_connection_creation' | 'pre_connection_deletion' | 'validate_connection';
+    action: 'post_connection_creation' | 'pre_connection_deletion' | 'validate_connection' | 'pre_connection_creation';
 }
 
 // TODO: rename to OperationConnection

--- a/packages/types/lib/providers/provider.ts
+++ b/packages/types/lib/providers/provider.ts
@@ -75,6 +75,7 @@ export interface BaseProvider {
     authorization_url_replacements?: Record<string, string>;
     redirect_uri_metadata?: string[];
     token_response_metadata?: string[];
+    refresh_token_response_metadata?: string[];
     webhook_response_metadata?: string[];
     authorization_code_param_in_webhook?: string;
     docs: string;
@@ -83,6 +84,7 @@ export interface BaseProvider {
     webhook_routing_script?: string;
     webhook_user_defined_secret?: boolean;
     post_connection_script?: string;
+    pre_connection_creation_script?: string;
     pre_connection_deletion_script?: string;
     credentials_verification_script?: string;
     categories?: string[];

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -40,6 +40,8 @@ export enum Types {
     POST_CONNECTION_FAILURE = 'nango.postConnection.failure',
     PRE_CONNECTION_DELETION_SUCCESS = 'nango.preConnectionDeletion.success',
     PRE_CONNECTION_DELETION_FAILURE = 'nango.preConnectionDeletion.failure',
+    PRE_CONNECTION__CREATION_SUCCESS = 'nango.preConnectionCreation.success',
+    PRE_CONNECTION__CREATION_FAILURE = 'nango.preConnectionCreation.failure',
 
     PROXY = 'nango.server.proxyCall',
     PROXY_SUCCESS = 'nango.server.proxy.success',

--- a/packages/webapp/src/pages/Logs/constants.tsx
+++ b/packages/webapp/src/pages/Logs/constants.tsx
@@ -151,6 +151,7 @@ export const typesList = Object.keys({
     'deploy:custom': null,
     'deploy:prebuilt': null,
     'events:post_connection_creation': null,
+    'events:pre_connection_creation': null,
     'events:pre_connection_deletion': null,
     'events:validate_connection': null,
     'proxy:call': null,


### PR DESCRIPTION
## Describe the problem and your solution

- Add `pre-connection-creation` script. Bullhorn requires us to run a `pre-connection-creation` script before starting the OAuth flow. This script obtains the OAuth URL, which we then add to the `connectionConfig` to proceed with the OAuth flow.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Pre-Connection-Creation Script Support to OAuth Provider Flow**

This PR introduces a new mechanism for executing a `pre-connection-creation` script during the OAuth authorization flow. The script allows providers (such as Bullhorn) to execute custom logic and configure dynamic values (like the OAuth URL) before proceeding with the standard OAuth process. The implementation involves additions and changes throughout the backend controller, hook infrastructure, provider type definitions, logging/telemetry pipelines, metadata extraction, connection refresh handling, and developer UI constants, ensuring the new pre-connection step is first-class and integrated end-to-end.

<details>
<summary><strong>Key Changes</strong></summary>

• Extended the `Provider` type in `packages/types/lib/providers/provider.ts` to include a new `pre_connection_creation_script` property and `refresh_token_response_metadata`.
• Implemented new handler and execution logic for pre-connection-creation scripts in `packages/server/lib/hooks/connection/pre-connection-creation.ts`.
• Added `connectionPreCreation` hook to `packages/server/lib/hooks/hooks.ts`, integrating script execution into the OAuth flow.
• Modified the main OAuth controller (`packages/server/lib/controllers/oauth.controller.ts`) to invoke the pre-connection script before the OAuth session starts and update `connectionConfig` accordingly.
• Refactored `getHandler` in `packages/server/lib/hooks/connection/internal-nango.ts` to dispatch pre-connection script handlers.
• Expanded log operation definitions in `packages/types/lib/logs/messages.ts` and operation-to-message logic in `packages/logs/lib/models/helpers.ts` to track new hook/action.
• Added new telemetry metrics (`PRE_CONNECTION__CREATION_SUCCESS`, `PRE_CONNECTION__CREATION_FAILURE`) in `packages/utils/lib/telemetry/metrics.ts` and instrumented them in relevant paths.
• Extended metadata extraction logic in `packages/shared/lib/utils/utils.ts` and connection refresh logic in `packages/shared/lib/services/connections/credentials/refresh.ts` to support new metadata fields.
• Updated UI constants in `packages/webapp/src/pages/Logs/constants.tsx` so log events related to pre-connection creation are properly labeled and filterable.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/oauth.controller.ts`
• `packages/server/lib/hooks/connection/pre-connection-creation.ts`
• `packages/server/lib/hooks/connection/internal-nango.ts`
• `packages/server/lib/hooks/hooks.ts`
• `packages/types/lib/providers/provider.ts`
• `packages/types/lib/logs/messages.ts`
• `packages/logs/lib/models/helpers.ts`
• `packages/shared/lib/utils/utils.ts`
• `packages/shared/lib/services/connections/credentials/refresh.ts`
• `packages/utils/lib/telemetry/metrics.ts`
• `packages/webapp/src/pages/Logs/constants.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*