### PR TITLE
docs: slack api gotchas

### DIFF
--- a/docs/integrations/all/slack.mdx
+++ b/docs/integrations/all/slack.mdx
@@ -107,7 +107,65 @@ import { StatusWidget } from "/snippets/api-down-watch/status-widget.jsx"
     <Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/slack.mdx)</Note>
   </Tab>
   <Tab title="🚨 API gotchas">
-    _No reported gotchas._
+    ### Bot Token vs User Token
+    
+    Slack issues two separate access tokens during OAuth:
+    - **Bot Token** (starts with `xoxb-`): Used for actions performed by your app's bot
+    - **User Token** (starts with `xoxp-`): Used for actions performed on behalf of the authorizing user
+    
+    **Important:** By default, Nango uses the bot token as the primary access token. This means when you make API calls through Nango's proxy, it will use the bot token by default.
+    
+    #### When You Need the User Token
+    
+    Some Slack API endpoints require user-scoped permissions and will only accept user tokens (e.g., certain user profile operations). If you try to call these endpoints with the bot token, Slack will reject the request.
+    
+    #### How to Use the User Token
+    
+    1. **Fetch the raw connection to get the user token:**
+    
+    ```typescript
+    import { Nango } from '@nangohq/node';
+    
+    const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+    
+    // Fetch the connection with raw credentials
+    const connection = await nango.getConnection(
+      '<INTEGRATION-ID>',
+      '<CONNECTION-ID>'
+    );
+    
+    // The user token is in the raw response
+    const userToken = connection.credentials.raw.authed_user?.access_token;
+    ```
+    
+    2. **Override the authorization header when making proxy calls:**
+    
+    ```typescript
+    // Use the user token by overriding the auth header
+    const response = await nango.get({
+      endpoint: '/users.profile.get',
+      providerConfigKey: '<INTEGRATION-ID>',
+      connectionId: '<CONNECTION-ID>',
+      headers: {
+        'nango-proxy-authorization': `Bearer ${userToken}`
+      }
+    });
+    ```
+    
+    #### When Creating Connections in Nango
+    
+    If you need user tokens for your integration, you can specify [user scopes](/reference/api/connect/sessions/create#body-integrations-config-defaults-key-user-scopes) when creating a connect session:
+    
+    ```typescript
+    const { data } = await nango.createConnectSession({
+      end_user_id: '<END-USER-ID>',
+      integrations_config_defaults: {
+        "slack": {
+          user_scopes: "users.profile:read, chat:write"
+        }
+      }
+    });
+    ```
 
     <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/slack.mdx)</Note>
   </Tab>

--- a/docs/snippets/generated/pennylane-company-api/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/pennylane-company-api/PreBuiltUseCases.mdx
@@ -2,4 +2,4 @@
 
 _No pre-built integration yet (time to contribute: &lt;48h)_
 
-<Tip>Not seeing the integration you need? [Build your own](https://docs.nango.dev/guides/platform/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/platform/functions) independently.</Tip>

--- a/docs/snippets/generated/shopify-api-key/PreBuiltTooling.mdx
+++ b/docs/snippets/generated/shopify-api-key/PreBuiltTooling.mdx
@@ -16,7 +16,7 @@
 | API unification | ✅ |
 | 2-way sync | ✅ |
 | Webhooks from Nango on data modifications | ✅ |
-| Real-time webhooks from 3rd-party API | 🚫 (time to contribute: &lt;48h) |
+| Real-time webhooks from 3rd-party API | ✅ |
 | Proxy requests | ✅ |
 </Accordion>
 <Accordion title="✅ Observability & data quality">


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Slack API gotchas section & minor doc tweaks**

This PR is purely documentation-oriented. It introduces a detailed "Bot Token vs User Token" subsection under the `🚨 API gotchas` tab in `docs/integrations/all/slack.mdx`, and performs two small consistency fixes in auto-generated snippet files.

<details>
<summary><strong>Key Changes</strong></summary>

• Added comprehensive guidance on choosing between bot (`xoxb-`) and user (`xoxp-`) tokens, including TypeScript samples, to `docs/integrations/all/slack.mdx`
• Updated broken guide link in `docs/snippets/generated/pennylane-company-api/PreBuiltUseCases.mdx` (old `docs.nango.dev/guides/...` → new `nango.dev/docs/guides/...`)
• Changed "Real-time webhooks from 3rd-party API" status from 🚫 to ✅ in `docs/snippets/generated/shopify-api-key/PreBuiltTooling.mdx`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs/integrations/all/slack.mdx`
• `docs/snippets/generated/pennylane-company-api/PreBuiltUseCases.mdx`
• `docs/snippets/generated/shopify-api-key/PreBuiltTooling.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*