### PR TITLE
fix: remove color-scheme declaration

### DIFF
--- a/packages/connect-ui/src/index.css
+++ b/packages/connect-ui/src/index.css
@@ -107,8 +107,6 @@
     :root,
     :host {
         @variant dark {
-            color-scheme: dark;
-
             --color-primary: var(--color-brand-500);
             --color-on-primary: var(--color-gray-50);
             --color-surface: var(--color-gray-1000);

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -358,8 +358,6 @@
     :root,
     :host {
         @variant dark {
-            color-scheme: dark;
-
             /* Functional */
             --color-bg-surface: var(--color-gray-1000);
             --color-bg-elevated: var(--color-gray-900);


### PR DESCRIPTION
Removes my recent addition of `color-scheme`. It hints the browser to render the scrollbar (and other default elements) in light or dark mode. But it messed up with the Connect UI background when the webapp declared `dark`, and Connect UI declared `light` (and vice versa). It makes the background opaque in order to not mix color schemes, but it's undesired behavior for us. I could not find alternatives, other than potentially customizing the scrollbar ourselves. For now, it's better to have the fix.

<!-- Summary by @propel-code-bot -->

---

**Remove `color-scheme` Declaration from Dark Mode Styles**

This PR removes the `color-scheme: dark;` CSS property from the dark mode style blocks in both `packages/connect-ui/src/index.css` and `packages/webapp/src/index.css`. The author notes that the declaration caused undesired UI effects when conflicting dark/light modes were applied between the Connect UI and the webapp, specifically resulting in opaque backgrounds that did not match design intent. This change reverts the recent addition of `color-scheme`, reverting to a more predictable visual behavior for dark mode and leaving further scrollbar customization for later consideration.

<details>
<summary><strong>Key Changes</strong></summary>

• Deleted `color-scheme: dark;` from the dark mode style blocks in `packages/connect-ui/src/index.css`.
• Deleted `color-scheme: dark;` from the dark mode style blocks in `packages/webapp/src/index.css`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/connect-ui/src/index.css`
• `packages/webapp/src/index.css`

</details>

---
*This summary was automatically generated by @propel-code-bot*