### PR TITLE
fix(providers): use api_domain as zoho base_url fallback

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -13775,8 +13775,10 @@ zoho:
         access_type: offline
     redirect_uri_metadata:
         - accounts-server
+    token_response_metadata:
+        - api_domain
     proxy:
-        base_url: https://www.zohoapis.${connectionConfig.extension} || ${connectionConfig.accounts-server}
+        base_url: https://www.zohoapis.${connectionConfig.extension} || ${connectionConfig.api_domain}
         paginate:
             type: offset
             response_path: data


### PR DESCRIPTION
## Describe the problem and your solution

- Use `token_response_metadata.api_domain` as zoho base_url fallback

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Zoho Provider: Use `api_domain` as `base_url` Fallback**

This pull request updates the Zoho provider configuration within `packages/providers/providers.yaml` to enhance `base_url` resolution. Specifically, it introduces `token_response_metadata.api_domain` as a fallback option for the Zoho `proxy.base_url`, ensuring correct API endpoint selection if the primary domain extension is unavailable.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `token_response_metadata` section with `api_domain` to the Zoho provider config.
• Changed `proxy.base_url` to use `${connectionConfig.api_domain}` as the fallback, replacing the prior `${connectionConfig.accounts-server}` fallback.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/providers/providers.yaml` (Zoho provider section)

</details>

---
*This summary was automatically generated by @propel-code-bot*