### PR TITLE
chore: track usageV2

### DIFF
--- a/packages/account-usage/lib/index.ts
+++ b/packages/account-usage/lib/index.ts
@@ -1,9 +1,12 @@
-import { getKVStore } from '@nangohq/kvstore';
+import { getKVStore, getRedis } from '@nangohq/kvstore';
 
 import { DbAccountUsageStore } from './accountUsageStore/dbAccountUsageStore.js';
 import { HybridAccountUsageStore } from './accountUsageStore/hybridAccountUsageStore.js';
 import { KvAccountUsageStore } from './accountUsageStore/kvAccountUsageStore.js';
 import { AccountUsageTracker } from './accountUsageTracker.js';
+import { UsageTracker, UsageTrackerNoOps } from './usage.js';
+
+import type { Usage } from './usage.js';
 
 export { AccountUsageTracker } from './accountUsageTracker.js';
 export type { AccountUsageStore } from './accountUsageStore/accountUsageStore.js';
@@ -34,4 +37,14 @@ export async function getAccountUsageTracker(): Promise<AccountUsageTracker> {
 
     usageTracker = await createAccountUsageTracker();
     return usageTracker;
+}
+
+export type { Usage } from './usage.js';
+
+export async function getUsageTracker(redisUrl: string | undefined): Promise<Usage> {
+    if (redisUrl) {
+        const redis = await getRedis(redisUrl);
+        return new UsageTracker(redis);
+    }
+    return new UsageTrackerNoOps();
 }

--- a/packages/account-usage/lib/index.ts
+++ b/packages/account-usage/lib/index.ts
@@ -6,7 +6,7 @@ import { KvAccountUsageStore } from './accountUsageStore/kvAccountUsageStore.js'
 import { AccountUsageTracker } from './accountUsageTracker.js';
 import { UsageTracker, UsageTrackerNoOps } from './usage.js';
 
-import type { Usage } from './usage.js';
+import type { IUsageTracker } from './usage.js';
 
 export { AccountUsageTracker } from './accountUsageTracker.js';
 export type { AccountUsageStore } from './accountUsageStore/accountUsageStore.js';
@@ -39,9 +39,9 @@ export async function getAccountUsageTracker(): Promise<AccountUsageTracker> {
     return usageTracker;
 }
 
-export type { Usage } from './usage.js';
+export type { IUsageTracker as Usage } from './usage.js';
 
-export async function getUsageTracker(redisUrl: string | undefined): Promise<Usage> {
+export async function getUsageTracker(redisUrl: string | undefined): Promise<IUsageTracker> {
     if (redisUrl) {
         const redis = await getRedis(redisUrl);
         return new UsageTracker(redis);

--- a/packages/account-usage/lib/metrics.ts
+++ b/packages/account-usage/lib/metrics.ts
@@ -6,7 +6,7 @@ export const metricFlags: Record<AccountUsageMetric, string> = {
     connections: 'connections_max'
 };
 
-export type UsageMetric = 'proxy' | 'connections' | 'function_executions' | 'function_compute_gbms' | 'records' | 'external_webhooks' | 'logs';
+export type UsageMetric = 'proxy' | 'connections' | 'function_executions' | 'function_compute_gbms' | 'records' | 'external_webhooks' | 'function_logs';
 export interface UsageMetricProperties {
     reset: 'monthly' | 'never';
 }
@@ -18,5 +18,5 @@ export const usageMetrics: Record<UsageMetric, UsageMetricProperties> = {
     function_compute_gbms: { reset: 'monthly' }, // Gigabyte/ms
     records: { reset: 'never' },
     external_webhooks: { reset: 'monthly' },
-    logs: { reset: 'monthly' }
+    function_logs: { reset: 'monthly' }
 };

--- a/packages/account-usage/lib/metrics.ts
+++ b/packages/account-usage/lib/metrics.ts
@@ -6,7 +6,7 @@ export const metricFlags: Record<AccountUsageMetric, string> = {
     connections: 'connections_max'
 };
 
-export type UsageMetric = 'proxy' | 'connections' | 'function_executions' | 'function_compute_ms' | 'records' | 'external_webhooks' | 'logs';
+export type UsageMetric = 'proxy' | 'connections' | 'function_executions' | 'function_compute_gbms' | 'records' | 'external_webhooks' | 'logs';
 export interface UsageMetricProperties {
     reset: 'monthly' | 'never';
 }
@@ -15,7 +15,7 @@ export const usageMetrics: Record<UsageMetric, UsageMetricProperties> = {
     proxy: { reset: 'monthly' },
     connections: { reset: 'never' },
     function_executions: { reset: 'monthly' },
-    function_compute_ms: { reset: 'monthly' },
+    function_compute_gbms: { reset: 'monthly' }, // Gigabyte/ms
     records: { reset: 'never' },
     external_webhooks: { reset: 'monthly' },
     logs: { reset: 'monthly' }

--- a/packages/account-usage/lib/usage.integration.test.ts
+++ b/packages/account-usage/lib/usage.integration.test.ts
@@ -41,7 +41,7 @@ describe('Usage', () => {
             const accountId = 1;
             const metric = 'connections';
             // Manually set an invalid entry in Redis
-            await redis.set(`usage:${accountId}:${metric}`, 'invalid-json');
+            await redis.set(`usageV2:${accountId}:${metric}`, 'invalid-json');
 
             const res = await usageTracker.get({ accountId, metric });
             expect(res.isErr()).toBe(true);

--- a/packages/account-usage/lib/usage.integration.test.ts
+++ b/packages/account-usage/lib/usage.integration.test.ts
@@ -2,11 +2,11 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 
 import { getRedis } from '@nangohq/kvstore';
 
-import { Usage } from './usage.js';
+import { UsageTracker } from './usage.js';
 
 describe('Usage', () => {
     let redis: Awaited<ReturnType<typeof getRedis>>;
-    let usage: Usage;
+    let usageTracker: UsageTracker;
 
     beforeAll(async () => {
         const redisUrl = process.env['NANGO_REDIS_URL'];
@@ -14,7 +14,7 @@ describe('Usage', () => {
             throw new Error('NANGO_REDIS_URL environment variable is not set.');
         }
         redis = await getRedis(redisUrl);
-        usage = new Usage(redis);
+        usageTracker = new UsageTracker(redis);
     });
 
     afterAll(async () => {
@@ -34,7 +34,7 @@ describe('Usage', () => {
 
     describe('get', () => {
         it('should return 0 for a non-existent-yet metric', async () => {
-            const res = (await usage.get({ accountId: 1, metric: 'connections' })).unwrap();
+            const res = (await usageTracker.get({ accountId: 1, metric: 'connections' })).unwrap();
             expect(res).toEqual({ accountId: 1, metric: 'connections', current: 0 });
         });
         it('should return an error if entry is invalid', async () => {
@@ -43,7 +43,7 @@ describe('Usage', () => {
             // Manually set an invalid entry in Redis
             await redis.set(`usage:${accountId}:${metric}`, 'invalid-json');
 
-            const res = await usage.get({ accountId, metric });
+            const res = await usageTracker.get({ accountId, metric });
             expect(res.isErr()).toBe(true);
             if (res.isErr()) {
                 expect(res.error.message).toBe('cache_get_error');
@@ -52,8 +52,8 @@ describe('Usage', () => {
         it('should return the current value for an existing metric', async () => {
             const accountId = 1;
             const metric = 'connections';
-            await usage.incr({ accountId, metric, delta: 5 });
-            const res = (await usage.get({ accountId, metric })).unwrap();
+            await usageTracker.incr({ accountId, metric, delta: 5 });
+            const res = (await usageTracker.get({ accountId, metric })).unwrap();
             expect(res).toEqual({ accountId, metric, current: 5 });
         });
     });
@@ -62,12 +62,12 @@ describe('Usage', () => {
         const accountId = 1;
         const metric = 'connections';
 
-        const revalidateSpy = vi.spyOn(Usage as any, 'revalidate');
+        const revalidateSpy = vi.spyOn(UsageTracker as any, 'revalidate');
 
-        let res = (await usage.incr({ accountId, metric, delta: 5 })).unwrap();
+        let res = (await usageTracker.incr({ accountId, metric, delta: 5 })).unwrap();
         expect(res).toEqual({ accountId, metric, current: 5 });
 
-        res = (await usage.incr({ accountId, metric, delta: -4 })).unwrap();
+        res = (await usageTracker.incr({ accountId, metric, delta: -4 })).unwrap();
         expect(res).toEqual({ accountId, metric, current: 1 });
         // revalidateAfter hasn't passed yet
         expect(revalidateSpy).not.toHaveBeenCalled();
@@ -75,14 +75,14 @@ describe('Usage', () => {
         // Move time forward by 1 day to pass revalidateAfter
         vi.advanceTimersByTime(24 * 60 * 60 * 1000);
 
-        res = (await usage.incr({ accountId, metric, delta: 10 })).unwrap();
+        res = (await usageTracker.incr({ accountId, metric, delta: 10 })).unwrap();
         expect(res).toEqual({ accountId, metric, current: 11 });
         expect(revalidateSpy).toHaveBeenCalledTimes(1);
     });
     it('should incr monthly metric', async () => {
         const accountId = 2;
         const metric = 'proxy';
-        const res = (await usage.incr({ accountId, metric, delta: 1 })).unwrap();
+        const res = (await usageTracker.incr({ accountId, metric, delta: 1 })).unwrap();
         expect(res).toEqual({ accountId, metric, current: 1 });
     });
 });

--- a/packages/account-usage/lib/usage.ts
+++ b/packages/account-usage/lib/usage.ts
@@ -1,4 +1,3 @@
-import { getRedis } from '@nangohq/kvstore';
 import { Err, Ok } from '@nangohq/utils';
 
 import { UsageCache } from './cache.js';
@@ -6,6 +5,7 @@ import { logger } from './logger.js';
 import { usageMetrics } from './metrics.js';
 
 import type { UsageMetric } from './metrics.js';
+import type { getRedis } from '@nangohq/kvstore';
 import type { Result } from '@nangohq/utils';
 
 export interface UsageStatus {
@@ -14,7 +14,7 @@ export interface UsageStatus {
     current: number;
 }
 
-interface Usage {
+export interface Usage {
     get(params: { accountId: number; metric: UsageMetric }): Promise<Result<UsageStatus>>;
     incr(params: { accountId: number; metric: UsageMetric; delta?: number }): Promise<Result<UsageStatus>>;
 }
@@ -100,12 +100,4 @@ export class UsageTracker implements Usage {
         logger.debug(`Revalidating usage for accountId=${accountId} metric=${metric}. Not implemented yet`);
         return Promise.resolve();
     }
-}
-
-export async function getUsageTracker(redisUrl: string | undefined): Promise<Usage> {
-    if (redisUrl) {
-        const redis = await getRedis(redisUrl);
-        return new UsageTracker(redis);
-    }
-    return new UsageTrackerNoOps();
 }

--- a/packages/account-usage/lib/usage.ts
+++ b/packages/account-usage/lib/usage.ts
@@ -14,12 +14,12 @@ export interface UsageStatus {
     current: number;
 }
 
-export interface Usage {
+export interface IUsageTracker {
     get(params: { accountId: number; metric: UsageMetric }): Promise<Result<UsageStatus>>;
     incr(params: { accountId: number; metric: UsageMetric; delta?: number }): Promise<Result<UsageStatus>>;
 }
 
-export class UsageTrackerNoOps implements Usage {
+export class UsageTrackerNoOps implements IUsageTracker {
     public async get({ accountId, metric }: { accountId: number; metric: UsageMetric }): Promise<Result<UsageStatus>> {
         return Promise.resolve(
             Ok({
@@ -41,7 +41,7 @@ export class UsageTrackerNoOps implements Usage {
     }
 }
 
-export class UsageTracker implements Usage {
+export class UsageTracker implements IUsageTracker {
     private cache: UsageCache;
 
     constructor(redis: Awaited<ReturnType<typeof getRedis>>) {

--- a/packages/account-usage/lib/usage.ts
+++ b/packages/account-usage/lib/usage.ts
@@ -14,12 +14,12 @@ export interface UsageStatus {
     current: number;
 }
 
-interface IUsage {
+interface Usage {
     get(params: { accountId: number; metric: UsageMetric }): Promise<Result<UsageStatus>>;
     incr(params: { accountId: number; metric: UsageMetric; delta?: number }): Promise<Result<UsageStatus>>;
 }
 
-export class UsageNoOps implements IUsage {
+export class UsageTrackerNoOps implements Usage {
     public async get({ accountId, metric }: { accountId: number; metric: UsageMetric }): Promise<Result<UsageStatus>> {
         return Promise.resolve(
             Ok({
@@ -41,7 +41,7 @@ export class UsageNoOps implements IUsage {
     }
 }
 
-export class Usage implements IUsage {
+export class UsageTracker implements Usage {
     private cache: UsageCache;
 
     constructor(redis: Awaited<ReturnType<typeof getRedis>>) {
@@ -50,7 +50,7 @@ export class Usage implements IUsage {
 
     public async get({ accountId, metric }: { accountId: number; metric: UsageMetric }): Promise<Result<UsageStatus>> {
         const now = new Date();
-        const { cacheKey } = Usage.getCacheEntryProps({ accountId, metric, now });
+        const { cacheKey } = UsageTracker.getCacheEntryProps({ accountId, metric, now });
         const entry = await this.cache.get(cacheKey);
         if (entry.isErr()) {
             return Err(entry.error);
@@ -64,7 +64,7 @@ export class Usage implements IUsage {
 
     public async incr({ accountId, metric, delta = 1 }: { accountId: number; metric: UsageMetric; delta?: number }): Promise<Result<UsageStatus>> {
         const now = new Date();
-        const { cacheKey, ttlMs } = Usage.getCacheEntryProps({ accountId, metric, now });
+        const { cacheKey, ttlMs } = UsageTracker.getCacheEntryProps({ accountId, metric, now });
         const entry = await this.cache.incr(cacheKey, { delta, ttlMs });
         if (entry.isErr()) {
             return Err(entry.error);
@@ -72,7 +72,7 @@ export class Usage implements IUsage {
 
         // revalidate if the entry is stale or expired
         if (entry.value.revalidateAfter && entry.value.revalidateAfter < now.getTime()) {
-            void Usage.revalidate({ accountId, metric });
+            void UsageTracker.revalidate({ accountId, metric });
         }
 
         return Ok({
@@ -83,7 +83,7 @@ export class Usage implements IUsage {
     }
 
     private static getCacheEntryProps({ accountId, metric, now }: { accountId: number; metric: UsageMetric; now: Date }): { cacheKey: string; ttlMs?: number } {
-        const cacheKey = `usage:${accountId}:${metric}`;
+        const cacheKey = `usageV2:${accountId}:${metric}`;
         if (usageMetrics[metric].reset === 'monthly') {
             // monthly metrics have a YYYY-MM suffix
             const yyyymm = now.toISOString().slice(0, 7);
@@ -102,10 +102,10 @@ export class Usage implements IUsage {
     }
 }
 
-export async function getUsage(redisUrl: string | undefined): Promise<IUsage> {
+export async function getUsageTracker(redisUrl: string | undefined): Promise<Usage> {
     if (redisUrl) {
         const redis = await getRedis(redisUrl);
-        return new Usage(redis);
+        return new UsageTracker(redis);
     }
-    return new UsageNoOps();
+    return new UsageTrackerNoOps();
 }

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -314,6 +314,22 @@ export async function handleSyncSuccess({
                 deletedKeys = res.value;
                 void logCtx.info(`${model}: "track_deletes" post deleted ${deletedKeys.length} records`);
             }
+            if (deletedKeys.length > 0) {
+                void pubsub.publisher.publish({
+                    subject: 'usage',
+                    type: 'usage.records',
+                    payload: {
+                        value: -deletedKeys.length,
+                        properties: {
+                            accountId: nangoProps.team.id,
+                            environmentId: nangoProps.environmentId,
+                            connectionId: nangoProps.nangoConnectionId,
+                            syncId: nangoProps.syncId,
+                            model
+                        }
+                    }
+                });
+            }
 
             const updatedResults: Record<string, SyncResult> = {
                 [model]: {

--- a/packages/metering/lib/app.ts
+++ b/packages/metering/lib/app.ts
@@ -1,6 +1,7 @@
 import './tracer.js';
 import * as cron from 'node-cron';
 
+import { getUsageTracker } from '@nangohq/account-usage';
 import { billing } from '@nangohq/billing';
 import { DefaultTransport } from '@nangohq/pubsub';
 import { initSentry, once, report } from '@nangohq/utils';
@@ -34,8 +35,11 @@ try {
         process.exit(1);
     }
 
+    // Usage
+    const usageTracker = await getUsageTracker(envs.NANGO_REDIS_URL);
+
     // Billing processor
-    const billingProc = new BillingProcessor(pubsubTransport);
+    const billingProc = new BillingProcessor(pubsubTransport, usageTracker);
     billingProc.start();
 
     // Team processor

--- a/packages/metering/lib/processors/billing.ts
+++ b/packages/metering/lib/processors/billing.ts
@@ -130,7 +130,7 @@ export class BillingProcessor {
                     }
                     const incrCompute = await this.usageTracker.incr({
                         accountId: event.payload.properties.accountId,
-                        metric: 'function_compute_ms',
+                        metric: 'function_compute_gbms',
                         delta: compute
                     });
                     if (incrCompute.isErr()) {

--- a/packages/metering/lib/processors/billing.ts
+++ b/packages/metering/lib/processors/billing.ts
@@ -7,6 +7,7 @@ import { Err, Ok, metrics, report, stringifyError } from '@nangohq/utils';
 
 import { logger } from '../utils.js';
 
+import type { Usage } from '@nangohq/account-usage';
 import type { Transport, UsageEvent } from '@nangohq/pubsub';
 import type { AccountUsageMetric } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
@@ -15,9 +16,11 @@ const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
 export class BillingProcessor {
     private subscriber: Subscriber;
+    private usageTracker: Usage;
 
-    constructor(transport: Transport) {
+    constructor(transport: Transport, usageTracker: Usage) {
         this.subscriber = new Subscriber(transport);
+        this.usageTracker = usageTracker;
     }
 
     public start(): void {
@@ -27,7 +30,7 @@ export class BillingProcessor {
             consumerGroup: 'billing',
             subject: 'usage',
             callback: async (event) => {
-                const result = await process(event);
+                const result = await this.process(event);
                 if (result.isErr()) {
                     report(new Error(`Failed to process billing event: ${result.error}`), { event });
                     return;
@@ -35,139 +38,227 @@ export class BillingProcessor {
             }
         });
     }
-}
 
-async function process(event: UsageEvent): Promise<Result<void>> {
-    try {
-        switch (event.type) {
-            case 'usage.monthly_active_records': {
-                const { connectionId } = event.payload.properties;
-                const connection = await connectionService.getConnectionById(connectionId);
-                if (!connection) {
-                    return Err(`Connection ${connectionId} not found`);
-                }
-                if (connection.created_at > new Date(Date.now() - 30 * DAY_IN_MS)) {
-                    return Ok(undefined); // Skip MAR for connections younger than 30 days
-                }
-                const mar = event.payload.value;
-                metrics.increment(metrics.Types.BILLED_RECORDS_COUNT, mar, { accountId: event.payload.properties.accountId });
-                await trackUsage({
-                    accountId: event.payload.properties.accountId,
-                    metric: 'active_records',
-                    delta: mar
-                });
+    public async process(event: UsageEvent): Promise<Result<void>> {
+        try {
+            switch (event.type) {
+                case 'usage.monthly_active_records': {
+                    const { connectionId } = event.payload.properties;
+                    const connection = await connectionService.getConnectionById(connectionId);
+                    if (!connection) {
+                        return Err(`Connection ${connectionId} not found`);
+                    }
+                    if (connection.created_at > new Date(Date.now() - 30 * DAY_IN_MS)) {
+                        return Ok(undefined); // Skip MAR for connections younger than 30 days
+                    }
+                    const mar = event.payload.value;
+                    metrics.increment(metrics.Types.BILLED_RECORDS_COUNT, mar, { accountId: event.payload.properties.accountId });
+                    await trackUsage({
+                        accountId: event.payload.properties.accountId,
+                        metric: 'active_records',
+                        delta: mar
+                    });
 
-                return billing.add([
-                    {
-                        type: 'monthly_active_records',
-                        properties: {
-                            count: mar,
-                            idempotencyKey: event.idempotencyKey,
-                            timestamp: event.createdAt,
-                            ...event.payload.properties
-                        }
-                    }
-                ]);
-            }
-            case 'usage.actions': {
-                await trackUsage({
-                    accountId: event.payload.properties.accountId,
-                    metric: 'actions',
-                    delta: event.payload.value
-                });
-                return billing.add([
-                    {
-                        type: 'billable_actions',
-                        properties: {
-                            count: event.payload.value,
-                            idempotencyKey: event.idempotencyKey,
-                            timestamp: event.createdAt,
-                            ...event.payload.properties
-                        }
-                    }
-                ]);
-            }
-            case 'usage.connections': {
-                await trackUsage({
-                    accountId: event.payload.properties.accountId,
-                    metric: 'connections',
-                    delta: event.payload.value
-                });
-                // No billing action for connections, just tracking usage
-                return Ok(undefined);
-            }
-            case 'usage.function_executions': {
-                const { telemetryBag, frequencyMs, success, ...rest } = event.payload.properties;
-                billing.add([
-                    {
-                        type: 'function_executions',
-                        properties: {
-                            count: event.payload.value,
-                            idempotencyKey: event.idempotencyKey,
-                            timestamp: event.createdAt,
-                            telemetry: {
-                                successes: success ? event.payload.value : 0,
-                                failures: success ? 0 : event.payload.value,
-                                durationMs: telemetryBag?.durationMs ?? 0,
-                                compute: telemetryBag ? telemetryBag?.durationMs * telemetryBag?.memoryGb : 0,
-                                customLogs: telemetryBag?.customLogs ?? 0,
-                                proxyCalls: telemetryBag?.proxyCalls ?? 0
-                            },
-                            ...rest,
-                            ...(frequencyMs ? { frequencyMs } : {})
-                        }
-                    }
-                ]);
-                return Ok(undefined);
-            }
-            case 'usage.proxy': {
-                const { success, ...rest } = event.payload.properties;
-                billing.add([
-                    {
-                        type: 'proxy',
-                        properties: {
-                            count: event.payload.value,
-                            idempotencyKey: event.idempotencyKey,
-                            timestamp: event.createdAt,
-                            ...rest,
-                            telemetry: {
-                                successes: success ? event.payload.value : 0,
-                                failures: success ? 0 : event.payload.value
+                    return billing.add([
+                        {
+                            type: 'monthly_active_records',
+                            properties: {
+                                count: mar,
+                                idempotencyKey: event.idempotencyKey,
+                                timestamp: event.createdAt,
+                                ...event.payload.properties
                             }
                         }
+                    ]);
+                }
+                case 'usage.records': {
+                    const incrRecords = await this.usageTracker.incr({
+                        accountId: event.payload.properties.accountId,
+                        metric: 'records',
+                        delta: event.payload.value
+                    });
+                    if (incrRecords.isErr()) {
+                        logger.error(`Failed to increment records for account ${event.payload.properties.accountId}: ${incrRecords.error}`);
                     }
-                ]);
-                return Ok(undefined);
-            }
-            case 'usage.webhook_forward': {
-                const { success, ...rest } = event.payload.properties;
-                billing.add([
-                    {
-                        type: 'webhook_forwards',
-                        properties: {
-                            count: event.payload.value,
-                            idempotencyKey: event.idempotencyKey,
-                            timestamp: event.createdAt,
-                            ...rest,
-                            telemetry: {
-                                successes: success ? event.payload.value : 0,
-                                failures: success ? 0 : event.payload.value
+                    return Ok(undefined); // No billing action for records, just tracking usage
+                }
+                case 'usage.actions': {
+                    await trackUsage({
+                        accountId: event.payload.properties.accountId,
+                        metric: 'actions',
+                        delta: event.payload.value
+                    });
+                    return billing.add([
+                        {
+                            type: 'billable_actions',
+                            properties: {
+                                count: event.payload.value,
+                                idempotencyKey: event.idempotencyKey,
+                                timestamp: event.createdAt,
+                                ...event.payload.properties
                             }
                         }
+                    ]);
+                }
+                case 'usage.connections': {
+                    await trackUsage({
+                        accountId: event.payload.properties.accountId,
+                        metric: 'connections',
+                        delta: event.payload.value
+                    });
+                    await this.usageTracker.incr({
+                        accountId: event.payload.properties.accountId,
+                        metric: 'connections',
+                        delta: event.payload.value
+                    });
+                    // No billing action for connections, just tracking usage
+                    return Ok(undefined);
+                }
+                case 'usage.function_executions': {
+                    const { accountId, type, telemetryBag, frequencyMs, success, ...rest } = event.payload.properties;
+                    const compute = telemetryBag ? telemetryBag.durationMs * telemetryBag.memoryGb : 0;
+                    const customLogs = telemetryBag?.customLogs ?? 0;
+
+                    // Usage tracking
+                    const incrExecutions = await this.usageTracker.incr({
+                        accountId: event.payload.properties.accountId,
+                        metric: 'function_executions',
+                        delta: event.payload.value
+                    });
+                    if (incrExecutions.isErr()) {
+                        logger.error(`Failed to increment function_executions for account ${event.payload.properties.accountId}: ${incrExecutions.error}`);
                     }
-                ]);
-                return Ok(undefined);
+                    const incrCompute = await this.usageTracker.incr({
+                        accountId: event.payload.properties.accountId,
+                        metric: 'function_compute_ms',
+                        delta: compute
+                    });
+                    if (incrCompute.isErr()) {
+                        logger.error(`Failed to increment function_compute_ms for account ${event.payload.properties.accountId}: ${incrCompute.error}`);
+                    }
+                    const incrLogs = await this.usageTracker.incr({
+                        accountId: event.payload.properties.accountId,
+                        metric: 'logs',
+                        delta: customLogs
+                    });
+                    if (incrLogs.isErr()) {
+                        logger.error(`Failed to increment logs for account ${event.payload.properties.accountId}: ${incrLogs.error}`);
+                    }
+                    if (type === 'webhook') {
+                        const incrWebhook = await this.usageTracker.incr({
+                            accountId: event.payload.properties.accountId,
+                            metric: 'external_webhooks',
+                            delta: event.payload.value
+                        });
+                        if (incrWebhook.isErr()) {
+                            logger.error(`Failed to increment external_webhooks for account ${event.payload.properties.accountId}: ${incrWebhook.error}`);
+                        }
+                    }
+
+                    // Billing
+                    billing.add([
+                        {
+                            type: 'function_executions',
+                            properties: {
+                                accountId,
+                                type,
+                                count: event.payload.value,
+                                idempotencyKey: event.idempotencyKey,
+                                timestamp: event.createdAt,
+                                telemetry: {
+                                    successes: success ? event.payload.value : 0,
+                                    failures: success ? 0 : event.payload.value,
+                                    durationMs: telemetryBag?.durationMs ?? 0,
+                                    compute,
+                                    customLogs,
+                                    proxyCalls: telemetryBag?.proxyCalls ?? 0
+                                },
+                                ...rest,
+                                ...(frequencyMs ? { frequencyMs } : {})
+                            }
+                        }
+                    ]);
+
+                    //Datadog
+                    const durationMs = telemetryBag?.durationMs || 0;
+                    // Bucket frequency into:
+                    // - ultra (<5 mins)
+                    // - fast (>=5 mins, <1h)
+                    // - medium (>= 1h, <12h)
+                    // - slow (>= 12h)
+                    let frequencyBucket = 'none';
+                    if (frequencyMs) {
+                        if (frequencyMs < 5 * 60 * 1000) {
+                            frequencyBucket = 'ultra';
+                        } else if (frequencyMs < 60 * 60 * 1000) {
+                            frequencyBucket = 'fast';
+                        } else if (frequencyMs < 12 * 60 * 60 * 1000) {
+                            frequencyBucket = 'medium';
+                        } else {
+                            frequencyBucket = 'slow';
+                        }
+                    }
+                    metrics.duration(metrics.Types.FUNCTION_EXECUTIONS, durationMs, { type, success: String(success), accountId, frequencyBucket });
+                    return Ok(undefined);
+                }
+                case 'usage.proxy': {
+                    const { success, ...rest } = event.payload.properties;
+                    // Usage tracking
+                    await this.usageTracker.incr({
+                        accountId: event.payload.properties.accountId,
+                        metric: 'proxy',
+                        delta: event.payload.value
+                    });
+                    // Billing
+                    billing.add([
+                        {
+                            type: 'proxy',
+                            properties: {
+                                count: event.payload.value,
+                                idempotencyKey: event.idempotencyKey,
+                                timestamp: event.createdAt,
+                                ...rest,
+                                telemetry: {
+                                    successes: success ? event.payload.value : 0,
+                                    failures: success ? 0 : event.payload.value
+                                }
+                            }
+                        }
+                    ]);
+                    return Ok(undefined);
+                }
+                case 'usage.webhook_forward': {
+                    const { success, ...rest } = event.payload.properties;
+                    // Billing
+                    billing.add([
+                        {
+                            type: 'webhook_forwards',
+                            properties: {
+                                count: event.payload.value,
+                                idempotencyKey: event.idempotencyKey,
+                                timestamp: event.createdAt,
+                                ...rest,
+                                telemetry: {
+                                    successes: success ? event.payload.value : 0,
+                                    failures: success ? 0 : event.payload.value
+                                }
+                            }
+                        }
+                    ]);
+                    return Ok(undefined);
+                }
+                default:
+                    ((_exhaustiveCheck: never) => {
+                        throw new Error(`Unhandled event type: ${JSON.stringify(_exhaustiveCheck)}`);
+                    })(event);
             }
-            default:
-                ((_exhaustiveCheck: never) => {
-                    throw new Error(`Unhandled event type: ${JSON.stringify(_exhaustiveCheck)}`);
-                })(event);
+        } catch (err) {
+            return Err(`Error processing billing event: ${stringifyError(err)}`);
         }
-    } catch (err) {
-        return Err(`Error processing billing event: ${stringifyError(err)}`);
     }
 }
 
+/** @deprecated legacy **/
 async function trackUsage({ accountId, metric, delta }: { accountId: number; metric: AccountUsageMetric; delta: number }): Promise<void> {
     try {
         if (metric !== 'connections') {

--- a/packages/metering/lib/processors/billing.ts
+++ b/packages/metering/lib/processors/billing.ts
@@ -138,7 +138,7 @@ export class BillingProcessor {
                     }
                     const incrLogs = await this.usageTracker.incr({
                         accountId: event.payload.properties.accountId,
-                        metric: 'logs',
+                        metric: 'function_logs',
                         delta: customLogs
                     });
                     if (incrLogs.isErr()) {

--- a/packages/metering/lib/processors/customer-tracking.ts
+++ b/packages/metering/lib/processors/customer-tracking.ts
@@ -1,7 +1,7 @@
 import db from '@nangohq/database';
 import { Subscriber } from '@nangohq/pubsub';
 import { accountService, connectionService, environmentService, productTracking } from '@nangohq/shared';
-import { Err, Ok, metrics, report, stringifyError } from '@nangohq/utils';
+import { Err, Ok, report, stringifyError } from '@nangohq/utils';
 
 import { logger } from '../utils.js';
 
@@ -42,29 +42,6 @@ async function process(event: UsageEvent): Promise<Result<void>> {
                     });
                 }
                 // No action for tracking connections
-                return Ok(undefined);
-            }
-            case 'usage.function_executions': {
-                const { type, accountId, success, telemetryBag, frequencyMs } = event.payload.properties;
-                const durationMs = telemetryBag?.durationMs || 0;
-                // Bucket frequency into:
-                // - ultra (<5 mins)
-                // - fast (>=5 mins, <1h)
-                // - medium (>= 1h, <12h)
-                // - slow (>= 12h)
-                let frequencyBucket = 'none';
-                if (frequencyMs) {
-                    if (frequencyMs < 5 * 60 * 1000) {
-                        frequencyBucket = 'ultra';
-                    } else if (frequencyMs < 60 * 60 * 1000) {
-                        frequencyBucket = 'fast';
-                    } else if (frequencyMs < 12 * 60 * 60 * 1000) {
-                        frequencyBucket = 'medium';
-                    } else {
-                        frequencyBucket = 'slow';
-                    }
-                }
-                metrics.duration(metrics.Types.FUNCTION_EXECUTIONS, durationMs, { type, success: String(success), accountId, frequencyBucket });
                 return Ok(undefined);
             }
             default:

--- a/packages/persist/lib/records.ts
+++ b/packages/persist/lib/records.ts
@@ -160,6 +160,15 @@ export async function persistRecords({
             });
         }
 
+        const delta = summary.addedKeys.length - (summary.deletedKeys?.length || 0);
+        if (delta !== 0) {
+            void pubsub.publisher.publish({
+                subject: 'usage',
+                type: 'usage.records',
+                payload: { value: delta, properties: { accountId, environmentId, connectionId, syncId, model } }
+            });
+        }
+
         // Datadog metrics
         let recordsSizeInBytes = 0;
         let modifiedRecordsSizeInBytes = 0;

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts
@@ -5,6 +5,8 @@ import { records } from '@nangohq/records';
 import { updateSyncJobResult } from '@nangohq/shared';
 import { validateRequest } from '@nangohq/utils';
 
+import { pubsub } from '../../../../../../../../../pubsub.js';
+
 import type { AuthLocals } from '../../../../../../../../../middleware/auth.middleware.js';
 import type { ApiError, DeleteOutdatedRecordsSuccess, Endpoint } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, Route, RouteHandler } from '@nangohq/utils';
@@ -53,7 +55,7 @@ const validate = validateRequest<DeleteOutdatedRecords>({
 const handler = async (_req: EndpointRequest, res: EndpointResponse<DeleteOutdatedRecords, AuthLocals>) => {
     const { nangoConnectionId, syncId, syncJobId } = res.locals.parsedParams;
     const { model, activityLogId } = res.locals.parsedBody;
-    const { account } = res.locals;
+    const { account, environment } = res.locals;
     const logCtx = logContextGetter.getStateLess({ id: String(activityLogId), accountId: account.id });
     const result = await records.deleteOutdatedRecords({
         connectionId: nangoConnectionId,
@@ -62,14 +64,31 @@ const handler = async (_req: EndpointRequest, res: EndpointResponse<DeleteOutdat
         model
     });
     if (result.isOk()) {
+        const deleted = result.value.length;
         const syncJobResultUpdate = {
             [model]: {
                 added: 0,
                 updated: 0,
-                deleted: result.value.length
+                deleted
             }
         };
         await updateSyncJobResult(syncJobId, syncJobResultUpdate, model);
+        if (deleted > 0) {
+            void pubsub.publisher.publish({
+                subject: 'usage',
+                type: 'usage.records',
+                payload: {
+                    value: -deleted,
+                    properties: {
+                        accountId: account.id,
+                        environmentId: environment.id,
+                        connectionId: nangoConnectionId,
+                        syncId,
+                        model
+                    }
+                }
+            });
+        }
         void logCtx.info(`Deleted ${result.value.length} outdated records for model ${model}`, { deletedKeys: result.value });
         res.status(200).json({ deletedKeys: result.value });
     } else {

--- a/packages/pubsub/lib/event.ts
+++ b/packages/pubsub/lib/event.ts
@@ -44,6 +44,19 @@ interface UsageEventBase<TType extends string, TPayload extends Serializable> ex
     };
 }
 
+export type UsageRecordsEvent = UsageEventBase<
+    'usage.records',
+    {
+        value: number;
+        properties: {
+            environmentId: number;
+            connectionId: number;
+            syncId: string;
+            model: string;
+        };
+    }
+>;
+
 export type UsageMarEvent = UsageEventBase<
     'usage.monthly_active_records',
     {
@@ -135,5 +148,5 @@ export type UsageWebhookForwardEvent = UsageEventBase<
 
 type EnforceUsageEventBase<T extends UsageEventBase<any, any>> = T;
 export type UsageEvent = EnforceUsageEventBase<
-    UsageMarEvent | UsageActionsEvent | UsageConnectionsEvent | UsageFunctionExecutionsEvent | UsageProxyEvent | UsageWebhookForwardEvent
+    UsageMarEvent | UsageRecordsEvent | UsageActionsEvent | UsageConnectionsEvent | UsageFunctionExecutionsEvent | UsageProxyEvent | UsageWebhookForwardEvent
 >;


### PR DESCRIPTION
Similarly to previous track usage, track usageV2 all happens in metering.

This PR also adds the `usage.records` events that didn't exist before (we were tracking MAR)

There is still not revalidation logic so data in redis will be partial. 
The next step is to implement capping at the entrypoint of each metered featured. 

<!-- Summary by @propel-code-bot -->

---

**Refactor Usage Tracking: Rename Usage to UsageTracker, Introduce usageV2, and Add usage.records Event**

This PR implements a significant refactor and extension of the usage tracking infrastructure in the codebase. The main changes include renaming the `Usage` interface and related classes to `UsageTracker` to resolve ambiguity, introducing a new Redis key schema (`usageV2:`) for separating new usage tracking data from legacy data, and implementing a new event type `usage.records` for more granular and explicit tracking of record insertions and deletions. The usage tracking code has been integrated across relevant subsystems, including persistence operations, job execution, and deletion endpoints, and metric handling has been standardized-e.g., renaming `function_compute_ms` to `function_compute_gbms` and `logs` to `function_logs`.

The `BillingProcessor` has been overhauled to use a dependency-injected `UsageTracker` and now processes usage events in a class method to allow more flexible and comprehensive tracking. The event wiring and behavior for tracking and updating usage have been implemented across the relevant APIs, processors, routes, and job runners. Test suites and utility interfaces have been updated for the new naming and API. All legacy Datadog metrics in `CustomerTrackingProcessor` have been removed for consistency. Revalidation and capping logic for usage remain as planned future work, and the current implementation purposely leaves Redis usage data partial. These changes lay the foundation for granular usage enforcement and analytics, de-risking future metering and capping implementations.

<details>
<summary><strong>Key Changes</strong></summary>

• Renamed all `Usage` interfaces, classes, and references to `UsageTracker` across the codebase.
• Introduced a new Redis key prefix (`usageV2:`) to prevent collision with legacy usage data.
• Added the new event type `usage.records` to `packages/pubsub/lib/event.ts`, emitted on record insertions, deletions, and outdated record removals.
• Refactored `BillingProcessor` to take a dependency-injected `UsageTracker`, moving event processing logic into a class method.
• Standardized metric names: `function_compute_ms` → `function_compute_gbms`, `logs` → `function_logs`.
• Updated metric definitions and usages in `packages/account-usage/lib/metrics.ts` and throughout.
• Wired new usage tracking/event emission into all relevant data mutation paths (e.g., `persistRecords`, sync jobs, record deletions).
• Refactored and updated test code to use `UsageTracker` and exercise the new storage key schema.
• Removed stray legacy Datadog metric calls from `CustomerTrackingProcessor`.
• Updated utility methods and APIs (`getUsageTracker` in `packages/account-usage/lib/index.ts`) to support the new system.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/account-usage/lib/usage.ts` (core rename, Redis key logic)
• `packages/pubsub/lib/event.ts` (new event type definition)
• `packages/persist/lib/records.ts`, `.../deleteOutdatedRecords.ts`, `packages/jobs/lib/execution/sync.ts` (usage event emission for records)
• `packages/metering/lib/processors/billing.ts` (major refactor, logic rewrite)
• `packages/metering/lib/app.ts` (BillingProcessor wiring, usage tracker bootstrap)
• `packages/account-usage/lib/index.ts`, `metrics.ts`, `usage.integration.test.ts` (support for new naming, updated APIs, tests)
• `packages/metering/lib/processors/customer-tracking.ts` (Datadog removal)

</details>

---
*This summary was automatically generated by @propel-code-bot*