### PR TITLE
docs: change url to platform functions, api spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Sign up for free:
 Our mission is to enable all SaaS to seamlessly integrate together. By being open source, every engineer can contribute improvements to the platform for everyone:
 
 - [Contribute an API](https://docs.nango.dev/guides/api-authorization/new-api-support)
-- [Create a custom integration](https://docs.nango.dev/guides/custom-integrations/overview)
+- [Create a custom integration](https://docs.nango.dev/guides/platform/functions)
 - [Extend an integration template](https://docs.nango.dev/guides/custom-integrations/extend-a-pre-built-integration)
 
 # 📚 Learn more

--- a/docs-v2/snippets/builder-io-public/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/builder-io-public/PreBuiltUseCases.mdx
@@ -2,4 +2,4 @@
 
 _No pre-built integration yet (time to contribute: &lt;48h)_
 
-<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/custom-integrations/overview) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/platform/functions) independently.</Tip>

--- a/docs-v2/snippets/cal-com-v2/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/cal-com-v2/PreBuiltUseCases.mdx
@@ -13,4 +13,4 @@
 
 </AccordionGroup>
 
-<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/custom-integrations/overview) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/platform/functions) independently.</Tip>

--- a/docs-v2/snippets/canva-scim/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/canva-scim/PreBuiltUseCases.mdx
@@ -2,4 +2,4 @@
 
 _No pre-built integration yet (time to contribute: &lt;48h)_
 
-<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/custom-integrations/overview) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/platform/functions) independently.</Tip>

--- a/docs-v2/snippets/generated/check/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/check/PreBuiltUseCases.mdx
@@ -2,4 +2,4 @@
 
 _No pre-built integration yet (time to contribute: &lt;48h)_
 
-<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/custom-integrations/overview) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/platform/functions) independently.</Tip>

--- a/docs-v2/snippets/generated/fillout-api-key/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/fillout-api-key/PreBuiltUseCases.mdx
@@ -2,4 +2,4 @@
 
 _No pre-built integration yet (time to contribute: &lt;48h)_
 
-<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/custom-integrations/overview) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/platform/functions) independently.</Tip>

--- a/docs-v2/snippets/generated/fillout/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/fillout/PreBuiltUseCases.mdx
@@ -2,4 +2,4 @@
 
 _No pre-built integration yet (time to contribute: &lt;48h)_
 
-<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/custom-integrations/overview) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/platform/functions) independently.</Tip>

--- a/docs-v2/snippets/generated/gemini/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/gemini/PreBuiltUseCases.mdx
@@ -2,4 +2,4 @@
 
 _No pre-built integration yet (time to contribute: &lt;48h)_
 
-<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/custom-integrations/overview) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/platform/functions) independently.</Tip>

--- a/docs-v2/snippets/generated/mip-on-premises/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/mip-on-premises/PreBuiltUseCases.mdx
@@ -2,4 +2,4 @@
 
 _No pre-built integration yet (time to contribute: &lt;48h)_
 
-<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/custom-integrations/overview) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/platform/functions) independently.</Tip>

--- a/docs-v2/snippets/generated/mip/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/mip/PreBuiltUseCases.mdx
@@ -2,4 +2,4 @@
 
 _No pre-built integration yet (time to contribute: &lt;48h)_
 
-<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/custom-integrations/overview) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/platform/functions) independently.</Tip>

--- a/docs-v2/snippets/generated/spotify-oauth-cc/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/spotify-oauth-cc/PreBuiltUseCases.mdx
@@ -2,4 +2,4 @@
 
 _No pre-built integration yet (time to contribute: &lt;48h)_
 
-<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/custom-integrations/overview) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/platform/functions) independently.</Tip>

--- a/docs-v2/snippets/generated/tiktok/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/tiktok/PreBuiltUseCases.mdx
@@ -2,4 +2,4 @@
 
 _No pre-built integration yet (time to contribute: &lt;48h)_
 
-<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/custom-integrations/overview) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/platform/functions) independently.</Tip>

--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -796,9 +796,13 @@ paths:
                                           title: GitHub App
                                           additionalProperties: false
                                           required:
+                                              - type
                                               - app_id
                                               - installation_id
                                           properties:
+                                              type:
+                                                  type: string
+                                                  enum: [APP]
                                               app_id:
                                                   type: string
                                               installation_id:

--- a/packages/webapp/src/pages/GettingStarted/ClassicGettingStarted.tsx
+++ b/packages/webapp/src/pages/GettingStarted/ClassicGettingStarted.tsx
@@ -172,7 +172,7 @@ export const ClassicGettingStarted: React.FC = () => {
 
                 <a
                     className="transition-all block border rounded-lg border-grayscale-700 p-7 group hover:border-gray-600 hover:shadow-card"
-                    href="https://docs.nango.dev/guides/custom-integrations/overview"
+                    href="https://docs.nango.dev/guides/platform/functions"
                     onClick={() => analyticsTrack('web:getting_started:custom')}
                     target="_blank"
                     rel="noreferrer"


### PR DESCRIPTION
## Changes


- change url to platform functions
- missing type in github app credentials
 
<!-- Summary by @propel-code-bot -->

---

**Update Documentation URLs and GitHub App Credential Spec**

This pull request updates all references to the custom integrations documentation URL, changing from `/guides/custom-integrations/overview` to the new `/guides/platform/functions` path across various markdown, markdownx, and TypeScript (`tsx`) files. Additionally, it corrects the `docs-v2/spec.yaml` API specification to include a missing required `type` field (with enum `[APP]`) in the definition of GitHub App credentials, ensuring the spec aligns with credential schema requirements.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated documentation links in multiple `.md`, `.mdx`, and `.tsx` files from `https://docs.nango.dev/guides/custom-integrations/overview` to `https://docs.nango.dev/guides/platform/functions`
• Changed the URL for the custom integration guide in the `README.md` file and UI component `packages/webapp/src/pages/GettingStarted/ClassicGettingStarted.tsx`
• In `docs-v2/spec.yaml`, added `type` as a required property for the GitHub App credentials object and defined the `type` field with allowed value `[APP]`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• docs-v2/spec.yaml
• README.md
• packages/webapp/src/pages/GettingStarted/ClassicGettingStarted.tsx
• docs-v2/snippets/*/PreBuiltUseCases.mdx

</details>

---
*This summary was automatically generated by @propel-code-bot*