### PR TITLE
docs: Add content for missing section in API Auth

### DIFF
--- a/docs-v2/guides/use-cases/api-auth.mdx
+++ b/docs-v2/guides/use-cases/api-auth.mdx
@@ -77,7 +77,7 @@ Watch a quick demo of the API auth flow and the detailed logs it creates.
 
 ### OAuth token refresh & validity
 
-If the external API requires OAuth access tokens to be refreshed, Nango will do this automatically for you before the token expires. If the refresh fails, it can [inform your app with a webhook](/guides/platform/webhooks-from-nango), and you can aks the user to reconnect.
+If the external API requires OAuth access tokens to be refreshed, Nango will do this automatically for you before the token expires. If the refresh fails, it can [inform your app with a webhook](/guides/platform/webhooks-from-nango), and you can ask the user to reconnect.
 
 Some APIs revoke refresh tokens that are unused. To avoid this, Nango refreshes each access token at least once every 24h.
 

--- a/docs-v2/guides/use-cases/api-auth.mdx
+++ b/docs-v2/guides/use-cases/api-auth.mdx
@@ -77,3 +77,8 @@ Watch a quick demo of the API auth flow and the detailed logs it creates.
 
 ### OAuth token refresh & validity
 
+If the external API requires OAuth access tokens to be refreshed, Nango will do this automatically for you before the token expires. If the refresh fails, it can [inform your app with a webhook](/guides/platform/webhooks-from-nango), and you can aks the user to reconnect.
+
+Some APIs revoke refresh tokens that are unused. To avoid this, Nango refreshes each access token at least once every 24h.
+
+Revoked access tokens, and therefore refresh failures, are a part of daily life with integrations. Read our [best practice guide on how to handle them](/implementation-guides/platform/common-issues#token-refresh-error-from-the-external-api) and make sure you [implement the re-authentication flow](/implementation-guides/api-auth/implement-api-auth#6-re-authorize-an-existing-connection) so your users can re-authenticate broken connections.

--- a/docs-v2/guides/use-cases/api-auth.mdx
+++ b/docs-v2/guides/use-cases/api-auth.mdx
@@ -81,4 +81,4 @@ If the external API requires OAuth access tokens to be refreshed, Nango will do 
 
 Some APIs revoke refresh tokens that are unused. To avoid this, Nango refreshes each access token at least once every 24h.
 
-Revoked access tokens, and therefore refresh failures, are a part of daily life with integrations. Read our [best practice guide on how to handle them](/implementation-guides/platform/common-issues#token-refresh-error-from-the-external-api) and make sure you [implement the re-authentication flow](/implementation-guides/api-auth/implement-api-auth#6-re-authorize-an-existing-connection) so your users can re-authenticate broken connections.
+Revoked access tokens, and refresh failures, happen to all integrations. Read our [best practice guide on handling revoked access tokens](/implementation-guides/platform/common-issues#token-refresh-error-from-the-external-api) and make sure you [implement the re-authentication flow](/implementation-guides/api-auth/implement-api-auth#6-re-authorize-an-existing-connection) so your users can re-authenticate broken connections.


### PR DESCRIPTION
Forgot a section when I migrated the docs to the new format.

<!-- Summary by @propel-code-bot -->

---

**Add OAuth Token Refresh Section to API Auth Documentation**

This pull request updates the `docs-v2/guides/use-cases/api-auth.mdx` documentation to add a missing section on OAuth token refresh and validity. The new content clearly explains how `Nango` handles automatic OAuth access token refreshing, proactive measures to prevent revocation of refresh tokens, handling of token refresh failures via webhooks, and includes references to best practices and guidance for re-authentication flows.

<details>
<summary><strong>Key Changes</strong></summary>

• Added a new 'OAuth token refresh & validity' section in `docs-v2/guides/use-cases/api-auth.mdx`.
• Documented that `Nango` automatically refreshes OAuth tokens before expiration.
• Described the approach of proactively refreshing tokens at least every 24 hours to avoid unused token revocation.
• Outlined use of webhooks to notify applications of token refresh failures, with instructions to prompt user reconnection.
• Linked to relevant best practice and re-authentication guide documentation.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs-v2/guides/use-cases/api-auth.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*