### PR TITLE
fix(jobs): accept undefined telemetry durationMs and memoryGb

### DIFF
--- a/packages/jobs/lib/routes/tasks/putTask.ts
+++ b/packages/jobs/lib/routes/tasks/putTask.ts
@@ -86,7 +86,7 @@ const validate = validateRequest<PutTask>({
                     .optional(),
                 output: jsonSchema.default(null),
                 telemetryBag: z
-                    .object({ customLogs: z.number(), proxyCalls: z.number(), durationMs: z.number(), memoryGb: z.number() })
+                    .object({ customLogs: z.number(), proxyCalls: z.number(), durationMs: z.number().default(0), memoryGb: z.number().default(1) })
                     .default({ customLogs: 0, proxyCalls: 0, durationMs: 0, memoryGb: 1 })
             })
             .parse(data),


### PR DESCRIPTION
I reverted too fast. Some old runners are still running tasks and won't have those telemetry fields defined. 
<!-- Summary by @propel-code-bot -->

---

**Permit Undefined Telemetry Fields in `putTask.ts` Schema**

This PR modifies the Zod validation schema in `putTask.ts` to accept cases where `durationMs` and `memoryGb` are not defined in the `telemetryBag` object. This change ensures compatibility with older runners that may not provide these telemetry fields, defaulting them to `0` and `1` respectively as needed.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `telemetryBag` schema to allow `durationMs` and `memoryGb` to be undefined by setting default values via `.default(0)` and `.default(1)` respectively.
• No changes to logic or processing beyond the schema validation layer.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/jobs/lib/routes/tasks/putTask.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*