### PR TITLE
fix: rename groupPrefix to groupPrefixPattern

### DIFF
--- a/packages/jobs/lib/processor/processor.ts
+++ b/packages/jobs/lib/processor/processor.ts
@@ -21,7 +21,7 @@ export class Processor {
                     new OrchestratorProcessor({
                         handler,
                         orchestratorClient,
-                        groupKey: config.groupKeyPattern,
+                        groupKeyPattern: config.groupKeyPattern,
                         maxConcurrency: config.maxConcurrency
                     })
             );

--- a/packages/jobs/lib/processor/processor.unit.test.ts
+++ b/packages/jobs/lib/processor/processor.unit.test.ts
@@ -25,7 +25,7 @@ vi.mock('@nangohq/utils', () => ({
 vi.mock('../env.js', () => ({
     envs: {
         JOBS_PROCESSOR_CONFIG: [
-            { groupKeyPattern: 'sync*', maxConcurrency: 200 },
+            { groupKeyPattern: 'sync*', maxConcurrency: 100 },
             { groupKeyPattern: 'action*', maxConcurrency: 100 },
             { groupKeyPattern: 'webhook*', maxConcurrency: 0 },
             { groupKeyPattern: 'on-event*', maxConcurrency: 50 }
@@ -49,9 +49,9 @@ describe('Processor', () => {
         expect(OrchestratorProcessor).toHaveBeenCalledTimes(3);
 
         // Verify correct processors were created
-        expect(OrchestratorProcessor).toHaveBeenCalledWith(expect.objectContaining({ groupKey: 'sync*', maxConcurrency: 200 }));
-        expect(OrchestratorProcessor).toHaveBeenCalledWith(expect.objectContaining({ groupKey: 'action*', maxConcurrency: 100 }));
-        expect(OrchestratorProcessor).toHaveBeenCalledWith(expect.objectContaining({ groupKey: 'on-event*', maxConcurrency: 50 }));
+        expect(OrchestratorProcessor).toHaveBeenCalledWith(expect.objectContaining({ groupKeyPattern: 'sync*', maxConcurrency: 100 }));
+        expect(OrchestratorProcessor).toHaveBeenCalledWith(expect.objectContaining({ groupKeyPattern: 'action*', maxConcurrency: 100 }));
+        expect(OrchestratorProcessor).toHaveBeenCalledWith(expect.objectContaining({ groupKeyPattern: 'on-event*', maxConcurrency: 50 }));
 
         // Verify webhook* was not created
         const webhookCall = (OrchestratorProcessor as any).mock.calls.find((call: any) => call[0].groupKey === 'webhook*');

--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -269,7 +269,7 @@ describe('OrchestratorClient', async () => {
         it('should support big output', async () => {
             const groupKey = nanoid();
             const actionA = await immediateAction(client, { groupKey });
-            await client.dequeue({ groupKey, limit: 1, longPolling: false });
+            await client.dequeue({ groupKeyPattern: groupKey, limit: 1, longPolling: false });
             const res = await client.succeed({ taskId: actionA.unwrap().taskId, output: { a: 'a'.repeat(10_000_000) } });
             expect(res.isOk()).toBe(true);
         });
@@ -287,7 +287,7 @@ describe('OrchestratorClient', async () => {
     });
     describe('dequeue', () => {
         it('should returns nothing if no scheduled task', async () => {
-            const res = await client.dequeue({ groupKey: 'abc', limit: 1, longPolling: false });
+            const res = await client.dequeue({ groupKeyPattern: 'abc', limit: 1, longPolling: false });
             expect(res.unwrap()).toEqual([]);
         });
         it('should return scheduled tasks', async () => {
@@ -312,7 +312,7 @@ describe('OrchestratorClient', async () => {
                     input: { foo: 'bar' }
                 }
             });
-            const res = await client.dequeue({ groupKey, limit: 2, longPolling: false });
+            const res = await client.dequeue({ groupKeyPattern: groupKey, limit: 2, longPolling: false });
             expect(res.unwrap().length).toBe(2);
             expect(res.unwrap()[0]?.isAction()).toBe(true);
             expect(res.unwrap()[1]?.isWebhook()).toBe(true);
@@ -520,7 +520,7 @@ class MockProcessor {
             for (const task of tasks) {
                 switch (task.state) {
                     case 'CREATED':
-                        scheduler.dequeue({ groupKey, limit: 1 });
+                        scheduler.dequeue({ groupKeyPattern: groupKey, limit: 1 });
                         break;
                     case 'STARTED':
                         process(task);

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -377,17 +377,18 @@ export class OrchestratorClient {
     }
 
     public async dequeue({
-        groupKey,
+        groupKeyPattern,
         limit,
         longPolling
     }: {
-        groupKey: string;
+        groupKeyPattern: string;
         limit: number;
         longPolling: boolean;
     }): Promise<Result<OrchestratorTask[], ClientError>> {
         const res = await this.routeFetch(postDequeueRoute)({
             body: {
-                groupKey,
+                groupKey: groupKeyPattern,
+                groupKeyPattern,
                 limit,
                 longPolling
             }
@@ -396,7 +397,7 @@ export class OrchestratorClient {
             return Err({
                 name: res.error.code,
                 message: res.error.message || `Error dequeueing tasks`,
-                payload: { groupKey, limit, response: res.error.payload as any }
+                payload: { groupKeyPattern, limit, response: res.error.payload as any }
             });
         } else {
             const dequeuedTasks = res.flatMap((task) => {

--- a/packages/orchestrator/lib/clients/processor.integration.test.ts
+++ b/packages/orchestrator/lib/clients/processor.integration.test.ts
@@ -71,7 +71,7 @@ async function processN({
     const processor = new OrchestratorProcessor({
         handler,
         orchestratorClient,
-        groupKey,
+        groupKeyPattern: groupKey,
         maxConcurrency: n
     });
     processor.start();

--- a/packages/orchestrator/lib/events.ts
+++ b/packages/orchestrator/lib/events.ts
@@ -171,10 +171,10 @@ class PgEventEmitter extends EventEmitter {
 
 export const taskEvents = {
     taskCreated: (prop: Task | string): string => {
-        if (typeof prop === 'string') {
-            return `task:created:${prop}`;
-        }
-        const groupKeyPrefix = prop.groupKey.split(GROUP_PREFIX_SEPARATOR)[0];
+        const groupKey = typeof prop === 'string' ? prop.replaceAll('*', '') : prop.groupKey;
+        // If the groupKey contains the separator, we only take the prefix part
+        // so that listeners can listen to a group of tasks
+        const groupKeyPrefix = groupKey.split(GROUP_PREFIX_SEPARATOR)[0];
         return `task:created:${groupKeyPrefix}`;
     },
     taskCompleted: (prop: Task | string): string | undefined => {

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -259,14 +259,12 @@ export async function transitionState(
     return Ok(DbTask.from(updated[0]));
 }
 
-export async function dequeue(db: knex.Knex, { groupKey, limit }: { groupKey: string; limit: number }): Promise<Result<Task[]>> {
+export async function dequeue(db: knex.Knex, { groupKeyPattern, limit }: { groupKeyPattern: string; limit: number }): Promise<Result<Task[]>> {
     try {
-        const groupKeyPattern = groupKey.replace(/\*{1,2}/g, '%');
-
         const tasks = await db.transaction(async (trx) => {
             // Acquire a lock to prevent concurrent dequeueing of the same group
             // in order to ensure max concurrency is respected
-            await trx.raw(`SELECT pg_advisory_xact_lock(?) as "lock_dequeue_${groupKey}"`, [stringToHash(groupKey)]);
+            await trx.raw(`SELECT pg_advisory_xact_lock(?) as "lock_dequeue_${groupKeyPattern}"`, [stringToHash(groupKeyPattern)]);
             return (
                 trx
                     // 1. select created tasks that are ready to be started alongside their group
@@ -276,7 +274,7 @@ export async function dequeue(db: knex.Knex, { groupKey, limit }: { groupKey: st
                         qb.select('id', 'group_key', 'created_at', 'group_max_concurrency')
                             .from(TASKS_TABLE)
                             .where('state', 'CREATED')
-                            .whereLike('group_key', groupKeyPattern)
+                            .whereLike('group_key', groupKeyPattern.replace(/\*/g, '%'))
                             .where('starts_after', '<=', db.fn.now())
                             .forUpdate()
                             .skipLocked();
@@ -333,7 +331,7 @@ export async function dequeue(db: knex.Knex, { groupKey, limit }: { groupKey: st
         }
         return Ok(tasks.map(DbTask.from));
     } catch (err) {
-        return Err(new Error(`Error dequeuing tasks for group key '${groupKey}': ${stringifyError(err)}`));
+        return Err(new Error(`Error dequeuing tasks for group key '${groupKeyPattern}': ${stringifyError(err)}`));
     }
 }
 

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -243,8 +243,8 @@ export class Scheduler {
      * @example
      * const dequeued = await scheduler.dequeue({ groupKey: 'test', limit: 1 });
      */
-    public async dequeue({ groupKey, limit }: { groupKey: string; limit: number }): Promise<Result<Task[]>> {
-        const dequeued = await tasks.dequeue(this.db, { groupKey, limit });
+    public async dequeue({ groupKeyPattern, limit }: { groupKeyPattern: string; limit: number }): Promise<Result<Task[]>> {
+        const dequeued = await tasks.dequeue(this.db, { groupKeyPattern, limit });
         if (dequeued.isOk()) {
             dequeued.value.forEach((task) => this.onCallbacks[task.state](task));
         }


### PR DESCRIPTION
dequeuing in the orchestrator used to be based on a strict prefix since we introduce the notion of group max concurrency dequeuing is now happening based on a pattern with potential wildcard (ie: sync*) This PR doesn't change any behavior but rename the groupPrefix param to groupPrefixPattern to make it easier to read/understand

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Refactor: Rename groupPrefix to groupKeyPattern Across Orchestrator Dequeue Logic**

This PR refactors the task dequeuing logic across the orchestrator, scheduler, jobs, and client codebases by renaming the `groupPrefix` (and closely related variables such as `groupKey`) to `groupKeyPattern`. The change makes it clearer that dequeuing operates on pattern matching using wildcards (e.g., `sync*`) rather than just strict prefix matches. No functional changes are introduced; this is a terminology update to improve API clarity and maintainability. Temporary support for old and new parameter names is added in API routes and client interfaces to enable a smooth, non-breaking rollout during deployments.

<details>
<summary><strong>Key Changes</strong></summary>

• Renamed all instances of `groupPrefix` and `groupKey` used in dequeue operations to `groupKeyPattern` across the orchestrator, scheduler, jobs, and client modules.
• Updated the signature for `dequeue` methods in `packages/scheduler/lib/scheduler.ts`, `packages/scheduler/lib/models/tasks.ts`, and corresponding TypeScript types to accept `groupKeyPattern`.
• Adjusted API route schema (`packages/orchestrator/lib/routes/v1/postDequeue.ts`) to accept both `groupKey` (deprecated, optional) and `groupKeyPattern` fields, ensuring backward compatibility.
• Refactored orchestrator/client and processor constructors and usage to require/use `groupKeyPattern` instead of `groupKey` or `groupPrefix`.
• Updated all related unit and integration test files to match new parameter names and contracts.
• Fixed `taskEvents.taskCreated()` construction to correctly handle pattern/wildcard removal in `packages/orchestrator/lib/events.ts`.
• Enhanced error handling/comments to reference `groupKeyPattern` where appropriate.
• Left in temporary support for both old and new parameters to facilitate phased rollout.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/scheduler/lib/scheduler.ts`
• `packages/scheduler/lib/models/tasks.ts`
• `packages/jobs/lib/processor/processor.ts`
• `packages/orchestrator/lib/clients/client.ts`
• `packages/orchestrator/lib/clients/processor.ts`
• `packages/orchestrator/lib/events.ts`
• `packages/orchestrator/lib/routes/v1/postDequeue.ts`
• Associated test files across scheduler, orchestrator, and jobs

</details>

---
*This summary was automatically generated by @propel-code-bot*