### PR TITLE
fix(docs): spec issues

### DIFF
--- a/docs-v2/spec.yaml
+++ b/docs-v2/spec.yaml
@@ -2016,9 +2016,15 @@ paths:
                         application/json:
                             schema:
                                 type: object
+                                required:
+                                    - error
                                 properties:
                                     error:
                                         type: object
+                                        required:
+                                            - message
+                                            - code
+                                            - payload
                                         properties:
                                             message:
                                                 type: string
@@ -2042,21 +2048,21 @@ paths:
                                                     body:
                                                         type: object
                                                         additionalProperties: true
-                                        required:
-                                            - message
-                                            - code
-                                            - payload
-                                    required:
-                                        - error
                 '500':
                     description: Action error
                     content:
                         application/json:
                             schema:
                                 type: object
+                                required:
+                                    - error
                                 properties:
                                     error:
                                         type: object
+                                        required:
+                                            - message
+                                            - code
+                                            - payload
                                         properties:
                                             message:
                                                 type: string
@@ -2064,12 +2070,6 @@ paths:
                                                 type: string
                                             payload:
                                                 type: object
-                                        required:
-                                            - message
-                                            - code
-                                            - payload
-                                    required:
-                                        - error
 
     /environment-variables:
         get:


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Based on [community feedback](https://nango-community.slack.com/archives/C04ABR352H0/p1759262297133419)

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Fix OpenAPI Spec: Error Schema Requirements**

This PR makes targeted corrections to the `docs-v2/spec.yaml` OpenAPI specification, specifically to error response schemas for certain endpoints, based on community feedback. The changes enforce required object properties for the `error` field across 400, 424, and 500 HTTP response objects-mainly ensuring the `error` object itself, along with its `message`, `code`, and `payload` sub-properties, are marked as required where applicable. Previously, these properties were only documented in the `properties` section but not actually enforced as required by the schema.

<details>
<summary><strong>Key Changes</strong></summary>

• Added the `required: [error]` property for top-level error objects in relevant response schemas, notably for 400, 424, and 500 response codes for key endpoints.
• Added a `required` array within the `error` object, specifying `message`, `code`, and `payload` as mandatory fields.
• Removed misplaced or duplicated `required` blocks to centralize and correctly enforce required error properties.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs-v2/spec.yaml`
• OpenAPI response schemas for error handling (HTTP 400, 424, 500) on `/action/trigger`, `/action/{actionId}` endpoints

</details>

---
*This summary was automatically generated by @propel-code-bot*