### PR TITLE
docs: Mark free self-hosted as whitelabel

### DIFF
--- a/docs-v2/guides/self-hosting/free-self-hosting/overview.mdx
+++ b/docs-v2/guides/self-hosting/free-self-hosting/overview.mdx
@@ -15,7 +15,7 @@ We also offer a [cloud-hosted version](https://app.nango.dev) and an [Enterprise
 | **Feature**                                                                                   | Free self-hosted version | Nango Cloud & Enterprise self-hosted |
 |----------------------------------------------------------------------------------------------|:-------------------------:|:------------------------------------:|
 | [Authorization for 500+ APIs](/guides/use-cases/api-auth)                                    |           ✅              |                 ✅                   |
-| Fully white-label authorization flow                                                         |           ❌              |                 ✅                   |
+| Fully white-label authorization flow                                                         |           ✅              |                 ✅                   |
 | End-user guides                                                                              |           ✅              |                 ✅                   |
 | Invalid credentials detection                                                                |           ✅              |                 ✅                   |
 | Management dashboard                                                                         |           ✅              |                 ✅                   |


### PR DESCRIPTION
See discussion on Slack.

<!-- Summary by @propel-code-bot -->

---

**Update: Mark Free Self-hosted Edition as White-label in Documentation**

This pull request updates the feature comparison table in the `docs-v2/guides/self-hosting/free-self-hosting/overview.mdx` documentation file. Specifically, it changes the status of the 'Fully white-label authorization flow' feature for the 'Free self-hosted version' from `❌` (not included) to `✅` (included), indicating support for white-label flows in the free edition.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated the 'Fully white-label authorization flow' row in the feature comparison table to show `✅` for 'Free self-hosted version' instead of `❌`.
• No changes to structure, content, or code outside of the specified documentation row.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs-v2/guides/self-hosting/free-self-hosting/overview.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*