### PR TITLE
fix: api url configuration via env var

### DIFF
--- a/packages/shared/lib/utils/utils.ts
+++ b/packages/shared/lib/utils/utils.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'url';
 
 import get from 'lodash-es/get.js';
 
-import { cloudHost, isEnterprise, isProd, isStaging, localhostUrl, stagingHost } from '@nangohq/utils';
+import { isEnterprise, localhostUrl } from '@nangohq/utils';
 
 import type { DBConnection, Provider } from '@nangohq/types';
 
@@ -161,12 +161,11 @@ export function getLocalOAuthCallbackUrlBaseUrl() {
 }
 
 export function getApiUrl() {
-    if (isStaging) {
-        return stagingHost;
-    } else if (isEnterprise) {
+    if (isEnterprise) {
         return process.env['NANGO_SERVER_URL'] as string;
-    } else if (isProd) {
-        return cloudHost;
+    }
+    if (process.env['SERVER_SERVICE_URL']) {
+        return process.env['SERVER_SERVICE_URL'];
     }
     return getServerBaseUrl();
 }


### PR DESCRIPTION
the objective is to allow the configuration of the api url so it can be set in the cloud to the private url of the server service.

@rossmcewan this is the simplest way to allow such changes without introducing a breaking changes. The env var must exist in k8s. We cannot default to a single value since this value depends on the environment (prod, staging, dev). Feel free to undraft and merge once the env var has been introduced
<!-- Summary by @propel-code-bot -->

---

**Allow API URL Configuration via Environment Variable**

This pull request modifies the logic for resolving the API URL in `getApiUrl()` within `packages/shared/lib/utils/utils.ts`. The change allows overriding the API URL using the `SERVER_SERVICE_URL` environment variable, thus enabling cloud deployments to specify a private service URL without needing a code change. The PR removes previous reliance on hardcoded staging, production, and cloud host logic, deferring to explicit environment configuration when present.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed imports and logic for `cloudHost`, `isProd`, `isStaging`, and `stagingHost` from `@nangohq/utils`.
• Updated `getApiUrl()` to first check for `isEnterprise` (using `NANGO_SERVER_URL`), then conditionally use `SERVER_SERVICE_URL` if defined.
• Fallback behavior for API URL defaults to `getServerBaseUrl()` if no relevant environment variable is set.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/utils/utils.ts`
• `getApiUrl()` function

</details>

---
*This summary was automatically generated by @propel-code-bot*