### PR TITLE
fix: remove update of sync last_fetched_at. it is not being used

### DIFF
--- a/packages/server/lib/controllers/records/getRecords.ts
+++ b/packages/server/lib/controllers/records/getRecords.ts
@@ -1,7 +1,7 @@
 import * as z from 'zod';
 
 import { records } from '@nangohq/records';
-import { connectionService, trackFetch } from '@nangohq/shared';
+import { connectionService } from '@nangohq/shared';
 import { metrics, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, modelSchema, providerConfigKeySchema, variantSchema } from '../../helpers/validation.js';
@@ -81,8 +81,6 @@ export const getPublicRecords = asyncWrapper<GetPublicRecords>(async (req, res) 
         res.status(500).send({ error: { code: 'server_error', message: 'Failed to fetch records' } });
         return;
     }
-
-    await trackFetch(connection.id);
 
     res.send({
         next_cursor: result.value.next_cursor || null,

--- a/packages/shared/lib/models/Sync.ts
+++ b/packages/shared/lib/models/Sync.ts
@@ -29,7 +29,6 @@ export interface Sync extends TimestampsAndDeleted {
         nanos?: number;
     };
     frequency: string | null;
-    last_fetched_at: Date | null;
     sync_config_id: number;
 }
 

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -75,7 +75,6 @@ export const createSync = async ({
         variant,
         frequency: null,
         last_sync_date: null,
-        last_fetched_at: null,
         sync_config_id: syncConfig.id
     };
 
@@ -553,10 +552,6 @@ export const getAndReconcileDifferences = async ({
         deletedModels
     };
 };
-
-export async function trackFetch(nango_connection_id: number): Promise<void> {
-    await db.knex.from<Sync>(`_nango_syncs`).where({ nango_connection_id, deleted: false }).update({ last_fetched_at: new Date() });
-}
 
 export async function hardDeleteSync(id: string) {
     await db.knex.from<Sync>('_nango_syncs').where({ id }).delete();


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Remove Unused `last_fetched_at` Update and Tracking Logic in Syncs**

This PR cleans up the sync-related code by removing the logic associated with updating and tracking the `last_fetched_at` property for sync objects. The `last_fetched_at` field and related service/helper functions were no longer used in the codebase. All references and the property definition have been removed for clarity and maintainability.

<details>
<summary><strong>Key Changes</strong></summary>

• Deleted the `trackFetch` function and its usage in `packages/server/lib/controllers/records/getRecords.ts` and `packages/shared/lib/services/sync/sync.service.ts`.
• Removed the `last_fetched_at` property from the `Sync` model in `packages/shared/lib/models/Sync.ts`.
• Cleaned up object creation and updates to exclude `last_fetched_at` field in `sync.service.ts`.
• Adjusted imports and code references to eliminate the unused function and property.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/services/sync/sync.service.ts`
• `packages/server/lib/controllers/records/getRecords.ts`
• `packages/shared/lib/models/Sync.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*