### PR TITLE
fix(kubernetes): add datadog logging annotation to runner pods

### DIFF
--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -170,6 +170,9 @@ class Kubernetes {
                 selector: { matchLabels: { app: name } },
                 template: {
                     metadata: {
+                        annotations: {
+                            'ad.datadoghq.com/orchestrator.logs': `[{"source":"nango","service":"${name}"}]`
+                        },
                         labels: { app: name }
                     },
                     spec: {

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -171,7 +171,7 @@ class Kubernetes {
                 template: {
                     metadata: {
                         annotations: {
-                            'ad.datadoghq.com/orchestrator.logs': `[{"source":"nango","service":"${name}"}]`
+                            [`ad.datadoghq.com/${name}.logs`]: `[{"source":"nango","service":"${name}"}]`
                         },
                         labels: { app: name }
                     },


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Datadog Logging Annotation to Runner Pods in Kubernetes**

This PR updates the Kubernetes runner pod deployment template to include a Datadog log collection annotation within the `metadata` block. The annotation `ad.datadoghq.com/.logs` is set to a value instructing Datadog to treat logs from these pods as having source `nango` and service ``. No other changes are made to the deployment logic or structure.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `annotations` property to the `metadata` block of the deployment's pod template in `packages/jobs/lib/runner/kubernetes.ts`.
• Set `ad.datadoghq.com/.logs` to `[{"source":"nango","service":""}]` for all runner pods to enable Datadog log collection and attribution.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/jobs/lib/runner/kubernetes.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*