### PR TITLE
fix: when a sync expires, webhook says type = INITIAL

### DIFF
--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -677,6 +677,7 @@ export async function abortSync(task: TaskSyncAbort): Promise<Result<void>> {
         const getEndUser = await getEndUserByConnectionId(db.knex, { connectionId: task.connection.id });
 
         const isCancel = task.abortedTask.state === 'CANCELLED';
+        const lastSyncDate = await getLastSyncDate(task.syncId);
         await onFailure({
             connection: {
                 id: task.connection.id,
@@ -704,6 +705,7 @@ export async function abortSync(task: TaskSyncAbort): Promise<Result<void>> {
             endUser: getEndUser.isOk()
                 ? { id: getEndUser.value.id, endUserId: getEndUser.value.endUserId, orgId: getEndUser.value.organization?.organizationId || null }
                 : null,
+            lastSyncDate: lastSyncDate || undefined,
             startedAt: new Date()
         });
         const setSuccess = await orchestratorClient.succeed({ taskId: task.id, output: {} });


### PR DESCRIPTION
sync type (intial or incremental) depends on the presence of lastSyncDate when a sync is being expired, the webhook sends to the customer specified the sync was INITIAL even when it was not the initial execution.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Fix incorrect webhook sync type on expiration**

Adds retrieval of `lastSyncDate` during sync abort/expiration handling and propagates it to the `onFailure` call. This allows the outbound webhook to compute the correct sync `operation` (`SyncJobsType.INCREMENTAL` vs `SyncJobsType.FULL`) instead of defaulting to `INITIAL` when the sync is expired.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `const lastSyncDate = await getLastSyncDate(task.syncId);` in `abortSync()` flow
• Passed `lastSyncDate` to the payload supplied to `onFailure()` (now forwarded to webhook)

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/jobs/lib/execution/sync.ts` (functions `abortSync` and surrounding failure logic)

</details>

---
*This summary was automatically generated by @propel-code-bot*