### PR TITLE
fix(server): apply permission overrides to CUI settings in connect-session

### DIFF
--- a/packages/server/lib/controllers/connect/getSession.integration.test.ts
+++ b/packages/server/lib/controllers/connect/getSession.integration.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import db from '@nangohq/database';
-import { connectUISettingsService, seeders } from '@nangohq/shared';
+import { connectUISettingsService, seeders, updatePlan } from '@nangohq/shared';
 
 import { isError, isSuccess, runServer, shouldBeProtected } from '../../utils/tests.js';
 
@@ -92,8 +92,10 @@ describe(`GET ${endpoint}`, () => {
         expect(res.res.status).toBe(200);
     });
 
-    it('should get a session with custom connect UI settings', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+    it('should get a session with custom connect UI settings when both customization flags are enabled', async () => {
+        const { env, plan } = await seeders.seedAccountEnvAndUser();
+        // Enable both features so custom settings can be preserved
+        await updatePlan(db.knex, { id: plan.id, can_customize_connect_ui_theme: true, can_disable_connect_ui_watermark: true });
         await seeders.createConfigSeed(env, 'github', 'github');
 
         // Create custom connect UI settings
@@ -132,6 +134,51 @@ describe(`GET ${endpoint}`, () => {
                 endUser: { id: endUserId, email: 'a@b.com', display_name: null, tags: null, organization: null },
                 allowed_integrations: ['github'],
                 connectUISettings: customConnectUISettings
+            }
+        });
+        expect(res.res.status).toBe(200);
+    });
+
+    it('should get a session with default connect UI settings when both customization flags are disabled', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+
+        // Create custom connect UI settings
+        const customConnectUISettings: ConnectUISettings = {
+            showWatermark: true,
+            defaultTheme: 'system',
+            theme: {
+                light: {
+                    primary: '#ffffff'
+                },
+                dark: {
+                    primary: '#000000'
+                }
+            }
+        };
+        await connectUISettingsService.upsertConnectUISettings(db.knex, env.id, customConnectUISettings);
+
+        // Create session
+        const endUserId = 'knownId';
+        const resCreate = await api.fetch('/connect/sessions', {
+            method: 'POST',
+            token: env.secret_key,
+            body: { end_user: { id: endUserId, email: 'a@b.com' }, allowed_integrations: ['github'] }
+        });
+        isSuccess(resCreate.json);
+
+        // Get session
+        const res = await api.fetch(endpoint, {
+            method: 'GET',
+            token: resCreate.json.data.token
+        });
+
+        isSuccess(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            data: {
+                endUser: { id: endUserId, email: 'a@b.com', display_name: null, tags: null, organization: null },
+                allowed_integrations: ['github'],
+                connectUISettings: connectUISettingsService.getDefaultConnectUISettings()
             }
         });
         expect(res.res.status).toBe(200);

--- a/packages/server/lib/controllers/connect/getSession.ts
+++ b/packages/server/lib/controllers/connect/getSession.ts
@@ -20,7 +20,7 @@ export const getConnectSession = asyncWrapper<GetConnectSession>(async (req, res
         return;
     }
 
-    const { connectSession, account, environment } = res.locals;
+    const { connectSession, account, environment, plan } = res.locals;
 
     let endUser: InternalEndUser;
     if (connectSession.endUserId) {
@@ -42,7 +42,7 @@ export const getConnectSession = asyncWrapper<GetConnectSession>(async (req, res
         return;
     }
 
-    const connectUISettingsResult = await connectUISettingsService.getConnectUISettings(db.knex, environment.id);
+    const connectUISettingsResult = await connectUISettingsService.getConnectUISettings(db.knex, environment.id, plan);
     if (connectUISettingsResult.isErr()) {
         // Not critical - report, but don't fail
         report(connectUISettingsResult.error);

--- a/packages/server/lib/controllers/v1/connectUISettings/getConnectUISettings.ts
+++ b/packages/server/lib/controllers/v1/connectUISettings/getConnectUISettings.ts
@@ -15,31 +15,12 @@ export const getConnectUISettings = asyncWrapper<GetConnectUISettings>(async (re
 
     const { environment, plan } = res.locals;
 
-    const connectUISettings = await connectUISettingsService.getConnectUISettings(db.knex, environment.id);
+    const connectUISettings = await connectUISettingsService.getConnectUISettings(db.knex, environment.id, plan);
     if (connectUISettings.isErr()) {
         report(connectUISettings.error);
         res.status(500).send({ error: { code: 'failed_to_get_connect_ui_settings', message: connectUISettings.error.message } });
         return;
     }
 
-    const defaultSettings = connectUISettingsService.getDefaultConnectUISettings();
-
-    if (!connectUISettings.value) {
-        res.status(200).send({ data: defaultSettings });
-        return;
-    }
-
-    const finalSettings = connectUISettings.value;
-
-    // Override settings to defaults if the plan does not have the feature
-    // This way if the plan downgrades, they go back to default without resetting settings in db
-    if (!connectUISettingsService.canCustomizeConnectUITheme(plan)) {
-        finalSettings.theme = defaultSettings.theme;
-    }
-
-    if (!connectUISettingsService.canDisableConnectUIWatermark(plan)) {
-        finalSettings.showWatermark = defaultSettings.showWatermark;
-    }
-
-    res.status(200).send({ data: finalSettings });
+    res.status(200).send({ data: connectUISettings.value });
 });

--- a/packages/server/lib/controllers/v1/connectUISettings/putConnectUISettings.integration.test.ts
+++ b/packages/server/lib/controllers/v1/connectUISettings/putConnectUISettings.integration.test.ts
@@ -83,7 +83,7 @@ describe(`PUT ${route}`, () => {
         });
 
         // Verify the settings were actually created in the database
-        const dbSettings = await connectUISettingsService.getConnectUISettings(db.knex, env.id);
+        const dbSettings = await connectUISettingsService.getRawConnectUISettings(db.knex, env.id);
         assert(dbSettings.isOk());
         expect(dbSettings.value).toStrictEqual(newSettings);
     });
@@ -127,7 +127,7 @@ describe(`PUT ${route}`, () => {
         });
 
         // Verify the settings were actually updated in the database
-        const dbSettings = await connectUISettingsService.getConnectUISettings(db.knex, env.id);
+        const dbSettings = await connectUISettingsService.getRawConnectUISettings(db.knex, env.id);
         assert(dbSettings.isOk());
         expect(dbSettings.value).toStrictEqual(updatedSettings);
     });
@@ -248,7 +248,7 @@ describe(`PUT ${route}`, () => {
         expect(res.json.data.showWatermark).toBe(false); // Should preserve custom value
 
         // Verify the settings were stored in database with theme overridden
-        const dbSettings = await connectUISettingsService.getConnectUISettings(db.knex, env.id);
+        const dbSettings = await connectUISettingsService.getRawConnectUISettings(db.knex, env.id);
         assert(dbSettings.isOk());
         expect(dbSettings.value?.theme).toStrictEqual(connectUISettingsService.getDefaultConnectUISettings().theme);
         expect(dbSettings.value?.showWatermark).toBe(false);
@@ -280,7 +280,7 @@ describe(`PUT ${route}`, () => {
         expect(res.json.data.theme).toStrictEqual(testSettings.theme); // Should preserve custom theme
 
         // Verify the settings were stored in database with showWatermark overridden
-        const dbSettings = await connectUISettingsService.getConnectUISettings(db.knex, env.id);
+        const dbSettings = await connectUISettingsService.getRawConnectUISettings(db.knex, env.id);
         assert(dbSettings.isOk());
         expect(dbSettings.value?.showWatermark).toBe(connectUISettingsService.getDefaultConnectUISettings().showWatermark);
         expect(dbSettings.value?.theme).toStrictEqual(testSettings.theme);
@@ -308,7 +308,7 @@ describe(`PUT ${route}`, () => {
         expect(res.json.data).toStrictEqual(connectUISettingsService.getDefaultConnectUISettings());
 
         // Verify the settings were stored in database with both features overridden
-        const dbSettings = await connectUISettingsService.getConnectUISettings(db.knex, env.id);
+        const dbSettings = await connectUISettingsService.getRawConnectUISettings(db.knex, env.id);
         assert(dbSettings.isOk());
         expect(dbSettings.value).toStrictEqual(connectUISettingsService.getDefaultConnectUISettings());
     });


### PR DESCRIPTION
The logic for getting connect-ui settings in the connect-session got out of sync with the one from the get endpoint after some permission tweaks. This abstracts the logic and gets it back in sync. Fixes this: https://nangohq.slack.com/archives/C07216H4BRT/p1759130498539079

<!-- Summary by @propel-code-bot -->

---

**Synchronize Permission Overrides Logic for Connect-UI Settings in Connect-Session**

This PR refactors and centralizes the logic for fetching and applying permission/plan-based overrides to `connect-ui` settings across `connect-session` and its related endpoints. The key change is the introduction of unified logic in `connect-ui-settings.service.ts`, ensuring that both the GET and session-related endpoints apply feature restrictions (such as for theme customization and watermark removal) based on the active plan or permissions. Integration tests and controller logic are updated to rely on this abstracted service, eliminating inconsistent or duplicated business logic.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `getRawConnectUISettings` in `packages/shared/lib/services/connect-ui-settings.service.ts` for retrieving database values without overrides.
• Refactored `getConnectUISettings` in `connect-ui-settings.service.ts` to apply plan and permission checks and accept an optional `plan` parameter.
• Updated controllers in `packages/server/lib/controllers/v1/connectUISettings/getConnectUISettings.ts` and `packages/server/lib/controllers/connect/getSession.ts` to consistently delegate to the new service logic.
• Enhanced integration tests in `putConnectUISettings.integration.test.ts` and `getSession.integration.test.ts` to distinguish between raw and processed settings and verify plan-based override behaviors.
• Changed database verification in tests to use `getRawConnectUISettings` instead of the plan-overridden `getConnectUISettings`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/services/connect-ui-settings.service.ts`
• `packages/server/lib/controllers/v1/connectUISettings/getConnectUISettings.ts`
• `packages/server/lib/controllers/connect/getSession.ts`
• `packages/server/lib/controllers/v1/connectUISettings/putConnectUISettings.integration.test.ts`
• `packages/server/lib/controllers/connect/getSession.integration.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*