### PR TITLE
fix(ci): do not push image and publish package from merge queue

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -36,7 +36,7 @@ jobs:
         needs: changes
         runs-on: ubuntu-latest
         env:
-            CAN_PUSH: "${{ secrets.DOCKER_PASSWORD != '' && secrets.DOCKER_USERNAME != '' }}"
+            CAN_PUSH: "${{ secrets.DOCKER_PASSWORD != '' && secrets.DOCKER_USERNAME != '' && github.event_name != 'merge_group' }}"
             SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
         steps:
@@ -75,6 +75,6 @@ jobs:
                   docker push nangohq/nango:${{ env.SHA }}
 
             - name: (self-hosted) Build and push
-              if: needs.changes.outputs.should_skip != 'true'
+              if: needs.changes.outputs.should_skip != 'true' && env.CAN_PUSH == 'true'
               run: |
                   ./scripts/build_docker_self_hosted.sh ${{ env.SHA }} ${{ env.CAN_PUSH }}

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -89,7 +89,7 @@ jobs:
                   npx zx ./scripts/publish.mjs --version=0.0.1-$GIT_HASH --skip-cli
 
             - name: Publish the cli privately under the correct scope
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.changes.outputs.docs_only != 'true' && github.event_name != 'merge_group'
               working-directory: packages/cli
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -111,14 +111,14 @@ jobs:
             packages: write
         steps:
             - uses: actions/setup-node@v4
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.changes.outputs.docs_only != 'true' && github.event_name != 'merge_group'
               with:
                   node-version: '20.18.1'
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@nangohq'
                   always-auth: true
             - name: Install the cli from the github package registry
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.changes.outputs.docs_only != 'true' && github.event_name != 'merge_group'
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |


### PR DESCRIPTION
We use the commit hash for package version and image tag. Since merging queue actually runs on the same commit that is then added to master the package publish and image push fail after the merge to master, trying to push/publish the same existing version. This commit modify the gh workflow so publishing the package and pushing the image doesn't happen on merge queue

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Prevent Package Publish and Image Push from Merge Queue CI Runs**

This pull request updates the GitHub Actions workflows to prevent publishing npm packages and pushing Docker images when the workflow is triggered from the merge queue (`merge_group` event). The intent is to avoid failures caused by version and tag collisions, since the same commit hash is used for both the pre-merge and post-merge runs, resulting in attempts to publish or push an already existing artifact after merging to `master`.

<details>
<summary><strong>Key Changes</strong></summary>

• Added additional condition (`github.event_name != 'merge_group'`) to the `CAN_PUSH` environment variable in `.github/workflows/build-image.yaml`.
• Modified step conditions in `.github/workflows/cli-verification.yaml` to prevent publish and install steps from running if `github.event_name == 'merge_group'`.
• Updated build-image and related steps to only run Docker image publish/push if not in a merge queue context.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• .github/workflows/build-image.yaml
• .github/workflows/cli-verification.yaml

</details>

---
*This summary was automatically generated by @propel-code-bot*