### PR TITLE
chore: adding provider dimensions to auth and connection creation/deletion metrics 

### DIFF
--- a/packages/server/lib/controllers/auth/postAppStore.ts
+++ b/packages/server/lib/controllers/auth/postAppStore.ts
@@ -22,6 +22,7 @@ import { errorRestrictConnectionId, isIntegrationAllowed } from '../../utils/aut
 import { hmacCheck } from '../../utils/hmac.js';
 
 import type { LogContext } from '@nangohq/logs';
+import type { Config as ProviderConfig } from '@nangohq/shared';
 import type { ConnectionConfig, PostPublicAppStoreAuthorization, ProviderAppleAppStore } from '@nangohq/types';
 import type { NextFunction } from 'express';
 
@@ -87,6 +88,7 @@ export const postPublicAppStoreAuthorization = asyncWrapper<PostPublicAppStoreAu
     }
 
     let logCtx: LogContext | undefined;
+    let config: ProviderConfig | null = null;
     try {
         logCtx =
             isConnectSession && connectSession.operationId
@@ -107,7 +109,7 @@ export const postPublicAppStoreAuthorization = asyncWrapper<PostPublicAppStoreAu
             }
         }
 
-        const config = await configService.getProviderConfig(providerConfigKey, environment.id);
+        config = await configService.getProviderConfig(providerConfigKey, environment.id);
         if (!config) {
             void logCtx.error('Unknown provider config');
             await logCtx.failed();
@@ -230,7 +232,7 @@ export const postPublicAppStoreAuthorization = asyncWrapper<PostPublicAppStoreAu
             logContextGetter
         );
 
-        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode });
+        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
 
         res.status(200).send({ connectionId, providerConfigKey });
     } catch (err) {
@@ -262,7 +264,7 @@ export const postPublicAppStoreAuthorization = asyncWrapper<PostPublicAppStoreAu
             metadata: { providerConfigKey, connectionId }
         });
 
-        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'APP_STORE' });
+        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'APP_STORE', ...(config ? { provider: config.provider } : {}) });
 
         next(err);
     }

--- a/packages/server/lib/controllers/auth/postBasic.ts
+++ b/packages/server/lib/controllers/auth/postBasic.ts
@@ -26,6 +26,7 @@ import { errorRestrictConnectionId, isIntegrationAllowed } from '../../utils/aut
 import { hmacCheck } from '../../utils/hmac.js';
 
 import type { LogContext } from '@nangohq/logs';
+import type { Config as ProviderConfig } from '@nangohq/shared';
 import type { BasicApiCredentials, PostPublicBasicAuthorization } from '@nangohq/types';
 import type { NextFunction } from 'express';
 
@@ -82,6 +83,7 @@ export const postPublicBasicAuthorization = asyncWrapper<PostPublicBasicAuthoriz
     }
 
     let logCtx: LogContext | undefined;
+    let config: ProviderConfig | null = null;
     try {
         logCtx =
             isConnectSession && connectSession.operationId
@@ -102,7 +104,7 @@ export const postPublicBasicAuthorization = asyncWrapper<PostPublicBasicAuthoriz
             }
         }
 
-        const config = await configService.getProviderConfig(providerConfigKey, environment.id);
+        config = await configService.getProviderConfig(providerConfigKey, environment.id);
         if (!config) {
             void logCtx.error('Unknown provider config');
             await logCtx.failed();
@@ -224,7 +226,7 @@ export const postPublicBasicAuthorization = asyncWrapper<PostPublicBasicAuthoriz
             logContextGetter
         );
 
-        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode });
+        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
 
         res.status(200).send({ connectionId, providerConfigKey });
     } catch (err) {
@@ -256,7 +258,7 @@ export const postPublicBasicAuthorization = asyncWrapper<PostPublicBasicAuthoriz
             metadata: { providerConfigKey, connectionId }
         });
 
-        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'BASIC' });
+        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'BASIC', ...(config ? { provider: config.provider } : {}) });
 
         next(err);
     }

--- a/packages/server/lib/controllers/auth/postBill.ts
+++ b/packages/server/lib/controllers/auth/postBill.ts
@@ -23,6 +23,7 @@ import { errorRestrictConnectionId, isIntegrationAllowed } from '../../utils/aut
 import { hmacCheck } from '../../utils/hmac.js';
 
 import type { LogContext } from '@nangohq/logs';
+import type { Config as ProviderConfig } from '@nangohq/shared';
 import type { PostPublicBillAuthorization, ProviderBill } from '@nangohq/types';
 import type { NextFunction } from 'express';
 
@@ -89,6 +90,7 @@ export const postPublicBillAuthorization = asyncWrapper<PostPublicBillAuthorizat
     }
 
     let logCtx: LogContext | undefined;
+    let config: ProviderConfig | null = null;
 
     try {
         logCtx =
@@ -110,7 +112,7 @@ export const postPublicBillAuthorization = asyncWrapper<PostPublicBillAuthorizat
             }
         }
 
-        const config = await configService.getProviderConfig(providerConfigKey, environment.id);
+        config = await configService.getProviderConfig(providerConfigKey, environment.id);
         if (!config) {
             void logCtx.error('Unknown provider config');
             await logCtx.failed();
@@ -225,7 +227,7 @@ export const postPublicBillAuthorization = asyncWrapper<PostPublicBillAuthorizat
             logContextGetter
         );
 
-        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode });
+        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
 
         res.status(200).send({ connectionId, providerConfigKey });
     } catch (err) {
@@ -257,7 +259,7 @@ export const postPublicBillAuthorization = asyncWrapper<PostPublicBillAuthorizat
             metadata: { providerConfigKey, connectionId }
         });
 
-        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'BILL' });
+        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'BILL', ...(config ? { provider: config.provider } : {}) });
 
         next(err);
     }

--- a/packages/server/lib/controllers/auth/postJwt.ts
+++ b/packages/server/lib/controllers/auth/postJwt.ts
@@ -27,6 +27,7 @@ import { errorRestrictConnectionId, isIntegrationAllowed } from '../../utils/aut
 import { hmacCheck } from '../../utils/hmac.js';
 
 import type { LogContext } from '@nangohq/logs';
+import type { Config as ProviderConfig } from '@nangohq/shared';
 import type { PostPublicJwtAuthorization, ProviderJwt } from '@nangohq/types';
 import type { NextFunction } from 'express';
 
@@ -85,6 +86,7 @@ export const postPublicJwtAuthorization = asyncWrapper<PostPublicJwtAuthorizatio
     }
 
     let logCtx: LogContext | undefined;
+    let config: ProviderConfig | null = null;
 
     try {
         logCtx =
@@ -106,7 +108,7 @@ export const postPublicJwtAuthorization = asyncWrapper<PostPublicJwtAuthorizatio
             }
         }
 
-        const config = await configService.getProviderConfig(providerConfigKey, environment.id);
+        config = await configService.getProviderConfig(providerConfigKey, environment.id);
         if (!config) {
             void logCtx.error('Unknown provider config');
             await logCtx.failed();
@@ -234,7 +236,7 @@ export const postPublicJwtAuthorization = asyncWrapper<PostPublicJwtAuthorizatio
             logContextGetter
         );
 
-        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode });
+        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
 
         res.status(200).send({ connectionId, providerConfigKey });
     } catch (err) {
@@ -266,7 +268,7 @@ export const postPublicJwtAuthorization = asyncWrapper<PostPublicJwtAuthorizatio
             metadata: { providerConfigKey, connectionId }
         });
 
-        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'JWT' });
+        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'JWT', ...(config ? { provider: config.provider } : {}) });
 
         next(err);
     }

--- a/packages/server/lib/controllers/auth/postSignature.ts
+++ b/packages/server/lib/controllers/auth/postSignature.ts
@@ -27,6 +27,7 @@ import { errorRestrictConnectionId, isIntegrationAllowed } from '../../utils/aut
 import { hmacCheck } from '../../utils/hmac.js';
 
 import type { LogContext } from '@nangohq/logs';
+import type { Config as ProviderConfig } from '@nangohq/shared';
 import type { PostPublicSignatureAuthorization, ProviderSignature } from '@nangohq/types';
 import type { NextFunction } from 'express';
 
@@ -92,6 +93,7 @@ export const postPublicSignatureAuthorization = asyncWrapper<PostPublicSignature
     }
 
     let logCtx: LogContext | undefined;
+    let config: ProviderConfig | null = null;
 
     try {
         logCtx =
@@ -113,7 +115,7 @@ export const postPublicSignatureAuthorization = asyncWrapper<PostPublicSignature
             }
         }
 
-        const config = await configService.getProviderConfig(providerConfigKey, environment.id);
+        config = await configService.getProviderConfig(providerConfigKey, environment.id);
         if (!config) {
             void logCtx.error('Unknown provider config');
             await logCtx.failed();
@@ -240,7 +242,7 @@ export const postPublicSignatureAuthorization = asyncWrapper<PostPublicSignature
             logContextGetter
         );
 
-        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode });
+        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
 
         res.status(200).send({ connectionId, providerConfigKey });
     } catch (err) {
@@ -272,7 +274,7 @@ export const postPublicSignatureAuthorization = asyncWrapper<PostPublicSignature
             metadata: { providerConfigKey, connectionId }
         });
 
-        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'SIGNATURE' });
+        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'SIGNATURE', ...(config ? { provider: config.provider } : {}) });
 
         next(err);
     }

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -319,6 +319,7 @@ class OAuthController {
         }
 
         let logCtx: LogContext | undefined;
+        let config: ProviderConfig | null = null;
 
         try {
             logCtx =
@@ -348,7 +349,7 @@ class OAuthController {
                 }
             }
 
-            const config = await configService.getProviderConfig(providerConfigKey, environment.id);
+            config = await configService.getProviderConfig(providerConfigKey, environment.id);
             if (!config) {
                 void logCtx.error('Unknown provider config');
                 await logCtx.failed();
@@ -470,7 +471,7 @@ class OAuthController {
                 logContextGetter
             );
 
-            metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode });
+            metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
 
             res.status(200).send({ providerConfigKey: providerConfigKey, connectionId: connectionId });
         } catch (err) {
@@ -505,7 +506,7 @@ class OAuthController {
                 }
             });
 
-            metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'OAUTH2_CC' });
+            metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'OAUTH2_CC', ...(config ? { provider: config.provider } : {}) });
 
             next(err);
         }
@@ -959,7 +960,7 @@ class OAuthController {
             void logCtx?.error('Unknown error', { error: err, url: req.originalUrl });
             await logCtx?.failed();
 
-            metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'OAUTH2' });
+            metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'OAUTH2', provider: session.provider });
 
             return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.UnknownError(prettyError));
         }
@@ -1506,7 +1507,7 @@ class OAuthController {
 
             await logCtx.success();
 
-            metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode });
+            metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
 
             if (res) {
                 await publisher.notifySuccess({
@@ -1550,7 +1551,7 @@ class OAuthController {
                 config
             );
 
-            metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'OAUTH2' });
+            metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'OAUTH2', provider: config.provider });
 
             if (res) {
                 return publisher.notifyErr(res, channel, providerConfigKey, connectionId, error);
@@ -1680,7 +1681,7 @@ class OAuthController {
                 );
                 await logCtx.success();
 
-                metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode });
+                metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
 
                 return publisher.notifySuccess({
                     res,
@@ -1721,7 +1722,7 @@ class OAuthController {
                     account,
                     config
                 );
-                metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'OAUTH1' });
+                metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'OAUTH1', provider: config.provider });
 
                 return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.UnknownError(prettyError));
             });

--- a/packages/server/lib/hooks/connection/post-connection.ts
+++ b/packages/server/lib/hooks/connection/post-connection.ts
@@ -46,10 +46,10 @@ async function execute(createdConnection: RecentlyCreatedConnection, providerNam
             await handler(internalNango);
             void logCtx.info(`post-connection-creation script succeeded`);
             await logCtx.success();
-            metrics.increment(metrics.Types.POST_CONNECTION_SUCCESS);
+            metrics.increment(metrics.Types.POST_CONNECTION_SUCCESS, 1, { provider: providerName });
         }
     } catch (err) {
-        metrics.increment(metrics.Types.POST_CONNECTION_FAILURE);
+        metrics.increment(metrics.Types.POST_CONNECTION_FAILURE, 1, { provider: providerName });
         void logCtx?.error('Post-connection script failed', { error: err });
         await logCtx?.failed();
     }

--- a/packages/server/lib/hooks/connection/pre-connection.ts
+++ b/packages/server/lib/hooks/connection/pre-connection.ts
@@ -49,10 +49,10 @@ async function execute({
             await handler(internalNango);
             void logCtx.info(`pre-connection-deletion script succeeded`);
             await logCtx.success();
-            metrics.increment(metrics.Types.PRE_CONNECTION_DELETION_SUCCESS);
+            metrics.increment(metrics.Types.PRE_CONNECTION_DELETION_SUCCESS, 1, { provider: providerName });
         }
     } catch (err) {
-        metrics.increment(metrics.Types.PRE_CONNECTION_DELETION_FAILURE);
+        metrics.increment(metrics.Types.PRE_CONNECTION_DELETION_FAILURE, 1, { provider: providerName });
         void logCtx?.error('Pre-connection deletion script failed', { error: err });
         await logCtx?.failed();
     }


### PR DESCRIPTION
We recently had an incident where all Slack auth did fail. 
Adding a provider dimension to the metrics so we can more easily monitor such provider related failure
<!-- Summary by @propel-code-bot -->

---

**Add Provider Dimension to Auth and Connection Metrics**

This pull request updates all authentication and connection creation/deletion metric events in the server codebase to include a `provider` label/dimension. These changes enable easier isolation and monitoring of provider-specific authentication and connection issues (e.g., distinguishing Slack failures from others). All locations where `metrics.increment` is called for authentication success/failure and pre/post-connection hook outcomes now pass the responsible provider, improving observability.

<details>
<summary><strong>Key Changes</strong></summary>

• Added a `provider` field to the third argument of `metrics.increment` calls for all `AUTH_SUCCESS` and `AUTH_FAILURE` metric invocations across all authentication controllers (e.g., `postBasic.ts`, `postOauthOutbound.ts`, `postApiKey.ts`, etc.)
• Updated pre- and post-connection hook scripts (`pre-connection.ts`, `post-connection.ts`) so metric events for connection creation/deletion success/failure also include the `provider` dimension
• Refactored controller implementations to obtain `provider` from `config` or function context to ensure the correct value is always available at the metric emission site
• Ensured defensive code with fallback or conditional spreading where `config` may be undefined to prevent passing `provider: undefined`
• Made minor type/interface/variable adjustments as needed to support the `provider` dimension

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/oauth.controller.ts`
• `packages/server/lib/controllers/auth/postBasic.ts`
• `packages/server/lib/controllers/auth/postSignature.ts`
• `packages/server/lib/controllers/auth/postOauthOutbound.ts`
• `packages/server/lib/controllers/auth/postApiKey.ts`
• `packages/server/lib/controllers/auth/postBill.ts`
• `packages/server/lib/controllers/auth/postJwt.ts`
• `packages/server/lib/controllers/auth/postTba.ts`
• `packages/server/lib/controllers/auth/postTwoStep.ts`
• `packages/server/lib/controllers/auth/postUnauthenticated.ts`
• `packages/server/lib/controllers/auth/postAppStore.ts`
• `packages/server/lib/hooks/connection/pre-connection.ts`
• `packages/server/lib/hooks/connection/post-connection.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*