### PR TITLE
feat: add frequency to usage.function_execution metering event

### DIFF
--- a/packages/utils/lib/frequency.ts
+++ b/packages/utils/lib/frequency.ts
@@ -1,0 +1,25 @@
+import ms from 'ms';
+
+import { Err, Ok } from './result.js';
+
+import type { Result } from './result.js';
+import type { StringValue } from 'ms';
+
+export function getFrequencyMs(intervalStr: string): Result<number> {
+    const runsMap = new Map([
+        ['every half day', '12h'],
+        ['every half hour', '30m'],
+        ['every quarter hour', '15m'],
+        ['every hour', '1h'],
+        ['every day', '1d'],
+        ['every month', '30d'],
+        ['every week', '7d']
+    ]);
+    const interval = runsMap.get(intervalStr) || intervalStr.replace('every ', '');
+    const intervalMs = ms((interval.trim() as StringValue) || 'not valid');
+    if (isNaN(intervalMs)) {
+        return Err('invalid_interval');
+    }
+
+    return Ok(intervalMs);
+}

--- a/packages/utils/lib/frequency.unit.test.ts
+++ b/packages/utils/lib/frequency.unit.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+
+import { getFrequencyMs } from './frequency.js';
+
+describe('getFrequencyMs', () => {
+    describe('predefined frequency strings', () => {
+        it('should convert "every half day" to 12 hours in milliseconds', () => {
+            const result = getFrequencyMs('every half day');
+            expect(result.unwrap()).toBe(12 * 60 * 60 * 1000); // 12 hours
+        });
+
+        it('should convert "every half hour" to 30 minutes in milliseconds', () => {
+            const result = getFrequencyMs('every half hour');
+            expect(result.unwrap()).toBe(30 * 60 * 1000); // 30 minutes
+        });
+
+        it('should convert "every quarter hour" to 15 minutes in milliseconds', () => {
+            const result = getFrequencyMs('every quarter hour');
+            expect(result.unwrap()).toBe(15 * 60 * 1000); // 15 minutes
+        });
+
+        it('should convert "every hour" to 1 hour in milliseconds', () => {
+            const result = getFrequencyMs('every hour');
+            expect(result.unwrap()).toBe(60 * 60 * 1000); // 1 hour
+        });
+
+        it('should convert "every day" to 24 hours in milliseconds', () => {
+            const result = getFrequencyMs('every day');
+            expect(result.unwrap()).toBe(24 * 60 * 60 * 1000); // 24 hours
+        });
+
+        it('should convert "every month" to 30 days in milliseconds', () => {
+            const result = getFrequencyMs('every month');
+            expect(result.unwrap()).toBe(30 * 24 * 60 * 60 * 1000); // 30 days
+        });
+
+        it('should convert "every week" to 7 days in milliseconds', () => {
+            const result = getFrequencyMs('every week');
+            expect(result.unwrap()).toBe(7 * 24 * 60 * 60 * 1000); // 7 days
+        });
+    });
+
+    describe('custom frequency strings with "every" prefix', () => {
+        it('should strip "every " prefix and parse custom intervals', () => {
+            const result = getFrequencyMs('every 5m');
+            expect(result.unwrap()).toBe(5 * 60 * 1000); // 5 minutes
+        });
+
+        it('should handle "every 2h" format', () => {
+            const result = getFrequencyMs('every 2h');
+            expect(result.unwrap()).toBe(2 * 60 * 60 * 1000); // 2 hours
+        });
+
+        it('should handle "every 3d" format', () => {
+            const result = getFrequencyMs('every 3d');
+            expect(result.unwrap()).toBe(3 * 24 * 60 * 60 * 1000); // 3 days
+        });
+    });
+
+    describe('direct time intervals', () => {
+        it('should parse minute intervals', () => {
+            const result = getFrequencyMs('10m');
+            expect(result.unwrap()).toBe(10 * 60 * 1000); // 10 minutes
+        });
+
+        it('should parse hour intervals', () => {
+            const result = getFrequencyMs('4h');
+            expect(result.unwrap()).toBe(4 * 60 * 60 * 1000); // 4 hours
+        });
+
+        it('should parse day intervals', () => {
+            const result = getFrequencyMs('2d');
+            expect(result.unwrap()).toBe(2 * 24 * 60 * 60 * 1000); // 2 days
+        });
+
+        it('should parse second intervals', () => {
+            const result = getFrequencyMs('30s');
+            expect(result.unwrap()).toBe(30 * 1000); // 30 seconds
+        });
+
+        it('should parse millisecond intervals', () => {
+            const result = getFrequencyMs('500ms');
+            expect(result.unwrap()).toBe(500); // 500 milliseconds
+        });
+
+        it('should parse week intervals', () => {
+            const result = getFrequencyMs('2w');
+            expect(result.unwrap()).toBe(2 * 7 * 24 * 60 * 60 * 1000); // 2 weeks
+        });
+
+        it('should handle negative values', () => {
+            const result = getFrequencyMs('-5m');
+            expect(result.unwrap()).toBe(-5 * 60 * 1000); // -5 minutes
+        });
+
+        it('should handle decimal values', () => {
+            const result = getFrequencyMs('1.5h');
+            expect(result.unwrap()).toBe(1.5 * 60 * 60 * 1000); // 1.5 hours
+        });
+
+        it('should handle zero values', () => {
+            const result = getFrequencyMs('0m');
+            expect(result.unwrap()).toBe(0);
+        });
+
+        it('should handle extra whitespace', () => {
+            const result = getFrequencyMs('  1ms  ');
+            expect(result.unwrap()).toBe(1); // 1ms
+        });
+    });
+
+    describe('invalid inputs', () => {
+        it('should return error for empty string', () => {
+            const result = getFrequencyMs('');
+            expect(result.unwrap).toThrowError('invalid_interval');
+        });
+
+        it('should return error for invalid format', () => {
+            const result = getFrequencyMs('invalid format');
+            expect(result.unwrap).toThrowError('invalid_interval');
+        });
+
+        it('should return error for non-numeric values', () => {
+            const result = getFrequencyMs('abc minutes');
+            expect(result.unwrap).toThrowError('invalid_interval');
+        });
+
+        it('should return error for unsupported units', () => {
+            const result = getFrequencyMs('5xyz');
+            expect(result.unwrap).toThrowError('invalid_interval');
+        });
+
+        it('should return error for unrecognized predefined frequency', () => {
+            const result = getFrequencyMs('every unknown period');
+            expect(result.unwrap).toThrowError('invalid_interval');
+        });
+        it('should handle case sensitivity for predefined frequencies', () => {
+            const result = getFrequencyMs('Every Hour');
+            expect(result.unwrap).toThrowError('invalid_interval');
+        });
+    });
+});

--- a/packages/utils/lib/index.ts
+++ b/packages/utils/lib/index.ts
@@ -25,3 +25,4 @@ export * from './http.js';
 export * from './version.js';
 export * from './wait.js';
 export * from './date.js';
+export * from './frequency.js';


### PR DESCRIPTION
the goal is to ingest frequencyMs as part of the Orb event in order to bucket functions execution based on sync frequency
<!-- Summary by @propel-code-bot -->

---

**Add Sync Frequency (frequencyMs) to Metering Event and Centralize Frequency Parsing**

This PR introduces a new utility function `getFrequencyMs` in `packages/utils/lib/frequency.ts` to parse and normalize various sync frequency string formats into milliseconds. The function is now the single source of truth for interpreting sync frequencies across the codebase, replacing all previous scattered implementations. The primary functional update is the inclusion of a `frequencyMs` property in the `usage.function_executions` metering event payload, allowing downstream systems (such as Orb) to bucket function executions by their configured sync frequency. Key components that deal with sync orchestration and event publishing have been updated to utilize this centralized logic. Thorough unit testing is provided to ensure robustness and correct error handling in frequency parsing.

<details>
<summary><strong>Key Changes</strong></summary>

• Added new utility function `getFrequencyMs` in `packages/utils/lib/frequency.ts` for parsing and validating sync frequency strings.
• Exported `getFrequencyMs` from `packages/utils/lib/index.ts` for shared use.
• Refactored `Orchestrator.getFrequencyMs()` in `packages/shared/lib/clients/orchestrator.ts` to delegate to the new utility, removing local parsing logic.
• Updated `packages/jobs/lib/execution/sync.ts` to extract `frequencyMs` and include it in the `usage.function_executions` event payload.
• Added comprehensive unit tests in `packages/utils/lib/frequency.unit.test.ts` for standard, custom, and error cases.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/utils/lib/frequency.ts`
• `packages/utils/lib/index.ts`
• `packages/shared/lib/clients/orchestrator.ts`
• `packages/jobs/lib/execution/sync.ts`
• `packages/utils/lib/frequency.unit.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*