### PR TITLE
fix: allow longer oauth tokens when importing connection

### DIFF
--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -97,8 +97,8 @@ export const sharedCredentialsSchema = z
     .strict();
 
 export const connectionCredentialsOauth2Schema = z.strictObject({
-    access_token: z.string().min(1).max(2048),
-    refresh_token: z.string().min(1).max(2048).optional(),
+    access_token: z.string().min(1).max(4096),
+    refresh_token: z.string().min(1).max(4096).optional(),
     expires_at: z.coerce.date().optional(),
     config_override: z
         .strictObject({


### PR DESCRIPTION
Allowing longer oauth tokens when importing a connection.
Jira access_token are 2.4K chars long for example

