### PR TITLE
feat: migration to backfill connect-ui settings and flags

### DIFF
--- a/packages/database/lib/migrations/20250918202800_backfill_connect_ui_settings.cjs
+++ b/packages/database/lib/migrations/20250918202800_backfill_connect_ui_settings.cjs
@@ -43,7 +43,7 @@ exports.up = async function (knex) {
     }));
 
     if (settingsToInsert.length > 0) {
-        await knex('connect_ui_settings').insert(settingsToInsert);
+        await knex('connect_ui_settings').insert(settingsToInsert).onConflict('environment_id').ignore();
     }
 };
 

--- a/packages/database/lib/migrations/20250918202800_backfill_connect_ui_settings.cjs
+++ b/packages/database/lib/migrations/20250918202800_backfill_connect_ui_settings.cjs
@@ -1,0 +1,53 @@
+exports.config = { transaction: true };
+
+const payingCustomerSettings = {
+    show_watermark: false,
+    default_theme: 'system',
+    theme: {
+        light: {
+            primary: '#00B2E3'
+        },
+        dark: {
+            primary: '#00B2E3'
+        }
+    }
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    /**
+     * Backfill plan:
+     * - Existing paying customers should have the watermark disabled and the ability to toggle (even if they usually wouldn't have that ability)
+     * - Growth plan should have the ability to customize the theme
+     * - Free plan are migrated to having the watermark and can't toggle it or customize the theme
+     */
+
+    // Every existing paying customer can toggle the watermark and have it disabled by default
+    await knex('plans').whereNot('name', 'free').update({ can_disable_connect_ui_watermark: true });
+
+    // Every existing growth plan can customize the theme
+    await knex('plans').where('name', 'growth').orWhere('name', 'growth-legacy').update({ can_customize_connect_ui_theme: true });
+
+    // Get all environments for paying customers
+    const payingCustomerEnvironments = await knex('_nango_environments')
+        .select('_nango_environments.id')
+        .innerJoin('plans', '_nango_environments.account_id', 'plans.account_id')
+        .whereNot('plans.name', 'free');
+
+    // Insert connect_ui_settings with disabled watermark for paying customers
+    const settingsToInsert = payingCustomerEnvironments.map((env) => ({
+        environment_id: env.id,
+        ...payingCustomerSettings
+    }));
+
+    if (settingsToInsert.length > 0) {
+        await knex('connect_ui_settings').insert(settingsToInsert);
+    }
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};


### PR DESCRIPTION
For new customers, the default flags will be applied on upgrade, but for existing customers, we need to backfill:

Free plans: ok to show the watermark for past accounts. Can't toggle or edit colors.
Starter: can toggle watermark (grandfathering, new customers won't)
Growth: can toggle watermark and customize colors

<!-- Summary by @propel-code-bot -->

---

**Backfill Migration for `connect-ui` Settings and Flags by Customer Plan**

This pull request introduces a new database migration (`20250918202800_backfill_connect_ui_settings.cjs`) to backfill `connect-ui` feature flags and settings for all existing customers based on their subscription plans. The migration updates the `plans` table to grant or restrict access to toggling watermarks and theme customization in line with current product rules (grandfathering specific features for legacy subscribers), and inserts default `connect_ui_settings` for all paying customer environments. The migration uses idempotent insertion logic to avoid duplicate key conflicts if rerun.

<details>
<summary><strong>Key Changes</strong></summary>

• Added migration file `packages/database/lib/migrations/20250918202800_backfill_connect_ui_settings.cjs`.
• Set `can_disable_connect_ui_watermark` to `true` for all non-`free` entries in `plans`.
• Enabled `can_customize_connect_ui_theme` for `growth` and `growth-legacy` plans in the `plans` table.
• Identified all environments for paying customers by joining `_nango_environments` and `plans`.
• Backfilled `connect_ui_settings` with watermark disabled and default color themes for paying customers (inserts are idempotent via `.onConflict('environment_id').ignore()`).

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/database/lib/migrations/20250918202800_backfill_connect_ui_settings.cjs`
• `plans` table
• `connect_ui_settings` table
• `_nango_environments` table (read/joins)

</details>

---
*This summary was automatically generated by @propel-code-bot*