### PR TITLE
feat(api-status): add more status widgets

### DIFF
--- a/docs-v2/integrations/all/bamboohr-basic.mdx
+++ b/docs-v2/integrations/all/bamboohr-basic.mdx
@@ -4,6 +4,10 @@ sidebarTitle: 'BambooHR (Basic Auth)'
 description: 'Access the BambooHR API in 2 minutes 💨'
 ---
 
+import { StatusWidget } from "/snippets/api-down-watch/status-widget.jsx"
+
+<StatusWidget service="bamboohr" />
+
 <Tabs>
   <Tab title="🚀 Quickstart">
     <Steps>
@@ -86,8 +90,8 @@ description: 'Access the BambooHR API in 2 minutes 💨'
     </Tip>
   </Tab>
   <Tab title="🔗 Useful links">
-    | Topic | Links | 
-    | - | - | 
+    | Topic | Links |
+    | - | - |
     | Authorization | [Guide to connect to BambooHR (Basic Auth) using Connect UI](/integrations/all/bamboohr-basic/connect) |
     | General | [BambooHR Website](https://www.bamboohr.com/) |
     | | [BambooHR Dashboard](https://app.bamboohr.com/login/) |

--- a/docs-v2/integrations/all/bamboohr.mdx
+++ b/docs-v2/integrations/all/bamboohr.mdx
@@ -7,6 +7,10 @@ import Overview from "/snippets/overview.mdx"
 import PreBuiltTooling from "/snippets/generated/bamboohr/PreBuiltTooling.mdx"
 import PreBuiltUseCases from "/snippets/generated/bamboohr/PreBuiltUseCases.mdx"
 
+import { StatusWidget } from "/snippets/api-down-watch/status-widget.jsx"
+
+<StatusWidget service="bamboohr" />
+
 <Overview />
 <PreBuiltTooling />
 <PreBuiltUseCases />

--- a/docs-v2/integrations/all/box.mdx
+++ b/docs-v2/integrations/all/box.mdx
@@ -4,6 +4,10 @@ sidebarTitle: 'Box'
 description: 'Access the Box API in 2 minutes 💨'
 ---
 
+import { StatusWidget } from "/snippets/api-down-watch/status-widget.jsx"
+
+<StatusWidget service="box" />
+
 <Tabs>
   <Tab title="🚀 Quickstart">
     <Steps>
@@ -68,20 +72,20 @@ description: 'Access the Box API in 2 minutes 💨'
     </Step>
 
     <Step title="Create a new application">
-        1. Go to the [Box Developer Console](https://app.box.com/developers/console).  
-        2. Click **Create Platform App**.  
-        3. Select **Custom App** as your **Platform App** from the list of application types.  
-        4. Enter the basic application details and choose **User Authentication (OAuth 2.0)** as your app's **Authentication Method**.  
+        1. Go to the [Box Developer Console](https://app.box.com/developers/console).
+        2. Click **Create Platform App**.
+        3. Select **Custom App** as your **Platform App** from the list of application types.
+        4. Enter the basic application details and choose **User Authentication (OAuth 2.0)** as your app's **Authentication Method**.
         5. In your app's **Configuration** tab, add `https://api.nango.dev/oauth/callback` as your **Redirect URI**, then click **Save Changes**.
         6. Scroll down to the **Application Scopes** section and select the scopes you need.
     </Step>
 
     <Step title="Obtain OAuth credentials">
-        1. In the same **Configuration** tab, under the **OAuth 2.0 Credentials** section, copy your **Client ID** and **Client Secret**, you’ll need these when configuring your integration in Nango.  
+        1. In the same **Configuration** tab, under the **OAuth 2.0 Credentials** section, copy your **Client ID** and **Client Secret**, you’ll need these when configuring your integration in Nango.
     </Step>
 
     <Step title="Start building your integration">
-        Follow the [Quickstart](/getting-started/quickstart) guide to build your integration.  
+        Follow the [Quickstart](/getting-started/quickstart) guide to build your integration.
     </Step>
     </Steps>
 

--- a/docs-v2/integrations/all/greenhouse-basic.mdx
+++ b/docs-v2/integrations/all/greenhouse-basic.mdx
@@ -4,6 +4,10 @@ sidebarTitle: 'Greenhouse (Basic Auth)'
 description: 'Access the Greenhouse API with Basic Authentication in 2 minutes 💨'
 ---
 
+import { StatusWidget } from "/snippets/api-down-watch/status-widget.jsx"
+
+<StatusWidget service="greenhouse" />
+
 <Tabs>
   <Tab title="🚀 Quickstart">
     <Steps>
@@ -62,13 +66,13 @@ description: 'Access the Greenhouse API with Basic Authentication in 2 minutes �
     </Tip>
   </Tab>
   <Tab title="🔗 Useful links">
-    | Topic | Links | 
-    | - | - | 
+    | Topic | Links |
+    | - | - |
     | Authorization | [Guide to connect to Greenhouse (Basic Auth) using Connect UI](/integrations/all/greenhouse-basic/connect) |
     | General | [Greenhouse Website](https://www.greenhouse.io/) |
     | | [Greenhouse Dashboard](https://app.greenhouse.io/) |
     | Developer| [Greenhouse API docs](https://developers.greenhouse.io) |
-  
+
     <Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs-v2/integrations/all/greenhouse-basic.mdx)</Note>
   </Tab>
   <Tab title="🚨 API gotchas">

--- a/docs-v2/integrations/all/greenhouse.mdx
+++ b/docs-v2/integrations/all/greenhouse.mdx
@@ -4,6 +4,10 @@ sidebarTitle: 'Greenhouse (OAuth)'
 description: 'Access the Greenhouse API with OAuth Authentication in 2 minutes ðŸ’¨'
 ---
 
+import { StatusWidget } from "/snippets/api-down-watch/status-widget.jsx"
+
+<StatusWidget service="greenhouse" />
+
 <Tabs>
   <Tab title="ðŸš€ Quickstart">
     <Steps>
@@ -71,7 +75,7 @@ description: 'Access the Greenhouse API with OAuth Authentication in 2 minutes ð
         After submitting your application information, Greenhouse will provide:
         - **Consumer Key**: Uniquely identifies your application.
         - **Consumer Secret**: Acts as proof of your application's identity (will be encrypted when emailed).
-        
+
         <Note>The consumer secret is confidential and will be encrypted by Greenhouse for security. They'll provide decryption instructions.</Note>
         After decrypting the consumer secret, copy both the **Consumer Key** (which serves as the Client ID) and **Consumer Secret** (which serves as the Client Secret) as you'll need them when configuring your integration in Nango.
       </Step>
@@ -90,8 +94,8 @@ description: 'Access the Greenhouse API with OAuth Authentication in 2 minutes ð
 
   </Tab>
   <Tab title="ðŸ”— Useful links">
-    | Topic | Links | 
-    | - | - | 
+    | Topic | Links |
+    | - | - |
     | Authorization | [Guide to connect to Greenhouse (OAuth) using Connect UI](/integrations/all/greenhouse/connect) |
     | General | [Greenhouse Website](https://www.greenhouse.io/) |
     | | [Greenhouse Dashboard](https://app.greenhouse.io/) |


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add API Status Widgets to Multiple Integration Docs**

This pull request introduces the `StatusWidget` component-imported from `/snippets/api-down-watch/status-widget.jsx`-into several integration documentation files in `docs-v2/integrations/all`. The widget is rendered near the top of each integration doc to display the real-time status of the relevant third-party API (e.g., `bamboohr`, `box`, `greenhouse`). In addition to these insertions, some markdown tables in the 'Useful links' sections had their header lines corrected, and minor whitespace consistency fixes were applied. No functional or backend code changes were made; all changes are limited to documentation (`.mdx` files).

<details>
<summary><strong>Key Changes</strong></summary>

• Imported `StatusWidget` component into `bamboohr.mdx`, `bamboohr-basic.mdx`, `box.mdx`, `greenhouse-basic.mdx`, and `greenhouse.mdx`.
• Inserted `<StatusWidget service="PROVIDER" />` at the top of each relevant doc (where `PROVIDER` matches the integration).
• Fixed table headers in various 'Useful links' sections for markdown correctness.
• Minor whitespace and formatting adjustments in a few files.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs-v2/integrations/all/bamboohr.mdx`
• `docs-v2/integrations/all/bamboohr-basic.mdx`
• `docs-v2/integrations/all/box.mdx`
• `docs-v2/integrations/all/greenhouse-basic.mdx`
• `docs-v2/integrations/all/greenhouse.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*