### PR TITLE
chore(kvstore): add more commands

### DIFF
--- a/packages/account-usage/lib/accountUsageStore/kvAccountUsageStore.ts
+++ b/packages/account-usage/lib/accountUsageStore/kvAccountUsageStore.ts
@@ -21,13 +21,13 @@ export class KvAccountUsageStore implements AccountUsageStore {
 
     async setUsage({ accountId, metric, value, month }: SetUsageParams): Promise<number> {
         const key = this.getKey(accountId, metric, month);
-        await this.kvStore.set(key, value.toString(), { ttlInMs: MONTH_IN_MS });
+        await this.kvStore.set(key, value.toString(), { ttlMs: MONTH_IN_MS });
         return value;
     }
 
     async incrementUsage({ accountId, metric, delta, month }: IncrementUsageParams): Promise<number> {
         const key = this.getKey(accountId, metric, month);
-        return this.kvStore.incr(key, { delta: delta ?? 1, ttlInMs: MONTH_IN_MS });
+        return this.kvStore.incr(key, { delta: delta ?? 1, ttlMs: MONTH_IN_MS });
     }
 
     private getKey(accountId: number, metric: AccountUsageIncrementableMetric, month?: Date): string {

--- a/packages/kvstore/lib/KVStore.ts
+++ b/packages/kvstore/lib/KVStore.ts
@@ -1,11 +1,14 @@
-import type { MaybePromise } from '@nangohq/types';
-
 export interface KVStore {
-    destroy(): MaybePromise<void>;
-    set(key: string, value: string, options?: { canOverride?: boolean; ttlInMs?: number }): Promise<void>;
+    destroy(): Promise<void>;
+    set(key: string, value: string, options?: { canOverride?: boolean; ttlMs?: number }): Promise<void>;
     get(key: string): Promise<string | null>;
     delete(key: string): Promise<void>;
     exists(key: string): Promise<boolean>;
-    incr(key: string, opts?: { ttlInMs?: number; delta?: number }): MaybePromise<number>;
+    incr(key: string, opts?: { ttlMs?: number; delta?: number }): Promise<number>;
     scan(pattern: string): AsyncGenerator<string>;
+    hSetAll(key: string, value: Record<string, string>, options?: { canOverride?: boolean; ttlMs?: number }): Promise<void>;
+    hSet(key: string, field: string, value: string, options: { canOverride?: boolean }): Promise<void>;
+    hGetAll(key: string): Promise<Record<string, string> | null>;
+    hGet(key: string, field: string): Promise<string | null>;
+    hIncrBy(key: string, field: string, delta: number): Promise<number>;
 }

--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -18,7 +18,7 @@ export { type Lock, Locking } from './Locking.js';
 // Not my best code
 
 let redis: RedisClientType | undefined;
-async function getRedis(url: string): Promise<RedisClientType> {
+export async function getRedis(url: string): Promise<RedisClientType> {
     if (redis) {
         return redis;
     }

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -57,7 +57,7 @@ async function setupPostgres() {
 
 export async function setupActiveMQ() {
     console.log('Starting ActiveMQ...');
-    const amq = await new GenericContainer('apache/activemq-classic:5.18.3').withExposedPorts(61614).start();
+    const amq = await new GenericContainer('apache/activemq-classic:5.18.3').withExposedPorts(61614).withName(`activemq-test-${randomUUID()}`).start();
     containers.push(amq);
 
     const url = `ws://${amq.getHost()}:${amq.getMappedPort(61614)}`;
@@ -68,8 +68,19 @@ export async function setupActiveMQ() {
     console.log('ActiveMQ running at', url);
 }
 
+export async function setupRedis() {
+    console.log('Starting Redis...');
+    const redis = await new GenericContainer('redis:8.0.4-alpine').withExposedPorts(6379).withName(`redis-test-${randomUUID()}`).start();
+    containers.push(redis);
+
+    const url = `redis://${redis.getHost()}:${redis.getMappedPort(6379)}`;
+
+    process.env['NANGO_REDIS_URL'] = url;
+    console.log('Redis running at', url);
+}
+
 export async function setup() {
-    await Promise.all([setupPostgres(), setupElasticsearch(), setupActiveMQ()]);
+    await Promise.all([setupPostgres(), setupElasticsearch(), setupActiveMQ(), setupRedis()]);
 }
 
 export const teardown = async () => {


### PR DESCRIPTION
I am using additional kvstore commands for the usage capping/reporting. Here is a dedicated PR so it is easier to review

This commit:
- adds `hSet`, `hSetAll`, `hGet`, `hGetAll`, and `hIncrBy` kvstore commands
- rename `ttlInMs` to `ttlMs` to be consitent with naming conventions in the reso of the repo
- simplify kvstore interface to always return a Promise
- adds integration tests for RedisKVStore

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Expand `kvstore`: Redis Hash Commands, Interface Unification, and Extended Testing**

This PR introduces significant enhancements to the `kvstore` module by adding new Redis hash operations (`hSet`, `hSetAll`, `hGet`, `hGetAll`, `hIncrBy`) to the `KVStore` interface, with full implementations for both `InMemoryKVStore` and `RedisKVStore`. It standardizes the interface to return Promises for all operations, unifies naming conventions by renaming all occurrences of `ttlInMs` to `ttlMs`, and updates the consumer code and test infrastructure accordingly. Comprehensive integration and unit tests, including Redis container spin-up in the test environment, ensure the correctness of the new functionalities.

<details>
<summary><strong>Key Changes</strong></summary>

• Added new hash commands to interface: `hSet`, `hSetAll`, `hGet`, `hGetAll`, `hIncrBy` in `KVStore`, `InMemoryKVStore`, and `RedisKVStore`.
• Standardized all TTL-related options/variables to `ttlMs` across the codebase.
• Unified `KVStore` interface: all methods now consistently return Promises (including `incr`).
• Refactored consumer and feature code (e.g., `kvAccountUsageStore.ts`, `Locking.ts`) to align with updated interfaces/naming.
• Introduced comprehensive Redis integration test suite and extended in-memory store unit tests.
• Test infrastructure now includes Redis container spin-up for integration tests.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/kvstore/lib/KVStore.ts`
• `packages/kvstore/lib/InMemoryStore.ts`
• `packages/kvstore/lib/InMemoryStore.unit.test.ts`
• `packages/kvstore/lib/RedisStore.ts`
• `packages/kvstore/lib/RedisStore.integration.test.ts`
• `packages/kvstore/lib/Locking.ts`
• `packages/kvstore/lib/index.ts`
• `packages/account-usage/lib/accountUsageStore/kvAccountUsageStore.ts`
• `tests/setup.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*