### PR TITLE
fix(custom-verification-script): grab the custom message correctly

### DIFF
--- a/packages/server/lib/controllers/auth/postAppStore.ts
+++ b/packages/server/lib/controllers/auth/postAppStore.ts
@@ -199,7 +199,7 @@ export const postPublicAppStoreAuthorization = asyncWrapper<PostPublicAppStoreAu
             }
 
             const payload = customValidationResponse.error?.payload;
-            const message = typeof payload['error'] === 'string' ? payload['error'] : 'Connection failed validation';
+            const message = typeof payload['message'] === 'string' ? payload['message'] : 'Connection failed validation';
 
             res.status(400).send({
                 error: {

--- a/packages/server/lib/controllers/auth/postBasic.ts
+++ b/packages/server/lib/controllers/auth/postBasic.ts
@@ -193,7 +193,7 @@ export const postPublicBasicAuthorization = asyncWrapper<PostPublicBasicAuthoriz
             }
 
             const payload = customValidationResponse.error?.payload;
-            const message = typeof payload['error'] === 'string' ? payload['error'] : 'Connection failed validation';
+            const message = typeof payload['message'] === 'string' ? payload['message'] : 'Connection failed validation';
 
             res.status(400).send({
                 error: {

--- a/packages/server/lib/controllers/auth/postBill.ts
+++ b/packages/server/lib/controllers/auth/postBill.ts
@@ -194,7 +194,7 @@ export const postPublicBillAuthorization = asyncWrapper<PostPublicBillAuthorizat
             }
 
             const payload = customValidationResponse.error?.payload;
-            const message = typeof payload['error'] === 'string' ? payload['error'] : 'Connection failed validation';
+            const message = typeof payload['message'] === 'string' ? payload['message'] : 'Connection failed validation';
 
             res.status(400).send({
                 error: {

--- a/packages/server/lib/controllers/auth/postJwt.ts
+++ b/packages/server/lib/controllers/auth/postJwt.ts
@@ -203,7 +203,7 @@ export const postPublicJwtAuthorization = asyncWrapper<PostPublicJwtAuthorizatio
             }
 
             const payload = customValidationResponse.error?.payload;
-            const message = typeof payload['error'] === 'string' ? payload['error'] : 'Connection failed validation';
+            const message = typeof payload['message'] === 'string' ? payload['message'] : 'Connection failed validation';
 
             res.status(400).send({
                 error: {

--- a/packages/server/lib/controllers/auth/postOauthOutbound.ts
+++ b/packages/server/lib/controllers/auth/postOauthOutbound.ts
@@ -169,7 +169,7 @@ export const postPublicOauthOutboundAuthorization = asyncWrapper<PostPublicOauth
             }
 
             const payload = customValidationResponse.error?.payload;
-            const message = typeof payload['error'] === 'string' ? payload['error'] : 'Connection failed validation';
+            const message = typeof payload['message'] === 'string' ? payload['message'] : 'Connection failed validation';
 
             res.status(400).send({
                 error: {

--- a/packages/server/lib/controllers/auth/postSignature.ts
+++ b/packages/server/lib/controllers/auth/postSignature.ts
@@ -209,7 +209,7 @@ export const postPublicSignatureAuthorization = asyncWrapper<PostPublicSignature
             }
 
             const payload = customValidationResponse.error?.payload;
-            const message = typeof payload['error'] === 'string' ? payload['error'] : 'Connection failed validation';
+            const message = typeof payload['message'] === 'string' ? payload['message'] : 'Connection failed validation';
 
             res.status(400).send({
                 error: {

--- a/packages/server/lib/controllers/auth/postTba.ts
+++ b/packages/server/lib/controllers/auth/postTba.ts
@@ -233,7 +233,7 @@ export const postPublicTbaAuthorization = asyncWrapper<PostPublicTbaAuthorizatio
             }
 
             const payload = customValidationResponse.error?.payload;
-            const message = typeof payload['error'] === 'string' ? payload['error'] : 'Connection failed validation';
+            const message = typeof payload['message'] === 'string' ? payload['message'] : 'Connection failed validation';
 
             res.status(400).send({
                 error: {

--- a/packages/server/lib/controllers/auth/postTwoStep.ts
+++ b/packages/server/lib/controllers/auth/postTwoStep.ts
@@ -202,7 +202,7 @@ export const postPublicTwoStepAuthorization = asyncWrapper<PostPublicTwoStepAuth
             }
 
             const payload = customValidationResponse.error?.payload;
-            const message = typeof payload['error'] === 'string' ? payload['error'] : 'Connection failed validation';
+            const message = typeof payload['message'] === 'string' ? payload['message'] : 'Connection failed validation';
 
             res.status(400).send({
                 error: {

--- a/packages/server/lib/controllers/auth/postUnauthenticated.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.ts
@@ -156,7 +156,7 @@ export const postPublicUnauthenticated = asyncWrapper<PostPublicUnauthenticatedA
             }
 
             const payload = customValidationResponse.error?.payload;
-            const message = typeof payload['error'] === 'string' ? payload['error'] : 'Connection failed validation';
+            const message = typeof payload['message'] === 'string' ? payload['message'] : 'Connection failed validation';
 
             res.status(400).send({
                 error: {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Take a thrown error and display it in the connect ui properly:

<img width="457" height="567" alt="image" src="https://github.com/user-attachments/assets/a79757ab-14b0-4fe3-973e-9eb7817d6e53" />

Stemming from a script
```import type { NangoAction } from '../../models';

export default async function onEvent(nango: NangoAction): Promise<void> {
    await nango.log('foo')
    throw new Error('Hey yo! no such endpoint');
}
```

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Fix Custom Validation Error Message Extraction in Auth Controllers**

This pull request updates the logic in multiple authentication controller files to correctly extract and display custom error messages resulting from validation checks. Previously, the code attempted to display error messages using the `error` property within the payload object, which did not align with how custom scripts or errors populate this object. The change standardizes extraction to use the `message` property if present, falling back to a default message if not. This ensures that when errors are thrown (e.g., from custom verification scripts), the intended error message appears correctly in the Connect UI.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated error message extraction logic from `payload['error']` to `payload['message']` in the following files: `postAppStore.ts`, `postBasic.ts`, `postBill.ts`, `postJwt.ts`, `postOauthOutbound.ts`, `postSignature.ts`, `postTba.ts`, `postTwoStep.ts`, `postUnauthenticated.ts`.
• Ensured fallback to 'Connection failed validation' remains if no suitable message is provided.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Authentication controller files: `postAppStore.ts`, `postBasic.ts`, `postBill.ts`, `postJwt.ts`, `postOauthOutbound.ts`, `postSignature.ts`, `postTba.ts`, `postTwoStep.ts`, `postUnauthenticated.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*