### PR TITLE
docs: Fix link in changelog

### DIFF
--- a/docs-v2/changelog/dev-updates.mdx
+++ b/docs-v2/changelog/dev-updates.mdx
@@ -56,7 +56,7 @@ Currently, if multiple connections share the same `end_user_id`, they also share
   ## Action payload output limit
 
   Nango actions currently have a documented output limit of 10MB. We are further restricting that limit
-  to 2MB. Instead of using an action for large payloads like this, we encourage usage of the Nango [proxy](https://docs.nango.dev/guides/proxy-requests#proxy-requests).
+  to 2MB. Instead of using an action for large payloads like this, we encourage usage of the Nango [proxy](https://docs.nango.dev/implementation-guides/requests-proxy/implement-requests-proxy).
 
   Additionally, we will also soon restrict action inputs so please take note of your inputs.
 


### PR DESCRIPTION
Fix link to proxy in dev changelog
<!-- Summary by @propel-code-bot -->

---

**Fix Broken Proxy Link in Developer Changelog**

This PR updates a broken documentation link in the `docs-v2/changelog/dev-updates.mdx` file, specifically within the section about action payload output limits. The link for 'Nango proxy' now points to the correct documentation page using the updated URL structure.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated the 'proxy' link in the 'Action payload output limit' section of `docs-v2/changelog/dev-updates.mdx` to the current valid URL: https://docs.nango.dev/implementation-guides/requests-proxy/implement-requests-proxy

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs-v2/changelog/dev-updates.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*