### PR TITLE
docs: outlook documentation migration

### DIFF
--- a/docs-v2/integrations/all/outlook.mdx
+++ b/docs-v2/integrations/all/outlook.mdx
@@ -1,112 +1,156 @@
 ---
-title: Outlook
-sidebarTitle: Outlook
+title: 'Outlook'
+sidebarTitle: 'Outlook'
+description: 'Access the Outlook API in 2 minutes 💨'
 ---
 
-import Overview from "/snippets/overview.mdx"
-import PreBuiltTooling from "/snippets/generated/outlook/PreBuiltTooling.mdx"
-import PreBuiltUseCases from "/snippets/generated/outlook/PreBuiltUseCases.mdx"
 import APIGotchas from "/snippets/microsoft-shared/api-gotchas.mdx"
 import UsefulLinks from "/snippets/microsoft-shared/useful-links.mdx"
 
-<Overview />
-<PreBuiltTooling />
-<PreBuiltUseCases />
+<Tabs>
+  <Tab title="🚀 Quickstart">
+    <Steps>
+      <Step title="Create an integration">
+        In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Outlook_. Nango doesn't provide a test OAuth app for Outlook yet. You’ll need to set up your own by following these [instructions](#🧑%E2%80%8D💻-oauth-app-setup). After that, make sure to add the OAuth client ID, secret, and scopes in the integration settings in Nango.
+      </Step>
+      <Step title="Authorize Outlook">
+        Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then log in to Outlook. Later, you'll let your users do the same directly from your app.
+      </Step>
+      <Step title="Call the Outlook API">
+        Let's make your first request to the Outlook (Microsoft Graph) API (fetch the profile of the currently signed-in user). Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+        <Tabs>
+            <Tab title="cURL">
 
-## Access requirements
-| Pre-Requisites | Status | Comment|
-| - | - | - |
-| Paid dev account | ✅ Not required | Free, self-signup for a [Microsoft account](https://account.microsoft.com/account) and [Azure account](https://azure.microsoft.com/free). |
-| Paid test account | ✅ Not required | Free Microsoft account can be used for testing. |
-| Partnership | ✅ Not required | |
-| App review | ⚠️ Conditional | Required only if you want to publish your app to the Microsoft commercial marketplace or if your app needs admin consent for certain permissions. |
-| Security audit | ✅ Not required | |
+                ```bash
+                curl "https://api.nango.dev/proxy/v1.0/me" \
+                  -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+                  -H "Provider-Config-Key: <INTEGRATION-ID>" \
+                  -H "Connection-Id: <CONNECTION-ID>"
+                ```
 
-## Setup guide
-<Steps>
-  <Step title="Create a Microsoft account and Azure account">
-    If you don't already have them, sign up for a [Microsoft account](https://account.microsoft.com/account) and an [Azure account](https://azure.microsoft.com/free).
-  </Step>
-  <Step title="Register an application in Microsoft Entra ID">
-    1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least an Application Developer.
-    2. If you have access to multiple tenants, use the Settings icon in the top menu to switch to the tenant in which you want to register the application.
-    3. From the search bar at the top of the Azure portal, search for **App registrations** and select it. Then choose **New registration**. Or from your left navigation tab, navigate to **Applications** > **App registrations** then choose **New registration**.
-    4. Enter a meaningful name for your application, for example "Nango Integration".
-    5. Under **Supported account types**, select the appropriate option based on your needs:
-       - **Accounts in any organizational directory** - For multitenant apps that you want users in any Microsoft Entra tenant to be able to use.
-       - **Accounts in any organizational directory and personal Microsoft accounts** - For multitenant apps that support both organizational and personal Microsoft accounts.
-    6. Leave the **Redirect URI** section blank for now; we'll configure it in a later step.
-    7. Click **Register** to complete the app registration.
-  </Step>
-  <Step title="Note your application (client) ID">
-    After registration, you'll be taken to the application's Overview page. Record the **Application (client) ID**, which uniquely identifies your application and is used in your application's code as part of validating security tokens.
-  </Step>
-  <Step title="Add a redirect URI">
-    1. In the left sidebar, select **Authentication**.
-    2. Under **Platform configurations**, select **Add a platform**.
-    3. Select **Web** as the platform type.
-    4. Enter `https://api.nango.dev/oauth/callback` as the Redirect URI.
-    5. Under **Implicit grant and hybrid flows**, check the boxes for **Access tokens** and **ID tokens** if your application needs them.
-    6. Under **Advanced settings**, set **Allow public client flows** to **No** for web applications.
-    7. Click **Configure** to save your changes.
-  </Step>
-  <Step title="Add API permissions">
-    1. In the left sidebar, select **API permissions**.
-    2. Click **Add a permission**.
-    3. Select **Microsoft Graph** to integrate with **Outlook**.
-    4. Choose the type of permissions:
-       - **Delegated permissions** - Your app accesses the API as the signed-in user.
-       - **Application permissions** - Your app accesses the API directly without a signed-in user.
-    5. Select the specific permissions your app requires, Please refer to the table below for some of the [commonly used scopes](#common-scopes).
-    6. Click **Add permissions**.
-    7. If your application requires admin consent, click **Grant admin consent for [tenant]** to pre-authorize the permissions.
-  </Step>
-  <Step title="Create a client secret">
-    1. In the left sidebar, select **Certificates & secrets**.
-    2. Under **Client secrets**, click **New client secret**.
-    3. Enter a description for the secret and select an expiration period (6 months, 12 months, 24 months, or custom).
-    4. Click **Add**.
-    5. **Important**: Copy the secret value immediately and store it securely. You won't be able to see it again after you leave this page.
-  </Step>
-  <Step title="Configure token settings (optional)">
-    1. In the left sidebar, select **Token configuration**.
-    2. Here you can configure optional claims to be included in the ID and access tokens issued to your application.
-    3. Click **Add optional claim** if you need to include additional information in your tokens.
-  </Step>
-  <Step title="Configure app visibility (optional)">
-    If you want users to see your app on their My Apps page:
-    
-    1. From the search bar at the top of the Azure portal, search for **Enterprise applications**, select it, and then choose your app.
-    2. On the **Properties** page, set **Visible to users?** to **Yes**.
-  </Step>
-  <Step title="Next">
-    Follow the [_Quickstart_](/getting-started/quickstart).
-  </Step>
-</Steps>
+            </Tab>
 
-<UsefulLinks />
-<Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/outlook.mdx)</Note>
+            <Tab title="Node">
 
-## Common Scopes
+            Install Nango's backend SDK with `npm i @nangohq/node`. Then run:
 
-| Scope                              | Description                                                                 |
-| ---------------------------------- | --------------------------------------------------------------------------- |
-| `Mail.Read`                        | Read the signed-in user's email messages                                    |
-| `Mail.ReadWrite`                   | Read and write the user's mail                                              |
-| `Mail.Send`                        | Send mail as the signed-in user                                             |
-| `Mail.ReadWrite.Shared`           | Read and write mail shared with the user                                    |
-| `Calendars.Read`                  | Read the user's calendar events                                             |
-| `Calendars.ReadWrite`             | Read and write the user's calendar events                                   |
-| `Calendars.Read.Shared`           | Read shared calendars that the user has access to                           |
-| `Calendars.ReadWrite.Shared`      | Read and write shared calendars that the user has access to                 |
-| `Contacts.Read`                   | Read the user's contacts                                                    |
-| `Contacts.ReadWrite`              | Read and write the user's contacts                                          |
-| `offline_access`                  | Access to refresh tokens for offline access                                 |
-| `User.Read.All`                   | Read user profiles in the organization                                      |
+            ```typescript
+            import { Nango } from '@nangohq/node';
 
+            const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
 
-## API gotchas
--   You can find permissions required for each API call in their corresponding API methods section, i.e, to list messages from Outlook, you can have a look at [List Messages permissions](https://learn.microsoft.com/en-us/graph/api/user-list-messages?view=graph-rest-1.0&tabs=http#permissions).
-<APIGotchas />
+            const res = await nango.get({
+                endpoint: '/v1.0/me',
+                providerConfigKey: '<INTEGRATION-ID>',
+                connectionId: '<CONNECTION-ID>'
+            });
 
-<Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/outlook.mdx)</Note>
+            console.log(res.data);
+            ```
+            </Tab>
+
+        </Tabs>
+
+        Or fetch credentials dynamically via the [Node SDK](/reference/sdks/node#get-a-connection-with-credentials) or [API](/reference/api/connection/get).
+
+      </Step>
+    </Steps>
+
+    ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+
+    <Tip>
+    Next step: [Embed the auth flow](/getting-started/quickstart/embed-in-your-app) in your app to let your users connect their Outlook accounts.
+    </Tip>
+  </Tab>
+  <Tab title="🧑‍💻 OAuth app setup">
+    <Steps>
+      <Step title="Create a Microsoft account and Azure account">
+        If you don't already have them, sign up for a [Microsoft account](https://account.microsoft.com/account) and an [Azure account](https://azure.microsoft.com/free).
+      </Step>
+      <Step title="Register an application in Microsoft Entra ID">
+        1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com) as at least an Application Developer.
+        2. If you have access to multiple tenants, use the Settings icon in the top menu to switch to the tenant in which you want to register the application.
+        3. From the search bar at the top of the Azure portal, search for **App registrations** and select it. Then choose **New registration**. Or from your left navigation tab, navigate to **Applications** > **App registrations** then choose **New registration**.
+        4. Enter a meaningful name for your application, for example "Nango Integration".
+        5. Under **Supported account types** you need to decide who can install your integration:
+           - **Accounts in any organizational directory** - Any user account in a professional Microsoft organization (Business, School, etc.)
+           - **Accounts in any organizational directory and personal Microsoft accounts** - The accounts from the first option, plus personal Microsoft accounts (pick this unless you want to restrict your integration to business accounts)
+        6. Leave the **Redirect URI** section blank for now; we'll configure it in a later step.
+        7. Click **Register** to complete the app registration.
+      </Step>
+      <Step title="Note your application (client) ID">
+        After registration, you'll be taken to the application's Overview page. Record the **Application (client) ID**, which uniquely identifies your application and is used in your application's code as part of validating security tokens.
+      </Step>
+      <Step title="Add a redirect URI">
+        1. In the left sidebar, select **Authentication**.
+        2. Under **Platform configurations**, select **Add a platform**.
+        3. Select **Web** as the platform type.
+        4. Enter `https://api.nango.dev/oauth/callback` as the Redirect URI.
+        5. Under **Advanced settings**, keep **Allow public client flows** set to the default **No** for web applications.
+        6. Click **Configure** to save your changes.
+      </Step>
+      <Step title="Add API permissions">
+        1. In the left sidebar, select **API permissions**.
+        2. Click **Add a permission**.
+        3. Select **Microsoft Graph** to integrate with **Outlook**.
+        4. Select the required permissions from the **Delegated permissions section**.
+        5. Select the specific permissions your app requires. Please refer to the table below for some of the [commonly used scopes](#common-scopes).
+        6. Click **Add permissions**.
+        7. If your application requires admin consent, click **Grant admin consent for [tenant]** to pre-authorize the permissions.
+      </Step>
+      <Step title="Create a client secret">
+        1. In the left sidebar, select **Certificates & secrets**.
+        2. Under **Client secrets**, click **New client secret**.
+        3. Enter a description for the secret and select an expiration period (6 months, 12 months, 24 months, or custom). Please select a date further in the future to avoid interruptions. Note that the **Custom** date can only be set to a maximum of 1 year from the current date. If the secret expires, you will need to regenerate a new one and update your integration within Nango.
+        4. Click **Add**.
+        5. **Important**: Copy the secret value immediately and store it securely. You won't be able to see it again after you leave this page.
+      </Step>
+      <Step title="Configure token settings (optional)">
+        1. In the left sidebar, select **Token configuration**. Here you can configure optional claims to be included in the access tokens issued for your application.
+        2. Click **Add optional claim** and select the claims you want to include in your access tokens.
+      </Step>
+      <Step title="Configure app visibility (optional)">
+        If you want users to see your app on their My Apps page:
+
+        1. From the search bar at the top of the Azure portal, search for **Enterprise applications**, select it, and then choose your app.
+        2. On the **Properties** page, set **Visible to users?** to **Yes**.
+      </Step>
+      <Step title="Next">
+        Follow the [_Quickstart_](/getting-started/quickstart).
+      </Step>
+    </Steps>
+
+    ## Common Scopes
+    | Scope                              | Description                                                                 |
+    | ---------------------------------- | --------------------------------------------------------------------------- |
+    | `Mail.Read`                        | Read the signed-in user's email messages                                    |
+    | `Mail.ReadWrite`                   | Read and write the user's mail                                              |
+    | `Mail.Send`                        | Send mail as the signed-in user                                             |
+    | `Mail.ReadWrite.Shared`           | Read and write mail shared with the user                                    |
+    | `Calendars.Read`                  | Read the user's calendar events                                             |
+    | `Calendars.ReadWrite`             | Read and write the user's calendar events                                   |
+    | `Calendars.Read.Shared`           | Read shared calendars that the user has access to                           |
+    | `Calendars.ReadWrite.Shared`      | Read and write shared calendars that the user has access to                 |
+    | `Contacts.Read`                   | Read the user's contacts                                                    |
+    | `Contacts.ReadWrite`              | Read and write the user's contacts                                          |
+    | `offline_access`                  | Access to refresh tokens for offline access                                 |
+    | `User.Read.All`                   | Read user profiles in the organization                                      |
+
+  </Tab>
+  <Tab title="🔗 Useful links">
+    <UsefulLinks />
+
+    <Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/outlook.mdx)</Note>
+  </Tab>
+  <Tab title="🚨 API gotchas">
+   - You can find permissions required for each API call in their corresponding API methods section, i.e, to list messages from Outlook, you can have a look at [List Messages permissions](https://learn.microsoft.com/en-us/graph/api/user-list-messages?view=graph-rest-1.0&tabs=http#permissions).
+
+    <APIGotchas />
+
+    <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/outlook.mdx)</Note>
+  </Tab>
+</Tabs>
+
+<Info>
+    Questions? Join us in the [Slack community](https://nango.dev/slack).
+</Info>


### PR DESCRIPTION
## Describe the problem and your solution

- Outlook documentation migration

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Outlook Integration Documentation Migration and Redesign**

This pull request significantly updates the `docs-v2/integrations/all/outlook.mdx` file to migrate and redesign the Outlook integration documentation. It replaces the older, linear documentation structure with a modernized, tabbed layout that splits the content into quickstart, OAuth setup, useful links, and API 'gotchas' for improved navigation and user experience. The rewritten documentation includes enhanced explanations, step-by-step setup instructions, sample API calls (with cURL and Node examples), and a more prominent quickstart guide aimed at rapid onboarding.

<details>
<summary><strong>Key Changes</strong></summary>

• Entirely replaced the contents of `docs-v2/integrations/all/outlook.mdx` with a new structure based on <Tabs> and <Tab> components.
• Added a prominent `Quickstart` tab containing step-by-step instructions, code samples (cURL and Node), and tips for initial integration.
• Refactored the OAuth application setup guide with improved clarity and explicit steps, including security advice on client secrets.
• Migrated the table of common OAuth scopes into its relevant section under the 'OAuth app setup' tab.
• Moved existing 'Useful Links' and 'API Gotchas' sections into dedicated tabs.
• Added an <Info> box promoting the community Slack for additional questions.
• Modernized headings, removed redundancies, and aligned documentation format with the rest of documentation v2.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs-v2/integrations/all/outlook.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*