### PR TITLE
fix(internal): add api to retrieve users by account id

### DIFF
--- a/packages/server/lib/controllers/users/getUsersProvider.ts
+++ b/packages/server/lib/controllers/users/getUsersProvider.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+import { userService } from '@nangohq/shared';
+import { zodErrorToHTTP } from '@nangohq/utils';
+
+import { userToAPI } from '../../formatters/user.js';
+import { asyncWrapper } from '../../utils/asyncWrapper.js';
+
+import type { GetUsers } from '@nangohq/types';
+
+const validationQuery = z.object({
+    accountId: z.coerce.number()
+});
+
+export const getUsersProvider = asyncWrapper<GetUsers>(async (req, res) => {
+    const valQuery = validationQuery.safeParse(req.query);
+    if (!valQuery.success) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valQuery.error) } });
+        return;
+    }
+
+    const users = await userService.getUsersByAccountId(valQuery.data.accountId);
+
+    const usersFormatted = users.map(userToAPI);
+
+    res.status(200).send({
+        data: usersFormatted
+    });
+});

--- a/packages/server/lib/controllers/users/getUsersProvider.ts
+++ b/packages/server/lib/controllers/users/getUsersProvider.ts
@@ -6,13 +6,13 @@ import { zodErrorToHTTP } from '@nangohq/utils';
 import { userToAPI } from '../../formatters/user.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 
-import type { GetUsers } from '@nangohq/types';
+import type { InternalGetUsers } from '@nangohq/types';
 
 const validationQuery = z.object({
     accountId: z.coerce.number()
 });
 
-export const getUsersProvider = asyncWrapper<GetUsers>(async (req, res) => {
+export const getUsersProvider = asyncWrapper<InternalGetUsers>(async (req, res) => {
     const valQuery = validationQuery.safeParse(req.query);
     if (!valQuery.success) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valQuery.error) } });
@@ -20,7 +20,6 @@ export const getUsersProvider = asyncWrapper<GetUsers>(async (req, res) => {
     }
 
     const users = await userService.getUsersByAccountId(valQuery.data.accountId);
-
     const usersFormatted = users.map(userToAPI);
 
     res.status(200).send({

--- a/packages/server/lib/routes.internal.ts
+++ b/packages/server/lib/routes.internal.ts
@@ -6,6 +6,7 @@ import { getSharedCredentialsProviders } from './controllers/sharedCredentials/g
 import { getSharedCredentialsProvider } from './controllers/sharedCredentials/id/getSharedCredential.js';
 import { patchSharedCredentialsProvider } from './controllers/sharedCredentials/id/patchSharedCredential.js';
 import { postSharedCredentialsProvider } from './controllers/sharedCredentials/postSharedCredential.js';
+import { getUsersProvider } from './controllers/users/getUsersProvider.js';
 import authMiddleware from './middleware/access.middleware.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
 
@@ -25,3 +26,5 @@ internalApi.route('/shared-credentials').get(interalApiAuth, getSharedCredential
 internalApi.route('/shared-credentials/:id').get(interalApiAuth, getSharedCredentialsProvider);
 internalApi.route('/shared-credentials').post(interalApiAuth, postSharedCredentialsProvider);
 internalApi.route('/shared-credentials/:id').patch(interalApiAuth, patchSharedCredentialsProvider);
+
+internalApi.route('/users').get(interalApiAuth, getUsersProvider);

--- a/packages/types/lib/user/api.ts
+++ b/packages/types/lib/user/api.ts
@@ -8,6 +8,15 @@ export type GetUser = Endpoint<{
     };
 }>;
 
+export type InternalGetUsers = Endpoint<{
+    Method: 'GET';
+    Path: `/internal/users`;
+    Query: { accountId: number };
+    Success: {
+        data: ApiUser[];
+    };
+}>;
+
 export type PatchUser = Endpoint<{
     Method: 'PATCH';
     Path: `/api/v1/user`;

--- a/packages/types/lib/user/api.ts
+++ b/packages/types/lib/user/api.ts
@@ -11,7 +11,7 @@ export type GetUser = Endpoint<{
 export type InternalGetUsers = Endpoint<{
     Method: 'GET';
     Path: `/internal/users`;
-    Query: { accountId: number };
+    Querystring: { accountId: number };
     Success: {
         data: ApiUser[];
     };


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Internal API Endpoint to Retrieve Users by Account ID**

This pull request introduces a new internal API endpoint (`GET /internal/users`) that allows retrieving users filtered by `accountId`. It adds server-side request validation, API typing, and route integration, enabling internal services to fetch user data associated with a specific account via the backend.

<details>
<summary><strong>Key Changes</strong></summary>

• Added new exported function `getUsersProvider` in `packages/server/lib/controllers/users/getUsersProvider.ts` for handling user retrieval by `accountId`.
• Introduced Zod schema validation (`validationQuery`) for query parameters to ensure valid `accountId` input.
• Integrated the endpoint route `/internal/users` to the `internalApi` router in `packages/server/lib/routes.internal.ts`.
• Defined `InternalGetUsers` API type in `packages/types/lib/user/api.ts` to specify endpoint contract and response format.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/users/getUsersProvider.ts`
• `packages/server/lib/routes.internal.ts`
• `packages/types/lib/user/api.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*