### PR TITLE
feat: usage/cache logic to store usage metric

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31237,10 +31237,23 @@
                 "@nangohq/email": "file:../email",
                 "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/shared": "file:../shared",
-                "@nangohq/types": "file:../types",
                 "@nangohq/utils": "file:../utils",
-                "dd-trace": "^5.52.0",
-                "he": "^1.2.0"
+                "dd-trace": "5.52.0",
+                "he": "1.2.0",
+                "zod": "4.0.5"
+            },
+            "devDependencies": {
+                "@nangohq/types": "file:../types",
+                "vitest": "3.2.4"
+            }
+        },
+        "packages/account-usage/node_modules/zod": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
+            "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "packages/billing": {

--- a/packages/account-usage/lib/cache.ts
+++ b/packages/account-usage/lib/cache.ts
@@ -1,0 +1,45 @@
+import { Err, Ok } from '@nangohq/utils';
+
+import type { KVStore } from '@nangohq/kvstore';
+import type { Result } from '@nangohq/utils';
+
+export interface UsageCacheEntry {
+    key: string;
+    count: number;
+    revalidateAfter: number;
+}
+
+export class UsageCache {
+    private store: KVStore;
+
+    constructor(store: KVStore) {
+        this.store = store;
+    }
+
+    public async incr(key: string, { delta, ttlMs }: { delta: number; ttlMs?: number | undefined }): Promise<Result<UsageCacheEntry>> {
+        try {
+            const oneHourMs = 60 * 60 * 1000; // TODO: make this configurable?
+            const revalidateAfter = Date.now() + oneHourMs + Math.random() * oneHourMs; // default revalidateAfter is between 1 and 2 hours to spread the load
+
+            const count = await this.store.hIncrBy(key, 'count', delta);
+            // set revalidateAfter if not exists
+            try {
+                await this.store.hSet(key, 'revalidateAfter', `${revalidateAfter}`, { canOverride: false });
+            } catch {
+                // ignore if already exists
+            }
+            if (ttlMs) {
+                await this.store.expires(key, ttlMs);
+            }
+
+            const entry = await this.store.hGetAll(key);
+            return Ok({
+                key,
+                count,
+                revalidateAfter: parseInt(entry?.['revalidateAfter'] || '0', 10)
+            });
+        } catch (err) {
+            return Err(new Error(`cache_incr_error`, { cause: err }));
+        }
+    }
+}

--- a/packages/account-usage/lib/cache.ts
+++ b/packages/account-usage/lib/cache.ts
@@ -1,19 +1,37 @@
+import * as z from 'zod';
+
 import { Err, Ok } from '@nangohq/utils';
 
-import type { KVStore } from '@nangohq/kvstore';
+import type { getRedis } from '@nangohq/kvstore';
 import type { Result } from '@nangohq/utils';
 
-export interface UsageCacheEntry {
-    key: string;
-    count: number;
-    revalidateAfter: number;
-}
+const UsageCacheEntrySchema = z.object({
+    key: z.string(),
+    count: z.coerce.number(),
+    revalidateAfter: z.coerce.number().min(0)
+});
+const UsageCacheEntryValueSchema = UsageCacheEntrySchema.omit({ key: true });
+type UsageCacheEntry = z.infer<typeof UsageCacheEntrySchema>;
+
+type Redis = Awaited<ReturnType<typeof getRedis>>;
 
 export class UsageCache {
-    private store: KVStore;
+    constructor(private store: Redis) {}
 
-    constructor(store: KVStore) {
-        this.store = store;
+    public async get(key: string): Promise<Result<UsageCacheEntry | null>> {
+        try {
+            const res = await this.store.multi().hGetAll(key).exec();
+            if (!res || res.length === 0 || !res[0]) {
+                return Ok(null);
+            }
+            const [data] = res;
+            if (!data || Object.keys(data).length === 0) {
+                return Ok(null);
+            }
+            return await this.validateEntry(key, data);
+        } catch (err) {
+            return Err(new Error(`cache_get_error`, { cause: err }));
+        }
     }
 
     public async incr(key: string, { delta, ttlMs }: { delta: number; ttlMs?: number | undefined }): Promise<Result<UsageCacheEntry>> {
@@ -21,25 +39,36 @@ export class UsageCache {
             const oneHourMs = 60 * 60 * 1000; // TODO: make this configurable?
             const revalidateAfter = Date.now() + oneHourMs + Math.random() * oneHourMs; // default revalidateAfter is between 1 and 2 hours to spread the load
 
-            const count = await this.store.hIncrBy(key, 'count', delta);
-            // set revalidateAfter if not exists
-            try {
-                await this.store.hSet(key, 'revalidateAfter', `${revalidateAfter}`, { canOverride: false });
-            } catch {
-                // ignore if already exists
-            }
+            const multi = this.store.multi();
+            multi.hIncrBy(key, 'count', delta);
+            multi.hSetNX(key, 'revalidateAfter', `${revalidateAfter}`);
             if (ttlMs) {
-                await this.store.expires(key, ttlMs);
+                multi.pExpire(key, ttlMs);
             }
-
-            const entry = await this.store.hGetAll(key);
-            return Ok({
-                key,
-                count,
-                revalidateAfter: parseInt(entry?.['revalidateAfter'] || '0', 10)
-            });
+            multi.hGetAll(key);
+            const res = await multi.exec();
+            if (!res || res.length === 0) {
+                return Err(new Error('cache_incr_error'));
+            }
+            return await this.validateEntry(key, res.at(-1));
         } catch (err) {
             return Err(new Error(`cache_incr_error`, { cause: err }));
         }
+    }
+
+    private async validateEntry(key: string, data: any): Promise<Result<UsageCacheEntry>> {
+        if (!data) {
+            return Err(new Error(`cache_entry_invalid`));
+        }
+        const validated = UsageCacheEntryValueSchema.safeParse(data);
+        if (!validated.success) {
+            // if the data is invalid, we delete the key to avoid returning invalid data again
+            await this.store.del(key);
+            return Err(new Error(`cache_entry_invalid`));
+        }
+        return Ok({
+            key,
+            ...validated.data
+        });
     }
 }

--- a/packages/account-usage/lib/metrics.ts
+++ b/packages/account-usage/lib/metrics.ts
@@ -5,3 +5,18 @@ export const metricFlags: Record<AccountUsageMetric, string> = {
     active_records: 'monthly_active_records_max',
     connections: 'connections_max'
 };
+
+export type UsageMetric = 'proxy' | 'connections' | 'function_executions' | 'function_compute_ms' | 'records' | 'external_webhooks' | 'logs';
+export interface UsageMetricProperties {
+    reset: 'monthly' | 'never';
+}
+
+export const usageMetrics: Record<UsageMetric, UsageMetricProperties> = {
+    proxy: { reset: 'monthly' },
+    connections: { reset: 'never' },
+    function_executions: { reset: 'monthly' },
+    function_compute_ms: { reset: 'monthly' },
+    records: { reset: 'never' },
+    external_webhooks: { reset: 'monthly' },
+    logs: { reset: 'monthly' }
+};

--- a/packages/account-usage/lib/usage.integration.test.ts
+++ b/packages/account-usage/lib/usage.integration.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getKVStore } from '@nangohq/kvstore';
+
+import { Usage } from './usage.js';
+
+import type { KVStore } from '@nangohq/kvstore';
+
+describe('Usage', () => {
+    let store: KVStore;
+    let usage: Usage;
+
+    beforeAll(async () => {
+        store = await getKVStore();
+        usage = new Usage(store);
+    });
+
+    afterAll(async () => {
+        await store.destroy();
+    });
+
+    beforeEach(async () => {
+        // Clear all usage data before each test
+        for await (const key of store.scan('usage:*')) {
+            await store.delete(key);
+        }
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+    });
+
+    afterEach(() => {
+        vi.clearAllTimers();
+        vi.resetAllMocks();
+        vi.useRealTimers();
+    });
+
+    it('should incr metric', async () => {
+        const accountId = 1;
+        const metric = 'connections';
+
+        const revalidateSpy = vi.spyOn(Usage as any, 'revalidate');
+
+        let res = (await usage.incr({ accountId, metric, delta: 5 })).unwrap();
+        expect(res).toEqual({ accountId, metric, current: 5 });
+
+        res = (await usage.incr({ accountId, metric, delta: -4 })).unwrap();
+        expect(res).toEqual({ accountId, metric, current: 1 });
+        // revalidateAfter hasn't passed yet
+        expect(revalidateSpy).not.toHaveBeenCalled();
+
+        // Move time forward by 1 day to pass revalidateAfter
+        vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+
+        res = (await usage.incr({ accountId, metric, delta: 10 })).unwrap();
+        expect(res).toEqual({ accountId, metric, current: 11 });
+        expect(revalidateSpy).toHaveBeenCalledTimes(1);
+    });
+    it('should incr monthly metric', async () => {
+        const accountId = 2;
+        const metric = 'proxy';
+        const res = (await usage.incr({ accountId, metric, delta: 1 })).unwrap();
+        expect(res).toEqual({ accountId, metric, current: 1 });
+    });
+});

--- a/packages/account-usage/lib/usage.ts
+++ b/packages/account-usage/lib/usage.ts
@@ -1,0 +1,78 @@
+import { Err, Ok } from '@nangohq/utils';
+
+import { UsageCache } from './cache.js';
+import { logger } from './logger.js';
+import { usageMetrics } from './metrics.js';
+
+import type { UsageMetric } from './metrics.js';
+import type { KVStore } from '@nangohq/kvstore';
+import type { Result } from '@nangohq/utils';
+
+export interface UsageStatus {
+    accountId: number;
+    metric: UsageMetric;
+    current: number;
+}
+
+interface IUsage {
+    incr(params: { accountId: number; metric: UsageMetric; delta?: number }): Promise<Result<UsageStatus>>;
+}
+
+export class UsageNoOps implements IUsage {
+    public async incr({ accountId, metric, delta = 1 }: { accountId: number; metric: UsageMetric; delta?: number }): Promise<Result<UsageStatus>> {
+        return Promise.resolve(
+            Ok({
+                accountId,
+                metric,
+                current: delta
+            })
+        );
+    }
+}
+
+export class Usage implements IUsage {
+    private cache: UsageCache;
+
+    constructor(store: KVStore) {
+        this.cache = new UsageCache(store);
+    }
+
+    public async incr({ accountId, metric, delta = 1 }: { accountId: number; metric: UsageMetric; delta?: number }): Promise<Result<UsageStatus>> {
+        const now = new Date();
+        const { cacheKey, ttlMs } = Usage.getCacheEntryProps({ accountId, metric, now });
+        const entry = await this.cache.incr(cacheKey, { delta, ttlMs });
+        if (entry.isErr()) {
+            return Err(entry.error);
+        }
+
+        // revalidate if the entry is stale or expired
+        if (entry.value.revalidateAfter && entry.value.revalidateAfter < now.getTime()) {
+            void Usage.revalidate({ accountId, metric });
+        }
+
+        return Ok({
+            accountId,
+            metric,
+            current: entry.value.count
+        });
+    }
+
+    private static getCacheEntryProps({ accountId, metric, now }: { accountId: number; metric: UsageMetric; now: Date }): { cacheKey: string; ttlMs?: number } {
+        const cacheKey = `usage:${accountId}:${metric}`;
+        if (usageMetrics[metric].reset === 'monthly') {
+            // monthly metrics have a YYYY-MM suffix
+            const yyyymm = now.toISOString().slice(0, 7);
+            const untilNextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 1); // first day of next month
+            return {
+                cacheKey: `${cacheKey}:${yyyymm}`,
+                ttlMs: untilNextMonth.getTime() - now.getTime() + 60 * 1000 // add 1 minute buffer
+            };
+        }
+        return { cacheKey };
+    }
+
+    private static async revalidate({ accountId, metric }: { accountId: number; metric: UsageMetric }): Promise<void> {
+        logger.debug(`Revalidating usage for accountId=${accountId} metric=${metric}. Not implemented yet`);
+        return Promise.resolve();
+    }
+}

--- a/packages/account-usage/package.json
+++ b/packages/account-usage/package.json
@@ -18,8 +18,9 @@
         "@nangohq/kvstore": "file:../kvstore",
         "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",
-        "dd-trace": "^5.52.0",
-        "he": "^1.2.0"
+        "dd-trace": "5.52.0",
+        "he": "1.2.0",
+        "zod": "4.0.5"
     },
     "devDependencies": {
         "@nangohq/types": "file:../types",

--- a/packages/account-usage/package.json
+++ b/packages/account-usage/package.json
@@ -17,10 +17,13 @@
         "@nangohq/email": "file:../email",
         "@nangohq/kvstore": "file:../kvstore",
         "@nangohq/shared": "file:../shared",
-        "@nangohq/types": "file:../types",
         "@nangohq/utils": "file:../utils",
         "dd-trace": "^5.52.0",
         "he": "^1.2.0"
+    },
+    "devDependencies": {
+        "@nangohq/types": "file:../types",
+        "vitest": "3.2.4"
     },
     "files": [
         "dist/**/*"

--- a/packages/kvstore/lib/InMemoryStore.ts
+++ b/packages/kvstore/lib/InMemoryStore.ts
@@ -55,6 +55,14 @@ export class InMemoryKVStore implements KVStore {
         return Promise.resolve(this.store.has(key));
     }
 
+    public async expires(key: string, ttlMs: number): Promise<void> {
+        const res = this.store.get(key);
+        if (res) {
+            this.store.set(key, { value: res.value, timestamp: res.timestamp, ttlMs: ttlMs });
+        }
+        return Promise.resolve();
+    }
+
     private isExpired(value: Value): boolean {
         if (value.ttlMs > 0 && value.timestamp + value.ttlMs < Date.now()) {
             return true;

--- a/packages/kvstore/lib/InMemoryStore.unit.test.ts
+++ b/packages/kvstore/lib/InMemoryStore.unit.test.ts
@@ -73,6 +73,15 @@ describe('InMemoryKVStore', () => {
         await store.set('key', 'value');
         await expect(store.exists('key')).resolves.toEqual(true);
     });
+
+    it('should allow setting expiration on a key', async () => {
+        await store.set('key', 'value', { canOverride: true });
+        await store.expires('key', 10);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        const value = await store.get('key');
+        expect(value).toBeNull();
+    });
+
     it('should increment a key', async () => {
         await expect(store.incr('key')).resolves.toEqual(1);
         await expect(store.incr('key')).resolves.toEqual(2);

--- a/packages/kvstore/lib/InMemoryStore.unit.test.ts
+++ b/packages/kvstore/lib/InMemoryStore.unit.test.ts
@@ -74,14 +74,6 @@ describe('InMemoryKVStore', () => {
         await expect(store.exists('key')).resolves.toEqual(true);
     });
 
-    it('should allow setting expiration on a key', async () => {
-        await store.set('key', 'value', { canOverride: true });
-        await store.expires('key', 10);
-        await new Promise((resolve) => setTimeout(resolve, 20));
-        const value = await store.get('key');
-        expect(value).toBeNull();
-    });
-
     it('should increment a key', async () => {
         await expect(store.incr('key')).resolves.toEqual(1);
         await expect(store.incr('key')).resolves.toEqual(2);
@@ -103,26 +95,5 @@ describe('InMemoryKVStore', () => {
             keys.push(key);
         }
         expect(keys.sort()).toEqual(['key1', 'key2']);
-    });
-    it('should set/get hash values', async () => {
-        await store.hSetAll('hashKey', { field1: 'value1', field2: 'value2' }, { canOverride: true });
-        const hash = await store.hGetAll('hashKey');
-        expect(hash).toEqual({ field1: 'value1', field2: 'value2' });
-        const field1 = await store.hGet('hashKey', 'field1');
-        expect(field1).toEqual('value1');
-        const field2 = await store.hGet('hashKey', 'field2');
-        expect(field2).toEqual('value2');
-        await store.hSet('hashKey', 'field3', 'value3', { canOverride: true });
-        const field3 = await store.hGet('hashKey', 'field3');
-        expect(field3).toEqual('value3');
-        const nonExistentField = await store.hGet('hashKey', 'nonExistentField');
-        expect(nonExistentField).toBeNull();
-    });
-    it('should increment hash fields', async () => {
-        await expect(store.hIncrBy('hashKey', 'field1', 5)).resolves.toEqual(5);
-        await expect(store.hIncrBy('hashKey', 'field1', 3)).resolves.toEqual(8);
-        await expect(store.hIncrBy('hashKey', 'field2', -2)).resolves.toEqual(-2);
-        const hash = await store.hGetAll('hashKey');
-        expect(hash).toEqual({ field1: '8', field2: '-2' });
     });
 });

--- a/packages/kvstore/lib/KVStore.ts
+++ b/packages/kvstore/lib/KVStore.ts
@@ -4,6 +4,7 @@ export interface KVStore {
     get(key: string): Promise<string | null>;
     delete(key: string): Promise<void>;
     exists(key: string): Promise<boolean>;
+    expires(key: string, ttlMs: number): Promise<void>;
     incr(key: string, opts?: { ttlMs?: number; delta?: number }): Promise<number>;
     scan(pattern: string): AsyncGenerator<string>;
     hSetAll(key: string, value: Record<string, string>, options?: { canOverride?: boolean; ttlMs?: number }): Promise<void>;

--- a/packages/kvstore/lib/KVStore.ts
+++ b/packages/kvstore/lib/KVStore.ts
@@ -4,12 +4,6 @@ export interface KVStore {
     get(key: string): Promise<string | null>;
     delete(key: string): Promise<void>;
     exists(key: string): Promise<boolean>;
-    expires(key: string, ttlMs: number): Promise<void>;
     incr(key: string, opts?: { ttlMs?: number; delta?: number }): Promise<number>;
     scan(pattern: string): AsyncGenerator<string>;
-    hSetAll(key: string, value: Record<string, string>, options?: { canOverride?: boolean; ttlMs?: number }): Promise<void>;
-    hSet(key: string, field: string, value: string, options: { canOverride?: boolean }): Promise<void>;
-    hGetAll(key: string): Promise<Record<string, string> | null>;
-    hGet(key: string, field: string): Promise<string | null>;
-    hIncrBy(key: string, field: string, delta: number): Promise<number>;
 }

--- a/packages/kvstore/lib/RedisStore.integration.test.ts
+++ b/packages/kvstore/lib/RedisStore.integration.test.ts
@@ -89,13 +89,6 @@ describe('RedisKVStore', () => {
         await store.set('key', 'value');
         await expect(store.exists('key')).resolves.toEqual(true);
     });
-    it('should allow setting expiration on a key', async () => {
-        await store.set('key', 'value', { canOverride: true });
-        await store.expires('key', 10);
-        await new Promise((resolve) => setTimeout(resolve, 200));
-        const value = await store.get('key');
-        expect(value).toBeNull();
-    });
 
     it('should increment a key', async () => {
         await expect(store.incr('key')).resolves.toEqual(1);
@@ -118,26 +111,5 @@ describe('RedisKVStore', () => {
             keys.push(key);
         }
         expect(keys.sort()).toEqual(['key1', 'key2']);
-    });
-    it('should set/get hash values', async () => {
-        await store.hSetAll('hashKey', { field1: 'value1', field2: 'value2' }, { canOverride: true });
-        const hash = await store.hGetAll('hashKey');
-        expect(hash).toEqual({ field1: 'value1', field2: 'value2' });
-        const field1 = await store.hGet('hashKey', 'field1');
-        expect(field1).toEqual('value1');
-        const field2 = await store.hGet('hashKey', 'field2');
-        expect(field2).toEqual('value2');
-        await store.hSet('hashKey', 'field3', 'value3', { canOverride: true });
-        const field3 = await store.hGet('hashKey', 'field3');
-        expect(field3).toEqual('value3');
-        const nonExistentField = await store.hGet('hashKey', 'nonExistentField');
-        expect(nonExistentField).toBeNull();
-    });
-    it('should increment hash fields', async () => {
-        await expect(store.hIncrBy('hashKey', 'field1', 5)).resolves.toEqual(5);
-        await expect(store.hIncrBy('hashKey', 'field1', 3)).resolves.toEqual(8);
-        await expect(store.hIncrBy('hashKey', 'field2', -2)).resolves.toEqual(-2);
-        const hash = await store.hGetAll('hashKey');
-        expect(hash).toEqual({ field1: '8', field2: '-2' });
     });
 });

--- a/packages/kvstore/lib/RedisStore.integration.test.ts
+++ b/packages/kvstore/lib/RedisStore.integration.test.ts
@@ -89,6 +89,14 @@ describe('RedisKVStore', () => {
         await store.set('key', 'value');
         await expect(store.exists('key')).resolves.toEqual(true);
     });
+    it('should allow setting expiration on a key', async () => {
+        await store.set('key', 'value', { canOverride: true });
+        await store.expires('key', 10);
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        const value = await store.get('key');
+        expect(value).toBeNull();
+    });
+
     it('should increment a key', async () => {
         await expect(store.incr('key')).resolves.toEqual(1);
         await expect(store.incr('key')).resolves.toEqual(2);

--- a/packages/kvstore/lib/RedisStore.ts
+++ b/packages/kvstore/lib/RedisStore.ts
@@ -40,6 +40,13 @@ export class RedisKVStore implements KVStore {
         await this.client.del(key);
     }
 
+    public async expires(key: string, ttlMs: number): Promise<void> {
+        const res = await this.client.pExpire(key, ttlMs);
+        if (!res) {
+            throw new Error(`expires_failed`);
+        }
+    }
+
     public async incr(key: string, opts?: { ttlMs?: number; delta?: number }): Promise<number> {
         const multi = this.client.multi();
         multi.incrBy(key, opts?.delta || 1);


### PR DESCRIPTION
Adding new usage and cache logic to account-usage package that will power usage capping and reporting.
I am changing the approach and using Redis directly. Since usage is cloud only anyway we can use Redis directly and the `mutli` command for minimum network roundtrip.

This logic is not wired yet. Making a PR to make it more digestible to review

Metric count will be store in Redis and revalidated periodically in the background. The objective is to have quick capping mechanism  since in most case it must be done inline, while treating the data in Redis as cached data that will be revalidated from the source of truth (orb, db) regularly

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Implement Redis-Based Usage Metric Caching and Simplify KVStore Interface**

This PR introduces a new usage tracking and caching subsystem in the `account-usage` package, using Redis for high-performance, atomic storage of usage metrics to support inline usage capping and near real-time reporting. It restructures usage-related logic around Redis, removes unused hash-based operations from the `KVStore` abstraction, and updates all related integration/unit tests, dependencies, and types. The Redis-based cache system allows for periodic background revalidation, relying on Redis as an efficient cache while leaving actual data reconciliation to future out-of-band processes. The new system is not yet enabled in production but lays the foundation for future usage capping and metering features.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced `Usage`, `UsageNoOps`, and `UsageCache` classes in `packages/account-usage/lib/usage.ts` and `packages/account-usage/lib/cache.ts` for encapsulating usage logic and Redis-based caching.
• Directly use Redis's `multi` command for atomic, low-latency increments and TTL handling, bypassing the need for complex KVStore hash operations.
• Added structured types and reset semantics for usage metrics (`UsageMetric`, `usageMetrics`) in `packages/account-usage/lib/metrics.ts`.
• Refactored/simplified `KVStore` by removing all hash-based operations and associated interfaces from `packages/kvstore/lib/KVStore.ts`, `InMemoryStore.ts`, and `RedisStore.ts`.
• Updated and expanded unit/integration tests to validate new cache logic and error handling in usage tracking.
• Revised package dependencies, adding `zod` for schema validation, and moved some dependencies (e.g., `@nangohq/types`, `vitest`) to `devDependencies`.
• Updated `package-lock.json` to reflect dependency changes across the monorepo.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/account-usage/lib/usage.ts`
• `packages/account-usage/lib/cache.ts`
• `packages/account-usage/lib/metrics.ts`
• `packages/kvstore/lib/KVStore.ts`
• `packages/kvstore/lib/InMemoryStore.ts`
• `packages/kvstore/lib/RedisStore.ts`
• `packages/account-usage/package.json`
• `packages/account-usage/lib/usage.integration.test.ts`
• `packages/kvstore/lib/InMemoryStore.unit.test.ts`
• `packages/kvstore/lib/RedisStore.integration.test.ts`
• `package-lock.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*