### PR TITLE
feat(server): allow free self-hosted to toggle watermark

### DIFF
--- a/packages/shared/lib/services/connect-ui-settings.service.ts
+++ b/packages/shared/lib/services/connect-ui-settings.service.ts
@@ -1,4 +1,4 @@
-import { Err, Ok, flagHasPlan, isEnterprise } from '@nangohq/utils';
+import { Err, Ok, flagHasPlan, isEnterprise, isHosted } from '@nangohq/utils';
 
 import type { ConnectUISettings, DBConnectUISettings, DBPlan, Result } from '@nangohq/types';
 import type { Knex } from 'knex';
@@ -66,7 +66,7 @@ export function canCustomizeConnectUITheme(plan?: DBPlan | null): boolean {
 
 export function canDisableConnectUIWatermark(plan?: DBPlan | null): boolean {
     if (!flagHasPlan || !plan) {
-        return isEnterprise;
+        return isHosted;
     }
 
     return plan.can_disable_connect_ui_watermark;

--- a/packages/shared/lib/services/connect-ui-settings.service.ts
+++ b/packages/shared/lib/services/connect-ui-settings.service.ts
@@ -66,7 +66,7 @@ export function canCustomizeConnectUITheme(plan?: DBPlan | null): boolean {
 
 export function canDisableConnectUIWatermark(plan?: DBPlan | null): boolean {
     if (!flagHasPlan || !plan) {
-        return isHosted;
+        return isHosted || isEnterprise;
     }
 
     return plan.can_disable_connect_ui_watermark;


### PR DESCRIPTION
It was decided that free self-hosted should be able to toggle off the watermark, so that we don't hurt existing customers when they update.

<!-- Summary by @propel-code-bot -->

---

**Enable Watermark Toggle for Free Self-Hosted Deployments**

This PR updates the logic in the `canDisableConnectUIWatermark` function within `packages/shared/lib/services/connect-ui-settings.service.ts` to allow free self-hosted users to disable the Connect UI watermark. Previously, only enterprise deployments could toggle this setting. Now, both enterprise and any self-hosted (regardless of plan) instances can turn off the watermark. This change aims to prevent newly-updated free self-hosted customers from losing the ability to disable the watermark.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `isHosted` into the import list from `@nangohq/utils` in `connect-ui-settings.service.ts`.
• Modified the condition in `canDisableConnectUIWatermark()` so that it returns `isHosted || isEnterprise` when no plan or flag is present.
• Ensured that all self-hosted users can toggle watermark visibility, aligning with updated product policy.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `canDisableConnectUIWatermark` logic in `packages/shared/lib/services/connect-ui-settings.service.ts`
• Import statements in `packages/shared/lib/services/connect-ui-settings.service.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*