### PR TITLE
fix(api): finish end user migration

### DIFF
--- a/packages/logs/lib/models/logContextGetter.ts
+++ b/packages/logs/lib/models/logContextGetter.ts
@@ -31,7 +31,6 @@ export const logContextGetter = {
 
         try {
             if (envs.NANGO_LOGS_ENABLED && !options?.dryRun) {
-                // TODO: remove this after full deploy
                 await createOperation(msg);
             } else if (options?.logToConsole !== false) {
                 logger.info(`[debug] operation(${JSON.stringify(msg)})`);

--- a/packages/scheduler/lib/db/migrations/20240604135056_schedules_model.ts
+++ b/packages/scheduler/lib/db/migrations/20240604135056_schedules_model.ts
@@ -29,7 +29,6 @@ export async function up(knex: Knex): Promise<void> {
             ALTER TABLE ${TASKS_TABLE}
             ADD COLUMN IF NOT EXISTS schedule_id uuid REFERENCES ${SCHEDULES_TABLE}(id) ON DELETE CASCADE;
         `);
-        // TODO: add indexes
     });
 }
 

--- a/packages/server/lib/controllers/connection/getConnections.ts
+++ b/packages/server/lib/controllers/connection/getConnections.ts
@@ -41,7 +41,6 @@ export const getPublicConnections = asyncWrapper<GetPublicConnections>(async (re
 
     res.status(200).send({
         connections: connections.map((data) => {
-            // TODO: return end_user
             return connectionSimpleToPublicApi({
                 data: data.connection,
                 activeLog: data.active_logs,

--- a/packages/types/lib/connect/session.ts
+++ b/packages/types/lib/connect/session.ts
@@ -2,9 +2,6 @@ import type { InternalEndUser } from '../endUser/index.js';
 
 export interface ConnectSession {
     readonly id: number;
-    /**
-     * @deprecated use endUser instead
-     */
     readonly endUserId: number | null;
     readonly accountId: number;
     readonly environmentId: number;


### PR DESCRIPTION
## Changes

- Finish end-user migration
Turns out endUserId is still needed because endUser is optional in the reconnect endpoint. 

- Bonus: remove fixed/irrelevant todos

<!-- Summary by @propel-code-bot -->

---

**Finalize End User Migration and Clean Up TODO Comments**

This pull request completes the migration to the new `endUser`-based flow for handling connections, fully deprecating the legacy `endUserId`-first logic in `syncEndUserToConnection` in favor of an `endUser`-centric approach when present. Additionally, the PR cleans up several files by removing now-irrelevant or outdated TODO comments and deprecated JSDoc, and applies minor documentation/comment cleanups across affected modules.

<details>
<summary><strong>Key Changes</strong></summary>

• Refactored `syncEndUserToConnection` in `packages/shared/lib/services/endUser.service.ts` to use only the `endUser` property and remove fallback logic for `endUserId`.
• Removed deprecated JSDoc from `endUserId` in the `ConnectSession` interface in `packages/types/lib/connect/session.ts`.
• Eliminated obsolete TODO comments from `packages/server/lib/controllers/connection/getConnections.ts`, `packages/logs/lib/models/logContextGetter.ts`, and `packages/scheduler/lib/db/migrations/20240604135056_schedules_model.ts`.
• Confirmed that the `endUserId` property remains for optional legacy support in edge cases where `endUser` is not provided.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/services/endUser.service.ts`
• `packages/types/lib/connect/session.ts`
• `packages/server/lib/controllers/connection/getConnections.ts`
• `packages/logs/lib/models/logContextGetter.ts`
• `packages/scheduler/lib/db/migrations/20240604135056_schedules_model.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*