### PR TITLE
fix(otlp-exporter): include /v1 prefix automitically

### DIFF
--- a/packages/logs/lib/otlp/otlpSpanProcessor.ts
+++ b/packages/logs/lib/otlp/otlpSpanProcessor.ts
@@ -102,7 +102,7 @@ export class RoutingSpanProcessor implements SpanProcessor {
         return new LoggingSpanExporter({
             routeConfig: route,
             exporter: new OTLPTraceExporter({
-                url: `${route.routingEndpoint}/traces`,
+                url: `${route.routingEndpoint}/v1/traces`.replace(/\/v1\/v1\//g, '/v1/'),
                 headers: route.routingHeaders
             })
         });


### PR DESCRIPTION
For some reason I don't recall 🤷  I didn't include /v1 in the OTLPTraceExporter url path and require the customer to add it in the otlp collector settings.
This was an error, most of the customers are confused by it even though it is in the docs and in the placeholder example.
In order not to break existing customers, we are making the /v1 optional with this commit. Once I have fixed all customers settings I will remove the call to replace()

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Automatically Add /v1 Prefix to OTLP Exporter URL**

This PR updates the OTLP exporter initialization logic in `RoutingSpanProcessor` to automatically append the `/v1` prefix to the trace export URL. The change is made to reduce confusion for users who previously had to add the `/v1` path segment manually in their OTLP collector settings. To avoid breaking existing configurations where `/v1` might already be present, a `.replace()` expression is used to deduplicate `/v1` segments in the final URL.

<details>
<summary><strong>Key Changes</strong></summary>

• Changed the `url` option for `OTLPTraceExporter` from `${route.routingEndpoint}/traces` to `${route.routingEndpoint}/v1/traces`.replace(/\/v1\/v1\//g, '/v1/')`
• Automatically deduplicates multiple `/v1` segments in the OTLP exporter URL to prevent accidental double `/v1` paths

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/logs/lib/otlp/otlpSpanProcessor.ts`
• `RoutingSpanProcessor.newExporter` method

</details>

---
*This summary was automatically generated by @propel-code-bot*