### PR TITLE
fix(kvstore): set defaults on getRedisClient

### DIFF
--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -89,7 +89,7 @@ export async function destroy(name: string, hard: boolean = false) {
 }
 
 async function createKVStore(options: KVStoreOptions): Promise<KVStore> {
-    if (options.url || (options.host && options.port && options.auth)) {
+    if (options.url || (options.host && options.auth)) {
         const store = await getRedisKVStore(options);
         return store;
     }

--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -25,15 +25,13 @@ function getRedis(options: KVStoreOptions): RedisClient {
     if (redisClients.has(name)) {
         return redisClients.get(name)!;
     }
-    if (!options.url && options.host && options.auth) {
+    if (options.host && options.auth) {
         const endpoint = options.host;
         const port = options.port || 6379;
         const auth = options.auth;
         if (endpoint && port && auth) {
             options.url = `rediss://:${auth}@${endpoint}:${port}`;
         }
-    } else {
-        throw new Error('Invalid Redis options');
     }
     const clientLibrary = options.clientLibrary || 'node-redis';
     switch (clientLibrary) {

--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -25,6 +25,16 @@ function getRedis(options: KVStoreOptions): RedisClient {
     if (redisClients.has(name)) {
         return redisClients.get(name)!;
     }
+    if (!options.url && options.host && options.auth) {
+        const endpoint = options.host;
+        const port = options.port || 6379;
+        const auth = options.auth;
+        if (endpoint && port && auth) {
+            options.url = `rediss://:${auth}@${endpoint}:${port}`;
+        }
+    } else {
+        throw new Error('Invalid Redis options');
+    }
     const clientLibrary = options.clientLibrary || 'node-redis';
     switch (clientLibrary) {
         case 'node-redis':
@@ -40,7 +50,7 @@ function getRedis(options: KVStoreOptions): RedisClient {
 }
 
 export async function getRedisClient(options: KVStoreOptions): Promise<RedisClient> {
-    const redis = getRedis(options);
+    const redis = getRedis({ ...defaultOptions, ...options });
     redis.on('error', (err) => {
         console.error(`Redis (kvstore) error: ${err}`);
     });
@@ -81,17 +91,9 @@ export async function destroy(name: string, hard: boolean = false) {
 }
 
 async function createKVStore(options: KVStoreOptions): Promise<KVStore> {
-    if (options.url) {
+    if (options.url || (options.host && options.port && options.auth)) {
         const store = await getRedisKVStore(options);
         return store;
-    } else {
-        const endpoint = options.host;
-        const port = options.port || 6379;
-        const auth = options.auth;
-        if (endpoint && port && auth) {
-            const store = await getRedisKVStore({ url: `rediss://:${auth}@${endpoint}:${port}`, connect: options.connect! });
-            return store;
-        }
     }
 
     return new InMemoryKVStore();
@@ -104,7 +106,7 @@ export async function getKVStore(options?: KVStoreOptions): Promise<KVStore> {
         return await kvstorePromises.get(name)!;
     }
 
-    const kvstorePromise = createKVStore({ ...defaultOptions, ...options });
+    const kvstorePromise = createKVStore(options || defaultOptions);
     kvstorePromises.set(name, kvstorePromise);
     return await kvstorePromise;
 }

--- a/packages/kvstore/lib/utils.ts
+++ b/packages/kvstore/lib/utils.ts
@@ -7,7 +7,8 @@ import type { RedisClientType } from 'redis';
 export function getDefaultKVStoreOptions(): KVStoreOptions {
     const options: KVStoreOptions = {
         name: 'default',
-        clientLibrary: (process.env['NANGO_REDIS_CLIENT_LIBRARY'] as KVStoreClientLibrary) || 'node-redis'
+        clientLibrary: (process.env['NANGO_REDIS_CLIENT_LIBRARY'] as KVStoreClientLibrary) || 'node-redis',
+        connect: true
     };
 
     if (process.env['NANGO_REDIS_URL']) options.url = process.env['NANGO_REDIS_URL'];


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Set and Simplify Defaults for Redis Client Retrieval in `kvstore`**

This PR refactors default option handling in the `kvstore` package, streamlining how Redis client connections are configured and ensuring safer defaults are consistently applied. Default behavior now merges options with a standardized set (`defaultOptions`), utilizes reasonable fallback values (e.g., defaulting `port` to 6379 and setting `connect` to true), and simplifies validation logic related to Redis connection parameters. The changes impact the internal retrieval and initialization of Redis and key-value store clients, reducing conditional complexity and potential misconfiguration.

<details>
<summary><strong>Key Changes</strong></summary>

• Refactored `getRedisClient` to merge user options with `defaultOptions`, ensuring defaults are always applied.
• Updated construction of the Redis `url` in `getRedis` to not require an explicit `port` if not provided.
• Simplified logic in `createKVStore`, evaluating both `url` or (`host` and `auth`) for Redis initialization, and consolidated conditional handling for fallbacks to `InMemoryKVStore`.
• Added `connect: true` as a default in `getDefaultKVStoreOptions`.
• Minor clean-up of option merging and parameter validation throughout `packages/kvstore/lib/index.ts`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/kvstore/lib/index.ts`
• `packages/kvstore/lib/utils.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*