### PR TITLE
fix(account): increment account created metric

### DIFF
--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -1,5 +1,5 @@
 import db from '@nangohq/database';
-import { flagHasPlan, report } from '@nangohq/utils';
+import { flagHasPlan, metrics, report } from '@nangohq/utils';
 
 import environmentService from './environment.service.js';
 import { LogActionEnum } from '../models/Telemetry.js';
@@ -144,7 +144,7 @@ class AccountService {
                 report(res.error);
             }
         }
-
+        metrics.increment(metrics.Types.ACCOUNT_CREATED, 1, { account_id: result[0].id });
         return result[0];
     }
 

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -1,6 +1,8 @@
 import tracer from 'dd-trace';
 
 export enum Types {
+    ACCOUNT_CREATED = 'nango.account.created',
+
     ACTION_INCOMING_PAYLOAD_SIZE_BYTES = 'nango.action.incoming.payloadSizeBytes',
 
     AUTH_GET_ENV_BY_CONNECT_SESSION = 'nango.auth.getEnvByConnectSession',


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Metric for Account Creation Events**

This PR introduces a metric that tracks when new accounts are created in the system. The change adds the `ACCOUNT_CREATED` metric type and ensures that the metric is incremented each time the `createAccount` function in `account.service.ts` is called, enabling improved observability and monitoring for account creation events.

<details>
<summary><strong>Key Changes</strong></summary>

• Added metric type `ACCOUNT_CREATED` to `metrics.Types` enum in `packages/utils/lib/telemetry/metrics.ts`
• Called `metrics.increment(metrics.Types.ACCOUNT_CREATED, 1, { account_id: ... })` in `AccountService.createAccount` after successful account creation

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/services/account.service.ts`
• `packages/utils/lib/telemetry/metrics.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*