### PR TITLE
fix(mcp): Improve mcp oauth types

### DIFF
--- a/packages/server/lib/controllers/config.controller.ts
+++ b/packages/server/lib/controllers/config.controller.ts
@@ -26,24 +26,26 @@ class ConfigController {
         try {
             const sharedCredentials = await sharedCredentialsService.getPreConfiguredProviderScopes();
 
-            const list = Object.entries(providers).map((providerProperties) => {
-                const [provider, properties] = providerProperties;
-                // check if provider has nango's preconfigured credentials
-                const preConfiguredInfo = sharedCredentials.isOk() ? sharedCredentials.value[provider] : undefined;
-                const isPreConfigured = preConfiguredInfo ? preConfiguredInfo.preConfigured : false;
-                const preConfiguredScopes = preConfiguredInfo ? preConfiguredInfo.scopes : [];
+            const list = Object.entries(providers)
+                .filter(([, properties]) => properties.auth_mode !== 'MCP_OAUTH2')
+                .map((providerProperties) => {
+                    const [provider, properties] = providerProperties;
+                    // check if provider has nango's preconfigured credentials
+                    const preConfiguredInfo = sharedCredentials.isOk() ? sharedCredentials.value[provider] : undefined;
+                    const isPreConfigured = preConfiguredInfo ? preConfiguredInfo.preConfigured : false;
+                    const preConfiguredScopes = preConfiguredInfo ? preConfiguredInfo.scopes : [];
 
-                return {
-                    name: provider,
-                    displayName: properties.display_name,
-                    defaultScopes: properties.default_scopes,
-                    authMode: properties.auth_mode,
-                    categories: properties.categories,
-                    docs: properties.docs,
-                    preConfigured: isPreConfigured,
-                    preConfiguredScopes: preConfiguredScopes
-                };
-            });
+                    return {
+                        name: provider,
+                        displayName: properties.display_name,
+                        defaultScopes: properties.default_scopes,
+                        authMode: properties.auth_mode,
+                        categories: properties.categories,
+                        docs: properties.docs,
+                        preConfigured: isPreConfigured,
+                        preConfiguredScopes: preConfiguredScopes
+                    };
+                });
             const sortedList = list.sort((a, b) => a.name.localeCompare(b.name));
             res.status(200).send(sortedList);
         } catch (err) {

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -74,6 +74,7 @@ import type {
     ProviderCustom,
     ProviderGithubApp,
     ProviderJwt,
+    ProviderMcpOAUTH2,
     ProviderOAuth2,
     ProviderSignature,
     ProviderTwoStep,
@@ -857,7 +858,11 @@ class ConnectionService {
 
     // Parses and arbitrary object (e.g. a server response or a user provided auth object) into AuthCredentials.
     // Throws if values are missing/missing the input is malformed.
-    public parseRawCredentials(rawCredentials: object, authMode: AuthModeType, template?: ProviderOAuth2 | ProviderTwoStep | ProviderCustom): AuthCredentials {
+    public parseRawCredentials(
+        rawCredentials: object,
+        authMode: AuthModeType,
+        template?: ProviderOAuth2 | ProviderTwoStep | ProviderCustom | ProviderMcpOAUTH2
+    ): AuthCredentials {
         const rawCreds = rawCredentials as Record<string, any>;
 
         switch (authMode) {

--- a/packages/types/lib/providers/provider.ts
+++ b/packages/types/lib/providers/provider.ts
@@ -94,9 +94,7 @@ export interface BaseProvider {
     require_client_certificate?: boolean;
 }
 
-export interface ProviderOAuth2 extends BaseProvider {
-    auth_mode: 'OAUTH2';
-
+interface BaseOAuth2Provider extends BaseProvider {
     disable_pkce?: boolean; // Defaults to false (=PKCE used) if not provided
 
     token_params?: {
@@ -113,6 +111,10 @@ export interface ProviderOAuth2 extends BaseProvider {
     expires_in_unit?: 'milliseconds';
 
     token_request_auth_method?: 'basic' | 'custom';
+}
+
+export interface ProviderOAuth2 extends BaseOAuth2Provider {
+    auth_mode: 'OAUTH2';
 }
 
 export interface ProviderOAuth1 extends BaseProvider {
@@ -136,7 +138,7 @@ export interface ProviderCustom extends Omit<ProviderOAuth2, 'auth_mode'> {
     };
 }
 
-export interface ProviderMcpOAUTH2 extends Omit<BaseProvider, 'body_format'> {
+export interface ProviderMcpOAUTH2 extends BaseOAuth2Provider {
     auth_mode: 'MCP_OAUTH2';
     registration_url?: string;
 }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Improve and Unify MCP OAuth Types Across Core Services**

This PR enhances type definitions and type safety for MCP OAuth (Multi-Connection Provider OAuth2) by refactoring interfaces and improving type usage throughout the codebase. The changes primarily involve unifying and extending `ProviderMcpOAUTH2` so it consistently inherits from the standard OAuth2 provider types, and adjusting all related type constraints and usages accordingly in both client and service logic. These changes enable more accurate typing and easier extension for MCP OAuth2 flows, while increasing robustness for credential parsing and refresh token logic.

<details>
<summary><strong>Key Changes</strong></summary>

• Refactored the `ProviderMcpOAUTH2` type in `packages/types/lib/providers/provider.ts` to extend from a new `BaseOAuth2Provider`, unifying its structure with `ProviderOAuth2`.
• Updated references and usages of provider types across `packages/shared/lib/clients/oauth2.client.ts` and `packages/shared/lib/services/connection.service.ts` to include `ProviderMcpOAUTH2`, improving compatibility and logic branching for MCP flows.
• Strengthened the conditional checks (e.g., for `token_request_auth_method`) to work broadly with any OAuth2 providers, including MCP variants.
• Expanded the credential parsing function's type signatures to accept the new unified MCP OAuth2 provider type.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/types/lib/providers/provider.ts`
• `packages/shared/lib/clients/oauth2.client.ts`
• `packages/shared/lib/services/connection.service.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*