### PR TITLE
fix(docs): fix docs on on-event scripts

### DIFF
--- a/docs-v2/implementation-guides/platform/implement-event-handler.mdx
+++ b/docs-v2/implementation-guides/platform/implement-event-handler.mdx
@@ -26,7 +26,7 @@ nango-integrations/
 ├── package.json
 └── salesforce # this is the integration id and must match an integration id in your Nango dashboard
     └── on-events
-    └────── setup.ts # your new event handler function
+        └── setup.ts # your new event handler function
 ```
 
 Paste the following scaffold into the file:

--- a/docs-v2/implementation-guides/platform/implement-event-handler.mdx
+++ b/docs-v2/implementation-guides/platform/implement-event-handler.mdx
@@ -25,7 +25,8 @@ nango-integrations/
 ├── index.ts
 ├── package.json
 └── salesforce # this is the integration id and must match an integration id in your Nango dashboard
-    └── setup.ts # your new event handler function
+    └── on-events
+    └────── setup.ts # your new event handler function
 ```
 
 Paste the following scaffold into the file:
@@ -47,7 +48,7 @@ The `exec` function kicks off when the associated event occurs.
 Also import your new event file in your `index.ts` file:
 
 ```typescript index.ts
-import './salesforce/setup';
+import './salesforce/on-events/setup';
 ```
 
 ### Step 3 - Implement the event function


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Not putting in the `on-events` directory throws an error 
```
Error loading file /nango-integrations/build/._on-events_setup.cjs ENOENT: no such file or directory, open '/nango-integrations/build/._on-events_setup.cjs'
```
<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Update Documentation for Correct Event Handler Script Placement**

This pull request clarifies and corrects the expected directory structure for storing event handler scripts in integration projects by updating the file `docs-v2/implementation-guides/platform/implement-event-handler.mdx`. The documentation now explicitly states that event scripts should reside in the `on-events` subdirectory within an integration, which matches the actual runtime expectation and prevents file loading errors. Examples and import paths are updated accordingly, and directory visualization formatting is improved for better clarity.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated directory tree example to include `on-events` subdirectory within the `salesforce` integration folder.
• Changed sample import statement in `index.ts` from `import './salesforce/setup';` to `import './salesforce/on-events/setup';`.
• Improved directory structure visualization for visual consistency and accuracy.
• Corrected the closing of the `<Tip>` markup to ensure it renders properly.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs-v2/implementation-guides/platform/implement-event-handler.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*