### PR TITLE
feat(credentials): keep credentials until they are hard deleted at 30 days

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -841,7 +841,7 @@ class ConnectionService {
                 environment_id: environmentId,
                 deleted: false
             })
-            .update({ deleted: true, credentials: {}, credentials_iv: null, credentials_tag: null, deleted_at: new Date() });
+            .update({ deleted: true, deleted_at: new Date() });
 
         // TODO: move the following side effects to a post deletion hook
         // so we can remove the orchestrator dependencies


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Retain Credentials Until Hard Deletion for Soft-Deleted Connections**

This PR modifies the `deleteConnection` logic in `packages/shared/lib/services/connection.service.ts` so that sensitive fields (`credentials`, `credentials_iv`, `credentials_tag`) are no longer wiped during a soft delete. Instead, these fields are now only deleted during hard deletion, usually performed 30 days after the soft delete. The change ensures that credentials remain recoverable during the soft-deleted period, aligning data retention with the system's deletion policy.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated the `.update` call in the `deleteConnection` method to remove wiping of `credentials`, `credentials_iv`, and `credentials_tag` fields.
• Now, only the `deleted` flag is set to `true` and `deleted_at` timestamp is set during a soft delete; credentials remain intact.
• The data-wiping of credentials for soft-deleted connections is deferred to the hard deletion phase.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `deleteConnection` method in `packages/shared/lib/services/connection.service.ts`
• Soft-delete mechanics and state of credentials for records in the `_nango_connections` database table

</details>

---
*This summary was automatically generated by @propel-code-bot*