### PR TITLE
feat: don't run all gh actions on docs update

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -70,7 +70,7 @@ jobs:
                   ./scripts/build_docker.sh build ${{ env.SHA }}
 
             - name: Push image
-              if: needs.changes.outputs.should_skip != 'true'
+              if: needs.changes.outputs.should_skip != 'true' && env.CAN_PUSH == 'true'
               run: |
                   docker push nangohq/nango:${{ env.SHA }}
 

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -9,7 +9,31 @@ on:
     merge_group:
 
 jobs:
+    changes:
+        runs-on: ubuntu-latest
+        outputs:
+            should_skip: ${{ steps.check.outputs.should_skip }}
+        steps:
+            - uses: actions/checkout@v4
+            - uses: dorny/paths-filter@v3
+              id: filter
+              with:
+                  filters: |
+                      docs_only:
+                          - 'docs-v2/**'
+            - name: Determine if should skip
+              id: check
+              run: |
+                  # Skip if:
+                  # - only docs were changed
+                  # - not on master branch (always building image on master so we can deploy any commit)
+                  if [[ "${{ steps.filter.outputs.docs_only }}" == "true" && "${{ github.ref }}" != "refs/heads/master" ]]; then
+                      echo "should_skip=true" >> $GITHUB_OUTPUT
+                  else
+                      echo "should_skip=false" >> $GITHUB_OUTPUT
+                  fi
     build-image:
+        needs: changes
         runs-on: ubuntu-latest
         env:
             CAN_PUSH: "${{ secrets.DOCKER_PASSWORD != '' && secrets.DOCKER_USERNAME != '' }}"
@@ -17,35 +41,40 @@ jobs:
 
         steps:
             - name: Check out
+              if: needs.changes.outputs.should_skip != 'true'
               uses: actions/checkout@v4
 
             - name: Set up QEMU
+              if: needs.changes.outputs.should_skip != 'true'
               uses: docker/setup-qemu-action@v3
 
             - name: Set up Docker Buildx
+              if: needs.changes.outputs.should_skip != 'true'
               uses: docker/setup-buildx-action@v3
 
             - name: Log in to Docker Hub
               uses: docker/login-action@v3
-              if: env.CAN_PUSH == 'true'
+              if: needs.changes.outputs.should_skip != 'true' && env.CAN_PUSH == 'true'
               with:
                   username: '${{ secrets.DOCKER_USERNAME }}'
                   password: '${{ secrets.DOCKER_PASSWORD }}'
 
             # Needed for buildx gha cache to work
             - name: Expose GitHub Runtime
+              if: needs.changes.outputs.should_skip != 'true'
               uses: crazy-max/ghaction-github-runtime@v2
 
             - name: Build image
+              if: needs.changes.outputs.should_skip != 'true'
               run: |
                   ./scripts/build_docker.sh build ${{ env.SHA }}
 
             - name: Push image
-              if: env.CAN_PUSH == 'true'
+              if: needs.changes.outputs.should_skip != 'true'
               run: |
                   docker push nangohq/nango:${{ env.SHA }}
 
             - name: (self-hosted) Build and push
-              if: github.ref == 'refs/heads/master'
+              if: needs.changes.outputs.should_skip != 'true'
               run: |
                   ./scripts/build_docker_self_hosted.sh ${{ env.SHA }} ${{ env.CAN_PUSH }}

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -13,7 +13,20 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    changes:
+        runs-on: ubuntu-latest
+        outputs:
+            docs_only: ${{ steps.filter.outputs.docs_only }}
+        steps:
+            - uses: actions/checkout@v4
+            - uses: dorny/paths-filter@v3
+              id: filter
+              with:
+                  filters: |
+                      docs_only:
+                          - 'docs-v2/**'
     publish:
+        needs: changes
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -22,8 +35,10 @@ jobs:
             GIT_HASH: ${{ steps.publish_step.outputs.hash }}
         steps:
             - uses: actions/checkout@v4
+              if: needs.changes.outputs.docs_only != 'true'
 
             - uses: actions/setup-node@v4
+              if: needs.changes.outputs.docs_only != 'true'
               with:
                   node-version-file: '.nvmrc'
                   registry-url: 'https://npm.pkg.github.com'
@@ -31,11 +46,13 @@ jobs:
                   always-auth: true
 
             - name: Build
+              if: needs.changes.outputs.docs_only != 'true'
               run: |
                   npm ci
                   npm run ts-build
 
             - name: Publish packages to github registry so they can be bumped
+              if: needs.changes.outputs.docs_only != 'true'
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
@@ -62,6 +79,7 @@ jobs:
 
             - id: publish_step
               name: Publish npm packages to the github registry
+              if: needs.changes.outputs.docs_only != 'true'
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               shell: bash
@@ -71,6 +89,7 @@ jobs:
                   npx zx ./scripts/publish.mjs --version=0.0.1-$GIT_HASH --skip-cli
 
             - name: Publish the cli privately under the correct scope
+              if: needs.changes.outputs.docs_only != 'true'
               working-directory: packages/cli
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -81,7 +100,9 @@ jobs:
                   npm publish
     verify:
         runs-on: ubuntu-latest
-        needs: publish
+        needs:
+            - changes
+            - publish
         env:
             NANGO_CLI_UPGRADE_MODE: ignore
             GIT_HASH: ${{ needs.publish.outputs.GIT_HASH }}
@@ -90,12 +111,14 @@ jobs:
             packages: write
         steps:
             - uses: actions/setup-node@v4
+              if: needs.changes.outputs.docs_only != 'true'
               with:
                   node-version: '20.18.1'
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@nangohq'
                   always-auth: true
             - name: Install the cli from the github package registry
+              if: needs.changes.outputs.docs_only != 'true'
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,21 +13,38 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    changes:
+        runs-on: ubuntu-latest
+        outputs:
+            docs_only: ${{ steps.filter.outputs.docs_only }}
+        steps:
+            - uses: actions/checkout@v4
+            - uses: dorny/paths-filter@v3
+              id: filter
+              with:
+                  filters: |
+                      docs_only:
+                          - 'docs-v2/**'
     docker_check_job:
+        needs: changes
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
+              if: needs.changes.outputs.docs_only != 'true'
               uses: actions/checkout@v4
 
             - name: Build the docker-compose stack
+              if: needs.changes.outputs.docs_only != 'true'
               run: docker compose up -d
 
             - name: Sleep
+              if: needs.changes.outputs.docs_only != 'true'
               uses: jakejarvis/wait-action@master
               with:
                   time: '30s'
 
             - name: Verify containers
+              if: needs.changes.outputs.docs_only != 'true'
               run: |
                   CONTAINER_NAME=nango-server
                   SERVER=$(docker ps -q -f status=running -f name=^/${CONTAINER_NAME}$)

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,24 +9,41 @@ on:
     merge_group:
 
 jobs:
-    lint-code:
+    changes:
         runs-on: ubuntu-latest
-
+        outputs:
+            docs_only: ${{ steps.filter.outputs.docs_only }}
         steps:
             - uses: actions/checkout@v4
+            - uses: dorny/paths-filter@v3
+              id: filter
+              with:
+                  filters: |
+                      docs_only:
+                          - 'docs-v2/**'
+    lint-code:
+        needs: changes
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              if: needs.changes.outputs.docs_only != 'true'
               with:
                   fetch-depth: '0'
 
             - uses: actions/setup-node@v4
+              if: needs.changes.outputs.docs_only != 'true'
               with:
                   cache: 'npm'
                   node-version-file: '.nvmrc'
 
             - name: Install dependencies
+              if: needs.changes.outputs.docs_only != 'true'
               run: npm ci
 
             - name: Build
+              if: needs.changes.outputs.docs_only != 'true'
               run: npm run ts-build
 
             - name: Lint
+              if: needs.changes.outputs.docs_only != 'true'
               run: npm run lint -- --quiet

--- a/.github/workflows/tests-clients.yaml
+++ b/.github/workflows/tests-clients.yaml
@@ -9,6 +9,18 @@ on:
     merge_group:
 
 jobs:
+    changes:
+        runs-on: ubuntu-latest
+        outputs:
+            docs_only: ${{ steps.filter.outputs.docs_only }}
+        steps:
+            - uses: actions/checkout@v4
+            - uses: dorny/paths-filter@v3
+              id: filter
+              with:
+                  filters: |
+                      docs_only:
+                          - 'docs-v2/**'
     compute-matrix:
         runs-on: ubuntu-latest
         outputs:
@@ -23,7 +35,9 @@ jobs:
                     echo "os-matrix=[\"ubuntu-latest\"]" >> $GITHUB_OUTPUT
                   fi
     tests:
-        needs: compute-matrix
+        needs:
+            - changes
+            - compute-matrix
         strategy:
             fail-fast: false
             matrix:
@@ -34,10 +48,12 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+              if: needs.changes.outputs.docs_only != 'true'
               with:
                   fetch-depth: '0'
 
             - name: Use Node.js ${{ matrix.node-version }}
+              if: needs.changes.outputs.docs_only != 'true'
               uses: actions/setup-node@v4
               with:
                   cache: 'npm'
@@ -45,18 +61,25 @@ jobs:
                   cache-dependency-path: 'package-lock.json'
 
             - run: npm ci
+              if: needs.changes.outputs.docs_only != 'true'
 
             - name: Build Typescript
+              if: needs.changes.outputs.docs_only != 'true'
               run: npm run ts-build
 
             - run: npm run test:cli
+              if: needs.changes.outputs.docs_only != 'true'
+
             - run: npm run test:unit -- packages/cli
+              if: needs.changes.outputs.docs_only != 'true'
 
             - name: Build Node Client
+              if: needs.changes.outputs.docs_only != 'true'
               run: |
                   npm run -w @nangohq/node build
 
             - name: Test Node CJS
+              if: needs.changes.outputs.docs_only != 'true'
               shell: bash
               run: |
                   RES=$(node packages/node-client/tests/built.cjs)
@@ -64,6 +87,7 @@ jobs:
                   [ "$RES" != *"Done"* ] || { exit 1; }
 
             - name: Test Node ESM
+              if: needs.changes.outputs.docs_only != 'true'
               shell: bash
               run: |
                   RES=$(node packages/node-client/tests/built.js)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,22 +13,43 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    tests:
+    changes:
         runs-on: ubuntu-latest
-
+        outputs:
+            docs_only: ${{ steps.filter.outputs.docs_only }}
+        steps:
+            - uses: actions/checkout@v4
+            - uses: dorny/paths-filter@v3
+              id: filter
+              with:
+                  filters: |
+                      docs_only:
+                          - 'docs-v2/**'
+    tests:
+        needs: changes
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout
+              if: needs.changes.outputs.docs_only != 'true'
               uses: actions/checkout@v4
               with:
                   fetch-depth: '0'
 
             - name: Use Node.js
+              if: needs.changes.outputs.docs_only != 'true'
               uses: actions/setup-node@v4
               with:
                   cache: 'npm'
                   node-version-file: '.nvmrc'
 
             - run: npm ci
+              if: needs.changes.outputs.docs_only != 'true'
+
             - run: npm run ts-build
+              if: needs.changes.outputs.docs_only != 'true'
+
             - run: npm run test:unit -- --exclude packages/cli/
+              if: needs.changes.outputs.docs_only != 'true'
+
             - run: npm run test:integration
+              if: needs.changes.outputs.docs_only != 'true'


### PR DESCRIPTION
This sucks but there is no simple way to skip github action workflows while being compatible with branch protection checks. 
Setting `paths-ignore` at the workflow level will prevent the workflow to run (good) but it will stay in pending state which will make the branch protection check complain that it is not successful 😢 
There has been tons of discussions about it for years (google `paths-ignore branch protection` if you are curious) and GH apparently doesn't care. 

The other workaround options would be as follow but they all sucks as well:
- a hack where having duplicates jobs with the same name as the required ones that would run on the opposite condition 🙄 
- a master job that orchestrates all the required sub-jobs. (there are even pre-build actions for it in the marketplace)
- (if you have too many bored developers) implement your own Github app with Google PubSub to orchestrate your CI jobs: https://medium.com/mixpaneleng/enforcing-required-checks-on-conditional-ci-jobs-in-a-github-monorepo-8d4949694340

<!-- Summary by @propel-code-bot -->

---

**Conditional Skipping of GitHub Actions for Documentation-Only Updates**

This pull request refactors all core GitHub Actions workflows to conditionally skip jobs when a pull request or commit only changes files within the `docs-v2/` directory. It introduces a new `changes` job to each workflow, leveraging the `dorny/paths-filter` action to detect documentation-only changes. Downstream jobs in each workflow now evaluate this output and are skipped accordingly, except on the `master` branch where all actions continue to run to ensure deployment consistency and branch protection compatibility. Special handling is added to the Docker build pipeline to correctly combine sensitive conditions, and all necessary job dependencies and logic are updated to ensure CI workflows remain green and compliant with branch protection rules, even when most jobs are skipped.

<details>
<summary><strong>Key Changes</strong></summary>

• Added a `changes` job using `dorny/paths-filter` in all major workflows (`.github/workflows/build-image.yaml`, `tests-clients.yaml`, `cli-verification.yaml`, `tests.yaml`, `lint.yaml`, `docker.yaml`) to filter for doc-only changes under `docs-v2/**`.
• Updated all workflow jobs to conditionally execute based on the `changes` job output (e.g., `if: needs.changes.outputs.docs_only != 'true'`), skipping unrelated runs for doc-only PRs.
• Workflows now explicitly require the `changes` job, maintaining at least one always-completed job for branch protection checks.
• Docker build workflow (`build-image.yaml`) employs branch-specific logic to always run on `master`, regardless of doc-only changes.
• Critical fix: The `Push image` step in `build-image.yaml` now checks both `should_skip` and `env.CAN_PUSH` to avoid unauthorized Docker pushes.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `.github/workflows/build-image.yaml`
• `.github/workflows/tests-clients.yaml`
• `.github/workflows/cli-verification.yaml`
• `.github/workflows/tests.yaml`
• `.github/workflows/lint.yaml`
• `.github/workflows/docker.yaml`

</details>

---
*This summary was automatically generated by @propel-code-bot*