### PR TITLE
fix(kubernetes): annotation name must match container not pod

### DIFF
--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -171,7 +171,7 @@ class Kubernetes {
                 template: {
                     metadata: {
                         annotations: {
-                            [`ad.datadoghq.com/${name}.logs`]: `[{"source":"nango","service":"${name}"}]`
+                            [`ad.datadoghq.com/runner.logs`]: `[{"source":"nango","service":"${name}"}]`
                         },
                         labels: { app: name }
                     },


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Correct Datadog Annotation to Match Container Name in Kubernetes Runner**

This PR updates the `kubernetes.ts` runner implementation to adjust the Datadog log annotation key. Previously, the annotation was set using the Pod `name` variable, which could create issues with log collection. The change ensures the Datadog log annotation now targets the correct container (`runner`) rather than the pod or application name.

<details>
<summary><strong>Key Changes</strong></summary>

• Changed the Datadog log annotation key from `ad.datadoghq.com/${name}.logs` to `ad.datadoghq.com/runner.logs` in the deployment manifest of `packages/jobs/lib/runner/kubernetes.ts`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/jobs/lib/runner/kubernetes.ts`
• Kubernetes deployment manifest generation for runners

</details>

---
*This summary was automatically generated by @propel-code-bot*