### PR TITLE
fix: allow redis url to be passed in as separate components

### DIFF
--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -39,6 +39,7 @@ async function getRedis(url: string): Promise<RedisClientType> {
 export async function destroy() {
     if (kvstorePromise) {
         await (await kvstorePromise).destroy();
+        kvstorePromise = undefined;
     }
     if (redis) {
         await redis.disconnect();
@@ -50,6 +51,15 @@ async function createKVStore(): Promise<KVStore> {
     if (url) {
         const store = new RedisKVStore(await getRedis(url));
         return store;
+    } else {
+        const endpoint = process.env['NANGO_REDIS_ENDPOINT'];
+        const port = process.env['NANGO_REDIS_PORT'] || 6379;
+        const auth = process.env['NANGO_REDIS_AUTH'];
+        if (endpoint && port && auth) {
+            console.log('creating redis store with endpoint', endpoint, 'port', port, 'auth', auth);
+            const store = new RedisKVStore(await getRedis(`rediss://:${auth}@${endpoint}:${port}`));
+            return store;
+        }
     }
 
     return new InMemoryKVStore();
@@ -58,6 +68,7 @@ async function createKVStore(): Promise<KVStore> {
 let kvstorePromise: Promise<KVStore> | undefined;
 export async function getKVStore(): Promise<KVStore> {
     if (kvstorePromise) {
+        console.log('promise is defined');
         return await kvstorePromise;
     }
 

--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -52,7 +52,7 @@ async function createKVStore(): Promise<KVStore> {
         const store = new RedisKVStore(await getRedis(url));
         return store;
     } else {
-        const endpoint = process.env['NANGO_REDIS_ENDPOINT'];
+        const endpoint = process.env['NANGO_REDIS_HOST'];
         const port = process.env['NANGO_REDIS_PORT'] || 6379;
         const auth = process.env['NANGO_REDIS_AUTH'];
         if (endpoint && port && auth) {

--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -56,7 +56,6 @@ async function createKVStore(): Promise<KVStore> {
         const port = process.env['NANGO_REDIS_PORT'] || 6379;
         const auth = process.env['NANGO_REDIS_AUTH'];
         if (endpoint && port && auth) {
-            console.log('creating redis store with endpoint', endpoint, 'port', port, 'auth', auth);
             const store = new RedisKVStore(await getRedis(`rediss://:${auth}@${endpoint}:${port}`));
             return store;
         }
@@ -68,7 +67,6 @@ async function createKVStore(): Promise<KVStore> {
 let kvstorePromise: Promise<KVStore> | undefined;
 export async function getKVStore(): Promise<KVStore> {
     if (kvstorePromise) {
-        console.log('promise is defined');
         return await kvstorePromise;
     }
 

--- a/packages/kvstore/lib/index.unit.test.ts
+++ b/packages/kvstore/lib/index.unit.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { InMemoryKVStore, RedisKVStore, destroy, getKVStore } from './index.js';
+
+// Mock redis
+vi.mock('redis', () => ({
+    createClient: vi.fn(() => ({
+        connect: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn().mockResolvedValue(undefined),
+        on: vi.fn()
+    }))
+}));
+
+describe('getKVStore', () => {
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        // Clear environment variables
+        delete process.env['NANGO_REDIS_URL'];
+        delete process.env['NANGO_REDIS_ENDPOINT'];
+        delete process.env['NANGO_REDIS_PORT'];
+        delete process.env['NANGO_REDIS_AUTH'];
+
+        // Clear the cached kvstorePromise
+        await destroy();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should use RedisKVStore when NANGO_REDIS_URL is provided', async () => {
+        process.env['NANGO_REDIS_URL'] = 'redis://localhost:6379';
+
+        const store = await getKVStore();
+
+        expect(store).toBeInstanceOf(RedisKVStore);
+    });
+
+    it('should use RedisKVStore when endpoint, auth, and port are provided', async () => {
+        process.env['NANGO_REDIS_ENDPOINT'] = 'localhost';
+        process.env['NANGO_REDIS_PORT'] = '6379';
+        process.env['NANGO_REDIS_AUTH'] = 'password';
+
+        const store = await getKVStore();
+
+        expect(store).toBeInstanceOf(RedisKVStore);
+    });
+    it('should return InMemoryKVStore when partial Redis config is provided', async () => {
+        process.env['NANGO_REDIS_ENDPOINT'] = 'localhost';
+        const store = await getKVStore();
+
+        expect(store).toBeInstanceOf(InMemoryKVStore);
+    });
+    it('should return InMemoryKVStore when no Redis config is provided', async () => {
+        const store = await getKVStore();
+
+        expect(store).toBeInstanceOf(InMemoryKVStore);
+    });
+});

--- a/packages/kvstore/lib/index.unit.test.ts
+++ b/packages/kvstore/lib/index.unit.test.ts
@@ -16,7 +16,7 @@ describe('getKVStore', () => {
         vi.clearAllMocks();
         // Clear environment variables
         delete process.env['NANGO_REDIS_URL'];
-        delete process.env['NANGO_REDIS_ENDPOINT'];
+        delete process.env['NANGO_REDIS_HOST'];
         delete process.env['NANGO_REDIS_PORT'];
         delete process.env['NANGO_REDIS_AUTH'];
 
@@ -37,7 +37,7 @@ describe('getKVStore', () => {
     });
 
     it('should use RedisKVStore when endpoint, auth, and port are provided', async () => {
-        process.env['NANGO_REDIS_ENDPOINT'] = 'localhost';
+        process.env['NANGO_REDIS_HOST'] = 'localhost';
         process.env['NANGO_REDIS_PORT'] = '6379';
         process.env['NANGO_REDIS_AUTH'] = 'password';
 
@@ -46,7 +46,7 @@ describe('getKVStore', () => {
         expect(store).toBeInstanceOf(RedisKVStore);
     });
     it('should return InMemoryKVStore when partial Redis config is provided', async () => {
-        process.env['NANGO_REDIS_ENDPOINT'] = 'localhost';
+        process.env['NANGO_REDIS_HOST'] = 'localhost';
         const store = await getKVStore();
 
         expect(store).toBeInstanceOf(InMemoryKVStore);

--- a/packages/shared/lib/utils/utils.ts
+++ b/packages/shared/lib/utils/utils.ts
@@ -54,7 +54,18 @@ export function getServerBaseUrl() {
 }
 
 export function getRedisUrl() {
-    return process.env['NANGO_REDIS_URL'] || undefined;
+    const url = process.env['NANGO_REDIS_URL'];
+    if (url) {
+        return url;
+    } else {
+        const endpoint = process.env['NANGO_REDIS_ENDPOINT'];
+        const port = process.env['NANGO_REDIS_PORT'] || 6379;
+        const auth = process.env['NANGO_REDIS_AUTH'];
+        if (endpoint && port && auth) {
+            return `rediss://:${auth}@${endpoint}:${port}`;
+        }
+        return undefined;
+    }
 }
 
 export function getOrchestratorUrl() {

--- a/packages/shared/lib/utils/utils.ts
+++ b/packages/shared/lib/utils/utils.ts
@@ -58,7 +58,7 @@ export function getRedisUrl() {
     if (url) {
         return url;
     } else {
-        const endpoint = process.env['NANGO_REDIS_ENDPOINT'];
+        const endpoint = process.env['NANGO_REDIS_HOST'];
         const port = process.env['NANGO_REDIS_PORT'] || 6379;
         const auth = process.env['NANGO_REDIS_AUTH'];
         if (endpoint && port && auth) {

--- a/packages/shared/lib/utils/utils.unit.test.ts
+++ b/packages/shared/lib/utils/utils.unit.test.ts
@@ -326,7 +326,7 @@ describe('getRedisUrl', () => {
 
     it('should return undefined when no relevant env vars are set', () => {
         delete process.env['NANGO_REDIS_URL'];
-        delete process.env['NANGO_REDIS_ENDPOINT'];
+        delete process.env['NANGO_REDIS_HOST'];
         delete process.env['NANGO_REDIS_PORT'];
         delete process.env['NANGO_REDIS_AUTH'];
 
@@ -336,7 +336,7 @@ describe('getRedisUrl', () => {
 
     it('should return NANGO_REDIS_URL when it is set', () => {
         process.env['NANGO_REDIS_URL'] = 'redis://localhost:6379';
-        delete process.env['NANGO_REDIS_ENDPOINT'];
+        delete process.env['NANGO_REDIS_HOST'];
         delete process.env['NANGO_REDIS_PORT'];
         delete process.env['NANGO_REDIS_AUTH'];
 
@@ -346,7 +346,7 @@ describe('getRedisUrl', () => {
 
     it('should return undefined when only some of the other env vars are set', () => {
         delete process.env['NANGO_REDIS_URL'];
-        process.env['NANGO_REDIS_ENDPOINT'] = 'localhost';
+        process.env['NANGO_REDIS_HOST'] = 'localhost';
         process.env['NANGO_REDIS_PORT'] = '6379';
         // NANGO_REDIS_AUTH is missing
 
@@ -356,7 +356,7 @@ describe('getRedisUrl', () => {
 
     it('should return constructed URL when all other env vars are set', () => {
         delete process.env['NANGO_REDIS_URL'];
-        process.env['NANGO_REDIS_ENDPOINT'] = 'localhost';
+        process.env['NANGO_REDIS_HOST'] = 'localhost';
         process.env['NANGO_REDIS_PORT'] = '6379';
         process.env['NANGO_REDIS_AUTH'] = 'password';
 

--- a/packages/shared/lib/utils/utils.unit.test.ts
+++ b/packages/shared/lib/utils/utils.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as utils from './utils.js';
 
@@ -309,5 +309,58 @@ describe('parseTokenExpirationDate', () => {
         const millisecondsTimestamp = Date.now();
         const expected = new Date(millisecondsTimestamp);
         expect(utils.parseTokenExpirationDate(millisecondsTimestamp)?.getTime()).toBe(expected.getTime());
+    });
+});
+
+describe('getRedisUrl', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        vi.resetModules();
+        process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+    });
+
+    it('should return undefined when no relevant env vars are set', () => {
+        delete process.env['NANGO_REDIS_URL'];
+        delete process.env['NANGO_REDIS_ENDPOINT'];
+        delete process.env['NANGO_REDIS_PORT'];
+        delete process.env['NANGO_REDIS_AUTH'];
+
+        const result = utils.getRedisUrl();
+        expect(result).toBeUndefined();
+    });
+
+    it('should return NANGO_REDIS_URL when it is set', () => {
+        process.env['NANGO_REDIS_URL'] = 'redis://localhost:6379';
+        delete process.env['NANGO_REDIS_ENDPOINT'];
+        delete process.env['NANGO_REDIS_PORT'];
+        delete process.env['NANGO_REDIS_AUTH'];
+
+        const result = utils.getRedisUrl();
+        expect(result).toBe('redis://localhost:6379');
+    });
+
+    it('should return undefined when only some of the other env vars are set', () => {
+        delete process.env['NANGO_REDIS_URL'];
+        process.env['NANGO_REDIS_ENDPOINT'] = 'localhost';
+        process.env['NANGO_REDIS_PORT'] = '6379';
+        // NANGO_REDIS_AUTH is missing
+
+        const result = utils.getRedisUrl();
+        expect(result).toBeUndefined();
+    });
+
+    it('should return constructed URL when all other env vars are set', () => {
+        delete process.env['NANGO_REDIS_URL'];
+        process.env['NANGO_REDIS_ENDPOINT'] = 'localhost';
+        process.env['NANGO_REDIS_PORT'] = '6379';
+        process.env['NANGO_REDIS_AUTH'] = 'password';
+
+        const result = utils.getRedisUrl();
+        expect(result).toBe('rediss://:password@localhost:6379');
     });
 });

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -276,7 +276,7 @@ export const ENVS = z.object({
 
     // Redis
     NANGO_REDIS_URL: z.url().optional(),
-    NANGO_REDIS_ENDPOINT: z.string().optional(),
+    NANGO_REDIS_HOST: z.string().optional(),
     NANGO_REDIS_PORT: z.coerce.number().optional().default(6379),
     NANGO_REDIS_AUTH: z.string().optional(),
 

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -276,6 +276,9 @@ export const ENVS = z.object({
 
     // Redis
     NANGO_REDIS_URL: z.url().optional(),
+    NANGO_REDIS_ENDPOINT: z.string().optional(),
+    NANGO_REDIS_PORT: z.coerce.number().optional().default(6379),
+    NANGO_REDIS_AUTH: z.string().optional(),
 
     // Render
     RENDER_API_KEY: z.string().optional(),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Enhanced Redis Configuration: Support for URL Component-Based Setup**

This PR refactors Redis connection setup to allow the Redis URL to be constructed from separate environment variables (`NANGO_REDIS_HOST`, `NANGO_REDIS_PORT`, and `NANGO_REDIS_AUTH`) in addition to the existing `NANGO_REDIS_URL` option. The logic for building and validating the Redis connection was updated across configuration utilities and the key-value store initialization, with comprehensive updates to the environment schema validation and a significant expansion in automated test coverage to ensure all configuration variants are reliably supported.

<details>
<summary><strong>Key Changes</strong></summary>

• Refactored the `getRedisUrl` function in `packages/shared/lib/utils/utils.ts` to construct Redis URLs from `NANGO_REDIS_HOST`, `NANGO_REDIS_PORT`, and `NANGO_REDIS_AUTH` when `NANGO_REDIS_URL` is not available.
• Updated `createKVStore` and `getKVStore` in `packages/kvstore/lib/index.ts` to properly support both full-url and component-based Redis config, maintaining fallback and backward compatibility with prior setups.
• Extended Zod environment schema validation (in `packages/utils/lib/environment/parse.ts`) to include the new component-based Redis environment variables.
• Refined `destroy` function in `packages/kvstore/lib/index.ts` to correctly clear `kvstorePromise`, improving resource cleanup.
• Significantly expanded test suites for both `getKVStore` and `getRedisUrl` across `packages/kvstore/lib/index.unit.test.ts` and `packages/shared/lib/utils/utils.unit.test.ts`, covering all fallback combinations and edge cases for Redis configuration.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/utils/utils.ts`
• `packages/kvstore/lib/index.ts`
• `packages/kvstore/lib/index.unit.test.ts`
• `packages/shared/lib/utils/utils.unit.test.ts`
• `packages/utils/lib/environment/parse.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*