### PR TITLE
fix: connectUI origin check to use baseURL.origin

### DIFF
--- a/packages/frontend/lib/connectUI.ts
+++ b/packages/frontend/lib/connectUI.ts
@@ -118,7 +118,7 @@ export class ConnectUI {
 
     private setupEventListeners() {
         this.listener = (event) => {
-            if (event.origin !== this.baseURL) {
+            if (event.origin !== baseURL.origin) {
                 return;
             }
 

--- a/packages/frontend/lib/connectUI.ts
+++ b/packages/frontend/lib/connectUI.ts
@@ -118,7 +118,7 @@ export class ConnectUI {
 
     private setupEventListeners() {
         this.listener = (event) => {
-            if (event.origin !== baseURL.origin) {
+            if (event.origin !== new URL(this.baseURL).origin) {
                 return;
             }
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
When self-hosting behind a reverse proxy under a subpath (e.g., https://test.com/nangoconnectui), the iframe’s postMessage origin is https://test.com. The previous check compared against the full baseURL (including the path), so the origin never matched and messages were dropped. By comparing only the origin (event.origin !== baseURL.origin), we accept messages from the same scheme/host/port regardless of path. This lets self-hosted deployments mount Connect UI at a subpath without needing a separate port or a root-level URL.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Fix ConnectUI Origin Check to Use `baseURL.origin`**

This pull request updates the origin-checking logic in the `setupEventListeners` method of the `ConnectUI` class within `packages/frontend/lib/connectUI.ts`. Previously, the origin from incoming postMessage events was compared to the full `baseURL`, which included any subpaths, breaking self-hosted scenarios mounted behind a reverse proxy or subpath. The updated implementation compares `event.origin` to the `origin` component (scheme, host, port) of `baseURL`, resolving issues when Connect UI is hosted beneath a subpath.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced origin equality check in `ConnectUI.setupEventListeners()` from `event.origin !== this.baseURL` to `event.origin !== new URL(this.baseURL).origin`
• Ensures iframe postMessage origin validation only considers scheme, host, and port, not subpath

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/frontend/lib/connectUI.ts`
• `ConnectUI.setupEventListeners` method

</details>

---
*This summary was automatically generated by @propel-code-bot*