### PR TITLE
feat: hide usage for old plans

### DIFF
--- a/packages/webapp/src/components-v2/AppSidebar/index.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/index.tsx
@@ -17,6 +17,7 @@ import {
     SidebarMenuButton,
     SidebarMenuItem
 } from '../ui/sidebar';
+import { useEnvironment } from '@/hooks/useEnvironment';
 import { useMeta } from '@/hooks/useMeta';
 import { apiPatchUser } from '@/hooks/useUser';
 import { useStore } from '@/store';
@@ -34,6 +35,7 @@ export const AppSidebar: React.FC = () => {
     const env = useStore((state) => state.env);
     const { meta, mutate: mutateMeta } = useMeta();
     const showGettingStarted = useStore((state) => state.showGettingStarted);
+    const { plan } = useEnvironment(env);
 
     const items = useMemo<SidebarItem[]>(() => {
         const gettingStarted = {
@@ -57,6 +59,11 @@ export const AppSidebar: React.FC = () => {
             { title: 'Environment settings', url: `/${env}/environment-settings`, icon: Settings2 }
         ].filter((item) => item !== null);
     }, [env, meta, mutateMeta, showGettingStarted]);
+
+    const showUsageCard = useMemo(() => {
+        if (!plan) return false;
+        return ['free', 'starter-v2', 'growth-v2'].includes(plan?.name);
+    }, [plan]);
 
     return (
         <Sidebar collapsible="none">
@@ -87,9 +94,11 @@ export const AppSidebar: React.FC = () => {
                 </SidebarGroup>
             </SidebarContent>
             <SidebarFooter className="p-0">
-                <div className="px-3 mb-8">
-                    <UsageCard />
-                </div>
+                {showUsageCard && (
+                    <div className="px-3 mb-8">
+                        <UsageCard />
+                    </div>
+                )}
                 <ProfileDropdown />
             </SidebarFooter>
         </Sidebar>


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Conditionally render `UsageCard` based on current subscription plan**

This PR adds a small feature to the webapp sidebar: the `UsageCard` is now shown only for environments on newer pricing plans (`free`, `starter-v2`, `growth-v2`). Older plans will no longer see the usage panel. The change is limited to a single React component and introduces a new hook call to obtain the current plan, plus a memoised boolean to gate the rendering.

<details>
<summary><strong>Key Changes</strong></summary>

• Imported `useEnvironment` in `packages/webapp/src/components-v2/AppSidebar/index.tsx` to access plan information
• Computed `{ plan } = useEnvironment(env)` and memoised `showUsageCard` with `useMemo`
• Replaced unconditional `UsageCard` rendering with `{showUsageCard && ...}` block
• Removed hard-coded wrapper `<div>` when `UsageCard` is not rendered

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/components-v2/AppSidebar/index.tsx` (sidebar rendering logic)

</details>

---
*This summary was automatically generated by @propel-code-bot*