### PR TITLE
feat(runner-sdk): add logger level concept (default to warn in cloud)

### DIFF
--- a/docs/guides/platform/logs.mdx
+++ b/docs/guides/platform/logs.mdx
@@ -16,7 +16,7 @@ We built Nango's logs based on three principles:
 
 - **Comprehensive**: Everything that happens in Nango for your integrations produces an "operation" in the logs
 - **Detailed**: Every operation and every log message contains detailed information about the integration, [connection](/guides/use-cases/api-auth#what-is-a-connection%3F), and [function](/guides/platform/functions). Error messages are as detailed as the external APIs allow.
-- **Customizable**: You can easily log your own messages from functions you write. To consume logs, you can either use our built-in interface or export them with our [OpenTelemetry exporter](#opentelemetry-logs-export)
+- **Customizable**: You can easily log your own messages from functions you write ([learn more](/reference/functions#logging)). To consume logs, you can either use our built-in interface or export them with our [OpenTelemetry exporter](#opentelemetry-logs-export)
 
 ## Overview of Nango logs
 

--- a/docs/reference/functions.mdx
+++ b/docs/reference/functions.mdx
@@ -392,25 +392,27 @@ await nango.log("This is an error", { level: 'error' });
 
 Nango supports the following log levels (from most to least verbose): `debug`, `info`, `warn`, `error`, `off`.
 
-Only logs with a level greater than or equal to the configured logger level will be ingested. For example, if the logger level is set to `warn`, only `warn` and `error` logs will be saved.
+Only logs with a level greater than or equal to the configured logger level will surfaced in the Nango UI Logs tab. For example, if the logger level is set to `warn`, only `warn` and `error` logs will be shown.
 
 **Default log levels:**
-- **Cloud/production**: `warn` (only warnings and errors are logged by default)
+- **All cloud environments**: `warn` (only warnings and errors are logged by default)
 - **CLI dry-run**: `debug` (all logs are shown in the console)
 
 ### Configuring Log Level
 
 You can override the default log level in two ways:
 
-1. **Environment variable**: Set `NANGO_LOGGER_LEVEL` in your environment settings (values: `debug`, `info`, `warn`, `error`, `off`)
+1. **Environment variable**: Set `NANGO_LOGGER_LEVEL` in your environment settings (values: `debug`, `info`, `warn`, `error`, `off`). It will apply to all your functions running in this environment and can be overridden in functions by using `nango.setLogger(...)`
 
 2. **In your function code**:
 ```ts
-nango.setLogger({ level: 'debug' }); // Enable all logs
-nango.setLogger({ level: 'off' }); // Disable all logs
+nango.setLogger({ level: 'debug' }); // All logs will show in your cloud environments. It will apply to all `nango.log()` following this statement.
+nango.setLogger({ level: 'off' }); // No logs will show
 ```
 
 Logs can be viewed & searched in the Nango UI. We plan to make them exportable in the future as well.
+
+You can monitor your usage of custom logs in the [billing tab](https://app.nango.dev/prod/team/billing) of your Nango dashboard.
 
 ## Environment variables
 

--- a/docs/reference/functions.mdx
+++ b/docs/reference/functions.mdx
@@ -382,7 +382,32 @@ You can collect logs in integration functions. This is particularly useful when:
 Collect logs in integration functions as follows:
 
 ```ts
-await nango.log("This is a log.");
+await nango.log("This is a log."); // default log level is 'info'
+await nango.log("This is an info log", { level: 'info' });
+await nango.log("This is a warning", { level: 'warn' });
+await nango.log("This is an error", { level: 'error' });
+```
+
+### Log Levels
+
+Nango supports the following log levels (from most to least verbose): `debug`, `info`, `warn`, `error`, `off`.
+
+Only logs with a level greater than or equal to the configured logger level will be ingested. For example, if the logger level is set to `warn`, only `warn` and `error` logs will be saved.
+
+**Default log levels:**
+- **Cloud/production**: `warn` (only warnings and errors are logged by default)
+- **CLI dry-run**: `debug` (all logs are shown in the console)
+
+### Configuring Log Level
+
+You can override the default log level in two ways:
+
+1. **Environment variable**: Set `NANGO_LOGGER_LEVEL` in your environment settings (values: `debug`, `info`, `warn`, `error`, `off`)
+
+2. **In your function code**:
+```ts
+nango.setLogger({ level: 'debug' }); // Enable all logs
+nango.setLogger({ level: 'off' }); // Disable all logs
 ```
 
 Logs can be viewed & searched in the Nango UI. We plan to make them exportable in the future as well.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32836,7 +32836,8 @@
                 "semver": "7.5.4",
                 "simple-oauth2": "5.1.0",
                 "undici": "6.21.2",
-                "uuid": "9.0.0"
+                "uuid": "9.0.0",
+                "zod": "4.0.5"
             },
             "devDependencies": {
                 "@nangohq/logs": "file:../logs",
@@ -32977,6 +32978,15 @@
             "license": "MIT",
             "bin": {
                 "uuid": "dist/bin/uuid"
+            }
+        },
+        "packages/shared/node_modules/zod": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
+            "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "packages/type": {

--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -403,6 +403,16 @@ export declare class NangoAction {
             }
         ]
     ): Promise<void>;
+    /**
+     * Set logger
+     * @desc Set the default logger level
+     * @param logger { level: 'debug' | 'info' | 'warn' | 'error' | 'off' }
+     * @example
+     * \`\`\`ts
+     * nango.setLogger({ level: 'warn' })
+     * \`\`\`
+     */
+    setLogger(logger: SdkLogger): void;
     getEnvironmentVariables(): Promise<EnvironmentVariable[] | null>;
     getFlowAttributes<A = object>(): A | null;
     paginate<T = any>(config: ProxyConfiguration): AsyncGenerator<T[], undefined, void>;

--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -26,7 +26,7 @@ import { ReadableError } from '../zeroYaml/utils.js';
 
 import type { GlobalOptions } from '../types.js';
 import type { NangoActionBase } from '@nangohq/runner-sdk';
-import type { DBSyncConfig, Metadata, NangoProps, NangoYamlParsed, ParsedNangoAction, ParsedNangoSync, ScriptFileType } from '@nangohq/types';
+import type { DBSyncConfig, Metadata, NangoProps, NangoYamlParsed, ParsedNangoAction, ParsedNangoSync, ScriptFileType, SdkLogger } from '@nangohq/types';
 import type { AxiosResponse } from 'axios';
 
 interface RunArgs extends GlobalOptions {
@@ -356,6 +356,10 @@ export class DryRunService {
                 sync_type: lastSyncDate ? 'incremental' : 'full',
                 version: '0.0.1'
             };
+            const sdkLogger: SdkLogger = { level: 'debug' };
+            if (debug) {
+                printDebug(`Nango logger.level is set to '${sdkLogger.level}'`);
+            }
             const nangoProps: NangoProps = {
                 isCLI: true,
                 scriptType: scriptInfo?.type || 'sync',
@@ -374,6 +378,7 @@ export class DryRunService {
                 syncVariant,
                 debug,
                 team: { id: 1, name: 'team' },
+                logger: sdkLogger,
                 runnerFlags: {
                     validateActionInput: this.validation, // irrelevant for cli
                     validateActionOutput: this.validation, // irrelevant for cli

--- a/packages/cli/lib/services/sdk.ts
+++ b/packages/cli/lib/services/sdk.ts
@@ -56,6 +56,8 @@ export class NangoActionCLI extends NangoActionBase {
             return;
         }
 
+        this.showLoggerLevelWarning();
+
         const lastArg = args[args.length - 1];
         const isUserDefinedLevel = (object: UserLogParameters): boolean => {
             return lastArg && typeof lastArg === 'object' && 'level' in object;
@@ -116,6 +118,21 @@ export class NangoActionCLI extends NangoActionBase {
     public override async releaseAllLocks(): Promise<void> {
         // Not applicable to CLI
     }
+
+    private showLoggerLevelWarning = (() => {
+        // only show it once
+        let called = false;
+        return () => {
+            if (!called) {
+                called = true;
+                console.log(
+                    chalk.yellow(
+                        'Note: In Nango Cloud, only logs with level "warn" or "error" will be shown by default. Learn more: https://nango.dev/docs/reference/functions#logging'
+                    )
+                );
+            }
+        };
+    })();
 }
 
 export class NangoSyncCLI extends NangoSyncBase {

--- a/packages/cli/lib/services/sdk.ts
+++ b/packages/cli/lib/services/sdk.ts
@@ -70,6 +70,10 @@ export class NangoActionCLI extends NangoActionBase {
 
         const logLevel = logLevelToLogger[level] ?? 'info';
 
+        if (!this.shouldLog(logLevel)) {
+            return;
+        }
+
         if (args.length > 1 && 'type' in args[1] && args[1].type === 'http') {
             console[logLevel](args[0], { status: args[1]?.response?.code || 'xxx' });
         } else {

--- a/packages/fleet/lib/fleet.integration.test.ts
+++ b/packages/fleet/lib/fleet.integration.test.ts
@@ -47,7 +47,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleMaxDurationMs: 1800
+                idleMaxDurationMs: 1_800_000
             };
             await nodeConfigOverrides.upsert(dbClient.db, props);
             const image = generateImage();
@@ -125,7 +125,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleMaxDurationMs: 1800
+                idleMaxDurationMs: 1_800_000
             };
             const nodeConfigOverride = (await fleet.overrideNodeConfig(props)).unwrap();
             expect(nodeConfigOverride).toStrictEqual({
@@ -151,7 +151,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: true,
                 isProfilingEnabled: true,
-                idleMaxDurationMs: 1800
+                idleMaxDurationMs: 1_800_000
             };
             await fleet.overrideNodeConfig(props);
             const updatedProps = {
@@ -162,7 +162,7 @@ describe('fleet', () => {
                 storageMb: 2000,
                 isTracingEnabled: true,
                 isProfilingEnabled: true,
-                idleMaxDurationMs: 1800
+                idleMaxDurationMs: 1_800_000
             };
             const nodeConfigOverride = (await fleet.overrideNodeConfig(updatedProps)).unwrap();
             expect(nodeConfigOverride).toStrictEqual({
@@ -188,7 +188,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleMaxDurationMs: 1800
+                idleMaxDurationMs: 1_800_000
             };
             await fleet.overrideNodeConfig(props);
 
@@ -211,7 +211,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleMaxDurationMs: 1800
+                idleMaxDurationMs: 1_800_000
             };
             await fleet.overrideNodeConfig(props);
 
@@ -223,7 +223,7 @@ describe('fleet', () => {
                 storageMb: null,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleMaxDurationMs: 1800
+                idleMaxDurationMs: 1_800_000
             };
             await fleet.overrideNodeConfig(defaultProps);
 
@@ -237,7 +237,7 @@ describe('fleet', () => {
                 storageMb: null,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleMaxDurationMs: 1800,
+                idleMaxDurationMs: 1_800_000,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });

--- a/packages/fleet/lib/models/helpers.test.ts
+++ b/packages/fleet/lib/models/helpers.test.ts
@@ -56,7 +56,7 @@ async function createNode(db: knex.Knex, { routingId, deploymentId }: { routingI
         storageMb: 512,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleMaxDurationMs: 1800
+        idleMaxDurationMs: 1_800_000
     });
     return node.unwrap();
 }

--- a/packages/fleet/lib/models/node_config_overrides.integration.test.ts
+++ b/packages/fleet/lib/models/node_config_overrides.integration.test.ts
@@ -22,7 +22,7 @@ describe('NodeConfgOverrides', () => {
         storageMb: 1000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleMaxDurationMs: 1800
+        idleMaxDurationMs: 1_800_000
     };
 
     it('should be successfully created', async () => {
@@ -80,7 +80,7 @@ describe('NodeConfgOverrides', () => {
             storageMb: 2000,
             isTracingEnabled: true,
             isProfilingEnabled: true,
-            idleMaxDurationMs: 1800
+            idleMaxDurationMs: 1_800_000
         };
         const updatedNodeConfigOverride = (await node_config_overrides.upsert(dbClient.db, updatedProps)).unwrap();
         expect(updatedNodeConfigOverride).toStrictEqual({

--- a/packages/fleet/lib/models/nodes.integration.test.ts
+++ b/packages/fleet/lib/models/nodes.integration.test.ts
@@ -37,7 +37,7 @@ describe('Nodes', () => {
                 storageMb: 512,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleMaxDurationMs: 1800
+                idleMaxDurationMs: 1_800_000
             })
         ).unwrap();
         expect(node).toStrictEqual({
@@ -52,7 +52,7 @@ describe('Nodes', () => {
             storageMb: 512,
             isTracingEnabled: false,
             isProfilingEnabled: false,
-            idleMaxDurationMs: 1800,
+            idleMaxDurationMs: 1_800_000,
             error: null,
             createdAt: expect.any(Date),
             lastStateTransitionAt: expect.any(Date)

--- a/packages/fleet/lib/node-providers/noop.ts
+++ b/packages/fleet/lib/node-providers/noop.ts
@@ -9,7 +9,7 @@ export const noopNodeProvider: NodeProvider = {
         storageMb: 1000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleMaxDurationMs: 1800
+        idleMaxDurationMs: 1_800_000
     },
     start: () => {
         return Promise.resolve(Ok(undefined));

--- a/packages/fleet/lib/supervisor/supervisor.integration.test.ts
+++ b/packages/fleet/lib/supervisor/supervisor.integration.test.ts
@@ -21,7 +21,7 @@ const mockNodeProvider = {
         storageMb: 1000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleMaxDurationMs: 1800
+        idleMaxDurationMs: 1_800_000
     },
     start: vi.fn().mockResolvedValue(Ok(undefined)),
     terminate: vi.fn().mockResolvedValue(Ok(undefined)),
@@ -144,7 +144,7 @@ describe('Supervisor', () => {
             memoryMb: 1234,
             storageMb: 567890,
             error: null,
-            idleMaxDurationMs: 1800
+            idleMaxDurationMs: 1_800_000
         });
     });
 

--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -26,7 +26,7 @@ import { pubsub } from '../utils/pubsub.js';
 import type { LogContext } from '@nangohq/logs';
 import type { OrchestratorTask, TaskAction } from '@nangohq/nango-orchestrator';
 import type { Config } from '@nangohq/shared';
-import type { ConnectionJobs, DBEnvironment, DBSyncConfig, DBTeam, NangoProps, TelemetryBag } from '@nangohq/types';
+import type { ConnectionJobs, DBEnvironment, DBSyncConfig, DBTeam, NangoProps, SdkLogger, TelemetryBag } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { JsonValue } from 'type-fest';
 
@@ -106,6 +106,13 @@ export async function startAction(task: TaskAction): Promise<Result<void>> {
             integration: task.connection.provider_config_key
         });
 
+        let sdkLogger: SdkLogger;
+        if (cappingFunctionLogsStatus.isCapped) {
+            sdkLogger = { level: 'off' };
+        } else {
+            sdkLogger = await environmentService.getSdkLogger(environment.id);
+        }
+
         const nangoProps: NangoProps = {
             scriptType: 'action',
             host: getApiUrl(),
@@ -124,6 +131,7 @@ export async function startAction(task: TaskAction): Promise<Result<void>> {
             attributes: syncConfig.attributes,
             syncConfig: syncConfig,
             debug: false,
+            logger: sdkLogger,
             runnerFlags: {
                 ...(await getRunnerFlags()),
                 functionLogs: !cappingFunctionLogsStatus.isCapped

--- a/packages/jobs/lib/execution/webhook.ts
+++ b/packages/jobs/lib/execution/webhook.ts
@@ -29,7 +29,7 @@ import { pubsub } from '../utils/pubsub.js';
 
 import type { TaskWebhook } from '@nangohq/nango-orchestrator';
 import type { Config, Job, Sync } from '@nangohq/shared';
-import type { ConnectionJobs, DBEnvironment, DBSyncConfig, DBTeam, NangoProps, TelemetryBag } from '@nangohq/types';
+import type { ConnectionJobs, DBEnvironment, DBSyncConfig, DBTeam, NangoProps, SdkLogger, TelemetryBag } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 export async function startWebhook(task: TaskWebhook): Promise<Result<void>> {
@@ -119,6 +119,13 @@ export async function startWebhook(task: TaskWebhook): Promise<Result<void>> {
             throw new Error(`Failed to create sync job for sync: ${sync.id}. TaskId: ${task.id}`);
         }
 
+        let sdkLogger: SdkLogger;
+        if (cappingFunctionLogsStatus.isCapped) {
+            sdkLogger = { level: 'off' };
+        } else {
+            sdkLogger = await environmentService.getSdkLogger(environment.id);
+        }
+
         const nangoProps: NangoProps = {
             scriptType: 'webhook',
             host: getApiUrl(),
@@ -139,6 +146,7 @@ export async function startWebhook(task: TaskWebhook): Promise<Result<void>> {
             syncId: sync.id,
             syncJobId: syncJob.id,
             debug: false,
+            logger: sdkLogger,
             runnerFlags: {
                 ...(await getRunnerFlags()),
                 functionLogs: !cappingFunctionLogsStatus.isCapped

--- a/packages/jobs/lib/routes/tasks/putTask.ts
+++ b/packages/jobs/lib/routes/tasks/putTask.ts
@@ -68,8 +68,13 @@ const nangoPropsSchema = z.looseObject({
         validateWebhookOutput: z.boolean().default(false),
         validateSyncRecords: z.boolean().default(false),
         validateSyncMetadata: z.boolean().default(false),
-        functionLogs: z.boolean().default(true)
-    })
+        functionLogs: z.boolean().default(true) //TODO: DEPRECATED
+    }),
+    logger: z
+        .looseObject({
+            level: z.enum(['debug', 'info', 'warn', 'error', 'off'])
+        })
+        .default({ level: 'info' })
 });
 
 const validate = validateRequest<PutTask>({

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -454,7 +454,7 @@ export const kubernetesNodeProvider: NodeProvider = {
         storageMb: 20000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleMaxDurationMs: 1800
+        idleMaxDurationMs: 1_800_000 // 30 minutes
     },
     start: async (node: Node) => {
         const kubernetes = Kubernetes.getInstance();

--- a/packages/jobs/lib/runner/local.ts
+++ b/packages/jobs/lib/runner/local.ts
@@ -20,7 +20,7 @@ export const localNodeProvider: NodeProvider = {
         storageMb: 20000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleMaxDurationMs: 1800
+        idleMaxDurationMs: 0 // No auto-shutdown for local runners
     },
     start: async (node) => {
         try {

--- a/packages/jobs/lib/runner/render.ts
+++ b/packages/jobs/lib/runner/render.ts
@@ -28,7 +28,7 @@ export const renderNodeProvider: NodeProvider = {
         storageMb: 20000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleMaxDurationMs: 1800
+        idleMaxDurationMs: 1_800_000
     },
     start: async (node) => {
         if (!envs.RUNNER_OWNER_ID) {

--- a/packages/runner-sdk/models.d.ts
+++ b/packages/runner-sdk/models.d.ts
@@ -360,6 +360,16 @@ export declare class NangoAction {
             }
         ]
     ): Promise<void>;
+    /**
+     * Set logger
+     * @desc Set the default logger level
+     * @param logger { level: 'debug' | 'info' | 'warn' | 'error' | 'off' }
+     * @example
+     * ```ts
+     * nango.setLogger({ level: 'warn' })
+     * ```
+     */
+    setLogger(logger: SdkLogger): void;
     getEnvironmentVariables(): Promise<EnvironmentVariable[] | null>;
     getFlowAttributes<A = object>(): A | null;
     paginate<T = any>(config: ProxyConfiguration): AsyncGenerator<T[], undefined, void>;

--- a/packages/runner/lib/client.unit.test.ts
+++ b/packages/runner/lib/client.unit.test.ts
@@ -31,7 +31,8 @@ describe('Runner client', () => {
         runnerFlags: {} as any,
         endUser: null,
         team: { id: 1, name: 'team' },
-        heartbeatTimeoutSecs: 30
+        heartbeatTimeoutSecs: 30,
+        logger: { level: 'off' }
     };
 
     beforeAll(() => {

--- a/packages/runner/lib/exec.unit.test.ts
+++ b/packages/runner/lib/exec.unit.test.ts
@@ -26,6 +26,7 @@ function getNangoProps(): NangoProps {
         debug: false,
         startedAt: new Date(),
         team: { id: 1, name: 'dev' },
+        logger: { level: 'off' },
         runnerFlags: {
             validateActionInput: false,
             validateActionOutput: false,

--- a/packages/runner/lib/sdk/sdk.integration.test.ts
+++ b/packages/runner/lib/sdk/sdk.integration.test.ts
@@ -57,7 +57,8 @@ describe('Connection service integration tests', () => {
                 runnerFlags: {} as any,
                 startedAt: new Date(),
                 endUser: null,
-                heartbeatTimeoutSecs: 30
+                heartbeatTimeoutSecs: 30,
+                logger: { level: 'off' }
             };
 
             const nango = new NangoActionRunner(nangoProps, { locks });

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -131,6 +131,11 @@ export class NangoActionRunner extends NangoActionBase<never, Record<string, str
             return;
         }
 
+        // if logging is turned off, we bail early
+        if (this.logger.level === 'off') {
+            return;
+        }
+
         if (args.length === 0) {
             return;
         }
@@ -145,7 +150,13 @@ export class NangoActionRunner extends NangoActionBase<never, Record<string, str
             args.pop();
         }
 
-        const level = userDefinedLevel?.level ?? 'info';
+        const legacyLevel = userDefinedLevel?.level ?? 'info';
+        const level = oldLevelToNewLevel[legacyLevel];
+
+        if (!this.shouldLog(level)) {
+            return;
+        }
+
         const [message, payload] = args;
 
         // arrays are not supported in the log meta, so we convert them to objects
@@ -153,7 +164,7 @@ export class NangoActionRunner extends NangoActionBase<never, Record<string, str
 
         await this.sendLogToPersist({
             type: 'log',
-            level: oldLevelToNewLevel[level],
+            level,
             source: 'user',
             message: stringifyAndTruncateValue(message),
             meta,

--- a/packages/runner/lib/sdk/sdk.unit.test.ts
+++ b/packages/runner/lib/sdk/sdk.unit.test.ts
@@ -35,7 +35,8 @@ const nangoProps: NangoProps = {
     runnerFlags: {} as any,
     startedAt: new Date(),
     endUser: null,
-    heartbeatTimeoutSecs: 30
+    heartbeatTimeoutSecs: 30,
+    logger: { level: 'info' }
 };
 
 const locks = new Locks();
@@ -479,6 +480,22 @@ describe('Log', () => {
 
     it('should enforce type: log message + object', async () => {
         await nangoAction.log('hello', { foo: 'bar' });
+    });
+
+    it('should respect logger level', async () => {
+        const nangoAction = new NangoActionRunner({ ...nangoProps, logger: { level: 'warn' } }, { persistClient, locks });
+        await nangoAction.log('hello', { level: 'info' });
+        expect(persistClient.saveLog).not.toHaveBeenCalled();
+    });
+    it('should allow setting logger level', () => {
+        const nangoAction = new NangoActionRunner({ ...nangoProps, logger: { level: 'debug' } }, { persistClient, locks });
+        nangoAction.setLogger({ level: 'info' });
+        expect(nangoAction['logger'].level).toBe('info');
+    });
+    it('should prevent setting logger level if off', () => {
+        const nangoAction = new NangoActionRunner({ ...nangoProps, logger: { level: 'off' } }, { persistClient, locks });
+        nangoAction.setLogger({ level: 'info' });
+        expect(nangoAction['logger'].level).toBe('off');
     });
 });
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -47,7 +47,8 @@
         "semver": "7.5.4",
         "simple-oauth2": "5.1.0",
         "undici": "6.21.2",
-        "uuid": "9.0.0"
+        "uuid": "9.0.0",
+        "zod": "4.0.5"
     },
     "devDependencies": {
         "@nangohq/logs": "file:../logs",

--- a/packages/types/lib/runner/index.ts
+++ b/packages/types/lib/runner/index.ts
@@ -20,5 +20,5 @@ export interface RunnerFlags {
     validateActionOutput: boolean;
     validateSyncRecords: boolean;
     validateSyncMetadata: boolean;
-    functionLogs: boolean;
+    functionLogs: boolean; // DEPRECATED
 }

--- a/packages/types/lib/runner/sdk.ts
+++ b/packages/types/lib/runner/sdk.ts
@@ -1,7 +1,12 @@
 import type { RunnerFlags } from './index.js';
+import type { LogLevel } from '../logs/messages.js';
 import type { DBSyncConfig } from '../syncConfigs/db.js';
 import type { DBTeam } from '../team/db.js';
 import type { AxiosError, AxiosInterceptorManager, AxiosRequestConfig, AxiosResponse } from 'axios';
+
+export interface SdkLogger {
+    level: LogLevel | 'off';
+}
 
 export interface NangoProps {
     scriptType: 'sync' | 'action' | 'webhook' | 'on-event';
@@ -24,6 +29,7 @@ export interface NangoProps {
     abortSignal?: AbortSignal;
     syncConfig: DBSyncConfig;
     runnerFlags: RunnerFlags;
+    logger: SdkLogger;
     /**
      * @deprecated not used
      */


### PR DESCRIPTION
Adding the concept of Nango logger level to the runner-sdk. `nango.log(...)` will only ingest logs if message level is greater or equal to the logger level.

Default logger level is `warn` when functions is executed on a runner and `debug` when using CLI dry-run (ie: all logs show in the console) 

Logger level can be overriden by customers via:
- setting NANGO_LOGGER_LEVEL environment variable for their environment
- calling `nango.setLogger({ level: ... })` in their function code



<!-- Summary by @propel-code-bot -->

---

**Introduce configurable logger levels and default cloud threshold to "warn"**

This PR adds first-class log-level filtering to the Runner SDK so users can control how much output is persisted. Five canonical levels (debug, info, warn, error, off) are now supported via a new runtime API (nango.setLogger) and the NANGO_LOGGER_LEVEL environment variable. All cloud executions default to "warn" to reduce noisy production logs while local CLI runs default to "debug" to preserve the current developer experience.

To enable this, every execution entry point (sync, action, webhook, onEvent, CLI dry-run) now initialises the SDK with a resolved logger level. Types, docs, and tests were updated accordingly, and an older flag (runnerFlags.functionLogs) is flagged for future deprecation. The change should lower log-ingestion costs and gives customers an explicit way to mute logs (level = off) in sensitive environments.

<details>
<summary><strong>Key Changes</strong></summary>

• Added LogLevel union type and SdkLogger interface (debug < info < warn < error < off)
• Implemented nango.setLogger({ level }) API and NANGO_LOGGER_LEVEL env var
• Cloud runners now default to level = warn; CLI dry-runs explicitly set level = debug
• Execution services initialise runner SDK with resolved level across sync, action, webhook and onEvent pathways
• Updated docs and guides with configuration examples and migration notes
• Extended/updated unit, integration and snapshot tests
• Minor bug-fix: runner auto-shutdown timer corrected from 1 800 ms to 30 min

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/runner-sdk
• execution entry points (sync/action/webhook/onEvent)
• environment.service (env var parsing)
• cli/dryrun.service
• types & models declarations
• documentation and guides
• test suites

</details>

---
*This summary was automatically generated by @propel-code-bot*