### PR TITLE
fix(runner): telemetry is optional until full deploy

### DIFF
--- a/packages/jobs/lib/routes/tasks/putTask.ts
+++ b/packages/jobs/lib/routes/tasks/putTask.ts
@@ -86,7 +86,7 @@ const validate = validateRequest<PutTask>({
                     .optional(),
                 output: jsonSchema.default(null),
                 telemetryBag: z
-                    .object({ customLogs: z.number(), proxyCalls: z.number(), durationMs: z.number(), memoryGb: z.number() })
+                    .object({ customLogs: z.number(), proxyCalls: z.number(), durationMs: z.number().optional(), memoryGb: z.number().optional() })
                     .default({ customLogs: 0, proxyCalls: 0, durationMs: 0, memoryGb: 1 })
             })
             .parse(data),

--- a/packages/types/lib/runner/sdk.ts
+++ b/packages/types/lib/runner/sdk.ts
@@ -46,9 +46,9 @@ export interface UserLogParameters {
     level?: 'info' | 'debug' | 'error' | 'warn' | 'http' | 'verbose' | 'silly';
 }
 
-export interface TelemetryBag extends Record<string, number> {
+export interface TelemetryBag extends Record<string, number | undefined> {
     customLogs: number;
     proxyCalls: number;
-    durationMs: number;
-    memoryGb: number;
+    durationMs?: number | undefined;
+    memoryGb?: number | undefined;
 }


### PR DESCRIPTION
## Change

- New telemetry is optional until full deploy
Otherwise, jobs won't accept current payload


<!-- Summary by @propel-code-bot -->

---

**Make New Telemetry Fields Optional Until Full Deployment**

This PR modifies the `TelemetryBag` interface in `packages/types/lib/runner/sdk.ts` and the validation schema in `packages/jobs/lib/routes/tasks/putTask.ts` to make the `durationMs` and `memoryGb` properties optional. The aim is to allow jobs to accept payloads that may not include these fields, ensuring compatibility until the telemetry feature is fully deployed across all components.

<details>
<summary><strong>Key Changes</strong></summary>

• Changed `durationMs` and `memoryGb` properties in `TelemetryBag` to be optional (`number | undefined`).
• Updated the Zod schema in `putTask.ts` so that `durationMs` and `memoryGb` within `telemetryBag` are defined as `z.number().optional()`.
• Retained default values in the validation schema for backward compatibility.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/types/lib/runner/sdk.ts`
• `packages/jobs/lib/routes/tasks/putTask.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*