### PR TITLE
feat(fleet): add idle timeout to node config and overrides

### DIFF
--- a/packages/fleet/lib/db/migrations/20251103174100_add_idle_timeout.ts
+++ b/packages/fleet/lib/db/migrations/20251103174100_add_idle_timeout.ts
@@ -4,9 +4,9 @@ import { NODE_CONFIG_OVERRIDES_TABLE } from '../../models/node_config_overrides.
 
 export async function up(knex: Knex): Promise<void> {
     await knex.raw(`ALTER TABLE ${NODES_TABLE}
-      ADD COLUMN IF NOT EXISTS idle_timeout int NOT NULL DEFAULT 1800`);
+      ADD COLUMN IF NOT EXISTS idle_timeout_secs int NOT NULL DEFAULT 1800`);
     await knex.raw(`ALTER TABLE ${NODE_CONFIG_OVERRIDES_TABLE}
-      ADD COLUMN IF NOT EXISTS idle_timeout int DEFAULT NULL`);
+      ADD COLUMN IF NOT EXISTS idle_timeout_secs int DEFAULT NULL`);
 }
 
 export async function down(): Promise<void> {}

--- a/packages/fleet/lib/db/migrations/20251103174100_add_idle_timeout.ts
+++ b/packages/fleet/lib/db/migrations/20251103174100_add_idle_timeout.ts
@@ -6,7 +6,7 @@ export async function up(knex: Knex): Promise<void> {
     await knex.raw(`ALTER TABLE ${NODES_TABLE}
       ADD COLUMN IF NOT EXISTS idle_timeout int NOT NULL DEFAULT 1800`);
     await knex.raw(`ALTER TABLE ${NODE_CONFIG_OVERRIDES_TABLE}
-      ADD COLUMN IF NOT EXISTS idle_timeout int NULLABLE DEFAULT NULL`);
+      ADD COLUMN IF NOT EXISTS idle_timeout int DEFAULT NULL`);
 }
 
 export async function down(): Promise<void> {}

--- a/packages/fleet/lib/db/migrations/20251103174100_add_idle_timeout.ts
+++ b/packages/fleet/lib/db/migrations/20251103174100_add_idle_timeout.ts
@@ -1,0 +1,12 @@
+import type { Knex } from 'knex';
+import { NODES_TABLE } from '../../models/nodes.js';
+import { NODE_CONFIG_OVERRIDES_TABLE } from '../../models/node_config_overrides.js';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`ALTER TABLE ${NODES_TABLE}
+      ADD COLUMN IF NOT EXISTS idle_timeout int NOT NULL DEFAULT 1800`);
+    await knex.raw(`ALTER TABLE ${NODE_CONFIG_OVERRIDES_TABLE}
+      ADD COLUMN IF NOT EXISTS idle_timeout int NULLABLE DEFAULT NULL`);
+}
+
+export async function down(): Promise<void> {}

--- a/packages/fleet/lib/db/migrations/20251103174100_add_idle_timeout.ts
+++ b/packages/fleet/lib/db/migrations/20251103174100_add_idle_timeout.ts
@@ -4,9 +4,9 @@ import { NODE_CONFIG_OVERRIDES_TABLE } from '../../models/node_config_overrides.
 
 export async function up(knex: Knex): Promise<void> {
     await knex.raw(`ALTER TABLE ${NODES_TABLE}
-      ADD COLUMN IF NOT EXISTS idle_timeout_secs int NOT NULL DEFAULT 1800`);
+      ADD COLUMN IF NOT EXISTS idle_max_duration_ms int NOT NULL DEFAULT 1800000`); // 30 minutes
     await knex.raw(`ALTER TABLE ${NODE_CONFIG_OVERRIDES_TABLE}
-      ADD COLUMN IF NOT EXISTS idle_timeout_secs int DEFAULT NULL`);
+      ADD COLUMN IF NOT EXISTS idle_max_duration_ms int DEFAULT NULL`); // 30 minutes
 }
 
 export async function down(): Promise<void> {}

--- a/packages/fleet/lib/fleet.integration.test.ts
+++ b/packages/fleet/lib/fleet.integration.test.ts
@@ -46,7 +46,8 @@ describe('fleet', () => {
                 memoryMb: 100,
                 storageMb: 100,
                 isTracingEnabled: false,
-                isProfilingEnabled: false
+                isProfilingEnabled: false,
+                idleTimeout: 1800
             };
             await nodeConfigOverrides.upsert(dbClient.db, props);
             const image = generateImage();
@@ -61,6 +62,7 @@ describe('fleet', () => {
                 storageMb: props.storageMb,
                 isTracingEnabled: props.isTracingEnabled,
                 isProfilingEnabled: props.isProfilingEnabled,
+                idleTimeout: props.idleTimeout,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });
@@ -122,7 +124,8 @@ describe('fleet', () => {
                 memoryMb: 100,
                 storageMb: 100,
                 isTracingEnabled: false,
-                isProfilingEnabled: false
+                isProfilingEnabled: false,
+                idleTimeout: 1800
             };
             const nodeConfigOverride = (await fleet.overrideNodeConfig(props)).unwrap();
             expect(nodeConfigOverride).toStrictEqual({
@@ -134,6 +137,7 @@ describe('fleet', () => {
                 storageMb: props.storageMb,
                 isTracingEnabled: props.isTracingEnabled,
                 isProfilingEnabled: props.isProfilingEnabled,
+                idleTimeout: props.idleTimeout,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });
@@ -146,7 +150,8 @@ describe('fleet', () => {
                 memoryMb: 100,
                 storageMb: 100,
                 isTracingEnabled: true,
-                isProfilingEnabled: true
+                isProfilingEnabled: true,
+                idleTimeout: 1800
             };
             await fleet.overrideNodeConfig(props);
             const updatedProps = {
@@ -156,7 +161,8 @@ describe('fleet', () => {
                 memoryMb: 2000,
                 storageMb: 2000,
                 isTracingEnabled: true,
-                isProfilingEnabled: true
+                isProfilingEnabled: true,
+                idleTimeout: 1800
             };
             const nodeConfigOverride = (await fleet.overrideNodeConfig(updatedProps)).unwrap();
             expect(nodeConfigOverride).toStrictEqual({
@@ -168,6 +174,7 @@ describe('fleet', () => {
                 storageMb: updatedProps.storageMb,
                 isTracingEnabled: updatedProps.isTracingEnabled,
                 isProfilingEnabled: updatedProps.isProfilingEnabled,
+                idleTimeout: updatedProps.idleTimeout,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });
@@ -180,7 +187,8 @@ describe('fleet', () => {
                 memoryMb: 100,
                 storageMb: 100,
                 isTracingEnabled: false,
-                isProfilingEnabled: false
+                isProfilingEnabled: false,
+                idleTimeout: 1800
             };
             await fleet.overrideNodeConfig(props);
 
@@ -202,7 +210,8 @@ describe('fleet', () => {
                 memoryMb: 100,
                 storageMb: 100,
                 isTracingEnabled: false,
-                isProfilingEnabled: false
+                isProfilingEnabled: false,
+                idleTimeout: 1800
             };
             await fleet.overrideNodeConfig(props);
 
@@ -213,7 +222,8 @@ describe('fleet', () => {
                 memoryMb: null,
                 storageMb: null,
                 isTracingEnabled: false,
-                isProfilingEnabled: false
+                isProfilingEnabled: false,
+                idleTimeout: 1800
             };
             await fleet.overrideNodeConfig(defaultProps);
 
@@ -227,6 +237,7 @@ describe('fleet', () => {
                 storageMb: null,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
+                idleTimeout: 1800,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });

--- a/packages/fleet/lib/fleet.integration.test.ts
+++ b/packages/fleet/lib/fleet.integration.test.ts
@@ -47,7 +47,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleTimeoutSecs: 1800
+                idleMaxDurationMs: 1800
             };
             await nodeConfigOverrides.upsert(dbClient.db, props);
             const image = generateImage();
@@ -62,7 +62,7 @@ describe('fleet', () => {
                 storageMb: props.storageMb,
                 isTracingEnabled: props.isTracingEnabled,
                 isProfilingEnabled: props.isProfilingEnabled,
-                idleTimeoutSecs: props.idleTimeoutSecs,
+                idleMaxDurationMs: props.idleMaxDurationMs,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });
@@ -125,7 +125,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleTimeoutSecs: 1800
+                idleMaxDurationMs: 1800
             };
             const nodeConfigOverride = (await fleet.overrideNodeConfig(props)).unwrap();
             expect(nodeConfigOverride).toStrictEqual({
@@ -137,7 +137,7 @@ describe('fleet', () => {
                 storageMb: props.storageMb,
                 isTracingEnabled: props.isTracingEnabled,
                 isProfilingEnabled: props.isProfilingEnabled,
-                idleTimeoutSecs: props.idleTimeoutSecs,
+                idleMaxDurationMs: props.idleMaxDurationMs,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });
@@ -151,7 +151,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: true,
                 isProfilingEnabled: true,
-                idleTimeoutSecs: 1800
+                idleMaxDurationMs: 1800
             };
             await fleet.overrideNodeConfig(props);
             const updatedProps = {
@@ -162,7 +162,7 @@ describe('fleet', () => {
                 storageMb: 2000,
                 isTracingEnabled: true,
                 isProfilingEnabled: true,
-                idleTimeoutSecs: 1800
+                idleMaxDurationMs: 1800
             };
             const nodeConfigOverride = (await fleet.overrideNodeConfig(updatedProps)).unwrap();
             expect(nodeConfigOverride).toStrictEqual({
@@ -174,7 +174,7 @@ describe('fleet', () => {
                 storageMb: updatedProps.storageMb,
                 isTracingEnabled: updatedProps.isTracingEnabled,
                 isProfilingEnabled: updatedProps.isProfilingEnabled,
-                idleTimeoutSecs: updatedProps.idleTimeoutSecs,
+                idleMaxDurationMs: updatedProps.idleMaxDurationMs,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });
@@ -188,7 +188,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleTimeoutSecs: 1800
+                idleMaxDurationMs: 1800
             };
             await fleet.overrideNodeConfig(props);
 
@@ -211,7 +211,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleTimeoutSecs: 1800
+                idleMaxDurationMs: 1800
             };
             await fleet.overrideNodeConfig(props);
 
@@ -223,7 +223,7 @@ describe('fleet', () => {
                 storageMb: null,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleTimeoutSecs: 1800
+                idleMaxDurationMs: 1800
             };
             await fleet.overrideNodeConfig(defaultProps);
 
@@ -237,7 +237,7 @@ describe('fleet', () => {
                 storageMb: null,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleTimeoutSecs: 1800,
+                idleMaxDurationMs: 1800,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });

--- a/packages/fleet/lib/fleet.integration.test.ts
+++ b/packages/fleet/lib/fleet.integration.test.ts
@@ -47,7 +47,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleTimeout: 1800
+                idleTimeoutSecs: 1800
             };
             await nodeConfigOverrides.upsert(dbClient.db, props);
             const image = generateImage();
@@ -62,7 +62,7 @@ describe('fleet', () => {
                 storageMb: props.storageMb,
                 isTracingEnabled: props.isTracingEnabled,
                 isProfilingEnabled: props.isProfilingEnabled,
-                idleTimeout: props.idleTimeout,
+                idleTimeoutSecs: props.idleTimeoutSecs,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });

--- a/packages/fleet/lib/fleet.integration.test.ts
+++ b/packages/fleet/lib/fleet.integration.test.ts
@@ -125,7 +125,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleTimeout: 1800
+                idleTimeoutSecs: 1800
             };
             const nodeConfigOverride = (await fleet.overrideNodeConfig(props)).unwrap();
             expect(nodeConfigOverride).toStrictEqual({
@@ -137,7 +137,7 @@ describe('fleet', () => {
                 storageMb: props.storageMb,
                 isTracingEnabled: props.isTracingEnabled,
                 isProfilingEnabled: props.isProfilingEnabled,
-                idleTimeout: props.idleTimeout,
+                idleTimeoutSecs: props.idleTimeoutSecs,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });
@@ -151,7 +151,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: true,
                 isProfilingEnabled: true,
-                idleTimeout: 1800
+                idleTimeoutSecs: 1800
             };
             await fleet.overrideNodeConfig(props);
             const updatedProps = {
@@ -162,7 +162,7 @@ describe('fleet', () => {
                 storageMb: 2000,
                 isTracingEnabled: true,
                 isProfilingEnabled: true,
-                idleTimeout: 1800
+                idleTimeoutSecs: 1800
             };
             const nodeConfigOverride = (await fleet.overrideNodeConfig(updatedProps)).unwrap();
             expect(nodeConfigOverride).toStrictEqual({
@@ -174,7 +174,7 @@ describe('fleet', () => {
                 storageMb: updatedProps.storageMb,
                 isTracingEnabled: updatedProps.isTracingEnabled,
                 isProfilingEnabled: updatedProps.isProfilingEnabled,
-                idleTimeout: updatedProps.idleTimeout,
+                idleTimeoutSecs: updatedProps.idleTimeoutSecs,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });
@@ -188,7 +188,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleTimeout: 1800
+                idleTimeoutSecs: 1800
             };
             await fleet.overrideNodeConfig(props);
 
@@ -211,7 +211,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleTimeout: 1800
+                idleTimeoutSecs: 1800
             };
             await fleet.overrideNodeConfig(props);
 
@@ -223,7 +223,7 @@ describe('fleet', () => {
                 storageMb: null,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleTimeout: 1800
+                idleTimeoutSecs: 1800
             };
             await fleet.overrideNodeConfig(defaultProps);
 
@@ -237,7 +237,7 @@ describe('fleet', () => {
                 storageMb: null,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleTimeout: 1800,
+                idleTimeoutSecs: 1800,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });

--- a/packages/fleet/lib/fleet.ts
+++ b/packages/fleet/lib/fleet.ts
@@ -189,7 +189,7 @@ export class Fleet {
                 defaultConfig.storageMb === override.storageMb &&
                 defaultConfig.isTracingEnabled === override.isTracingEnabled &&
                 defaultConfig.isProfilingEnabled === override.isProfilingEnabled &&
-                defaultConfig.idleTimeoutSecs === override.idleTimeoutSecs;
+                defaultConfig.idleMaxDurationMs === override.idleMaxDurationMs;
 
             if (isDefault) {
                 return nodeConfigOverrides.remove(trx, override.routingId);

--- a/packages/fleet/lib/fleet.ts
+++ b/packages/fleet/lib/fleet.ts
@@ -188,7 +188,8 @@ export class Fleet {
                 defaultConfig.memoryMb === override.memoryMb &&
                 defaultConfig.storageMb === override.storageMb &&
                 defaultConfig.isTracingEnabled === override.isTracingEnabled &&
-                defaultConfig.isProfilingEnabled === override.isProfilingEnabled;
+                defaultConfig.isProfilingEnabled === override.isProfilingEnabled &&
+                defaultConfig.idleTimeout === override.idleTimeout;
 
             if (isDefault) {
                 return nodeConfigOverrides.remove(trx, override.routingId);

--- a/packages/fleet/lib/fleet.ts
+++ b/packages/fleet/lib/fleet.ts
@@ -189,7 +189,7 @@ export class Fleet {
                 defaultConfig.storageMb === override.storageMb &&
                 defaultConfig.isTracingEnabled === override.isTracingEnabled &&
                 defaultConfig.isProfilingEnabled === override.isProfilingEnabled &&
-                defaultConfig.idleTimeout === override.idleTimeout;
+                defaultConfig.idleTimeoutSecs === override.idleTimeoutSecs;
 
             if (isDefault) {
                 return nodeConfigOverrides.remove(trx, override.routingId);

--- a/packages/fleet/lib/models/helpers.test.ts
+++ b/packages/fleet/lib/models/helpers.test.ts
@@ -56,7 +56,7 @@ async function createNode(db: knex.Knex, { routingId, deploymentId }: { routingI
         storageMb: 512,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleTimeoutSecs: 1800
+        idleMaxDurationMs: 1800
     });
     return node.unwrap();
 }

--- a/packages/fleet/lib/models/helpers.test.ts
+++ b/packages/fleet/lib/models/helpers.test.ts
@@ -56,7 +56,7 @@ async function createNode(db: knex.Knex, { routingId, deploymentId }: { routingI
         storageMb: 512,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleTimeout: 1800
+        idleTimeoutSecs: 1800
     });
     return node.unwrap();
 }

--- a/packages/fleet/lib/models/helpers.test.ts
+++ b/packages/fleet/lib/models/helpers.test.ts
@@ -55,7 +55,8 @@ async function createNode(db: knex.Knex, { routingId, deploymentId }: { routingI
         memoryMb: 1024,
         storageMb: 512,
         isTracingEnabled: false,
-        isProfilingEnabled: false
+        isProfilingEnabled: false,
+        idleTimeout: 1800
     });
     return node.unwrap();
 }

--- a/packages/fleet/lib/models/node_config_overrides.integration.test.ts
+++ b/packages/fleet/lib/models/node_config_overrides.integration.test.ts
@@ -22,7 +22,7 @@ describe('NodeConfgOverrides', () => {
         storageMb: 1000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleTimeout: 1800
+        idleTimeoutSecs: 1800
     };
 
     it('should be successfully created', async () => {
@@ -36,7 +36,7 @@ describe('NodeConfgOverrides', () => {
             storageMb: props.storageMb,
             isTracingEnabled: props.isTracingEnabled,
             isProfilingEnabled: props.isProfilingEnabled,
-            idleTimeout: props.idleTimeout,
+            idleTimeoutSecs: props.idleTimeoutSecs,
             createdAt: expect.any(Date),
             updatedAt: expect.any(Date)
         });
@@ -52,7 +52,7 @@ describe('NodeConfgOverrides', () => {
                 storageMb: null,
                 isTracingEnabled: null,
                 isProfilingEnabled: null,
-                idleTimeout: null
+                idleTimeoutSecs: null
             })
         ).unwrap();
         expect(nodeConfigOverride).toStrictEqual({
@@ -64,7 +64,7 @@ describe('NodeConfgOverrides', () => {
             storageMb: null,
             isTracingEnabled: null,
             isProfilingEnabled: null,
-            idleTimeout: null,
+            idleTimeoutSecs: null,
             createdAt: expect.any(Date),
             updatedAt: expect.any(Date)
         });
@@ -80,7 +80,7 @@ describe('NodeConfgOverrides', () => {
             storageMb: 2000,
             isTracingEnabled: true,
             isProfilingEnabled: true,
-            idleTimeout: 1800
+            idleTimeoutSecs: 1800
         };
         const updatedNodeConfigOverride = (await node_config_overrides.upsert(dbClient.db, updatedProps)).unwrap();
         expect(updatedNodeConfigOverride).toStrictEqual({
@@ -91,7 +91,7 @@ describe('NodeConfgOverrides', () => {
             storageMb: updatedProps.storageMb,
             isTracingEnabled: updatedProps.isTracingEnabled,
             isProfilingEnabled: updatedProps.isProfilingEnabled,
-            idleTimeout: updatedProps.idleTimeout,
+            idleTimeoutSecs: updatedProps.idleTimeoutSecs,
             updatedAt: expect.any(Date)
         });
     });

--- a/packages/fleet/lib/models/node_config_overrides.integration.test.ts
+++ b/packages/fleet/lib/models/node_config_overrides.integration.test.ts
@@ -22,7 +22,7 @@ describe('NodeConfgOverrides', () => {
         storageMb: 1000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleTimeoutSecs: 1800
+        idleMaxDurationMs: 1800
     };
 
     it('should be successfully created', async () => {
@@ -36,7 +36,7 @@ describe('NodeConfgOverrides', () => {
             storageMb: props.storageMb,
             isTracingEnabled: props.isTracingEnabled,
             isProfilingEnabled: props.isProfilingEnabled,
-            idleTimeoutSecs: props.idleTimeoutSecs,
+            idleMaxDurationMs: props.idleMaxDurationMs,
             createdAt: expect.any(Date),
             updatedAt: expect.any(Date)
         });
@@ -52,7 +52,7 @@ describe('NodeConfgOverrides', () => {
                 storageMb: null,
                 isTracingEnabled: null,
                 isProfilingEnabled: null,
-                idleTimeoutSecs: null
+                idleMaxDurationMs: null
             })
         ).unwrap();
         expect(nodeConfigOverride).toStrictEqual({
@@ -64,7 +64,7 @@ describe('NodeConfgOverrides', () => {
             storageMb: null,
             isTracingEnabled: null,
             isProfilingEnabled: null,
-            idleTimeoutSecs: null,
+            idleMaxDurationMs: null,
             createdAt: expect.any(Date),
             updatedAt: expect.any(Date)
         });
@@ -80,7 +80,7 @@ describe('NodeConfgOverrides', () => {
             storageMb: 2000,
             isTracingEnabled: true,
             isProfilingEnabled: true,
-            idleTimeoutSecs: 1800
+            idleMaxDurationMs: 1800
         };
         const updatedNodeConfigOverride = (await node_config_overrides.upsert(dbClient.db, updatedProps)).unwrap();
         expect(updatedNodeConfigOverride).toStrictEqual({
@@ -91,7 +91,7 @@ describe('NodeConfgOverrides', () => {
             storageMb: updatedProps.storageMb,
             isTracingEnabled: updatedProps.isTracingEnabled,
             isProfilingEnabled: updatedProps.isProfilingEnabled,
-            idleTimeoutSecs: updatedProps.idleTimeoutSecs,
+            idleMaxDurationMs: updatedProps.idleMaxDurationMs,
             updatedAt: expect.any(Date)
         });
     });

--- a/packages/fleet/lib/models/node_config_overrides.integration.test.ts
+++ b/packages/fleet/lib/models/node_config_overrides.integration.test.ts
@@ -21,7 +21,8 @@ describe('NodeConfgOverrides', () => {
         memoryMb: 1000,
         storageMb: 1000,
         isTracingEnabled: false,
-        isProfilingEnabled: false
+        isProfilingEnabled: false,
+        idleTimeout: 1800
     };
 
     it('should be successfully created', async () => {
@@ -35,6 +36,7 @@ describe('NodeConfgOverrides', () => {
             storageMb: props.storageMb,
             isTracingEnabled: props.isTracingEnabled,
             isProfilingEnabled: props.isProfilingEnabled,
+            idleTimeout: props.idleTimeout,
             createdAt: expect.any(Date),
             updatedAt: expect.any(Date)
         });
@@ -49,7 +51,8 @@ describe('NodeConfgOverrides', () => {
                 memoryMb: null,
                 storageMb: null,
                 isTracingEnabled: null,
-                isProfilingEnabled: null
+                isProfilingEnabled: null,
+                idleTimeout: null
             })
         ).unwrap();
         expect(nodeConfigOverride).toStrictEqual({
@@ -61,6 +64,7 @@ describe('NodeConfgOverrides', () => {
             storageMb: null,
             isTracingEnabled: null,
             isProfilingEnabled: null,
+            idleTimeout: null,
             createdAt: expect.any(Date),
             updatedAt: expect.any(Date)
         });
@@ -75,7 +79,8 @@ describe('NodeConfgOverrides', () => {
             memoryMb: 2000,
             storageMb: 2000,
             isTracingEnabled: true,
-            isProfilingEnabled: true
+            isProfilingEnabled: true,
+            idleTimeout: 1800
         };
         const updatedNodeConfigOverride = (await node_config_overrides.upsert(dbClient.db, updatedProps)).unwrap();
         expect(updatedNodeConfigOverride).toStrictEqual({
@@ -86,6 +91,7 @@ describe('NodeConfgOverrides', () => {
             storageMb: updatedProps.storageMb,
             isTracingEnabled: updatedProps.isTracingEnabled,
             isProfilingEnabled: updatedProps.isProfilingEnabled,
+            idleTimeout: updatedProps.idleTimeout,
             updatedAt: expect.any(Date)
         });
     });

--- a/packages/fleet/lib/models/node_config_overrides.ts
+++ b/packages/fleet/lib/models/node_config_overrides.ts
@@ -18,6 +18,7 @@ interface DBNodeConfigOverride {
     readonly storage_mb: number | null;
     readonly is_tracing_enabled: boolean | null;
     readonly is_profiling_enabled: boolean | null;
+    readonly idle_timeout: number | null;
     readonly created_at: Date;
     readonly updated_at: Date;
 }
@@ -33,6 +34,7 @@ const DBNodeConfigOverride = {
             storage_mb: nodeConfigOverride.storageMb,
             is_tracing_enabled: nodeConfigOverride.isTracingEnabled,
             is_profiling_enabled: nodeConfigOverride.isProfilingEnabled,
+            idle_timeout: nodeConfigOverride.idleTimeout,
             created_at: nodeConfigOverride.createdAt,
             updated_at: nodeConfigOverride.updatedAt
         };
@@ -47,6 +49,7 @@ const DBNodeConfigOverride = {
             storageMb: dbNodeConfigOverride.storage_mb,
             isTracingEnabled: dbNodeConfigOverride.is_tracing_enabled,
             isProfilingEnabled: dbNodeConfigOverride.is_profiling_enabled,
+            idleTimeout: dbNodeConfigOverride.idle_timeout,
             createdAt: dbNodeConfigOverride.created_at,
             updatedAt: dbNodeConfigOverride.updated_at
         };
@@ -68,6 +71,7 @@ export async function upsert(
             storage_mb: props.storageMb ?? null,
             is_tracing_enabled: props.isTracingEnabled ?? null,
             is_profiling_enabled: props.isProfilingEnabled ?? null,
+            idle_timeout: props.idleTimeout ?? null,
             created_at: now,
             updated_at: now
         };
@@ -79,6 +83,7 @@ export async function upsert(
             ...(props.storageMb !== undefined ? { storage_mb: props.storageMb } : {}),
             ...(props.isTracingEnabled !== undefined ? { is_tracing_enabled: props.isTracingEnabled } : {}),
             ...(props.isProfilingEnabled !== undefined ? { is_profiling_enabled: props.isProfilingEnabled } : {}),
+            ...(props.idleTimeout !== undefined ? { idle_timeout: props.idleTimeout } : {}),
             updated_at: now
         };
 

--- a/packages/fleet/lib/models/node_config_overrides.ts
+++ b/packages/fleet/lib/models/node_config_overrides.ts
@@ -18,7 +18,7 @@ interface DBNodeConfigOverride {
     readonly storage_mb: number | null;
     readonly is_tracing_enabled: boolean | null;
     readonly is_profiling_enabled: boolean | null;
-    readonly idle_timeout_secs: number | null;
+    readonly idle_max_duration_ms: number | null;
     readonly created_at: Date;
     readonly updated_at: Date;
 }
@@ -34,7 +34,7 @@ const DBNodeConfigOverride = {
             storage_mb: nodeConfigOverride.storageMb,
             is_tracing_enabled: nodeConfigOverride.isTracingEnabled,
             is_profiling_enabled: nodeConfigOverride.isProfilingEnabled,
-            idle_timeout_secs: nodeConfigOverride.idleTimeoutSecs,
+            idle_max_duration_ms: nodeConfigOverride.idleMaxDurationMs,
             created_at: nodeConfigOverride.createdAt,
             updated_at: nodeConfigOverride.updatedAt
         };
@@ -49,7 +49,7 @@ const DBNodeConfigOverride = {
             storageMb: dbNodeConfigOverride.storage_mb,
             isTracingEnabled: dbNodeConfigOverride.is_tracing_enabled,
             isProfilingEnabled: dbNodeConfigOverride.is_profiling_enabled,
-            idleTimeoutSecs: dbNodeConfigOverride.idle_timeout_secs,
+            idleMaxDurationMs: dbNodeConfigOverride.idle_max_duration_ms,
             createdAt: dbNodeConfigOverride.created_at,
             updatedAt: dbNodeConfigOverride.updated_at
         };
@@ -71,7 +71,7 @@ export async function upsert(
             storage_mb: props.storageMb ?? null,
             is_tracing_enabled: props.isTracingEnabled ?? null,
             is_profiling_enabled: props.isProfilingEnabled ?? null,
-            idle_timeout_secs: props.idleTimeoutSecs ?? null,
+            idle_max_duration_ms: props.idleMaxDurationMs ?? null,
             created_at: now,
             updated_at: now
         };
@@ -83,7 +83,7 @@ export async function upsert(
             ...(props.storageMb !== undefined ? { storage_mb: props.storageMb } : {}),
             ...(props.isTracingEnabled !== undefined ? { is_tracing_enabled: props.isTracingEnabled } : {}),
             ...(props.isProfilingEnabled !== undefined ? { is_profiling_enabled: props.isProfilingEnabled } : {}),
-            ...(props.idleTimeoutSecs !== undefined ? { idle_timeout_secs: props.idleTimeoutSecs } : {}),
+            ...(props.idleMaxDurationMs !== undefined ? { idle_max_duration_ms: props.idleMaxDurationMs } : {}),
             updated_at: now
         };
 

--- a/packages/fleet/lib/models/node_config_overrides.ts
+++ b/packages/fleet/lib/models/node_config_overrides.ts
@@ -18,7 +18,7 @@ interface DBNodeConfigOverride {
     readonly storage_mb: number | null;
     readonly is_tracing_enabled: boolean | null;
     readonly is_profiling_enabled: boolean | null;
-    readonly idle_timeout: number | null;
+    readonly idle_timeout_secs: number | null;
     readonly created_at: Date;
     readonly updated_at: Date;
 }
@@ -34,7 +34,7 @@ const DBNodeConfigOverride = {
             storage_mb: nodeConfigOverride.storageMb,
             is_tracing_enabled: nodeConfigOverride.isTracingEnabled,
             is_profiling_enabled: nodeConfigOverride.isProfilingEnabled,
-            idle_timeout: nodeConfigOverride.idleTimeout,
+            idle_timeout_secs: nodeConfigOverride.idleTimeoutSecs,
             created_at: nodeConfigOverride.createdAt,
             updated_at: nodeConfigOverride.updatedAt
         };
@@ -49,7 +49,7 @@ const DBNodeConfigOverride = {
             storageMb: dbNodeConfigOverride.storage_mb,
             isTracingEnabled: dbNodeConfigOverride.is_tracing_enabled,
             isProfilingEnabled: dbNodeConfigOverride.is_profiling_enabled,
-            idleTimeout: dbNodeConfigOverride.idle_timeout,
+            idleTimeoutSecs: dbNodeConfigOverride.idle_timeout_secs,
             createdAt: dbNodeConfigOverride.created_at,
             updatedAt: dbNodeConfigOverride.updated_at
         };
@@ -71,7 +71,7 @@ export async function upsert(
             storage_mb: props.storageMb ?? null,
             is_tracing_enabled: props.isTracingEnabled ?? null,
             is_profiling_enabled: props.isProfilingEnabled ?? null,
-            idle_timeout: props.idleTimeout ?? null,
+            idle_timeout_secs: props.idleTimeoutSecs ?? null,
             created_at: now,
             updated_at: now
         };
@@ -83,7 +83,7 @@ export async function upsert(
             ...(props.storageMb !== undefined ? { storage_mb: props.storageMb } : {}),
             ...(props.isTracingEnabled !== undefined ? { is_tracing_enabled: props.isTracingEnabled } : {}),
             ...(props.isProfilingEnabled !== undefined ? { is_profiling_enabled: props.isProfilingEnabled } : {}),
-            ...(props.idleTimeout !== undefined ? { idle_timeout: props.idleTimeout } : {}),
+            ...(props.idleTimeoutSecs !== undefined ? { idle_timeout_secs: props.idleTimeoutSecs } : {}),
             updated_at: now
         };
 

--- a/packages/fleet/lib/models/nodes.integration.test.ts
+++ b/packages/fleet/lib/models/nodes.integration.test.ts
@@ -37,7 +37,7 @@ describe('Nodes', () => {
                 storageMb: 512,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleTimeoutSecs: 1800
+                idleMaxDurationMs: 1800
             })
         ).unwrap();
         expect(node).toStrictEqual({
@@ -52,7 +52,7 @@ describe('Nodes', () => {
             storageMb: 512,
             isTracingEnabled: false,
             isProfilingEnabled: false,
-            idleTimeoutSecs: 1800,
+            idleMaxDurationMs: 1800,
             error: null,
             createdAt: expect.any(Date),
             lastStateTransitionAt: expect.any(Date)

--- a/packages/fleet/lib/models/nodes.integration.test.ts
+++ b/packages/fleet/lib/models/nodes.integration.test.ts
@@ -36,7 +36,8 @@ describe('Nodes', () => {
                 memoryMb: 1024,
                 storageMb: 512,
                 isTracingEnabled: false,
-                isProfilingEnabled: false
+                isProfilingEnabled: false,
+                idleTimeout: 1800
             })
         ).unwrap();
         expect(node).toStrictEqual({
@@ -51,6 +52,7 @@ describe('Nodes', () => {
             storageMb: 512,
             isTracingEnabled: false,
             isProfilingEnabled: false,
+            idleTimeout: 1800,
             error: null,
             createdAt: expect.any(Date),
             lastStateTransitionAt: expect.any(Date)

--- a/packages/fleet/lib/models/nodes.integration.test.ts
+++ b/packages/fleet/lib/models/nodes.integration.test.ts
@@ -37,7 +37,7 @@ describe('Nodes', () => {
                 storageMb: 512,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleTimeout: 1800
+                idleTimeoutSecs: 1800
             })
         ).unwrap();
         expect(node).toStrictEqual({
@@ -52,7 +52,7 @@ describe('Nodes', () => {
             storageMb: 512,
             isTracingEnabled: false,
             isProfilingEnabled: false,
-            idleTimeout: 1800,
+            idleTimeoutSecs: 1800,
             error: null,
             createdAt: expect.any(Date),
             lastStateTransitionAt: expect.any(Date)

--- a/packages/fleet/lib/models/nodes.ts
+++ b/packages/fleet/lib/models/nodes.ts
@@ -53,7 +53,7 @@ interface DBNode {
     readonly storage_mb: number;
     readonly is_tracing_enabled: boolean;
     readonly is_profiling_enabled: boolean;
-    readonly idle_timeout: number | null;
+    readonly idle_timeout_secs: number | null;
     readonly error: string | null;
     readonly created_at: Date;
     readonly last_state_transition_at: Date;
@@ -73,7 +73,7 @@ const DBNode = {
             storage_mb: node.storageMb,
             is_tracing_enabled: node.isTracingEnabled,
             is_profiling_enabled: node.isProfilingEnabled,
-            idle_timeout: node.idleTimeout,
+            idle_timeout_secs: node.idleTimeoutSecs,
             error: node.error,
             created_at: node.createdAt,
             last_state_transition_at: node.lastStateTransitionAt
@@ -92,7 +92,7 @@ const DBNode = {
             storageMb: dbNode.storage_mb,
             isTracingEnabled: dbNode.is_tracing_enabled,
             isProfilingEnabled: dbNode.is_profiling_enabled,
-            idleTimeout: dbNode.idle_timeout,
+            idleTimeoutSecs: dbNode.idle_timeout_secs,
             error: dbNode.error,
             createdAt: dbNode.created_at,
             lastStateTransitionAt: dbNode.last_state_transition_at
@@ -115,7 +115,7 @@ export async function create(
         storage_mb: nodeProps.storageMb,
         is_tracing_enabled: nodeProps.isTracingEnabled,
         is_profiling_enabled: nodeProps.isProfilingEnabled,
-        idle_timeout: nodeProps.idleTimeout,
+        idle_timeout_secs: nodeProps.idleTimeoutSecs,
         error: null,
         created_at: now,
         last_state_transition_at: now

--- a/packages/fleet/lib/models/nodes.ts
+++ b/packages/fleet/lib/models/nodes.ts
@@ -53,6 +53,7 @@ interface DBNode {
     readonly storage_mb: number;
     readonly is_tracing_enabled: boolean;
     readonly is_profiling_enabled: boolean;
+    readonly idle_timeout: number | null;
     readonly error: string | null;
     readonly created_at: Date;
     readonly last_state_transition_at: Date;
@@ -72,6 +73,7 @@ const DBNode = {
             storage_mb: node.storageMb,
             is_tracing_enabled: node.isTracingEnabled,
             is_profiling_enabled: node.isProfilingEnabled,
+            idle_timeout: node.idleTimeout,
             error: node.error,
             created_at: node.createdAt,
             last_state_transition_at: node.lastStateTransitionAt
@@ -90,6 +92,7 @@ const DBNode = {
             storageMb: dbNode.storage_mb,
             isTracingEnabled: dbNode.is_tracing_enabled,
             isProfilingEnabled: dbNode.is_profiling_enabled,
+            idleTimeout: dbNode.idle_timeout,
             error: dbNode.error,
             createdAt: dbNode.created_at,
             lastStateTransitionAt: dbNode.last_state_transition_at
@@ -112,6 +115,7 @@ export async function create(
         storage_mb: nodeProps.storageMb,
         is_tracing_enabled: nodeProps.isTracingEnabled,
         is_profiling_enabled: nodeProps.isProfilingEnabled,
+        idle_timeout: nodeProps.idleTimeout,
         error: null,
         created_at: now,
         last_state_transition_at: now

--- a/packages/fleet/lib/models/nodes.ts
+++ b/packages/fleet/lib/models/nodes.ts
@@ -53,7 +53,7 @@ interface DBNode {
     readonly storage_mb: number;
     readonly is_tracing_enabled: boolean;
     readonly is_profiling_enabled: boolean;
-    readonly idle_timeout_secs: number | null;
+    readonly idle_max_duration_ms: number | null;
     readonly error: string | null;
     readonly created_at: Date;
     readonly last_state_transition_at: Date;
@@ -73,7 +73,7 @@ const DBNode = {
             storage_mb: node.storageMb,
             is_tracing_enabled: node.isTracingEnabled,
             is_profiling_enabled: node.isProfilingEnabled,
-            idle_timeout_secs: node.idleTimeoutSecs,
+            idle_max_duration_ms: node.idleMaxDurationMs,
             error: node.error,
             created_at: node.createdAt,
             last_state_transition_at: node.lastStateTransitionAt
@@ -92,7 +92,7 @@ const DBNode = {
             storageMb: dbNode.storage_mb,
             isTracingEnabled: dbNode.is_tracing_enabled,
             isProfilingEnabled: dbNode.is_profiling_enabled,
-            idleTimeoutSecs: dbNode.idle_timeout_secs,
+            idleMaxDurationMs: dbNode.idle_max_duration_ms,
             error: dbNode.error,
             createdAt: dbNode.created_at,
             lastStateTransitionAt: dbNode.last_state_transition_at
@@ -115,7 +115,7 @@ export async function create(
         storage_mb: nodeProps.storageMb,
         is_tracing_enabled: nodeProps.isTracingEnabled,
         is_profiling_enabled: nodeProps.isProfilingEnabled,
-        idle_timeout_secs: nodeProps.idleTimeoutSecs,
+        idle_max_duration_ms: nodeProps.idleMaxDurationMs,
         error: null,
         created_at: now,
         last_state_transition_at: now

--- a/packages/fleet/lib/node-providers/noop.ts
+++ b/packages/fleet/lib/node-providers/noop.ts
@@ -9,7 +9,7 @@ export const noopNodeProvider: NodeProvider = {
         storageMb: 1000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleTimeout: 1800
+        idleTimeoutSecs: 1800
     },
     start: () => {
         return Promise.resolve(Ok(undefined));

--- a/packages/fleet/lib/node-providers/noop.ts
+++ b/packages/fleet/lib/node-providers/noop.ts
@@ -9,7 +9,7 @@ export const noopNodeProvider: NodeProvider = {
         storageMb: 1000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleTimeoutSecs: 1800
+        idleMaxDurationMs: 1800
     },
     start: () => {
         return Promise.resolve(Ok(undefined));

--- a/packages/fleet/lib/node-providers/noop.ts
+++ b/packages/fleet/lib/node-providers/noop.ts
@@ -8,7 +8,8 @@ export const noopNodeProvider: NodeProvider = {
         memoryMb: 1000,
         storageMb: 1000,
         isTracingEnabled: false,
-        isProfilingEnabled: false
+        isProfilingEnabled: false,
+        idleTimeout: 1800
     },
     start: () => {
         return Promise.resolve(Ok(undefined));

--- a/packages/fleet/lib/supervisor/supervisor.integration.test.ts
+++ b/packages/fleet/lib/supervisor/supervisor.integration.test.ts
@@ -21,7 +21,7 @@ const mockNodeProvider = {
         storageMb: 1000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleTimeout: 1800
+        idleTimeoutSecs: 1800
     },
     start: vi.fn().mockResolvedValue(Ok(undefined)),
     terminate: vi.fn().mockResolvedValue(Ok(undefined)),
@@ -144,7 +144,7 @@ describe('Supervisor', () => {
             memoryMb: 1234,
             storageMb: 567890,
             error: null,
-            idleTimeout: 1800
+            idleTimeoutSecs: 1800
         });
     });
 
@@ -159,7 +159,7 @@ describe('Supervisor', () => {
             storageMb: node.storageMb,
             isTracingEnabled: node.isTracingEnabled,
             isProfilingEnabled: node.isProfilingEnabled,
-            idleTimeout: node.idleTimeout
+            idleTimeoutSecs: node.idleTimeoutSecs
         });
 
         await supervisor.tick();

--- a/packages/fleet/lib/supervisor/supervisor.integration.test.ts
+++ b/packages/fleet/lib/supervisor/supervisor.integration.test.ts
@@ -21,7 +21,7 @@ const mockNodeProvider = {
         storageMb: 1000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleTimeoutSecs: 1800
+        idleMaxDurationMs: 1800
     },
     start: vi.fn().mockResolvedValue(Ok(undefined)),
     terminate: vi.fn().mockResolvedValue(Ok(undefined)),
@@ -144,7 +144,7 @@ describe('Supervisor', () => {
             memoryMb: 1234,
             storageMb: 567890,
             error: null,
-            idleTimeoutSecs: 1800
+            idleMaxDurationMs: 1800
         });
     });
 
@@ -159,7 +159,7 @@ describe('Supervisor', () => {
             storageMb: node.storageMb,
             isTracingEnabled: node.isTracingEnabled,
             isProfilingEnabled: node.isProfilingEnabled,
-            idleTimeoutSecs: node.idleTimeoutSecs
+            idleMaxDurationMs: node.idleMaxDurationMs
         });
 
         await supervisor.tick();

--- a/packages/fleet/lib/supervisor/supervisor.integration.test.ts
+++ b/packages/fleet/lib/supervisor/supervisor.integration.test.ts
@@ -20,7 +20,8 @@ const mockNodeProvider = {
         memoryMb: 1000,
         storageMb: 1000,
         isTracingEnabled: false,
-        isProfilingEnabled: false
+        isProfilingEnabled: false,
+        idleTimeout: 1800
     },
     start: vi.fn().mockResolvedValue(Ok(undefined)),
     terminate: vi.fn().mockResolvedValue(Ok(undefined)),
@@ -142,7 +143,8 @@ describe('Supervisor', () => {
             cpuMilli: 10000,
             memoryMb: 1234,
             storageMb: 567890,
-            error: null
+            error: null,
+            idleTimeout: 1800
         });
     });
 
@@ -156,7 +158,8 @@ describe('Supervisor', () => {
             memoryMb: node.memoryMb,
             storageMb: node.storageMb,
             isTracingEnabled: node.isTracingEnabled,
-            isProfilingEnabled: node.isProfilingEnabled
+            isProfilingEnabled: node.isProfilingEnabled,
+            idleTimeout: node.idleTimeout
         });
 
         await supervisor.tick();

--- a/packages/fleet/lib/supervisor/supervisor.ts
+++ b/packages/fleet/lib/supervisor/supervisor.ts
@@ -204,7 +204,7 @@ export class Supervisor {
                     if (configOverride.isProfilingEnabled !== null && configOverride.isProfilingEnabled !== node.isProfilingEnabled) {
                         return true;
                     }
-                    if (configOverride.idleTimeout && configOverride.idleTimeout !== node.idleTimeout) {
+                    if (configOverride.idleTimeoutSecs && configOverride.idleTimeoutSecs !== node.idleTimeoutSecs) {
                         return true;
                     }
                     return false;
@@ -250,7 +250,7 @@ export class Supervisor {
                 // Timeout IDLE nodes if they are taking too long (nodeProvider probably failed to terminate the node)
                 plan.push(
                     ...(nodes.IDLE || []).flatMap<Operation>((node) => {
-                        const idleTimeout = node.idleTimeout ? node.idleTimeout * 1000 : STATE_TIMEOUT_MS.IDLE;
+                        const idleTimeout = node.idleTimeoutSecs ? node.idleTimeoutSecs * 1000 : STATE_TIMEOUT_MS.IDLE;
                         if (Date.now() - node.lastStateTransitionAt.getTime() > idleTimeout) {
                             return [{ type: 'FAIL', node, reason: 'idle_timeout_reached' as const }];
                         }
@@ -355,7 +355,7 @@ export class Supervisor {
                 storageMb: nodeConfigOverrideValue.storageMb || newNodeConfig.storageMb,
                 isTracingEnabled: nodeConfigOverrideValue.isTracingEnabled || newNodeConfig.isTracingEnabled,
                 isProfilingEnabled: nodeConfigOverrideValue.isProfilingEnabled || newNodeConfig.isProfilingEnabled,
-                idleTimeout: nodeConfigOverrideValue.idleTimeout || newNodeConfig.idleTimeout
+                idleTimeoutSecs: nodeConfigOverrideValue.idleTimeoutSecs || newNodeConfig.idleTimeoutSecs
             };
         }
 
@@ -368,7 +368,7 @@ export class Supervisor {
             storageMb: newNodeConfig.storageMb,
             isTracingEnabled: newNodeConfig.isTracingEnabled,
             isProfilingEnabled: newNodeConfig.isProfilingEnabled,
-            idleTimeout: newNodeConfig.idleTimeout
+            idleTimeoutSecs: newNodeConfig.idleTimeoutSecs
         });
     }
 

--- a/packages/fleet/lib/supervisor/supervisor.ts
+++ b/packages/fleet/lib/supervisor/supervisor.ts
@@ -204,7 +204,7 @@ export class Supervisor {
                     if (configOverride.isProfilingEnabled !== null && configOverride.isProfilingEnabled !== node.isProfilingEnabled) {
                         return true;
                     }
-                    if (configOverride.idleTimeoutSecs && configOverride.idleTimeoutSecs !== node.idleTimeoutSecs) {
+                    if (configOverride.idleMaxDurationMs && configOverride.idleMaxDurationMs !== node.idleMaxDurationMs) {
                         return true;
                     }
                     return false;
@@ -250,8 +250,7 @@ export class Supervisor {
                 // Timeout IDLE nodes if they are taking too long (nodeProvider probably failed to terminate the node)
                 plan.push(
                     ...(nodes.IDLE || []).flatMap<Operation>((node) => {
-                        const idleTimeout = node.idleTimeoutSecs ? node.idleTimeoutSecs * 1000 : STATE_TIMEOUT_MS.IDLE;
-                        if (Date.now() - node.lastStateTransitionAt.getTime() > idleTimeout) {
+                        if (Date.now() - node.lastStateTransitionAt.getTime() > STATE_TIMEOUT_MS.IDLE) {
                             return [{ type: 'FAIL', node, reason: 'idle_timeout_reached' as const }];
                         }
                         return [];
@@ -355,7 +354,7 @@ export class Supervisor {
                 storageMb: nodeConfigOverrideValue.storageMb || newNodeConfig.storageMb,
                 isTracingEnabled: nodeConfigOverrideValue.isTracingEnabled || newNodeConfig.isTracingEnabled,
                 isProfilingEnabled: nodeConfigOverrideValue.isProfilingEnabled || newNodeConfig.isProfilingEnabled,
-                idleTimeoutSecs: nodeConfigOverrideValue.idleTimeoutSecs || newNodeConfig.idleTimeoutSecs
+                idleMaxDurationMs: nodeConfigOverrideValue.idleMaxDurationMs || newNodeConfig.idleMaxDurationMs
             };
         }
 
@@ -368,7 +367,7 @@ export class Supervisor {
             storageMb: newNodeConfig.storageMb,
             isTracingEnabled: newNodeConfig.isTracingEnabled,
             isProfilingEnabled: newNodeConfig.isProfilingEnabled,
-            idleTimeoutSecs: newNodeConfig.idleTimeoutSecs
+            idleMaxDurationMs: newNodeConfig.idleMaxDurationMs
         });
     }
 

--- a/packages/fleet/lib/supervisor/supervisor.ts
+++ b/packages/fleet/lib/supervisor/supervisor.ts
@@ -204,6 +204,9 @@ export class Supervisor {
                     if (configOverride.isProfilingEnabled !== null && configOverride.isProfilingEnabled !== node.isProfilingEnabled) {
                         return true;
                     }
+                    if (configOverride.idleTimeout && configOverride.idleTimeout !== node.idleTimeout) {
+                        return true;
+                    }
                     return false;
                 };
                 plan.push(
@@ -350,7 +353,8 @@ export class Supervisor {
                 memoryMb: nodeConfigOverrideValue.memoryMb || newNodeConfig.memoryMb,
                 storageMb: nodeConfigOverrideValue.storageMb || newNodeConfig.storageMb,
                 isTracingEnabled: nodeConfigOverrideValue.isTracingEnabled || newNodeConfig.isTracingEnabled,
-                isProfilingEnabled: nodeConfigOverrideValue.isProfilingEnabled || newNodeConfig.isProfilingEnabled
+                isProfilingEnabled: nodeConfigOverrideValue.isProfilingEnabled || newNodeConfig.isProfilingEnabled,
+                idleTimeout: nodeConfigOverrideValue.idleTimeout || newNodeConfig.idleTimeout
             };
         }
 
@@ -362,7 +366,8 @@ export class Supervisor {
             memoryMb: newNodeConfig.memoryMb,
             storageMb: newNodeConfig.storageMb,
             isTracingEnabled: newNodeConfig.isTracingEnabled,
-            isProfilingEnabled: newNodeConfig.isProfilingEnabled
+            isProfilingEnabled: newNodeConfig.isProfilingEnabled,
+            idleTimeout: newNodeConfig.idleTimeout
         });
     }
 

--- a/packages/fleet/lib/supervisor/supervisor.ts
+++ b/packages/fleet/lib/supervisor/supervisor.ts
@@ -250,7 +250,8 @@ export class Supervisor {
                 // Timeout IDLE nodes if they are taking too long (nodeProvider probably failed to terminate the node)
                 plan.push(
                     ...(nodes.IDLE || []).flatMap<Operation>((node) => {
-                        if (Date.now() - node.lastStateTransitionAt.getTime() > STATE_TIMEOUT_MS.IDLE) {
+                        const idleTimeout = node.idleTimeout ? node.idleTimeout * 1000 : STATE_TIMEOUT_MS.IDLE;
+                        if (Date.now() - node.lastStateTransitionAt.getTime() > idleTimeout) {
                             return [{ type: 'FAIL', node, reason: 'idle_timeout_reached' as const }];
                         }
                         return [];

--- a/packages/fleet/lib/types.ts
+++ b/packages/fleet/lib/types.ts
@@ -15,7 +15,7 @@ export interface Node {
     readonly storageMb: NodeConfig['storageMb'];
     readonly isTracingEnabled: NodeConfig['isTracingEnabled'];
     readonly isProfilingEnabled: NodeConfig['isProfilingEnabled'];
-    readonly idleTimeoutSecs: number | null;
+    readonly idleMaxDurationMs: number | null;
     readonly error: string | null;
     readonly createdAt: Date;
     readonly lastStateTransitionAt: Date;
@@ -30,7 +30,7 @@ export interface NodeConfigOverride {
     readonly storageMb: NodeConfig['storageMb'] | null;
     readonly isTracingEnabled: NodeConfig['isTracingEnabled'] | null;
     readonly isProfilingEnabled: NodeConfig['isProfilingEnabled'] | null;
-    readonly idleTimeoutSecs: number | null;
+    readonly idleMaxDurationMs: number | null;
     readonly createdAt: Date;
     readonly updatedAt: Date;
 }

--- a/packages/fleet/lib/types.ts
+++ b/packages/fleet/lib/types.ts
@@ -15,6 +15,7 @@ export interface Node {
     readonly storageMb: NodeConfig['storageMb'];
     readonly isTracingEnabled: NodeConfig['isTracingEnabled'];
     readonly isProfilingEnabled: NodeConfig['isProfilingEnabled'];
+    readonly idleTimeout: number | null;
     readonly error: string | null;
     readonly createdAt: Date;
     readonly lastStateTransitionAt: Date;
@@ -29,6 +30,7 @@ export interface NodeConfigOverride {
     readonly storageMb: NodeConfig['storageMb'] | null;
     readonly isTracingEnabled: NodeConfig['isTracingEnabled'] | null;
     readonly isProfilingEnabled: NodeConfig['isProfilingEnabled'] | null;
+    readonly idleTimeout: number | null;
     readonly createdAt: Date;
     readonly updatedAt: Date;
 }

--- a/packages/fleet/lib/types.ts
+++ b/packages/fleet/lib/types.ts
@@ -15,7 +15,7 @@ export interface Node {
     readonly storageMb: NodeConfig['storageMb'];
     readonly isTracingEnabled: NodeConfig['isTracingEnabled'];
     readonly isProfilingEnabled: NodeConfig['isProfilingEnabled'];
-    readonly idleTimeout: number | null;
+    readonly idleTimeoutSecs: number | null;
     readonly error: string | null;
     readonly createdAt: Date;
     readonly lastStateTransitionAt: Date;
@@ -30,7 +30,7 @@ export interface NodeConfigOverride {
     readonly storageMb: NodeConfig['storageMb'] | null;
     readonly isTracingEnabled: NodeConfig['isTracingEnabled'] | null;
     readonly isProfilingEnabled: NodeConfig['isProfilingEnabled'] | null;
-    readonly idleTimeout: number | null;
+    readonly idleTimeoutSecs: number | null;
     readonly createdAt: Date;
     readonly updatedAt: Date;
 }

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -453,7 +453,8 @@ export const kubernetesNodeProvider: NodeProvider = {
         memoryMb: 512,
         storageMb: 20000,
         isTracingEnabled: false,
-        isProfilingEnabled: false
+        isProfilingEnabled: false,
+        idleTimeout: 1800
     },
     start: async (node: Node) => {
         const kubernetes = Kubernetes.getInstance();

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -454,7 +454,7 @@ export const kubernetesNodeProvider: NodeProvider = {
         storageMb: 20000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleTimeout: 1800
+        idleTimeoutSecs: 1800
     },
     start: async (node: Node) => {
         const kubernetes = Kubernetes.getInstance();

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -408,7 +408,7 @@ class Kubernetes {
             { name: 'NODE_OPTIONS', value: `--max-old-space-size=${Math.floor((node.memoryMb / 4) * 3)}` },
             { name: 'RUNNER_NODE_ID', value: `${node.id}` },
             { name: 'RUNNER_URL', value: runnerUrl },
-            { name: 'IDLE_MAX_DURATION_MS', value: `${25 * 60 * 60 * 1000}` }, // 25 hours
+            { name: 'IDLE_MAX_DURATION_MS', value: `${node.idleMaxDurationMs}` },
             { name: 'PERSIST_SERVICE_URL', value: getPersistAPIUrl() },
             { name: 'NANGO_TELEMETRY_SDK', value: process.env['NANGO_TELEMETRY_SDK'] || 'false' },
             ...(envs.DD_ENV ? [{ name: 'DD_ENV', value: envs.DD_ENV }] : []),
@@ -454,7 +454,7 @@ export const kubernetesNodeProvider: NodeProvider = {
         storageMb: 20000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleTimeoutSecs: 1800
+        idleMaxDurationMs: 1800
     },
     start: async (node: Node) => {
         const kubernetes = Kubernetes.getInstance();

--- a/packages/jobs/lib/runner/local.ts
+++ b/packages/jobs/lib/runner/local.ts
@@ -19,7 +19,8 @@ export const localNodeProvider: NodeProvider = {
         memoryMb: 512,
         storageMb: 20000,
         isTracingEnabled: false,
-        isProfilingEnabled: false
+        isProfilingEnabled: false,
+        idleTimeout: 1800
     },
     start: async (node) => {
         try {

--- a/packages/jobs/lib/runner/local.ts
+++ b/packages/jobs/lib/runner/local.ts
@@ -20,7 +20,7 @@ export const localNodeProvider: NodeProvider = {
         storageMb: 20000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleTimeoutSecs: 1800
+        idleMaxDurationMs: 1800
     },
     start: async (node) => {
         try {

--- a/packages/jobs/lib/runner/local.ts
+++ b/packages/jobs/lib/runner/local.ts
@@ -20,7 +20,7 @@ export const localNodeProvider: NodeProvider = {
         storageMb: 20000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleTimeout: 1800
+        idleTimeoutSecs: 1800
     },
     start: async (node) => {
         try {

--- a/packages/jobs/lib/runner/render.ts
+++ b/packages/jobs/lib/runner/render.ts
@@ -27,7 +27,8 @@ export const renderNodeProvider: NodeProvider = {
         memoryMb: 512,
         storageMb: 20000,
         isTracingEnabled: false,
-        isProfilingEnabled: false
+        isProfilingEnabled: false,
+        idleTimeout: 1800
     },
     start: async (node) => {
         if (!envs.RUNNER_OWNER_ID) {

--- a/packages/jobs/lib/runner/render.ts
+++ b/packages/jobs/lib/runner/render.ts
@@ -57,7 +57,7 @@ export const renderNodeProvider: NodeProvider = {
                     { key: 'NODE_OPTIONS', value: `--max-old-space-size=${Math.floor((node.memoryMb / 4) * 3)}` },
                     { key: 'RUNNER_NODE_ID', value: `${node.id}` },
                     { key: 'RUNNER_URL', value: `http://${name}` },
-                    { key: 'IDLE_MAX_DURATION_MS', value: `${node.idleMaxDurationMs}` }, // 25 hours
+                    { key: 'IDLE_MAX_DURATION_MS', value: `${node.idleMaxDurationMs}` },
                     { key: 'PERSIST_SERVICE_URL', value: getPersistAPIUrl() },
                     { key: 'NANGO_TELEMETRY_SDK', value: process.env['NANGO_TELEMETRY_SDK'] || 'false' },
                     ...(envs.DD_ENV ? [{ key: 'DD_ENV', value: envs.DD_ENV }] : []),

--- a/packages/jobs/lib/runner/render.ts
+++ b/packages/jobs/lib/runner/render.ts
@@ -28,7 +28,7 @@ export const renderNodeProvider: NodeProvider = {
         storageMb: 20000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleTimeout: 1800
+        idleTimeoutSecs: 1800
     },
     start: async (node) => {
         if (!envs.RUNNER_OWNER_ID) {

--- a/packages/jobs/lib/runner/render.ts
+++ b/packages/jobs/lib/runner/render.ts
@@ -28,7 +28,7 @@ export const renderNodeProvider: NodeProvider = {
         storageMb: 20000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleTimeoutSecs: 1800
+        idleMaxDurationMs: 1800
     },
     start: async (node) => {
         if (!envs.RUNNER_OWNER_ID) {
@@ -57,7 +57,7 @@ export const renderNodeProvider: NodeProvider = {
                     { key: 'NODE_OPTIONS', value: `--max-old-space-size=${Math.floor((node.memoryMb / 4) * 3)}` },
                     { key: 'RUNNER_NODE_ID', value: `${node.id}` },
                     { key: 'RUNNER_URL', value: `http://${name}` },
-                    { key: 'IDLE_MAX_DURATION_MS', value: `${25 * 60 * 60 * 1000}` }, // 25 hours
+                    { key: 'IDLE_MAX_DURATION_MS', value: `${node.idleMaxDurationMs}` }, // 25 hours
                     { key: 'PERSIST_SERVICE_URL', value: getPersistAPIUrl() },
                     { key: 'NANGO_TELEMETRY_SDK', value: process.env['NANGO_TELEMETRY_SDK'] || 'false' },
                     ...(envs.DD_ENV ? [{ key: 'DD_ENV', value: envs.DD_ENV }] : []),

--- a/packages/types/lib/fleet/index.ts
+++ b/packages/types/lib/fleet/index.ts
@@ -14,5 +14,5 @@ export interface NodeConfig {
     readonly storageMb: number;
     readonly isTracingEnabled: boolean;
     readonly isProfilingEnabled: boolean;
-    readonly idleTimeout: number;
+    readonly idleTimeoutSecs: number;
 }

--- a/packages/types/lib/fleet/index.ts
+++ b/packages/types/lib/fleet/index.ts
@@ -14,5 +14,5 @@ export interface NodeConfig {
     readonly storageMb: number;
     readonly isTracingEnabled: boolean;
     readonly isProfilingEnabled: boolean;
-    readonly idleTimeoutSecs: number;
+    readonly idleMaxDurationMs: number;
 }

--- a/packages/types/lib/fleet/index.ts
+++ b/packages/types/lib/fleet/index.ts
@@ -14,4 +14,5 @@ export interface NodeConfig {
     readonly storageMb: number;
     readonly isTracingEnabled: boolean;
     readonly isProfilingEnabled: boolean;
+    readonly idleTimeout: number;
 }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Introduce per-node idle timeout (`idleMaxDurationMs`) across Fleet**

This PR adds first-class support for a configurable idle timeout at node level. It extends the DB schema, domain models, supervisor logic, node providers and public type packages so each node (or override) can specify `idleMaxDurationMs`, replacing the former global constant. A new migration seeds existing rows, default values are injected by every provider, and CRUD paths/tests are updated accordingly.

<details>
<summary><strong>Key Changes</strong></summary>

• DB migration `packages/fleet/lib/db/migrations/20251103174100_add_idle_timeout.ts` adds `idle_max_duration_ms` to `nodes` (NOT NULL, default `1800000`) and `node_config_overrides` (nullable).
• Updated domain entities (`Node`, `NodeConfigOverride`, `NodeConfig`) and generated typings in `packages/types` to include `idleMaxDurationMs`.
• Extended `packages/fleet/lib/models` CRUD to read/write the new column; updated helper utilities and integration tests.
• Supervisor (`packages/fleet/lib/supervisor/supervisor.ts`) now considers `idleMaxDurationMs` when deciding to OUTDATE nodes and when creating nodes from overrides.
• All node providers (`noop`, `local`, `kubernetes`, `render`) expose the new default and propagate it to runner env via `IDLE_MAX_DURATION_MS`.
• Fleet service (`packages/fleet/lib/fleet.ts`) updates equality check in `overrideNodeConfig()` to account for the new field.
• Large test refresh to assert the additional attribute everywhere.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `nodes` and `node_config_overrides` tables
• `packages/fleet/lib/models/*`
• `packages/fleet/lib/supervisor`
• `packages/fleet/lib/fleet.ts`
• All node provider implementations
• Public `@nangohq/types` package

</details>

---
*This summary was automatically generated by @propel-code-bot*