### PR TITLE
feat(validation): add validation script to other types

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "test:cli": "vitest --config ./vite.cli.config.ts",
         "test:cli:update-snapshots": "vitest --config ./vite.cli.config.ts --update",
         "test:openapi": "npx @apidevtools/swagger-cli validate docs/spec.yaml && npx @redocly/cli lint docs/spec.yaml",
+        "run:runner": "cd ./packages/runner && npm run dev",
         "test:providers": "npx tsx scripts/validation/providers/validate.ts",
         "docs": "tsx scripts/docs-gen-snippets.ts && cd ./docs && npx mintlify dev --port 3033",
         "docs:generate": "tsx scripts/docs-gen-snippets.ts",

--- a/packages/server/lib/utils/web-socket-error.ts
+++ b/packages/server/lib/utils/web-socket-error.ts
@@ -101,6 +101,13 @@ export function InvalidConnectionConfig(url: string, params: string): WSErr {
     };
 }
 
+export function FailedCredentialsCheck(errorMessage: string): WSErr {
+    return {
+        type: 'connection_validation_failed',
+        message: `Error while validating credentials: ${errorMessage}`
+    };
+}
+
 export function UnknownError(errorMessage?: string): WSErr {
     return {
         type: 'unknown_err',


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
OAuth2 and OAuth2_CC didn't have the ability to validate credentials via a script

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Validation Script Support for OAuth2 and OAuth2_CC Connections**

This PR introduces the ability to validate credentials via custom scripts for `OAuth2` and `OAuth2_CC` authentication flows. It does so by integrating calls to the `validateConnection` function at the point of connection creation and connection callback handling in the `OAuthController`, covering several OAuth entrypoints. Validation errors trigger user-facing messages and, for new connections, automatic cleanup of the invalid connection. This also introduces a dedicated web socket error for credential validation failures and adds a utility script command in the root `package.json`.

<details>
<summary><strong>Key Changes</strong></summary>

• Injected `validateConnection` checks into key OAuth connection flows in `packages/server/lib/controllers/oauth.controller.ts` covering OAuth2, OAuth2_CC, and callback flows.
• If custom validation fails, the API responds with specific error messages, logs the result, and deletes invalid connections created in the current operation.
• Added `FailedCredentialsCheck()` utility to `packages/server/lib/utils/web-socket-error.ts` to standardize connection validation error handling.
• Minor update to `package.json` to add `run:runner` script (not strictly related to the validation change).

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/oauth.controller.ts`
• `packages/server/lib/utils/web-socket-error.ts`
• `package.json` (script section)

</details>

---
*This summary was automatically generated by @propel-code-bot*