### PR TITLE
fix(deploy-versions): dont force version

### DIFF
--- a/packages/cli/lib/zeroYaml/definitions.ts
+++ b/packages/cli/lib/zeroYaml/definitions.ts
@@ -192,7 +192,7 @@ export function buildSync({
         sync_type: params.syncType,
         track_deletes: params.trackDeletes === true,
         usedModels: Array.from(usedModels.values()),
-        version: params.version || '0.0.1',
+        version: params.version || '',
         webhookSubscriptions: params.webhookSubscriptions || []
     };
     return Ok({ sync, models });
@@ -233,7 +233,7 @@ export function buildAction({
         output: [output.name],
         scopes: params.scopes || [],
         usedModels: [input.name, output.name],
-        version: params.version || '0.0.1'
+        version: params.version || ''
     };
     return { action, models };
 }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Remove hard-coded default version (`'0.0.1'`) in sync/action builders**

The PR stops assigning a fallback version string of `'0.0.1'` when a caller omits `params.version` in the `createSync` and `createAction` builder utilities inside `packages/cli/lib/zeroYaml/definitions.ts`. Instead, an empty string (`''`) is propagated, allowing upstream tooling or validation layers to decide how to treat unspecified versions.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced default `version: params.version || '0.0.1'` with `version: params.version || ''` in `buildSync()`
• Applied the same change in `buildAction()`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/cli/lib/zeroYaml/definitions.ts` – logic that builds `ParsedNangoSync` and `ParsedNangoAction` objects

</details>

---
*This summary was automatically generated by @propel-code-bot*