### PR TITLE
fix(runner): optionally set datadog profiling for runners

### DIFF
--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -414,10 +414,16 @@ class Kubernetes {
             ...(envs.DD_ENV ? [{ name: 'DD_ENV', value: envs.DD_ENV }] : []),
             ...(envs.DD_SITE ? [{ name: 'DD_SITE', value: envs.DD_SITE }] : []),
             ...(envs.DD_TRACE_AGENT_URL ? [{ name: 'DD_TRACE_AGENT_URL', value: envs.DD_TRACE_AGENT_URL }] : []),
+            { name: 'DD_PROFILING_ENABLED', value: String(this.isProfilingEnabled(node)) },
             { name: 'JOBS_SERVICE_URL', value: getJobsUrl() },
             { name: 'PROVIDERS_URL', value: getProvidersUrl() },
             { name: 'PROVIDERS_RELOAD_INTERVAL', value: envs.PROVIDERS_RELOAD_INTERVAL.toString() }
         ];
+    }
+
+    private isProfilingEnabled(node: Node): boolean {
+        const accountId = node.routingId.split('-')[3]; //this index is based on routing id being in the format {stage}-runner-account-{accountId}-{suffix}
+        return accountId ? envs.RUNNER_PROFILED_ACCOUNTS.includes(accountId) : false;
     }
 
     private getResourceLimits(node: Node): { requests: { cpu: string; memory: string }; limits: { cpu: string; memory: string } } {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -121,6 +121,18 @@ export const ENVS = z.object({
         .optional()
         .default('nango_runners'),
     RUNNER_DO_NOT_DISRUPT: z.stringbool().optional().default(true),
+    RUNNER_PROFILED_ACCOUNTS: z
+        .string()
+        .transform((s, ctx) => {
+            try {
+                return JSON.parse(s);
+            } catch {
+                ctx.addIssue(`RUNNER_PROFILED_ACCOUNTS must be a valid JSON array of strings`);
+                return z.NEVER; // tells Zod to stop here and mark parse as failed
+            }
+        })
+        .pipe(z.array(z.string()))
+        .default([]),
     RUNNER_SERVICE_URL: z.url().optional(),
     NANGO_RUNNER_PATH: z.string().optional(),
     RUNNER_OWNER_ID: z.string().optional(),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Optional Datadog Profiling for Runners Based on Configured Accounts**

This PR introduces conditional enabling of Datadog profiling for Kubernetes-based runners. By parsing a new environment variable `RUNNER_PROFILED_ACCOUNTS` (as a JSON array of account IDs), a runner's environment is set to enable Datadog profiling (`DD_PROFILING_ENABLED=true`) only for accounts specified in this list. The implementation adds needed parsing and validation in the environment config and wires this value through to the runner Kubernetes deployment.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `RUNNER_PROFILED_ACCOUNTS` to `packages/utils/lib/environment/parse.ts`, parsing it as a JSON array of strings with validation.
• In `packages/jobs/lib/runner/kubernetes.ts`, added the runner environment variable `DD_PROFILING_ENABLED` based on whether the runner's account ID is listed in `RUNNER_PROFILED_ACCOUNTS`.
• Introduced method `isProfilingEnabled()` to determine per-runner profiling status by parsing `routingId`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/utils/lib/environment/parse.ts`
• `packages/jobs/lib/runner/kubernetes.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*