### PR TITLE
chore(usage): revalidate billing metrics from orb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31465,6 +31465,7 @@
             "version": "1.0.0",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
+                "@nangohq/billing": "file:../billing",
                 "@nangohq/database": "file:../database",
                 "@nangohq/email": "file:../email",
                 "@nangohq/kvstore": "file:../kvstore",
@@ -31473,6 +31474,7 @@
                 "@nangohq/utils": "file:../utils",
                 "dd-trace": "5.52.0",
                 "he": "1.2.0",
+                "rate-limiter-flexible": "5.0.3",
                 "zod": "4.0.5"
             },
             "devDependencies": {

--- a/packages/account-usage/lib/cache.ts
+++ b/packages/account-usage/lib/cache.ts
@@ -2,6 +2,8 @@ import * as z from 'zod';
 
 import { Err, Ok } from '@nangohq/utils';
 
+import { envs } from './env.js';
+
 import type { getRedis } from '@nangohq/kvstore';
 import type { Result } from '@nangohq/utils';
 
@@ -78,8 +80,8 @@ export class UsageCache {
     }
 
     private static revalidateAfter(): number {
-        const oneHourMs = 60 * 60 * 1000; // TODO: make this configurable
-        return Date.now() + oneHourMs + Math.random() * oneHourMs; // revalidateAfter is between 1 and 2 hours to spread the load
+        const revalidateAfterMs = envs.USAGE_REVALIDATE_AFTER_MS;
+        return Date.now() + revalidateAfterMs + Math.random() * revalidateAfterMs; // add jitter to avoid thundering herd
     }
 
     private async validateEntry(key: string, data: any): Promise<Result<UsageCacheEntry>> {

--- a/packages/account-usage/lib/env.ts
+++ b/packages/account-usage/lib/env.ts
@@ -1,0 +1,3 @@
+import { ENVS, parseEnvs } from '@nangohq/utils';
+
+export const envs = parseEnvs(ENVS);

--- a/packages/account-usage/lib/usage.ts
+++ b/packages/account-usage/lib/usage.ts
@@ -245,6 +245,8 @@ export class UsageTracker implements IUsageTracker {
             return this.billingClient.getUsage(subscriptionId);
         });
         if (billingUsage.isErr()) {
+            // Note: errors (including rate limit errors) are not being retried
+            // revalidateAfter isn't being updated, so next incr will attempt to revalidate again
             return Err(billingUsage.error);
         }
         const res = {} as Record<UsageMetric, number>;

--- a/packages/account-usage/lib/usage.ts
+++ b/packages/account-usage/lib/usage.ts
@@ -155,7 +155,7 @@ export class UsageTracker implements IUsageTracker {
 
     public async revalidate({ accountId, metric }: { accountId: number; metric: UsageMetric }): Promise<Result<void>> {
         const source = sources[metric];
-        return tracer.trace('nango.usage.revalidate', { tags: { accountId, metric, source } }, async (span) => {
+        return await tracer.trace('nango.usage.revalidate', { tags: { accountId, metric, source } }, async (span) => {
             // Acquire a lock to avoid multiple revalidations in parallel
             const lockKey = `${cacheKeyPrefix}:revalidate:${accountId}:${source}`;
             const lock = await this.cache.tryAcquireLock(lockKey, { ttlMs: 60_000 });

--- a/packages/account-usage/lib/usage.ts
+++ b/packages/account-usage/lib/usage.ts
@@ -1,16 +1,22 @@
 import tracer from 'dd-trace';
+import { RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible';
 
+import { billing } from '@nangohq/billing';
+import db from '@nangohq/database';
 import { records } from '@nangohq/records';
-import { connectionService, environmentService } from '@nangohq/shared';
+import { connectionService, environmentService, getPlan } from '@nangohq/shared';
 import { Err, Ok } from '@nangohq/utils';
 
 import { UsageCache } from './cache.js';
+import { envs } from './env.js';
 import { logger } from './logger.js';
 import { usageMetrics } from './metrics.js';
 
 import type { UsageMetric } from './metrics.js';
 import type { getRedis } from '@nangohq/kvstore';
+import type { BillingUsageMetric } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
+import type { IRateLimiterRedisOptions } from 'rate-limiter-flexible';
 
 const cacheKeyPrefix = 'usageV2';
 
@@ -67,9 +73,18 @@ export class UsageTrackerNoOps implements IUsageTracker {
 
 export class UsageTracker implements IUsageTracker {
     private cache: UsageCache;
+    private throttler: Throttler;
+    private billingClient: typeof billing;
 
     constructor(redis: Awaited<ReturnType<typeof getRedis>>) {
         this.cache = new UsageCache(redis);
+        this.throttler = new Throttler({
+            storeClient: redis,
+            keyPrefix: 'billing',
+            points: envs.USAGE_BILLING_API_MAX_RPS,
+            duration: 1
+        });
+        this.billingClient = billing;
     }
 
     public async get({ accountId, metric }: { accountId: number; metric: UsageMetric }): Promise<Result<UsageStatus>> {
@@ -139,29 +154,23 @@ export class UsageTracker implements IUsageTracker {
     }
 
     public async revalidate({ accountId, metric }: { accountId: number; metric: UsageMetric }): Promise<Result<void>> {
-        const sources: Record<UsageMetric, string> = {
-            connections: 'db:connections',
-            records: 'db:records',
-            // Orb related metrics are fetched from the same orb endpoint, hence the same source
-            proxy: 'orb:subscription:usage',
-            function_executions: 'orb:subscription:usage',
-            function_compute_gbms: 'orb:subscription:usage',
-            webhook_forwards: 'orb:subscription:usage',
-            function_logs: 'orb:subscription:usage'
-        };
-        return tracer.trace('nango.usage.revalidate', { tags: { accountId, metric } }, async (span) => {
+        const source = sources[metric];
+        return tracer.trace('nango.usage.revalidate', { tags: { accountId, metric, source } }, async (span) => {
             // Acquire a lock to avoid multiple revalidations in parallel
-            const lockKey = `${cacheKeyPrefix}:revalidate:${accountId}:${sources[metric]}`;
+            const lockKey = `${cacheKeyPrefix}:revalidate:${accountId}:${source}`;
             const lock = await this.cache.tryAcquireLock(lockKey, { ttlMs: 60_000 });
             if (lock.isErr()) {
+                // another revalidation is in progress, skip
                 return Ok(undefined);
             }
             try {
-                let count: number | undefined = undefined;
+                const now = new Date();
                 switch (metric) {
                     case 'connections': {
-                        count = await connectionService.countByAccountId(accountId);
-                        break;
+                        const count = await connectionService.countByAccountId(accountId);
+                        const { cacheKey } = UsageTracker.getCacheEntryProps({ accountId, metric, now });
+                        await this.cache.overwrite(cacheKey, count);
+                        return Ok(undefined);
                     }
                     case 'records': {
                         const envs = await environmentService.getEnvironmentsByAccountId(accountId);
@@ -171,31 +180,40 @@ export class UsageTracker implements IUsageTracker {
                             if (res.isErr()) {
                                 throw res.error;
                             }
-                            count = res.value.reduce((acc, entry) => acc + entry.count, 0);
+                            const count = res.value.reduce((acc, entry) => acc + entry.count, 0);
+                            const { cacheKey } = UsageTracker.getCacheEntryProps({ accountId, metric, now });
+                            await this.cache.overwrite(cacheKey, count);
+                            span?.setTag('count', count);
                         }
-                        break;
+                        return Ok(undefined);
                     }
                     case 'proxy':
                     case 'function_executions':
                     case 'function_compute_gbms':
                     case 'webhook_forwards':
-                    case 'function_logs':
-                        // TODO
-                        break;
+                    case 'function_logs': {
+                        const billingUsage = await this.getBillingUsage(accountId);
+                        if (billingUsage.isErr()) {
+                            logger.warning(`Failed to fetch billing usage for accountId: ${accountId}`, billingUsage.error);
+                            if (billingUsage.error.message === 'rate_limit_exceeded') {
+                                span?.setTag('rate_limited', true);
+                            }
+                            throw billingUsage.error;
+                        }
+                        // update all billing-related metrics
+                        for (const [metric, count] of Object.entries(billingUsage.value)) {
+                            const { cacheKey } = UsageTracker.getCacheEntryProps({ accountId, metric: metric as UsageMetric, now });
+                            await this.cache.overwrite(cacheKey, count);
+                        }
+                        return Ok(undefined);
+                    }
                 }
-                if (count !== undefined) {
-                    const now = new Date();
-                    const { cacheKey } = UsageTracker.getCacheEntryProps({ accountId, metric, now });
-                    await this.cache.overwrite(cacheKey, count);
-                    span?.setTag('count', count);
-                }
-                return Ok(undefined);
             } catch (err) {
                 logger.error(`Failed to revalidate usage for accountId: ${accountId}, metric: ${metric}`, err);
                 span?.setTag('error', err);
                 return Err(new Error('usage_revalidate_error'));
             } finally {
-                // not releasing the lock on purpose to avoid quick re-entrance in case of error
+                // not releasing the lock to avoid quick re-entrance in case of error
             }
         });
     }
@@ -213,4 +231,77 @@ export class UsageTracker implements IUsageTracker {
         }
         return { cacheKey };
     }
+
+    private async getBillingUsage(accountId: number): Promise<Result<Record<UsageMetric, number>>> {
+        const billingUsage: Result<BillingUsageMetric[]> = await this.throttler.execute('usage', async () => {
+            const plan = await getPlan(db.knex, { accountId });
+            if (plan.isErr()) {
+                return Err(plan.error);
+            }
+            if (!plan.value.orb_subscription_id) {
+                return Err(new Error('orb_subscription_id_missing'));
+            }
+            const subscriptionId = plan.value.orb_subscription_id;
+            return this.billingClient.getUsage(subscriptionId);
+        });
+        if (billingUsage.isErr()) {
+            return Err(billingUsage.error);
+        }
+        const res = {} as Record<UsageMetric, number>;
+        for (const billingMetric of billingUsage.value) {
+            const usageMetric = billingMetricToUsageMetric(billingMetric.name);
+            if (usageMetric) {
+                res[usageMetric] = billingMetric.quantity;
+            }
+        }
+        return Ok(res);
+    }
 }
+
+class Throttler {
+    private throttler: RateLimiterRedis;
+
+    constructor(opts: IRateLimiterRedisOptions) {
+        this.throttler = new RateLimiterRedis(opts);
+    }
+
+    public async execute<T>(key: string, fn: () => Promise<T>): Promise<T> {
+        try {
+            await this.throttler.consume(key);
+            return await fn();
+        } catch (err) {
+            if (err instanceof RateLimiterRes) {
+                throw new Error('rate_limit_exceeded');
+            }
+            throw err;
+        }
+    }
+}
+
+function billingMetricToUsageMetric(name: string): UsageMetric | null {
+    // Not ideal to match on BillingMetric name but Orb only exposes the user friendly name or internal ids
+    const lowerName = name.toLowerCase();
+    // order matters here
+    if (lowerName.includes('legacy')) return null;
+    if (lowerName.includes('logs')) return 'function_logs';
+    if (lowerName.includes('proxy')) return 'proxy';
+    if (lowerName.includes('forward')) return 'webhook_forwards';
+    if (lowerName.includes('compute')) return 'function_compute_gbms';
+    if (lowerName.includes('records')) return 'records';
+    if (lowerName.includes('connections')) return 'connections';
+    if (lowerName.includes('function')) return 'function_executions';
+
+    return null;
+}
+
+const sources: Record<UsageMetric, string> = {
+    // source of truth for connections and records is main internal db
+    connections: 'db:connections',
+    records: 'db:records',
+    // billing related metrics are fetched from the same billing endpoint, hence the same source
+    proxy: 'billing:subscription:usage',
+    function_executions: 'billing:subscription:usage',
+    function_compute_gbms: 'billing:subscription:usage',
+    webhook_forwards: 'billing:subscription:usage',
+    function_logs: 'billing:subscription:usage'
+};

--- a/packages/account-usage/package.json
+++ b/packages/account-usage/package.json
@@ -13,6 +13,7 @@
         "directory": "packages/account-usage"
     },
     "dependencies": {
+        "@nangohq/billing": "file:../billing",
         "@nangohq/database": "file:../database",
         "@nangohq/email": "file:../email",
         "@nangohq/kvstore": "file:../kvstore",
@@ -21,6 +22,7 @@
         "@nangohq/utils": "file:../utils",
         "dd-trace": "5.52.0",
         "he": "1.2.0",
+        "rate-limiter-flexible": "5.0.3",
         "zod": "4.0.5"
     },
     "devDependencies": {

--- a/packages/account-usage/tsconfig.json
+++ b/packages/account-usage/tsconfig.json
@@ -6,6 +6,9 @@
     },
     "references": [
         {
+            "path": "../billing"
+        },
+        {
             "path": "../utils"
         },
         {
@@ -22,6 +25,9 @@
         },
         {
             "path": "../email"
+        },
+        {
+            "path": "../records"
         }
     ],
     "include": ["lib/**/*", "../utils/lib/vitest.d.ts"]

--- a/packages/billing/lib/clients/orb.ts
+++ b/packages/billing/lib/clients/orb.ts
@@ -178,7 +178,7 @@ export class OrbClient implements BillingClient {
                 })
             );
         } catch (err) {
-            return Err(new Error('failed_to_get_customer', { cause: err }));
+            return Err(new Error('failed_to_get_usage', { cause: err }));
         }
     }
 

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -214,6 +214,8 @@ export const ENVS = z.object({
 
     // Usage
     USAGE_CAPPING_ENABLED: z.stringbool().optional().default(false),
+    USAGE_REVALIDATE_AFTER_MS: z.coerce.number().optional().default(3_600_000), // 1 hour
+    USAGE_BILLING_API_MAX_RPS: z.coerce.number().optional().default(5), // max requests per second to Orb API usage endpoint is 10, keeping some margin
 
     // --- Third parties
     // AWS


### PR DESCRIPTION
Revalidating all the remaining usage metrics from Orb, throttling the API call to ensure we don't go over their limit of 10rps

<!-- Summary by @propel-code-bot -->

---

**Integrate Orb-based billing usage revalidation with Redis throttling**

This PR replaces local counting for most billing-related usage metrics with real-time figures fetched from Orb. It augments `UsageTracker` to call the Orb API once per account, throttled via a lightweight Redis-backed rate limiter, and writes the results back into the existing Redis cache. New environment variables make the throttle window and cache revalidation interval configurable. Several supporting refactors were made (env parsing, lock keying, error typo fix, TypeScript project refs, dependency additions).

<details>
<summary><strong>Key Changes</strong></summary>

• Extended `packages/account-usage/lib/usage.ts` - added `throttler`, `billingClient`, `getBillingUsage()` and consolidated revalidation logic under a single `source` lock key
• Introduced `Throttler` wrapper around `rate-limiter-flexible`; new env `USAGE_BILLING_API_MAX_RPS`
• Made cache revalidation interval configurable via `USAGE_REVALIDATE_AFTER_MS` and updated `UsageCache.revalidateAfter()`
• Added mapping helper `billingMetricToUsageMetric()` to translate Orb metric names to internal `UsageMetric` enum
• Created new `packages/account-usage/lib/env.ts` and expanded `packages/utils/lib/environment/parse.ts` schema
• Added `@nangohq/billing` and `rate-limiter-flexible` dependencies plus tsconfig reference updates
• Fixed error code typo in `packages/billing/lib/clients/orb.ts` (`failed_to_get_usage`)

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/account-usage/lib/usage.ts`
• `packages/account-usage/lib/cache.ts`
• `packages/account-usage/lib/env.ts`
• `packages/utils/lib/environment/parse.ts`
• `packages/billing/lib/clients/orb.ts`
• workspace `package.json` / `package-lock.json`
• TypeScript project references

</details>

---
*This summary was automatically generated by @propel-code-bot*