### PR TITLE
feat: ingest proxy billing events

### DIFF
--- a/packages/billing/lib/grouping.ts
+++ b/packages/billing/lib/grouping.ts
@@ -16,6 +16,8 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
             switch (event.type) {
                 case 'billable_actions':
                     return omitProperties(event, ['idempotencyKey', 'timestamp', 'count']);
+                case 'proxy':
+                    return omitProperties(event, ['idempotencyKey', 'timestamp', 'count', 'telemetry']);
                 case 'function_executions':
                     return omitProperties(event, ['idempotencyKey', 'timestamp', 'count', 'telemetry']);
                 case 'monthly_active_records':
@@ -64,6 +66,26 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
                         count: a.properties.count + b.properties.count
                     }
                 };
+            case 'proxy': {
+                const _a = a as typeof b; // To satisfy ts compiler that b has the same type as a
+                return {
+                    type: b.type,
+                    properties: {
+                        count: _a.properties.count + b.properties.count,
+                        timestamp: b.properties.timestamp,
+                        idempotencyKey: b.properties.idempotencyKey,
+                        accountId: b.properties.accountId,
+                        environmentId: b.properties.environmentId,
+                        connectionId: b.properties.connectionId,
+                        providerConfigKey: b.properties.providerConfigKey,
+                        provider: b.properties.provider,
+                        telemetry: {
+                            successes: _a.properties.telemetry.successes + b.properties.telemetry.successes,
+                            failures: _a.properties.telemetry.failures + b.properties.telemetry.failures
+                        }
+                    }
+                };
+            }
             case 'monthly_active_records':
                 return {
                     type: b.type,

--- a/packages/metering/lib/processors/billing.ts
+++ b/packages/metering/lib/processors/billing.ts
@@ -122,7 +122,22 @@ async function process(event: UsageEvent): Promise<Result<void>> {
                 return Ok(undefined);
             }
             case 'usage.proxy': {
-                // TODO: ingest to Orb
+                const { success, ...rest } = event.payload.properties;
+                billing.add([
+                    {
+                        type: 'proxy',
+                        properties: {
+                            count: event.payload.value,
+                            idempotencyKey: event.idempotencyKey,
+                            timestamp: event.createdAt,
+                            ...rest,
+                            telemetry: {
+                                successes: success ? event.payload.value : 0,
+                                failures: success ? 0 : event.payload.value
+                            }
+                        }
+                    }
+                ]);
                 return Ok(undefined);
             }
             default:

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -98,8 +98,28 @@ export type FunctionExecutionsBillingEvent = BillingEventBase<
     }
 >;
 
+export type ProxyBillingEvent = BillingEventBase<
+    'proxy',
+    {
+        connectionId: number;
+        environmentId: number;
+        providerConfigKey: string;
+        provider: string;
+        telemetry: {
+            successes: number;
+            failures: number;
+        };
+    }
+>;
+
 export type ConnectionsBillingEvent = BillingEventBase<'billable_connections'>;
 
 export type ActiveConnectionsBillingEvent = BillingEventBase<'billable_active_connections'>;
 
-export type BillingEvent = MarBillingEvent | ActionsBillingEvent | ConnectionsBillingEvent | FunctionExecutionsBillingEvent | ActiveConnectionsBillingEvent;
+export type BillingEvent =
+    | MarBillingEvent
+    | ActionsBillingEvent
+    | ProxyBillingEvent
+    | FunctionExecutionsBillingEvent
+    | ConnectionsBillingEvent
+    | ActiveConnectionsBillingEvent;


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Ingestion and Aggregation for `proxy` Billing Events**

This pull request introduces full support for `proxy` billing events across the billing ingestion pipeline. It extends the billing event type system, implements grouping and aggregation logic for the new event type, updates the billing processing pipeline to properly ingest and record proxy event metrics, and expands the unit test suite to validate grouping and aggregation behavior for proxy events.

<details>
<summary><strong>Key Changes</strong></summary>

• Added new `ProxyBillingEvent` type to `packages/types/lib/billing/types.ts` and updated the `BillingEvent` union type to include it.
• Extended the logic in `BillingEventGrouping.groupingKey()` and `BillingEventGrouping.aggregate()` (in `packages/billing/lib/grouping.ts`) to correctly group and aggregate proxy billing events, including telemetry data (successes, failures).
• Modified `packages/metering/lib/processors/billing.ts` to handle `usage.proxy` events by creating `proxy` billing events with appropriate telemetry property mapping.
• Substantially expanded tests in `packages/billing/lib/grouping.unit.test.ts` to add coverage for `proxy` events and verify aggregate behavior.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/types/lib/billing/types.ts`
• `packages/billing/lib/grouping.ts`
• `packages/metering/lib/processors/billing.ts`
• `packages/billing/lib/grouping.unit.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*