### PR TITLE
fix(tests): fix tests

### DIFF
--- a/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts
@@ -158,7 +158,7 @@ describe(`POST ${endpoint}`, () => {
             runs: 'every day',
             sdk_version: expect.any(String),
             sync_type: 'full',
-            track_deletes: true,
+            track_deletes: false,
             updated_at: expect.any(Date),
             version: '1.0.0',
             webhook_subscriptions: null


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Track deletes are called via a function now so no need for configuration. This test had trackDeletes registered as true via the config

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Update Test to Reflect `track_deletes` Logic Change**

This PR updates a test in `postDeploy.integration.test.ts` to align with a recent behavioral change: `track_deletes` is now managed directly via a function call instead of through explicit configuration. The test previously assumed `track_deletes` to be `true` by config, but this is no longer accurate based on the current implementation, so its expected value is set to `false`.

<details>
<summary><strong>Key Changes</strong></summary>

• Modified expected value of `track_deletes` property from `true` to `false` in the sync configuration assertion in `postDeploy.integration.test.ts`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*