### PR TITLE
fix: disable console in sandboxed code

### DIFF
--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -72,7 +72,13 @@ export async function exec({
                 filename
             });
             const sandbox: vm.Context = {
-                console,
+                // disable console in the sandboxed code
+                console: new Proxy(
+                    {},
+                    {
+                        get: () => () => {} // Returns no-op function for any console method
+                    }
+                ),
                 require: (moduleName: string) => {
                     switch (moduleName) {
                         case 'url':


### PR DESCRIPTION
we don't want console.log to be written to std out and ingested into our logs.
Note: this is not touching dry run execution, only execution of the functions when run by the runner

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Disable `console` in Sandboxed Code Execution**

This change updates `packages/runner/lib/exec.ts` so that all `console` methods are disabled inside the Node.js VM context used to execute user code in the runner. Instead of allowing outputs like `console.log` to reach standard output-and thus polluting system logs-the sandboxed `console` is replaced with a Proxy that returns a no-op function for any method. The change only affects execution via the runner, not dry runs.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced the standard `console` object in the VM sandbox with a Proxy that returns a no-op function for all properties.
• Added an inline code comment explaining the intention to disable `console` in the sandbox.
• Ensured changes apply only to actual function executions in the runner (not dry runs).

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/runner/lib/exec.ts` (sandbox setup for user code execution)

</details>

---
*This summary was automatically generated by @propel-code-bot*