### PR TITLE
fix(providers): fix intercom url

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -6596,7 +6596,7 @@ intercom:
         - surveys
         - ticketing
     auth_mode: OAUTH2
-    authorization_url: https://app.${connectionConfig.region}.intercom.com || https://app.intercom.com/oauth
+    authorization_url: https://app.${connectionConfig.region}.intercom.com/oauth || https://app.intercom.com/oauth
     token_url: https://api.${connectionConfig.region}.intercom.io/auth/eagle/token || https://api.intercom.io/auth/eagle/token
     proxy:
         base_url: https://api.${connectionConfig.region}.intercom.io || https://api.intercom.io


### PR DESCRIPTION
## Describe the problem and your solution

- fix intercom url

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Correct `/oauth` suffix in regional `intercom` OAuth URL**

Single-line fix in `packages/providers/providers.yaml` for the `intercom` provider. Adds missing `/oauth` segment to the region-specific `authorization_url`, bringing it in line with the non-regional fallback and preventing OAuth redirect failures for EU/AU tenants.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `authorization_url` from `https://app.${connectionConfig.region}.intercom.com` to `https://app.${connectionConfig.region}.intercom.com/oauth` in `intercom` provider definition

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/providers/providers.yaml` (Intercom provider block)

</details>

---
*This summary was automatically generated by @propel-code-bot*