### PR TITLE
fix(docs): status not status_code

### DIFF
--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -2074,7 +2074,7 @@ paths:
                                             upstream:
                                                 type: object
                                                 properties:
-                                                    status_code:
+                                                    status:
                                                         type: integer
                                                     headers:
                                                         type: object


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Correct OpenAPI Spec Property: `status` Instead of `status_code`**

This PR updates the OpenAPI specification in `docs/spec.yaml` by renaming a response schema property under the `upstream` object from `status_code` to `status`. The change aligns the documentation with the intended API response structure and ensures consistency between specification and implementation.

<details>
<summary><strong>Key Changes</strong></summary>

• Renamed the `status_code` property to `status` in the `upstream` object's properties within `docs/spec.yaml`.
• Maintained the type for the `status` property as `integer`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs/spec.yaml` (OpenAPI specification)

</details>

---
*This summary was automatically generated by @propel-code-bot*