### PR TITLE
fix(mcp): restrict mcp

### DIFF
--- a/packages/server/lib/controllers/config.controller.ts
+++ b/packages/server/lib/controllers/config.controller.ts
@@ -26,24 +26,26 @@ class ConfigController {
         try {
             const sharedCredentials = await sharedCredentialsService.getPreConfiguredProviderScopes();
 
-            const list = Object.entries(providers).map((providerProperties) => {
-                const [provider, properties] = providerProperties;
-                // check if provider has nango's preconfigured credentials
-                const preConfiguredInfo = sharedCredentials.isOk() ? sharedCredentials.value[provider] : undefined;
-                const isPreConfigured = preConfiguredInfo ? preConfiguredInfo.preConfigured : false;
-                const preConfiguredScopes = preConfiguredInfo ? preConfiguredInfo.scopes : [];
+            const list = Object.entries(providers)
+                .filter(([, properties]) => properties.auth_mode !== 'MCP_OAUTH2')
+                .map((providerProperties) => {
+                    const [provider, properties] = providerProperties;
+                    // check if provider has nango's preconfigured credentials
+                    const preConfiguredInfo = sharedCredentials.isOk() ? sharedCredentials.value[provider] : undefined;
+                    const isPreConfigured = preConfiguredInfo ? preConfiguredInfo.preConfigured : false;
+                    const preConfiguredScopes = preConfiguredInfo ? preConfiguredInfo.scopes : [];
 
-                return {
-                    name: provider,
-                    displayName: properties.display_name,
-                    defaultScopes: properties.default_scopes,
-                    authMode: properties.auth_mode,
-                    categories: properties.categories,
-                    docs: properties.docs,
-                    preConfigured: isPreConfigured,
-                    preConfiguredScopes: preConfiguredScopes
-                };
-            });
+                    return {
+                        name: provider,
+                        displayName: properties.display_name,
+                        defaultScopes: properties.default_scopes,
+                        authMode: properties.auth_mode,
+                        categories: properties.categories,
+                        docs: properties.docs,
+                        preConfigured: isPreConfigured,
+                        preConfiguredScopes: preConfiguredScopes
+                    };
+                });
             const sortedList = list.sort((a, b) => a.name.localeCompare(b.name));
             res.status(200).send(sortedList);
         } catch (err) {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Restrict `MCP_OAUTH2` Providers from Yaml Provider List**

This pull request modifies the logic in the `listProvidersFromYaml` method of the `ConfigController` to exclude providers with `auth_mode` set to `MCP_OAUTH2` from the returned list. The change introduces a `.filter` step to the providers processing logic before the mapping and sorting, ensuring only relevant providers are included in API responses. No other business logic or files are changed.

<details>
<summary><strong>Key Changes</strong></summary>

• Added a `.filter(([, properties]) => properties.auth_mode !== 'MCP_OAUTH2')` to the provider list processing in `listProvidersFromYaml`.
• Now only providers not using the `MCP_OAUTH2` auth mode appear in the response.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/config.controller.ts` - specifically the `listProvidersFromYaml` method

</details>

---
*This summary was automatically generated by @propel-code-bot*