### PR TITLE
fix(webapp): spacing in verify email screen

### DIFF
--- a/packages/webapp/src/pages/Account/VerifyEmail.tsx
+++ b/packages/webapp/src/pages/Account/VerifyEmail.tsx
@@ -76,8 +76,8 @@ export function VerifyEmail() {
                     <div className="py-3">
                         <h2 className="mt-4 text-center text-[20px] text-white">Verify your email</h2>
                         {email ? (
-                            <form className="mt-6 space-y-6" onSubmit={resendEmail}>
-                                <span className="text-text-light-gray mb-4 text-[14px]">Check {email} to verify your account and get started.</span>
+                            <form className="mt-6 flex flex-col gap-6" onSubmit={resendEmail}>
+                                <span className="text-text-light-gray text-[14px]">Check {email} to verify your account and get started.</span>
                                 <div className="flex justify-center">
                                     <button className="min-w-8 bg-white flex h-11 justify-center rounded-md border px-4 pt-3 text-[14px] text-black shadow-sm active:ring-2 active:ring-offset-2">
                                         Resend verification email


### PR DESCRIPTION
space-y doesn't seem to work anymore. Using flex is better generally anyway.

Before:
<img width="720" height="453" alt="image" src="https://github.com/user-attachments/assets/329b503f-d42c-41ac-a271-bb7a986d90ae" />

After:
<img width="818" height="531" alt="image" src="https://github.com/user-attachments/assets/40eb6c00-d099-40b4-81cc-5e01007b7ffc" />


<!-- Summary by @propel-code-bot -->

---

**Update Spacing on Verify Email Screen to Use Flex Layout**

This pull request updates the styling for the spacing between elements in the `VerifyEmail` component of the web application. The previous usage of the `space-y-6` utility was not functioning as intended; it has been replaced with a `flex flex-col gap-6` layout for more consistent vertical spacing, aligning with the author's stated intent.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced `className="mt-6 space-y-6"` with `className="mt-6 flex flex-col gap-6"` on the form in `VerifyEmail.tsx`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/pages/Account/VerifyEmail.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*