### PR TITLE
feat: more billing events

### DIFF
--- a/packages/billing/lib/grouping.ts
+++ b/packages/billing/lib/grouping.ts
@@ -19,7 +19,7 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
                 case 'proxy':
                     return omitProperties(event, ['idempotencyKey', 'timestamp', 'count', 'telemetry']);
                 case 'webhook_forwards':
-                    return omitProperties(event, ['idempotencyKey', 'timestamp', 'count']);
+                    return omitProperties(event, ['idempotencyKey', 'timestamp', 'count', 'telemetry']);
                 case 'function_executions':
                     return omitProperties(event, ['idempotencyKey', 'timestamp', 'count', 'telemetry']);
                 case 'monthly_active_records':
@@ -88,7 +88,8 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
                     }
                 };
             }
-            case 'webhook_forwards':
+            case 'webhook_forwards': {
+                const _a = a as typeof b; // To satisfy ts compiler that b has the same type as a
                 return {
                     type: b.type,
                     properties: {
@@ -98,9 +99,14 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
                         environmentId: b.properties.environmentId,
                         provider: b.properties.provider,
                         providerConfigKey: b.properties.providerConfigKey,
-                        count: a.properties.count + b.properties.count
+                        count: a.properties.count + b.properties.count,
+                        telemetry: {
+                            successes: _a.properties.telemetry.successes + b.properties.telemetry.successes,
+                            failures: _a.properties.telemetry.failures + b.properties.telemetry.failures
+                        }
                     }
                 };
+            }
             case 'monthly_active_records':
                 return {
                     type: b.type,

--- a/packages/billing/lib/grouping.ts
+++ b/packages/billing/lib/grouping.ts
@@ -138,7 +138,7 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
                             successes: _a.properties.telemetry.successes + b.properties.telemetry.successes,
                             failures: _a.properties.telemetry.failures + b.properties.telemetry.failures,
                             durationMs: _a.properties.telemetry.durationMs + b.properties.telemetry.durationMs,
-                            memoryGb: _a.properties.telemetry.memoryGb + b.properties.telemetry.memoryGb,
+                            compute: _a.properties.telemetry.compute + b.properties.telemetry.compute,
                             customLogs: _a.properties.telemetry.customLogs + b.properties.telemetry.customLogs,
                             proxyCalls: _a.properties.telemetry.proxyCalls + b.properties.telemetry.proxyCalls
                         }

--- a/packages/billing/lib/grouping.ts
+++ b/packages/billing/lib/grouping.ts
@@ -24,6 +24,8 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
                     return omitProperties(event, ['idempotencyKey', 'timestamp', 'count', 'telemetry']);
                 case 'monthly_active_records':
                     return omitProperties(event, ['idempotencyKey', 'timestamp', 'count']);
+                case 'records':
+                    return omitProperties(event, ['idempotencyKey', 'timestamp', 'count', 'telemetry']);
                 case 'billable_active_connections':
                     return omitProperties(event, ['idempotencyKey', 'timestamp', 'count']);
                 case 'billable_connections':
@@ -122,6 +124,22 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
                         count: a.properties.count + b.properties.count
                     }
                 };
+            case 'records': {
+                const _a = a as typeof b; // To satisfy ts compiler that b has the same type as a
+                return {
+                    type: b.type,
+                    properties: {
+                        timestamp: b.properties.timestamp,
+                        idempotencyKey: b.properties.idempotencyKey,
+                        accountId: b.properties.accountId,
+                        environmentId: b.properties.environmentId,
+                        telemetry: {
+                            sizeBytes: _a.properties.telemetry.sizeBytes + b.properties.telemetry.sizeBytes
+                        },
+                        count: a.properties.count + b.properties.count
+                    }
+                };
+            }
             case 'function_executions': {
                 const _a = a as typeof b; // To satisfy ts compiler that b has the same type as a
                 return {

--- a/packages/billing/lib/grouping.unit.test.ts
+++ b/packages/billing/lib/grouping.unit.test.ts
@@ -105,6 +105,18 @@ describe('BillingEventGrouping', () => {
                 }
             },
             {
+                type: 'records',
+                properties: {
+                    accountId: 1,
+                    environmentId: 3,
+                    count: 100,
+                    timestamp: new Date(),
+                    telemetry: {
+                        sizeBytes: 2048
+                    }
+                }
+            },
+            {
                 type: 'billable_connections',
                 properties: {
                     accountId: 1,
@@ -129,6 +141,7 @@ describe('BillingEventGrouping', () => {
             'function_executions|accountId:1|connectionId:2|type:action',
             'function_executions|accountId:1|connectionId:2|frequencyMs:100|type:sync',
             'monthly_active_records|accountId:1|connectionId:2|environmentId:3|model:model1|providerConfigKey:providerConfigKey2|syncId:sync1',
+            'records|accountId:1|environmentId:3',
             'billable_connections|accountId:1',
             'billable_active_connections|accountId:1'
         ]);
@@ -411,6 +424,45 @@ describe('BillingEventGrouping', () => {
                     telemetry: {
                         successes: 21,
                         failures: 0
+                    }
+                }
+            });
+        });
+        it('should aggregate recoreds', () => {
+            const a: BillingEvent = {
+                type: 'records',
+                properties: {
+                    accountId: 1,
+                    environmentId: 3,
+                    count: 6,
+                    timestamp: new Date('2024-01-01T00:00:00Z'),
+                    telemetry: {
+                        sizeBytes: 2048
+                    }
+                }
+            };
+            const b: BillingEvent = {
+                type: 'records',
+                properties: {
+                    accountId: 1,
+                    environmentId: 3,
+                    count: 30,
+                    timestamp: new Date('2024-01-02T00:00:00Z'),
+                    telemetry: {
+                        sizeBytes: 4096
+                    }
+                }
+            };
+            const aggregated = grouping.aggregate(a, b);
+            expect(aggregated).toMatchObject({
+                type: 'records',
+                properties: {
+                    accountId: 1,
+                    environmentId: 3,
+                    count: 36,
+                    timestamp: new Date('2024-01-02T00:00:00Z'),
+                    telemetry: {
+                        sizeBytes: 6144
                     }
                 }
             });

--- a/packages/billing/lib/grouping.unit.test.ts
+++ b/packages/billing/lib/grouping.unit.test.ts
@@ -47,7 +47,11 @@ describe('BillingEventGrouping', () => {
                     provider: 'provider1',
                     providerConfigKey: 'providerConfigKey1',
                     count: 6,
-                    timestamp: new Date()
+                    timestamp: new Date(),
+                    telemetry: {
+                        successes: 6,
+                        failures: 0
+                    }
                 }
             },
             {
@@ -372,7 +376,11 @@ describe('BillingEventGrouping', () => {
                     provider: 'provider1',
                     providerConfigKey: 'providerConfigKey1',
                     count: 6,
-                    timestamp: new Date('2024-01-01T00:00:00Z')
+                    timestamp: new Date('2024-01-01T00:00:00Z'),
+                    telemetry: {
+                        successes: 6,
+                        failures: 0
+                    }
                 }
             };
             const b: BillingEvent = {
@@ -383,7 +391,11 @@ describe('BillingEventGrouping', () => {
                     provider: 'provider1',
                     providerConfigKey: 'providerConfigKey1',
                     count: 15,
-                    timestamp: new Date('2024-01-02T00:00:00Z')
+                    timestamp: new Date('2024-01-02T00:00:00Z'),
+                    telemetry: {
+                        successes: 15,
+                        failures: 0
+                    }
                 }
             };
             const aggregated = grouping.aggregate(a, b);
@@ -395,7 +407,11 @@ describe('BillingEventGrouping', () => {
                     provider: 'provider1',
                     providerConfigKey: 'providerConfigKey1',
                     count: 21,
-                    timestamp: new Date('2024-01-02T00:00:00Z')
+                    timestamp: new Date('2024-01-02T00:00:00Z'),
+                    telemetry: {
+                        successes: 21,
+                        failures: 0
+                    }
                 }
             });
         });

--- a/packages/billing/lib/grouping.unit.test.ts
+++ b/packages/billing/lib/grouping.unit.test.ts
@@ -64,7 +64,7 @@ describe('BillingEventGrouping', () => {
                         successes: 2,
                         failures: 0,
                         durationMs: 150,
-                        memoryGb: 1,
+                        compute: 230,
                         customLogs: 7,
                         proxyCalls: 3
                     },
@@ -83,7 +83,7 @@ describe('BillingEventGrouping', () => {
                         customLogs: 10,
                         proxyCalls: 3,
                         durationMs: 200,
-                        memoryGb: 1,
+                        compute: 200,
                         successes: 6,
                         failures: 1
                     },
@@ -268,7 +268,7 @@ describe('BillingEventGrouping', () => {
                         successes: 6,
                         failures: 1,
                         durationMs: 200,
-                        memoryGb: 1,
+                        compute: 100,
                         customLogs: 10,
                         proxyCalls: 3
                     },
@@ -287,7 +287,7 @@ describe('BillingEventGrouping', () => {
                         successes: 7,
                         failures: 2,
                         durationMs: 100,
-                        memoryGb: 0.5,
+                        compute: 50,
                         customLogs: 5,
                         proxyCalls: 1
                     },
@@ -309,7 +309,7 @@ describe('BillingEventGrouping', () => {
                         customLogs: 15,
                         failures: 3,
                         durationMs: 300,
-                        memoryGb: 1.5,
+                        compute: 150,
                         proxyCalls: 4,
                         successes: 13
                     }

--- a/packages/metering/lib/processors/billing.ts
+++ b/packages/metering/lib/processors/billing.ts
@@ -141,6 +141,7 @@ async function process(event: UsageEvent): Promise<Result<void>> {
                 return Ok(undefined);
             }
             case 'usage.webhook_forward': {
+                const { success, ...rest } = event.payload.properties;
                 billing.add([
                     {
                         type: 'webhook_forwards',
@@ -148,7 +149,11 @@ async function process(event: UsageEvent): Promise<Result<void>> {
                             count: event.payload.value,
                             idempotencyKey: event.idempotencyKey,
                             timestamp: event.createdAt,
-                            ...event.payload.properties
+                            ...rest,
+                            telemetry: {
+                                successes: success ? event.payload.value : 0,
+                                failures: success ? 0 : event.payload.value
+                            }
                         }
                     }
                 ]);

--- a/packages/metering/lib/processors/billing.ts
+++ b/packages/metering/lib/processors/billing.ts
@@ -110,7 +110,7 @@ async function process(event: UsageEvent): Promise<Result<void>> {
                                 successes: success ? event.payload.value : 0,
                                 failures: success ? 0 : event.payload.value,
                                 durationMs: telemetryBag?.durationMs ?? 0,
-                                memoryGb: telemetryBag?.memoryGb ?? 0,
+                                compute: telemetryBag ? telemetryBag?.durationMs * telemetryBag?.memoryGb : 0,
                                 customLogs: telemetryBag?.customLogs ?? 0,
                                 proxyCalls: telemetryBag?.proxyCalls ?? 0
                             },

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -118,6 +118,10 @@ export type WebhookForwardBillingEvent = BillingEventBase<
         environmentId: number;
         providerConfigKey: string;
         provider: string;
+        telemetry: {
+            successes: number;
+            failures: number;
+        };
     }
 >;
 

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -71,6 +71,16 @@ export type MarBillingEvent = BillingEventBase<
     }
 >;
 
+export type RecordsBillingEvent = BillingEventBase<
+    'records',
+    {
+        environmentId: number;
+        telemetry: {
+            sizeBytes: number;
+        };
+    }
+>;
+
 export type ActionsBillingEvent = BillingEventBase<
     'billable_actions',
     {
@@ -131,6 +141,7 @@ export type ActiveConnectionsBillingEvent = BillingEventBase<'billable_active_co
 
 export type BillingEvent =
     | MarBillingEvent
+    | RecordsBillingEvent
     | ActionsBillingEvent
     | ProxyBillingEvent
     | WebhookForwardBillingEvent

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -90,7 +90,7 @@ export type FunctionExecutionsBillingEvent = BillingEventBase<
             successes: number;
             failures: number;
             durationMs: number;
-            memoryGb: number;
+            compute: number;
             customLogs: number;
             proxyCalls: number;
         };


### PR DESCRIPTION
3 commits:
- add successes/failures properties for `webhook_forwards` events. Right now we only report the successes but it makes it consistent with other events like functions_executions and ready for when we report the failures ;)
- replace function_executions `memoryGb` (which doesn't make sense to aggregate) by a `compute` property which is `durationMs * memoryGb`. Right now we assume `memoryGb` is 1 so compute is always the same as `durationMs` for now
- add `records` billing event (with sizeBytes. Note the sizeBytes accounts for all the stored records in the db, including the one marked as deleted while the records.count is only the non deleted one)

<!-- Summary by @propel-code-bot -->

---

**Expand and Refactor Billing Event Tracking: Records, Webhook Forwards, and Function Executions**

This PR significantly enhances the billing event tracking system by introducing a new `records` billing event type, updating and unifying telemetry properties for `webhook_forwards`, and refactoring function execution metering from reporting `memoryGb` to a `compute` metric (`durationMs * memoryGb`). A wide range of logic in event aggregation, grouping, metric collection, and typing is updated or extended to support these changes. The updates also include improved metrics reporting, more consistent event schemas, and new or adapted unit tests to ensure correct aggregation and reporting.

<details>
<summary><strong>Key Changes</strong></summary>

• Added new `records` billing event, including a `sizeBytes` property that measures storage for all records per environment (including deleted).
• Unified telemetry properties of `webhook_forwards` to include both `successes` and `failures`, making it consistent with other billing events.
• Removed the `memoryGb` telemetry property in `function_executions` billing events and replaced it with a `compute` property (`durationMs * memoryGb`).
• Updated type definitions in `packages/types/lib/billing/types.ts` for new/changed billing events and telemetry fields.
• Refactored aggregation and grouping logic in `packages/billing/lib/grouping.ts` to properly combine the new and revised event types.
• Rewrote and extended unit tests in `packages/billing/lib/grouping.unit.test.ts` to cover all changes.
• Modified metrics reporting in `packages/metering/lib/crons/usage.ts` and `packages/records/lib/models/records.ts` to use new event types and to report all pertinent records.
• Updated billing event emission logic in `packages/metering/lib/processors/billing.ts` to generate and send the revised event payloads.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/types/lib/billing/types.ts`
• `packages/billing/lib/grouping.ts`
• `packages/billing/lib/grouping.unit.test.ts`
• `packages/metering/lib/crons/usage.ts`
• `packages/metering/lib/processors/billing.ts`
• `packages/records/lib/models/records.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*