### PR TITLE
fix(runner-sdk): types of deleteRecordsFromPreviousExecutions function

### DIFF
--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -453,7 +453,7 @@ export declare class NangoSync extends NangoAction {
     batchUpdate<T extends object>(results: T[], model: string): Promise<boolean | null>;
     getMetadata<T = Metadata>(): Promise<T>;
     setMergingStrategy(merging: { strategy: 'ignore_if_modified_after' | 'override' }, model: string): Promise<void>;
-    deleteRecordsFromPreviousExecutions(model: TModelName): MaybePromise<{ deletedKeys: string[] }>;
+    deleteRecordsFromPreviousExecutions(model: string): Promise<{ deletedKeys: string[] }>;
     getRecordsByIds<K = string | number, T = any>(ids: K[], model: string): Promise<Map<K, T>>;
 }
 /**

--- a/packages/runner-sdk/models.d.ts
+++ b/packages/runner-sdk/models.d.ts
@@ -410,7 +410,7 @@ export declare class NangoSync extends NangoAction {
     batchUpdate<T extends object>(results: T[], model: string): Promise<boolean | null>;
     getMetadata<T = Metadata>(): Promise<T>;
     setMergingStrategy(merging: { strategy: 'ignore_if_modified_after' | 'override' }, model: string): Promise<void>;
-    deleteRecordsFromPreviousExecutions(model: TModelName): MaybePromise<{ deletedKeys: string[] }>;
+    deleteRecordsFromPreviousExecutions(model: string): Promise<{ deletedKeys: string[] }>;
     getRecordsByIds<K = string | number, T = any>(ids: K[], model: string): Promise<Map<K, T>>;
 }
 /**


### PR DESCRIPTION
TModelName and MaybePromise are internal types. 

<!-- Summary by @propel-code-bot -->

---

**Update Signature and Return Type of `deleteRecordsFromPreviousExecutions` in Runner SDK**

This PR updates the TypeScript typings for the `deleteRecordsFromPreviousExecutions` function in the `Runner SDK`, specifically within the `NangoSync` class and related interfaces. The change removes the SDK's dependence on the internal types `TModelName` and `MaybePromise`, instead using a direct `string` type for the `model` parameter and returning a `Promise<{ deletedKeys: string[] }>` for better compatibility and clarity in public SDK consumption. Corresponding test snapshot outputs have also been updated to reflect the revised function signature.

<details>
<summary><strong>Key Changes</strong></summary>

• Changed `deleteRecordsFromPreviousExecutions(model: TModelName): MaybePromise<{ deletedKeys: string[] }>` to `deleteRecordsFromPreviousExecutions(model: string): Promise<{ deletedKeys: string[] }>` in `packages/runner-sdk/models.d.ts`.
• Updated test snapshot in `packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap` to match the new type definition.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/runner-sdk/models.d.ts`
• `packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap`

</details>

---
*This summary was automatically generated by @propel-code-bot*