### PR TITLE
feat: records size and count to DD with account dimension

### DIFF
--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -255,6 +255,17 @@ class EnvironmentService {
         return result.map((env) => encryptionManager.decryptEnvironment(env));
     }
 
+    async getEnvironmentsByIds(environmentIds: number[]): Promise<DBEnvironment[]> {
+        if (environmentIds.length === 0) {
+            return [];
+        }
+        const result = await db.knex.select('*').from<DBEnvironment>(TABLE).whereIn('id', environmentIds).andWhere({ deleted: false });
+        if (!result) {
+            return [];
+        }
+        return result;
+    }
+
     async getSlackNotificationsEnabled(environmentId: number, trx = db.knex): Promise<boolean | null> {
         const result = await trx.select('slack_notifications').from<DBEnvironment>(TABLE).where({ id: environmentId, deleted: false });
 

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -101,6 +101,7 @@ export enum Types {
     CONNECTIONS_WITH_WEBHOOKS_COUNT = 'nango.connections.withWebhooks.count',
 
     RECORDS_TOTAL_COUNT = 'nango.records.total.count',
+    RECORDS_TOTAL_SIZE_IN_BYTES = 'nango.records.total.sizeInBytes',
 
     CRON_PERSIST_ACCOUNT_USAGE = 'nango.server.cron.persistAccountUsage',
 


### PR DESCRIPTION
Pushing records count and size to datadog with account dimension.
I limited it to environments that have more than 10mb of records or more than 1M records in order not to push too many metrics
<!-- Summary by @propel-code-bot -->

---

**Export Record Size and Count Metrics to Datadog Grouped by Account**

This pull request enhances records usage observability by exporting total records count and storage size as metrics to Datadog, with an `accountId` dimension for aggregation. Metrics are only reported for environments exceeding 10MB in storage or 1 million records, reducing unnecessary metric volume. Key changes include replacing the old aggregate metric collection (which was per-record only) with a batched account-level aggregation, the addition of efficient batched environment lookups for mapping environments to account IDs, and the introduction of a new Datadog metric for record storage size. Supporting changes include extending the records model for batched aggregation and updating utility and service layers accordingly.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `metrics()` function to `packages/records/lib/models/records.ts` for aggregating records count and storage per `environment_id`, with threshold-based filtering
• Replaced `countMetric()` usage in `exportRecordsMetrics` (in `packages/metering/lib/crons/usage.ts`) with the new account-aware grouping and export logic
• Batch-fetching environments in `exportRecordsMetrics` via the new `environmentService.getEnvironmentsByIds()` for mapping to `account_id`
• Introduced the `RECORDS_TOTAL_SIZE_IN_BYTES` metric type in `packages/utils/lib/telemetry/metrics.ts`
• Added `getEnvironmentsByIds()` to `packages/shared/lib/services/environment.service.ts` for efficient bulk environment retrieval

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/metering/lib/crons/usage.ts`
• `packages/records/lib/models/records.ts`
• `packages/shared/lib/services/environment.service.ts`
• `packages/utils/lib/telemetry/metrics.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*