### PR TITLE
fix(webapp): nav bar links should open in new tab

### DIFF
--- a/packages/webapp/src/components-v2/AppHeader.tsx
+++ b/packages/webapp/src/components-v2/AppHeader.tsx
@@ -6,11 +6,11 @@ import { SlackIcon } from '@/assets/SlackIcon';
 export const AppHeader: React.FC = () => {
     return (
         <header className="h-16 px-10 py-2.5 items-center flex justify-end shrink-0 gap-1.5">
-            <ButtonLink to="https://nango.dev/docs" variant="secondary" size="sm">
+            <ButtonLink to="https://nango.dev/docs" target="_blank" variant="secondary" size="sm">
                 <BookOpen />
                 Docs
             </ButtonLink>
-            <ButtonLink to="https://nango.dev/slack" variant="secondary" size="sm">
+            <ButtonLink to="https://nango.dev/slack" target="_blank" variant="secondary" size="sm">
                 <SlackIcon />
                 Help
             </ButtonLink>


### PR DESCRIPTION
<img width="6012" height="3086" alt="image" src="https://github.com/user-attachments/assets/f63aa19b-acb7-4d90-be8b-d1013f3edc6d" />
<!-- Summary by @propel-code-bot -->

---

**Ensure Navbar Links Open in New Tab in `AppHeader.tsx`**

This pull request updates the `AppHeader` component in the web application's navigation bar so that the 'Docs' and 'Help' links now open in a new browser tab. Specifically, it adds the `target="_blank"` attribute to both external `ButtonLink` components directing to external resources.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `target="_blank"` to the `ButtonLink` for `https://nango.dev/docs` in `AppHeader.tsx`
• Added `target="_blank"` to the `ButtonLink` for `https://nango.dev/slack` in `AppHeader.tsx`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/components-v2/AppHeader.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*