### PR TITLE
fix(billing): aggregate records billing events per account

### DIFF
--- a/packages/billing/lib/grouping.ts
+++ b/packages/billing/lib/grouping.ts
@@ -132,7 +132,6 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
                         timestamp: b.properties.timestamp,
                         idempotencyKey: b.properties.idempotencyKey,
                         accountId: b.properties.accountId,
-                        environmentId: b.properties.environmentId,
                         telemetry: {
                             sizeBytes: _a.properties.telemetry.sizeBytes + b.properties.telemetry.sizeBytes
                         },

--- a/packages/billing/lib/grouping.unit.test.ts
+++ b/packages/billing/lib/grouping.unit.test.ts
@@ -108,7 +108,6 @@ describe('BillingEventGrouping', () => {
                 type: 'records',
                 properties: {
                     accountId: 1,
-                    environmentId: 3,
                     count: 100,
                     timestamp: new Date(),
                     frequencyMs: 60_000,
@@ -143,7 +142,7 @@ describe('BillingEventGrouping', () => {
             'function_executions|accountId:1|connectionId:2|type:action',
             'function_executions|accountId:1|connectionId:2|frequencyMs:100|type:sync',
             'monthly_active_records|accountId:1|connectionId:2|environmentId:3|model:model1|providerConfigKey:providerConfigKey2|syncId:sync1',
-            'records|accountId:1|environmentId:3',
+            'records|accountId:1',
             'billable_connections_v2|accountId:1',
             'billable_connections|accountId:1'
         ]);
@@ -415,7 +414,6 @@ describe('BillingEventGrouping', () => {
                 type: 'records',
                 properties: {
                     accountId: 1,
-                    environmentId: 3,
                     count: 6,
                     timestamp: new Date('2024-01-01T00:00:00Z'),
                     frequencyMs: 60_000,
@@ -428,7 +426,6 @@ describe('BillingEventGrouping', () => {
                 type: 'records',
                 properties: {
                     accountId: 1,
-                    environmentId: 3,
                     count: 30,
                     timestamp: new Date('2024-01-02T00:00:00Z'),
                     frequencyMs: 60_000,
@@ -442,7 +439,6 @@ describe('BillingEventGrouping', () => {
                 type: 'records',
                 properties: {
                     accountId: 1,
-                    environmentId: 3,
                     count: 36,
                     timestamp: new Date('2024-01-02T00:00:00Z'),
                     frequencyMs: 60_000,

--- a/packages/metering/lib/crons/usage.ts
+++ b/packages/metering/lib/crons/usage.ts
@@ -103,7 +103,6 @@ const observability = {
                 // records metrics are per environment, we need to get the account ids
                 const envIds = res.value.map((r) => r.environmentId);
                 const envs = await environmentService.getEnvironmentsByIds(envIds);
-
                 const metricsWithAccount = res.value.flatMap(({ environmentId, count, sizeBytes }) => {
                     const env = envs.find((e) => e.id === environmentId);
                     if (!env) {
@@ -112,32 +111,36 @@ const observability = {
                     return [{ environmentId, accountId: env.account_id, count, sizeBytes }];
                 });
 
-                // Send billing events
-                const frequencyMs = cronMinutes * 60 * 1000;
-                const billingEvents = metricsWithAccount.map(({ accountId, environmentId, count, sizeBytes }) => {
-                    return {
-                        type: 'records' as const,
-                        properties: { count, accountId, environmentId, timestamp: new Date(), frequencyMs, telemetry: { sizeBytes } }
-                    };
-                });
-                const sendBilling = usageBilling.add(billingEvents);
-                if (sendBilling.isErr()) {
-                    throw sendBilling.error;
-                }
-
-                // Group by account and send to datadog
+                // Group by account
                 const metricsByAccount = new Map<number, { count: number; sizeBytes: number }>();
-                for (const metrics of metricsWithAccount) {
-                    const existing = metricsByAccount.get(metrics.accountId);
+                for (const metric of metricsWithAccount) {
+                    const existing = metricsByAccount.get(metric.accountId);
                     if (existing) {
-                        existing.count += metrics.count;
-                        existing.sizeBytes += metrics.sizeBytes;
+                        existing.count += metric.count;
+                        existing.sizeBytes += metric.sizeBytes;
                     } else {
-                        metricsByAccount.set(metrics.accountId, { count: metrics.count, sizeBytes: metrics.sizeBytes });
+                        metricsByAccount.set(metric.accountId, { count: metric.count, sizeBytes: metric.sizeBytes });
                     }
                 }
 
                 for (const [accountId, { count, sizeBytes }] of metricsByAccount.entries()) {
+                    // to orb
+                    const toOrb = usageBilling.add([
+                        {
+                            type: 'records' as const,
+                            properties: {
+                                count,
+                                accountId,
+                                timestamp: new Date(),
+                                frequencyMs: cronMinutes * 60 * 1000,
+                                telemetry: { sizeBytes }
+                            }
+                        }
+                    ]);
+                    if (toOrb.isErr()) {
+                        logger.error(`Failed to ingest records metric for account ${accountId}: ${toOrb.error}`);
+                    }
+                    // to datadog
                     metrics.gauge(metrics.Types.RECORDS_TOTAL_COUNT, count, { accountId });
                     metrics.gauge(metrics.Types.RECORDS_TOTAL_SIZE_IN_BYTES, sizeBytes, { accountId });
                 }

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -74,7 +74,6 @@ export type MarBillingEvent = BillingEventBase<
 export type RecordsBillingEvent = BillingEventBase<
     'records',
     {
-        environmentId: number;
         frequencyMs: number;
         telemetry: {
             sizeBytes: number;


### PR DESCRIPTION
Records events must be aggregated by account for the average calculation to work in orb.
Also it helps ingesting less events 

<!-- Summary by @propel-code-bot -->

---

**Aggregate Records Billing Events Per Account**

This pull request updates the aggregation logic for `records` billing events, switching from grouping by `environmentId` to grouping by `accountId`. This change adjusts both the event creation in the billing metering cron and the event shape to ensure averages calculated in the Orb billing system work as intended, and to reduce the volume of ingested events. Corresponding TypeScript types, grouping logic, and unit tests have been updated to support the new event structure.

<details>
<summary><strong>Key Changes</strong></summary>

• Modified aggregation in `packages/metering/lib/crons/usage.ts` to group records metrics by `accountId` instead of `environmentId`.
• Changed the `RecordsBillingEvent` type in `packages/types/lib/billing/types.ts` to remove the `environmentId` property.
• Updated `aggregate` logic for `records` events in `packages/billing/lib/grouping.ts` to match the new event shape.
• Refactored tests in `packages/billing/lib/grouping.unit.test.ts` to align with the new event properties and grouping key.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/metering/lib/crons/usage.ts`
• `packages/types/lib/billing/types.ts`
• `packages/billing/lib/grouping.ts`
• `packages/billing/lib/grouping.unit.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*