### PR TITLE
fix(managed-release): bitnami has deprecated support for many public …

### DIFF
--- a/.github/workflows/managed-release.yaml
+++ b/.github/workflows/managed-release.yaml
@@ -112,7 +112,7 @@ jobs:
                   echo "commit_hash: ${{ inputs.commit_hash }}"
 
                   # Debug: Show the exact command
-                  HELM_CMD="helm upgrade --install nango nangohq/nango --version 1.1.5 --namespace nango --create-namespace --set shared.namespace=nango --set shared.tag=\"${{ inputs.commit_hash }}\" --set shared.encryptionEnabled=true --set shared.NANGO_SERVER_URL=\"http://localhost:3003\" --set shared.NANGO_CALLBACK_URL=\"http://localhost:3003/oauth/callback\" --set shared.NANGO_LOGS_ENABLED=false --set server.useLoadBalancer=false --set server.RECORDS_DATABASE_SSL=false --set elasticsearch.enabled=false --set postgresql.auth.postgresPassword=nango123 --wait=false"
+                  HELM_CMD="helm upgrade --install nango nangohq/nango --version 1.1.5 --namespace nango --create-namespace --set shared.namespace=nango --set shared.tag=\"${{ inputs.commit_hash }}\" --set shared.encryptionEnabled=true --set shared.NANGO_SERVER_URL=\"http://localhost:3003\" --set shared.NANGO_CALLBACK_URL=\"http://localhost:3003/oauth/callback\" --set shared.NANGO_LOGS_ENABLED=false --set server.useLoadBalancer=false --set server.RECORDS_DATABASE_SSL=false --set elasticsearch.enabled=false --set postgresql.auth.postgresPassword=nango123 --set postgresql.image.repository=bitnamilegacy/postgresql --set postgresql.image.tag=16.1.0-debian-11-r9 --wait=false"
                   echo "Executing: $HELM_CMD"
 
                   # Execute the command


### PR DESCRIPTION
…images. Must use bitnamilegacy

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Update PostgreSQL Helm Chart to Use `bitnamilegacy` Repository**

This PR updates the `HELM_CMD` in the `.github/workflows/managed-release.yaml` GitHub Actions workflow to specify the use of the `bitnamilegacy/postgresql` image for PostgreSQL deployment. The previous reference to the default Bitnami PostgreSQL image was removed because Bitnami has deprecated support for many of its public images. The Helm upgrade/install command now explicitly sets both the `postgresql.image.repository` and `postgresql.image.tag` fields to ensure compatibility and continued support.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated the `HELM_CMD` in `.github/workflows/managed-release.yaml` to add `--set postgresql.image.repository=bitnamilegacy/postgresql --set postgresql.image.tag=16.1.0-debian-11-r9`.
• Ensured the workflow now pulls the officially supported legacy Bitnami PostgreSQL image.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• .github/workflows/managed-release.yaml

</details>

---
*This summary was automatically generated by @propel-code-bot*