### PR TITLE
fix(docs): add note about .nango directory

### DIFF
--- a/docs-v2/implementation-guides/building-integrations/functions-setup.mdx
+++ b/docs-v2/implementation-guides/building-integrations/functions-setup.mdx
@@ -48,7 +48,7 @@ nango-integrations/
 ```
 
 <Tip>
-**The `.nango` directory should be committed to source control. It is used by the Nango CLI internally.**.
+**The `.nango` directory should be committed to source control. It is used by the Nango CLI internally.**
 </Tip>
 
 ## Authenticate the CLI

--- a/docs-v2/implementation-guides/building-integrations/functions-setup.mdx
+++ b/docs-v2/implementation-guides/building-integrations/functions-setup.mdx
@@ -47,6 +47,10 @@ nango-integrations/
         └── github-issue-example.ts
 ```
 
+<Tip>
+**The `.nango` directory should be committed to source control. It is used by the Nango CLI internally.**.
+</Tip>
+
 ## Authenticate the CLI
 
 In an `.env` file in `./nango-integrations`, add the following environment variables:

--- a/package-lock.json
+++ b/package-lock.json
@@ -22167,9 +22167,10 @@
             "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
         },
         "node_modules/nodemailer": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.2.tgz",
-            "integrity": "sha512-SYsisPeLFYli5Q+BCGSyHT5CVvezPmQjHgINV9KVvVLV1aktuoD4E0Np9Q3ND9I481qIHzUQzVT+Tl/Tw7Ivdg==",
+            "version": "7.0.9",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.9.tgz",
+            "integrity": "sha512-9/Qm0qXIByEP8lEV2qOqcAW7bRpL8CR9jcTwk3NBnHJNmP9fIJ86g2fgmIXqHY+nj55ZEMwWqYAT2QTDpRUYiQ==",
+            "license": "MIT-0",
             "engines": {
                 "node": ">=6.0.0"
             }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
- add in compile to be a listed command
- remove generate since that doesn't work with zero yaml
- move generate:tests out of the hidden section
- Add docs about `.nango` directory

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Expose `compile` Command, Update CLI Docs, and Adjust Command Visibility**

This pull request updates both the documentation and the CLI interface for the Nango project. It promotes the `compile` command to a first-class, visible position in the CLI, removes the `generate` command from visible commands (since it is not applicable to zero-yaml projects), moves `generate:tests` out from the hidden commands to be directly accessible, and adds a documentation tip instructing users to commit the `.nango` directory to source control. Additionally, it updates the `nodemailer` package in `package-lock.json` to version 7.0.9.

<details>
<summary><strong>Key Changes</strong></summary>

• Promoted `compile` command in `packages/cli/lib/index.ts` to be a visible, documented top-level CLI command
• Moved `generate:tests` command to be visible and accessible directly through the CLI
• Removed the `generate` command from visible commands and marked it as hidden due to incompatibility with zero-yaml
• Added documentation tip in `docs-v2/implementation-guides/building-integrations/functions-setup.mdx` to commit the `.nango` directory to version control
• Upgraded `nodemailer` dependency in `package-lock.json` from version `7.0.2` to `7.0.9`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/cli/lib/index.ts`
• `docs-v2/implementation-guides/building-integrations/functions-setup.mdx`
• `package-lock.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*