### PR TITLE
feat: ConnectUI settings rework

### DIFF
--- a/packages/connect-ui/src/components/Layout.tsx
+++ b/packages/connect-ui/src/components/Layout.tsx
@@ -9,7 +9,7 @@ import NangoLogoSVG from '@/svg/logo.svg?react';
 export const Layout: React.FC = () => {
     const ref = useRef<HTMLDivElement>(null);
 
-    const { isEmbedded } = useGlobal();
+    const { isEmbedded, showWatermark } = useGlobal();
 
     useClickAway(ref, () => {
         triggerClose('click:outside');
@@ -22,22 +22,24 @@ export const Layout: React.FC = () => {
     if (isEmbedded) {
         return (
             <div ref={ref} className="h-screen w-screen flex flex-col max-w-[500px] max-h-[700px] rounded-md bg-elevated p-px">
-                <div className="flex-1 w-full bg-surface text-text-primary rounded-md rounded-b-none overflow-y-scroll">
+                <div className="flex-1 w-full bg-surface text-text-primary rounded-md -only:rounded-b-none overflow-y-scroll">
                     <div className="min-h-full overflow-auto p-10 flex flex-col">
                         <Outlet />
                     </div>
                 </div>
-                <div className="p-5 w-full text-center">
-                    <a
-                        className="shrink-0 text-xs text-text-tertiary"
-                        href="https://www.nango.dev?utm_source=connectui"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                    >
-                        Secured by
-                        <NangoLogoSVG className="h-4 w-auto inline-block ml-2" />
-                    </a>
-                </div>
+                {showWatermark && (
+                    <div className="p-5 w-full text-center">
+                        <a
+                            className="shrink-0 text-xs text-text-tertiary"
+                            href="https://www.nango.dev?utm_source=connectui"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                        >
+                            Secured by
+                            <NangoLogoSVG className="h-4 w-auto inline-block ml-2" />
+                        </a>
+                    </div>
+                )}
             </div>
         );
     }
@@ -45,22 +47,24 @@ export const Layout: React.FC = () => {
     return (
         <div className="absolute h-screen w-screen overflow-hidden flex flex-col justify-center items-center p-14 bg-subtle/80">
             <div ref={ref} className="flex flex-col w-[500px] h-[700px] rounded-md bg-elevated p-px">
-                <div className="flex-1 w-full bg-surface text-text-primary rounded-md rounded-b-none overflow-y-scroll">
+                <div className="flex-1 w-full bg-surface text-text-primary rounded-md -only:rounded-b-none overflow-y-scroll">
                     <div className="min-h-full overflow-auto p-10 flex flex-col">
                         <Outlet />
                     </div>
                 </div>
-                <div className="p-5 w-full text-center">
-                    <a
-                        className="shrink-0 text-xs text-text-tertiary"
-                        href="https://www.nango.dev?utm_source=connectui"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                    >
-                        Secured by
-                        <NangoLogoSVG className="h-4 w-auto inline-block ml-2" />
-                    </a>
-                </div>
+                {showWatermark && (
+                    <div className="p-5 w-full text-center">
+                        <a
+                            className="shrink-0 text-xs text-text-tertiary"
+                            href="https://www.nango.dev?utm_source=connectui"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                        >
+                            Secured by
+                            <NangoLogoSVG className="h-4 w-auto inline-block ml-2" />
+                        </a>
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/packages/connect-ui/src/lib/store.ts
+++ b/packages/connect-ui/src/lib/store.ts
@@ -15,6 +15,7 @@ interface State {
     detectClosedAuthWindow: boolean;
     isEmbedded: boolean;
     isPreview: boolean;
+    showWatermark: boolean;
     setApiURL: (value: string) => void;
     setDetectClosedAuthWindow: (value: boolean) => void;
     setIsEmbedded: (value: boolean) => void;
@@ -24,6 +25,7 @@ interface State {
     setNango: (value: Nango) => void;
     setIsDirty: (value: boolean) => void;
     setIsSingleIntegration: (value: boolean) => void;
+    setShowWatermark: (value: boolean) => void;
     set: (provider: GetPublicProvider['Success']['data'], integration: GetPublicIntegration['Success']['data']) => void;
     reset: () => void;
 }
@@ -40,6 +42,7 @@ export const useGlobal = create<State>((set) => ({
     isEmbedded: false,
     detectClosedAuthWindow: false,
     isPreview: false,
+    showWatermark: false,
     setApiURL: (value) => set({ apiURL: value }),
     setIsEmbedded: (value) => set({ isEmbedded: value }),
     setDetectClosedAuthWindow: (value) => set({ detectClosedAuthWindow: value }),
@@ -49,6 +52,7 @@ export const useGlobal = create<State>((set) => ({
     setNango: (value) => set({ nango: value }),
     setIsDirty: (value) => set({ isDirty: value }),
     setIsSingleIntegration: (value) => set({ isSingleIntegration: value }),
+    setShowWatermark: (value) => set({ showWatermark: value }),
     set: (provider, integration) => {
         set({ provider, integration });
     },

--- a/packages/connect-ui/src/lib/theme.ts
+++ b/packages/connect-ui/src/lib/theme.ts
@@ -4,10 +4,6 @@ export function setTheme(theme: ConnectUIThemeSettings) {
     return;
     const root = document.documentElement;
 
-    root.style.setProperty('--color-background-surface', theme.light.backgroundSurface);
-    root.style.setProperty('--color-background-elevated', theme.light.backgroundElevated);
-    root.style.setProperty('--color-primary', theme.light.primary);
-    root.style.setProperty('--color-on-primary', theme.light.onPrimary);
-    root.style.setProperty('--color-text-primary', theme.light.textPrimary);
-    root.style.setProperty('--color-text-secondary', theme.light.textSecondary);
+    root.style.setProperty('--color-primary', theme.light.buttonBackground);
+    root.style.setProperty('--color-primary-foreground', theme.light.buttonText);
 }

--- a/packages/connect-ui/src/lib/theme.ts
+++ b/packages/connect-ui/src/lib/theme.ts
@@ -3,6 +3,57 @@ import type { ConnectUIThemeSettings } from '@nangohq/types';
 export function setTheme(theme: ConnectUIThemeSettings) {
     const root = document.documentElement;
 
-    root.style.setProperty('--color-primary', theme.light.buttonBackground);
-    root.style.setProperty('--color-on-primary', theme.light.buttonText);
+    const primary = theme.light.primary;
+    if (!primary) {
+        return;
+    }
+
+    root.style.setProperty('--color-primary', primary);
+
+    const brandHex = cssColorToHex(primary);
+    root.style.setProperty('--color-on-primary', hexColorIsDark(brandHex) ? '#ffffff' : '#000000');
+}
+
+/**
+ * Converts any CSS color (hex, rgb, hsl, named colors, etc.) to hex format
+ * @param cssColor - Any valid CSS color string
+ * @returns Hex color string (e.g., "red" -> "#ff0000")
+ */
+function cssColorToHex(cssColor: string): string {
+    if (cssColor.startsWith('#')) {
+        return cssColor;
+    }
+
+    // Create a temporary element to leverage browser's color parsing
+    const tempElement = document.createElement('div');
+    tempElement.style.color = cssColor;
+    document.body.appendChild(tempElement);
+
+    // Get the computed color value
+    const computedColor = window.getComputedStyle(tempElement).color;
+
+    // Clean up
+    document.body.removeChild(tempElement);
+
+    // Convert rgb(r,g,b) to hex
+    const rgbMatch = computedColor.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+    if (rgbMatch) {
+        const r = parseInt(rgbMatch[1], 10);
+        const g = parseInt(rgbMatch[2], 10);
+        const b = parseInt(rgbMatch[3], 10);
+        return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+    }
+
+    // Fallback: return the original color if parsing fails
+    return cssColor;
+}
+
+// From: https://stackoverflow.com/a/41491220
+
+function hexColorIsDark(bgColor: string) {
+    const color = bgColor.charAt(0) === '#' ? bgColor.substring(1, 7) : bgColor;
+    const r = parseInt(color.substring(0, 2), 16); // hexToR
+    const g = parseInt(color.substring(2, 4), 16); // hexToG
+    const b = parseInt(color.substring(4, 6), 16); // hexToB
+    return r * 0.299 + g * 0.587 + b * 0.114 <= 186;
 }

--- a/packages/connect-ui/src/lib/theme.ts
+++ b/packages/connect-ui/src/lib/theme.ts
@@ -1,9 +1,8 @@
 import type { ConnectUIThemeSettings } from '@nangohq/types';
 
 export function setTheme(theme: ConnectUIThemeSettings) {
-    return;
     const root = document.documentElement;
 
     root.style.setProperty('--color-primary', theme.light.buttonBackground);
-    root.style.setProperty('--color-primary-foreground', theme.light.buttonText);
+    root.style.setProperty('--color-on-primary', theme.light.buttonText);
 }

--- a/packages/connect-ui/src/lib/updateSettings.ts
+++ b/packages/connect-ui/src/lib/updateSettings.ts
@@ -1,0 +1,9 @@
+import { useGlobal } from './store';
+import { setTheme } from './theme';
+
+import type { ConnectUISettings } from '@nangohq/types';
+
+export function updateSettings(settings: ConnectUISettings) {
+    setTheme(settings.theme);
+    useGlobal.getState().setShowWatermark(settings.showWatermark);
+}

--- a/packages/connect-ui/src/views/Home.tsx
+++ b/packages/connect-ui/src/views/Home.tsx
@@ -9,7 +9,7 @@ import { getConnectSession } from '@/lib/api';
 import { triggerReady } from '@/lib/events';
 import { useGlobal } from '@/lib/store';
 import { telemetry } from '@/lib/telemetry';
-import { setTheme } from '@/lib/theme';
+import { updateSettings } from '@/lib/updateSettings';
 
 import type { ConnectUIEventSettingsChanged, ConnectUIEventToken } from '@nangohq/frontend';
 
@@ -42,7 +42,7 @@ export const Home: React.FC = () => {
                         break;
                     }
                     const data = evt.data as ConnectUIEventSettingsChanged;
-                    setTheme(data.payload.theme);
+                    updateSettings(data.payload);
                     break;
                 }
             }
@@ -81,7 +81,7 @@ export const Home: React.FC = () => {
     useEffect(() => {
         if (data) {
             setSession(data.data);
-            setTheme(data.data.connectUISettings.theme);
+            updateSettings(data.data.connectUISettings);
             void navigate({ to: '/integrations' });
         }
     }, [data]);

--- a/packages/server/lib/controllers/connect/getSession.integration.test.ts
+++ b/packages/server/lib/controllers/connect/getSession.integration.test.ts
@@ -101,20 +101,12 @@ describe(`GET ${endpoint}`, () => {
             showWatermark: true,
             theme: {
                 light: {
-                    backgroundSurface: '#ffffff',
-                    backgroundElevated: '#ffffff',
-                    primary: '#ffffff',
-                    onPrimary: '#ffffff',
-                    textPrimary: '#ffffff',
-                    textSecondary: '#ffffff'
+                    buttonBackground: '#ffffff',
+                    buttonText: '#ffffff'
                 },
                 dark: {
-                    backgroundSurface: '#000000',
-                    backgroundElevated: '#000000',
-                    primary: '#000000',
-                    onPrimary: '#000000',
-                    textPrimary: '#000000',
-                    textSecondary: '#000000'
+                    buttonBackground: '#000000',
+                    buttonText: '#000000'
                 }
             }
         };

--- a/packages/server/lib/controllers/connect/getSession.integration.test.ts
+++ b/packages/server/lib/controllers/connect/getSession.integration.test.ts
@@ -101,12 +101,10 @@ describe(`GET ${endpoint}`, () => {
             showWatermark: true,
             theme: {
                 light: {
-                    buttonBackground: '#ffffff',
-                    buttonText: '#ffffff'
+                    primary: '#ffffff'
                 },
                 dark: {
-                    buttonBackground: '#000000',
-                    buttonText: '#000000'
+                    primary: '#000000'
                 }
             }
         };

--- a/packages/server/lib/controllers/v1/connectUISettings/getConnectUISettings.integration.test.ts
+++ b/packages/server/lib/controllers/v1/connectUISettings/getConnectUISettings.integration.test.ts
@@ -15,20 +15,12 @@ function getCustomSettings(): ConnectUISettings {
         showWatermark: false,
         theme: {
             light: {
-                backgroundSurface: '#eeeeee',
-                backgroundElevated: '#eeeeee',
-                primary: '#eeeeee',
-                onPrimary: '#eeeeee',
-                textPrimary: '#eeeeee',
-                textSecondary: '#eeeeee'
+                buttonBackground: '#eeeeee',
+                buttonText: '#eeeeee'
             },
             dark: {
-                backgroundSurface: '#111111',
-                backgroundElevated: '#111111',
-                primary: '#111111',
-                onPrimary: '#111111',
-                textPrimary: '#111111',
-                textSecondary: '#111111'
+                buttonBackground: '#111111',
+                buttonText: '#111111'
             }
         }
     };

--- a/packages/server/lib/controllers/v1/connectUISettings/getConnectUISettings.integration.test.ts
+++ b/packages/server/lib/controllers/v1/connectUISettings/getConnectUISettings.integration.test.ts
@@ -15,12 +15,10 @@ function getCustomSettings(): ConnectUISettings {
         showWatermark: false,
         theme: {
             light: {
-                buttonBackground: '#eeeeee',
-                buttonText: '#eeeeee'
+                primary: '#eeeeee'
             },
             dark: {
-                buttonBackground: '#111111',
-                buttonText: '#111111'
+                primary: '#111111'
             }
         }
     };

--- a/packages/server/lib/controllers/v1/connectUISettings/putConnectUISettings.integration.test.ts
+++ b/packages/server/lib/controllers/v1/connectUISettings/putConnectUISettings.integration.test.ts
@@ -15,20 +15,12 @@ function getCustomSettings(): ConnectUISettings {
         showWatermark: false,
         theme: {
             light: {
-                backgroundSurface: '#eeeeee',
-                backgroundElevated: '#eeeeee',
-                primary: '#eeeeee',
-                onPrimary: '#eeeeee',
-                textPrimary: '#eeeeee',
-                textSecondary: '#eeeeee'
+                buttonBackground: '#eeeeee',
+                buttonText: '#eeeeee'
             },
             dark: {
-                backgroundSurface: '#111111',
-                backgroundElevated: '#111111',
-                primary: '#111111',
-                onPrimary: '#111111',
-                textPrimary: '#111111',
-                textSecondary: '#111111'
+                buttonBackground: '#111111',
+                buttonText: '#111111'
             }
         }
     };
@@ -109,24 +101,16 @@ describe(`PUT ${route}`, () => {
         await connectUISettingsService.upsertConnectUISettings(db.knex, env.id, initialSettings);
 
         // Update the settings
-        const updatedSettings = {
+        const updatedSettings: ConnectUISettings = {
             showWatermark: false,
             theme: {
                 light: {
-                    backgroundSurface: '#dddddd',
-                    backgroundElevated: '#dddddd',
-                    primary: '#dddddd',
-                    onPrimary: '#dddddd',
-                    textPrimary: '#dddddd',
-                    textSecondary: '#dddddd'
+                    buttonBackground: '#dddddd',
+                    buttonText: '#dddddd'
                 },
                 dark: {
-                    backgroundSurface: '#222222',
-                    backgroundElevated: '#222222',
-                    primary: '#222222',
-                    onPrimary: '#222222',
-                    textPrimary: '#222222',
-                    textSecondary: '#222222'
+                    buttonBackground: '#222222',
+                    buttonText: '#222222'
                 }
             }
         };
@@ -188,20 +172,12 @@ describe(`PUT ${route}`, () => {
             // Missing showWatermark
             theme: {
                 light: {
-                    backgroundSurface: '#eeeeee',
-                    backgroundElevated: '#eeeeee',
-                    primary: '#eeeeee',
-                    onPrimary: '#eeeeee',
-                    textPrimary: '#eeeeee'
-                    // Missing textMuted
+                    buttonBackground: '#eeeeee'
+                    // Missing buttonText
                 },
                 dark: {
-                    // Missing textMuted
-                    backgroundElevated: '#111111',
-                    primary: '#111111',
-                    onPrimary: '#111111',
-                    textPrimary: '#111111',
-                    textSecondary: '#111111'
+                    // Missing buttonBackground
+                    buttonText: '#111111'
                 }
             }
         } as ConnectUISettings;
@@ -222,12 +198,12 @@ describe(`PUT ${route}`, () => {
                     {
                         code: 'invalid_type',
                         message: 'Invalid input: expected string, received undefined',
-                        path: ['theme', 'light', 'textSecondary']
+                        path: ['theme', 'light', 'buttonText']
                     },
                     {
                         code: 'invalid_type',
                         message: 'Invalid input: expected string, received undefined',
-                        path: ['theme', 'dark', 'backgroundSurface']
+                        path: ['theme', 'dark', 'buttonBackground']
                     },
                     {
                         code: 'invalid_type',

--- a/packages/server/lib/controllers/v1/connectUISettings/putConnectUISettings.integration.test.ts
+++ b/packages/server/lib/controllers/v1/connectUISettings/putConnectUISettings.integration.test.ts
@@ -15,12 +15,10 @@ function getCustomSettings(): ConnectUISettings {
         showWatermark: false,
         theme: {
             light: {
-                buttonBackground: '#eeeeee',
-                buttonText: '#eeeeee'
+                primary: '#eeeeee'
             },
             dark: {
-                buttonBackground: '#111111',
-                buttonText: '#111111'
+                primary: '#111111'
             }
         }
     };
@@ -105,12 +103,10 @@ describe(`PUT ${route}`, () => {
             showWatermark: false,
             theme: {
                 light: {
-                    buttonBackground: '#dddddd',
-                    buttonText: '#dddddd'
+                    primary: '#dddddd'
                 },
                 dark: {
-                    buttonBackground: '#222222',
-                    buttonText: '#222222'
+                    primary: '#222222'
                 }
             }
         };
@@ -172,12 +168,10 @@ describe(`PUT ${route}`, () => {
             // Missing showWatermark
             theme: {
                 light: {
-                    buttonBackground: '#eeeeee'
-                    // Missing buttonText
+                    // Missing primary
                 },
                 dark: {
-                    // Missing buttonBackground
-                    buttonText: '#111111'
+                    // Missing primary
                 }
             }
         } as ConnectUISettings;
@@ -198,12 +192,12 @@ describe(`PUT ${route}`, () => {
                     {
                         code: 'invalid_type',
                         message: 'Invalid input: expected string, received undefined',
-                        path: ['theme', 'light', 'buttonText']
+                        path: ['theme', 'light', 'primary']
                     },
                     {
                         code: 'invalid_type',
                         message: 'Invalid input: expected string, received undefined',
-                        path: ['theme', 'dark', 'buttonBackground']
+                        path: ['theme', 'dark', 'primary']
                     },
                     {
                         code: 'invalid_type',

--- a/packages/server/lib/controllers/v1/connectUISettings/putConnectUISettings.ts
+++ b/packages/server/lib/controllers/v1/connectUISettings/putConnectUISettings.ts
@@ -9,8 +9,7 @@ import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import type { ConnectUISettings, PutConnectUISettings } from '@nangohq/types';
 
 const colorPaletteSchema = z.strictObject({
-    buttonBackground: z.string(),
-    buttonText: z.string()
+    primary: z.string()
 });
 
 const bodyValidation = z.strictObject({

--- a/packages/server/lib/controllers/v1/connectUISettings/putConnectUISettings.ts
+++ b/packages/server/lib/controllers/v1/connectUISettings/putConnectUISettings.ts
@@ -9,12 +9,8 @@ import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import type { ConnectUISettings, PutConnectUISettings } from '@nangohq/types';
 
 const colorPaletteSchema = z.strictObject({
-    backgroundSurface: z.string(),
-    backgroundElevated: z.string(),
-    primary: z.string(),
-    onPrimary: z.string(),
-    textPrimary: z.string(),
-    textSecondary: z.string()
+    buttonBackground: z.string(),
+    buttonText: z.string()
 });
 
 const bodyValidation = z.strictObject({

--- a/packages/shared/lib/services/connect-ui-settings.service.ts
+++ b/packages/shared/lib/services/connect-ui-settings.service.ts
@@ -7,20 +7,12 @@ export const defaultConnectUISettings: ConnectUISettings = {
     showWatermark: true,
     theme: {
         light: {
-            backgroundSurface: '#ffffff',
-            backgroundElevated: '#f9fafb',
-            primary: '#00b2e3',
-            onPrimary: '#ffffff',
-            textPrimary: '#18191b',
-            textSecondary: '#626366'
+            buttonBackground: '#00B2E3',
+            buttonText: '#ffffff'
         },
         dark: {
-            backgroundSurface: '#0b0b0c',
-            backgroundElevated: '#18191b',
-            primary: '#00b2e3',
-            onPrimary: '#ffffff',
-            textPrimary: '#ffffff',
-            textSecondary: '#8b8c8f'
+            buttonBackground: '#00B2E3',
+            buttonText: '#ffffff'
         }
     }
 };

--- a/packages/shared/lib/services/connect-ui-settings.service.ts
+++ b/packages/shared/lib/services/connect-ui-settings.service.ts
@@ -7,12 +7,10 @@ export const defaultConnectUISettings: ConnectUISettings = {
     showWatermark: true,
     theme: {
         light: {
-            buttonBackground: '#00B2E3',
-            buttonText: '#ffffff'
+            primary: '#00B2E3'
         },
         dark: {
-            buttonBackground: '#00B2E3',
-            buttonText: '#ffffff'
+            primary: '#00B2E3'
         }
     }
 };

--- a/packages/types/lib/connectUISettings/dto.ts
+++ b/packages/types/lib/connectUISettings/dto.ts
@@ -9,10 +9,6 @@ export interface ConnectUIThemeSettings {
 }
 
 export interface ConnectUIColorPalette {
-    backgroundSurface: string;
-    backgroundElevated: string;
-    primary: string;
-    onPrimary: string;
-    textPrimary: string;
-    textSecondary: string;
+    buttonBackground: string;
+    buttonText: string;
 }

--- a/packages/types/lib/connectUISettings/dto.ts
+++ b/packages/types/lib/connectUISettings/dto.ts
@@ -9,6 +9,5 @@ export interface ConnectUIThemeSettings {
 }
 
 export interface ConnectUIColorPalette {
-    buttonBackground: string;
-    buttonText: string;
+    primary: string;
 }

--- a/packages/webapp/src/pages/ConnectUI/Show.tsx
+++ b/packages/webapp/src/pages/ConnectUI/Show.tsx
@@ -6,7 +6,7 @@ import { ColorInput, isValidCSSColor } from './components/ColorInput';
 import { ConnectUIPreview } from './components/ConnectUIPreview';
 import { LeftNavBarItems } from '../../components/LeftNavBar';
 import LinkWithIcon from '../../components/LinkWithIcon';
-import { Checkbox } from '../../components/ui/Checkbox';
+import { Switch } from '../../components/ui/Switch';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../components/ui/Tooltip';
 import { Button } from '../../components/ui/button/Button';
 import { useConnectUISettings, useUpdateConnectUISettings } from '../../hooks/useConnectUISettings';
@@ -25,28 +25,12 @@ type ThemePath = {
 
 const lightThemeFields: { name: ThemePath; label: string }[] = [
     {
-        name: 'theme.light.backgroundSurface',
-        label: 'Background Surface'
+        name: 'theme.light.buttonBackground',
+        label: 'Button Background'
     },
     {
-        name: 'theme.light.backgroundElevated',
-        label: 'Background Elevated'
-    },
-    {
-        name: 'theme.light.primary',
-        label: 'Primary'
-    },
-    {
-        name: 'theme.light.onPrimary',
-        label: 'On Primary'
-    },
-    {
-        name: 'theme.light.textPrimary',
-        label: 'Text Primary'
-    },
-    {
-        name: 'theme.light.textSecondary',
-        label: 'Text Secondary'
+        name: 'theme.light.buttonText',
+        label: 'Button Text'
     }
 ];
 
@@ -77,6 +61,7 @@ export const ConnectUISettingsPage = () => {
                         title: 'Connect UI settings updated',
                         variant: 'success'
                     });
+                    state.formApi.reset();
                 },
                 onError: () => {
                     toast.toast({
@@ -89,41 +74,78 @@ export const ConnectUISettingsPage = () => {
     });
 
     return (
-        <DashboardLayout selectedItem={LeftNavBarItems.ConnectUI} className="p-6 w-full">
+        <DashboardLayout selectedItem={LeftNavBarItems.ConnectUI} className="w-full h-full">
             <Helmet>
                 <title>Connect UI - Nango</title>
             </Helmet>
-            <div className="flex flex-col h-full">
-                <h2 className="mb-8 text-3xl font-semibold tracking-tight text-white">Connect UI Settings</h2>
-                <div className="flex justify-center gap-8">
-                    {/** Form */}
-                    <form
-                        onSubmit={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            void form.handleSubmit();
-                        }}
-                        className="flex flex-col gap-8 mr-24"
-                    >
-                        {/** Other settings */}
-                        <div className="space-y-4">
-                            <h2 className="text-lg font-bold text-grayscale-100">Settings</h2>
-                            <form.Field name="showWatermark">
+            <div className="flex w-full h-full ">
+                <form
+                    onSubmit={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        void form.handleSubmit();
+                    }}
+                    className="w-full flex flex-col gap-10 p-11 border-r border-grayscale-4"
+                >
+                    <h2 className="text-2xl font-bold text-white">Connect UI Settings</h2>
+                    <div className="flex flex-col gap-6">
+                        {lightThemeFields.map((themeField) => (
+                            <form.Field
+                                key={themeField.name}
+                                name={themeField.name}
+                                validators={{
+                                    onChange: ({ value }: { value: string }) => (!isValidCSSColor(value) ? 'Invalid CSS color' : undefined)
+                                }}
+                            >
                                 {(field) => (
+                                    <div className="w-full flex gap-2 justify-between items-center">
+                                        <label htmlFor={themeField.name} className="text-sm font-medium text-grayscale-300">
+                                            {themeField.label}
+                                        </label>
+                                        <Tooltip delayDuration={0}>
+                                            <TooltipTrigger asChild>
+                                                <div className="flex flex-col gap-1">
+                                                    <ColorInput
+                                                        value={field.state.value}
+                                                        onChange={(e) => field.handleChange(e.target.value)}
+                                                        onBlur={field.handleBlur}
+                                                        disabled={!environment.plan?.can_customize_connect_ui_theme}
+                                                    />
+                                                    {!field.state.meta.isValid && (
+                                                        <em role="alert" className="text-sm text-red-500">
+                                                            {field.state.meta.errors.join(', ')}
+                                                        </em>
+                                                    )}
+                                                </div>
+                                            </TooltipTrigger>
+                                            {!environment.plan?.can_customize_connect_ui_theme && (
+                                                <TooltipContent side="bottom" className="text-grayscale-300">
+                                                    Customizing the theme is only available for Growth plans.{' '}
+                                                    <LinkWithIcon to={`/${env}/team/billing`}>Upgrade your plan</LinkWithIcon>
+                                                </TooltipContent>
+                                            )}
+                                        </Tooltip>
+                                    </div>
+                                )}
+                            </form.Field>
+                        ))}
+                        <form.Field name="showWatermark">
+                            {(field) => (
+                                <div className="flex gap-5 items-center">
+                                    <label htmlFor={field.name} className={`text-sm font-medium text-grayscale-300`}>
+                                        Display Nango watermark
+                                    </label>
                                     <Tooltip delayDuration={0}>
                                         <TooltipTrigger asChild>
-                                            <div className="flex gap-2 items-center">
-                                                <Checkbox
+                                            <div className="flex items-center">
+                                                <Switch
                                                     id={field.name}
                                                     name={field.name}
                                                     checked={field.state.value}
-                                                    onCheckedChange={(checked) => field.handleChange(checked === 'indeterminate' ? true : checked)}
+                                                    onCheckedChange={(checked) => field.handleChange(checked)}
                                                     onBlur={field.handleBlur}
                                                     disabled={!environment.plan?.can_disable_connect_ui_watermark}
                                                 />
-                                                <label htmlFor={field.name} className={`text-sm font-medium text-grayscale-300`}>
-                                                    Show watermark
-                                                </label>
                                             </div>
                                         </TooltipTrigger>
                                         {!environment.plan?.can_disable_connect_ui_watermark && (
@@ -133,72 +155,28 @@ export const ConnectUISettingsPage = () => {
                                             </TooltipContent>
                                         )}
                                     </Tooltip>
-                                )}
-                            </form.Field>
-                        </div>
-
-                        {/** Theme */}
-                        <div className="space-y-4">
-                            <h2 className="text-lg font-bold text-grayscale-100">Theme</h2>
-                            <div className="flex gap-8 h-fit">
-                                <div className="flex flex-col gap-4">
-                                    {lightThemeFields.map((themeField) => (
-                                        <Tooltip key={themeField.name} delayDuration={0}>
-                                            <TooltipTrigger asChild>
-                                                <form.Field
-                                                    name={themeField.name}
-                                                    validators={{
-                                                        onChange: ({ value }: { value: string }) => (!isValidCSSColor(value) ? 'Invalid CSS color' : undefined)
-                                                    }}
-                                                >
-                                                    {(field) => (
-                                                        <div className="flex flex-col gap-1">
-                                                            <ColorInput
-                                                                value={field.state.value}
-                                                                label={themeField.label}
-                                                                onChange={(e) => field.handleChange(e.target.value)}
-                                                                onBlur={field.handleBlur}
-                                                                disabled={!environment.plan?.can_customize_connect_ui_theme}
-                                                            />
-                                                            {!field.state.meta.isValid && (
-                                                                <em role="alert" className="text-sm text-red-500">
-                                                                    {field.state.meta.errors.join(', ')}
-                                                                </em>
-                                                            )}
-                                                        </div>
-                                                    )}
-                                                </form.Field>
-                                            </TooltipTrigger>
-                                            {!environment.plan?.can_customize_connect_ui_theme && (
-                                                <TooltipContent side="bottom" className="text-grayscale-300">
-                                                    Customizing the theme is only available for Growth plans.{' '}
-                                                    <LinkWithIcon to={`/${env}/team/billing`}>Upgrade your plan</LinkWithIcon>
-                                                </TooltipContent>
-                                            )}
-                                        </Tooltip>
-                                    ))}
                                 </div>
-                            </div>
-                        </div>
-
-                        {/** Save Button */}
-                        <form.Subscribe selector={(state) => [state.canSubmit, state.isDirty, state.isSubmitting]}>
-                            {([canSubmit, isDirty]) => (
-                                <Button
-                                    type="submit"
-                                    variant="primary"
-                                    size="md"
-                                    className="self-end"
-                                    disabled={!canSubmit || !isDirty || isUpdatingConnectUISettings}
-                                >
-                                    {isUpdatingConnectUISettings ? 'Saving...' : 'Save settings'}
-                                </Button>
                             )}
-                        </form.Subscribe>
-                    </form>
+                        </form.Field>
+                    </div>
 
-                    {/** Preview */}
-                    <ConnectUIPreview ref={connectUIPreviewRef} className="h-auto w-[500px]" />
+                    {/** Save Button */}
+                    <form.Subscribe selector={(state) => [state.canSubmit, state.isDirty, state.isSubmitting]}>
+                        {([canSubmit, isDirty]) => (
+                            <Button
+                                type="submit"
+                                variant="primary"
+                                size="md"
+                                className="self-start"
+                                disabled={!canSubmit || !isDirty || isUpdatingConnectUISettings}
+                            >
+                                {isUpdatingConnectUISettings ? 'Saving...' : 'Save settings'}
+                            </Button>
+                        )}
+                    </form.Subscribe>
+                </form>
+                <div className="w-full h-full p-11 flex justify-center items-center">
+                    <ConnectUIPreview ref={connectUIPreviewRef} className="w-full h-full max-w-[500px] max-h-[700px]" />
                 </div>
             </div>
         </DashboardLayout>

--- a/packages/webapp/src/pages/ConnectUI/Show.tsx
+++ b/packages/webapp/src/pages/ConnectUI/Show.tsx
@@ -164,9 +164,10 @@ export const ConnectUISettingsPage = () => {
                                 variant="primary"
                                 size="md"
                                 className="self-start"
-                                disabled={!canSubmit || !isDirty || isUpdatingConnectUISettings}
+                                disabled={!canSubmit || !isDirty}
+                                isLoading={isUpdatingConnectUISettings}
                             >
-                                {isUpdatingConnectUISettings ? 'Saving...' : 'Save settings'}
+                                Save settings
                             </Button>
                         )}
                     </form.Subscribe>

--- a/packages/webapp/src/pages/ConnectUI/Show.tsx
+++ b/packages/webapp/src/pages/ConnectUI/Show.tsx
@@ -25,12 +25,8 @@ type ThemePath = {
 
 const lightThemeFields: { name: ThemePath; label: string }[] = [
     {
-        name: 'theme.light.buttonBackground',
-        label: 'Button Background'
-    },
-    {
-        name: 'theme.light.buttonText',
-        label: 'Button Text'
+        name: 'theme.light.primary',
+        label: 'Primary color'
     }
 ];
 
@@ -133,7 +129,7 @@ export const ConnectUISettingsPage = () => {
                             {(field) => (
                                 <div className="flex gap-5 items-center">
                                     <label htmlFor={field.name} className={`text-sm font-medium text-grayscale-300`}>
-                                        Display Nango watermark
+                                        Nango watermark
                                     </label>
                                     <Tooltip delayDuration={0}>
                                         <TooltipTrigger asChild>


### PR DESCRIPTION
Plugs customization back in.
We have significantly reduced customization options. We now have:
- Show watermark
- A single "primary" color (only used for the main button)
- The on-primary color (for text over the primary color) is chosen between black or white based on best contrast.

Necessary changes to ConnectUI settings screen to match new settings (removed most colors)

Preview:
<img width="1505" height="803" alt="image" src="https://github.com/user-attachments/assets/c8637d56-1c23-46b5-b0dd-8c5532dfcea1" />

Dark mode coming soon™
<!-- Summary by @propel-code-bot -->

---

**Major Overhaul: ConnectUI Settings Simplification and Centralized Theme Logic**

This PR introduces a large-scale rework of the ConnectUI customization and theming system. It reduces the previous range of settings to only two configurable options: `showWatermark` (boolean) and a single `primary` color, which is used exclusively for the main button. All legacy theme fields and related UI, types, schema validation, service logic, and tests are refactored to enforce these new constraints across the frontend, backend, and shared libraries. The `on-primary` color for button text is now always computed for optimal contrast (black or white) using a new client-side color-contrast algorithm. The update includes wider codebase changes: UI forms, feature gating logic, utility functions, type definitions, API validation, and extensive test coverage have been fully aligned with the new minimal model. Utility logic has been centralized to ensure all theming and watermark updates propagate consistently.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed all former theme color fields (e.g., `backgroundSurface`, `backgroundElevated`, `onPrimary`, `textPrimary`, `textSecondary`) from `ConnectUIColorPalette`, DTOs, and related types.
• Frontend forms in `Show.tsx` updated to allow only the `primary` color and `showWatermark` toggle. Legacy UI elements and plan gating logic adjusted.
• Introduced a new algorithm in `setTheme` to calculate proper `on-primary` (button text) color (black/white) for contrast using a CSS color to hex converter.
• Added new utility function `updateSettings` to centralize application of theme/watermark settings in the ConnectUI client.
• Backend validation schemas, service logic, and default values updated for strictly enforcing the reduced settings contract.
• Extensive refactor or removal of former test cases, seed data, and integration tests to match the new model.
• Consistent watermark rendering in both embedded and standalone layouts, reflecting `showWatermark` updates and plan gating.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/types/lib/connectUISettings/dto.ts` (types, interfaces)
• `packages/webapp/src/pages/ConnectUI/Show.tsx` (settings UI logic, form fields)
• `packages/connect-ui/src/lib/theme.ts` (theme setting, color-contrast logic)
• `packages/connect-ui/src/lib/updateSettings.ts` (new settings propagation utility)
• `packages/connect-ui/src/lib/store.ts` (global state: `showWatermark`)
• `packages/connect-ui/src/components/Layout.tsx` (watermark rendering and cleanup)
• `packages/server/lib/controllers/v1/connectUISettings/putConnectUISettings.ts` (API body schema, endpoint)
• `packages/shared/lib/services/connect-ui-settings.service.ts` (defaults, storage logic)
• Backend and integration tests for ConnectUI settings API

</details>

---
*This summary was automatically generated by @propel-code-bot*