### PR TITLE
fix(docs): docs clean and add apidownwatch status

### DIFF
--- a/docs-v2/integrations/all/anthropic.mdx
+++ b/docs-v2/integrations/all/anthropic.mdx
@@ -37,9 +37,9 @@ _No setup guide yet._
 ## Useful links
 
 -   [Generate an API key in your Anthropic account](https://console.anthropic.com/account/keys)
--   [Anthropic API docs](https://docs.anthropic.com/en/api/getting-started)
--   [Anthropic Authentication](https://docs.anthropic.com/en/api/getting-started#authentication)
--   [Anthropic rate limiting](https://docs.anthropic.com/en/api/rate-limits)
+-   [Anthropic API docs](https://docs.claude.com/en/api/overview)
+-   [Anthropic Authentication](https://docs.claude.com/en/api/overview#authentication)
+-   [Anthropic rate limiting](https://docs.claude.com/en/api/rate-limits)
 
 <Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/anthropic.mdx)</Note>
 

--- a/docs-v2/integrations/all/dropbox.mdx
+++ b/docs-v2/integrations/all/dropbox.mdx
@@ -7,6 +7,10 @@ import Overview from "/snippets/overview.mdx"
 import PreBuiltTooling from "/snippets/generated/dropbox/PreBuiltTooling.mdx"
 import PreBuiltUseCases from "/snippets/generated/dropbox/PreBuiltUseCases.mdx"
 
+import { StatusWidget } from "/snippets/api-down-watch/status-widget.jsx"
+
+<StatusWidget service="dropbox" />
+
 <Overview />
 <PreBuiltTooling />
 <PreBuiltUseCases />

--- a/docs-v2/integrations/all/harvest.mdx
+++ b/docs-v2/integrations/all/harvest.mdx
@@ -7,6 +7,10 @@ import Overview from "/snippets/overview.mdx"
 import PreBuiltTooling from "/snippets/generated/harvest/PreBuiltTooling.mdx"
 import PreBuiltUseCases from "/snippets/generated/harvest/PreBuiltUseCases.mdx"
 
+import { StatusWidget } from "/snippets/api-down-watch/status-widget.jsx"
+
+<StatusWidget service="harvest" />
+
 <Overview />
 <PreBuiltTooling />
 <PreBuiltUseCases />


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Documentation Cleanup and Addition of API Down Watch Status Widgets**

This pull request introduces documentation improvements across three provider integration pages: `anthropic`, `dropbox`, and `harvest`. Key updates include cleaning and updating API reference links for Anthropic and adding the `StatusWidget` (API down watch status display) for Dropbox and Harvest docs, improving user visibility into the operational status of these provider APIs.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced outdated Anthropic documentation links in `docs-v2/integrations/all/anthropic.mdx` with updated `docs.claude.com` URLs.
• Inserted the `StatusWidget` from `/snippets/api-down-watch/status-widget.jsx` into `docs-v2/integrations/all/dropbox.mdx` and `docs-v2/integrations/all/harvest.mdx` to show real-time API status.
• General documentation file cleanup (removal of obsolete links, standardized imports in all affected MDX files).

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs-v2/integrations/all/anthropic.mdx`
• `docs-v2/integrations/all/dropbox.mdx`
• `docs-v2/integrations/all/harvest.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*