### PR TITLE
fix(webhook): fix return statement for sentry-oauth

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -235,7 +235,7 @@ adobe-umapi:
 adobe-workfront:
     display_name: Adobe Workfront
     categories:
-        - sports
+        - productivity
     auth_mode: OAUTH2
     authorization_url: https://${connectionConfig.hostname}/integrations/oauth2/authorize
     token_url: https://${connectionConfig.hostname}/integrations/oauth2/api/v1/token

--- a/packages/server/lib/webhook/sentry-oauth.ts
+++ b/packages/server/lib/webhook/sentry-oauth.ts
@@ -72,21 +72,21 @@ async function handleCreateWebhook(nango: InternalNango, body: SentryOauthWebhoo
     );
 
     if (!connections || connections.length === 0) {
-        logger.error('No connections found for actor', String(get(body, 'actor.id')));
+        logger.info('No connections found for actor', String(get(body, 'actor.id')));
         return Ok(undefined);
     } else {
         const [connection] = connections;
-
-        // if there is no matching connection found, exit
-        if (!connection) {
-            logger.error('no connection found');
-            return Err(new NangoError('webhook_no_connection'));
-        }
 
         const provider = getProvider(nango.integration.provider);
         if (!provider) {
             logger.error('unknown provider');
             return Err(new NangoError('webhook_unknown_provider'));
+        }
+
+        // if there is no matching connection found, exit
+        if (!connection || !connection.connection_config['pendingLog']) {
+            logger.error('no connection found');
+            return Err(new NangoError('webhook_no_connection'));
         }
 
         const activityLogId = connection.connection_config['pendingLog'];

--- a/packages/server/lib/webhook/sentry-oauth.ts
+++ b/packages/server/lib/webhook/sentry-oauth.ts
@@ -72,7 +72,7 @@ async function handleCreateWebhook(nango: InternalNango, body: SentryOauthWebhoo
     );
 
     if (!connections || connections.length === 0) {
-        logger.info('No connections found for actor', String(get(body, 'actor.id')));
+        logger.error('No connections found for actor', String(get(body, 'actor.id')));
         return Ok(undefined);
     } else {
         const [connection] = connections;


### PR DESCRIPTION
## Describe the problem and your solution 

- Fix return statement for sentry-oauth

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Fix Error Handling in Sentry OAuth Webhook and Provider Category Correction**

This pull request updates the error handling logic in the `handleCreateWebhook` function within `packages/server/lib/webhook/sentry-oauth.ts`. The change involves reordering the provider existence check and tightening the condition that returns an error for missing connection or its `pendingLog`. Additionally, the PR corrects the category of the `adobe-workfront` provider in `packages/providers/providers.yaml` from `sports` to `productivity`.

<details>
<summary><strong>Key Changes</strong></summary>

• Moved the check for a valid `provider` before accessing `connection.connection_config` in the `handleCreateWebhook` function.
• Updated the conditional to return an error (`Err(new NangoError('webhook_no_connection'))`) if either `connection` or its `pendingLog` value is missing.
• Removed the previous early error return for only missing connections, now conditioned on both `connection` and `pendingLog` existence.
• Adjusted log ordering to correspond with the new conditional flow in `handleCreateWebhook`.
• Changed the provider category for `adobe-workfront` from `sports` to `productivity` in `packages/providers/providers.yaml`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/webhook/sentry-oauth.ts`
• `handleCreateWebhook` function
• `packages/providers/providers.yaml` (entry for `adobe-workfront`)

</details>

---
*This summary was automatically generated by @propel-code-bot*