### PR TITLE
fix(connect-ui): close button alignment on single integration

### DIFF
--- a/packages/connect-ui/src/components/HeaderButtons.tsx
+++ b/packages/connect-ui/src/components/HeaderButtons.tsx
@@ -23,11 +23,11 @@ export const HeaderButtons: React.FC<HeaderButtonsProps> = ({
     const { t } = useI18n();
 
     return (
-        <header {...props} className={cn('flex justify-end', onClickBack && 'justify-between', props.className)}>
+        <header {...props} className={cn('flex justify-end', backLink && 'justify-between', props.className)}>
             {backLink && (
                 <Link to={backLink} onClick={onClickBack}>
                     <Button size={'icon'} title={t('common.back')} variant={'transparent'}>
-                        <ArrowLeft className="w-4 h-4 mr-1" /> {t('common.back')}
+                        <ArrowLeft className="size-4 mr-1" /> {t('common.back')}
                     </Button>
                 </Link>
             )}


### PR DESCRIPTION
On single integration, existing condition would not work to properly align close button.

Before:
<img width="525" height="731" alt="image" src="https://github.com/user-attachments/assets/9f0aaf46-b965-4a8c-bc91-33572e230b4f" />

After:
<img width="519" height="717" alt="image" src="https://github.com/user-attachments/assets/27183313-8f3b-4a76-9396-e25aaddf5df0" />
<!-- Summary by @propel-code-bot -->

---

**Fix Close Button Alignment in Single Integration View (Connect UI)**

This pull request corrects a UI alignment issue for the `close` button in the single integration view of the Connect UI. The update modifies the condition controlling header layout justification in `HeaderButtons.tsx` and standardizes the icon size class, ensuring the `close` button is properly aligned when only a single integration is present.

<details>
<summary><strong>Key Changes</strong></summary>

• Changed header layout justification condition from `onClickBack` to `backLink` in `HeaderButtons.tsx` to improve alignment logic.
• Standardized the arrow icon's size class from `w-4 h-4` to `size-4` for consistency.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/connect-ui/src/components/HeaderButtons.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*