### PR TITLE
fix(debug): logging to capture the error

### DIFF
--- a/packages/shared/lib/services/notification/slack.service.ts
+++ b/packages/shared/lib/services/notification/slack.service.ts
@@ -793,7 +793,12 @@ export class SlackService {
                 return Err('not_in_channel');
             }
 
-            return Ok(slackMessage.value.data as PostSlackMessageResponse);
+            if (!slackMessage.value.data) {
+                logger.error('No response data from Slack');
+                logger.error(slackMessage.value);
+            }
+
+            return Ok(slackMessage.value.data);
         };
 
         const send = await sendMessage();


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Error Logging for Missing Slack API Response Data**

This PR introduces additional error logging within the `sendMessage` function in `packages/shared/lib/services/notification/slack.service.ts`. Specifically, it captures and logs cases where the Slack API response is missing required data, enhancing visibility into potential failures when interacting with Slack.

<details>
<summary><strong>Key Changes</strong></summary>

• Added conditional block in `sendMessage` to check if `slackMessage.value.data` is absent.
• Introduced `logger.error` calls to log the absence of Slack response data and the raw response object.
• Adjusted the code to return `Ok(slackMessage.value.data)` after logging, instead of directly casting the data.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/services/notification/slack.service.ts`
• `sendMessage` logic in `proxySlackMessage`

</details>

---
*This summary was automatically generated by @propel-code-bot*