### PR TITLE
feat: add webhook_forwards event and ingest it as a billing event

### DIFF
--- a/packages/billing/lib/grouping.ts
+++ b/packages/billing/lib/grouping.ts
@@ -18,6 +18,8 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
                     return omitProperties(event, ['idempotencyKey', 'timestamp', 'count']);
                 case 'proxy':
                     return omitProperties(event, ['idempotencyKey', 'timestamp', 'count', 'telemetry']);
+                case 'webhook_forwards':
+                    return omitProperties(event, ['idempotencyKey', 'timestamp', 'count']);
                 case 'function_executions':
                     return omitProperties(event, ['idempotencyKey', 'timestamp', 'count', 'telemetry']);
                 case 'monthly_active_records':
@@ -86,6 +88,19 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
                     }
                 };
             }
+            case 'webhook_forwards':
+                return {
+                    type: b.type,
+                    properties: {
+                        timestamp: b.properties.timestamp,
+                        idempotencyKey: b.properties.idempotencyKey,
+                        accountId: b.properties.accountId,
+                        environmentId: b.properties.environmentId,
+                        provider: b.properties.provider,
+                        providerConfigKey: b.properties.providerConfigKey,
+                        count: a.properties.count + b.properties.count
+                    }
+                };
             case 'monthly_active_records':
                 return {
                     type: b.type,

--- a/packages/billing/lib/grouping.unit.test.ts
+++ b/packages/billing/lib/grouping.unit.test.ts
@@ -40,6 +40,17 @@ describe('BillingEventGrouping', () => {
                 }
             },
             {
+                type: 'webhook_forwards',
+                properties: {
+                    accountId: 1,
+                    environmentId: 3,
+                    provider: 'provider1',
+                    providerConfigKey: 'providerConfigKey1',
+                    count: 6,
+                    timestamp: new Date()
+                }
+            },
+            {
                 type: 'function_executions',
                 properties: {
                     accountId: 1,
@@ -110,6 +121,7 @@ describe('BillingEventGrouping', () => {
         expect(keys).toEqual([
             'billable_actions|accountId:1|actionName:action1|connectionId:2|environmentId:3|providerConfigKey:providerConfigKey1',
             'proxy|accountId:1|connectionId:2|environmentId:3|provider:provider1|providerConfigKey:providerConfigKey1',
+            'webhook_forwards|accountId:1|environmentId:3|provider:provider1|providerConfigKey:providerConfigKey1',
             'function_executions|accountId:1|connectionId:2|type:action',
             'function_executions|accountId:1|connectionId:2|frequencyMs:100|type:sync',
             'monthly_active_records|accountId:1|connectionId:2|environmentId:3|model:model1|providerConfigKey:providerConfigKey2|syncId:sync1',
@@ -348,6 +360,42 @@ describe('BillingEventGrouping', () => {
                         successes: 4,
                         failures: 1
                     }
+                }
+            });
+        });
+        it('should aggregate webhook_forwards', () => {
+            const a: BillingEvent = {
+                type: 'webhook_forwards',
+                properties: {
+                    accountId: 1,
+                    environmentId: 3,
+                    provider: 'provider1',
+                    providerConfigKey: 'providerConfigKey1',
+                    count: 6,
+                    timestamp: new Date('2024-01-01T00:00:00Z')
+                }
+            };
+            const b: BillingEvent = {
+                type: 'webhook_forwards',
+                properties: {
+                    accountId: 1,
+                    environmentId: 3,
+                    provider: 'provider1',
+                    providerConfigKey: 'providerConfigKey1',
+                    count: 15,
+                    timestamp: new Date('2024-01-02T00:00:00Z')
+                }
+            };
+            const aggregated = grouping.aggregate(a, b);
+            expect(aggregated).toMatchObject({
+                type: 'webhook_forwards',
+                properties: {
+                    accountId: 1,
+                    environmentId: 3,
+                    provider: 'provider1',
+                    providerConfigKey: 'providerConfigKey1',
+                    count: 21,
+                    timestamp: new Date('2024-01-02T00:00:00Z')
                 }
             });
         });

--- a/packages/metering/lib/processors/billing.ts
+++ b/packages/metering/lib/processors/billing.ts
@@ -140,6 +140,10 @@ async function process(event: UsageEvent): Promise<Result<void>> {
                 ]);
                 return Ok(undefined);
             }
+            case 'usage.webhook_forward': {
+                logger.info('Billing webhook forwards is not implemented yet');
+                return Ok(undefined);
+            }
             default:
                 ((_exhaustiveCheck: never) => {
                     throw new Error(`Unhandled event type`);

--- a/packages/metering/lib/processors/billing.ts
+++ b/packages/metering/lib/processors/billing.ts
@@ -141,12 +141,22 @@ async function process(event: UsageEvent): Promise<Result<void>> {
                 return Ok(undefined);
             }
             case 'usage.webhook_forward': {
-                logger.info('Billing webhook forwards is not implemented yet');
+                billing.add([
+                    {
+                        type: 'webhook_forwards',
+                        properties: {
+                            count: event.payload.value,
+                            idempotencyKey: event.idempotencyKey,
+                            timestamp: event.createdAt,
+                            ...event.payload.properties
+                        }
+                    }
+                ]);
                 return Ok(undefined);
             }
             default:
                 ((_exhaustiveCheck: never) => {
-                    throw new Error(`Unhandled event type`);
+                    throw new Error(`Unhandled event type: ${JSON.stringify(_exhaustiveCheck)}`);
                 })(event);
         }
     } catch (err) {

--- a/packages/pubsub/lib/event.ts
+++ b/packages/pubsub/lib/event.ts
@@ -40,7 +40,7 @@ interface UsageEventBase<TType extends string, TPayload extends Serializable> ex
     type: TType;
     payload: TPayload & {
         value: number;
-        properties: { accountId: number; connectionId: number };
+        properties: { accountId: number };
     };
 }
 
@@ -49,7 +49,6 @@ export type UsageMarEvent = UsageEventBase<
     {
         value: number;
         properties: {
-            accountId: number;
             environmentId: number;
             providerConfigKey: string;
             connectionId: number;
@@ -64,7 +63,6 @@ export type UsageActionsEvent = UsageEventBase<
     {
         value: number;
         properties: {
-            accountId: number;
             connectionId: number;
             environmentId: number;
             providerConfigKey: string;
@@ -78,7 +76,6 @@ export type UsageConnectionsEvent = UsageEventBase<
     {
         value: number;
         properties: {
-            accountId: number;
             environmentId: number;
             providerConfigKey: string;
             connectionId: number;
@@ -123,5 +120,20 @@ export type UsageProxyEvent = UsageEventBase<
     }
 >;
 
+export type UsageWebhookForwardEvent = UsageEventBase<
+    'usage.webhook_forward',
+    {
+        value: number;
+        properties: {
+            environmentId: number;
+            provider: string;
+            providerConfigKey: string;
+            success: boolean;
+        };
+    }
+>;
+
 type EnforceUsageEventBase<T extends UsageEventBase<any, any>> = T;
-export type UsageEvent = EnforceUsageEventBase<UsageMarEvent | UsageActionsEvent | UsageConnectionsEvent | UsageFunctionExecutionsEvent | UsageProxyEvent>;
+export type UsageEvent = EnforceUsageEventBase<
+    UsageMarEvent | UsageActionsEvent | UsageConnectionsEvent | UsageFunctionExecutionsEvent | UsageProxyEvent | UsageWebhookForwardEvent
+>;

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -112,6 +112,15 @@ export type ProxyBillingEvent = BillingEventBase<
     }
 >;
 
+export type WebhookForwardBillingEvent = BillingEventBase<
+    'webhook_forwards',
+    {
+        environmentId: number;
+        providerConfigKey: string;
+        provider: string;
+    }
+>;
+
 export type ConnectionsBillingEvent = BillingEventBase<'billable_connections'>;
 
 export type ActiveConnectionsBillingEvent = BillingEventBase<'billable_active_connections'>;
@@ -120,6 +129,7 @@ export type BillingEvent =
     | MarBillingEvent
     | ActionsBillingEvent
     | ProxyBillingEvent
+    | WebhookForwardBillingEvent
     | FunctionExecutionsBillingEvent
     | ConnectionsBillingEvent
     | ActiveConnectionsBillingEvent;


### PR DESCRIPTION
Adding webhook forward event and billing

<!-- Summary by @propel-code-bot -->

---

**Add Webhook Forward Billing Event Tracking and Ingestion**

This pull request introduces a new usage event type, `usage.webhook_forward`, to enable formal tracking of webhook forwarding activities and associated billing. The change spans the addition of event publishing after a successful webhook forward, updates to data models and event payloads, metering and aggregation logic for billing, and comprehensive test coverage. It ensures that each webhook forward operation is now consistently tracked, published to the event bus, processed for billing aggregation, and included in overall billing calculations.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced `usage.webhook_forward` event type in `packages/pubsub/lib/event.ts` with structured payload, and updated `UsageEvent` union type.
• Updated `forwardWebhook` in `packages/webhooks/lib/forward.ts` to return a result indicating the number of webhooks forwarded, including more granular forwarding/failure tracking.
• Modified `packages/server/lib/webhook/webhook.manager.ts` to emit `usage.webhook_forward` events after successful webhook forwards.
• Extended billing processing in `packages/metering/lib/processors/billing.ts` to handle `usage.webhook_forward` events and convert them to a new billing event type, `webhook_forwards`.
• Enhanced the billing event aggregation/grouping logic in `packages/billing/lib/grouping.ts` to support combining `webhook_forwards` events with explicit rules.
• Added a new `WebhookForwardBillingEvent` type to `packages/types/lib/billing/types.ts` and included it in the main `BillingEvent` union.
• Expanded unit tests (`packages/billing/lib/grouping.unit.test.ts`) to verify correct grouping and aggregation of `webhook_forwards` billing events.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/pubsub/lib/event.ts`
• `packages/webhooks/lib/forward.ts`
• `packages/server/lib/webhook/webhook.manager.ts`
• `packages/metering/lib/processors/billing.ts`
• `packages/billing/lib/grouping.ts`
• `packages/billing/lib/grouping.unit.test.ts`
• `packages/types/lib/billing/types.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*