### PR TITLE
chore: add plan.webhook_forwards_max column

### DIFF
--- a/packages/database/lib/migrations/20251016192800_plans_usagev2_webhook_forward.cjs
+++ b/packages/database/lib/migrations/20251016192800_plans_usagev2_webhook_forward.cjs
@@ -1,0 +1,21 @@
+exports.config = { transaction: true };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`
+        ALTER TABLE plans
+        ADD COLUMN IF NOT EXISTS webhook_forwards_max INTEGER
+    `);
+
+    // set default value for existing free plans
+    await knex.raw(`
+        UPDATE plans
+        SET
+            webhook_forwards_max = 100000
+        WHERE name = 'free'
+    `);
+};
+
+exports.down = async function () {};


### PR DESCRIPTION
I misunderstood one of the capping metric. `external_webhooks` should actually be `webhook_forwards`.
Renaming the column in plan. Next PR will modify the code
