### PR TITLE
fix: do not push self-hosted image on PR build

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -88,6 +88,6 @@ jobs:
                   docker push nangohq/nango:${{ env.SHA }}
 
             - name: (self-hosted) Build and push
-              if: needs.should-run.outputs.should_skip != 'true'
+              if: needs.should-run.outputs.should_skip != 'true' && github.event_name != 'pull_request'
               run: |
                   ./scripts/build_docker_self_hosted.sh ${{ env.SHA }} ${{ env.CAN_PUSH }}


### PR DESCRIPTION
when revamping the github workflow when the merge queue was introduced I remove an condition where self-hosted image would only be built and pushed on master. This is a problem since it means that all PR ends up as usable self-hosted image.
Fixing this issue by making sure self-hosted image are not pushed on PRs
<!-- Summary by @propel-code-bot -->

---

**Prevent self-hosted Docker image push on PR builds**

Adds an extra condition to the `build-image` GitHub workflow so that the self-hosted Docker image is only built/pushed on non-PR events (e.g., `push`, `merge_group`). This restores previous behavior and avoids publishing temporary images for every pull request.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `if` clause for step `(self-hosted) Build and push` in `.github/workflows/build-image.yaml` to include `github.event_name != 'pull_request'`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• .github/workflows/build-image.yaml

</details>

---
*This summary was automatically generated by @propel-code-bot*