### PR TITLE
docs: migrate from public key

### DIFF
--- a/docs-v2/implementation-guides/migrations/migrate-from-public-key.mdx
+++ b/docs-v2/implementation-guides/migrations/migrate-from-public-key.mdx
@@ -43,11 +43,62 @@ The deprecated public key, however, was only compatible with custom authorizatio
 
 # Migration steps
 
+This migration is split into 3 steps. You can migrate at your own pace, but we recommend doing it in this order.
+During the migration, both connect session and public key authentication will work so you don't have to do all 3 steps at once.
+
+<Note>
+    Existing connections will keep the custom id you have used until now but new connections will have a random id. Your code will need to support both.
+</Note>
+
+## Step 1: Attach a user to all existing connections
+
+Attach a user to all existing connections.
+This step will allow you to use connect sessions with existing connections.
+This will also be used to attribute webhooks to the correct end user.
+
+<Tabs>
+  <Tab title="Node">
+  ```ts
+  import { Nango } from '@nangohq/node';
+
+const nango = new Nango({ secretKey: process.env['<NANGO-SECRET-KEY>'] });
+await nango.patchConnection({
+    connectionId: '<CONNECTION-ID>',
+    provider_config_key: '<INTEGRATION-ID>',
+}, {
+    end_user: {
+        id: '<USER-ID>',
+        [...]
+    }
+});
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X PATCH https://api.nango.dev/v1/connections/<CONNECTION-ID> \
+-H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+-H "Content-Type: application/json" \
+-d '{
+    "end_user": {
+        "id": "<USER-ID>",
+        [...]
+    }
+}'
+```
+  </Tab>
+</Tabs>
+
+
+Check endpoint documentation [here](/reference/api/connections/patch).
+
+
+## Step 2: Implement the Connect and reconnect flows
+
 Follow the steps in this [guide](/implementation-guides/api-auth/implement-api-auth), focusing on these key changes:
 
-- Fetch a **Connect session token** from your backend, pass it to your frontend, and update Nango frontend SDK method signatures accordingly
-- Connection credentials are now **received via webhooks**, not the frontend SDK. You must specify a **user ID** (and optionally some **tags**) when fetching the Connect session token to correctly attribute webhooks. You can also attach additional information to connections for better UI display
-- Store all **existing and future connection IDs** with your customer data. Since Nango now generates connection IDs randomly, they can no longer be inferred from other identifiers
+Connect session token is now required to be passed to the frontend SDK. This improves security and allows you to pass additional information to the connection.
+
+### Step 3: Clean up
 
 Finally, remove all usage of the **public key and HMAC** from your frontend.
 

--- a/docs-v2/reference/sdks/node.mdx
+++ b/docs-v2/reference/sdks/node.mdx
@@ -458,7 +458,7 @@ Patch a connection.
 ```js
 await nango.patchConnection({
     connectionId: '<CONNECTION-ID>',
-    providerConfigKey: '<INTEGRATION-ID>'
+    provider_config_key: '<INTEGRATION-ID>'
   },
   { ...body });
 ```

--- a/docs-v2/snippets/generated/fillout-api-key/PreBuiltTooling.mdx
+++ b/docs-v2/snippets/generated/fillout-api-key/PreBuiltTooling.mdx
@@ -16,7 +16,7 @@
 | API unification | ✅ |
 | 2-way sync | ✅ |
 | Webhooks from Nango on data modifications | ✅ |
-| Real-time webhooks from 3rd-party API | 🚫 (time to contribute: &lt;48h) |
+| Real-time webhooks from 3rd-party API | ✅ |
 | Proxy requests | ✅ |
 </Accordion>
 <Accordion title="✅ Observability & data quality">

--- a/docs-v2/snippets/generated/fillout/PreBuiltTooling.mdx
+++ b/docs-v2/snippets/generated/fillout/PreBuiltTooling.mdx
@@ -16,7 +16,7 @@
 | API unification | ✅ |
 | 2-way sync | ✅ |
 | Webhooks from Nango on data modifications | ✅ |
-| Real-time webhooks from 3rd-party API | 🚫 (time to contribute: &lt;48h) |
+| Real-time webhooks from 3rd-party API | ✅ |
 | Proxy requests | ✅ |
 </Accordion>
 <Accordion title="✅ Observability & data quality">

--- a/docs-v2/snippets/generated/kintone-user-api/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/kintone-user-api/PreBuiltUseCases.mdx
@@ -2,4 +2,4 @@
 
 _No pre-built integration yet (time to contribute: &lt;48h)_
 
-<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/custom-integrations/overview) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/platform/functions) independently.</Tip>

--- a/docs-v2/snippets/generated/kintone/PreBuiltUseCases.mdx
+++ b/docs-v2/snippets/generated/kintone/PreBuiltUseCases.mdx
@@ -2,4 +2,4 @@
 
 _No pre-built integration yet (time to contribute: &lt;48h)_
 
-<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/custom-integrations/overview) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/platform/functions) independently.</Tip>


### PR DESCRIPTION
## Changes

- Document how to migrate to connect session

<!-- Summary by @propel-code-bot -->

---

**Documentation: Migration Guide for Deprecating Public Key in Favor of Connect Session**

This pull request significantly updates the migration documentation for moving from using a public key (and HMAC) to leveraging a connect session token within the Nango API platform. The updated guide in `docs-v2/implementation-guides/migrations/migrate-from-public-key.mdx` structures the migration into three explicit steps-attaching users to existing connections, implementing connect/reconnect flows, and removing deprecated authentication usage-with expanded notes, dual compatibility guidance, and step-by-step code examples for both Node and cURL. Additionally, various documentation snippets and code samples are corrected or updated for consistency (including parameter naming in `docs-v2/reference/sdks/node.mdx` and accurate support status in fillout-related tooling docs), while references to custom integration documentation for Kintone are updated to point to the current platform functions documentation.

<details>
<summary><strong>Key Changes</strong></summary>

• Major rewrite and expansion of `docs-v2/implementation-guides/migrations/migrate-from-public-key.mdx`, segmenting the migration into clear, phased steps with code examples for both Node SDK and cURL.
• Inserted notes about dual compatibility during migration and clarified that both connection ID formats (custom and random) must be supported in client code.
• Updated parameter naming in `docs-v2/reference/sdks/node.mdx` to use `provider_config_key` for consistency across the docs and code samples.
• Changed the support status in fillout snippet documentation (`PreBuiltTooling.mdx`) to indicate 'Real-time webhooks from 3rd-party API' as now supported.
• Corrected documentation links in Kintone-related use-case snippets (`kintone-user-api/PreBuiltUseCases.mdx` and `kintone/PreBuiltUseCases.mdx`) to reference up-to-date platform functions documentation.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs-v2/implementation-guides/migrations/migrate-from-public-key.mdx`
• `docs-v2/reference/sdks/node.mdx`
• `docs-v2/snippets/generated/fillout-api-key/PreBuiltTooling.mdx`
• `docs-v2/snippets/generated/fillout/PreBuiltTooling.mdx`
• `docs-v2/snippets/generated/kintone-user-api/PreBuiltUseCases.mdx`
• `docs-v2/snippets/generated/kintone/PreBuiltUseCases.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*