### PR TITLE
fix(runner): add node selector and toleration

### DIFF
--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -160,6 +160,22 @@ class Kubernetes {
     }
 
     private async createDeployment(node: Node, name: string, namespace: string, runnerUrl: string): Promise<Result<void>> {
+        let noDisruptSpec = {};
+        if (envs.RUNNER_DO_NOT_DISRUPT) {
+            noDisruptSpec = {
+                nodeSelector: {
+                    'nango.dev/lifecycle': 'no-disrupt'
+                },
+                tolerations: [
+                    {
+                        key: 'nango.dev/lifecycle',
+                        operator: 'Equal',
+                        value: 'no-disrupt',
+                        effect: 'NoSchedule'
+                    }
+                ]
+            };
+        }
         const deploymentManifest: k8s.V1Deployment = {
             metadata: {
                 name,
@@ -177,17 +193,7 @@ class Kubernetes {
                         labels: { app: name }
                     },
                     spec: {
-                        nodeSelector: {
-                            'nango.dev/lifecycle': 'no-disrupt'
-                        },
-                        tolerations: [
-                            {
-                                key: 'nango.dev/lifecycle',
-                                operator: 'Equal',
-                                value: 'no-disrupt',
-                                effect: 'NoSchedule'
-                            }
-                        ],
+                        ...noDisruptSpec,
                         containers: [
                             {
                                 name: 'runner',

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -177,6 +177,16 @@ class Kubernetes {
                         labels: { app: name }
                     },
                     spec: {
+                        nodeSelector: {
+                            'nango.dev/used-by': 'runner'
+                        },
+                        tolerations: [
+                            {
+                                key: 'nango.dev/no-disrupt',
+                                operator: 'Exists',
+                                effect: 'NoSchedule'
+                            }
+                        ],
                         containers: [
                             {
                                 name: 'runner',

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -178,12 +178,13 @@ class Kubernetes {
                     },
                     spec: {
                         nodeSelector: {
-                            'nango.dev/used-by': 'runner'
+                            'nango.dev/lifecycle': 'no-disrupt'
                         },
                         tolerations: [
                             {
-                                key: 'nango.dev/no-disrupt',
-                                operator: 'Exists',
+                                key: 'nango.dev/lifecycle',
+                                operator: 'Equal',
+                                value: 'no-disrupt',
                                 effect: 'NoSchedule'
                             }
                         ],


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Kubernetes Node Selector and Toleration to Runner Deployments**

This pull request updates the `createDeployment` logic in `packages/jobs/lib/runner/kubernetes.ts` to add conditional `nodeSelector` and `tolerations` fields for runner pods, based on the `RUNNER_DO_NOT_DISRUPT` environment variable. These fields ensure runner pods are scheduled only on nodes labeled with `nango.dev/lifecycle: no-disrupt` and can tolerate the `nango.dev/lifecycle=no-disrupt:NoSchedule` taint, improving control over pod placement and environment in Kubernetes deployments.

<details>
<summary><strong>Key Changes</strong></summary>

• Added conditional construction of `noDisruptSpec` to contain `nodeSelector` and `tolerations` for runner pods when `envs.RUNNER_DO_NOT_DISRUPT` is set.
• Spread `...noDisruptSpec` into the deployment manifest pod spec to inject node scheduling constraints.
• Modified deployment manifest logic within `createDeployment` to support targeted node scheduling and taint toleration.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/jobs/lib/runner/kubernetes.ts` (runner deployment manifest generation)

</details>

---
*This summary was automatically generated by @propel-code-bot*