### PR TITLE
fix(deps): upgrade axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11747,9 +11747,9 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+            "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.6",
@@ -27993,7 +27993,7 @@
                 "@types/unzipper": "0.10.11",
                 "ajv": "8.17.1",
                 "ajv-errors": "3.0.0",
-                "axios": "1.11.0",
+                "axios": "1.12.0",
                 "chalk": "5.4.1",
                 "chokidar": "3.5.3",
                 "columnify": "1.6.0",
@@ -28492,7 +28492,7 @@
                 "@nangohq/shared": "file:../shared",
                 "@nangohq/utils": "file:../utils",
                 "@nangohq/webhooks": "file:../webhooks",
-                "axios": "1.11.0",
+                "axios": "1.12.0",
                 "dd-trace": "5.52.0",
                 "express": "5.1.0",
                 "get-port": "7.1.0",
@@ -28823,7 +28823,7 @@
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@nangohq/types": "0.67.7",
-                "axios": "1.11.0"
+                "axios": "1.12.0"
             },
             "devDependencies": {
                 "tsup": "8.5.0",
@@ -29009,7 +29009,7 @@
                 "@nangohq/utils": "file:../utils",
                 "@trpc/client": "10.45.1",
                 "@trpc/server": "10.45.1",
-                "axios": "1.11.0",
+                "axios": "1.12.0",
                 "botbuilder": "4.23.2",
                 "connect-timeout": "1.9.1",
                 "dd-trace": "5.52.0",
@@ -29043,7 +29043,7 @@
             "devDependencies": {
                 "@nangohq/types": "0.67.7",
                 "@types/json-schema": "7.0.15",
-                "axios": "1.11.0",
+                "axios": "1.12.0",
                 "json-schema": "0.4.0",
                 "vitest": "3.2.4"
             },
@@ -29170,7 +29170,7 @@
                 "@nangohq/utils": "file:../utils",
                 "@nangohq/webhooks": "file:../webhooks",
                 "@workos-inc/node": "6.2.0",
-                "axios": "1.11.0",
+                "axios": "1.12.0",
                 "body-parser": "2.2.0",
                 "connect-session-knex": "4.0.0",
                 "cookie-parser": "1.4.7",
@@ -29320,7 +29320,7 @@
                 "ajv": "8.17.1",
                 "ajv-formats": "3.0.1",
                 "archiver": "7.0.1",
-                "axios": "1.11.0",
+                "axios": "1.12.0",
                 "braintree": "3.15.0",
                 "dd-trace": "5.52.0",
                 "exponential-backoff": "3.1.1",
@@ -29489,7 +29489,7 @@
             "version": "0.67.7",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "axios": "1.11.0",
+                "axios": "1.12.0",
                 "json-schema": "0.4.0",
                 "type-fest": "4.41.0"
             },
@@ -29504,7 +29504,7 @@
             "dependencies": {
                 "@colors/colors": "1.6.0",
                 "@sentry/node": "9.3.0",
-                "axios": "1.11.0",
+                "axios": "1.12.0",
                 "dd-trace": "5.52.0",
                 "exponential-backoff": "3.1.1",
                 "fast-safe-stringify": "2.1.1",
@@ -30098,7 +30098,7 @@
             "dependencies": {
                 "@nangohq/logs": "file:../logs",
                 "@nangohq/utils": "file:../utils",
-                "axios": "1.11.0",
+                "axios": "1.12.0",
                 "dayjs": "1.11.7",
                 "dayjs-plugin-utc": "0.1.2"
             },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,7 @@
         "@types/unzipper": "0.10.11",
         "ajv": "8.17.1",
         "ajv-errors": "3.0.0",
-        "axios": "1.11.0",
+        "axios": "1.12.0",
         "chalk": "5.4.1",
         "chokidar": "3.5.3",
         "columnify": "1.6.0",

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -28,7 +28,7 @@
         "@nangohq/utils": "file:../utils",
         "@nangohq/webhooks": "file:../webhooks",
         "@nangohq/account-usage": "file:../account-usage",
-        "axios": "1.11.0",
+        "axios": "1.12.0",
         "dd-trace": "5.52.0",
         "express": "5.1.0",
         "get-port": "7.1.0",

--- a/packages/node-client/package.json
+++ b/packages/node-client/package.json
@@ -26,7 +26,7 @@
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
         "@nangohq/types": "0.67.7",
-        "axios": "1.11.0"
+        "axios": "1.12.0"
     },
     "engines": {
         "node": ">=20.0"

--- a/packages/runner-sdk/package.json
+++ b/packages/runner-sdk/package.json
@@ -15,7 +15,7 @@
     "devDependencies": {
         "@nangohq/types": "0.67.7",
         "@types/json-schema": "7.0.15",
-        "axios": "1.11.0",
+        "axios": "1.12.0",
         "json-schema": "0.4.0",
         "vitest": "3.2.4"
     },

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -25,7 +25,7 @@
         "@nangohq/utils": "file:../utils",
         "@trpc/client": "10.45.1",
         "@trpc/server": "10.45.1",
-        "axios": "1.11.0",
+        "axios": "1.12.0",
         "botbuilder": "4.23.2",
         "connect-timeout": "1.9.1",
         "dd-trace": "5.52.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,7 +37,7 @@
         "@nangohq/webhooks": "file:../webhooks",
         "@nangohq/pubsub": "file:../pubsub",
         "@workos-inc/node": "6.2.0",
-        "axios": "1.11.0",
+        "axios": "1.12.0",
         "body-parser": "2.2.0",
         "connect-session-knex": "4.0.0",
         "cookie-parser": "1.4.7",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -28,7 +28,7 @@
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
         "archiver": "7.0.1",
-        "axios": "1.11.0",
+        "axios": "1.12.0",
         "braintree": "3.15.0",
         "dd-trace": "5.52.0",
         "exponential-backoff": "3.1.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -12,7 +12,7 @@
         "directory": "packages/utils"
     },
     "dependencies": {
-        "axios": "1.11.0",
+        "axios": "1.12.0",
         "json-schema": "0.4.0",
         "type-fest": "4.41.0"
     },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@colors/colors": "1.6.0",
         "@sentry/node": "9.3.0",
-        "axios": "1.11.0",
+        "axios": "1.12.0",
         "dd-trace": "5.52.0",
         "exponential-backoff": "3.1.1",
         "fast-safe-stringify": "2.1.1",

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@nangohq/logs": "file:../logs",
         "@nangohq/utils": "file:../utils",
-        "axios": "1.11.0",
+        "axios": "1.12.0",
         "dayjs": "1.11.7",
         "dayjs-plugin-utc": "0.1.2"
     },


### PR DESCRIPTION
## Changes

Closes #4654

- Upgrade axios
To fix high vuln (we were not directly impacted but still)
<!-- Summary by @propel-code-bot -->

---

**Upgrade `axios` Dependency to Address Security Advisory**

This pull request updates the `axios` dependency from version `1.11.0` to `1.12.0` across all relevant packages in the repository. The update addresses a high-severity vulnerability reported in the older version, although the project was not directly impacted. The changes are strictly limited to dependency version bumps in multiple `package.json` files and to synchronizing the `package-lock.json` to ensure consistency across the monorepo.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `axios` version from `1.11.0` to `1.12.0` in all affected `package.json` files (`cli`, `node-client`, `types`, `webhooks`, `jobs`, `runner-sdk`, `runner`, `server`, `shared`, `utils`)
• Updated all instances of `axios` in top-level `package-lock.json` to `1.12.0`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/cli/package.json`
• `packages/node-client/package.json`
• `packages/types/package.json`
• `packages/webhooks/package.json`
• `packages/jobs/package.json`
• `packages/runner-sdk/package.json`
• `packages/runner/package.json`
• `packages/server/package.json`
• `packages/shared/package.json`
• `packages/utils/package.json`
• `package-lock.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*