### PR TITLE
feat(billing): send runner telemetry to orb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15367,6 +15367,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/es-toolkit": {
+            "version": "1.39.10",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.10.tgz",
+            "integrity": "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==",
+            "license": "MIT",
+            "workspaces": [
+                "docs",
+                "benchmarks"
+            ]
+        },
         "node_modules/esbuild": {
             "version": "0.25.5",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
@@ -28488,6 +28498,7 @@
                 "@nangohq/logs": "file:../logs",
                 "@nangohq/nango-orchestrator": "file:../orchestrator",
                 "@nangohq/nango-runner": "file:../runner",
+                "@nangohq/pubsub": "file:../pubsub",
                 "@nangohq/records": "file:../records",
                 "@nangohq/shared": "file:../shared",
                 "@nangohq/utils": "file:../utils",
@@ -28782,6 +28793,7 @@
                 "@nangohq/shared": "file:../shared",
                 "@nangohq/utils": "file:../utils",
                 "dd-trace": "5.52.0",
+                "es-toolkit": "1.39.10",
                 "node-cron": "3.0.2",
                 "zod": "4.0.5"
             },

--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -11,6 +11,7 @@ import { envs } from './env.js';
 import { Processor } from './processor/processor.js';
 import { runnersFleet } from './runner/fleet.js';
 import { server } from './server.js';
+import { pubsub } from './utils/pubsub.js';
 
 const logger = getLogger('Jobs');
 
@@ -56,6 +57,11 @@ try {
         }
     };
     void check();
+
+    const pubsubConnect = await pubsub.connect();
+    if (pubsubConnect.isErr()) {
+        logger.error(`PubSub: Failed to connect to transport: ${pubsubConnect.error.message}`);
+    }
 
     const close = once(() => {
         logger.info('Closing...');

--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -19,11 +19,12 @@ import { bigQueryClient, slackService } from '../clients.js';
 import { startScript } from './operations/start.js';
 import { getRunnerFlags } from '../utils/flags.js';
 import { setTaskFailed, setTaskSuccess } from './operations/state.js';
+import { pubsub } from '../utils/pubsub.js';
 
 import type { LogContext } from '@nangohq/logs';
 import type { OrchestratorTask, TaskAction } from '@nangohq/nango-orchestrator';
 import type { Config } from '@nangohq/shared';
-import type { ConnectionJobs, DBEnvironment, DBSyncConfig, DBTeam, NangoProps } from '@nangohq/types';
+import type { ConnectionJobs, DBEnvironment, DBSyncConfig, DBTeam, NangoProps, TelemetryBag } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { JsonValue } from 'type-fest';
 
@@ -135,7 +136,17 @@ export async function startAction(task: TaskAction): Promise<Result<void>> {
         return Err(error);
     }
 }
-export async function handleActionSuccess({ taskId, nangoProps, output }: { taskId: string; nangoProps: NangoProps; output: JsonValue }): Promise<void> {
+export async function handleActionSuccess({
+    taskId,
+    nangoProps,
+    output,
+    telemetryBag
+}: {
+    taskId: string;
+    nangoProps: NangoProps;
+    output: JsonValue;
+    telemetryBag: TelemetryBag;
+}): Promise<void> {
     const logCtx = logContextGetter.get({ id: nangoProps.activityLogId, accountId: nangoProps.team.id });
     const { environment, account } = (await environmentService.getAccountAndEnvironment({ environmentId: nangoProps.environmentId })) || {
         environment: undefined,
@@ -160,7 +171,8 @@ export async function handleActionSuccess({ taskId, nangoProps, output }: { task
             team: account,
             environment: environment,
             syncConfig: nangoProps.syncConfig,
-            endUser: nangoProps.endUser
+            endUser: nangoProps.endUser,
+            telemetryBag
         });
         return;
     }
@@ -215,9 +227,34 @@ export async function handleActionSuccess({ taskId, nangoProps, output }: { task
         internalIntegrationId: nangoProps.syncConfig.nango_config_id,
         endUser: nangoProps.endUser
     });
+
+    void pubsub.publisher.publish({
+        subject: 'usage',
+        type: 'usage.function_executions',
+        payload: {
+            value: 1,
+            properties: {
+                accountId: nangoProps.team.id,
+                connectionId: connection.id,
+                type: 'sync',
+                success: true,
+                telemetryBag
+            }
+        }
+    });
 }
 
-export async function handleActionError({ taskId, nangoProps, error }: { taskId: string; nangoProps: NangoProps; error: NangoError }): Promise<void> {
+export async function handleActionError({
+    taskId,
+    nangoProps,
+    error,
+    telemetryBag
+}: {
+    taskId: string;
+    nangoProps: NangoProps;
+    error: NangoError;
+    telemetryBag: TelemetryBag;
+}): Promise<void> {
     const accountAndEnv = await environmentService.getAccountAndEnvironment({ environmentId: nangoProps.environmentId });
     if (!accountAndEnv) {
         throw new Error(`Account and environment not found`);
@@ -242,7 +279,8 @@ export async function handleActionError({ taskId, nangoProps, error }: { taskId:
             team: account,
             environment: environment,
             syncConfig: nangoProps.syncConfig,
-            endUser: nangoProps.endUser
+            endUser: nangoProps.endUser,
+            telemetryBag
         });
         return;
     }
@@ -283,7 +321,8 @@ export async function handleActionError({ taskId, nangoProps, error }: { taskId:
         team: account,
         environment: environment,
         syncConfig: nangoProps.syncConfig,
-        endUser: nangoProps.endUser
+        endUser: nangoProps.endUser,
+        telemetryBag
     });
 }
 
@@ -298,7 +337,8 @@ function onFailure({
     syncConfig,
     runTime,
     error,
-    endUser
+    endUser,
+    telemetryBag
 }: {
     team?: DBTeam | undefined;
     environment?: DBEnvironment | undefined;
@@ -311,6 +351,7 @@ function onFailure({
     runTime: number;
     error: NangoError;
     endUser: NangoProps['endUser'];
+    telemetryBag?: TelemetryBag | undefined;
 }): void {
     if (team && environment) {
         try {
@@ -355,6 +396,21 @@ function onFailure({
             createdAt: Date.now(),
             internalIntegrationId: syncConfig?.nango_config_id || null,
             endUser
+        });
+
+        void pubsub.publisher.publish({
+            subject: 'usage',
+            type: 'usage.function_executions',
+            payload: {
+                value: 1,
+                properties: {
+                    accountId: team.id,
+                    connectionId: connection.id,
+                    type: 'action',
+                    success: false,
+                    telemetryBag
+                }
+            }
         });
     }
     metrics.increment(metrics.Types.ACTION_FAILURE);

--- a/packages/jobs/lib/execution/operations/handler.ts
+++ b/packages/jobs/lib/execution/operations/handler.ts
@@ -5,27 +5,47 @@ import { handleSyncError, handleSyncSuccess } from '../sync.js';
 import { handleWebhookError, handleWebhookSuccess } from '../webhook.js';
 import { toNangoError } from './utils/errors.js';
 
-import type { NangoProps, RunnerOutputError } from '@nangohq/types';
+import type { NangoProps, RunnerOutputError, TelemetryBag } from '@nangohq/types';
 import type { JsonValue } from 'type-fest';
 
-export async function handleSuccess({ taskId, nangoProps, output }: { taskId: string; nangoProps: NangoProps; output: JsonValue }): Promise<void> {
+export async function handleSuccess({
+    taskId,
+    nangoProps,
+    output,
+    telemetryBag
+}: {
+    taskId: string;
+    nangoProps: NangoProps;
+    output: JsonValue;
+    telemetryBag: TelemetryBag;
+}): Promise<void> {
     switch (nangoProps.scriptType) {
         case 'action':
-            await handleActionSuccess({ taskId, nangoProps, output });
+            await handleActionSuccess({ taskId, nangoProps, output, telemetryBag });
             break;
         case 'sync':
-            await handleSyncSuccess({ taskId, nangoProps });
+            await handleSyncSuccess({ taskId, nangoProps, telemetryBag });
             break;
         case 'webhook':
-            await handleWebhookSuccess({ taskId, nangoProps });
+            await handleWebhookSuccess({ taskId, nangoProps, telemetryBag });
             break;
         case 'on-event':
-            await handleOnEventSuccess({ taskId, nangoProps });
+            await handleOnEventSuccess({ taskId, nangoProps, telemetryBag });
             break;
     }
 }
 
-export async function handleError({ taskId, nangoProps, error }: { taskId: string; nangoProps: NangoProps; error: RunnerOutputError }): Promise<void> {
+export async function handleError({
+    taskId,
+    nangoProps,
+    error,
+    telemetryBag
+}: {
+    taskId: string;
+    nangoProps: NangoProps;
+    error: RunnerOutputError;
+    telemetryBag: TelemetryBag;
+}): Promise<void> {
     if (error.type === 'script_aborted') {
         // do nothing, the script was aborted and its state already updated
         logger.info(`Script was aborted. Ignoring output.`, {
@@ -46,16 +66,16 @@ export async function handleError({ taskId, nangoProps, error }: { taskId: strin
 
     switch (nangoProps.scriptType) {
         case 'action':
-            await handleActionError({ taskId, nangoProps, error: formattedError });
+            await handleActionError({ taskId, nangoProps, error: formattedError, telemetryBag });
             break;
         case 'sync':
-            await handleSyncError({ taskId, nangoProps, error: formattedError });
+            await handleSyncError({ taskId, nangoProps, error: formattedError, telemetryBag });
             break;
         case 'webhook':
-            await handleWebhookError({ taskId, nangoProps, error: formattedError });
+            await handleWebhookError({ taskId, nangoProps, error: formattedError, telemetryBag });
             break;
         case 'on-event':
-            await handleOnEventError({ taskId, nangoProps, error: formattedError });
+            await handleOnEventError({ taskId, nangoProps, error: formattedError, telemetryBag });
             break;
     }
 }

--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -252,7 +252,7 @@ const runJob = async (
     };
     await updateSyncJobResult(syncJob.id, updatedResults, model);
 
-    await handleSyncSuccess({ taskId: 'abc', nangoProps: nangoProps.value });
+    await handleSyncSuccess({ taskId: 'abc', nangoProps: nangoProps.value, telemetryBag: { customLogs: 0, proxyCalls: 0 } });
 
     const latestSyncJob = await getLatestSyncJob(sync.id);
     if (!latestSyncJob) {

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -36,11 +36,12 @@ import { abortTaskWithId } from './operations/abort.js';
 import { startScript } from './operations/start.js';
 import { getRunnerFlags } from '../utils/flags.js';
 import { setTaskFailed, setTaskSuccess } from './operations/state.js';
+import { pubsub } from '../utils/pubsub.js';
 
 import type { LogContextOrigin } from '@nangohq/logs';
 import type { TaskSync, TaskSyncAbort } from '@nangohq/nango-orchestrator';
 import type { Config, Job } from '@nangohq/shared';
-import type { ConnectionJobs, DBEnvironment, DBPlan, DBSyncConfig, DBTeam, NangoProps, SyncResult, SyncTypeLiteral } from '@nangohq/types';
+import type { ConnectionJobs, DBEnvironment, DBPlan, DBSyncConfig, DBTeam, NangoProps, SyncResult, SyncTypeLiteral, TelemetryBag } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 export async function startSync(task: TaskSync, startScriptFn = startScript): Promise<Result<NangoProps>> {
@@ -227,7 +228,15 @@ export async function startSync(task: TaskSync, startScriptFn = startScript): Pr
     }
 }
 
-export async function handleSyncSuccess({ taskId, nangoProps }: { taskId: string; nangoProps: NangoProps }): Promise<void> {
+export async function handleSyncSuccess({
+    taskId,
+    nangoProps,
+    telemetryBag
+}: {
+    taskId: string;
+    nangoProps: NangoProps;
+    telemetryBag: TelemetryBag;
+}): Promise<void> {
     const logCtx = logContextGetter.get({ id: nangoProps.activityLogId, accountId: nangoProps.team.id });
     logCtx.attachSpan(
         new OtlpSpan(
@@ -335,7 +344,8 @@ export async function handleSyncSuccess({ taskId, nangoProps }: { taskId: string
                     syncConfig: nangoProps.syncConfig,
                     error: new NangoError('sync_job_update_failure', { syncJobId: nangoProps.syncJobId, model }),
                     endUser: nangoProps.endUser,
-                    startedAt: nangoProps.startedAt
+                    startedAt: nangoProps.startedAt,
+                    telemetryBag
                 });
                 return;
             }
@@ -478,6 +488,21 @@ export async function handleSyncSuccess({ taskId, nangoProps }: { taskId: string
         metrics.duration(metrics.Types.SYNC_TRACK_RUNTIME, Date.now() - nangoProps.startedAt.getTime());
         metrics.increment(metrics.Types.SYNC_SUCCESS);
 
+        void pubsub.publisher.publish({
+            subject: 'usage',
+            type: 'usage.function_executions',
+            payload: {
+                value: 1,
+                properties: {
+                    accountId: team.id,
+                    connectionId: connection.id,
+                    type: 'sync',
+                    success: true,
+                    telemetryBag
+                }
+            }
+        });
+
         await logCtx.success();
     } catch (err) {
         await onFailure({
@@ -506,12 +531,23 @@ export async function handleSyncSuccess({ taskId, nangoProps }: { taskId: string
             isCancel: false,
             error: new NangoError('sync_script_failure', { error: err instanceof Error ? err.message : err }),
             endUser: nangoProps.endUser,
-            startedAt: nangoProps.startedAt
+            startedAt: nangoProps.startedAt,
+            telemetryBag
         });
     }
 }
 
-export async function handleSyncError({ taskId, nangoProps, error }: { taskId: string; nangoProps: NangoProps; error: NangoError }): Promise<void> {
+export async function handleSyncError({
+    taskId,
+    nangoProps,
+    error,
+    telemetryBag
+}: {
+    taskId: string;
+    nangoProps: NangoProps;
+    error: NangoError;
+    telemetryBag?: TelemetryBag | undefined;
+}): Promise<void> {
     let team: DBTeam | undefined;
     let environment: DBEnvironment | undefined;
     let providerConfig: Config | null = null;
@@ -558,7 +594,8 @@ export async function handleSyncError({ taskId, nangoProps, error }: { taskId: s
         isCancel: false,
         error,
         endUser: nangoProps.endUser,
-        startedAt: nangoProps.startedAt
+        startedAt: nangoProps.startedAt,
+        telemetryBag
     });
 }
 
@@ -669,7 +706,8 @@ async function onFailure({
     failureSource,
     error,
     endUser,
-    startedAt
+    startedAt,
+    telemetryBag
 }: {
     team?: DBTeam | undefined;
     environment?: DBEnvironment | undefined;
@@ -692,6 +730,7 @@ async function onFailure({
     failureSource?: ErrorSourceEnum;
     error: NangoError;
     endUser: NangoProps['endUser'];
+    telemetryBag?: TelemetryBag | undefined;
 }): Promise<void> {
     const logCtx = activityLogId && team ? logContextGetter.get({ id: activityLogId, accountId: team.id }) : null;
 
@@ -847,4 +886,21 @@ async function onFailure({
 
     metrics.increment(metrics.Types.SYNC_FAILURE);
     metrics.duration(metrics.Types.SYNC_TRACK_RUNTIME, Date.now() - startedAt.getTime());
+
+    if (team) {
+        void pubsub.publisher.publish({
+            subject: 'usage',
+            type: 'usage.function_executions',
+            payload: {
+                value: 1,
+                properties: {
+                    accountId: team.id,
+                    connectionId: connection.id,
+                    type: 'sync',
+                    success: false,
+                    telemetryBag
+                }
+            }
+        });
+    }
 }

--- a/packages/jobs/lib/routes/tasks/putTask.ts
+++ b/packages/jobs/lib/routes/tasks/putTask.ts
@@ -93,15 +93,16 @@ const validate = validateRequest<PutTask>({
 
 const handler = async (_req: EndpointRequest, res: EndpointResponse<PutTask>) => {
     const { taskId } = res.locals.parsedParams;
-    const { nangoProps, error, output } = res.locals.parsedBody;
+    const { nangoProps, error, output, telemetryBag } = res.locals.parsedBody;
     if (!nangoProps) {
         res.status(400).json({ error: { code: 'put_task_failed', message: 'missing nangoProps' } });
         return;
     }
+    console.log('telemetryBag', telemetryBag);
     if (error) {
-        await handleError({ taskId, nangoProps, error });
+        await handleError({ taskId, nangoProps, error, telemetryBag });
     } else {
-        await handleSuccess({ taskId, nangoProps, output: output || null });
+        await handleSuccess({ taskId, nangoProps, output: output || null, telemetryBag });
     }
     res.status(204).send();
     return;

--- a/packages/jobs/lib/utils/pubsub.ts
+++ b/packages/jobs/lib/utils/pubsub.ts
@@ -1,0 +1,24 @@
+import { DefaultTransport, Publisher } from '@nangohq/pubsub';
+
+import type { Transport } from '@nangohq/pubsub';
+import type { Result } from '@nangohq/utils';
+
+class PubSub {
+    public publisher: Publisher;
+    public transport: Transport;
+
+    constructor() {
+        this.transport = new DefaultTransport();
+        this.publisher = new Publisher(this.transport);
+    }
+
+    async connect(): Promise<Result<void>> {
+        return this.transport.connect();
+    }
+
+    async disconnect(): Promise<Result<void>> {
+        return this.transport.disconnect();
+    }
+}
+
+export const pubsub = new PubSub();

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -28,6 +28,7 @@
         "@nangohq/utils": "file:../utils",
         "@nangohq/webhooks": "file:../webhooks",
         "@nangohq/account-usage": "file:../account-usage",
+        "@nangohq/pubsub": "file:../pubsub",
         "axios": "1.12.0",
         "dd-trace": "5.52.0",
         "express": "5.1.0",

--- a/packages/jobs/tsconfig.json
+++ b/packages/jobs/tsconfig.json
@@ -48,6 +48,9 @@
             "path": "../fleet"
         },
         {
+            "path": "../pubsub"
+        },
+        {
             "path": "../account-usage"
         }
     ],

--- a/packages/metering/lib/processors/billing.ts
+++ b/packages/metering/lib/processors/billing.ts
@@ -1,3 +1,5 @@
+import { flattenObject } from 'es-toolkit';
+
 import { getAccountUsageTracker, onUsageIncreased } from '@nangohq/account-usage';
 import { billing } from '@nangohq/billing';
 import db from '@nangohq/database';
@@ -83,6 +85,16 @@ async function process(event: UsageEvent): Promise<Result<void>> {
                     delta: event.payload.value
                 });
                 // No billing action for connections, just tracking usage
+                return Ok(undefined);
+            }
+            case 'usage.function_executions': {
+                const { telemetryBag, ...rest } = event.payload.properties;
+                billing.add('function_executions', event.payload.value, {
+                    idempotencyKey: event.idempotencyKey,
+                    timestamp: event.createdAt,
+                    ...rest,
+                    ...(telemetryBag ? flattenObject({ telemetry: telemetryBag as Record<string, unknown> }) : {})
+                });
                 return Ok(undefined);
             }
             default:

--- a/packages/metering/package.json
+++ b/packages/metering/package.json
@@ -23,6 +23,7 @@
         "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",
         "dd-trace": "5.52.0",
+        "es-toolkit": "1.39.10",
         "node-cron": "3.0.2",
         "zod": "4.0.5"
     },

--- a/packages/pubsub/lib/event.ts
+++ b/packages/pubsub/lib/event.ts
@@ -25,7 +25,7 @@ export type UserCreatedEvent = EventBase<
 
 export type UsageEvent = EventBase<
     'usage',
-    'usage.monthly_active_records' | 'usage.actions' | 'usage.connections',
+    'usage.monthly_active_records' | 'usage.actions' | 'usage.connections' | 'usage.function_executions',
     {
         value: number;
         properties: {

--- a/packages/runner-sdk/lib/errors.ts
+++ b/packages/runner-sdk/lib/errors.ts
@@ -1,4 +1,4 @@
-import type { RunnerOutputError } from '@nangohq/types';
+import type { RunnerOutputError, TelemetryBag } from '@nangohq/types';
 
 export abstract class SDKError extends Error {
     abstract code: string;
@@ -51,13 +51,15 @@ export class ExecutionError extends Error {
     payload: RunnerOutputError['payload'];
     status: RunnerOutputError['status'];
     additional_properties: RunnerOutputError['additional_properties'];
+    telemetryBag: TelemetryBag;
 
-    constructor(payload: RunnerOutputError) {
+    constructor(payload: RunnerOutputError & { telemetryBag: TelemetryBag }) {
         super();
         this.type = payload.type;
         this.payload = payload.payload;
         this.status = payload.status;
         this.additional_properties = payload.additional_properties;
+        this.telemetryBag = payload.telemetryBag;
     }
 
     toJSON(): RunnerOutputError {

--- a/packages/runner/lib/clients/jobs.ts
+++ b/packages/runner/lib/clients/jobs.ts
@@ -29,7 +29,7 @@ class JobsClient {
         return Ok(undefined as PostHeartbeat['Success']);
     }
 
-    async putTask({ taskId, nangoProps, error, output }: PutTask['Body'] & PutTask['Params']): Promise<Result<PutTask['Success']>> {
+    async putTask({ taskId, nangoProps, error, output, telemetryBag }: PutTask['Body'] & PutTask['Params']): Promise<Result<PutTask['Success']>> {
         const res = await retryWithBackoff(async () => {
             const resp = await httpFetch(`${this.baseUrl}/tasks/${taskId}`, {
                 method: 'PUT',
@@ -38,7 +38,7 @@ class JobsClient {
                 },
                 body: JSON.stringify({
                     nangoProps: nangoProps,
-                    ...(error ? { error } : { output })
+                    ...(error ? { error, telemetryBag } : { output, telemetryBag })
                 })
             });
             if (!resp.ok) {
@@ -54,7 +54,8 @@ class JobsClient {
                             payload: {
                                 message: 'Output is too large'
                             }
-                        }
+                        },
+                        telemetryBag: { customLogs: 0, proxyCalls: 0 }
                     });
                 }
                 return Err(`putTask_failed`);

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -203,7 +203,8 @@ export async function exec({
                         payload: truncateJson(
                             Array.isArray(payload) || (typeof payload !== 'object' && payload !== null) ? { message: payload } : payload || {}
                         ), // TODO: fix ActionError so payload is always an object
-                        status: 500
+                        status: 500,
+                        telemetryBag: nango.telemetryBag
                     })
                 );
             }
@@ -214,7 +215,8 @@ export async function exec({
                     new ExecutionError({
                         type: err.code,
                         payload: truncateJson(err.payload),
-                        status: 500
+                        status: 500,
+                        telemetryBag: nango.telemetryBag
                     })
                 );
             } else if (isAxiosError<unknown, unknown>(err)) {
@@ -262,7 +264,8 @@ export async function exec({
                                     headers,
                                     body: responseBody
                                 }
-                            }
+                            },
+                            telemetryBag: nango.telemetryBag
                         })
                     );
                 } else {
@@ -271,7 +274,8 @@ export async function exec({
                         new ExecutionError({
                             type: 'script_network_error',
                             payload: truncateJson({ name: tmp.name || 'Error', code: tmp.code, message: tmp.message }),
-                            status: 500
+                            status: 500,
+                            telemetryBag: nango.telemetryBag
                         })
                     );
                 }
@@ -283,7 +287,8 @@ export async function exec({
                     new ExecutionError({
                         type: 'script_internal_error',
                         payload: truncateJson({ name: tmp.name || 'Error', code: tmp.code, message: tmp.message }),
-                        status: 500
+                        status: 500,
+                        telemetryBag: nango.telemetryBag
                     })
                 );
             } else {
@@ -307,7 +312,8 @@ export async function exec({
                             message: tmp.message,
                             ...(stacktrace.length > 0 ? { stacktrace } : {})
                         }),
-                        status: 500
+                        status: 500,
+                        telemetryBag: nango.telemetryBag
                     })
                 );
             }

--- a/packages/runner/lib/server.ts
+++ b/packages/runner/lib/server.ts
@@ -100,7 +100,7 @@ function startProcedure() {
                         taskId,
                         nangoProps,
                         ...(execRes.isErr()
-                            ? { error: execRes.error.toJSON() }
+                            ? { error: execRes.error.toJSON(), telemetryBag: execRes.error.telemetryBag }
                             : { output: execRes.value.output as any, telemetryBag: execRes.value.telemetryBag })
                     });
                 } finally {

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -48,7 +48,7 @@ export interface BillingPlan {
 }
 
 export interface BillingIngestEvent {
-    type: 'monthly_active_records' | 'billable_connections' | 'billable_actions' | 'billable_active_connections';
+    type: 'monthly_active_records' | 'billable_connections' | 'billable_actions' | 'billable_active_connections' | 'function_executions';
     idempotencyKey: string;
     accountId: number;
     timestamp: Date;

--- a/packages/types/lib/jobs/api.ts
+++ b/packages/types/lib/jobs/api.ts
@@ -24,7 +24,7 @@ export type PutTask = Endpoint<{
         nangoProps?: NangoProps | undefined;
         error?: RunnerOutputError | undefined;
         output?: JsonValue | undefined;
-        telemetryBag?: TelemetryBag | undefined;
+        telemetryBag: TelemetryBag;
     };
     Error: ApiError<'put_task_failed'>;
     Success: never;

--- a/packages/types/lib/runner/index.ts
+++ b/packages/types/lib/runner/index.ts
@@ -3,6 +3,9 @@ import type { TelemetryBag } from './sdk.js';
 export interface RunnerOutputError {
     type: string;
     payload: Record<string, unknown> | unknown[];
+    /**
+     * @deprecated useless now
+     */
     status: number;
     additional_properties?: Record<string, unknown> | undefined;
 }


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-3910/track-functions-executions-metadata-in-a-single-orb-event

- Send runner telemetry to Orb in a new generic event
This event allows us to compute 3 metrics: function executions, custom logs volume, and proxy calls inside scripts.
Right now, only logs are useful for the new pricing, but it was necessary for us to have a generic event because we need to compute it globally, not just for syncs. 

<!-- Summary by @propel-code-bot -->

---

**Add Runner Telemetry Reporting to Orb for Global Billing & Usage Metrics**

This PR introduces comprehensive changes to collect and transmit telemetry data from the runner (function executions, custom logs, proxy calls) as a new event type (`usage.function_executions`) via pubsub to the Orb billing and metering system. The new telemetry event is emitted for all script executions (including syncs, actions, webhooks, and on-event scripts) in both success and error paths, supporting more accurate, global usage analytics and billing computations. This required modifications across the runner, jobs, and metering codebases, consistent propagation of a structured `telemetryBag` throughout the API, introduction of a pubsub utility, billing processor logic updates, extensive flow/type enforcement, and updates to related test and configuration files.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced `usage.function_executions` event type and telemetry schema, enabling the reporting of function execution occurrences, custom log volume, and proxy call counts.
• Extended runner and jobs pipeline to build and propagate a `telemetryBag` object across all function executions and errors, ultimately including it in pubsub events sent to Orb.
• Modified all major script execution handlers (`handleActionSuccess`, `handleSyncSuccess`, `handleWebhookSuccess`, `handleOnEventSuccess`, and their error paths) to send a telemetry event via the new pubsub utility.
• Added `packages/jobs/lib/utils/pubsub.ts` to provide a standardized pubsub connection, initialization, and event publishing API, used throughout job handlers.
• Updated API contract and related types so `telemetryBag` is a consistent, required property on the `PutTask` endpoint and payloads.
• Extended `packages/metering/lib/processors/billing.ts` to process the new event type and project telemetry properties as billing metrics (flattened via `es-toolkit`).
• Revised the error and output data contract for runner errors to include `telemetryBag`, with supporting changes in `packages/runner-sdk/lib/errors.ts` and downstream usage.
• Updated test(s), JSON schemas, and package/config manifests (including new dependency on `@nangohq/pubsub` and `es-toolkit`).

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/jobs/lib/execution/*` (all script, error, and handler paths)
• `packages/jobs/lib/utils/pubsub.ts` (new pubsub abstraction)
• `packages/jobs/lib/routes/tasks/putTask.ts` (API + schema updates)
• `packages/runner/lib/exec.ts`, `packages/runner/lib/clients/jobs.ts`, `packages/runner/lib/server.ts` (error/output shape, contracts)
• `packages/metering/lib/processors/billing.ts` (billing event pipeline)
• `packages/pubsub/lib/event.ts` (event type system)
• `packages/types/lib/runner/index.ts`, `packages/types/lib/jobs/api.ts`, `packages/types/lib/billing/types.ts` (typeflow/type changes)
• Various config files: `package.json`, `tsconfig.json`, `package-lock.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*