### PR TITLE
fix(http): handle empty string in redact

### DIFF
--- a/packages/utils/lib/http.ts
+++ b/packages/utils/lib/http.ts
@@ -75,6 +75,9 @@ export function redactHeaders({
 
     for (const key of Object.keys(safeHeaders)) {
         for (const value of valuesToFilter) {
+            if (value === '') {
+                continue;
+            }
             if (safeHeaders[key]?.includes(value)) {
                 safeHeaders[key] = 'REDACTED';
             }
@@ -85,7 +88,13 @@ export function redactHeaders({
 }
 
 export function redactURL({ url, valuesToFilter }: { url: string; valuesToFilter: string[] }) {
+    if (valuesToFilter.length === 0) {
+        return url;
+    }
     return valuesToFilter.reduce((curr, value) => {
+        if (value === '') {
+            return curr;
+        }
         return curr.replace(value, 'REDACTED');
     }, url);
 }

--- a/packages/utils/lib/http.unit.test.ts
+++ b/packages/utils/lib/http.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { redactHeaders } from './http.js';
+import { redactHeaders, redactURL } from './http.js';
 
 describe('redactHeaders', () => {
     it('should not do anything if empty', () => {
@@ -38,5 +38,30 @@ describe('redactHeaders', () => {
             authorization: 'REDACTED',
             'x-not-filtered': 'hello'
         });
+    });
+
+    it('should not try to redact empty secret', () => {
+        expect(
+            redactHeaders({
+                headers: { test: 'test' },
+                valuesToFilter: ['']
+            })
+        ).toStrictEqual({
+            test: 'test'
+        });
+    });
+});
+
+describe('redactURL', () => {
+    it('should redact the url', () => {
+        expect(redactURL({ url: 'https://example.com/test?apiKey=foobar', valuesToFilter: ['foobar'] })).toBe('https://example.com/test?apiKey=REDACTED');
+    });
+
+    it('should not redact the url if no values to filter', () => {
+        expect(redactURL({ url: 'https://example.com/test', valuesToFilter: [] })).toBe('https://example.com/test');
+    });
+
+    it('should not try to redact empty secret', () => {
+        expect(redactURL({ url: 'https://example.com/test', valuesToFilter: [''] })).toBe('https://example.com/test');
     });
 });


### PR DESCRIPTION
## Changes

Fixes https://linear.app/nango/issue/NAN-2790/headers-redaction-should-ignore-whitespaceinvalid-value

- handle empty string in redact
mostly useful for providers with weird basic auth implem (e.g, empty pwd)

<!-- Summary by @propel-code-bot -->

---

**Handle Empty String Values in Header and URL Redaction**

This pull request updates the redaction logic in `redactHeaders` and `redactURL` to properly ignore empty string values in the `valuesToFilter` parameter. The change prevents unwanted or unnecessary redaction behaviors, particularly for providers that may have empty secrets (such as an empty password in basic authentication). Associated unit tests have been added and extended to verify the new expected behavior.

<details>
<summary><strong>Key Changes</strong></summary>

• Modified `redactHeaders` in `packages/utils/lib/http.ts` to skip empty string values in `valuesToFilter` when redacting headers.
• Modified `redactURL` in `packages/utils/lib/http.ts` to ignore empty string values and return the URL unchanged if `valuesToFilter` is empty.
• Updated and expanded tests in `packages/utils/lib/http.unit.test.ts` to cover cases with empty string redaction values.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/utils/lib/http.ts` (`redactHeaders` and `redactURL` functions)
• `packages/utils/lib/http.unit.test.ts` (unit tests for redaction)

</details>

---
*This summary was automatically generated by @propel-code-bot*