### PR TITLE
fix(deploy): ensure we filter on the type

### DIFF
--- a/packages/shared/lib/services/deploy/utils.ts
+++ b/packages/shared/lib/services/deploy/utils.ts
@@ -12,6 +12,7 @@ export async function switchActiveSyncConfig(oldSyncConfigId: number, trx: Knex.
                 ON old_config.sync_name = active_config.sync_name
                 AND old_config.nango_config_id = active_config.nango_config_id
                 AND old_config.environment_id = active_config.environment_id
+                AND old_config.type = active_config.type
             WHERE old_config.id = ?
                 AND active_config.active = true
         )

--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -314,7 +314,8 @@ async function compileDeployInfo({
         throw new NangoError('file_upload_error');
     }
 
-    const oldConfigs = await getSyncAndActionConfigsBySyncNameAndConfigId(environment_id, config.id as number, syncName);
+    const oldConfigsAll = await getSyncAndActionConfigsBySyncNameAndConfigId(environment_id, config.id as number, syncName);
+    const oldConfigs = oldConfigsAll.filter((c: DBSyncConfig) => c.type === type);
     let lastSyncWasEnabled = true;
 
     if (oldConfigs.length > 0) {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Filter sync/action operations by `type` to avoid cross-pollution**

Small bug-fix PR that makes sure deployment flow treats `sync` and `action` configurations independently. It adds an explicit `type` filter both when: (1) searching historical configs in `deploy.service.ts`, and (2) choosing the active config in `deploy/utils.ts` raw SQL. This prevents a deploy of a `sync` from incorrectly deactivating or switching an `action` with the same `sync_name` (or vice-versa).

<details>
<summary><strong>Key Changes</strong></summary>

• In `packages/shared/lib/services/sync/config/deploy.service.ts`: replaced single call `oldConfigs = getSyncAndActionConfigsBySyncNameAndConfigId(...)` with two-step logic (`oldConfigsAll` + `.filter((c) => c.type === type)`).
• In `packages/shared/lib/services/deploy/utils.ts`: added `AND old_config.type = active_config.type` to the join condition inside `switchActiveSyncConfig` SQL.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `deploy.service.ts` – version-bump & deactivation logic
• `deploy/utils.ts` – SQL that remaps `syncs.sync_config_id`

</details>

---
*This summary was automatically generated by @propel-code-bot*