### PR TITLE
feat(integrations): add support for aimfox oauth

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -280,6 +280,7 @@
               "integrations/all/adyen",
               "integrations/all/affinity",
               "integrations/all/aimfox",
+              "integrations/all/aimfox-oauth",
               "integrations/all/aircall",
               "integrations/all/aircall-basic",
               "integrations/all/airtable",

--- a/docs/integrations/all/aimfox-oauth.mdx
+++ b/docs/integrations/all/aimfox-oauth.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Aimfox (OAuth)'
-sidebarTitle: 'Aimfox (OAuth)' 
+sidebarTitle: 'Aimfox (OAuth)'
 description: 'Access the Aimfox (OAuth) API in 2 minutes 💨'
 ---
 

--- a/docs/integrations/all/aimfox-oauth.mdx
+++ b/docs/integrations/all/aimfox-oauth.mdx
@@ -1,0 +1,75 @@
+---
+title: 'Aimfox (OAuth)'
+sidebarTitle: 'Aimfox (OAuth)' 
+description: 'Access the Aimfox (OAuth) API in 2 minutes 💨'
+---
+
+<Tabs>
+  <Tab title="🚀 Quickstart">
+    <Steps>
+      <Step title="Create an integration">
+        In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Aimfox_. Nango doesn't provide a test OAuth app for Aimfox yet. You'll need to reach out to the Aimfox team to help with setting up your OAuth application. After that, make sure to add the OAuth client ID, secret, and scopes in the integration settings in Nango.
+      </Step>
+      <Step title="Authorize Aimfox (OAuth)">
+        Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then log in to Aimfox. Later, you'll let your users do the same directly from your app.
+      </Step>
+      <Step title="Call the Aimfox (OAuth) API">
+        Let's make your first request to the Aimfox (OAuth) API (fetch a list of workspaces). Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+        <Tabs>
+            <Tab title="cURL">
+                ```bash
+                curl "https://api.nango.dev/proxy/v1/workspaces" \
+                  -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+                  -H "Provider-Config-Key: <INTEGRATION-ID>" \
+                  -H "Connection-Id: <CONNECTION-ID>"
+                ```
+            </Tab>
+
+            <Tab title="Node">
+
+            Install Nango's backend SDK with `npm i @nangohq/node`. Then run:
+
+            ```typescript
+            import { Nango } from '@nangohq/node';
+
+            const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+
+            const res = await nango.get({
+                endpoint: '/v1/workspaces',
+                providerConfigKey: '<INTEGRATION-ID>',
+                connectionId: '<CONNECTION-ID>'
+            });
+
+            console.log(JSON.stringify(res.data, null, 2));
+            ```
+            </Tab>
+
+        </Tabs>
+
+        Or fetch credentials dynamically via the [Node SDK](/reference/sdks/node#get-a-connection-with-credentials) or [API](/reference/api/connection/get).
+
+      </Step>
+    </Steps>
+
+    ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+
+    <Tip>
+    Next step: [Embed the auth flow](/getting-started/quickstart/embed-in-your-app) in your app to let your users connect their Aimfox accounts.
+    </Tip>
+  </Tab>
+  <Tab title="🧑‍💻 OAuth app setup">
+    <Note>
+    Aimfox OAuth integration setup requires assistance from the Aimfox team. Please reach out to [Aimfox support](mailto:support@aimfox.com) to help you configure your OAuth application and obtain the necessary client credentials.
+    </Note>
+  </Tab>
+  <Tab title="🚨 API gotchas">
+    - This integration is currently private and the API documentation is not publicly available.
+    - You will need to reach out to the Aimfox team to help with obtaining access to the integration and documentation.
+
+    <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/aimfox-oauth.mdx)</Note>
+  </Tab>
+</Tabs>
+
+<Info>
+    Questions? Join us in the [Slack community](https://nango.dev/slack).
+</Info>

--- a/docs/snippets/generated/aimfox-oauth/PreBuiltTooling.mdx
+++ b/docs/snippets/generated/aimfox-oauth/PreBuiltTooling.mdx
@@ -13,11 +13,11 @@
 <Accordion title="✅ Read & write data">
 | Tools | Status |
 | - | - |
-| Pre-built integrations | ✅ |
+| Pre-built integrations | 🚫 (time to contribute: &lt;48h) |
 | API unification | ✅ |
 | 2-way sync | ✅ |
 | Webhooks from Nango on data modifications | ✅ |
-| Real-time webhooks from 3rd-party API | ✅ |
+| Real-time webhooks from 3rd-party API | 🚫 (time to contribute: &lt;48h) |
 | Proxy requests | ✅ |
 </Accordion>
 <Accordion title="✅ Observability & data quality">
@@ -34,7 +34,7 @@
 | Tools | Status |
 | - | - |
 | Create or customize use-cases | ✅ |
-| Pre-configured pagination | ✅ |
+| Pre-configured pagination | 🚫 (time to contribute: &lt;48h) |
 | Pre-configured rate-limit handling | 🚫 (time to contribute: &lt;48h) |
 | Per-customer configurations | ✅ |
 </Accordion>

--- a/docs/snippets/generated/aimfox-oauth/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/aimfox-oauth/PreBuiltUseCases.mdx
@@ -1,0 +1,5 @@
+## Pre-built integrations
+
+_No pre-built integration yet (time to contribute: &lt;48h)_
+
+<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/platform/functions) independently.</Tip>

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -403,6 +403,24 @@ aimfox:
             example: 123e4567-e89b-12d3-a456-426614174000
             doc_section: '#step-1-generating-your-api-key'
 
+aimfox-oauth:
+    display_name: Aimfox (OAuth)
+    categories:
+        - surveys
+    auth_mode: OAUTH2
+    authorization_url: https://id.aimfox.com/realms/aimfox-prod/protocol/openid-connect/auth
+    token_url: https://id.aimfox.com/realms/aimfox-prod/protocol/openid-connect/token
+    disable_pkce: true
+    authorization_params:
+        response_type: code
+    token_params:
+        grant_type: authorization_code
+    refresh_params:
+        grant_type: refresh_token
+    proxy:
+        base_url: https://api.aimfox.com/api
+    docs: https://nango.dev/docs/integrations/all/aimfox-oauth
+
 aircall:
     display_name: Aircall (OAuth)
     categories:

--- a/packages/webapp/public/images/template-logos/aimfox-oauth.svg
+++ b/packages/webapp/public/images/template-logos/aimfox-oauth.svg
@@ -1,0 +1,1 @@
+aimfox.svg


### PR DESCRIPTION
##  Describe the problem and your solution

- add support for aimfox-oauth

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Support for Aimfox OAuth Integration**

This pull request introduces a new integration for `aimfox-oauth` based on OAuth2 within the provider ecosystem. It covers the full lifecycle for adding a new provider: inclusion in the `providers.yaml` manifest, detailed integration documentation, auto-generated documentation snippets, navigation wiring in `docs.json`, and provider branding.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `aimfox-oauth` configuration block to `packages/providers/providers.yaml` with OAuth2 parameters, endpoints, and metadata.
• Created new provider documentation at `docs/integrations/all/aimfox-oauth.mdx` detailing setup instructions, authentication flow, API usage, and caveats.
• Added pre-built tooling and use-case documentation snippets to `docs/snippets/generated/aimfox-oauth/PreBuiltTooling.mdx` and `PreBuiltUseCases.mdx`.
• Injected the `aimfox-oauth` entry into `docs/docs.json` to make the integration available in documentation navigation.
• Added a provider logo reference file at `packages/webapp/public/images/template-logos/aimfox-oauth.svg` that redirects to the existing `aimfox.svg`.
• Updated `docs/snippets/generated/notion/PreBuiltTooling.mdx` to reflect real-time webhooks from 3rd-party API as available.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/providers/providers.yaml`
• `docs/integrations/all/aimfox-oauth.mdx`
• `docs/snippets/generated/aimfox-oauth/PreBuiltTooling.mdx`
• `docs/snippets/generated/aimfox-oauth/PreBuiltUseCases.mdx`
• `docs/docs.json`
• `docs/snippets/generated/notion/PreBuiltTooling.mdx`
• `packages/webapp/public/images/template-logos/aimfox-oauth.svg`

</details>

---
*This summary was automatically generated by @propel-code-bot*