### PR TITLE
chore(metrics): remove some account breakdown, add for auth type

### DIFF
--- a/packages/metering/lib/crons/usage.ts
+++ b/packages/metering/lib/crons/usage.ts
@@ -67,10 +67,10 @@ const observability = {
                     throw connRes.error;
                 }
                 for (const { accountId, count, withActions, withSyncs, withWebhooks } of connRes.value) {
-                    metrics.gauge(metrics.Types.CONNECTIONS_COUNT, count, { accountId: accountId });
-                    metrics.gauge(metrics.Types.CONNECTIONS_WITH_ACTIONS_COUNT, withActions, { accountId });
-                    metrics.gauge(metrics.Types.CONNECTIONS_WITH_SYNCS_COUNT, withSyncs, { accountId });
-                    metrics.gauge(metrics.Types.CONNECTIONS_WITH_WEBHOOKS_COUNT, withWebhooks, { accountId });
+                    metrics.gauge(metrics.Types.CONNECTIONS_COUNT, count, { accountId });
+                    metrics.gauge(metrics.Types.CONNECTIONS_WITH_ACTIONS_COUNT, withActions);
+                    metrics.gauge(metrics.Types.CONNECTIONS_WITH_SYNCS_COUNT, withSyncs);
+                    metrics.gauge(metrics.Types.CONNECTIONS_WITH_WEBHOOKS_COUNT, withWebhooks);
                 }
             } catch (err) {
                 span.setTag('error', err);

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -416,7 +416,7 @@ export class AccessMiddleware {
                 res.locals['plan'] = connectSessionResult.value.plan;
                 tagTraceUser(connectSessionResult.value);
 
-                metrics.increment(metrics.Types.AUTH_WITH_CONNECT_SESSION);
+                metrics.increment(metrics.Types.AUTH_WITH_CONNECT_SESSION, 1, { accountId: connectSessionResult.value.account.id });
             } else {
                 const publicKey = req.query['public_key'] as string;
 
@@ -452,7 +452,7 @@ export class AccessMiddleware {
                 res.locals['plan'] = result.value.plan;
                 tagTraceUser(result.value);
 
-                metrics.increment(metrics.Types.AUTH_WITH_PUBLIC_KEY);
+                metrics.increment(metrics.Types.AUTH_WITH_PUBLIC_KEY, 1, { accountId: result.value.account.id });
             }
             next();
         } catch (err) {


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-3908/contain-dd-metrics
Fixes https://linear.app/nango/issue/NAN-4025/auth-metrics-breakdown-per-customer

- Remove some account breakdown
not used
- Add account breakdown for auth type
will allow us to see migration's progress (to be removed at some point I guess)

<!-- Summary by @propel-code-bot -->

---

**Adjust Metrics Breakdown: Remove Some Account-Level Metrics, Add Auth Type Breakdown**

This pull request modifies the metrics reporting for connections and authentication events. Specifically, it removes the `accountId` breakdown (tagging) from several connection-related metrics in `packages/metering/lib/crons/usage.ts`, which helps reduce metric cardinality and addresses over-reporting issues. Conversely, it adds per-account breakdown (i.e., adds the `accountId` tag) to authentication-type metrics (`AUTH_WITH_CONNECT_SESSION` and `AUTH_WITH_PUBLIC_KEY`) in `packages/server/lib/middleware/access.middleware.ts`, enabling improved monitoring of authentication method usage per account. These changes support migration tracking and are linked to organizational metrics reporting goals.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed `accountId` tag from `metrics.Types.CONNECTIONS_WITH_ACTIONS_COUNT`, `metrics.Types.CONNECTIONS_WITH_SYNCS_COUNT`, and `metrics.Types.CONNECTIONS_WITH_WEBHOOKS_COUNT` in `packages/metering/lib/crons/usage.ts`.
• Retained `accountId` tag for `metrics.Types.CONNECTIONS_COUNT` only.
• Added per-account breakdown (via `accountId` tag) to `metrics.Types.AUTH_WITH_CONNECT_SESSION` and `metrics.Types.AUTH_WITH_PUBLIC_KEY` in `packages/server/lib/middleware/access.middleware.ts`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/metering/lib/crons/usage.ts`
• `packages/server/lib/middleware/access.middleware.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*