### PR TITLE
fix: set helm chart version to 1.1.5

### DIFF
--- a/.github/workflows/managed-release.yaml
+++ b/.github/workflows/managed-release.yaml
@@ -112,7 +112,7 @@ jobs:
                   echo "commit_hash: ${{ inputs.commit_hash }}"
 
                   # Debug: Show the exact command
-                  HELM_CMD="helm upgrade --install nango nangohq/nango --namespace nango --create-namespace --set shared.namespace=nango --set shared.tag=\"${{ inputs.commit_hash }}\" --set shared.encryptionEnabled=true --set shared.NANGO_SERVER_URL=\"http://localhost:3003\" --set shared.NANGO_CALLBACK_URL=\"http://localhost:3003/oauth/callback\" --set shared.NANGO_LOGS_ENABLED=false --set server.useLoadBalancer=false --set server.RECORDS_DATABASE_SSL=false --set elasticsearch.enabled=false --set postgresql.auth.postgresPassword=nango123 --wait=false"
+                  HELM_CMD="helm upgrade --install nango nangohq/nango --version 1.1.5 --namespace nango --create-namespace --set shared.namespace=nango --set shared.tag=\"${{ inputs.commit_hash }}\" --set shared.encryptionEnabled=true --set shared.NANGO_SERVER_URL=\"http://localhost:3003\" --set shared.NANGO_CALLBACK_URL=\"http://localhost:3003/oauth/callback\" --set shared.NANGO_LOGS_ENABLED=false --set server.useLoadBalancer=false --set server.RECORDS_DATABASE_SSL=false --set elasticsearch.enabled=false --set postgresql.auth.postgresPassword=nango123 --wait=false"
                   echo "Executing: $HELM_CMD"
 
                   # Execute the command


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Pin Helm Chart Version to 1.1.5 in Managed Release Workflow**

This pull request updates the GitHub Actions workflow file `.github/workflows/managed-release.yaml` to pin the Helm chart used in the managed release workflow to version `1.1.5`. The `helm upgrade --install` command is explicitly provided a `--version 1.1.5` argument, ensuring that the release workflow uses a specific, known chart version. No other changes to workflow logic, deployment settings, or infrastructure are introduced.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `--version 1.1.5` to the `helm upgrade --install` command in `.github/workflows/managed-release.yaml`
• Ensures deterministic deployment behavior for the managed release process

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• .github/workflows/managed-release.yaml

</details>

---
*This summary was automatically generated by @propel-code-bot*