### PR TITLE
fix(providers): fix regex pattern for endpointURL

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -6219,8 +6219,9 @@ jira-data-center:
             type: string
             title: Domain
             description: The domain of your Jira Data Center account
-            pattern: '^https://[a-z0-9.-]+.atlassian.net$'
-            example: https://foobar.atlassian.net
+            format: hostname
+            prefix: https://
+            example: foobar.atlassian.net
 
 jira-data-center-api-key:
     display_name: Jira Data Center (API Key)


### PR DESCRIPTION
## Describe the problem and your solution

- Fix the regex pattern for `endpointURL`. This isn’t domain-specific, as it may change since this is the self-hosted version of [Jira](https://docs.atlassian.com/software/jira/docs/api/REST/9.14.0/).

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Relax Regex Validation for `endpointURL` in Jira Data Center Provider**

This PR updates the `endpointURL` field configuration for the Jira Data Center provider in `packages/providers/providers.yaml`. The previous strict `pattern` for validating the domain was removed in favor of a schema utilizing `format: hostname` and a `prefix: https://` to better support the diversity of possible self-hosted Jira Data Center domains. The example for this field has also been updated to omit the protocol, ensuring a more flexible and generic configuration.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed the `pattern: '^https://[a-z0-9.-]+.atlassian.net$'` constraint from the `endpointURL` definition.
• Added `format: hostname` and `prefix: https://` to the `endpointURL` field.
• Updated the `example` for `endpointURL` to `foobar.atlassian.net`, omitting the protocol prefix.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/providers/providers.yaml` (Jira Data Center provider configuration)

</details>

---
*This summary was automatically generated by @propel-code-bot*