### PR TITLE
fix(cli-tests): update path with changed api

### DIFF
--- a/packages/cli/lib/services/response-saver.service.ts
+++ b/packages/cli/lib/services/response-saver.service.ts
@@ -84,7 +84,7 @@ export function onAxiosRequestFulfilled({
     }
     const directoryName = `${process.env['NANGO_MOCKS_RESPONSE_DIRECTORY'] ?? ''}${providerConfigKey}`;
 
-    if (response.request.path.includes(`/connection/${connectionId}?provider_config_key=${providerConfigKey}`)) {
+    if (response.request.path.includes(`/connections/${connectionId}`)) {
         const connection = response.data as GetPublicConnection['Success'];
 
         // getConnection could be getMetadata as well which would be cached


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Update API Path Logic in CLI Test Response Saving**

This pull request updates the logic for matching the API path in the `onAxiosRequestFulfilled` function of `response-saver.service.ts`, reflecting the changes in the underlying API endpoint structure. Specifically, it adjusts the path check for test response saving from `/connection/<id>?provider_config_key=<key>` to `/connections/<id>`, ensuring compatibility with the updated API convention. Only one line in the file is changed, minimizing the scope of this fix.

<details>
<summary><strong>Key Changes</strong></summary>

• Modified the path-matching condition from `response.request.path.includes(`/connection/${connectionId}?provider_config_key=${providerConfigKey}`)` to `response.request.path.includes(`/connections/${connectionId}`)` in `onAxiosRequestFulfilled` function of `packages/cli/lib/services/response-saver.service.ts`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/cli/lib/services/response-saver.service.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*