### PR TITLE
fix: sync max concurrency per environment

### DIFF
--- a/packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts
+++ b/packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts
@@ -65,7 +65,7 @@ export class SchedulingDaemon extends SchedulerDaemon {
                                         name: `${schedule.name}:${now.toISOString()}`,
                                         payload: schedule.payload,
                                         groupKey: schedule.groupKey,
-                                        groupMaxConcurrency: 0,
+                                        groupMaxConcurrency: envs.SYNC_ENVIRONMENT_MAX_CONCURRENCY,
                                         retryCount: 0,
                                         retryMax: schedule.retryMax,
                                         createdToStartedTimeoutSecs: schedule.createdToStartedTimeoutSecs,

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -740,12 +740,14 @@ export class Orchestrator {
                 return Err(frequencyMs.error);
             }
 
-            const groupKey = `sync`;
             const schedule = await this.client.recurring({
                 name: ScheduleName.get({ environmentId: nangoConnection.environment_id, syncId: sync.id }),
                 state: syncData.auto_start ? 'STARTED' : 'PAUSED',
                 frequencyMs: frequencyMs.value,
-                group: { key: groupKey, maxConcurrency: 0 },
+                group: {
+                    key: `sync:environment:${nangoConnection.environment_id}`,
+                    maxConcurrency: 0
+                },
                 retry: { max: 0 },
                 timeoutSettingsInSecs: {
                     createdToStarted: 60 * 60, // 1 hour


### PR DESCRIPTION
When implementing queuing/backpressure of function execution per environment last week I forgot to apply it to scheduled syncs

Note: this requires a one off update of the db to modified the groupKey of existing schedules to `sync:environment:N`

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Apply Environment-Level Max Concurrency to Scheduled Syncs**

This PR updates the scheduling logic for function executions to ensure that max concurrency is enforced per environment for scheduled syncs, not just on-demand ones. Scheduled sync tasks are now grouped by environment using a specific `groupKey` and use the max concurrency value from the configuration, aligning them with the intended queuing and backpressure strategy. A one-time database update of existing schedule `groupKey` values to the new format (`sync:environment:N`) is required.

<details>
<summary><strong>Key Changes</strong></summary>

• Changed assignment of `group.key` for scheduled syncs in `packages/shared/lib/clients/orchestrator.ts` to `sync:environment:${nangoConnection.environment_id}`.
• Set `groupMaxConcurrency` for scheduled syncs in `packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts` based on `envs.SYNC_ENVIRONMENT_MAX_CONCURRENCY` instead of hardcoding 0.
• Removed previous hardcoded concurrency settings for scheduled sync tasks.
• Requires a manual update of existing schedule records in the database to adopt the new `groupKey` format.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/clients/orchestrator.ts`
• `packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*