### PR TITLE
fix(account): change dimension attribute name

### DIFF
--- a/packages/server/lib/controllers/mcp/server.ts
+++ b/packages/server/lib/controllers/mcp/server.ts
@@ -92,7 +92,7 @@ function callToolRequestHandler(
     providerConfig: Config
 ): (request: CallToolRequest) => Promise<CallToolResult> {
     return async (request: CallToolRequest) => {
-        metrics.increment(metrics.Types.ACTION_CALLED_BY_MCP_SERVER, 1, { account_id: account.id });
+        metrics.increment(metrics.Types.ACTION_CALLED_BY_MCP_SERVER, 1, { accountId: account.id });
 
         const active = tracer.scope().active();
         const span = tracer.startSpan('server.mcp.triggerAction', {

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -144,7 +144,7 @@ class AccountService {
                 report(res.error);
             }
         }
-        metrics.increment(metrics.Types.ACCOUNT_CREATED, 1, { account_id: result[0].id });
+        metrics.increment(metrics.Types.ACCOUNT_CREATED, 1, { accountId: result[0].id });
         return result[0];
     }
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Standardize Metric Dimension Attribute Name to camelCase**

This pull request updates the dimension attribute used in metric logging from `account_id` to `accountId` in two locations: the `metrics.increment` call within the `createAccount` method in `AccountService` and within the MCP server's action call metric logging. This change ensures consistency with camelCase attribute naming used elsewhere in the codebase and aligns metric schema conventions.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated the third argument of `metrics.increment` from `{ account_id: ... }` to `{ accountId: ... }` in the `createAccount` method of `AccountService` (`packages/shared/lib/services/account.service.ts`)
• Performed the same attribute key renaming on a metric increment in the MCP server request handler (`packages/server/lib/controllers/mcp/server.ts`)

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/services/account.service.ts`
• `packages/server/lib/controllers/mcp/server.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*