### PR TITLE
fix(server): set keep-alive and header timeouts

### DIFF
--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -56,6 +56,8 @@ app.use('/', router);
 
 const server = http.createServer(app);
 
+server.keepAliveTimeout = envs.NANGO_SERVER_KEEP_ALIVE_TIMEOUT;
+server.headersTimeout = envs.NANGO_SERVER_KEEP_ALIVE_TIMEOUT + 1000; //needs to be longer than the keep alive timeout to avoid premature disconnections
 // -------
 // Websocket
 const wss = new WebSocketServer({ server, path: getWebsocketsPath() });

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -21,6 +21,7 @@ export const ENVS = z.object({
     NANGO_PORT: z.coerce.number().optional().default(3003), // Sync those two ports?
     SERVER_PORT: z.coerce.number().optional().default(3003),
     NANGO_SERVER_URL: z.url().optional(),
+    NANGO_SERVER_KEEP_ALIVE_TIMEOUT: z.coerce.number().optional().default(61_000),
     DEFAULT_RATE_LIMIT_PER_MIN: z.coerce.number().min(1).optional(),
     NANGO_CACHE_ENV_KEYS: z.stringbool().optional().default(false),
     NANGO_SERVER_WEBSOCKETS_PATH: z.string().optional(),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Set HTTP keep-alive & header timeouts via env var**

Adds explicit timeout management to the HTTP server to reduce the risk of long-lived idle sockets and header stalls. The change introduces a new configurable environment variable so operators can tune the timeout without code changes.

<details>
<summary><strong>Key Changes</strong></summary>

• Set `server.keepAliveTimeout` from `envs.NANGO_SERVER_KEEP_ALIVE_TIMEOUT` in `packages/server/lib/server.ts`
• Set `server.headersTimeout` to `envs.NANGO_SERVER_KEEP_ALIVE_TIMEOUT + 1000` to satisfy Node.js requirement that it exceeds keep-alive timeout
• Declare new env schema key `NANGO_SERVER_KEEP_ALIVE_TIMEOUT` with default `61_000` (61 s) in `packages/utils/lib/environment/parse.ts`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/server.ts`
• `packages/utils/lib/environment/parse.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*