### PR TITLE
fix(runner): be more explicit with the runner sizing

### DIFF
--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -427,74 +427,18 @@ class Kubernetes {
     }
 
     private getResourceLimits(node: Node): { requests: { cpu: string; memory: string }; limits: { cpu: string; memory: string } } {
-        if (node.cpuMilli >= 8000 && node.memoryMb >= 32000) {
-            return {
-                requests: {
-                    cpu: '4000m',
-                    memory: '16384Mi'
-                },
-                limits: {
-                    cpu: '8000m',
-                    memory: '32768Mi'
-                }
-            };
-        }
-        if (node.cpuMilli >= 4000 && node.memoryMb >= 16000) {
-            return {
-                requests: {
-                    cpu: '4000m',
-                    memory: '8192Mi'
-                },
-                limits: {
-                    cpu: '4000m',
-                    memory: '16384Mi'
-                }
-            };
-        }
-        if (node.cpuMilli >= 4000 && node.memoryMb >= 8000) {
-            return {
-                requests: {
-                    cpu: '2000m',
-                    memory: '4096Mi'
-                },
-                limits: {
-                    cpu: '4000m',
-                    memory: '8192Mi'
-                }
-            };
-        }
-        if (node.cpuMilli > 2000 || node.memoryMb >= 4000) {
-            return {
-                requests: {
-                    cpu: '1000m',
-                    memory: '2048Mi'
-                },
-                limits: {
-                    cpu: '2000m',
-                    memory: '4096Mi'
-                }
-            };
-        }
-        if (node.cpuMilli > 1000 || node.memoryMb >= 2000) {
-            return {
-                requests: {
-                    cpu: '500m',
-                    memory: '1024Mi'
-                },
-                limits: {
-                    cpu: '1000m',
-                    memory: '2048Mi'
-                }
-            };
-        }
+        const requestCpu = Math.floor(node.cpuMilli * 0.6);
+        const requsetMemory = Math.floor(node.memoryMb * 0.6);
+        const limitCpu = node.cpuMilli;
+        const limitMemory = node.memoryMb;
         return {
             requests: {
-                cpu: '500m',
-                memory: '512Mi'
+                cpu: `${requestCpu}m`,
+                memory: `${requsetMemory}Mi`
             },
             limits: {
-                cpu: '500m',
-                memory: '1024Mi'
+                cpu: `${limitCpu}m`,
+                memory: `${limitMemory}Mi`
             }
         };
     }

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -426,11 +426,15 @@ class Kubernetes {
         return accountId ? envs.RUNNER_PROFILED_ACCOUNTS.includes(accountId) : false;
     }
 
+    private MAX_REQUEST_CPU = 4000;
+    private MAX_REQUEST_MEMORY = 16384;
+    private MIN_REQUEST_CPU = 100;
+    private MIN_REQUEST_MEMORY = 128;
     private getResourceLimits(node: Node): { requests: { cpu: string; memory: string }; limits: { cpu: string; memory: string } } {
-        const requestCpu = Math.floor(node.cpuMilli * 0.6);
-        const requestMemory = Math.floor(node.memoryMb * 0.6);
-        const limitCpu = node.cpuMilli;
-        const limitMemory = node.memoryMb;
+        const requestCpu = Math.max(this.MIN_REQUEST_CPU, Math.min(this.MAX_REQUEST_CPU, Math.floor(node.cpuMilli * 0.6)));
+        const requestMemory = Math.max(this.MIN_REQUEST_MEMORY, Math.min(this.MAX_REQUEST_MEMORY, Math.floor(node.memoryMb * 0.6)));
+        const limitCpu = Math.max(this.MIN_REQUEST_CPU, Math.min(this.MAX_REQUEST_CPU, node.cpuMilli));
+        const limitMemory = Math.max(this.MIN_REQUEST_MEMORY, Math.min(this.MAX_REQUEST_MEMORY, node.memoryMb));
         return {
             requests: {
                 cpu: `${requestCpu}m`,

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -428,13 +428,13 @@ class Kubernetes {
 
     private getResourceLimits(node: Node): { requests: { cpu: string; memory: string }; limits: { cpu: string; memory: string } } {
         const requestCpu = Math.floor(node.cpuMilli * 0.6);
-        const requsetMemory = Math.floor(node.memoryMb * 0.6);
+        const requestMemory = Math.floor(node.memoryMb * 0.6);
         const limitCpu = node.cpuMilli;
         const limitMemory = node.memoryMb;
         return {
             requests: {
                 cpu: `${requestCpu}m`,
-                memory: `${requsetMemory}Mi`
+                memory: `${requestMemory}Mi`
             },
             limits: {
                 cpu: `${limitCpu}m`,

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -426,10 +426,10 @@ class Kubernetes {
         return accountId ? envs.RUNNER_PROFILED_ACCOUNTS.includes(accountId) : false;
     }
 
-    private MAX_REQUEST_CPU = 4000;
-    private MAX_REQUEST_MEMORY = 16384;
-    private MIN_REQUEST_CPU = 100;
-    private MIN_REQUEST_MEMORY = 128;
+    private MAX_REQUEST_CPU = envs.RUNNER_MAX_REQUEST_CPU;
+    private MAX_REQUEST_MEMORY = envs.RUNNER_MAX_REQUEST_MEMORY;
+    private MIN_REQUEST_CPU = envs.RUNNER_MIN_REQUEST_CPU;
+    private MIN_REQUEST_MEMORY = envs.RUNNER_MIN_REQUEST_MEMORY;
     private getResourceLimits(node: Node): { requests: { cpu: string; memory: string }; limits: { cpu: string; memory: string } } {
         const requestCpu = Math.max(this.MIN_REQUEST_CPU, Math.min(this.MAX_REQUEST_CPU, Math.floor(node.cpuMilli * 0.6)));
         const requestMemory = Math.max(this.MIN_REQUEST_MEMORY, Math.min(this.MAX_REQUEST_MEMORY, Math.floor(node.memoryMb * 0.6)));

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -433,8 +433,8 @@ class Kubernetes {
     private getResourceLimits(node: Node): { requests: { cpu: string; memory: string }; limits: { cpu: string; memory: string } } {
         const requestCpu = Math.max(this.MIN_REQUEST_CPU, Math.min(this.MAX_REQUEST_CPU, Math.floor(node.cpuMilli * 0.6)));
         const requestMemory = Math.max(this.MIN_REQUEST_MEMORY, Math.min(this.MAX_REQUEST_MEMORY, Math.floor(node.memoryMb * 0.6)));
-        const limitCpu = Math.max(this.MIN_REQUEST_CPU, Math.min(this.MAX_REQUEST_CPU, node.cpuMilli));
-        const limitMemory = Math.max(this.MIN_REQUEST_MEMORY, Math.min(this.MAX_REQUEST_MEMORY, node.memoryMb));
+        const limitCpu = Math.max(requestCpu, Math.min(this.MAX_REQUEST_CPU, node.cpuMilli));
+        const limitMemory = Math.max(requestMemory, Math.min(this.MAX_REQUEST_MEMORY, node.memoryMb));
         return {
             requests: {
                 cpu: `${requestCpu}m`,

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -430,9 +430,12 @@ class Kubernetes {
     private MAX_REQUEST_MEMORY = envs.RUNNER_MAX_REQUEST_MEMORY;
     private MIN_REQUEST_CPU = envs.RUNNER_MIN_REQUEST_CPU;
     private MIN_REQUEST_MEMORY = envs.RUNNER_MIN_REQUEST_MEMORY;
+    private REQUEST_CPU_MULTIPLIER = envs.RUNNER_REQUEST_CPU_MULTIPLIER;
+    private REQUEST_MEMORY_MULTIPLIER = envs.RUNNER_REQUEST_MEMORY_MULTIPLIER;
+
     private getResourceLimits(node: Node): { requests: { cpu: string; memory: string }; limits: { cpu: string; memory: string } } {
-        const requestCpu = Math.max(this.MIN_REQUEST_CPU, Math.min(this.MAX_REQUEST_CPU, Math.floor(node.cpuMilli * 0.6)));
-        const requestMemory = Math.max(this.MIN_REQUEST_MEMORY, Math.min(this.MAX_REQUEST_MEMORY, Math.floor(node.memoryMb * 0.6)));
+        const requestCpu = Math.max(this.MIN_REQUEST_CPU, Math.min(this.MAX_REQUEST_CPU, Math.floor(node.cpuMilli * this.REQUEST_CPU_MULTIPLIER)));
+        const requestMemory = Math.max(this.MIN_REQUEST_MEMORY, Math.min(this.MAX_REQUEST_MEMORY, Math.floor(node.memoryMb * this.REQUEST_MEMORY_MULTIPLIER)));
         const limitCpu = Math.max(requestCpu, Math.min(this.MAX_REQUEST_CPU, node.cpuMilli));
         const limitMemory = Math.max(requestMemory, Math.min(this.MAX_REQUEST_MEMORY, node.memoryMb));
         return {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -147,6 +147,10 @@ export const ENVS = z.object({
     RUNNER_CLIENT_HEADERS_TIMEOUT_MS: z.coerce.number().optional().default(10_000),
     RUNNER_CLIENT_CONNECT_TIMEOUT_MS: z.coerce.number().optional().default(5000),
     RUNNER_CLIENT_RESPONSE_TIMEOUT_MS: z.coerce.number().optional().default(15_000),
+    RUNNER_MAX_REQUEST_CPU: z.coerce.number().optional().default(4000),
+    RUNNER_MAX_REQUEST_MEMORY: z.coerce.number().optional().default(16384),
+    RUNNER_MIN_REQUEST_CPU: z.coerce.number().optional().default(500),
+    RUNNER_MIN_REQUEST_MEMORY: z.coerce.number().optional().default(512),
 
     // FLEET
     RUNNERS_DATABASE_URL: z.url().optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -151,6 +151,8 @@ export const ENVS = z.object({
     RUNNER_MAX_REQUEST_MEMORY: z.coerce.number().optional().default(16384),
     RUNNER_MIN_REQUEST_CPU: z.coerce.number().optional().default(500),
     RUNNER_MIN_REQUEST_MEMORY: z.coerce.number().optional().default(512),
+    RUNNER_REQUEST_CPU_MULTIPLIER: z.coerce.number().optional().default(0.6),
+    RUNNER_REQUEST_MEMORY_MULTIPLIER: z.coerce.number().optional().default(0.6),
 
     // FLEET
     RUNNERS_DATABASE_URL: z.url().optional(),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Formula-based Kubernetes runner sizing with env-driven guardrails**

The PR removes the hard-coded, tiered sizing table for Kubernetes runners and replaces it with a proportional formula. CPU and memory requests are now derived as a percentage (default 60 %) of the underlying node capacity, then clamped between new minimum/maximum values defined via environment variables. The same env vars are parsed and validated in `parse.ts`, making resource envelopes configurable without code changes.

<details>
<summary><strong>Key Changes</strong></summary>

• Deleted legacy decision tree in `getResourceLimits()` and introduced formula using `REQUEST_CPU_MULTIPLIER` / `REQUEST_MEMORY_MULTIPLIER`
• Added eight private constants (`MAX_REQUEST_CPU`, `MIN_REQUEST_CPU`, etc.) sourced from `envs` for clamping
• Extended `packages/utils/lib/environment/parse.ts` with six new Zod-validated env vars: `RUNNER_MAX_REQUEST_CPU`, `RUNNER_MAX_REQUEST_MEMORY`, `RUNNER_MIN_REQUEST_CPU`, `RUNNER_MIN_REQUEST_MEMORY`, `RUNNER_REQUEST_CPU_MULTIPLIER`, `RUNNER_REQUEST_MEMORY_MULTIPLIER`
• Default upper bound lowered from 8 CPU / 32 GiB to 4 CPU / 16 GiB unless overridden by env
• Net diff: −64 lines (deleted logic) +21 lines (new formula and env parsing)

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/jobs/lib/runner/kubernetes.ts` (resource calculation, new fields)
• `packages/utils/lib/environment/parse.ts` (env parsing schema)
• Runner provisioning behaviour in Kubernetes clusters

</details>

---
*This summary was automatically generated by @propel-code-bot*