### PR TITLE
chore: add usage max columns to plans table

### DIFF
--- a/packages/database/lib/migrations/20251014191600_plans_usagev2_columns.cjs
+++ b/packages/database/lib/migrations/20251014191600_plans_usagev2_columns.cjs
@@ -1,0 +1,31 @@
+exports.config = { transaction: true };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`
+        ALTER TABLE plans
+        ADD COLUMN IF NOT EXISTS proxy_max INTEGER,
+        ADD COLUMN IF NOT EXISTS function_executions_max INTEGER,
+        ADD COLUMN IF NOT EXISTS function_compute_gmbs_max INTEGER,
+        ADD COLUMN IF NOT EXISTS records_max INTEGER,
+        ADD COLUMN IF NOT EXISTS external_webhooks_max INTEGER,
+        ADD COLUMN IF NOT EXISTS function_logs_max INTEGER
+    `);
+
+    // set default values for existing free plans
+    await knex.raw(`
+        UPDATE plans
+        SET
+            proxy_max = 100000,
+            function_executions_max = 100000,
+            function_compute_gmbs_max = 50000000,
+            records_max = 100000,
+            external_webhooks_max = 100000,
+            function_logs_max = 100000
+        WHERE name = 'free'
+    `);
+};
+
+exports.down = async function () {};

--- a/packages/database/lib/migrations/20251014191600_plans_usagev2_columns.cjs
+++ b/packages/database/lib/migrations/20251014191600_plans_usagev2_columns.cjs
@@ -8,7 +8,7 @@ exports.up = async function (knex) {
         ALTER TABLE plans
         ADD COLUMN IF NOT EXISTS proxy_max INTEGER,
         ADD COLUMN IF NOT EXISTS function_executions_max INTEGER,
-        ADD COLUMN IF NOT EXISTS function_compute_gmbs_max INTEGER,
+        ADD COLUMN IF NOT EXISTS function_compute_gbms_max INTEGER,
         ADD COLUMN IF NOT EXISTS records_max INTEGER,
         ADD COLUMN IF NOT EXISTS external_webhooks_max INTEGER,
         ADD COLUMN IF NOT EXISTS function_logs_max INTEGER
@@ -20,7 +20,7 @@ exports.up = async function (knex) {
         SET
             proxy_max = 100000,
             function_executions_max = 100000,
-            function_compute_gmbs_max = 50000000,
+            function_compute_gbms_max = 50000000,
             records_max = 100000,
             external_webhooks_max = 100000,
             function_logs_max = 100000


### PR DESCRIPTION
Values will be used to cap free account
<!-- Summary by @propel-code-bot -->

---

**Add Usage Cap Columns to `plans` Table for Free Account Limits**

This pull request introduces a schema migration that augments the `plans` database table with six new nullable integer columns: `proxy_max`, `function_executions_max`, `function_compute_gbms_max`, `records_max`, `external_webhooks_max`, and `function_logs_max`. The migration also updates all plans named `free` to assign concrete cap values for these new columns, setting the groundwork for resource usage enforcement for free-tier users.

<details>
<summary><strong>Key Changes</strong></summary>

• Added six new nullable integer columns to the `plans` table: `proxy_max`, `function_executions_max`, `function_compute_gbms_max`, `records_max`, `external_webhooks_max`, and `function_logs_max`.
• Populated these columns with fixed caps for rows where `name = 'free'`.
• Created migration file `packages/database/lib/migrations/20251014191600_plans_usagev2_columns.cjs` to implement schema and data updates.
• Corrected a typo in the column name from `function_compute_gmbs_max` to `function_compute_gbms_max` in a follow-up commit.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `plans` table schema
• Database migration logic in `packages/database/lib/migrations/20251014191600_plans_usagev2_columns.cjs`

</details>

---
*This summary was automatically generated by @propel-code-bot*