### PR TITLE
chore(billing): billable_connections_v2 and records event tweak

### DIFF
--- a/packages/billing/lib/grouping.ts
+++ b/packages/billing/lib/grouping.ts
@@ -30,6 +30,8 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
                     return omitProperties(event, ['idempotencyKey', 'timestamp', 'count']);
                 case 'billable_connections':
                     return omitProperties(event, ['idempotencyKey', 'timestamp', 'count']);
+                case 'billable_connections_v2':
+                    return omitProperties(event, ['idempotencyKey', 'timestamp', 'count', 'frequencyMs']); // frequencyMs is used as the billing metric interval so we don't group by it
                 default:
                     ((_: never) => {
                         throw new Error(`Unhandled event type`);
@@ -161,6 +163,18 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
                             customLogs: _a.properties.telemetry.customLogs + b.properties.telemetry.customLogs,
                             proxyCalls: _a.properties.telemetry.proxyCalls + b.properties.telemetry.proxyCalls
                         }
+                    }
+                };
+            }
+            case 'billable_connections_v2': {
+                return {
+                    type: b.type,
+                    properties: {
+                        timestamp: b.properties.timestamp,
+                        idempotencyKey: b.properties.idempotencyKey,
+                        accountId: b.properties.accountId,
+                        count: a.properties.count + b.properties.count,
+                        frequencyMs: b.properties.frequencyMs
                     }
                 };
             }

--- a/packages/billing/lib/grouping.ts
+++ b/packages/billing/lib/grouping.ts
@@ -25,7 +25,7 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
                 case 'monthly_active_records':
                     return omitProperties(event, ['idempotencyKey', 'timestamp', 'count']);
                 case 'records':
-                    return omitProperties(event, ['idempotencyKey', 'timestamp', 'count', 'telemetry']);
+                    return omitProperties(event, ['idempotencyKey', 'timestamp', 'count', 'telemetry', 'frequencyMs']); // frequencyMs is used as the billing metric interval so we don't group by it
                 case 'billable_active_connections':
                     return omitProperties(event, ['idempotencyKey', 'timestamp', 'count']);
                 case 'billable_connections':
@@ -136,6 +136,7 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
                         telemetry: {
                             sizeBytes: _a.properties.telemetry.sizeBytes + b.properties.telemetry.sizeBytes
                         },
+                        frequencyMs: b.properties.frequencyMs,
                         count: a.properties.count + b.properties.count
                     }
                 };

--- a/packages/billing/lib/grouping.unit.test.ts
+++ b/packages/billing/lib/grouping.unit.test.ts
@@ -111,6 +111,7 @@ describe('BillingEventGrouping', () => {
                     environmentId: 3,
                     count: 100,
                     timestamp: new Date(),
+                    frequencyMs: 60_000,
                     telemetry: {
                         sizeBytes: 2048
                     }
@@ -428,7 +429,7 @@ describe('BillingEventGrouping', () => {
                 }
             });
         });
-        it('should aggregate recoreds', () => {
+        it('should aggregate records', () => {
             const a: BillingEvent = {
                 type: 'records',
                 properties: {
@@ -436,6 +437,7 @@ describe('BillingEventGrouping', () => {
                     environmentId: 3,
                     count: 6,
                     timestamp: new Date('2024-01-01T00:00:00Z'),
+                    frequencyMs: 60_000,
                     telemetry: {
                         sizeBytes: 2048
                     }
@@ -448,6 +450,7 @@ describe('BillingEventGrouping', () => {
                     environmentId: 3,
                     count: 30,
                     timestamp: new Date('2024-01-02T00:00:00Z'),
+                    frequencyMs: 60_000,
                     telemetry: {
                         sizeBytes: 4096
                     }
@@ -461,6 +464,7 @@ describe('BillingEventGrouping', () => {
                     environmentId: 3,
                     count: 36,
                     timestamp: new Date('2024-01-02T00:00:00Z'),
+                    frequencyMs: 60_000,
                     telemetry: {
                         sizeBytes: 6144
                     }

--- a/packages/billing/lib/grouping.unit.test.ts
+++ b/packages/billing/lib/grouping.unit.test.ts
@@ -118,6 +118,15 @@ describe('BillingEventGrouping', () => {
                 }
             },
             {
+                type: 'billable_connections_v2',
+                properties: {
+                    accountId: 1,
+                    count: 10,
+                    timestamp: new Date(),
+                    frequencyMs: 86_400_000
+                }
+            },
+            {
                 type: 'billable_connections',
                 properties: {
                     accountId: 1,
@@ -143,6 +152,7 @@ describe('BillingEventGrouping', () => {
             'function_executions|accountId:1|connectionId:2|frequencyMs:100|type:sync',
             'monthly_active_records|accountId:1|connectionId:2|environmentId:3|model:model1|providerConfigKey:providerConfigKey2|syncId:sync1',
             'records|accountId:1|environmentId:3',
+            'billable_connections_v2|accountId:1',
             'billable_connections|accountId:1',
             'billable_active_connections|accountId:1'
         ]);
@@ -468,6 +478,36 @@ describe('BillingEventGrouping', () => {
                     telemetry: {
                         sizeBytes: 6144
                     }
+                }
+            });
+        });
+        it('should aggregate billable_connections_v2', () => {
+            const a: BillingEvent = {
+                type: 'billable_connections_v2',
+                properties: {
+                    accountId: 1,
+                    count: 7,
+                    timestamp: new Date('2024-01-01T00:00:00Z'),
+                    frequencyMs: 60_000
+                }
+            };
+            const b: BillingEvent = {
+                type: 'billable_connections_v2',
+                properties: {
+                    accountId: 1,
+                    count: 40,
+                    timestamp: new Date('2024-01-02T00:00:00Z'),
+                    frequencyMs: 60_000
+                }
+            };
+            const aggregated = grouping.aggregate(a, b);
+            expect(aggregated).toMatchObject({
+                type: 'billable_connections_v2',
+                properties: {
+                    accountId: 1,
+                    count: 47,
+                    timestamp: new Date('2024-01-02T00:00:00Z'),
+                    frequencyMs: 60_000
                 }
             });
         });

--- a/packages/metering/lib/crons/usage.ts
+++ b/packages/metering/lib/crons/usage.ts
@@ -98,8 +98,12 @@ const observability = {
                 });
 
                 // Send billing events
+                const frequencyMs = cronMinutes * 60 * 1000; // for simplicity we use the cron frequency as the event interval
                 const billingEvents = metricsWithAccount.map(({ accountId, environmentId, count, sizeBytes }) => {
-                    return { type: 'records' as const, properties: { count, accountId, environmentId, timestamp: new Date(), telemetry: { sizeBytes } } };
+                    return {
+                        type: 'records' as const,
+                        properties: { count, accountId, environmentId, timestamp: new Date(), frequencyMs, telemetry: { sizeBytes } }
+                    };
                 });
                 const sendBilling = usageBilling.add(billingEvents);
                 if (sendBilling.isErr()) {

--- a/packages/metering/lib/crons/usage.ts
+++ b/packages/metering/lib/crons/usage.ts
@@ -44,6 +44,7 @@ export async function exec(): Promise<void> {
         }
 
         try {
+            // TODO: get rid of billing exports which are legacy events
             await billing.exportBillableConnections();
             await billing.exportActiveConnections();
             await observability.exportConnectionsMetrics();
@@ -61,11 +62,23 @@ const observability = {
     exportConnectionsMetrics: async (): Promise<void> => {
         await tracer.trace<Promise<void>>('nango.cron.exportUsage.observability.connections', async (span) => {
             try {
-                const connRes = await connectionService.countMetric();
-                if (connRes.isErr()) {
-                    throw connRes.error;
+                const counts = await connectionService.countMetric();
+                if (counts.isErr()) {
+                    throw counts.error;
                 }
-                for (const { accountId, count, withActions, withSyncs, withWebhooks } of connRes.value) {
+                for (const { accountId, count, withActions, withSyncs, withWebhooks } of counts.value) {
+                    usageBilling.add([
+                        {
+                            type: 'billable_connections_v2' as const,
+                            properties: {
+                                accountId,
+                                count,
+                                timestamp: new Date(),
+                                frequencyMs: cronMinutes * 60 * 1000
+                            }
+                        }
+                    ]);
+
                     metrics.gauge(metrics.Types.CONNECTIONS_COUNT, count, { accountId });
                     metrics.gauge(metrics.Types.CONNECTIONS_WITH_ACTIONS_COUNT, withActions);
                     metrics.gauge(metrics.Types.CONNECTIONS_WITH_SYNCS_COUNT, withSyncs);
@@ -98,7 +111,7 @@ const observability = {
                 });
 
                 // Send billing events
-                const frequencyMs = cronMinutes * 60 * 1000; // for simplicity we use the cron frequency as the event interval
+                const frequencyMs = cronMinutes * 60 * 1000;
                 const billingEvents = metricsWithAccount.map(({ accountId, environmentId, count, sizeBytes }) => {
                     return {
                         type: 'records' as const,

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -75,6 +75,7 @@ export type RecordsBillingEvent = BillingEventBase<
     'records',
     {
         environmentId: number;
+        frequencyMs: number;
         telemetry: {
             sizeBytes: number;
         };

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -138,6 +138,13 @@ export type WebhookForwardBillingEvent = BillingEventBase<
 
 export type ConnectionsBillingEvent = BillingEventBase<'billable_connections'>;
 
+export type ConnectionsBillingEventV2 = BillingEventBase<
+    'billable_connections_v2',
+    {
+        frequencyMs: number;
+    }
+>;
+
 export type ActiveConnectionsBillingEvent = BillingEventBase<'billable_active_connections'>;
 
 export type BillingEvent =
@@ -148,4 +155,5 @@ export type BillingEvent =
     | WebhookForwardBillingEvent
     | FunctionExecutionsBillingEvent
     | ConnectionsBillingEvent
+    | ConnectionsBillingEventV2
     | ActiveConnectionsBillingEvent;


### PR DESCRIPTION
In order to simplify the calculation of metrics like records or
connections, @bastienbeurier and I have agreed to the frequency at which the data is being
ingested and treat it in orb as the time interval the value applies to . 
ie: in orb, each value is accounted for a 1/Nth of the month
(N being the interval). 
Ex: we send records count every hour = each value in Orb count for 1h in the month that are summed to arrive at the total cost

<!-- Summary by @propel-code-bot -->

---

**Add `frequencyMs` to Billing Events, Introduce `billable_connections_v2` Event Type, and Update Aggregation Logic**

This PR updates several billing and usage-related modules to include explicit time interval (`frequencyMs`) data with event metrics, enabling each metric to represent the frequency at which it is reported. It also introduces a new `billable_connections_v2` billing event type to report connection metrics with better granularity. Supporting changes include updates to the event grouping and aggregation logic, expansions of billing event TypeScript types, and comprehensive unit test additions to validate the new semantics and integration.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated the `records` event and related logic to include a new `frequencyMs` property representing the reporting interval in milliseconds.
• Introduced the `billable_connections_v2` event type, with a `frequencyMs` field, to more accurately account for the frequency of connection metrics.
• Enhanced billing event TypeScript types in `packages/types/lib/billing/types.ts` to add `frequencyMs` to `records` and to define `ConnectionsBillingEventV2`.
• Adjusted the grouping and aggregation logic in `packages/billing/lib/grouping.ts` to correctly handle `frequencyMs` in grouping keys and sum events of the new types.
• Updated `packages/metering/lib/crons/usage.ts` to emit `billable_connections_v2` and `records` events with `frequencyMs` on each reporting interval.
• Extended and revised unit tests in `packages/billing/lib/grouping.unit.test.ts` to cover new event types and validate correct grouping and aggregation behaviors.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/billing/lib/grouping.ts` (grouping key logic, aggregation, and type handling for billing events)
• `packages/types/lib/billing/types.ts` (event type definitions, especially for records and connections events)
• `packages/metering/lib/crons/usage.ts` (billing/metric exporting and emission logic)
• `packages/billing/lib/grouping.unit.test.ts` (unit test coverage for grouping/aggregation behaviors)

</details>

---
*This summary was automatically generated by @propel-code-bot*