### PR TITLE
fix(kvstore): reduce ping interval and make configurable

### DIFF
--- a/packages/kvstore/lib/KVStore.ts
+++ b/packages/kvstore/lib/KVStore.ts
@@ -11,6 +11,9 @@ export interface KVStoreOptions {
     port?: string;
     auth?: string;
     connect?: boolean;
+    pingInterval?: number;
+    connectTimeout?: number;
+    keepAlive?: number;
 }
 export type RedisClient = RedisClientType | Redis;
 

--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -36,10 +36,10 @@ function getRedis(options: KVStoreOptions): RedisClient {
     const clientLibrary = options.clientLibrary || 'node-redis';
     switch (clientLibrary) {
         case 'node-redis':
-            redisClients.set(name, getNodeRedis(options.url!));
+            redisClients.set(name, getNodeRedis(options));
             break;
         case 'ioredis':
-            redisClients.set(name, getIORedis(options.url!));
+            redisClients.set(name, getIORedis(options));
             break;
         default:
             throw new Error(`Invalid Redis client library: ${clientLibrary}`);

--- a/packages/kvstore/lib/utils.ts
+++ b/packages/kvstore/lib/utils.ts
@@ -57,7 +57,8 @@ export function getIORedis(options: KVStoreOptions): Redis {
 
     const redis = new Redis(url, {
         lazyConnect: true, // connect when you actually need it
-        connectTimeout: 5_000,
+        connectTimeout: options.connectTimeout || 5_000,
+        keepAlive: options.keepAlive || 60_000,
         maxRetriesPerRequest: 3, // bound per-command retries
         enableReadyCheck: true,
         enableAutoPipelining: true, // batches multiple commands per tick

--- a/packages/kvstore/lib/utils.ts
+++ b/packages/kvstore/lib/utils.ts
@@ -8,33 +8,40 @@ export function getDefaultKVStoreOptions(): KVStoreOptions {
     const options: KVStoreOptions = {
         name: 'default',
         clientLibrary: (process.env['NANGO_REDIS_CLIENT_LIBRARY'] as KVStoreClientLibrary) || 'node-redis',
-        connect: true
+        connect: true,
+        pingInterval: 1_000,
+        connectTimeout: 10_000,
+        keepAlive: 60_000
     };
 
     if (process.env['NANGO_REDIS_URL']) options.url = process.env['NANGO_REDIS_URL'];
     if (process.env['NANGO_REDIS_HOST']) options.host = process.env['NANGO_REDIS_HOST'];
     if (process.env['NANGO_REDIS_PORT']) options.port = process.env['NANGO_REDIS_PORT'];
     if (process.env['NANGO_REDIS_AUTH']) options.auth = process.env['NANGO_REDIS_AUTH'];
+    if (process.env['NANGO_REDIS_PING_INTERVAL']) options.pingInterval = parseInt(process.env['NANGO_REDIS_PING_INTERVAL']);
+    if (process.env['NANGO_REDIS_CONNECT_TIMEOUT']) options.connectTimeout = parseInt(process.env['NANGO_REDIS_CONNECT_TIMEOUT']);
+    if (process.env['NANGO_REDIS_KEEP_ALIVE']) options.keepAlive = parseInt(process.env['NANGO_REDIS_KEEP_ALIVE']);
 
     return options;
 }
 
-export function getNodeRedis(url: string): RedisClientType {
+export function getNodeRedis(options: KVStoreOptions): RedisClientType {
+    const url = options.url!;
     const isExternal = url.startsWith('rediss://');
     const socket = isExternal
         ? {
               reconnectStrategy: (retries: number) => Math.min(retries * 200, 2000),
-              connectTimeout: 10_000,
+              connectTimeout: options.connectTimeout || 10_000,
               tls: true,
               servername: new URL(url).hostname,
-              keepAlive: 60_000
+              keepAlive: options.keepAlive || 60_000
           }
         : {};
 
     const redis = createClient({
         url: url,
         disableOfflineQueue: true,
-        pingInterval: 30_000,
+        pingInterval: options.pingInterval || 1_000,
         socket
     });
     redis.on('error', (err) => {
@@ -44,7 +51,8 @@ export function getNodeRedis(url: string): RedisClientType {
     return redis as RedisClientType;
 }
 
-export function getIORedis(url: string): Redis {
+export function getIORedis(options: KVStoreOptions): Redis {
+    const url = options.url!;
     const isExternal = url.startsWith('rediss://');
 
     const redis = new Redis(url, {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Make Redis Ping Interval, Timeout, and Keep-Alive Configurable in `kvstore`**

This PR updates the `kvstore` package to make `pingInterval`, `connectTimeout`, and `keepAlive` settings for Redis connections configurable via the `KVStoreOptions` interface and corresponding environment variables. The changes enable both `node-redis` and `ioredis` clients to utilize these configurable parameters, defaulting to more aggressive connection checking (default `pingInterval` reduced to 1 second), which is intended to improve connection reliability, particularly in hosted and ephemeral environments. Relevant construction logic and option propagation is refactored across the `kvstore` package.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `pingInterval`, `connectTimeout`, and `keepAlive` fields to `KVStoreOptions` in `packages/kvstore/lib/KVStore.ts`.
• Modified `getDefaultKVStoreOptions()` to support defaults and environment variable overrides for the new fields in `packages/kvstore/lib/utils.ts`.
• Refactored `getNodeRedis()` and `getIORedis()` to receive the entire `KVStoreOptions` object and use the new configuration fields.
• Updated `packages/kvstore/lib/index.ts` to always pass the full `KVStoreOptions` to Redis client constructors.
• Decreased the default `pingInterval` from 30_000ms to 1_000ms.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/kvstore/lib/utils.ts`
• `packages/kvstore/lib/KVStore.ts`
• `packages/kvstore/lib/index.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*