### PR TITLE
fix(cli): default to nango-integrations if no path provided

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -113,7 +113,7 @@ program
     .action(async function (this: Command) {
         const { debug, ai, copy } = this.opts<GlobalOptions & { ai: string[]; copy: boolean }>();
         const currentPath = process.cwd();
-        const absolutePath = path.resolve(currentPath, this.args[0] || '');
+        const absolutePath = path.resolve(currentPath, this.args[0] || 'nango-integrations');
 
         const setupAI = async (): Promise<void> => {
             const ok = await initAI({ absolutePath, debug, aiOpts: ai });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Issue

> By default, all the files and folders are generated in place, which is painful if you run the command at the root.
It actually overrides .env, tsconfig.json, package.json . 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Default `nango init` Projects to `nango-integrations` Folder**

This pull request modifies the CLI behavior for the `init` command in `packages/cli/lib/index.ts`. The change ensures that if no path argument is specified when running `nango init`, it now defaults to initializing the project in a folder named `nango-integrations`, rather than the current directory.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated the `absolutePath` assignment in the `init` command to use `'nango-integrations'` as the default directory if no path is provided

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/cli/lib/index.ts`
• `init` command logic in the CLI

</details>

---
*This summary was automatically generated by @propel-code-bot*