### PR TITLE
fix(runner): error handling and retry in jobs client

### DIFF
--- a/packages/runner/lib/clients/http.ts
+++ b/packages/runner/lib/clients/http.ts
@@ -1,17 +1,46 @@
+import { retryWithBackoff } from '@nangohq/utils';
+
 import { logger } from '../logger.js';
 
-import type { RequestInfo } from 'undici/types/index.js';
-
-export async function httpFetch(resource: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-    const res = await fetch(resource, init);
-    if (res.status >= 400) {
-        let content;
-        if (res.headers.get('content-type')?.includes('application/json')) {
-            content = await res.json().catch(() => 'Cannot parse response as JSON.');
-        } else {
-            content = await res.text();
-        }
-        logger.error(`Error: ${init?.method} ${resource as string} -> ${res.status} ${JSON.stringify(content)}`);
+export async function httpFetch(
+    url: string | URL,
+    init?: RequestInit,
+    backoffOptions?: {
+        startingDelay?: number;
+        timeMultiple?: number;
+        numOfAttempts?: number;
     }
-    return res;
+): Promise<Response> {
+    try {
+        const response = await retryWithBackoff(async () => {
+            let res: Response;
+
+            try {
+                res = await fetch(url, init);
+            } catch (err) {
+                logger.error(`Network error: ${init?.method || 'GET'} ${url.toString()} -> ${(err as Error).message}`);
+                // Retry on network errors
+                throw err;
+            }
+
+            if (!res.ok) {
+                logger.error(`${init?.method || 'GET'} ${url.toString()} -> ${res.status} ${res.statusText}`);
+            }
+
+            // Retry only on 5xx or 429 responses
+            if (res.status >= 500 || res.status === 429) {
+                throw new Error(`${init?.method || 'GET'} ${url.toString()} -> ${res.status} ${res.statusText}`);
+            }
+
+            return res;
+        }, backoffOptions);
+
+        return response;
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return new Response(JSON.stringify({ error: message }), {
+            status: 599,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    }
 }

--- a/packages/runner/lib/clients/jobs.ts
+++ b/packages/runner/lib/clients/jobs.ts
@@ -1,4 +1,4 @@
-import { Err, Ok, retryWithBackoff } from '@nangohq/utils';
+import { Err, Ok } from '@nangohq/utils';
 
 import { httpFetch } from './http.js';
 import { jobsServiceUrl } from '../env.js';
@@ -20,95 +20,82 @@ class JobsClient {
     }
 
     async postHeartbeat({ taskId }: PostHeartbeat['Params']): Promise<Result<PostHeartbeat['Success']>> {
-        try {
-            const resp = await httpFetch(`${this.baseUrl}/tasks/${taskId}/heartbeat`, {
-                method: 'POST'
-            });
-            if (!resp.ok) {
-                throw new Error('heartbeat_failed');
-            }
-            return Ok(undefined as PostHeartbeat['Success']);
-        } catch {
+        const resp = await httpFetch(`${this.baseUrl}/tasks/${taskId}/heartbeat`, {
+            method: 'POST'
+        });
+        if (!resp.ok) {
             return Err(`heartbeat_failed`);
         }
+        return Ok(undefined as PostHeartbeat['Success']);
     }
 
     async putTask({ taskId, nangoProps, error, output, telemetryBag }: PutTask['Body'] & PutTask['Params']): Promise<Result<PutTask['Success']>> {
-        try {
-            const res = await retryWithBackoff(async () => {
-                const resp = await httpFetch(`${this.baseUrl}/tasks/${taskId}`, {
-                    method: 'PUT',
-                    headers: {
-                        'Content-Type': 'application/json'
+        const resp = await httpFetch(
+            `${this.baseUrl}/tasks/${taskId}`,
+            {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    nangoProps: nangoProps,
+                    ...(error ? { error, telemetryBag } : { output, telemetryBag })
+                })
+            },
+            defaultRetryOptions
+        );
+        if (!resp.ok) {
+            // If the response is request content too large
+            // we send a separate request to update the task with the error
+            if (resp.status === 413) {
+                return this.putTask({
+                    taskId,
+                    nangoProps,
+                    error: {
+                        type: 'script_output_too_large',
+                        status: 413,
+                        payload: {
+                            message: 'Output is too large'
+                        }
                     },
-                    body: JSON.stringify({
-                        nangoProps: nangoProps,
-                        ...(error ? { error, telemetryBag } : { output, telemetryBag })
-                    })
+                    telemetryBag: { customLogs: 0, proxyCalls: 0, durationMs: 0, memoryGb: 1 }
                 });
-                if (!resp.ok) {
-                    // If the response is request content too large
-                    // we send a separate request to update the task with the error
-                    if (resp.status === 413) {
-                        return this.putTask({
-                            taskId,
-                            nangoProps,
-                            error: {
-                                type: 'script_output_too_large',
-                                status: 413,
-                                payload: {
-                                    message: 'Output is too large'
-                                }
-                            },
-                            telemetryBag: { customLogs: 0, proxyCalls: 0, durationMs: 0, memoryGb: 1 }
-                        });
-                    }
-                    throw new Error('put_task_failed');
-                }
-                return Ok(undefined as PutTask['Success']);
-            }, defaultRetryOptions);
-            return res as Result<PutTask['Success']>;
-        } catch {
+            }
             return Err(`put_task_failed`);
         }
+        return Ok(undefined as PutTask['Success']);
     }
 
     async postRegister({ nodeId, url }: PostRegister['Params'] & PostRegister['Body']): Promise<Result<PostRegister['Success']>> {
-        try {
-            const res = await retryWithBackoff(async () => {
-                const resp = await httpFetch(`${this.baseUrl}/runners/${nodeId}/register`, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({ url })
-                });
-                if (!resp.ok) {
-                    throw new Error('register_failed');
-                }
-                return Ok((await resp.json()) as PostRegister['Success']);
-            }, defaultRetryOptions);
-            return res as Result<PostRegister['Success']>;
-        } catch {
+        const resp = await httpFetch(
+            `${this.baseUrl}/runners/${nodeId}/register`,
+            {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ url })
+            },
+            defaultRetryOptions
+        );
+        if (!resp.ok) {
             return Err(`register_failed`);
         }
+        return Ok((await resp.json()) as PostRegister['Success']);
     }
 
     async postIdle({ nodeId }: PostIdle['Params']): Promise<Result<PostIdle['Success']>> {
-        try {
-            const res = await retryWithBackoff(async () => {
-                const resp = await httpFetch(`${this.baseUrl}/runners/${nodeId}/idle`, {
-                    method: 'POST'
-                });
-                if (!resp.ok) {
-                    throw new Error(`idle_failed`);
-                }
-                return Ok((await resp.json()) as PostIdle['Success']);
-            }, defaultRetryOptions);
-            return res as Result<PostIdle['Success']>;
-        } catch {
+        const resp = await httpFetch(
+            `${this.baseUrl}/runners/${nodeId}/idle`,
+            {
+                method: 'POST'
+            },
+            defaultRetryOptions
+        );
+        if (!resp.ok) {
             return Err(`idle_failed`);
         }
+        return Ok((await resp.json()) as PostIdle['Success']);
     }
 }
 

--- a/packages/runner/lib/clients/jobs.ts
+++ b/packages/runner/lib/clients/jobs.ts
@@ -20,79 +20,95 @@ class JobsClient {
     }
 
     async postHeartbeat({ taskId }: PostHeartbeat['Params']): Promise<Result<PostHeartbeat['Success']>> {
-        const resp = await httpFetch(`${this.baseUrl}/tasks/${taskId}/heartbeat`, {
-            method: 'POST'
-        });
-        if (!resp.ok) {
-            return Err(`postHeartbeat_failed`);
-        }
-        return Ok(undefined as PostHeartbeat['Success']);
-    }
-
-    async putTask({ taskId, nangoProps, error, output, telemetryBag }: PutTask['Body'] & PutTask['Params']): Promise<Result<PutTask['Success']>> {
-        const res = await retryWithBackoff(async () => {
-            const resp = await httpFetch(`${this.baseUrl}/tasks/${taskId}`, {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({
-                    nangoProps: nangoProps,
-                    ...(error ? { error, telemetryBag } : { output, telemetryBag })
-                })
-            });
-            if (!resp.ok) {
-                // If the response is request content too large
-                // we send a separate request to update the task with the error
-                if (resp.status === 413) {
-                    return this.putTask({
-                        taskId,
-                        nangoProps,
-                        error: {
-                            type: 'script_output_too_large',
-                            status: 413,
-                            payload: {
-                                message: 'Output is too large'
-                            }
-                        },
-                        telemetryBag: { customLogs: 0, proxyCalls: 0, durationMs: 0, memoryGb: 1 }
-                    });
-                }
-                return Err(`putTask_failed`);
-            }
-            return Ok(undefined as PutTask['Success']);
-        }, defaultRetryOptions);
-        return res as Result<PutTask['Success']>;
-    }
-
-    async postRegister({ nodeId, url }: PostRegister['Params'] & PostRegister['Body']): Promise<Result<PostRegister['Success']>> {
-        const res = await retryWithBackoff(async () => {
-            const resp = await httpFetch(`${this.baseUrl}/runners/${nodeId}/register`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({ url })
-            });
-            if (!resp.ok) {
-                return Err(`PostRegister_failed`);
-            }
-            return Ok((await resp.json()) as PostRegister['Success']);
-        }, defaultRetryOptions);
-        return res as Result<PostRegister['Success']>;
-    }
-
-    async postIdle({ nodeId }: PostIdle['Params']): Promise<Result<PostIdle['Success']>> {
-        const res = await retryWithBackoff(async () => {
-            const resp = await httpFetch(`${this.baseUrl}/runners/${nodeId}/idle`, {
+        try {
+            const resp = await httpFetch(`${this.baseUrl}/tasks/${taskId}/heartbeat`, {
                 method: 'POST'
             });
             if (!resp.ok) {
-                return Err(`postIdle_failed`);
+                throw new Error('heartbeat_failed');
             }
-            return Ok((await resp.json()) as PostIdle['Success']);
-        }, defaultRetryOptions);
-        return res as Result<PostIdle['Success']>;
+            return Ok(undefined as PostHeartbeat['Success']);
+        } catch {
+            return Err(`heartbeat_failed`);
+        }
+    }
+
+    async putTask({ taskId, nangoProps, error, output, telemetryBag }: PutTask['Body'] & PutTask['Params']): Promise<Result<PutTask['Success']>> {
+        try {
+            const res = await retryWithBackoff(async () => {
+                const resp = await httpFetch(`${this.baseUrl}/tasks/${taskId}`, {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        nangoProps: nangoProps,
+                        ...(error ? { error, telemetryBag } : { output, telemetryBag })
+                    })
+                });
+                if (!resp.ok) {
+                    // If the response is request content too large
+                    // we send a separate request to update the task with the error
+                    if (resp.status === 413) {
+                        return this.putTask({
+                            taskId,
+                            nangoProps,
+                            error: {
+                                type: 'script_output_too_large',
+                                status: 413,
+                                payload: {
+                                    message: 'Output is too large'
+                                }
+                            },
+                            telemetryBag: { customLogs: 0, proxyCalls: 0, durationMs: 0, memoryGb: 1 }
+                        });
+                    }
+                    throw new Error('put_task_failed');
+                }
+                return Ok(undefined as PutTask['Success']);
+            }, defaultRetryOptions);
+            return res as Result<PutTask['Success']>;
+        } catch {
+            return Err(`put_task_failed`);
+        }
+    }
+
+    async postRegister({ nodeId, url }: PostRegister['Params'] & PostRegister['Body']): Promise<Result<PostRegister['Success']>> {
+        try {
+            const res = await retryWithBackoff(async () => {
+                const resp = await httpFetch(`${this.baseUrl}/runners/${nodeId}/register`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ url })
+                });
+                if (!resp.ok) {
+                    throw new Error('register_failed');
+                }
+                return Ok((await resp.json()) as PostRegister['Success']);
+            }, defaultRetryOptions);
+            return res as Result<PostRegister['Success']>;
+        } catch {
+            return Err(`register_failed`);
+        }
+    }
+
+    async postIdle({ nodeId }: PostIdle['Params']): Promise<Result<PostIdle['Success']>> {
+        try {
+            const res = await retryWithBackoff(async () => {
+                const resp = await httpFetch(`${this.baseUrl}/runners/${nodeId}/idle`, {
+                    method: 'POST'
+                });
+                if (!resp.ok) {
+                    throw new Error(`idle_failed`);
+                }
+                return Ok((await resp.json()) as PostIdle['Success']);
+            }, defaultRetryOptions);
+            return res as Result<PostIdle['Success']>;
+        } catch {
+            return Err(`idle_failed`);
+        }
     }
 }
 

--- a/packages/runner/lib/idle.ts
+++ b/packages/runner/lib/idle.ts
@@ -7,14 +7,13 @@ import { logger } from './logger.js';
 import type { Result } from '@nangohq/utils';
 
 export async function idle(): Promise<Result<void>> {
-    try {
-        if (envs.RUNNER_NODE_ID) {
-            await jobsClient.postIdle({ nodeId: envs.RUNNER_NODE_ID });
-        } else {
-            logger.info(`No idle: RUNNER_NODE_ID not set`);
+    if (envs.RUNNER_NODE_ID) {
+        const res = await jobsClient.postIdle({ nodeId: envs.RUNNER_NODE_ID });
+        if (res.isErr()) {
+            return Err(res.error);
         }
-        return Ok(undefined);
-    } catch (err) {
-        return Err(new Error('failed to idle runner', { cause: err }));
+    } else {
+        logger.info(`No idle: RUNNER_NODE_ID not set`);
     }
+    return Ok(undefined);
 }

--- a/packages/runner/lib/register.ts
+++ b/packages/runner/lib/register.ts
@@ -7,14 +7,13 @@ import { logger } from './logger.js';
 import type { Result } from '@nangohq/utils';
 
 export async function register(): Promise<Result<void>> {
-    try {
-        if (envs.RUNNER_NODE_ID && envs.RUNNER_URL) {
-            await jobsClient.postRegister({ nodeId: envs.RUNNER_NODE_ID, url: envs.RUNNER_URL });
-        } else {
-            logger.info(`No registration: RUNNER_NODE_ID or RUNNER_URL not set`);
+    if (envs.RUNNER_NODE_ID && envs.RUNNER_URL) {
+        const res = await jobsClient.postRegister({ nodeId: envs.RUNNER_NODE_ID, url: envs.RUNNER_URL });
+        if (res.isErr()) {
+            return Err(res.error);
         }
-        return Ok(undefined);
-    } catch (err) {
-        return Err(new Error('failed to register runner', { cause: err }));
+    } else {
+        logger.info(`No registration: RUNNER_NODE_ID or RUNNER_URL not set`);
     }
+    return Ok(undefined);
 }


### PR DESCRIPTION
retry mechanism relies on a rejected promise so we cannot wrap the output with Result.
But we can catch everything in the jobs client functions so downstream code doesn't have to deal with exception but only Result

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Refactor runner HTTP layer to return `Result` objects and centralize retry logic**

This moderate-sized PR (~170 LOC touched) removes in-function `try/catch` blocks from runner call-sites and moves retry/error handling down into the shared HTTP utilities. `packages/runner/lib/clients/jobs.ts` now always returns a `Result` (`Ok`/`Err`) so callers (`idle.ts`, `register.ts`) can use `isErr()` instead of their own exception logic. The new implementation delegates network retries to an enhanced `httpFetch`, which retries only on network failures, 5xx, and 429 status codes and logs errors consistently. Special handling for 413 (payload too large) is preserved.

Default back-off parameters are defined once (`defaultRetryOptions`) and passed through, reducing duplicate code.

<details>
<summary><strong>Key Changes</strong></summary>

• Added centralized retry/error logic in `httpFetch` using `retryWithBackoff` and status-code filtering
• Updated `packages/runner/lib/clients/jobs.ts` methods (`postHeartbeat`, `putTask`, `postRegister`, `postIdle`) to wrap responses in `Result` and replace local retry blocks
• Changed error constant names to snake_case (e.g., `heartbeat_failed`, `put_task_failed`)
• Simplified `packages/runner/lib/idle.ts` and `packages/runner/lib/register.ts` – they now check `res.isErr()` instead of catching exceptions
• Introduced `defaultRetryOptions` constant and optional back-off options parameter in `httpFetch`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/runner/lib/clients/http.ts`
• `packages/runner/lib/clients/jobs.ts`
• `packages/runner/lib/idle.ts`
• `packages/runner/lib/register.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*