### PR TITLE
fix(providers): add a default value for medallia gatewayUrl

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -8093,6 +8093,7 @@ medallia:
             type: string
             title: ''
             description: ''
+            default_value: ''
             hidden: true # deprecating this in favor of apiHostUrl
 
 metabase:

--- a/scripts/validation/providers/schema.json
+++ b/scripts/validation/providers/schema.json
@@ -629,6 +629,9 @@
                                 "automated": {
                                     "type": "boolean"
                                 },
+                                "default_value": {
+                                    "type": "string"
+                                },
                                 "hidden": {
                                     "type": "boolean"
                                 }


### PR DESCRIPTION
## Describe the problem and your solution

- add a default value for medallia `gatewayUrl`

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Set default empty string for deprecated `gatewayUrl` & extend provider schema**

This minor PR prevents validation failures when `gatewayUrl` is omitted from Medallia provider configs by (1) attaching `default_value: ''` to the field in `packages/providers/providers.yaml`, and (2) updating `scripts/validation/providers/schema.json` so the JSON-schema permits an optional string property named `default_value` for any `connection_config` entry.

No application code or runtime logic is touched—only static provider metadata and its validation schema—so risk is low and scope is limited to configuration parsing.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `default_value: ''` under `medallia.connection_config.gatewayUrl` in `packages/providers/providers.yaml`
• Extended `scripts/validation/providers/schema.json` to allow optional `default_value` (type `string`) inside each `connection_config` property

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/providers/providers.yaml` (Medallia provider block)
• `scripts/validation/providers/schema.json` (schema for provider definitions)

</details>

---
*This summary was automatically generated by @propel-code-bot*