### PR TITLE
fix: cleanup after dequeue groupKeyPattern param rename

### DIFF
--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -387,7 +387,6 @@ export class OrchestratorClient {
     }): Promise<Result<OrchestratorTask[], ClientError>> {
         const res = await this.routeFetch(postDequeueRoute)({
             body: {
-                groupKey: groupKeyPattern,
                 groupKeyPattern,
                 limit,
                 longPolling

--- a/packages/orchestrator/lib/routes/v1/postDequeue.ts
+++ b/packages/orchestrator/lib/routes/v1/postDequeue.ts
@@ -16,8 +16,7 @@ type PostDequeue = Endpoint<{
     Method: typeof method;
     Path: typeof path;
     Body: {
-        groupKey?: string | undefined;
-        groupKeyPattern?: string | undefined;
+        groupKeyPattern: string;
         limit: number;
         longPolling: boolean;
     };
@@ -29,10 +28,9 @@ const validate = validateRequest<PostDequeue>({
     parseBody: (data) =>
         z
             .object({
-                groupKey: z.string().min(1).optional(),
                 limit: z.coerce.number().positive(),
                 longPolling: z.coerce.boolean(),
-                groupKeyPattern: z.string().min(1).optional()
+                groupKeyPattern: z.string().min(1)
             })
             .strict()
             .parse(data)
@@ -50,9 +48,8 @@ export const routeHandler = (scheduler: Scheduler, eventEmitter: EventEmitter): 
 
 const handler = (scheduler: Scheduler, eventEmitter: EventEmitter) => {
     return async (_req: EndpointRequest, res: EndpointResponse<PostDequeue>) => {
-        const { groupKey, groupKeyPattern: optionalGroupKeyPattern, limit, longPolling } = res.locals.parsedBody;
+        const { groupKeyPattern, limit, longPolling } = res.locals.parsedBody;
         const longPollingTimeoutMs = 10_000;
-        const groupKeyPattern = optionalGroupKeyPattern ?? groupKey!;
         const eventId = taskEvents.taskCreated(groupKeyPattern);
         const cleanupAndRespond = (respond: (res: EndpointResponse<PostDequeue>) => void) => {
             if (timeout) {


### PR DESCRIPTION
cleaning up after #4730

<!-- Summary by @propel-code-bot -->

---

**Cleanup Post-Dequeue API Usage of `groupKeyPattern` Parameter**

This pull request completes the migration from the legacy `groupKey` parameter to `groupKeyPattern` in the dequeue API and related client code. All residual references, optionality, and schema branch logic supporting `groupKey` have been removed so that only the required `groupKeyPattern` parameter remains in the request/validation/handler paths and the client API call.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed all optional `groupKey` and outdated `groupKeyPattern` fields from the `Body` type in `packages/orchestrator/lib/routes/v1/postDequeue.ts`; now only a required `groupKeyPattern` is accepted.
• Updated request validation schema to require `groupKeyPattern` and fully dropped support for `groupKey` in `packages/orchestrator/lib/routes/v1/postDequeue.ts`.
• Simplified the endpoint handler: only `groupKeyPattern` is referenced from the parsed request body.
• Updated `dequeue` method in `packages/orchestrator/lib/clients/client.ts` to submit only `groupKeyPattern`, with `groupKey` parameter removed.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/orchestrator/lib/routes/v1/postDequeue.ts` (request typing, validation, handler)
• `packages/orchestrator/lib/clients/client.ts` (API client call parameter construction)

</details>

---
*This summary was automatically generated by @propel-code-bot*