### PR TITLE
chore(usage): revalidate connections and records usage metrics in cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31468,6 +31468,7 @@
                 "@nangohq/database": "file:../database",
                 "@nangohq/email": "file:../email",
                 "@nangohq/kvstore": "file:../kvstore",
+                "@nangohq/records": "file:../records",
                 "@nangohq/shared": "file:../shared",
                 "@nangohq/utils": "file:../utils",
                 "dd-trace": "5.52.0",

--- a/packages/account-usage/lib/capping.ts
+++ b/packages/account-usage/lib/capping.ts
@@ -68,7 +68,7 @@ export class Capping {
             const dimensions = {
                 accountId: plan.account_id,
                 dryRun: this.options?.enabled ? 'false' : 'true',
-                ...Object.fromEntries(Object.keys(status.metrics).map((key) => [key, 'true']))
+                ...Object.fromEntries(Object.keys(status.metrics).map((key) => [`metric-${key}`, 'true']))
             };
             ddMetrics.increment(ddMetrics.Types.USAGE_IS_CAPPED, 1, dimensions);
         }

--- a/packages/account-usage/lib/usage.integration.test.ts
+++ b/packages/account-usage/lib/usage.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getRedis } from '@nangohq/kvstore';
+import { Ok } from '@nangohq/utils';
 
 import { UsageTracker } from './usage.js';
 
@@ -63,7 +64,8 @@ describe('Usage', () => {
             const accountId = 1;
             const metric = 'connections';
 
-            const revalidateSpy = vi.spyOn(UsageTracker as any, 'revalidate');
+            const revalidateSpy = vi.spyOn(usageTracker, 'revalidate');
+            revalidateSpy.mockReturnValue(Promise.resolve(Ok(undefined)));
 
             let res = (await usageTracker.incr({ accountId, metric, delta: 5 })).unwrap();
             expect(res).toEqual({ accountId, metric, current: 5 });

--- a/packages/account-usage/package.json
+++ b/packages/account-usage/package.json
@@ -16,6 +16,7 @@
         "@nangohq/database": "file:../database",
         "@nangohq/email": "file:../email",
         "@nangohq/kvstore": "file:../kvstore",
+        "@nangohq/records": "file:../records",
         "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",
         "dd-trace": "5.52.0",

--- a/packages/server/lib/controllers/connection/connectionId/deleteConnection.ts
+++ b/packages/server/lib/controllers/connection/connectionId/deleteConnection.ts
@@ -6,6 +6,7 @@ import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
 import { preConnectionDeletion } from '../../../hooks/connection/on/pre-connection-deletion.js';
+import { pubsub } from '../../../pubsub.js';
 import { slackService } from '../../../services/slack.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../utils/utils.js';
@@ -62,6 +63,20 @@ export const deletePublicConnection = asyncWrapper<DeletePublicConnection>(async
         orchestrator,
         slackService,
         preDeletionHook
+    });
+
+    void pubsub.publisher.publish({
+        subject: 'usage',
+        type: 'usage.connections',
+        payload: {
+            value: -1,
+            properties: {
+                accountId: team.id,
+                connectionId: connection.id,
+                environmentId: connection.environment_id,
+                providerConfigKey: query.provider_config_key
+            }
+        }
     });
 
     res.status(200).send({ success: deleted > 0 });


### PR DESCRIPTION
Revalidating usage metrics that are fetched from the db (records and connections). Revalidation of the metrics stored in orb will come in next PR
<!-- Summary by @propel-code-bot -->

---

**Revalidation Logic for Usage Metrics: Connections and Records**

This PR implements robust revalidation for cached usage metrics pertaining to `connections` and `records`, ensuring that cache state remains consistent with underlying database values, especially after deletions or when metrics become stale. A new `revalidate()` method is introduced in the `UsageTracker`, allowing for both scheduled and explicit cache overwrites directly from the most recent database state with concurrency controls using distributed locks. Calls to this logic are now triggered on key state changes (notably, connection deletion), and the cache infrastructure (`UsageCache`) is upgraded to support overwriting, locking, and improved revalidation timing. The integration also updates related controller logic and expands test coverage to verify correct invalidation, concurrency, and DB sync behaviors.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `revalidate()` method to `UsageTracker` for on-demand and conditional cache re-synchronization from DB.
• Extended `incr()` in `UsageTracker` to accept `forceRevalidation`, ensuring instant sync on decrements and deletions.
• Upgraded `UsageCache` with support for cache overwrites and distributed locking (`tryAcquireLock`) via Redis.
• Refactored `records.metrics()` to support filtering by environment IDs, improving targeted metric queries.
• On connection deletion (REST controllers), a `usage.connections` event with `delta: -1` is published, forcibly revalidating relevant usage metrics.
• Expanded and improved automated and integration tests for cache revalidation, overwrite paths, and error handling.
• Dependency and import map updates, notably adding `@nangohq/records` in affected `package.json` manifests.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/account-usage/lib/usage.ts`
• `packages/account-usage/lib/cache.ts`
• `packages/account-usage/lib/usage.integration.test.ts`
• `packages/account-usage/lib/capping.ts`
• `packages/records/lib/models/records.ts`
• `packages/records/lib/models/records.integration.test.ts`
• `packages/metering/lib/processors/billing.ts`
• `packages/server/lib/controllers/connection/connectionId/deleteConnection.ts`
• `packages/server/lib/controllers/v1/connections/connectionId/deleteConnection.ts`
• `packages/account-usage/package.json`
• `package-lock.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*