### PR TITLE
fix(server): add ready endpoint

### DIFF
--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -11,6 +11,7 @@ import { securityMiddlewares } from './middleware/security.js';
 import { internalApi } from './routes.internal.js';
 import { privateApi } from './routes.private.js';
 import { publicAPI } from './routes.public.js';
+import { isShuttingDown } from './utils/state.js';
 import { dirname } from './utils/utils.js';
 
 import type { ApiError } from '@nangohq/types';
@@ -23,6 +24,13 @@ router.use(...securityMiddlewares());
 // -------
 // No auth routes
 router.get('/health', (_, res) => {
+    res.status(200).send({ result: 'ok' });
+});
+router.get('/ready', (_, res) => {
+    if (isShuttingDown()) {
+        res.status(500).send({ result: 'shutting down' });
+        return;
+    }
     res.status(200).send({ result: 'ok' });
 });
 router.get('/env.js', getEnvJs);

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -26,6 +26,7 @@ import { runnersFleet } from './fleet.js';
 import { pubsub } from './pubsub.js';
 import { router } from './routes.js';
 import migrate from './utils/migrate.js';
+import { setShuttingDown } from './utils/state.js';
 
 import type { WebSocket } from 'ws';
 
@@ -106,6 +107,7 @@ server.listen(port, () => {
 
 // --- Close function
 const close = once(() => {
+    setShuttingDown(true);
     logger.info('Closing...');
 
     cron.getTasks().forEach((task) => task.stop());

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -107,7 +107,6 @@ server.listen(port, () => {
 
 // --- Close function
 const close = once(() => {
-    setShuttingDown(true);
     logger.info('Closing...');
 
     cron.getTasks().forEach((task) => task.stop());
@@ -139,5 +138,6 @@ process.on('SIGINT', () => {
 
 process.on('SIGTERM', () => {
     logger.info('Received SIGTERM...');
-    close();
+    setShuttingDown(true);
+    setTimeout(close, envs.SERVER_SHUTDOWN_DELAY);
 });

--- a/packages/server/lib/utils/state.ts
+++ b/packages/server/lib/utils/state.ts
@@ -1,0 +1,9 @@
+let shuttingDown = false;
+
+export function setShuttingDown(value: boolean) {
+    shuttingDown = value;
+}
+
+export function isShuttingDown() {
+    return shuttingDown;
+}

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -27,6 +27,7 @@ export const ENVS = z.object({
     NANGO_SERVER_WEBSOCKETS_PATH: z.string().optional(),
     NANGO_ADMIN_INVITE_TOKEN: z.string().optional(),
     NANGO_SERVER_PUBLIC_BODY_LIMIT: z.string().optional().default('75mb'),
+    SERVER_SHUTDOWN_DELAY: z.coerce.number().optional().default(0),
 
     // Connect
     NANGO_PUBLIC_CONNECT_URL: z.url().optional(),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add `/ready` readiness endpoint with shutdown flag & delay**

Introduces a lightweight readiness probe so orchestrators can stop routing traffic before the process terminates. A new global flag tracks shutdown state; `process.on('SIGTERM')` now sets this flag and waits an optional `SERVER_SHUTDOWN_DELAY` before invoking the existing `close()` routine. The new `/ready` route returns 500 while the flag is true, 200 otherwise.

<details>
<summary><strong>Key Changes</strong></summary>

• Created `packages/server/lib/utils/state.ts` with `setShuttingDown()` and `isShuttingDown()` helpers
• Added `/ready` route in `packages/server/lib/routes.ts`; returns 500 when `isShuttingDown()` is true
• Updated `packages/server/lib/server.ts`: on `SIGTERM` call `setShuttingDown(true)` and `setTimeout(close, envs.SERVER_SHUTDOWN_DELAY)`
• Extended env schema in `packages/utils/lib/environment/parse.ts` to include `SERVER_SHUTDOWN_DELAY` (number, default 0)

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/utils/state.ts`
• `packages/server/lib/routes.ts`
• `packages/server/lib/server.ts`
• `packages/utils/lib/environment/parse.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*