### PR TITLE
chore: dd metric when usage is capped

### DIFF
--- a/packages/account-usage/lib/capping.ts
+++ b/packages/account-usage/lib/capping.ts
@@ -1,3 +1,5 @@
+import { metrics as ddMetrics } from '@nangohq/utils';
+
 import type { UsageMetric } from './metrics.js';
 import type { IUsageTracker } from './usage.js';
 import type { DBPlan } from '@nangohq/types';
@@ -26,7 +28,7 @@ export class Capping {
     public async getStatus(plan: DBPlan | null, ...metrics: UsageMetric[]): Promise<CappingStatus> {
         const status: CappingStatus = { isCapped: false, metrics: {} };
 
-        if (!plan || !this.options?.enabled) {
+        if (!plan) {
             return status;
         }
 
@@ -61,7 +63,20 @@ export class Capping {
             status.message = messages.join(' ') + ' Please upgrade your plan to remove the limits.';
         }
 
-        // TODO: DD metric
+        // Emit a datadog metric if the account is capped on any metric
+        if (status.isCapped) {
+            const dimensions = {
+                accountId: plan.account_id,
+                dryRun: this.options?.enabled ? 'false' : 'true',
+                ...Object.fromEntries(Object.keys(status.metrics).map((key) => [key, 'true']))
+            };
+            ddMetrics.increment(ddMetrics.Types.USAGE_IS_CAPPED, 1, dimensions);
+        }
+
+        // If capping is disabled, always return not capped
+        if (!this.options?.enabled) {
+            return { isCapped: false, metrics: {} };
+        }
 
         return status;
     }

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -95,7 +95,9 @@ export enum Types {
 
     ACTION_CALLED_BY_MCP_SERVER = 'nango.mcp.called.action',
 
-    ORB_BILLING_EVENTS_INGESTED = 'nango.billing.orb.ingested'
+    ORB_BILLING_EVENTS_INGESTED = 'nango.billing.orb.ingested',
+
+    USAGE_IS_CAPPED = 'nango.capping.isCapped'
 }
 
 type Dimensions = Record<string, string | number> | undefined;


### PR DESCRIPTION
Before we enabled the usage/capping v2, the metric will allow us to do a sanity check of who/when customers are capped
After the flag is enabled it would be useful to monitor heavily capped accounts
<!-- Summary by @propel-code-bot -->

---

**Add Datadog Metric Emission for Capped Usage Events**

This pull request introduces logic to emit a Datadog metric when a customer's account is capped on any usage metric. The metric includes relevant dimensions, such as the account ID, capping state, and which usage metrics are capped, to allow for telemetry and monitoring of capped events both before and after the capping feature is enabled. Additionally, the PR defines the new metric type `USAGE_IS_CAPPED` in the central metrics enum.

<details>
<summary><strong>Key Changes</strong></summary>

• Imported `metrics as ddMetrics` from `@nangohq/utils` in `packages/account-usage/lib/capping.ts`
• Emitted `ddMetrics.increment(ddMetrics.Types.USAGE_IS_CAPPED, 1, dimensions)` when usage is capped in `Capping.getStatus()`
• Constructed the `dimensions` object to include `accountId`, `dryRun` state, and a flag for each capped metric
• Added `USAGE_IS_CAPPED` to `Types` enum in `packages/utils/lib/telemetry/metrics.ts`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/account-usage/lib/capping.ts`
• `packages/utils/lib/telemetry/metrics.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*