### PR TITLE
fix(usage): don't overwrite records/connections with orb metrics

### DIFF
--- a/packages/account-usage/lib/usage.ts
+++ b/packages/account-usage/lib/usage.ts
@@ -294,8 +294,6 @@ function billingMetricToUsageMetric(name: string): UsageMetric | null {
     if (lowerName.includes('proxy')) return 'proxy';
     if (lowerName.includes('forward')) return 'webhook_forwards';
     if (lowerName.includes('compute')) return 'function_compute_gbms';
-    if (lowerName.includes('records')) return 'records';
-    if (lowerName.includes('connections')) return 'connections';
     if (lowerName.includes('function')) return 'function_executions';
 
     return null;


### PR DESCRIPTION
Orb metrics for records/connections doesn't correspond to the current value but the pro-rated calculation over a month.
Let's not overide the cache usage value for those 2 metrics with orb since the source of truth for current value is the db

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Stop mapping Orb 'records' and 'connections' metrics to internal usage cache**

This PR removes the two lines that translated Orb-reported metric names containing `records` or `connections` into internal `UsageMetric` values. By no longer mapping those strings, the usage tracker will ignore Orb’s pro-rated figures and keep relying on the database as the single source of truth for current record and connection counts.

<details>
<summary><strong>Key Changes</strong></summary>

• Deleted two conditional branches in `billingMetricToUsageMetric()` that returned `'records'` and `'connections'`
• No other files or logic modified

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/account-usage/lib/usage.ts` – `billingMetricToUsageMetric` helper

</details>

---
*This summary was automatically generated by @propel-code-bot*