### PR TITLE
fix(cli): support optional and undefined for nango.yaml

### DIFF
--- a/packages/cli/fixtures/nango-yaml/v2/advanced-syntax/nango.yaml
+++ b/packages/cli/fixtures/nango-yaml/v2/advanced-syntax/nango.yaml
@@ -29,6 +29,7 @@ models:
         obj:
             nested: string
         optional?: string
+        optional2?: string | undefined
         arrayLiteral: array
         objectLiteral: object
         any: any

--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -502,6 +502,7 @@ export interface Base {
   literalNull: null[];
   obj: {  nested: string;};
   optional?: string | undefined;
+  optional2?: string | undefined;
   arrayLiteral: any[];
   objectLiteral: Record<string, any>;
   any: any;

--- a/packages/cli/lib/services/model.service.ts
+++ b/packages/cli/lib/services/model.service.ts
@@ -163,7 +163,7 @@ export function fieldToTypescript({ field }: { field: NangoModelField }): string
         output = `${field.value}${field.array ? '[]' : ''}`;
     }
 
-    if (field.optional) {
+    if (field.optional && !output.includes('undefined')) {
         output = `${output} | undefined`;
     }
 


### PR DESCRIPTION
## Changes

- Support optional and undefined for nango.yaml
It was working before, but when we introduced zod we had to add `| undefined` to all optionals, and thus introduced a regression for people who were already doing that

<!-- Summary by @propel-code-bot -->

---

**Support Optional and Undefined Types in `nango.yaml` Parsing**

This PR addresses a regression in the handling of optional fields and `undefined` types in `nango.yaml` model definitions within the CLI. Previously, with the introduction of `zod`, all optional fields required an explicit `| undefined`, causing problems for users who already manually included `| undefined`. The code update ensures that `| undefined` is only added when not already present, restoring previous behavior. Test fixtures and snapshots have been updated to include and verify the new supported syntax.

<details>
<summary><strong>Key Changes</strong></summary>

• Modified `fieldToTypescript` in `packages/cli/lib/services/model.service.ts` to append `| undefined` only if it is not already present in the output.
• Updated the test fixture `packages/cli/fixtures/nango-yaml/v2/advanced-syntax/nango.yaml` to include a new case (`optional2?: string | undefined`).
• Adjusted snapshot `packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap` to reflect the supported syntax and output changes.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/cli/lib/services/model.service.ts` (model parsing/type generation)
• `packages/cli/fixtures/nango-yaml/v2/advanced-syntax/nango.yaml` (test fixture)
• `packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap` (unit test snapshot)

</details>

---
*This summary was automatically generated by @propel-code-bot*