### PR TITLE
feat(server): add usage.proxy events

### DIFF
--- a/packages/metering/lib/processors/billing.ts
+++ b/packages/metering/lib/processors/billing.ts
@@ -97,6 +97,10 @@ async function process(event: UsageEvent): Promise<Result<void>> {
                 });
                 return Ok(undefined);
             }
+            case 'usage.proxy': {
+                // TODO: ingest to Orb
+                return Ok(undefined);
+            }
             default:
                 return Err(`Unknown billing event type: ${event.type}`);
         }

--- a/packages/pubsub/lib/event.ts
+++ b/packages/pubsub/lib/event.ts
@@ -25,7 +25,7 @@ export type UserCreatedEvent = EventBase<
 
 export type UsageEvent = EventBase<
     'usage',
-    'usage.monthly_active_records' | 'usage.actions' | 'usage.connections' | 'usage.function_executions',
+    'usage.monthly_active_records' | 'usage.actions' | 'usage.connections' | 'usage.function_executions' | 'usage.proxy',
     {
         value: number;
         properties: {


### PR DESCRIPTION
usage.proxy events are not yet ingested into Orb yet. I am gonna first implement events aggregation to limit the number of events being sent to Orb

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add `usage.proxy` Event Emission and Type Support**

This PR introduces a new `usage.proxy` event that is emitted each time the proxy endpoint in `allProxy.ts` is invoked. The update adds plumbing to publish this event on the internal pubsub system, extends the `UsageEvent` type definition to include `usage.proxy`, and ensures the event is recognized and safely ignored by the billing processor for now. Actual ingestion or billing action for these events is intentionally deferred, with a placeholder in the billing code.

<details>
<summary><strong>Key Changes</strong></summary>

• Emits a `usage.proxy` event via `pubsub.publisher.publish` after each proxy call in `allProxy.ts`, capturing metadata such as `accountId`, `connectionId`, `environmentId`, `provider`, `providerConfigKey`, and `success` status.
• Extends `UsageEvent` type in `packages/pubsub/lib/event.ts` to include `usage.proxy`.
• Updates `packages/metering/lib/processors/billing.ts` to recognize and no-op on `usage.proxy` events, setting groundwork for future billing integration.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/proxy/allProxy.ts`
• `packages/pubsub/lib/event.ts`
• `packages/metering/lib/processors/billing.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*