### PR TITLE
fix(orch): simplify dequeue query

### DIFF
--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -281,14 +281,12 @@ export async function dequeue(db: knex.Knex, { groupKey, limit }: { groupKey: st
                             .forUpdate()
                             .skipLocked();
                     })
-                    // 2. count the number of running tasks for each group
+                    // 2. count the number of running tasks
                     .with('running', (qb) => {
                         qb.select(db.raw('count(id) as running_count'), 'group_key')
                             .from(TASKS_TABLE)
                             .where('state', 'STARTED')
-                            .whereIn('group_key', function () {
-                                this.distinct('group_key').from('candidates');
-                            })
+                            .whereLike('group_key', groupKeyPattern)
                             .groupBy('group_key');
                     })
                     // 3. rank the candidate tasks by created_at for each group


### PR DESCRIPTION
with the introduction of multiple sync groups, the dequeue query is randomly blocking when calculating the count of running tasks for each group.
This commit simplify the `running` CTE query, not making it dependent on the `candidates` CTE and calculating running count for all sync groups. It will result in some groups not be used because they don't have an candidates tasks but the CTE will be consistently fast (using the idx_tasks_group_key_started index) wthout the more expensive `IN subquery`

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Simplify `dequeue` Query for Task Scheduler Performance**

This pull request updates the `dequeue` query logic in `packages/scheduler/lib/models/tasks.ts` to optimize the process of counting running tasks across sync groups. The change addresses performance bottlenecks introduced with multiple sync groups by refactoring the `running` Common Table Expression (CTE). The revised approach eliminates the dependency on the `candidates` CTE, instead using a faster index-supported query that counts running tasks for all relevant sync groups matching a pattern.

<details>
<summary><strong>Key Changes</strong></summary>

• Refactored the `running` CTE in the `dequeue` function to remove its dependency on the `candidates` CTE.
• Replaced the `.whereIn('group_key', ...)` filtering of `group_key` with a `.whereLike('group_key', groupKeyPattern)` filter.
• The modified CTE now directly queries running tasks for all `group_key` values matching the pattern, leveraging the `idx_tasks_group_key_started` index for consistent query performance.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/scheduler/lib/models/tasks.ts` (specifically the `dequeue` function's internal query logic and CTE chain)

</details>

---
*This summary was automatically generated by @propel-code-bot*