### PR TITLE
fix: update sync job result on deleteRecordsFromPreviousExecutions

### DIFF
--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -412,8 +412,18 @@ describe('Persist API', () => {
                 { id: '3', name: 'new3' }
             ]);
 
-            // increment the job id to simulate a new sync run
-            seed.syncJob.id += 1;
+            // create another sync job to simulate a new run
+            const newSyncJob = await createSyncJob({
+                sync_id: seed.sync.id,
+                type: SyncJobsType.FULL,
+                status: SyncStatus.RUNNING,
+                job_id: `another-job`,
+                nangoConnection: seed.connection
+            });
+            if (!newSyncJob) {
+                throw new Error('Sync job not created');
+            }
+
             await insertRecords(seed, model, [
                 { id: '3', name: 'new3' },
                 { id: '4', name: 'new4' },
@@ -421,7 +431,7 @@ describe('Persist API', () => {
             ]);
 
             const response = await fetch(
-                `${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/sync/${seed.sync.id}/job/${seed.syncJob.id}/outdated`,
+                `${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/sync/${seed.sync.id}/job/${newSyncJob.id}/outdated`,
                 {
                     method: 'DELETE',
                     body: JSON.stringify({


### PR DESCRIPTION
Deleting records via `nango.deleteRecordsFromPreviousExecutions()` should update the sync job result summary

<!-- Summary by @propel-code-bot -->

---

**Sync Job Result Update on Record Deletion**

This pull request ensures that calls to `nango.deleteRecordsFromPreviousExecutions()` properly update the sync job result summary to reflect the number of records deleted. Changes are focused on the `deleteOutdatedRecords.ts` handler, which now updates the sync job result when outdated records are deleted for a given model, and corresponding integration test logic is improved for accuracy.

<details>
<summary><strong>Key Changes</strong></summary>

• Added import and usage of `updateSyncJobResult` from `@nangohq/shared` in `deleteOutdatedRecords.ts`
• Adjusted ordering to initialize `logCtx` before record deletion
• After deletion, constructed a result update object marking the number of deleted records, and called `updateSyncJobResult`
• Improved the integration test: replaced direct job ID increment with the creation of a new `syncJob` to match realistic scenarios

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts`
• `packages/persist/lib/server.integration.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*