### PR TITLE
fix(connect-ui): overflow-auto to fix scrollbar

### DIFF
--- a/packages/connect-ui/src/components/Layout.tsx
+++ b/packages/connect-ui/src/components/Layout.tsx
@@ -22,8 +22,8 @@ export const Layout: React.FC = () => {
     if (isEmbedded) {
         return (
             <div ref={ref} className="h-screen w-screen flex flex-col max-w-[500px] max-h-[700px] rounded-md bg-elevated p-px overflow-hidden">
-                <div className="flex-1 w-full bg-surface text-text-primary rounded-md -only:rounded-b-none overflow-y-scroll">
-                    <div className="min-h-full overflow-auto p-10 flex flex-col">
+                <div className="flex-1 w-full bg-surface text-text-primary rounded-md -only:rounded-b-none overflow-y-auto">
+                    <div className="min-h-full p-10 flex flex-col">
                         <Outlet />
                     </div>
                 </div>
@@ -47,8 +47,8 @@ export const Layout: React.FC = () => {
     return (
         <div className="absolute h-screen w-screen overflow-hidden flex flex-col justify-center items-center p-14 bg-subtle/80">
             <div ref={ref} className="flex flex-col w-[500px] h-[700px] rounded-md bg-elevated p-px overflow-hidden">
-                <div className="flex-1 w-full bg-surface text-text-primary rounded-md -only:rounded-b-none overflow-y-scroll">
-                    <div className="min-h-full overflow-auto p-10 flex flex-col">
+                <div className="flex-1 w-full bg-surface text-text-primary rounded-md -only:rounded-b-none overflow-y-auto">
+                    <div className="min-h-full p-10 flex flex-col">
                         <Outlet />
                     </div>
                 </div>

--- a/packages/connect-ui/src/index.css
+++ b/packages/connect-ui/src/index.css
@@ -107,6 +107,8 @@
     :root,
     :host {
         @variant dark {
+            color-scheme: dark;
+
             --color-primary: var(--color-brand-500);
             --color-on-primary: var(--color-gray-50);
             --color-surface: var(--color-gray-1000);
@@ -120,24 +122,6 @@
 
             --color-error: var(--color-red-500);
         }
-    }
-}
-
-/*
-  The default border color has changed to `currentcolor` in Tailwind CSS v4,
-  so we've added these compatibility styles to make sure everything still
-  looks the same as it did with Tailwind CSS v3.
-
-  If we ever want to remove these styles, we need to add an explicit border
-  color utility to any element that depends on these defaults.
-*/
-@layer base {
-    *,
-    ::after,
-    ::before,
-    ::backdrop,
-    ::file-selector-button {
-        border-color: var(--color-gray-200, currentcolor);
     }
 }
 

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -358,6 +358,8 @@
     :root,
     :host {
         @variant dark {
+            color-scheme: dark;
+
             /* Functional */
             --color-bg-surface: var(--color-gray-1000);
             --color-bg-elevated: var(--color-gray-900);

--- a/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/components/ConnectUIPreview.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/components/ConnectUIPreview.tsx
@@ -110,7 +110,7 @@ export const ConnectUIPreview = forwardRef<ConnectUIPreviewRef, { className?: st
         connectUIContainer.current.appendChild(iframe);
     }, [env, environmentAndAccount, trySendSessionToken, sessionToken]);
 
-    return <div ref={connectUIContainer} className={cn('overflow-hidden h-full w-full', className)} />;
+    return <div ref={connectUIContainer} className={cn('rounded-md overflow-hidden h-full w-full', className)} />;
 });
 
 ConnectUIPreview.displayName = 'ConnectUIPreview';


### PR DESCRIPTION
Removes scrollbar where not needed (by using `overflow-y-auto` instead of `overflow-y-scroll`).
Minor improvement to ConnectUI preview (rounded borders so background html color of iframe is hidden).
Hints browser to use dark scrollbars in dark mode (for webapp as well).
Before:
<img width="634" height="968" alt="image" src="https://github.com/user-attachments/assets/62347202-0d6a-4938-99cf-254ecf01f444" />

After:
<img width="634" height="969" alt="image" src="https://github.com/user-attachments/assets/e103a3e5-31bd-4524-8c65-61f7a77d0c40" />


<!-- Summary by @propel-code-bot -->

**Adjust Scrollbar Appearance with `overflow-y-auto` in Connect UI Layout**

This pull request updates the `Layout.tsx` component in the `connect-ui` package, targeting the scrollbar behavior within main modal and embedded view containers. Specifically, it replaces the `overflow-y-scroll` class with `overflow-y-auto` on two primary wrapper `div`s to adjust when and how scrollbars are displayed. The intent is to make scrollbars appear only when necessary, aligning with common UI expectations.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced `overflow-y-scroll` with `overflow-y-auto` on main content `div`s in `packages/connect-ui/src/components/Layout.tsx`.
• Removed `overflow-auto` from the nested content `div`, consolidating scroll behavior in the parent container.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/connect-ui/src/components/Layout.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*