### PR TITLE
chore: skip github workflows on master (if not direct push) 

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -9,7 +9,7 @@ on:
     merge_group:
 
 jobs:
-    changes:
+    should-run:
         runs-on: ubuntu-latest
         outputs:
             should_skip: ${{ steps.check.outputs.should_skip }}
@@ -24,16 +24,26 @@ jobs:
             - name: Determine if should skip
               id: check
               run: |
-                  # Skip if:
-                  # - only docs were changed
-                  # - not on master branch (always building image on master so we can deploy any commit)
-                  if [[ "${{ steps.filter.outputs.docs_only }}" == "true" && "${{ github.ref }}" != "refs/heads/master" ]]; then
-                      echo "should_skip=true" >> $GITHUB_OUTPUT
-                  else
-                      echo "should_skip=false" >> $GITHUB_OUTPUT
+                  # Run on PRs only if not docs only
+                  # Always run on merge queue
+                  # Always run on direct pushes to master (not merge queue bot)
+                  IS_PR="${{ github.event_name == 'pull_request' }}"
+                  IS_MERGE_QUEUE="${{ github.event_name == 'merge_group' }}"
+                  IS_DIRECT_PUSH_TO_MASTER="${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.actor != 'github-merge-queue[bot]' }}"
+                  IS_DOCS_ONLY="${{ steps.filter.outputs.docs_only }}"
+
+                  SHOULD_SKIP="true"
+                  # Always run on merge queue and direct push to master
+                  if [[ "$IS_MERGE_QUEUE" == "true" || "$IS_DIRECT_PUSH_TO_MASTER" == "true" ]]; then
+                      SHOULD_SKIP="false"
+                  # Run on PR only if not docs only
+                  elif [[ "$IS_PR" == "true" && "$IS_DOCS_ONLY" != "true" ]]; then
+                      SHOULD_SKIP="false"
                   fi
+
+                  echo "should_skip=$SHOULD_SKIP" >> $GITHUB_OUTPUT
     build-image:
-        needs: changes
+        needs: should-run
         runs-on: ubuntu-latest
         env:
             CAN_PUSH: "${{ secrets.DOCKER_PASSWORD != '' && secrets.DOCKER_USERNAME != '' && github.event_name != 'merge_group' }}"
@@ -41,40 +51,40 @@ jobs:
 
         steps:
             - name: Check out
-              if: needs.changes.outputs.should_skip != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               uses: actions/checkout@v4
 
             - name: Set up QEMU
-              if: needs.changes.outputs.should_skip != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               uses: docker/setup-qemu-action@v3
 
             - name: Set up Docker Buildx
-              if: needs.changes.outputs.should_skip != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               uses: docker/setup-buildx-action@v3
 
             - name: Log in to Docker Hub
               uses: docker/login-action@v3
-              if: needs.changes.outputs.should_skip != 'true' && env.CAN_PUSH == 'true'
+              if: needs.should-run.outputs.should_skip != 'true' && env.CAN_PUSH == 'true'
               with:
                   username: '${{ secrets.DOCKER_USERNAME }}'
                   password: '${{ secrets.DOCKER_PASSWORD }}'
 
             # Needed for buildx gha cache to work
             - name: Expose GitHub Runtime
-              if: needs.changes.outputs.should_skip != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               uses: crazy-max/ghaction-github-runtime@v2
 
             - name: Build image
-              if: needs.changes.outputs.should_skip != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               run: |
                   ./scripts/build_docker.sh build ${{ env.SHA }}
 
             - name: Push image
-              if: needs.changes.outputs.should_skip != 'true' && env.CAN_PUSH == 'true'
+              if: needs.should-run.outputs.should_skip != 'true' && env.CAN_PUSH == 'true'
               run: |
                   docker push nangohq/nango:${{ env.SHA }}
 
             - name: (self-hosted) Build and push
-              if: needs.changes.outputs.should_skip != 'true' && env.CAN_PUSH == 'true'
+              if: needs.should-run.outputs.should_skip != 'true' && env.CAN_PUSH == 'true'
               run: |
                   ./scripts/build_docker_self_hosted.sh ${{ env.SHA }} ${{ env.CAN_PUSH }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -46,7 +46,7 @@ jobs:
         needs: should-run
         runs-on: ubuntu-latest
         env:
-            CAN_PUSH: "${{ secrets.DOCKER_PASSWORD != '' && secrets.DOCKER_USERNAME != '' && github.event_name != 'merge_group' }}"
+            CAN_PUSH: "${{ secrets.DOCKER_PASSWORD != '' && secrets.DOCKER_USERNAME != '' }}"
             SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
         steps:
@@ -85,6 +85,6 @@ jobs:
                   docker push nangohq/nango:${{ env.SHA }}
 
             - name: (self-hosted) Build and push
-              if: needs.should-run.outputs.should_skip != 'true' && env.CAN_PUSH == 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               run: |
                   ./scripts/build_docker_self_hosted.sh ${{ env.SHA }} ${{ env.CAN_PUSH }}

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -110,7 +110,7 @@ jobs:
                   npx zx ./scripts/publish.mjs --version=0.0.1-$GIT_HASH --skip-cli
 
             - name: Publish the cli privately under the correct scope
-              if: needs.should-run.outputs.should_skip != 'true' && github.event_name != 'merge_group'
+              if: needs.should-run.outputs.should_skip != 'true'
               working-directory: packages/cli
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -132,14 +132,14 @@ jobs:
             packages: write
         steps:
             - uses: actions/setup-node@v4
-              if: needs.should-run.outputs.should_skip != 'true' && github.event_name != 'merge_group'
+              if: needs.should-run.outputs.should_skip != 'true'
               with:
                   node-version: '20.18.1'
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@nangohq'
                   always-auth: true
             - name: Install the cli from the github package registry
-              if: needs.should-run.outputs.should_skip != 'true' && github.event_name != 'merge_group'
+              if: needs.should-run.outputs.should_skip != 'true'
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -13,10 +13,10 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    changes:
+    should-run:
         runs-on: ubuntu-latest
         outputs:
-            docs_only: ${{ steps.filter.outputs.docs_only }}
+            should_skip: ${{ steps.check.outputs.should_skip }}
         steps:
             - uses: actions/checkout@v4
             - uses: dorny/paths-filter@v3
@@ -25,8 +25,29 @@ jobs:
                   filters: |
                       docs_only:
                           - 'docs-v2/**'
+            - name: Determine if should skip
+              id: check
+              run: |
+                  # Run on PRs only if not docs only
+                  # Always run on merge queue
+                  # Always run on direct pushes to master (not merge queue bot)
+                  IS_PR="${{ github.event_name == 'pull_request' }}"
+                  IS_MERGE_QUEUE="${{ github.event_name == 'merge_group' }}"
+                  IS_DIRECT_PUSH_TO_MASTER="${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.actor != 'github-merge-queue[bot]' }}"
+                  IS_DOCS_ONLY="${{ steps.filter.outputs.docs_only }}"
+
+                  SHOULD_SKIP="true"
+                  # Always run on merge queue and direct push to master
+                  if [[ "$IS_MERGE_QUEUE" == "true" || "$IS_DIRECT_PUSH_TO_MASTER" == "true" ]]; then
+                      SHOULD_SKIP="false"
+                  # Run on PR only if not docs only
+                  elif [[ "$IS_PR" == "true" && "$IS_DOCS_ONLY" != "true" ]]; then
+                      SHOULD_SKIP="false"
+                  fi
+
+                  echo "should_skip=$SHOULD_SKIP" >> $GITHUB_OUTPUT
     publish:
-        needs: changes
+        needs: should-run
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -35,10 +56,10 @@ jobs:
             GIT_HASH: ${{ steps.publish_step.outputs.hash }}
         steps:
             - uses: actions/checkout@v4
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
 
             - uses: actions/setup-node@v4
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               with:
                   node-version-file: '.nvmrc'
                   registry-url: 'https://npm.pkg.github.com'
@@ -46,13 +67,13 @@ jobs:
                   always-auth: true
 
             - name: Build
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               run: |
                   npm ci
                   npm run ts-build
 
             - name: Publish packages to github registry so they can be bumped
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
@@ -79,7 +100,7 @@ jobs:
 
             - id: publish_step
               name: Publish npm packages to the github registry
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               shell: bash
@@ -89,7 +110,7 @@ jobs:
                   npx zx ./scripts/publish.mjs --version=0.0.1-$GIT_HASH --skip-cli
 
             - name: Publish the cli privately under the correct scope
-              if: needs.changes.outputs.docs_only != 'true' && github.event_name != 'merge_group'
+              if: needs.should-run.outputs.should_skip != 'true' && github.event_name != 'merge_group'
               working-directory: packages/cli
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -101,7 +122,7 @@ jobs:
     verify:
         runs-on: ubuntu-latest
         needs:
-            - changes
+            - should-run
             - publish
         env:
             NANGO_CLI_UPGRADE_MODE: ignore
@@ -111,14 +132,14 @@ jobs:
             packages: write
         steps:
             - uses: actions/setup-node@v4
-              if: needs.changes.outputs.docs_only != 'true' && github.event_name != 'merge_group'
+              if: needs.should-run.outputs.should_skip != 'true' && github.event_name != 'merge_group'
               with:
                   node-version: '20.18.1'
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@nangohq'
                   always-auth: true
             - name: Install the cli from the github package registry
-              if: needs.changes.outputs.docs_only != 'true' && github.event_name != 'merge_group'
+              if: needs.should-run.outputs.should_skip != 'true' && github.event_name != 'merge_group'
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -47,25 +47,25 @@ jobs:
 
                   echo "should_skip=$SHOULD_SKIP" >> $GITHUB_OUTPUT
     docker_check_job:
-        needs: shoud-run
+        needs: should-run
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              if: needs.shoud-run.outputs.should_skip != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               uses: actions/checkout@v4
 
             - name: Build the docker-compose stack
-              if: needs.shoud-run.outputs.should_skip != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               run: docker compose up -d
 
             - name: Sleep
-              if: needs.shoud-run.outputs.should_skip != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               uses: jakejarvis/wait-action@master
               with:
                   time: '30s'
 
             - name: Verify containers
-              if: needs.shoud-run.outputs.should_skip != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               run: |
                   CONTAINER_NAME=nango-server
                   SERVER=$(docker ps -q -f status=running -f name=^/${CONTAINER_NAME}$)

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,10 +13,10 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    changes:
+    should-run:
         runs-on: ubuntu-latest
         outputs:
-            docs_only: ${{ steps.filter.outputs.docs_only }}
+            should_skip: ${{ steps.check.outputs.should_skip }}
         steps:
             - uses: actions/checkout@v4
             - uses: dorny/paths-filter@v3
@@ -25,26 +25,47 @@ jobs:
                   filters: |
                       docs_only:
                           - 'docs-v2/**'
+            - name: Determine if should skip
+              id: check
+              run: |
+                  # Run on PRs only if not docs only
+                  # Always run on merge queue
+                  # Always run on direct pushes to master (not merge queue bot)
+                  IS_PR="${{ github.event_name == 'pull_request' }}"
+                  IS_MERGE_QUEUE="${{ github.event_name == 'merge_group' }}"
+                  IS_DIRECT_PUSH_TO_MASTER="${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.actor != 'github-merge-queue[bot]' }}"
+                  IS_DOCS_ONLY="${{ steps.filter.outputs.docs_only }}"
+
+                  SHOULD_SKIP="true"
+                  # Always run on merge queue and direct push to master
+                  if [[ "$IS_MERGE_QUEUE" == "true" || "$IS_DIRECT_PUSH_TO_MASTER" == "true" ]]; then
+                      SHOULD_SKIP="false"
+                  # Run on PR only if not docs only
+                  elif [[ "$IS_PR" == "true" && "$IS_DOCS_ONLY" != "true" ]]; then
+                      SHOULD_SKIP="false"
+                  fi
+
+                  echo "should_skip=$SHOULD_SKIP" >> $GITHUB_OUTPUT
     docker_check_job:
-        needs: changes
+        needs: shoud-run
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.shoud-run.outputs.should_skip != 'true'
               uses: actions/checkout@v4
 
             - name: Build the docker-compose stack
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.shoud-run.outputs.should_skip != 'true'
               run: docker compose up -d
 
             - name: Sleep
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.shoud-run.outputs.should_skip != 'true'
               uses: jakejarvis/wait-action@master
               with:
                   time: '30s'
 
             - name: Verify containers
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.shoud-run.outputs.should_skip != 'true'
               run: |
                   CONTAINER_NAME=nango-server
                   SERVER=$(docker ps -q -f status=running -f name=^/${CONTAINER_NAME}$)

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,10 +9,10 @@ on:
     merge_group:
 
 jobs:
-    changes:
+    should-run:
         runs-on: ubuntu-latest
         outputs:
-            docs_only: ${{ steps.filter.outputs.docs_only }}
+            should_skip: ${{ steps.check.outputs.should_skip }}
         steps:
             - uses: actions/checkout@v4
             - uses: dorny/paths-filter@v3
@@ -21,29 +21,50 @@ jobs:
                   filters: |
                       docs_only:
                           - 'docs-v2/**'
+            - name: Determine if should skip
+              id: check
+              run: |
+                  # Run on PRs only if not docs only
+                  # Always run on merge queue
+                  # Always run on direct pushes to master (not merge queue bot)
+                  IS_PR="${{ github.event_name == 'pull_request' }}"
+                  IS_MERGE_QUEUE="${{ github.event_name == 'merge_group' }}"
+                  IS_DIRECT_PUSH_TO_MASTER="${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.actor != 'github-merge-queue[bot]' }}"
+                  IS_DOCS_ONLY="${{ steps.filter.outputs.docs_only }}"
+
+                  SHOULD_SKIP="true"
+                  # Always run on merge queue and direct push to master
+                  if [[ "$IS_MERGE_QUEUE" == "true" || "$IS_DIRECT_PUSH_TO_MASTER" == "true" ]]; then
+                      SHOULD_SKIP="false"
+                  # Run on PR only if not docs only
+                  elif [[ "$IS_PR" == "true" && "$IS_DOCS_ONLY" != "true" ]]; then
+                      SHOULD_SKIP="false"
+                  fi
+
+                  echo "should_skip=$SHOULD_SKIP" >> $GITHUB_OUTPUT
     lint-code:
-        needs: changes
+        needs: should-run
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               with:
                   fetch-depth: '0'
 
             - uses: actions/setup-node@v4
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               with:
                   cache: 'npm'
                   node-version-file: '.nvmrc'
 
             - name: Install dependencies
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               run: npm ci
 
             - name: Build
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               run: npm run ts-build
 
             - name: Lint
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               run: npm run lint -- --quiet

--- a/.github/workflows/tests-clients.yaml
+++ b/.github/workflows/tests-clients.yaml
@@ -9,10 +9,10 @@ on:
     merge_group:
 
 jobs:
-    changes:
+    should-run:
         runs-on: ubuntu-latest
         outputs:
-            docs_only: ${{ steps.filter.outputs.docs_only }}
+            should_skip: ${{ steps.check.outputs.should_skip }}
         steps:
             - uses: actions/checkout@v4
             - uses: dorny/paths-filter@v3
@@ -21,6 +21,27 @@ jobs:
                   filters: |
                       docs_only:
                           - 'docs-v2/**'
+            - name: Determine if should skip
+              id: check
+              run: |
+                  # Run on PRs only if not docs only
+                  # Always run on merge queue
+                  # Always run on direct pushes to master (not merge queue bot)
+                  IS_PR="${{ github.event_name == 'pull_request' }}"
+                  IS_MERGE_QUEUE="${{ github.event_name == 'merge_group' }}"
+                  IS_DIRECT_PUSH_TO_MASTER="${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.actor != 'github-merge-queue[bot]' }}"
+                  IS_DOCS_ONLY="${{ steps.filter.outputs.docs_only }}"
+
+                  SHOULD_SKIP="true"
+                  # Always run on merge queue and direct push to master
+                  if [[ "$IS_MERGE_QUEUE" == "true" || "$IS_DIRECT_PUSH_TO_MASTER" == "true" ]]; then
+                      SHOULD_SKIP="false"
+                  # Run on PR only if not docs only
+                  elif [[ "$IS_PR" == "true" && "$IS_DOCS_ONLY" != "true" ]]; then
+                      SHOULD_SKIP="false"
+                  fi
+
+                  echo "should_skip=$SHOULD_SKIP" >> $GITHUB_OUTPUT
     compute-matrix:
         runs-on: ubuntu-latest
         outputs:
@@ -36,7 +57,7 @@ jobs:
                   fi
     tests:
         needs:
-            - changes
+            - should-run
             - compute-matrix
         strategy:
             fail-fast: false
@@ -48,12 +69,12 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               with:
                   fetch-depth: '0'
 
             - name: Use Node.js ${{ matrix.node-version }}
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               uses: actions/setup-node@v4
               with:
                   cache: 'npm'
@@ -61,25 +82,25 @@ jobs:
                   cache-dependency-path: 'package-lock.json'
 
             - run: npm ci
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
 
             - name: Build Typescript
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               run: npm run ts-build
 
             - run: npm run test:cli
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
 
             - run: npm run test:unit -- packages/cli
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
 
             - name: Build Node Client
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               run: |
                   npm run -w @nangohq/node build
 
             - name: Test Node CJS
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               shell: bash
               run: |
                   RES=$(node packages/node-client/tests/built.cjs)
@@ -87,7 +108,7 @@ jobs:
                   [ "$RES" != *"Done"* ] || { exit 1; }
 
             - name: Test Node ESM
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               shell: bash
               run: |
                   RES=$(node packages/node-client/tests/built.js)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,10 +13,10 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    changes:
+    should-run:
         runs-on: ubuntu-latest
         outputs:
-            docs_only: ${{ steps.filter.outputs.docs_only }}
+            should_skip: ${{ steps.check.outputs.should_skip }}
         steps:
             - uses: actions/checkout@v4
             - uses: dorny/paths-filter@v3
@@ -25,31 +25,52 @@ jobs:
                   filters: |
                       docs_only:
                           - 'docs-v2/**'
+            - name: Determine if should skip
+              id: check
+              run: |
+                  # Run on PRs only if not docs only
+                  # Always run on merge queue
+                  # Always run on direct pushes to master (not merge queue bot)
+                  IS_PR="${{ github.event_name == 'pull_request' }}"
+                  IS_MERGE_QUEUE="${{ github.event_name == 'merge_group' }}"
+                  IS_DIRECT_PUSH_TO_MASTER="${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.actor != 'github-merge-queue[bot]' }}"
+                  IS_DOCS_ONLY="${{ steps.filter.outputs.docs_only }}"
+
+                  SHOULD_SKIP="true"
+                  # Always run on merge queue and direct push to master
+                  if [[ "$IS_MERGE_QUEUE" == "true" || "$IS_DIRECT_PUSH_TO_MASTER" == "true" ]]; then
+                      SHOULD_SKIP="false"
+                  # Run on PR only if not docs only
+                  elif [[ "$IS_PR" == "true" && "$IS_DOCS_ONLY" != "true" ]]; then
+                      SHOULD_SKIP="false"
+                  fi
+
+                  echo "should_skip=$SHOULD_SKIP" >> $GITHUB_OUTPUT
     tests:
-        needs: changes
+        needs: should-run
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               uses: actions/checkout@v4
               with:
                   fetch-depth: '0'
 
             - name: Use Node.js
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
               uses: actions/setup-node@v4
               with:
                   cache: 'npm'
                   node-version-file: '.nvmrc'
 
             - run: npm ci
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
 
             - run: npm run ts-build
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
 
             - run: npm run test:unit -- --exclude packages/cli/
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'
 
             - run: npm run test:integration
-              if: needs.changes.outputs.docs_only != 'true'
+              if: needs.should-run.outputs.should_skip != 'true'


### PR DESCRIPTION
The objective is to make CI even faster by skipping jobs like lint,
build image, tests when coming from the merge queue since merge queue
commit is fast forwarded on top of master and all those workflows have
already run on the exact same commit.
No need to wait for the image to be built again for instance, it would
have been already pushed by the merge queue.
We are still running the workflows though if the push to master isn't
from the merge queue (direct force push, automated push via bot, ...)

<!-- Summary by @propel-code-bot -->

---

**Optimize GitHub Actions CI: Centralized Skip Logic for Master/Merge Queue**

This PR refactors all major GitHub Actions YAML workflows to centralize and enhance conditional job skipping logic across CI pipelines. The main objective is to avoid redundant execution (lint, build image, publish, test) on the `master` branch after merge queue operations, as these jobs have already run against the same commit in the merge queue. A unified `should-run` job is added to each workflow to determine whether jobs should execute, supporting scenarios including PRs, docs-only changes, merge group pushes, and direct or bot pushes to `master`. Workflow dependencies and conditional executions are updated throughout to consistently utilize the new output.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced per-workflow `changes` jobs and various conditional logic with a standardized `should-run` job in all major CI workflows
• Introduced a consolidated Bash logic block to set `should_skip` based on event type, branch, actor, and docs-only changes
• Updated all job and step dependencies from referencing `changes` to reference `should-run` and consistently consume `should_skip` outputs
• Ensured that all heavy/expensive CI jobs (for example, image builds and publishing) are skipped for fast-forwarded merge queue commits on `master`
• Removed obsolete job outputs and if-conditions related to the old `changes` and `docs_only` mechanisms
• Standardized conditional gating for each downstream job to prevent execution if `should_skip` is true

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• .github/workflows/build-image.yaml
• .github/workflows/lint.yaml
• .github/workflows/cli-verification.yaml
• .github/workflows/tests.yaml
• .github/workflows/tests-clients.yaml
• .github/workflows/docker.yaml

</details>

---
*This summary was automatically generated by @propel-code-bot*