### PR TITLE
fix(github-app-oauth): add more context to error logs

### DIFF
--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -1415,7 +1415,16 @@ class OAuthController {
                     connCreatedHook
                 );
                 if (createRes.isErr()) {
-                    void logCtx.error('Failed to create credentials');
+                    let responseData = null;
+                    const errorWithCause = createRes.error as any;
+                    if (errorWithCause.cause && typeof errorWithCause.cause === 'object' && 'response' in errorWithCause.cause) {
+                        const axiosError = errorWithCause.cause;
+                        responseData = axiosError.response?.data;
+                    }
+
+                    void logCtx.error('Failed to create credentials', {
+                        responseData: responseData ? JSON.stringify(responseData, null, 2) : null
+                    });
                     await logCtx.failed();
                     if (res) {
                         await publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.UnknownError('failed to create credentials'));

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -1416,10 +1416,14 @@ class OAuthController {
                 );
                 if (createRes.isErr()) {
                     let responseData = null;
-                    const errorWithCause = createRes.error as any;
-                    if (errorWithCause.cause && typeof errorWithCause.cause === 'object' && 'response' in errorWithCause.cause) {
-                        const axiosError = errorWithCause.cause;
-                        responseData = axiosError.response?.data;
+                    if (
+                        createRes.error instanceof Error &&
+                        'cause' in createRes.error &&
+                        createRes.error.cause &&
+                        typeof createRes.error.cause === 'object' &&
+                        'response' in createRes.error.cause
+                    ) {
+                        responseData = (createRes.error.cause as any).response?.data;
                     }
 
                     void logCtx.error('Failed to create credentials', {


### PR DESCRIPTION
## Describe the problem and your solution

- Add more context to github app oauth error logs

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Enhance Context in GitHub App OAuth Error Logs**

This pull request augments error logging in the GitHub App OAuth flow by capturing and serializing additional context from nested error objects (notably Axios-style network error payloads in the `response.data` property). The added context is serialized and included in the error log outputs when credential creation fails, thus improving debuggability by exposing previously hidden error payloads. Type guards and null checks were implemented to ensure safe property access and prevent runtime failures during the error extraction process.

<details>
<summary><strong>Key Changes</strong></summary>

• Modified error handling in `oauth.controller.ts` to check for and extract the `response.data` property from nested error causes.
• Error context is now serialized and passed as an object to `logCtx.error` when logging credential creation failures.
• Included null checks and type guards to safely access nested error data and avoid runtime exceptions.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/oauth.controller.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*