### PR TITLE
fix(record count): do not count records from deleted connections

### DIFF
--- a/packages/account-usage/lib/usage.ts
+++ b/packages/account-usage/lib/usage.ts
@@ -196,7 +196,6 @@ export class UsageTracker implements IUsageTracker {
                 case 'function_logs': {
                     const billingUsage = await this.getBillingUsage(accountId);
                     if (billingUsage.isErr()) {
-                        logger.warning(`Failed to fetch billing usage for accountId: ${accountId}`, billingUsage.error);
                         if (billingUsage.error.message === 'rate_limit_exceeded') {
                             span?.setTag('rate_limited', true);
                         }

--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -941,6 +941,51 @@ describe('Records service', () => {
             expect(res).toMatchObject([expect.objectContaining({ environmentId: env1, count: 11, sizeBytes: expect.any(Number) })]);
         });
     });
+    describe('paginateRecordCounts', () => {
+        it('should paginate through record counts', async () => {
+            const res1 = await upsertNRecords(15);
+            const res2 = await upsertNRecords(25);
+            const res3 = await upsertNRecords(35);
+
+            const received = [];
+            for await (const res of Records.paginateRecordCounts({ batchSize: 2 })) {
+                if (res.isErr()) {
+                    throw res.error;
+                }
+                received.push(...res.value);
+            }
+
+            expect(received).toHaveLength(3);
+            expect(received).toEqual(
+                expect.arrayContaining([
+                    {
+                        environment_id: res1.environmentId,
+                        connection_id: res1.connectionId,
+                        model: res1.model,
+                        count: 15,
+                        size_bytes: expect.any(String),
+                        updated_at: expect.any(Date)
+                    },
+                    {
+                        environment_id: res2.environmentId,
+                        connection_id: res2.connectionId,
+                        model: res2.model,
+                        count: 25,
+                        size_bytes: expect.any(String),
+                        updated_at: expect.any(Date)
+                    },
+                    {
+                        environment_id: res3.environmentId,
+                        connection_id: res3.connectionId,
+                        model: res3.model,
+                        count: 35,
+                        size_bytes: expect.any(String),
+                        updated_at: expect.any(Date)
+                    }
+                ])
+            );
+        });
+    });
 });
 
 async function upsertNRecords(n: number): Promise<{ environmentId: number; connectionId: number; model: string; syncId: string; result: UpsertSummary }> {

--- a/packages/shared/lib/services/connection.service.integration.test.ts
+++ b/packages/shared/lib/services/connection.service.integration.test.ts
@@ -255,4 +255,29 @@ describe('Connection service integration tests', () => {
             expect(count.withError).toBe(2);
         });
     });
+
+    describe('paginate', () => {
+        it('should paginate through connections', async () => {
+            const env = await createEnvironmentSeed();
+
+            await createConfigSeed(env, 'notion', 'notion');
+
+            const connection1 = await createConnectionSeed({ env, provider: 'notion' });
+            const connection2 = await createConnectionSeed({ env, provider: 'notion' });
+            const connection3 = await createConnectionSeed({ env, provider: 'notion' });
+            const connectionIds = [connection1.id, connection2.id, connection3.id];
+
+            const paginatedConnections: number[] = [];
+            for await (const res of connectionService.paginateConnections({ connectionIds, batchSize: 2 })) {
+                if (res.isErr()) {
+                    throw res.error;
+                }
+                for (const c of res.value) {
+                    paginatedConnections.push(c.connection.id);
+                }
+            }
+
+            expect(paginatedConnections).toEqual(connectionIds);
+        });
+    });
 });


### PR DESCRIPTION
Record counts table entries are not deleted when a connection is soft deleted (only when hard deleted) which means that records are still counted until the connection is hard deleted.
Since we delete connections from different places in the codebase it would require a big refactoring to delete the record counts table when connections is soft deleted. Main pain point is connections are soft-deleted when an integration is soft-deleted, deep inside the shared package, which hasn't any knowledge of the records packages :(
Instead I decided to account for the deleted connections when we report the record counts. The logic was already quite cumbersome and wasn't supporting pagination.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Exclude soft-deleted connections from record metrics + add pagination helpers**

Soft-deleted connections were still represented in the `record_counts` table, so the "Records" usage metric billed/observed more data than actually active. This PR avoids modifying the underlying table and instead filters record-count rows at read-time. It introduces paginated accessors in both the Records and Connections layers and rewrites the metering cron to join these two paginated streams, aggregating only active (non-deleted) connections. Additional integration tests ensure the new iterators and counting logic behave as expected.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `records.paginateRecordCounts()` – offset-based async generator that yields batches from `RECORD_COUNTS_TABLE`.
• Added `connectionService.paginateConnections()` – cursor-based async generator returning active connections with related account/env rows; supports optional `connectionIds` filter.
• Re-implemented `observability.exportRecordsMetrics()` in `packages/metering/lib/crons/usage.ts` to: a) page through record counts, b) fetch matching connections, c) skip deleted connections, and d) aggregate metrics per account.
• Updated unit/integration tests for Records and Connection services to cover new pagination helpers and counting logic.
• Minor cleanup: removed unused `environmentService` import, dropped redundant warning log in usage tracker.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/metering/lib/crons/usage.ts`
• `packages/shared/lib/services/connection.service.ts`
• `packages/records/lib/models/records.ts`
• Associated integration test suites
• `packages/account-usage/lib/usage.ts` (small log change)

</details>

---
*This summary was automatically generated by @propel-code-bot*