### PR TITLE
feat(webhooks): add support for shopify-api-key webhooks

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -11435,6 +11435,8 @@ shopify-api-key:
                 content-type: application/json
             endpoints:
                 - /admin/api/2024-10/graphql.json?query=%7B__schema%7Btypes%7Bname%2Ckind%2Cfields%7Bname%7D%7D%7D%7D
+    webhook_routing_script: shopifyWebhookRouting
+    webhook_user_defined_secret: true
     docs: https://nango.dev/docs/integrations/all/shopify-api-key
     docs_connect: https://nango.dev/docs/integrations/all/shopify-api-key/connect
     connection_config:

--- a/packages/server/lib/webhook/index.ts
+++ b/packages/server/lib/webhook/index.ts
@@ -19,4 +19,5 @@ export { default as jobdivaWebhookRouting } from './jobdiva-webhook-routing.js';
 export { default as highlevelWebhookRouting } from './highlevel-webhook-routing.js';
 export { default as notionWebhookRouting } from './notion-webhook-routing.js';
 export { default as affinityWebhookRouting } from './affinity-webhook-routing.js';
+export { default as shopifyWebhookRouting } from './shopify-webhook-routing.js';
 export type * from './types.js';

--- a/packages/server/lib/webhook/shopify-webhook-routing.ts
+++ b/packages/server/lib/webhook/shopify-webhook-routing.ts
@@ -1,0 +1,67 @@
+import crypto from 'node:crypto';
+
+import { NangoError } from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
+
+import type { WebhookHandler } from './types.js';
+
+function validateShopifySignature(secret: string, headerSignature: string, rawBody: string): boolean {
+    const calculatedHmac = crypto.createHmac('sha256', secret).update(rawBody, 'utf8').digest('base64');
+
+    return crypto.timingSafeEqual(Buffer.from(calculatedHmac, 'base64'), Buffer.from(headerSignature, 'base64'));
+}
+
+function getHeader(headers: Record<string, any>, headerName: string): string | undefined {
+    const lowerName = headerName.toLowerCase();
+    for (const [key, value] of Object.entries(headers)) {
+        if (key.toLowerCase() === lowerName) {
+            return value as string;
+        }
+    }
+    return undefined;
+}
+
+const route: WebhookHandler = async (nango, headers, body, rawBody) => {
+    // extract Shopify webhook headers (case-insensitive)
+    // https://shopify.dev/docs/apps/build/webhooks#headers
+    // https://shopify.dev/docs/api/webhooks
+    const signature = getHeader(headers, 'x-shopify-hmac-sha256');
+    const topic = getHeader(headers, 'x-shopify-topic');
+    const shopDomain = getHeader(headers, 'x-shopify-shop-domain');
+    const url = new URL(`https://${shopDomain}`);
+    const subdomain = url.hostname.split('.')[0];
+
+    if (!subdomain) {
+        return Err(new NangoError('webhook_missing_shop_domain'));
+    }
+
+    const webhookSecret = nango.integration.custom?.['webhookSecret'];
+
+    if (webhookSecret) {
+        if (!signature) {
+            return Err(new NangoError('webhook_missing_signature'));
+        }
+
+        if (!validateShopifySignature(webhookSecret, signature, rawBody)) {
+            return Err(new NangoError('webhook_invalid_signature'));
+        }
+    }
+
+    const response = await nango.executeScriptForWebhooks({
+        body,
+        webhookTypeValue: topic ?? '',
+        connectionIdentifierValue: subdomain,
+        propName: 'subdomain'
+    });
+
+    const connectionIds = response?.connectionIds || [];
+
+    return Ok({
+        content: { status: 'success' },
+        statusCode: 200,
+        connectionIds,
+        toForward: body
+    });
+};
+
+export default route;


### PR DESCRIPTION
## Describe the problem and your solution

- Add support for `shopify-api-key` webhooks

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add webhook support for `shopify-api-key` integration**

Introduces a dedicated routing script for Shopify API-Key webhooks and extends core webhook execution logic to allow identifier/topic values to be supplied from HTTP headers (needed for Shopify). Provider metadata is updated to wire the new script and enable user-defined secrets. No unrelated code paths modified.

<details>
<summary><strong>Key Changes</strong></summary>

• New file `packages/server/lib/webhook/shopify-webhook-routing.ts` implementing HMAC-SHA256 signature validation, topic extraction (`x-shopify-topic`), and connection identification via store sub-domain.
• Extended `InternalNango.executeScriptForWebhooks()` to accept optional `webhookTypeValue` and `connectionIdentifierValue` parameters and to resolve identifier/topic from either headers or body.
• Registered routing script export in `packages/server/lib/webhook/index.ts`.
• Updated `shopify-api-key` block in `packages/providers/providers.yaml` with `webhook_routing_script: shopifyWebhookRouting` and `webhook_user_defined_secret: true`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/webhook/shopify-webhook-routing.ts`
• `packages/server/lib/webhook/internal-nango.ts`
• `packages/server/lib/webhook/index.ts`
• `packages/providers/providers.yaml`

</details>

---
*This summary was automatically generated by @propel-code-bot*