### PR TITLE
fix(providers): fix snowflake username validation

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -11041,7 +11041,6 @@ snowflake-jwt:
             title: User Name
             description: The username for your Snowflake account used for authentication
             example: MYUSER
-            pattern: ^[A-Z0-9]+$
             doc_section: '#step-3-finding-your-user-name'
         privateKey:
             type: string


### PR DESCRIPTION
## Describe the problem and your solution

- This rule was initially enforced for users created through the UI. However, it turns out that users can also be created using [SQL](https://docs.snowflake.com/en/sql-reference/sql/create-user) and login using their `LOGIN_NAME`, which accepts any string, including spaces and non-alphanumeric characters.
<img width="421" height="583" alt="Screenshot 2025-09-20 at 12 37 06" src="https://github.com/user-attachments/assets/1f1c3073-bc2d-47d5-9a5b-43f4ec24e872" />


<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Remove Overly Strict Snowflake Username Validation**

This pull request removes the `pattern: ^[A-Z0-9]+$` regex from the `userName` credential validation in the `Snowflake` provider's configuration within `packages/providers/providers.yaml`. The change aligns support for `userName` with actual Snowflake `LOGIN_NAME` behavior, which allows any string, not just uppercase alphanumeric usernames. This ensures users created through both the UI and SQL are handled correctly.

<details>
<summary><strong>Key Changes</strong></summary>

• Deleted the `pattern: ^[A-Z0-9]+$` line for the `userName` credential in the `Snowflake` provider section of `packages/providers/providers.yaml`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/providers/providers.yaml` (specifically the Snowflake provider configuration)

</details>

---
*This summary was automatically generated by @propel-code-bot*