### PR TITLE
fix(otlp-exporter): remove temporary url fix

### DIFF
--- a/docs-v2/implementation-guides/platform/open-telemetry-logs-export.mdx
+++ b/docs-v2/implementation-guides/platform/open-telemetry-logs-export.mdx
@@ -30,7 +30,7 @@ The following operations are currently exported (as of November 2024):
     </Step>
     <Step title="Configure OpenTelemetry Export">
         In the Environment Settings, provide the following information:
-        - OpenTelemetry endpoint: The endpoint URL of your OpenTelemetry collector. Ex: https://my.otlp.collector:4318/v1/
+        - OpenTelemetry endpoint: The endpoint URL of your OpenTelemetry collector. Ex: https://my.otlp.collector:4318
         - Headers (Optional): Any authorization headers or additional headers required to access your collector.
     </Step>
 </Steps>

--- a/packages/logs/lib/otlp/otlpSpanProcessor.ts
+++ b/packages/logs/lib/otlp/otlpSpanProcessor.ts
@@ -102,7 +102,7 @@ export class RoutingSpanProcessor implements SpanProcessor {
         return new LoggingSpanExporter({
             routeConfig: route,
             exporter: new OTLPTraceExporter({
-                url: `${route.routingEndpoint}/v1/traces`.replace(/\/v1\/v1\//g, '/v1/'),
+                url: `${route.routingEndpoint}/v1/traces`,
                 headers: route.routingHeaders
             })
         });

--- a/packages/webapp/src/pages/Environment/Settings/Export.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Export.tsx
@@ -120,7 +120,7 @@ export const ExportSettings: React.FC = () => {
                     originalValue={environmentAndAccount?.environment.otlp_settings?.endpoint || ''}
                     apiCall={(value) => apiPatchEnvironment(env, { otlp_endpoint: value })}
                     onSuccess={() => void mutate()}
-                    placeholder="https://my.otlp.commector:4318/v1"
+                    placeholder="https://my.otlp.commector:4318"
                 />
                 <fieldset className="flex flex-col gap-1">
                     <label htmlFor="otlp_headers" className="text-s">


### PR DESCRIPTION
follow-up of #4675 
To merge only after customers settings have been fixed to not include /v1 in their otlp endpoint

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Remove Temporary OTLP URL Workaround and Update Documentation/Placeholders**

This pull request removes a temporary workaround in the OpenTelemetry trace exporter implementation that previously corrected for duplicate `/v1` path segments in the OTLP endpoint URL. The modifications ensure the URL for the `OTLPTraceExporter` is now consistently constructed as `${route.routingEndpoint}/v1/traces` without post-processing, based on the assumption that customer settings have been updated to exclude an extra `/v1`. Additionally, related documentation and UI placeholder text are updated to match the revised configuration by removing the `/v1` suffix from user-supplied endpoints.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed `.replace(/\/v1\/v1\//g, '/v1/')` string fix from the `url` parameter in `OTLPTraceExporter` initialization in `packages/logs/lib/otlp/otlpSpanProcessor.ts`.
• Updated the placeholder text for OTLP endpoints in `packages/webapp/src/pages/Environment/Settings/Export.tsx` to exclude `/v1`.
• Adjusted example OTLP endpoint in documentation (`docs-v2/implementation-guides/platform/open-telemetry-logs-export.mdx`) to no longer include `/v1`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/logs/lib/otlp/otlpSpanProcessor.ts`
• `packages/webapp/src/pages/Environment/Settings/Export.tsx`
• `docs-v2/implementation-guides/platform/open-telemetry-logs-export.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*