### PR TITLE
fix(kubernetes): smallest pod request size fix

### DIFF
--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -463,7 +463,7 @@ class Kubernetes {
         return {
             requests: {
                 cpu: '500m',
-                memory: '1023Mi'
+                memory: '512Mi'
             },
             limits: {
                 cpu: '500m',


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Update Kubernetes Smallest Pod Memory Request to 512Mi**

This pull request makes a minor adjustment to the smallest Kubernetes pod resource request configuration by changing the memory request value from `1023Mi` to `512Mi` in the `getResourceLimits` method of `packages/jobs/lib/runner/kubernetes.ts`. This change ensures that pods with the minimal size are now requested with a lower, standard memory footprint.

<details>
<summary><strong>Key Changes</strong></summary>

• Changed the `memory` request value for the smallest pod size from `1023Mi` to `512Mi` in the `getResourceLimits` function within `packages/jobs/lib/runner/kubernetes.ts`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/jobs/lib/runner/kubernetes.ts`
• `getResourceLimits` function

</details>

---
*This summary was automatically generated by @propel-code-bot*