### PR TITLE
feat(webapp): redesign UsageCard

### DIFF
--- a/packages/server/lib/controllers/v1/plans/usage/getUsage.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getUsage.ts
@@ -33,35 +33,35 @@ export const getUsage = asyncWrapper<GetUsage>(async (req, res) => {
                 usage: usage.value.connections.current,
                 limit: plan.connections_max
             },
-            records: {
-                label: 'Records',
-                usage: usage.value.records.current,
-                limit: plan.records_max
-            },
             proxy: {
-                label: 'Proxy Requests',
+                label: 'Proxy requests',
                 usage: usage.value.proxy.current,
                 limit: plan.proxy_max
             },
-            functionExecutions: {
-                label: 'Function Executions',
-                usage: usage.value.function_executions.current,
-                limit: plan.function_executions_max
-            },
             functionCompute: {
-                label: 'Compute (GB/ms)',
+                label: 'Function time (ms)',
                 usage: usage.value.function_compute_gbms.current,
                 limit: plan.function_compute_gbms_max
             },
-            webhookForwards: {
-                label: 'Webhook Forwards',
-                usage: usage.value.webhook_forwards.current,
-                limit: plan.webhook_forwards_max
+            functionExecutions: {
+                label: 'Function runs',
+                usage: usage.value.function_executions.current,
+                limit: plan.function_executions_max
             },
             functionLogs: {
-                label: 'Function Logs',
+                label: 'Function logs',
                 usage: usage.value.function_logs.current,
                 limit: plan.function_logs_max
+            },
+            records: {
+                label: 'Sync records',
+                usage: usage.value.records.current,
+                limit: plan.records_max
+            },
+            webhookForwards: {
+                label: 'Webhook forwarding',
+                usage: usage.value.webhook_forwards.current,
+                limit: plan.webhook_forwards_max
             }
         };
 

--- a/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
@@ -40,7 +40,7 @@ export default function UsageCard() {
     return (
         <Link
             to={`/${env}/team/billing#usage`}
-            className="group/usage-card flex flex-col gap-4.5 px-3 py-3.5 text-xs rounded-sm bg-bg-surface border border-border-muted cursor-pointer hover:bg-bg-elevated hover:border-border-default"
+            className="group/usage-card flex flex-col gap-4.5 px-3 py-3.5 text-xs rounded-sm bg-bg-surface border-[0.5px] border-border-muted cursor-pointer hover:bg-bg-elevated hover:border-border-default"
         >
             {isLoading ? (
                 <>

--- a/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
@@ -40,7 +40,7 @@ export default function UsageCard() {
     return (
         <Link
             to={`/${env}/team/billing#usage`}
-            className="group flex flex-col gap-4.5 px-3 py-3.5 text-xs rounded-sm bg-bg-surface border border-border-muted cursor-pointer hover:bg-bg-elevated hover:border-border-default"
+            className="group/usage-card flex flex-col gap-4.5 px-3 py-3.5 text-xs rounded-sm bg-bg-surface border border-border-muted cursor-pointer hover:bg-bg-elevated hover:border-border-default"
         >
             {isLoading ? (
                 <>
@@ -64,7 +64,7 @@ export default function UsageCard() {
 
 function getStylesForUsage(usage: number, limit: number | null) {
     if (!limit) {
-        return 'text-text-primary bg-bg-subtle group-hover:bg-bg-surface';
+        return 'text-text-primary bg-bg-subtle group-hover/usage-card:bg-bg-surface';
     }
     if (usage >= limit) {
         return 'text-feedback-error-fg bg-feedback-error-bg';
@@ -72,7 +72,7 @@ function getStylesForUsage(usage: number, limit: number | null) {
     if (usage >= limit * 0.8) {
         return 'text-feedback-warning-fg bg-feedback-warning-bg';
     }
-    return 'text-text-primary bg-bg-subtle group-hover:bg-bg-surface';
+    return 'text-text-primary bg-bg-subtle group-hover/usage-card:bg-bg-surface';
 }
 
 interface UsageBadgeProps {

--- a/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
@@ -40,7 +40,7 @@ export default function UsageCard() {
     return (
         <Link
             to={`/${env}/team/billing#usage`}
-            className="group/usage-card flex flex-col gap-4.5 px-3 py-3.5 text-xs rounded-sm bg-bg-surface border-[0.5px] border-border-muted cursor-pointer hover:bg-bg-elevated hover:border-border-default"
+            className="flex flex-col gap-4.5 px-3 py-3.5 text-xs rounded-sm bg-bg-surface border-[0.5px] border-border-muted cursor-pointer hover:bg-bg-elevated hover:border-transparent"
         >
             {isLoading ? (
                 <>
@@ -64,7 +64,7 @@ export default function UsageCard() {
 
 function getStylesForUsage(usage: number, limit: number | null) {
     if (!limit) {
-        return 'text-text-primary bg-bg-subtle group-hover/usage-card:bg-bg-surface';
+        return 'text-text-primary bg-bg-subtle';
     }
     if (usage >= limit) {
         return 'text-feedback-error-fg bg-feedback-error-bg';
@@ -72,7 +72,7 @@ function getStylesForUsage(usage: number, limit: number | null) {
     if (usage >= limit * 0.8) {
         return 'text-feedback-warning-fg bg-feedback-warning-bg';
     }
-    return 'text-text-primary bg-bg-subtle group-hover/usage-card:bg-bg-surface';
+    return 'text-text-primary bg-bg-subtle';
 }
 
 interface UsageBadgeProps {

--- a/packages/webapp/src/components-v2/AppSidebar/index.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/index.tsx
@@ -17,7 +17,6 @@ import {
     SidebarMenuButton,
     SidebarMenuItem
 } from '../ui/sidebar';
-import { useEnvironment } from '@/hooks/useEnvironment';
 import { useMeta } from '@/hooks/useMeta';
 import { apiPatchUser } from '@/hooks/useUser';
 import { useStore } from '@/store';
@@ -33,7 +32,6 @@ interface SidebarItem {
 
 export const AppSidebar: React.FC = () => {
     const env = useStore((state) => state.env);
-    const { plan } = useEnvironment(env);
     const { meta, mutate: mutateMeta } = useMeta();
     const showGettingStarted = useStore((state) => state.showGettingStarted);
 
@@ -89,11 +87,9 @@ export const AppSidebar: React.FC = () => {
                 </SidebarGroup>
             </SidebarContent>
             <SidebarFooter className="p-0">
-                {plan?.name === 'free' && (
-                    <div className="px-3 mb-8">
-                        <UsageCard />
-                    </div>
-                )}
+                <div className="px-3 mb-8">
+                    <UsageCard />
+                </div>
                 <ProfileDropdown />
             </SidebarFooter>
         </Sidebar>

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -179,12 +179,14 @@
     --color-code-orange: #f09745;
     --color-code-yellow: #f7c752;
 
-    --text-xs: 11px;
-    --text-xs--line-height: 16px;
+    --text-xs: 10px;
+    --text-xs--line-height: 12px;
     --text-s: 12px;
     --text-s--line-height: 18px;
     --text-sm: 14px;
-    --text-base: 16px;
+    --text-sm--line-height: 20px;
+    --text-base: 14px;
+    --text-base--line-height: 20px;
     --text-xl: 20px;
     --text-2xl: 24px;
     --text-3xl: 28px;

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -12,7 +12,7 @@ export const TeamBilling: React.FC = () => {
             <Helmet>
                 <title>Billing & usage - Nango</title>
             </Helmet>
-            <h2 className="text-text-primary text-2xl font-bold">Billing & usage</h2>
+            <h2 className="text-text-primary text-2xl font-semibold">Billing & usage</h2>
             <Navigation defaultValue="usage" className="max-w-full">
                 <NavigationList>
                     <NavigationTrigger value={'usage'}>Usage</NavigationTrigger>


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Redesign of `UsageCard` and aligned usage-metric mapping**

This PR modernises the sidebar `UsageCard` UX and aligns usage-metric labels between frontend and backend. The UI is simplified into a single clickable `Link` that navigates directly to `#/team/billing#usage`, introduces a reusable `UsageBadge`, and removes legacy upgrade / tooltip logic. Correspondingly, the server's `getUsage.ts` now returns reordered and relabelled metrics that match the new display. Minor typography variables are updated to fit the tighter card design, and the card is now shown to **all** users, not just those on the free plan.

<details>
<summary><strong>Key Changes</strong></summary>

• Refactored `packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx` into a single `Link`, added `UsageBadge`, deleted obsolete helpers
• Exposed `UsageCard` unconditionally in `packages/webapp/src/components-v2/AppSidebar/index.tsx` (removes `plan` check)
• Re-mapped metric labels/order in `packages/server/lib/controllers/v1/plans/usage/getUsage.ts` (e.g. 'Proxy requests', 'Function time (ms)')
• Adjusted global typography tokens in `packages/webapp/src/index.css` (sizes & line heights)
• Minor heading weight fix in `packages/webapp/src/pages/Team/Billing/Show.tsx`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `webapp` sidebar and billing pages
• `UsageCard` component
• `server` usage controller
• Global CSS token definitions

</details>

---
*This summary was automatically generated by @propel-code-bot*