### PR TITLE
chore: remove active connections billing event

### DIFF
--- a/packages/billing/lib/grouping.ts
+++ b/packages/billing/lib/grouping.ts
@@ -26,8 +26,6 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
                     return omitProperties(event, ['idempotencyKey', 'timestamp', 'count']);
                 case 'records':
                     return omitProperties(event, ['idempotencyKey', 'timestamp', 'count', 'telemetry', 'frequencyMs']); // frequencyMs is used as the billing metric interval so we don't group by it
-                case 'billable_active_connections':
-                    return omitProperties(event, ['idempotencyKey', 'timestamp', 'count']);
                 case 'billable_connections':
                     return omitProperties(event, ['idempotencyKey', 'timestamp', 'count']);
                 case 'billable_connections_v2':
@@ -180,8 +178,6 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
             }
             case 'billable_connections':
                 return b; // billable connections are already aggregated
-            case 'billable_active_connections':
-                return b; // billable active connections are already aggregated
             default:
                 ((_: never) => {
                     throw new Error(`Unhandled event type`);

--- a/packages/billing/lib/grouping.unit.test.ts
+++ b/packages/billing/lib/grouping.unit.test.ts
@@ -133,14 +133,6 @@ describe('BillingEventGrouping', () => {
                     count: 11,
                     timestamp: new Date()
                 }
-            },
-            {
-                type: 'billable_active_connections',
-                properties: {
-                    accountId: 1,
-                    count: 12,
-                    timestamp: new Date()
-                }
             }
         ];
         const keys = events.map((event) => grouping.groupingKey(event));
@@ -153,32 +145,11 @@ describe('BillingEventGrouping', () => {
             'monthly_active_records|accountId:1|connectionId:2|environmentId:3|model:model1|providerConfigKey:providerConfigKey2|syncId:sync1',
             'records|accountId:1|environmentId:3',
             'billable_connections_v2|accountId:1',
-            'billable_connections|accountId:1',
-            'billable_active_connections|accountId:1'
+            'billable_connections|accountId:1'
         ]);
     });
 
     describe('aggregate', () => {
-        it('should aggregate billable_active_connections', () => {
-            const a: BillingEvent = {
-                type: 'billable_active_connections',
-                properties: {
-                    accountId: 1,
-                    count: 5,
-                    timestamp: new Date('2024-01-01T00:00:00Z')
-                }
-            };
-            const b: BillingEvent = {
-                type: 'billable_active_connections',
-                properties: {
-                    accountId: 1,
-                    count: 7,
-                    timestamp: new Date('2024-01-02T00:00:00Z')
-                }
-            };
-            const aggregated = grouping.aggregate(a, b);
-            expect(aggregated).toEqual(b);
-        });
         it('should aggregate billable_connections', () => {
             const a: BillingEvent = {
                 type: 'billable_connections',

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1704,47 +1704,6 @@ class ConnectionService {
             return Err(new NangoError('failed_to_track_execution', { id, error: err }));
         }
     }
-
-    /**
-     * Note:
-     * Some plan are billed per active connections in prod environment
-     * A connection is considered active if it has at least one script execution during the month
-     */
-    async billableActiveConnections(referenceDate: Date): Promise<
-        Result<
-            {
-                accountId: number;
-                count: number;
-                year: number;
-                month: number;
-            }[],
-            NangoError
-        >
-    > {
-        const year = referenceDate.getUTCFullYear();
-        const month = referenceDate.getUTCMonth();
-
-        const start = new Date(Date.UTC(year, month, 1));
-        const end = new Date(Date.UTC(year, month + 1, 1));
-
-        const res = await db.readOnly
-            .select('e.account_id as accountId')
-            .count('c.id as count')
-            .select(db.readOnly.raw(`${year} as year`))
-            .select(db.readOnly.raw(`${month + 1} as month`)) // js months are 0-based
-            .from('_nango_connections as c')
-            .join('_nango_environments as e', 'c.environment_id', 'e.id')
-            .where('c.last_execution_at', '>=', start)
-            .where('c.last_execution_at', '<', end)
-            .where('e.name', 'prod') // only consider prod environment
-            .groupBy('e.account_id')
-            .havingRaw('count(c.id) > 0');
-
-        if (res) {
-            return Ok(res);
-        }
-        return Err(new NangoError('failed_to_get_billable_active_connections'));
-    }
 }
 
 export default new ConnectionService();

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -145,8 +145,6 @@ export type ConnectionsBillingEventV2 = BillingEventBase<
     }
 >;
 
-export type ActiveConnectionsBillingEvent = BillingEventBase<'billable_active_connections'>;
-
 export type BillingEvent =
     | MarBillingEvent
     | RecordsBillingEvent
@@ -155,5 +153,4 @@ export type BillingEvent =
     | WebhookForwardBillingEvent
     | FunctionExecutionsBillingEvent
     | ConnectionsBillingEvent
-    | ConnectionsBillingEventV2
-    | ActiveConnectionsBillingEvent;
+    | ConnectionsBillingEventV2;


### PR DESCRIPTION
This event is not being used. Removing to make sure we don't hit orb rate limit when exporting all the billing events in the cron job

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Remove Unused Active Connections Billing Event**

This pull request removes all code and references related to the `billable_active_connections` billing event across the codebase. These changes eliminate an unused event type from service logic, type definitions, billing grouping, the metering cron job, and related tests, ensuring that only active billing events are exported, thereby reducing the risk of hitting external rate limits during export routines.

<details>
<summary><strong>Key Changes</strong></summary>

• Deleted `billable_active_connections` logic from `connection.service.ts` by removing the `billableActiveConnections` method.
• Removed the `exportActiveConnections` function and all calls to it from `packages/metering/lib/crons/usage.ts`.
• Updated `BillingEvent` type in `packages/types/lib/billing/types.ts` to remove all references to `billable_active_connections` and the associated type definitions.
• Modified the `BillingEventGrouping` implementation in `packages/billing/lib/grouping.ts` to remove handling of `billable_active_connections` for grouping keys and aggregation.
• Cleaned up corresponding unit tests in `packages/billing/lib/grouping.unit.test.ts` to eliminate all cases related to `billable_active_connections`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/services/connection.service.ts`
• `packages/metering/lib/crons/usage.ts`
• `packages/types/lib/billing/types.ts`
• `packages/billing/lib/grouping.ts`
• `packages/billing/lib/grouping.unit.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*