### PR TITLE
fix: set default frequency of usage export cron to 60mins

### DIFF
--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -32,7 +32,7 @@ export const ENVS = z.object({
     NANGO_CONNECT_UI_PORT: z.coerce.number().optional().default(3009),
 
     // Crons
-    CRON_EXPORT_USAGE_MINUTES: z.coerce.number().optional().default(5),
+    CRON_EXPORT_USAGE_MINUTES: z.coerce.number().optional().default(60),
     CRON_TIMEOUT_LOGS_MINUTES: z.coerce.number().optional().default(10),
     CRON_DELETE_OLD_JOBS_LIMIT: z.coerce.number().optional().default(1000),
     CRON_DELETE_OLD_DATA_EVERY_MIN: z.coerce.number().optional().default(10),


### PR DESCRIPTION
The goal is to reduce the number of billing events sent to orb. 60mins granularity is more than enough for billing at the moment. Potential improvement: split dd export (where we pay per dimensions and send as much data points are we want) and orb export (where we have a limit in term of ingested events volume)

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Set Default Frequency of Usage Export Cron to 60 Minutes**

This pull request updates the default value for the `CRON_EXPORT_USAGE_MINUTES` environment variable from 5 minutes to 60 minutes within the `ENVS` schema in `packages/utils/lib/environment/parse.ts`. The stated goal is to reduce the number of billing events sent to Orb, as a higher granularity is sufficient for current billing requirements. The change affects only the environment variable's default and does not alter any business logic or other system functionality.

<details>
<summary><strong>Key Changes</strong></summary>

• Changed default value of `CRON_EXPORT_USAGE_MINUTES` from 5 to 60 in the `ENVS` schema in `packages/utils/lib/environment/parse.ts`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/utils/lib/environment/parse.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*