### PR TITLE
Fix: Replace insecure SHA256 hash with HMAC-SHA256 for webhook signature verification

### DIFF
--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -1038,8 +1038,8 @@ export class Nango {
     public verifyWebhookSignature(signatureInHeader: string, jsonPayload: unknown): boolean {
         return (
             crypto
-                .createHash('sha256')
-                .update(`${this.secretKey}${JSON.stringify(jsonPayload)}`)
+                .createHmac('sha256', this.secretKey)
+                .update(JSON.stringify(jsonPayload))
                 .digest('hex') === signatureInHeader
         );
     }


### PR DESCRIPTION
## Problem
The current webhook signature verification implementation uses a plain SHA256 hash instead of HMAC-SHA256, which is an anti-pattern for cryptographic signature verification.

**Current implementation:**
```typescript
crypto
    .createHash('sha256')
    .update(`${this.secretKey}${JSON.stringify(jsonPayload)}`)
    .digest('hex')
```

## Security Issues

1. **Not using HMAC**: Uses `createHash()` instead of `createHmac()`, which means the secret is concatenated with the message rather than used as a cryptographic key
2. **Vulnerable to length-extension attacks**: Plain SHA256 hashing with concatenated secrets is susceptible to length-extension attacks where an attacker can forge valid signatures without knowing the secret
3. **Non-standard approach**: This pattern is not compatible with standard webhook verification systems (e.g., GitHub, Stripe, Slack, Hatchet) that expect proper HMAC signatures
4. **JSON serialization inconsistency**: While not the primary issue, `JSON.stringify()` output can vary across implementations

## Solution

Replace with proper HMAC-SHA256:

```typescript
crypto
    .createHmac('sha256', this.secretKey)
    .update(JSON.stringify(jsonPayload))
    .digest('hex')
```

## Why HMAC Matters

- **Cryptographically secure**: HMAC uses the secret as a key in a way that's resistant to cryptographic attacks
- **Industry standard**: All major webhook providers (GitHub, Stripe, Slack, Twilio) use HMAC for signature verification
- **Length-extension resistance**: HMAC is specifically designed to prevent length-extension attacks
- **Interoperability**: Makes Nango webhooks compatible with standard webhook validation systems like Hatchet

## Impact

- **Breaking change**: Existing webhook signatures will no longer validate
- **Migration required**: Webhook consumers will need to update their verification logic or regenerate signatures
- **Security improvement**: Significantly improves the security posture of webhook verification

## References

- [[HMAC Wikipedia](https://en.wikipedia.org/wiki/HMAC)](https://en.wikipedia.org/wiki/HMAC)
- [[Length-extension attacks](https://en.wikipedia.org/wiki/Length_extension_attack)](https://en.wikipedia.org/wiki/Length_extension_attack)
- [[OWASP: Using a broken or risky cryptographic algorithm](https://owasp.org/www-community/vulnerabilities/Using_a_broken_or_risky_cryptographic_algorithm)](https://owasp.org/www-community/vulnerabilities/Using_a_broken_or_risky_cryptographic_algorithm)

<!-- Summary by @propel-code-bot -->

---

**Replace Insecure SHA256 with HMAC-SHA256 for Webhook Signature Verification**

This pull request modifies the `verifyWebhookSignature` method in `packages/node-client/lib/index.ts` to enhance webhook security. The implementation now uses `crypto.createHmac('sha256', this.secretKey)` instead of the previous concatenated secret with `crypto.createHash('sha256')`, which was susceptible to length-extension attacks and did not conform to standard webhook verification practices.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced `crypto.createHash('sha256')` with `crypto.createHmac('sha256', this.secretKey)` in the `verifyWebhookSignature` method.
• Dropped the pattern of concatenating the secret key before hashing; now the secret is used as an HMAC key.
• Ensured the resulting HMAC digest is compared to the incoming signature as before.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/node-client/lib/index.ts`
• `verifyWebhookSignature` method

</details>

---
*This summary was automatically generated by @propel-code-bot*