### PR TITLE
chore: add dd metrics for orb billing event ingestion

### DIFF
--- a/packages/billing/lib/billing.ts
+++ b/packages/billing/lib/billing.ts
@@ -1,4 +1,4 @@
-import { Err, Ok, flagHasUsage, report } from '@nangohq/utils';
+import { Err, Ok, flagHasUsage } from '@nangohq/utils';
 
 import { Batcher } from './batcher.js';
 import { envs } from './envs.js';
@@ -104,10 +104,6 @@ export class Billing {
 
     // Note: Events are sent immediately
     private async ingest(events: BillingEvent[]): Promise<Result<void>> {
-        const res = await this.client.ingest(events);
-        if (res.isErr()) {
-            report(res.error);
-        }
-        return res;
+        return this.client.ingest(events);
     }
 }

--- a/packages/billing/lib/clients/orb.ts
+++ b/packages/billing/lib/clients/orb.ts
@@ -1,7 +1,7 @@
 import Orb from 'orb-billing';
 import { uuidv7 } from 'uuidv7';
 
-import { Err, Ok, retry } from '@nangohq/utils';
+import { Err, Ok, metrics, retry } from '@nangohq/utils';
 
 import { envs } from '../envs.js';
 
@@ -42,7 +42,9 @@ export class OrbClient implements BillingClient {
                         }
                     }
                 );
+                metrics.increment(metrics.Types.ORB_BILLING_EVENTS_INGESTED, batch.length, { success: 'true' });
             } catch (err) {
+                metrics.increment(metrics.Types.ORB_BILLING_EVENTS_INGESTED, batch.length, { success: 'false' });
                 return Err(new Error('failed_to_ingest_events', { cause: err }));
             }
         }

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -93,7 +93,9 @@ export enum Types {
 
     DEPLOY_INCOMING_PAYLOAD_SIZE_BYTES = 'nango.server.deploy.incoming.payloadSizeBytes',
 
-    ACTION_CALLED_BY_MCP_SERVER = 'nango.mcp.called.action'
+    ACTION_CALLED_BY_MCP_SERVER = 'nango.mcp.called.action',
+
+    ORB_BILLING_EVENTS_INGESTED = 'nango.billing.orb.ingested'
 }
 
 type Dimensions = Record<string, string | number> | undefined;


### PR DESCRIPTION
We are currently monitoring the requests made to the Orb ingestion API but monitoring events ingested is more meaningful. That's what Orb charges for, it would take into account retries, etc...

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Datadog Metrics for Orb Billing Event Ingestion**

This pull request adds new Datadog (`dd-trace`) metrics for tracking the ingestion of billing events in the Orb billing integration. By instrumenting success and failure counts for each ingested batch, the update provides visibility into the actual events processed by the Orb API, which is more aligned with usage-based billing than simply monitoring API requests. The PR introduces a new metric `ORB_BILLING_EVENTS_INGESTED` and emits increment calls with a `success` tag indicating the outcome of each ingestion operation.

<details>
<summary><strong>Key Changes</strong></summary>

• Added a new metrics type `ORB_BILLING_EVENTS_INGESTED` in `packages/utils/lib/telemetry/metrics.ts`.
• Modified `OrbClient.ingest()` in `packages/billing/lib/clients/orb.ts` to increment the new metric on each ingestion attempt, distinguishing success and failure using a `success` tag.
• Updated import paths in `packages/billing/lib/clients/orb.ts` to include the new `metrics` import.
• Minor cleanup in `packages/billing/lib/billing.ts` to remove unused `report` dependency and simplify error handling for ingestion.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/billing/lib/clients/orb.ts` (Orb billing ingestion)
• `packages/utils/lib/telemetry/metrics.ts` (metrics enumeration)
• `packages/billing/lib/billing.ts` (error handling for ingestion)

</details>

---
*This summary was automatically generated by @propel-code-bot*