### PR TITLE
fix(jobs): only start processors if max concurrency > 0

### DIFF
--- a/packages/jobs/lib/processor/processor.ts
+++ b/packages/jobs/lib/processor/processor.ts
@@ -39,8 +39,8 @@ export class Processor {
                     orchestratorClient: orchestratorClient,
                     groupKey: 'on-event',
                     maxConcurrency: envs.ONEVENT_PROCESSOR_MAX_CONCURRENCY
-                }).filter(Boolean)
-        ];
+                })
+        ].filter(Boolean);
     }
 
     start() {

--- a/packages/jobs/lib/processor/processor.ts
+++ b/packages/jobs/lib/processor/processor.ts
@@ -33,7 +33,7 @@ export class Processor {
     }
 
     start() {
-        logger.info('Starting task processors');
+        logger.info(`Starting ${this.processors.length} task processors`);
         this.processors.forEach((p) => p.start());
     }
 

--- a/packages/jobs/lib/processor/processor.ts
+++ b/packages/jobs/lib/processor/processor.ts
@@ -40,7 +40,7 @@ export class Processor {
                     groupKey: 'on-event',
                     maxConcurrency: envs.ONEVENT_PROCESSOR_MAX_CONCURRENCY
                 })
-        ].filter(Boolean);
+        ].filter(Boolean) as OrchestratorProcessor[];
     }
 
     start() {

--- a/packages/jobs/lib/processor/processor.ts
+++ b/packages/jobs/lib/processor/processor.ts
@@ -12,30 +12,34 @@ export class Processor {
     constructor(orchestratorServiceUrl: string) {
         const orchestratorClient = new OrchestratorClient({ baseUrl: orchestratorServiceUrl });
         this.processors = [
-            new OrchestratorProcessor({
-                handler,
-                orchestratorClient: orchestratorClient,
-                groupKey: 'sync',
-                maxConcurrency: envs.SYNC_PROCESSOR_MAX_CONCURRENCY
-            }),
-            new OrchestratorProcessor({
-                handler,
-                orchestratorClient: orchestratorClient,
-                groupKey: 'action',
-                maxConcurrency: envs.ACTION_PROCESSOR_MAX_CONCURRENCY
-            }),
-            new OrchestratorProcessor({
-                handler,
-                orchestratorClient: orchestratorClient,
-                groupKey: 'webhook',
-                maxConcurrency: envs.WEBHOOK_PROCESSOR_MAX_CONCURRENCY
-            }),
-            new OrchestratorProcessor({
-                handler,
-                orchestratorClient: orchestratorClient,
-                groupKey: 'on-event',
-                maxConcurrency: envs.ONEVENT_PROCESSOR_MAX_CONCURRENCY
-            })
+            envs.SYNC_PROCESSOR_MAX_CONCURRENCY > 0 &&
+                new OrchestratorProcessor({
+                    handler,
+                    orchestratorClient: orchestratorClient,
+                    groupKey: 'sync',
+                    maxConcurrency: envs.SYNC_PROCESSOR_MAX_CONCURRENCY
+                }),
+            envs.ACTION_PROCESSOR_MAX_CONCURRENCY > 0 &&
+                new OrchestratorProcessor({
+                    handler,
+                    orchestratorClient: orchestratorClient,
+                    groupKey: 'action',
+                    maxConcurrency: envs.ACTION_PROCESSOR_MAX_CONCURRENCY
+                }),
+            envs.WEBHOOK_PROCESSOR_MAX_CONCURRENCY > 0 &&
+                new OrchestratorProcessor({
+                    handler,
+                    orchestratorClient: orchestratorClient,
+                    groupKey: 'webhook',
+                    maxConcurrency: envs.WEBHOOK_PROCESSOR_MAX_CONCURRENCY
+                }),
+            envs.ONEVENT_PROCESSOR_MAX_CONCURRENCY > 0 &&
+                new OrchestratorProcessor({
+                    handler,
+                    orchestratorClient: orchestratorClient,
+                    groupKey: 'on-event',
+                    maxConcurrency: envs.ONEVENT_PROCESSOR_MAX_CONCURRENCY
+                }).filter(Boolean)
         ];
     }
 

--- a/packages/jobs/lib/processor/processor.ts
+++ b/packages/jobs/lib/processor/processor.ts
@@ -11,36 +11,25 @@ export class Processor {
 
     constructor(orchestratorServiceUrl: string) {
         const orchestratorClient = new OrchestratorClient({ baseUrl: orchestratorServiceUrl });
-        this.processors = [
-            envs.SYNC_PROCESSOR_MAX_CONCURRENCY > 0 &&
-                new OrchestratorProcessor({
-                    handler,
-                    orchestratorClient: orchestratorClient,
-                    groupKey: 'sync',
-                    maxConcurrency: envs.SYNC_PROCESSOR_MAX_CONCURRENCY
-                }),
-            envs.ACTION_PROCESSOR_MAX_CONCURRENCY > 0 &&
-                new OrchestratorProcessor({
-                    handler,
-                    orchestratorClient: orchestratorClient,
-                    groupKey: 'action',
-                    maxConcurrency: envs.ACTION_PROCESSOR_MAX_CONCURRENCY
-                }),
-            envs.WEBHOOK_PROCESSOR_MAX_CONCURRENCY > 0 &&
-                new OrchestratorProcessor({
-                    handler,
-                    orchestratorClient: orchestratorClient,
-                    groupKey: 'webhook',
-                    maxConcurrency: envs.WEBHOOK_PROCESSOR_MAX_CONCURRENCY
-                }),
-            envs.ONEVENT_PROCESSOR_MAX_CONCURRENCY > 0 &&
-                new OrchestratorProcessor({
-                    handler,
-                    orchestratorClient: orchestratorClient,
-                    groupKey: 'on-event',
-                    maxConcurrency: envs.ONEVENT_PROCESSOR_MAX_CONCURRENCY
-                })
-        ].filter(Boolean) as OrchestratorProcessor[];
+
+        const processorConfigs = [
+            { groupKey: 'sync', maxConcurrency: envs.SYNC_PROCESSOR_MAX_CONCURRENCY },
+            { groupKey: 'action', maxConcurrency: envs.ACTION_PROCESSOR_MAX_CONCURRENCY },
+            { groupKey: 'webhook', maxConcurrency: envs.WEBHOOK_PROCESSOR_MAX_CONCURRENCY },
+            { groupKey: 'on-event', maxConcurrency: envs.ONEVENT_PROCESSOR_MAX_CONCURRENCY }
+        ];
+
+        this.processors = processorConfigs
+            .filter((config) => config.maxConcurrency > 0)
+            .map(
+                (config) =>
+                    new OrchestratorProcessor({
+                        handler,
+                        orchestratorClient,
+                        groupKey: config.groupKey,
+                        maxConcurrency: config.maxConcurrency
+                    })
+            );
     }
 
     start() {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Prevent Processors from Starting When Max Concurrency Is Zero**

This pull request updates the initialization logic of the `Processor` class in `packages/jobs/lib/processor/processor.ts`. Instead of always instantiating all processor types, it now dynamically constructs processor configurations and only creates `OrchestratorProcessor` instances where the associated `maxConcurrency` value is greater than zero. This reduces unnecessary resource usage when some processor types are intentionally disabled. The refactor also makes the code more maintainable and eliminates duplication in processor instantiation logic.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaces direct instantiation of all processor types with a dynamic array of configuration objects.
• Applies a `.filter()` to exclude processors where `maxConcurrency` is not greater than zero before instantiation.
• Uses `.map()` to create the `OrchestratorProcessor` instances from filtered configurations.
• Enhances logging in the `start()` method to include the number of started processors.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/jobs/lib/processor/processor.ts` (`Processor` class constructor and `start()` method)

</details>

---
*This summary was automatically generated by @propel-code-bot*