### PR TITLE
fix(ui-copy): add copy button and allow pasting

### DIFF
--- a/packages/webapp/src/pages/Environment/Settings/Variables.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Variables.tsx
@@ -54,7 +54,6 @@ export const VariablesSettings: React.FC = () => {
     };
 
     const onPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
-        e.preventDefault();
         const filtered = handlePastedEnv(
             e.clipboardData.getData('Text'),
             vars.map((v) => v.name)
@@ -62,6 +61,8 @@ export const VariablesSettings: React.FC = () => {
         if (!filtered || filtered.size === 0) {
             return;
         }
+
+        e.preventDefault();
 
         setVars((prev) => {
             const copy = [...prev].filter((v) => v.value !== '');
@@ -147,6 +148,7 @@ export const VariablesSettings: React.FC = () => {
                                     <SecretInput
                                         value={envVar.value}
                                         onChange={(e) => onUpdate('value', e.target.value, i)}
+                                        copy={true}
                                         inputSize={'lg'}
                                         variant={'black'}
                                         onPaste={(e) => onPaste(e)}


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Allow Standard Paste & Expose Copy Button in ENV Var Form**

Removes the unconditional clipboard interception that blocked normal pasting in environment-variable input fields and introduces a copy-to-clipboard button on the secret value input. Only one file (`packages/webapp/src/pages/Environment/Settings/Variables.tsx`) is touched with three net additions and one deletion.

<details>
<summary><strong>Key Changes</strong></summary>

• Relocated `e.preventDefault()` so it fires only when a valid `KEY=VAL` payload is detected
• Passed `copy={true}` to `SecretInput` to render copy-to-clipboard control

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/pages/Environment/Settings/Variables.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*