### PR TITLE
chore: more logging cleaning

### DIFF
--- a/packages/server/lib/webhook/attio-webhook-routing.ts
+++ b/packages/server/lib/webhook/attio-webhook-routing.ts
@@ -30,8 +30,6 @@ const route: WebhookHandler<AttioWebhook> = async (nango, headers, body, rawBody
         logger.info('no webhook secret configured, skipping signature validation', { configId: nango.integration.id });
     }
 
-    logger.info('received', { configId: nango.integration.id });
-
     const parsedBody = body;
 
     // For empty events we can just return success
@@ -42,7 +40,6 @@ const route: WebhookHandler<AttioWebhook> = async (nango, headers, body, rawBody
 
     let connectionIds: string[] = [];
     for (const event of parsedBody.events) {
-        logger.info(`processing event ${event.event_type}`, { configId: nango.integration.id });
         const response = await nango.executeScriptForWebhooks({
             body: event,
             webhookType: 'event_type',

--- a/packages/server/lib/webhook/cache.ts
+++ b/packages/server/lib/webhook/cache.ts
@@ -1,9 +1,5 @@
 import axios from 'axios';
 
-import { getLogger } from '@nangohq/utils';
-
-const logger = getLogger('Webhook.GoogleJWKSCache');
-
 interface JWKSResponse {
     keys: Record<string, string>[];
 }
@@ -21,7 +17,6 @@ export async function getGoogleJWKS(): Promise<JWKSResponse['keys']> {
     const now = Date.now();
 
     if (jwksCache && jwksCache.expiresAt > now) {
-        logger.debug('Using cached Google JWKS');
         return jwksCache.keys;
     }
 
@@ -35,8 +30,6 @@ export async function getGoogleJWKS(): Promise<JWKSResponse['keys']> {
         keys: response.data.keys,
         expiresAt
     };
-
-    logger.debug(`Cached Google JWKS until ${new Date(expiresAt).toISOString()}`);
 
     return response.data.keys;
 }

--- a/packages/server/lib/webhook/checkr-partner-webhook-routing.ts
+++ b/packages/server/lib/webhook/checkr-partner-webhook-routing.ts
@@ -34,8 +34,6 @@ const route: WebhookHandler<CheckrBody> = async (nango, headers, body, rawBody) 
         return Err(new NangoError('webhook_missing_signature'));
     }
 
-    logger.info('received', { configId: nango.integration.id });
-
     if (!validate(nango.integration, signature, rawBody)) {
         logger.error('invalid signature', { configId: nango.integration.id });
         // TODO the verification should use the API key
@@ -43,7 +41,6 @@ const route: WebhookHandler<CheckrBody> = async (nango, headers, body, rawBody) 
     }
 
     const parsedBody = body;
-    logger.info(`valid ${parsedBody.type}`, { configId: nango.integration.id });
 
     const response = await nango.executeScriptForWebhooks({
         body: parsedBody,

--- a/packages/server/lib/webhook/github-app-oauth-webhook-routing.ts
+++ b/packages/server/lib/webhook/github-app-oauth-webhook-routing.ts
@@ -91,7 +91,7 @@ async function handleCreateWebhook(nango: InternalNango, body: any): Promise<Res
 
         // if there is no matching connection or if the connection config already has an installation_id, exit
         if (!connection || connection.connection_config['installation_id']) {
-            logger.info('no connection or existing installation_id');
+            logger.error('no connection or existing installation_id');
             return Err(new NangoError('webhook_no_connection_or_existing_installation_id'));
         }
 

--- a/packages/server/lib/webhook/github-app-webhook-routing.ts
+++ b/packages/server/lib/webhook/github-app-webhook-routing.ts
@@ -24,7 +24,6 @@ const route: WebhookHandler = async (nango, headers, body) => {
     const signature = headers['x-hub-signature-256'];
 
     if (signature) {
-        logger.info('Signature found, verifying...');
         const valid = validate(nango.integration, signature, body);
 
         if (!valid) {

--- a/packages/server/lib/webhook/linear-webhook-routing.ts
+++ b/packages/server/lib/webhook/linear-webhook-routing.ts
@@ -31,15 +31,12 @@ const route: WebhookHandler<LinearBody> = async (nango, headers, body, rawBody) 
         return Err(new NangoError('webhook_missing_signature'));
     }
 
-    logger.info('received', { configId: nango.integration.id });
-
     if (!validate(nango.integration, signature, rawBody)) {
         logger.error('invalid signature', { configId: nango.integration.id });
         return Err(new NangoError('webhook_invalid_signature'));
     }
 
     const parsedBody = body;
-    logger.info(`valid ${parsedBody.type}`, { configId: nango.integration.id });
 
     const response = await nango.executeScriptForWebhooks({
         body: parsedBody,

--- a/packages/server/lib/webhook/sentry-oauth.ts
+++ b/packages/server/lib/webhook/sentry-oauth.ts
@@ -72,14 +72,14 @@ async function handleCreateWebhook(nango: InternalNango, body: SentryOauthWebhoo
     );
 
     if (!connections || connections.length === 0) {
-        logger.info('No connections found for actor', String(get(body, 'actor.id')));
+        logger.error('No connections found for actor', String(get(body, 'actor.id')));
         return Ok(undefined);
     } else {
         const [connection] = connections;
 
         // if there is no matching connection found, exit
         if (!connection) {
-            logger.info('no connection found');
+            logger.error('no connection found');
             return Err(new NangoError('webhook_no_connection'));
         }
 

--- a/packages/server/lib/webhook/xero-webhook-routing.ts
+++ b/packages/server/lib/webhook/xero-webhook-routing.ts
@@ -46,8 +46,6 @@ const route: WebhookHandler<XeroWebhookBody> = async (nango, headers, body, rawB
         return Err(new NangoError('webhook_missing_signature'));
     }
 
-    logger.info('Received Xero webhook', { configId: nango.integration.id });
-
     const isValidSignature = validate(nango.integration, signature, rawBody);
     if (!isValidSignature) {
         logger.error('Invalid signature', { configId: nango.integration.id });
@@ -55,11 +53,9 @@ const route: WebhookHandler<XeroWebhookBody> = async (nango, headers, body, rawB
     }
 
     const parsedBody = body;
-    logger.info('Valid webhook received', { configId: nango.integration.id });
 
     // For empty events, just return success
     if (parsedBody.events.length === 0) {
-        logger.info('Empty events array, returning success', { configId: nango.integration.id });
         return Ok({ content: { status: 'success' }, statusCode: 200 });
     }
 

--- a/packages/shared/lib/services/notification/slack.service.ts
+++ b/packages/shared/lib/services/notification/slack.service.ts
@@ -344,8 +344,6 @@ export class SlackService {
                 };
             }
 
-            logger.info(`Notifying connection:${nangoConnection.id} type:${type} name:${name}`);
-
             if (!isOpen) {
                 const created = await this.createNotification(nangoConnection, name, type, trx);
 
@@ -446,8 +444,6 @@ export class SlackService {
             if (index === -1) {
                 return;
             }
-
-            logger.info(`Resolving ${nangoConnection.id} type:${type} name:${name}`);
 
             connection_list.splice(index, 1);
 

--- a/packages/shared/lib/utils/error.manager.ts
+++ b/packages/shared/lib/utils/error.manager.ts
@@ -30,8 +30,6 @@ class ErrorManager {
      * TODO: reuse information in res.locals when possible
      */
     public report(err: unknown, config: ErrorOptionalConfig = { source: ErrorSourceEnum.PLATFORM }): void {
-        logger.error('Exception caught', errorToObject(err));
-
         if (err instanceof Error) {
             // Log to datadog manually
             // https://github.com/DataDog/dd-trace-js/issues/1944

--- a/packages/utils/lib/logger.ts
+++ b/packages/utils/lib/logger.ts
@@ -47,7 +47,7 @@ if (!isCloud && !isEnterprise) {
     formatters = [
         winston.format.printf((info) => {
             const splat = info[SPLAT] && info[SPLAT].length > 0 ? JSON.stringify(info[SPLAT]) : '';
-            return `${info.message} ${splat}`;
+            return `${info['service'] ? ` [${info['service']}] ` : ''}${info.message} ${splat}`;
         })
     ];
 }


### PR DESCRIPTION
- Remove log.info in webhook handler
- reinstate the logger name as the log message prefix
- remove logging error in report. The message itself is often not helpful and traces already have this info (plus more dimensions)
<!-- Summary by @propel-code-bot -->

---

**Refactor: Clean Up and Refactor Logging Across Webhook Handlers and Services**

This pull request removes unnecessary or redundant `logger.info` statements from multiple webhook handlers and related modules, aiming to reduce noise in log output and improve log relevance. The PR also updates the Winston logger formatting logic to consistently reinstate the logger name (service name) as a log message prefix, and modifies some log levels to better reflect error conditions. Additionally, the `ErrorManager`'s `report` method no longer logs errors directly, relying on traces for error reporting, which aligns with the goal of reducing log clutter and enhancing observability through more appropriately scoped log levels.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed multiple instances of `logger.info` and some low-value logging statements from webhook handlers (`attio`, `checkr-partner`, `linear`, `github-app`, `github-app-oauth`, `xero`, `sentry-oauth`) and the `slack.service.ts` service
• Winston logger format updated to prefix log messages with the logger/service name, ensuring consistent log context
• Changed some information-level logs to error-level (e.g., `logger.error` in webhook handlers when no connection found or on error conditions)
• Removed direct error logging from `ErrorManager.report`, leaving spans/traces to capture exceptions instead
• Small code path cleanups associated with removed log statements (e.g., elimination of unused logger variables and related lines in `webhook/cache.ts`)

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/webhook/attio-webhook-routing.ts`
• `packages/server/lib/webhook/checkr-partner-webhook-routing.ts`
• `packages/server/lib/webhook/github-app-webhook-routing.ts`
• `packages/server/lib/webhook/github-app-oauth-webhook-routing.ts`
• `packages/server/lib/webhook/linear-webhook-routing.ts`
• `packages/server/lib/webhook/sentry-oauth.ts`
• `packages/server/lib/webhook/xero-webhook-routing.ts`
• `packages/server/lib/webhook/cache.ts`
• `packages/shared/lib/services/notification/slack.service.ts`
• `packages/shared/lib/utils/error.manager.ts`
• `packages/utils/lib/logger.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*