### PR TITLE
fix(action-output): throw if > 2MB

### DIFF
--- a/packages/utils/lib/environment/detection.ts
+++ b/packages/utils/lib/environment/detection.ts
@@ -33,3 +33,5 @@ export const flagEnforceCLIVersion = process.env['FLAG_ENFORCE_CLI_VERSION'] ===
 export const flags = {
     hasAdminCapabilities: Boolean(process.env['NANGO_ADMIN_UUID'])
 };
+
+export const actionAllowListCustomers = [0, 662, 1760, 1920, 4530, 5166, 7157, 7359, 7696, 2981, 6254];


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Enforce 2MB Limit on Action Output Payloads; Centralize Allowlist**

This pull request enforces a strict 2MB payload size limit for outputs from action scripts, affecting all non-Enterprise and non-allowlisted cloud customers. The previously hardcoded allowlist of exempt customers is centralized as the `actionAllowListCustomers` export in `packages/utils/lib/environment/detection.ts`, enabling consistent use across the codebase. The size check is now performed directly within the action execution logic in `packages/runner/lib/exec.ts`, ensuring that oversized outputs result in an exception for non-eligible accounts; legacy logging and warnings about large payloads have been cleaned up.

<details>
<summary><strong>Key Changes</strong></summary>

• Added enforced 2MB output size check within `packages/runner/lib/exec.ts` for actions, throwing an error if exceeded and not in the Enterprise tier or allowlist.
• Centralized allowlist by exporting `actionAllowListCustomers` in `packages/utils/lib/environment/detection.ts`.
• Standardized the use of the centralized allowlist in both `exec.ts` and `postTriggerAction.ts`, removing previously scattered hardcoded allowlist references.
• Removed redundant logging and deprecation warnings for oversized payloads in `packages/server/lib/controllers/action/postTriggerAction.ts`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/runner/lib/exec.ts`
• `packages/server/lib/controllers/action/postTriggerAction.ts`
• `packages/utils/lib/environment/detection.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*