### PR TITLE
chore: usage widget in dashboard to support usagev2 metrics

### DIFF
--- a/packages/account-usage/lib/capping.ts
+++ b/packages/account-usage/lib/capping.ts
@@ -19,7 +19,7 @@ export interface CappingStatus {
 
 export class Capping {
     constructor(
-        private readonly usageTracker: IUsageTracker,
+        public readonly usageTracker: IUsageTracker,
         private options?: { enabled?: boolean }
     ) {}
 

--- a/packages/server/lib/controllers/v1/plans/usage/getUsage.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getUsage.ts
@@ -1,7 +1,9 @@
 import { getAccountUsageTracker } from '@nangohq/account-usage';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import { envs } from '../../../../env.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { capping } from '../../../../utils/capping.js';
 
 import type { GetUsage } from '@nangohq/types';
 
@@ -18,10 +20,56 @@ export const getUsage = asyncWrapper<GetUsage>(async (req, res) => {
         return;
     }
 
+    if (envs.USAGE_CAPPING_ENABLED) {
+        const usage = await capping.usageTracker.getAll(account.id);
+        if (usage.isErr()) {
+            res.status(500).send({ error: { code: 'generic_error_support', message: usage.error.message } });
+            return;
+        }
+
+        const data = {
+            connections: {
+                label: 'Connections',
+                usage: usage.value.connections.current,
+                limit: plan.connections_max
+            },
+            records: {
+                label: 'Records',
+                usage: usage.value.records.current,
+                limit: plan.records_max
+            },
+            proxy: {
+                label: 'Proxy requests',
+                usage: usage.value.proxy.current,
+                limit: plan.proxy_max
+            },
+            functionExecutions: {
+                label: 'Function Executions',
+                usage: usage.value.function_executions.current,
+                limit: plan.function_executions_max
+            },
+            functionCompute: {
+                label: 'Compute (GB/s)',
+                usage: usage.value.function_compute_gbms.current,
+                limit: plan.function_compute_gbms_max
+            },
+            externalWebhooks: {
+                label: 'External Webhooks',
+                usage: usage.value.external_webhooks.current,
+                limit: plan.external_webhooks_max
+            },
+            functionLogs: {
+                label: 'Function Logs',
+                usage: usage.value.function_logs.current,
+                limit: plan.function_logs_max
+            }
+        };
+
+        res.status(200).send({ data });
+        return;
+    }
+
     const accountUsageTracker = await getAccountUsageTracker();
     const usage = await accountUsageTracker.getAccountMetricsUsageSummary(account, plan);
-
-    res.status(200).send({
-        data: usage
-    });
+    res.status(200).send({ data: usage });
 });

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -1,5 +1,5 @@
 import type { BillingCustomer, BillingUsageMetric } from '../billing/types.js';
-import type { AccountMetricsUsageSummary } from '../usage/dto.js';
+import type { MetricUsageSummary } from '../usage/dto.js';
 import type { ReplaceInObject } from '../utils.js';
 import type { DBPlan } from './db.js';
 import type { Endpoint } from '../api.js';
@@ -61,7 +61,7 @@ export type GetUsage = Endpoint<{
     Path: '/api/v1/plans/usage';
     Querystring: { env: string };
     Success: {
-        data: AccountMetricsUsageSummary;
+        data: Record<string, MetricUsageSummary>; //TODO: clean type
     };
 }>;
 

--- a/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
@@ -29,16 +29,31 @@ function getDaysUntilNextMonth() {
 }
 
 /**
- * Formats multiples of 1000 to k
- * @example 1000 -> 1k
- * @example 2000 -> 2k
+ * Formats multiples of 1000 to K or M
+ * @example 1000 -> 1K
+ * @example 2000 -> 2K
  * @example 2025 -> 2025
+ * @example 1000000 -> 1M
+ * @example 1234000 -> 1234K
  */
 function formatLimit(limit: number) {
+    if (limit >= 1_000_000 && limit % 1_000_000 === 0) {
+        return `${(limit / 1_000_000).toFixed(0)}M`;
+    }
     if (limit >= 1000 && limit % 1000 === 0) {
-        return `${(limit / 1000).toFixed(0)}k`;
+        return `${(limit / 1000).toFixed(0)}K`;
     }
     return limit;
+}
+
+function formatUsage(usage: number) {
+    if (usage >= 1_000_000) {
+        return `${(usage / 1_000_000).toFixed(0)}M`;
+    }
+    if (usage >= 1000) {
+        return `${(usage / 1000).toFixed(0)}K`;
+    }
+    return usage;
 }
 
 export default function UsageCard() {
@@ -81,7 +96,7 @@ export default function UsageCard() {
                                     )}
                                 </div>
                                 <div>
-                                    <span className={cn('text-s font-bold', getColorForUsage(usage.usage, usage.limit))}>{usage.usage}</span>
+                                    <span className={cn('text-s font-bold', getColorForUsage(usage.usage, usage.limit))}>{formatUsage(usage.usage)}</span>
                                     {usage.limit && <span className="text-text-tertiary text-s">/{formatLimit(usage.limit)}</span>}
                                 </div>
                             </div>


### PR DESCRIPTION
Show the new usage metrics in the sidebar widget of the Nango dashboard. 
Currently behind the same capping flag so UI will reflect the new capping has soon as we set it to true. You can enable `USAGE_CAPPING_ENABLED` to test it locally

<!-- Summary by @propel-code-bot -->

---

**Dashboard Usage Widget Updated to Support UsageV2 Metrics**

This PR updates the Nango dashboard's sidebar usage widget and supporting backend components to display data from the new UsageV2 metrics endpoint. The change ensures that, when usage capping is enabled, the UI and APIs provide expanded, more granular usage information, with the widget formatting improved for larger number readability. Server-side, the API for `/api/v1/plans/usage` now conditionally uses UsageV2 metric aggregation and error handling logic, and new usage tracking interfaces are introduced.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `/api/v1/plans/usage` in `packages/server/lib/controllers/v1/plans/usage/getUsage.ts` to return UsageV2 metrics when capping is enabled, using new logic from `capping.usageTracker.getAll()`.
• Extended `IUsageTracker` interface in `packages/account-usage/lib/usage.ts` to add a new `getAll()` method for retrieving all usage metrics at once.
• Implemented `getAll()` in both `UsageTracker` and `UsageTrackerNoOps` to support the new aggregation API, including Redis aggregation on server.
• Changed `usageTracker` property in `Capping` (in `packages/account-usage/lib/capping.ts`) from private to public to allow usage from route handlers.
• Updated API types for `GetUsage` in `packages/types/lib/plans/http.api.ts` to match the new MetricUsageSummary format.
• Improved number formatting in the React `UsageCard` (`packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx`) widget to better display large numbers-e.g., showing 1M for one million, 1K for thousands.
• Adjusted frontend logic to use the new format and usage shape for each metric in the dashboard widget.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/v1/plans/usage/getUsage.ts`
• `packages/account-usage/lib/usage.ts`
• `packages/account-usage/lib/capping.ts`
• `packages/types/lib/plans/http.api.ts`
• `packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*