### PR TITLE
fix(mcp-action): throw the entire object to get the stack trace included

### DIFF
--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -35,7 +35,7 @@ function formatStackTrace(stack: string | undefined, filename: string): string[]
         .split('\n')
         .filter((s, i) => i === 0 || s.includes(filename))
         .map((s) => s.trim())
-        .slice(0, 5); // max 5 lines
+        .slice(0, 10);
 }
 
 export async function exec({

--- a/packages/server/lib/controllers/mcp/server.ts
+++ b/packages/server/lib/controllers/mcp/server.ts
@@ -159,7 +159,7 @@ function callToolRequestHandler(
             span.setTag('nango.error', actionResponse.error);
             await logCtx.failed();
 
-            throw actionResponse.error;
+            throw new Error(JSON.stringify(actionResponse.error));
         }
     };
 }

--- a/packages/server/lib/controllers/mcp/server.ts
+++ b/packages/server/lib/controllers/mcp/server.ts
@@ -158,7 +158,8 @@ function callToolRequestHandler(
         } else {
             span.setTag('nango.error', actionResponse.error);
             await logCtx.failed();
-            throw new Error(actionResponse.error.message);
+
+            throw actionResponse.error;
         }
     };
 }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
So agents can have more details on action failures

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Enhance Error Reporting for Actions and Stack Traces**

This PR updates error handling in the `callToolRequestHandler` function in `packages/server/lib/controllers/mcp/server.ts` by throwing the complete `actionResponse.error` object using `JSON.stringify`, rather than creating a new `Error` with only the message. This change is intended to preserve the original error's full metadata, providing more granular details about failures to agent consumers. Additionally, it modifies the `formatStackTrace` function in `packages/runner/lib/exec.ts` to increase the maximum number of stack trace lines included from 5 to 10, thereby expanding diagnostic context in error logs.

<details>
<summary><strong>Key Changes</strong></summary>

• Changed `callToolRequestHandler` in `packages/server/lib/controllers/mcp/server.ts` to throw new `Error(JSON.stringify(actionResponse.error))` instead of just the message.
• Increased stack trace context limit in `formatStackTrace` in `packages/runner/lib/exec.ts` from 5 to 10 lines.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/mcp/server.ts` (server-side action error propagation)
• `packages/runner/lib/exec.ts` (stack trace formatting in error logging)

</details>

---
*This summary was automatically generated by @propel-code-bot*