### PR TITLE
fix: remove legacy usage table

### DIFF
--- a/packages/database/lib/migrations/20251031182500_drop_accounts_usage_table.cjs
+++ b/packages/database/lib/migrations/20251031182500_drop_accounts_usage_table.cjs
@@ -1,0 +1,13 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.schema.dropTableIfExists('accounts_usage');
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};


### PR DESCRIPTION
Code writing to this table has been remove in https://github.com/NangoHQ/nango/pull/4918

<!-- Summary by @propel-code-bot -->

---

**Remove legacy `accounts_usage` table via migration**

Adds a single database migration that drops the obsolete `accounts_usage` table. No other code changes are introduced, aligning with prior removal of all write paths to this table in PR #4918.

<details>
<summary><strong>Key Changes</strong></summary>

• Added migration `packages/database/lib/migrations/20251031182500_drop_accounts_usage_table.cjs` with `exports.up` that executes `knex.schema.dropTableIfExists('accounts_usage')`
• Sets `exports.config.transaction = false`, and leaves `exports.down` empty (non-reversible)

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Database migration layer (`knex` migrations)

</details>

---
*This summary was automatically generated by @propel-code-bot*