### PR TITLE
fix(plan): xl api_rate_limit_size for growth plan

### DIFF
--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -80,7 +80,7 @@ export const growthV1Plan: PlanDefinition = {
     hidden: true,
     basePrice: 500,
     flags: {
-        api_rate_limit_size: 'l',
+        api_rate_limit_size: 'xl',
         environments_max: 10,
         has_otel: true,
         has_sync_variants: true,


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Correct `api_rate_limit_size` for `growth` plan from 'l' to 'xl'**

Single-line fix in `plan` definitions adjusting the `api_rate_limit_size` flag for the legacy **Growth (v1)** plan. This aligns the code with the intended XL rate-limit tier for that plan.

<details>
<summary><strong>Key Changes</strong></summary>

• Changed `api_rate_limit_size` in `growthV1Plan.flags` from 'l' to 'xl'

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/services/plans/definitions.ts` (growth plan flags)

</details>

---
*This summary was automatically generated by @propel-code-bot*