### PR TITLE
feat: ConnectUI dark theme support

### DIFF
--- a/docs-v2/reference/sdks/frontend.mdx
+++ b/docs-v2/reference/sdks/frontend.mdx
@@ -81,6 +81,10 @@ const connectUI = nango.openConnectUI({ sessionToken: 'SESSION_TOKEN' });
   <ResponseField name="lang" type="string">
     The language to use for the UI. Defaults to browser language or english if not supported.
   </ResponseField>
+
+  <ResponseField name="themeOverride" type="string">
+    The theme (light, dark, system) to use for the UI. Overrides your global setting in the dashboard.
+  </ResponseField>
 </Expandable>
 
 **Response**

--- a/packages/connect-ui/src/App.tsx
+++ b/packages/connect-ui/src/App.tsx
@@ -6,10 +6,14 @@ import { I18nProvider } from './lib/i18n';
 import { getLanguage } from './lib/i18n/utils.js';
 import { queryClient } from './lib/query.js';
 import { router } from './lib/routes.js';
+import { setTheme } from './lib/theme.js';
 
 export const App: React.FC = () => {
     const languageParam = useSearchParam('lang');
     const language = getLanguage(languageParam);
+
+    // Always default to system theme
+    setTheme('system');
 
     return (
         <QueryErrorResetBoundary>

--- a/packages/connect-ui/src/index.css
+++ b/packages/connect-ui/src/index.css
@@ -104,7 +104,8 @@
 }
 
 @layer theme {
-    :root {
+    :root,
+    :host {
         @variant dark {
             --color-primary: var(--color-brand-500);
             --color-on-primary: var(--color-gray-50);

--- a/packages/connect-ui/src/lib/theme.ts
+++ b/packages/connect-ui/src/lib/theme.ts
@@ -1,5 +1,9 @@
 import type { ConnectUIThemeSettings, Theme } from '@nangohq/types';
 
+export function isValidTheme(theme: string): theme is Theme {
+    return ['light', 'dark', 'system'].includes(theme);
+}
+
 export function setTheme(theme: Theme) {
     document.documentElement.classList.toggle('dark', theme === 'dark' || (theme === 'system' && getSystemTheme() === 'dark'));
 }

--- a/packages/connect-ui/src/lib/theme.ts
+++ b/packages/connect-ui/src/lib/theme.ts
@@ -1,17 +1,39 @@
-import type { ConnectUIThemeSettings } from '@nangohq/types';
+import type { ConnectUIThemeSettings, Theme } from '@nangohq/types';
 
-export function setTheme(theme: ConnectUIThemeSettings) {
+export function setTheme(theme: Theme) {
+    document.documentElement.classList.toggle('dark', theme === 'dark' || (theme === 'system' && getSystemTheme() === 'dark'));
+}
+
+/* Resolves system theme to light or dark, otherwise returns the theme */
+export function getEffectiveTheme(theme: Theme): 'light' | 'dark' {
+    return theme === 'system' ? getSystemTheme() : theme;
+}
+
+export function getSystemTheme(): 'light' | 'dark' {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function setColors(theme: ConnectUIThemeSettings, themeToUse: Theme): void {
     const root = document.documentElement;
 
-    const primary = theme.light.primary;
-    if (!primary) {
-        return;
+    const effectiveTheme = getEffectiveTheme(themeToUse);
+    if (effectiveTheme === 'light') {
+        const lightPrimary = theme.light.primary;
+        if (lightPrimary) {
+            root.style.setProperty('--color-primary', lightPrimary);
+            const lightBrandHex = cssColorToHex(lightPrimary);
+            root.style.setProperty('--color-on-primary', hexColorIsDark(lightBrandHex) ? '#ffffff' : '#000000');
+        }
     }
 
-    root.style.setProperty('--color-primary', primary);
-
-    const brandHex = cssColorToHex(primary);
-    root.style.setProperty('--color-on-primary', hexColorIsDark(brandHex) ? '#ffffff' : '#000000');
+    if (effectiveTheme === 'dark') {
+        const darkPrimary = theme.dark.primary;
+        if (darkPrimary) {
+            root.style.setProperty('--color-primary', darkPrimary);
+            const darkBrandHex = cssColorToHex(darkPrimary);
+            root.style.setProperty('--color-on-primary', hexColorIsDark(darkBrandHex) ? '#ffffff' : '#000000');
+        }
+    }
 }
 
 /**

--- a/packages/connect-ui/src/lib/updateSettings.ts
+++ b/packages/connect-ui/src/lib/updateSettings.ts
@@ -1,9 +1,11 @@
 import { useGlobal } from './store';
-import { setTheme } from './theme';
+import { getEffectiveTheme, setColors, setTheme } from './theme';
 
-import type { ConnectUISettings } from '@nangohq/types';
+import type { ConnectUISettings, Theme } from '@nangohq/types';
 
-export function updateSettings(settings: ConnectUISettings) {
-    setTheme(settings.theme);
+export function updateSettings(settings: ConnectUISettings, themeOverride?: Theme) {
+    const themeToUse = getEffectiveTheme(themeOverride ?? settings.defaultTheme);
+    setTheme(themeToUse);
+    setColors(settings.theme, themeToUse);
     useGlobal.getState().setShowWatermark(settings.showWatermark);
 }

--- a/packages/connect-ui/src/views/Home.tsx
+++ b/packages/connect-ui/src/views/Home.tsx
@@ -12,6 +12,7 @@ import { telemetry } from '@/lib/telemetry';
 import { updateSettings } from '@/lib/updateSettings';
 
 import type { ConnectUIEventSettingsChanged, ConnectUIEventToken } from '@nangohq/frontend';
+import type { Theme } from '@nangohq/types';
 
 export const Home: React.FC = () => {
     const navigate = useNavigate();
@@ -19,6 +20,7 @@ export const Home: React.FC = () => {
 
     const { data, error } = useQuery({ enabled: sessionToken !== null, queryKey: ['sessionToken'], queryFn: getConnectSession });
     const apiURL = useSearchParam('apiURL');
+    const theme = useSearchParam('theme');
     const isEmbedded = useSearchParam('embedded');
     const isPreview = useSearchParam('preview') === 'true';
     const detectClosedAuthWindow = useSearchParam('detectClosedAuthWindow');
@@ -81,7 +83,8 @@ export const Home: React.FC = () => {
     useEffect(() => {
         if (data) {
             setSession(data.data);
-            updateSettings(data.data.connectUISettings);
+            const themeOverride = theme && theme in ['light', 'dark', 'system'] ? (theme as Theme) : undefined;
+            updateSettings(data.data.connectUISettings, themeOverride);
             void navigate({ to: '/integrations' });
         }
     }, [data]);

--- a/packages/connect-ui/src/views/Home.tsx
+++ b/packages/connect-ui/src/views/Home.tsx
@@ -9,10 +9,10 @@ import { getConnectSession } from '@/lib/api';
 import { triggerReady } from '@/lib/events';
 import { useGlobal } from '@/lib/store';
 import { telemetry } from '@/lib/telemetry';
+import { isValidTheme, setTheme } from '@/lib/theme';
 import { updateSettings } from '@/lib/updateSettings';
 
 import type { ConnectUIEventSettingsChanged, ConnectUIEventToken } from '@nangohq/frontend';
-import type { Theme } from '@nangohq/types';
 
 export const Home: React.FC = () => {
     const navigate = useNavigate();
@@ -78,12 +78,13 @@ export const Home: React.FC = () => {
         if (detectClosedAuthWindow) setDetectClosedAuthWindow(detectClosedAuthWindow === 'true');
         if (isEmbedded) setIsEmbedded(isEmbedded === 'true');
         if (isPreview) setIsPreview(isPreview);
-    }, [apiURL, detectClosedAuthWindow, isEmbedded, isPreview, setApiURL, setDetectClosedAuthWindow, setIsEmbedded, setIsPreview]);
+        if (theme && isValidTheme(theme)) setTheme(theme);
+    }, [apiURL, detectClosedAuthWindow, isEmbedded, isPreview, setApiURL, setDetectClosedAuthWindow, setIsEmbedded, setIsPreview, theme]);
 
     useEffect(() => {
         if (data) {
             setSession(data.data);
-            const themeOverride = theme && theme in ['light', 'dark', 'system'] ? (theme as Theme) : undefined;
+            const themeOverride = theme && isValidTheme(theme) ? theme : undefined;
             updateSettings(data.data.connectUISettings, themeOverride);
             void navigate({ to: '/integrations' });
         }

--- a/packages/frontend/lib/connectUI.ts
+++ b/packages/frontend/lib/connectUI.ts
@@ -1,5 +1,5 @@
 import type { ConnectUIEvent, ConnectUIEventToken } from './types.js';
-import type { MaybePromise } from '@nangohq/types';
+import type { MaybePromise, Theme } from '@nangohq/types';
 
 export type OnConnectEvent = (event: ConnectUIEvent) => MaybePromise<void>;
 export interface ConnectUIProps {
@@ -33,6 +33,12 @@ export interface ConnectUIProps {
      * @example `en` or `fr`
      */
     lang?: string;
+
+    /**
+     * The theme (light, dark, system) to use for the UI.
+     * Overrides your global setting in the dashboard.
+     */
+    themeOverride?: Theme;
 }
 
 export class ConnectUI {
@@ -46,6 +52,7 @@ export class ConnectUI {
     private onEvent;
     private detectClosedAuthWindow?: boolean | undefined;
     private lang?: string | undefined;
+    private themeOverride?: Theme | undefined;
 
     constructor({
         sessionToken,
@@ -53,7 +60,8 @@ export class ConnectUI {
         apiURL = 'https://api.nango.dev',
         detectClosedAuthWindow,
         onEvent,
-        lang
+        lang,
+        themeOverride
     }: ConnectUIProps) {
         this.sessionToken = sessionToken;
         this.baseURL = baseURL;
@@ -61,6 +69,7 @@ export class ConnectUI {
         this.onEvent = onEvent;
         this.detectClosedAuthWindow = detectClosedAuthWindow;
         this.lang = lang;
+        this.themeOverride = themeOverride;
     }
 
     /**
@@ -85,6 +94,9 @@ export class ConnectUI {
         }
         if (this.lang) {
             baseURL.searchParams.append('lang', this.lang);
+        }
+        if (this.themeOverride) {
+            baseURL.searchParams.append('theme', this.themeOverride);
         }
 
         const iframe = document.createElement('iframe');

--- a/packages/webapp/src/pages/ConnectUI/Show.tsx
+++ b/packages/webapp/src/pages/ConnectUI/Show.tsx
@@ -1,3 +1,4 @@
+import { IconHelpCircle, IconMoon, IconSun } from '@tabler/icons-react';
 import { useForm } from '@tanstack/react-form';
 import { useRef } from 'react';
 import { Helmet } from 'react-helmet';
@@ -6,6 +7,8 @@ import { ColorInput, isValidCSSColor } from './components/ColorInput';
 import { ConnectUIPreview } from './components/ConnectUIPreview';
 import { LeftNavBarItems } from '../../components/LeftNavBar';
 import LinkWithIcon from '../../components/LinkWithIcon';
+import { SimpleTooltip } from '../../components/SimpleTooltip';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../components/ui/Select';
 import { Switch } from '../../components/ui/Switch';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../components/ui/Tooltip';
 import { Button } from '../../components/ui/button/Button';
@@ -16,7 +19,7 @@ import DashboardLayout from '../../layout/DashboardLayout';
 import { useStore } from '../../store';
 
 import type { ConnectUIPreviewRef } from './components/ConnectUIPreview';
-import type { ConnectUIColorPalette } from '@nangohq/types';
+import type { ConnectUIColorPalette, Theme } from '@nangohq/types';
 
 // Utility type to generate all possible theme paths
 type ThemePath = {
@@ -26,6 +29,13 @@ type ThemePath = {
 const lightThemeFields: { name: ThemePath; label: string }[] = [
     {
         name: 'theme.light.primary',
+        label: 'Primary color'
+    }
+];
+
+const darkThemeFields: { name: ThemePath; label: string }[] = [
+    {
+        name: 'theme.dark.primary',
         label: 'Primary color'
     }
 ];
@@ -48,7 +58,7 @@ export const ConnectUISettingsPage = () => {
                     connectUIPreviewRef.current.sendSettingsChanged(state.formApi.state.values);
                 }
             },
-            onChangeDebounceMs: 500
+            onChangeDebounceMs: 100
         },
         onSubmit: (state) => {
             updateConnectUISettings(state.formApi.state.values, {
@@ -74,7 +84,7 @@ export const ConnectUISettingsPage = () => {
             <Helmet>
                 <title>Connect UI - Nango</title>
             </Helmet>
-            <div className="flex w-full h-full ">
+            <div className="flex w-full h-full min-w-[1000px] overflow-w-auto">
                 <form
                     onSubmit={(e) => {
                         e.preventDefault();
@@ -85,46 +95,47 @@ export const ConnectUISettingsPage = () => {
                 >
                     <h2 className="text-2xl font-bold text-white">Connect UI Settings</h2>
                     <div className="flex flex-col gap-6">
-                        {lightThemeFields.map((themeField) => (
-                            <form.Field
-                                key={themeField.name}
-                                name={themeField.name}
-                                validators={{
-                                    onChange: ({ value }: { value: string }) => (!isValidCSSColor(value) ? 'Invalid CSS color' : undefined)
-                                }}
-                            >
-                                {(field) => (
-                                    <div className="w-full flex gap-2 justify-between items-center">
-                                        <label htmlFor={themeField.name} className="text-sm font-medium text-grayscale-300">
-                                            {themeField.label}
-                                        </label>
-                                        <Tooltip delayDuration={0}>
-                                            <TooltipTrigger asChild>
-                                                <div className="flex flex-col gap-1">
-                                                    <ColorInput
-                                                        value={field.state.value}
-                                                        onChange={(e) => field.handleChange(e.target.value)}
-                                                        onBlur={field.handleBlur}
-                                                        disabled={!environment.plan?.can_customize_connect_ui_theme}
-                                                    />
-                                                    {!field.state.meta.isValid && (
-                                                        <em role="alert" className="text-sm text-red-500">
-                                                            {field.state.meta.errors.join(', ')}
-                                                        </em>
-                                                    )}
-                                                </div>
-                                            </TooltipTrigger>
-                                            {!environment.plan?.can_customize_connect_ui_theme && (
-                                                <TooltipContent side="bottom" className="text-grayscale-300">
-                                                    Customizing the theme is only available for Growth plans.{' '}
-                                                    <LinkWithIcon to={`/${env}/team/billing`}>Upgrade your plan</LinkWithIcon>
-                                                </TooltipContent>
-                                            )}
-                                        </Tooltip>
+                        <form.Field name="defaultTheme">
+                            {(field) => (
+                                <div className="w-full flex gap-2 justify-between items-center">
+                                    <label htmlFor={field.name} className="text-sm font-medium text-grayscale-300 flex items-center gap-1">
+                                        Default theme{' '}
+                                        <SimpleTooltip
+                                            side="right"
+                                            tooltipContent={
+                                                <p>
+                                                    You can override the theme per session from the{' '}
+                                                    <LinkWithIcon to="https://docs.nango.dev/reference/sdks/frontend#param-theme-override" type="external">
+                                                        Frontend SDK
+                                                    </LinkWithIcon>
+                                                </p>
+                                            }
+                                        >
+                                            <IconHelpCircle className="w-4 h-4" />
+                                        </SimpleTooltip>
+                                    </label>
+                                    <div className="flex items-center">
+                                        <Select name={field.name} value={field.state.value} onValueChange={(value) => field.handleChange(value as Theme)}>
+                                            <SelectTrigger className="w-[180px] text-text-primary text-sm">
+                                                <SelectValue placeholder="Default theme" />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                <SelectItem value="system">System</SelectItem>
+                                                <SelectItem value="light">Light</SelectItem>
+                                                <SelectItem value="dark">Dark</SelectItem>
+                                            </SelectContent>
+                                        </Select>
                                     </div>
-                                )}
-                            </form.Field>
-                        ))}
+                                    {!environment.plan?.can_disable_connect_ui_watermark && (
+                                        <TooltipContent className="text-grayscale-300">
+                                            Disabling the watermark is only available for Growth plans.{' '}
+                                            <LinkWithIcon to={`/${env}/team/billing`}>Upgrade your plan</LinkWithIcon>
+                                        </TooltipContent>
+                                    )}
+                                </div>
+                            )}
+                        </form.Field>
+
                         <form.Field name="showWatermark">
                             {(field) => (
                                 <div className="flex gap-5 items-center">
@@ -154,6 +165,99 @@ export const ConnectUISettingsPage = () => {
                                 </div>
                             )}
                         </form.Field>
+                    </div>
+
+                    <div className="flex flex-col border border-grayscale-4">
+                        <div className="flex justify-between items-center p-4 py-3 border-b border-grayscale-4">
+                            <div className="w-full">
+                                <h3 className="text-lg font-bold text-white flex items-center gap-1.5">
+                                    Light Theme <IconSun className="w-5 h-5" />
+                                </h3>
+                            </div>
+                            <div className="w-full">
+                                <h3 className="text-lg font-bold text-white flex items-center gap-1.5">
+                                    Dark Theme <IconMoon className="w-5 h-5" />
+                                </h3>
+                            </div>
+                        </div>
+                        <div className="flex justify-between">
+                            <div className="w-full flex flex-col gap-6 p-4">
+                                {lightThemeFields.map((themeField) => (
+                                    <form.Field
+                                        key={themeField.name}
+                                        name={themeField.name}
+                                        validators={{
+                                            onChange: ({ value }: { value: string }) => (!isValidCSSColor(value) ? 'Invalid CSS color' : undefined)
+                                        }}
+                                    >
+                                        {(field) => (
+                                            <Tooltip delayDuration={0}>
+                                                <TooltipTrigger asChild>
+                                                    <div className="flex flex-col gap-1">
+                                                        <ColorInput
+                                                            label={themeField.label}
+                                                            value={field.state.value}
+                                                            onChange={(e) => field.handleChange(e.target.value)}
+                                                            onBlur={field.handleBlur}
+                                                            disabled={!environment.plan?.can_customize_connect_ui_theme}
+                                                        />
+                                                        {!field.state.meta.isValid && (
+                                                            <em role="alert" className="text-sm text-red-500">
+                                                                {field.state.meta.errors.join(', ')}
+                                                            </em>
+                                                        )}
+                                                    </div>
+                                                </TooltipTrigger>
+                                                {!environment.plan?.can_customize_connect_ui_theme && (
+                                                    <TooltipContent side="bottom" className="text-grayscale-300">
+                                                        Customizing the theme is only available for Growth plans.{' '}
+                                                        <LinkWithIcon to={`/${env}/team/billing`}>Upgrade your plan</LinkWithIcon>
+                                                    </TooltipContent>
+                                                )}
+                                            </Tooltip>
+                                        )}
+                                    </form.Field>
+                                ))}
+                            </div>
+                            <div className="w-full flex flex-col gap-6 p-4">
+                                {darkThemeFields.map((themeField) => (
+                                    <form.Field
+                                        key={themeField.name}
+                                        name={themeField.name}
+                                        validators={{
+                                            onChange: ({ value }: { value: string }) => (!isValidCSSColor(value) ? 'Invalid CSS color' : undefined)
+                                        }}
+                                    >
+                                        {(field) => (
+                                            <Tooltip delayDuration={0}>
+                                                <TooltipTrigger asChild>
+                                                    <div className="flex flex-col gap-1">
+                                                        <ColorInput
+                                                            label={themeField.label}
+                                                            value={field.state.value}
+                                                            onChange={(e) => field.handleChange(e.target.value)}
+                                                            onBlur={field.handleBlur}
+                                                            disabled={!environment.plan?.can_customize_connect_ui_theme}
+                                                        />
+                                                        {!field.state.meta.isValid && (
+                                                            <em role="alert" className="text-sm text-red-500">
+                                                                {field.state.meta.errors.join(', ')}
+                                                            </em>
+                                                        )}
+                                                    </div>
+                                                </TooltipTrigger>
+                                                {!environment.plan?.can_customize_connect_ui_theme && (
+                                                    <TooltipContent side="bottom" className="text-grayscale-300">
+                                                        Customizing the theme is only available for Growth plans.{' '}
+                                                        <LinkWithIcon to={`/${env}/team/billing`}>Upgrade your plan</LinkWithIcon>
+                                                    </TooltipContent>
+                                                )}
+                                            </Tooltip>
+                                        )}
+                                    </form.Field>
+                                ))}
+                            </div>
+                        </div>
                     </div>
 
                     {/** Save Button */}


### PR DESCRIPTION
> [!note]
> Depends on https://github.com/NangoHQ/nango/pull/4672

- Adds theme selection (dark/light/system) in ConnectUI settings.
- Adds `themeOverride` parameter to`nango.openConnectUI`.
- Adds dark mode to ConnectUI (this was basically done with previous PR, this one makes it accessible)

Preview:
<img width="1919" height="966" alt="image" src="https://github.com/user-attachments/assets/1ecab986-93d9-4599-8434-da8708b67025" />
<!-- Summary by @propel-code-bot -->

---

**Add Theme Selection and Dark Mode Support to ConnectUI, Expose Per-Session Theme Override**

This PR integrates dark theme support and advanced theme selection functionality into the `ConnectUI` system. Users can now choose a global ConnectUI theme (dark, light, or system) via a new selector in the dashboard, while developers can use the new `themeOverride` parameter to specify the theme per session in the frontend SDK (`nango.openConnectUI`). The change includes extensive refactoring and upgrades to the theming logic, session runtime parameter propagation, and improved CSS variable scoping for iframe/host isolation. Documentation has also been updated to describe new configuration options and usage patterns. This PR depends on theme data migration from a prior PR (#4672) and revises both UI and backend theme-handling mechanisms for flexibility and extensibility.

<details>
<summary><strong>Key Changes</strong></summary>

• Added a theme selector (`light`/`dark`/`system`) to ConnectUI dashboard settings in `packages/webapp/src/pages/ConnectUI/Show.tsx`.
• Introduced the `themeOverride` parameter to `ConnectUIProps` in `packages/frontend/lib/connectUI.ts`, propagated as a URL param to the iframe.
• Refactored theming utilities and color resolution logic in `packages/connect-ui/src/lib/theme.ts` to support both global and per-session theme selection, with correct system detection.
• Redesigned settings update handling in `packages/connect-ui/src/lib/updateSettings.ts` to support the combined theme override and runtime theme application.
• Extended ConnectUI core and Home screen (`packages/connect-ui/src/views/Home.tsx`, `App.tsx`) to initialize, apply, and respond to theme params instantly.
• Enhanced CSS scoping for theme variables in `packages/connect-ui/src/index.css` by applying within `:root` and `:host` for correct isolation and inheritance.
• Expanded frontend SDK documentation (`docs-v2/reference/sdks/frontend.mdx`) to describe theme precedence and options.
• Minor UI/UX improvements: lower debounce on settings update, preview/dev fixes for settings pages, and improved color input validation for both themes.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/pages/ConnectUI/Show.tsx`
• `packages/frontend/lib/connectUI.ts`
• `packages/connect-ui/src/lib/theme.ts`
• `packages/connect-ui/src/lib/updateSettings.ts`
• `packages/connect-ui/src/views/Home.tsx`
• `packages/connect-ui/src/App.tsx`
• `packages/connect-ui/src/index.css`
• `docs-v2/reference/sdks/frontend.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*