### PR TITLE
fix(plain): fix verification url and endpoints

### DIFF
--- a/docs-v2/integrations/all/plain.mdx
+++ b/docs-v2/integrations/all/plain.mdx
@@ -32,8 +32,8 @@ _No setup guide yet._
 
 ## Useful links
 
--   [Plain API docs](https://www.plain.com/docs/quickstart)
--   [Authentication and API key](https://www.plain.com/docs/api-reference/graphql/authentication)
+-   [Plain API docs](https://www.plain.com/docs/graphql/introduction)
+-   [Authentication and API key](https://www.plain.com/docs/graphql/authentication)
 
 <Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/plain.mdx)</Note>
 

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -9116,13 +9116,13 @@ plain:
     proxy:
         headers:
             authorization: Bearer ${apiKey}
-        base_url: https://core-api.uk.plain.com/graphql/v1
+        base_url: https://core-api.uk.plain.com/graphql
         verification:
             method: GET
             headers:
                 content-type: application/json
             endpoints:
-                - ?query=%7B__schema%7Btypes%7Bname,kind,fields%7Bname%7D%7D%7D%7D
+                - /v1?query=%7B__schema%7Btypes%7Bname,kind,fields%7Bname%7D%7D%7D%7D
     docs: https://docs.nango.dev/integrations/all/plain
     docs_connect: https://docs.nango.dev/integrations/all/plain/connect
     credentials:


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

Adjusting base url + endpoints for Plain, for correct verification. Also updating links to Plain docs.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Update Plain Provider Verification URL, Endpoints, and Documentation Links**

This pull request makes targeted corrections to the `plain` provider configuration in `packages/providers/providers.yaml`, specifically updating the `base_url` and verification `endpoints` to align with the latest Plain API requirements. It also refreshes links to the Plain API documentation in `docs-v2/integrations/all/plain.mdx` and adjusts related references in two Kintone snippet files to ensure accuracy.

<details>
<summary><strong>Key Changes</strong></summary>

• Corrected `base_url` for the `plain` provider in `packages/providers/providers.yaml` from `https://core-api.uk.plain.com/graphql/v1` to `https://core-api.uk.plain.com/graphql`.
• Fixed the verification `endpoints` path for the `plain` provider from `?query=...` to `/v1?query=...`.
• Updated external documentation URLs in `docs-v2/integrations/all/plain.mdx` for more accurate and up-to-date Plain API reference.
• Adjusted related links in `docs-v2/snippets/generated/kintone/PreBuiltUseCases.mdx` and `docs-v2/snippets/generated/kintone-user-api/PreBuiltUseCases.mdx` to reflect the latest docs location.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/providers/providers.yaml`
• `docs-v2/integrations/all/plain.mdx`
• `docs-v2/snippets/generated/kintone/PreBuiltUseCases.mdx`
• `docs-v2/snippets/generated/kintone-user-api/PreBuiltUseCases.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*