### PR TITLE
fix(import): allow github-app-oauth

### DIFF
--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -84,6 +84,7 @@ export type PostPublicConnection = Endpoint<{
             | Omit<BasicApiCredentials, 'raw'>
             | Omit<TbaCredentials, 'raw'>
             | { type: 'APP'; app_id: string; installation_id: string }
+            | { type: 'CUSTOM'; app_id: string; installation_id: string }
             | { type: 'NONE' };
         end_user?: EndUserInput | undefined;
     };


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Enable Support for `github-app-oauth` Import via `CUSTOM` Auth Type**

This pull request adds support for importing connections of type `github-app-oauth` by introducing a new `CUSTOM` authentication type to the `credentials` discriminated union. The controller logic for handling connection imports is updated to process `CUSTOM` type connections similarly to existing `APP` GitHub App connections, but with additional flexibility for `connection_config` overrides. Associated TypeScript type definitions are also extended to recognize the new `CUSTOM` credential structure.

<details>
<summary><strong>Key Changes</strong></summary>

• Extended `credentials` discriminated union in `packages/server/lib/controllers/connection/postConnection.ts` and `schemaBody` to support a new `CUSTOM` type leveraging `connectionCredentialsGithubAppSchema`.
• Added logic in `postPublicConnection` handler to process `CUSTOM` credentials: constructs a `connectionConfig`, calls `githubAppClient.createCredentials`, and performs connection upsertion.
• Updated TypeScript type definition in `packages/types/lib/connection/api/get.ts` (`PostPublicConnection.Body.credentials`) to allow `{ type: 'CUSTOM', app_id: string, installation_id: string }`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/connection/postConnection.ts`
• `packages/types/lib/connection/api/get.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*