### PR TITLE
fix(webapp): env settings scroll

### DIFF
--- a/packages/webapp/src/layout/DashboardLayout.tsx
+++ b/packages/webapp/src/layout/DashboardLayout.tsx
@@ -17,7 +17,7 @@ interface DashboardLayoutI {
 
 const DashboardLayout = forwardRef<HTMLDivElement, DashboardLayoutI>(function DashboardLayout({ children, selectedItem, fullWidth = false, className }, ref) {
     return (
-        <div className="h-full min-h-screen flex bg-pure-black">
+        <div className="h-full min-h-screen flex bg-pure-black overflow-hidden">
             <div className="absolute w-screen z-20">
                 <DebugMode />
             </div>


### PR DESCRIPTION
Tried multiple things, I can't really find the real cause, but this fixes it.

<!-- Summary by @propel-code-bot -->

---

**Add `overflow-hidden` to Fix Environment Settings Scroll in `DashboardLayout`**

This pull request resolves an unintended scroll issue on the environment settings page by adding the `overflow-hidden` CSS class to the root `div` element in the `DashboardLayout` component. The change is isolated to a single line and targets only the scroll behavior for layout rendering within the web application's dashboard.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `overflow-hidden` to the root `div`'s `className` in `DashboardLayout` component within `packages/webapp/src/layout/DashboardLayout.tsx`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/layout/DashboardLayout.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*