### PR TITLE
refactor: function executions metrics

### DIFF
--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -12,7 +12,7 @@ import {
     getEndUserByConnectionId,
     getSyncConfigRaw
 } from '@nangohq/shared';
-import { Err, Ok, metrics, tagTraceUser } from '@nangohq/utils';
+import { Err, Ok, tagTraceUser } from '@nangohq/utils';
 import { sendAsyncActionWebhook } from '@nangohq/webhooks';
 
 import { bigQueryClient, slackService } from '../clients.js';
@@ -99,8 +99,6 @@ export async function startAction(task: TaskAction): Promise<Result<void>> {
             heartbeatTimeoutSecs: task.heartbeatTimeoutSecs
         };
 
-        metrics.increment(metrics.Types.ACTION_EXECUTION, 1, { accountId: account.id });
-
         const res = await startScript({
             taskId: task.id,
             nangoProps,
@@ -182,8 +180,6 @@ export async function handleActionSuccess({
         integration: nangoProps.providerConfigKey
     });
     void logCtx.success();
-
-    metrics.increment(metrics.Types.ACTION_SUCCESS);
 
     const connection: ConnectionJobs = {
         id: nangoProps.nangoConnectionId,
@@ -413,7 +409,6 @@ function onFailure({
             }
         });
     }
-    metrics.increment(metrics.Types.ACTION_FAILURE);
 }
 
 function formatAttempts(task: OrchestratorTask | Result<OrchestratorTask>): string {

--- a/packages/jobs/lib/execution/onEvent.ts
+++ b/packages/jobs/lib/execution/onEvent.ts
@@ -1,7 +1,7 @@
 import db from '@nangohq/database';
 import { logContextGetter } from '@nangohq/logs';
 import { NangoError, configService, environmentService, getApiUrl, getEndUserByConnectionId } from '@nangohq/shared';
-import { Err, Ok, metrics, tagTraceUser } from '@nangohq/utils';
+import { Err, Ok, tagTraceUser } from '@nangohq/utils';
 
 import { bigQueryClient } from '../clients.js';
 import { startScript } from './operations/start.js';
@@ -98,8 +98,6 @@ export async function startOnEvent(task: TaskOnEvent): Promise<Result<void>> {
             endUser,
             heartbeatTimeoutSecs: task.heartbeatTimeoutSecs
         };
-
-        metrics.increment(metrics.Types.ON_EVENT_SCRIPT_EXECUTION, 1, { accountId: account.id });
 
         const res = await startScript({
             taskId: task.id,

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -28,7 +28,7 @@ import {
     updateSyncJobResult,
     updateSyncJobStatus
 } from '@nangohq/shared';
-import { Err, Ok, flagHasPlan, getFrequencyMs, metrics, tagTraceUser } from '@nangohq/utils';
+import { Err, Ok, flagHasPlan, getFrequencyMs, tagTraceUser } from '@nangohq/utils';
 import { sendSync as sendSyncWebhook } from '@nangohq/webhooks';
 
 import { bigQueryClient, orchestratorClient, slackService } from '../clients.js';
@@ -185,8 +185,6 @@ export async function startSync(task: TaskSync, startScriptFn = startScript): Pr
         if (task.debug) {
             void logCtx.debug(`Last sync date is ${lastSyncDate?.toISOString()}`);
         }
-
-        metrics.increment(metrics.Types.SYNC_EXECUTION, 1, { accountId: team.id });
 
         const res = await startScriptFn({
             taskId: task.id,
@@ -485,9 +483,6 @@ export async function handleSyncSuccess({
             internalIntegrationId: nangoProps.syncConfig.nango_config_id,
             endUser: nangoProps.endUser
         });
-
-        metrics.duration(metrics.Types.SYNC_TRACK_RUNTIME, Date.now() - nangoProps.startedAt.getTime());
-        metrics.increment(metrics.Types.SYNC_SUCCESS);
 
         const sync = await getSyncById(nangoProps.syncId);
         const frequency = sync?.frequency || nangoProps.syncConfig.runs;
@@ -895,9 +890,6 @@ async function onFailure({
             active: true
         });
     }
-
-    metrics.increment(metrics.Types.SYNC_FAILURE);
-    metrics.duration(metrics.Types.SYNC_TRACK_RUNTIME, Date.now() - startedAt.getTime());
 
     if (team) {
         void pubsub.publisher.publish({

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -3,7 +3,7 @@ import ms from 'ms';
 import { v4 as uuid } from 'uuid';
 
 import { OtlpSpan } from '@nangohq/logs';
-import { Err, Ok, errorToObject, getFrequencyMs, metrics, stringifyError } from '@nangohq/utils';
+import { Err, Ok, errorToObject, getFrequencyMs, stringifyError } from '@nangohq/utils';
 
 import { LogActionEnum } from '../models/Telemetry.js';
 import { SyncCommand, SyncStatus } from '../models/index.js';
@@ -146,7 +146,6 @@ export class Orchestrator {
             tags: spanTags,
             ...(activeSpan ? { childOf: activeSpan } : {})
         });
-        const startTime = Date.now();
         try {
             let parsedInput: JsonValue = null;
             try {
@@ -228,12 +227,6 @@ export class Orchestrator {
             span.setTag('error', formattedError);
             return Err(formattedError);
         } finally {
-            // only track duration when action is executed inline
-            if (!async) {
-                const endTime = Date.now();
-                const totalRunTime = (endTime - startTime) / 1000;
-                metrics.duration(metrics.Types.ACTION_TRACK_RUNTIME, totalRunTime);
-            }
             span.finish();
         }
     }
@@ -400,7 +393,6 @@ export class Orchestrator {
             tags: spanTags,
             ...(activeSpan ? { childOf: activeSpan } : {})
         });
-        const startTime = Date.now();
         try {
             const groupKey = 'on-event:environment:${connection.environment_id}';
             const executionId = `${groupKey}:connection:${connection.id}:on-event-script:${name}:at:${new Date().toISOString()}:${uuid()}`;
@@ -443,7 +435,6 @@ export class Orchestrator {
                 integration: connection.provider_config_key
             });
 
-            metrics.increment(metrics.Types.ON_EVENT_SCRIPT_SUCCESS);
             return res as Result<T, NangoError>;
         } catch (err) {
             let formattedError: NangoError;
@@ -473,13 +464,9 @@ export class Orchestrator {
                 }
             });
 
-            metrics.increment(metrics.Types.ON_EVENT_SCRIPT_FAILURE);
             span.setTag('error', formattedError);
             return Err(formattedError);
         } finally {
-            const endTime = Date.now();
-            const totalRunTime = (endTime - startTime) / 1000;
-            metrics.duration(metrics.Types.ON_EVENT_SCRIPT_RUNTIME, totalRunTime);
             span.finish();
         }
     }

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -1,10 +1,6 @@
 import tracer from 'dd-trace';
 
 export enum Types {
-    ACTION_EXECUTION = 'nango.jobs.actionExecution',
-    ACTION_SUCCESS = 'nango.orch.action.success',
-    ACTION_FAILURE = 'nango.orch.action.failure',
-    ACTION_TRACK_RUNTIME = 'action_track_runtime',
     ACTION_INCOMING_PAYLOAD_SIZE_BYTES = 'nango.action.incoming.payloadSizeBytes',
 
     AUTH_GET_ENV_BY_CONNECT_SESSION = 'nango.auth.getEnvByConnectSession',
@@ -31,11 +27,6 @@ export enum Types {
     PERSIST_RECORDS_MODIFIED_COUNT = 'nango.persist.records.modified.count',
     PERSIST_RECORDS_MODIFIED_SIZE_IN_BYTES = 'nango.persist.records.modified.sizeInBytes',
 
-    ON_EVENT_SCRIPT_EXECUTION = 'nango.jobs.onEventScriptExecution',
-    ON_EVENT_SCRIPT_RUNTIME = 'nango.jobs.onEventScriptRuntime',
-    ON_EVENT_SCRIPT_SUCCESS = 'nango.orch.onEventScript.success',
-    ON_EVENT_SCRIPT_FAILURE = 'nango.orch.onEventScript.failure',
-
     POST_CONNECTION_SUCCESS = 'nango.postConnection.success',
     POST_CONNECTION_FAILURE = 'nango.postConnection.failure',
     PRE_CONNECTION_DELETION_SUCCESS = 'nango.preConnectionDeletion.success',
@@ -59,15 +50,8 @@ export enum Types {
     RUNNER_INVALID_SYNCS_RECORDS = 'nango.runner.invalidSyncsRecords',
     RUNNER_MEMORY_USAGE = 'nango.runner.memoryUsage',
 
-    SYNC_EXECUTION = 'nango.jobs.syncExecution',
-    SYNC_TRACK_RUNTIME = 'sync_script_track_runtime',
-    SYNC_SUCCESS = 'nango.orch.sync.success',
-    SYNC_FAILURE = 'nango.orch.sync.failure',
+    FUNCTION_EXECUTIONS = 'nango.jobs.function.executions',
 
-    WEBHOOK_EXECUTION = 'nango.jobs.webhookExecution',
-    WEBHOOK_TRACK_RUNTIME = 'webhook_track_runtime',
-    WEBHOOK_SUCCESS = 'nango.orch.webhook.success',
-    WEBHOOK_FAILURE = 'nango.orch.webhook.failure',
     WEBHOOK_INCOMING_RECEIVED = 'nango.webhook.incoming.received',
     WEBHOOK_INCOMING_FORWARDED_SUCCESS = 'nango.webhook.incoming.forwarded.success',
     WEBHOOK_INCOMING_FORWARDED_FAILED = 'nango.webhook.incoming.forwarded.failed',


### PR DESCRIPTION
replace all functions executions related DD metrics by one metric (with dimensions), pushing it from metering.

Note: I will fix widgets/monitor in DD that depends on previous metrics

<!-- Summary by @propel-code-bot -->

---

**Refactor Function Executions Metrics to Unified Metric with Dimensions**

This pull request refactors how function execution metrics are collected and emitted for Datadog (DD). It consolidates various function execution-related metrics (for `sync`, `action`, `webhook`, and `on-event`) into a single unified metric (`nango.jobs.function.executions`), utilizing dimensions to encapsulate function type, outcome (success/failure), frequency bucket, and account. All metric reporting is now centralized and pushed from the metering logic, removing legacy, event-specific metric calls throughout execution handlers.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed multiple Datadog metric types related to function executions (e.g., `SYNC_EXECUTION`, `ACTION_EXECUTION`, `WEBHOOK_EXECUTION`, etc.) from `metrics.Types` in `packages/utils/lib/telemetry/metrics.ts`.
• Added new metric type `FUNCTION_EXECUTIONS` with support for dimensions (function type, result, frequency bucket, etc.)
• Centralized metrics emission in event processing (`packages/metering/lib/processors/customer-tracking.ts`), now handling all function executions under `usage.function_executions` events and bucketing frequency appropriately.
• Removed all per-function metric increment, duration, and success/failure calls from execution handlers in `sync.ts`, `webhook.ts`, `onEvent.ts`, and `action.ts`, now publishing unified usage events.
• Deprecated code that handled metric duration/increment for each execution event and replaced with logic to push one metric per function execution with relevant metadata.
• Adjusted imports, removed unused `metrics` references, and updated test and activity logging code accordingly in all affected files.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/metering/lib/processors/customer-tracking.ts`
• `packages/jobs/lib/execution/sync.ts`
• `packages/jobs/lib/execution/webhook.ts`
• `packages/jobs/lib/execution/onEvent.ts`
• `packages/jobs/lib/execution/action.ts`
• `packages/shared/lib/clients/orchestrator.ts`
• `packages/utils/lib/telemetry/metrics.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*