### PR TITLE
fix(fleet): race condition when node being created

### DIFF
--- a/packages/fleet/lib/fleet.integration.test.ts
+++ b/packages/fleet/lib/fleet.integration.test.ts
@@ -1,3 +1,5 @@
+import { setTimeout } from 'node:timers/promises';
+
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { nanoid } from '@nangohq/utils';
@@ -90,6 +92,20 @@ describe('fleet', () => {
             });
             const res = await fleet.getRunningNode(routingId);
             expect(res.unwrap()).toStrictEqual(outdatedNode);
+        });
+        it('should create a single node when called concurrently', async () => {
+            const routingId = nanoid();
+            const promises = Array.from({ length: 100 }).map(() => fleet.getRunningNode(routingId).then(() => {}));
+            // wait and transition nodes to RUNNING to simulate the nodes being ready
+            promises.push(
+                setTimeout(200).then(async () => {
+                    await dbClient.db.from('nodes').where({ routing_id: routingId }).update({ state: 'RUNNING' });
+                })
+            );
+            await Promise.all(promises);
+
+            const nodes = await dbClient.db.from('nodes').where({ routing_id: routingId });
+            expect(nodes.length).toBe(1);
         });
     });
 

--- a/packages/fleet/lib/fleet.ts
+++ b/packages/fleet/lib/fleet.ts
@@ -17,6 +17,7 @@ import type { NodeProvider } from './node-providers/node_provider.js';
 import type { Node, NodeConfigOverride } from './types.js';
 import type { Deployment, RoutingId } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
+import type knex from 'knex';
 
 const defaultDbUrl =
     envs.RUNNERS_DATABASE_URL ||
@@ -81,6 +82,20 @@ export class Fleet {
     }
 
     public async getRunningNode(routingId: RoutingId): Promise<Result<Node>> {
+        const searchNode = async (trx: knex.Knex): Promise<Result<Node | undefined>> => {
+            const search = await nodes.search(trx, {
+                states: ['PENDING', 'STARTING', 'RUNNING', 'OUTDATED'],
+                routingId
+            });
+            if (search.isErr()) {
+                return Err(search.error);
+            }
+
+            const byState = search.value.get(routingId);
+            const node = byState?.RUNNING?.[0] || byState?.OUTDATED?.[0] || byState?.STARTING?.[0] || byState?.PENDING?.[0];
+            return Ok(node);
+        };
+
         const recurse = async (supervisor: Supervisor | undefined, start: Date): Promise<Result<Node>> => {
             if (!supervisor) {
                 return Err(new FleetError('fleet_misconfigured', { context: { fleetId: this.fleetId } }));
@@ -88,29 +103,28 @@ export class Fleet {
             if (new Date().getTime() - start.getTime() > envs.FLEET_TIMEOUT_GET_RUNNING_NODE_MS) {
                 return Err(new FleetError('fleet_node_not_ready_timeout', { context: { routingId } }));
             }
-            const search = await nodes.search(this.dbClient.db, {
-                states: ['PENDING', 'STARTING', 'RUNNING', 'OUTDATED'],
-                routingId
-            });
-            if (search.isErr()) {
-                return Err(search.error);
-            }
-            const running = search.value.get(routingId)?.RUNNING || [];
-            if (running[0]) {
-                return Ok(running[0]);
-            }
-            const outdated = search.value.get(routingId)?.OUTDATED || [];
-            if (outdated[0]) {
-                return Ok(outdated[0]);
-            }
-            const starting = search.value.get(routingId)?.STARTING || [];
-            const pending = search.value.get(routingId)?.PENDING || [];
 
-            if (!starting[0] && !pending[0]) {
-                await withPgLock({
+            // search for existing node
+            let node = await searchNode(this.dbClient.db);
+            if (node.isErr()) {
+                return Err(node.error);
+            }
+
+            // create node if it does not exist yet
+            if (!node.value) {
+                const createNode = await withPgLock({
                     db: this.dbClient.db,
                     lockKey: `fleet_${this.fleetId}_create_node_${routingId}`,
                     fn: async (trx): Promise<Result<Node>> => {
+                        // double check node was not created while acquiring lock
+                        const node = await searchNode(trx);
+                        if (node.isErr()) {
+                            return Err(node.error);
+                        }
+                        if (node.value) {
+                            return Ok(node.value);
+                        }
+
                         const deployment = await deployments.getActive(trx);
                         if (deployment.isErr()) {
                             return Err(deployment.error);
@@ -122,6 +136,15 @@ export class Fleet {
                     },
                     timeoutMs: 10 * 1000
                 });
+                if (createNode.isErr()) {
+                    return Err(createNode.error);
+                }
+                node = createNode;
+            }
+
+            // RUNNING or OUTDATED nodes are able to accept tasks
+            if (node.value?.state === 'RUNNING' || node?.value?.state === 'OUTDATED') {
+                return Ok(node.value);
             }
 
             // wait for node to be ready


### PR DESCRIPTION
multiple execution of getRunningNode could enter the if condition and create node (even if the creation itself is protected by a lock. The solution is the classic lock double check. It is an extra query when a node needs to be created but that doesn't happen very often, while keeping the more common scenario (getting a running node) fast and lock-free
<!-- Summary by @propel-code-bot -->

---

**Fix Race Condition in Fleet Node Creation**

This PR resolves a race condition in the `Fleet.getRunningNode` method where concurrent invocations could lead to multiple nodes being created for the same `routingId`. The root cause was that, despite locking around node creation, multiple threads could still pass an outer existence check before the lock was acquired. The refactor introduces a double-checked locking pattern-revalidating node existence within the lock before creating a new node. Node search logic is extracted into a helper (`searchNode`) that is reused both before and after acquiring the lock. An integration test has been added to ensure that, even under heavy concurrency (100 simultaneous calls), only one node is created.

<details>
<summary><strong>Key Changes</strong></summary>

• Refactored `Fleet.getRunningNode()` to use double-checked locking before creating a node.
• Extracted node search logic to new helper function `searchNode`.
• Added an integration test in `fleet.integration.test.ts` to verify single node creation under concurrent `getRunningNode` calls.
• Added explicit import of `setTimeout` for type safety and clarity.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/fleet/lib/fleet.ts` (main node management and locking logic)
• `packages/fleet/lib/fleet.integration.test.ts` (integration test coverage for concurrency)

</details>

---
*This summary was automatically generated by @propel-code-bot*