### PR TITLE
fix: create an billing subscription when signup via Google

### DIFF
--- a/packages/server/lib/controllers/v1/account/managed/getCallback.ts
+++ b/packages/server/lib/controllers/v1/account/managed/getCallback.ts
@@ -6,7 +6,7 @@ import { basePublicUrl, flagHasUsage, getLogger, nanoid, report } from '@nangohq
 
 import { getWorkOSClient } from '../../../../clients/workos.client.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
-import { linkBillingCustomer } from '../../../../utils/billing.js';
+import { linkBillingCustomer, linkBillingFreeSubscription } from '../../../../utils/billing.js';
 
 import type { InviteAccountState } from './postSignup.js';
 import type { DBInvitation, DBTeam, GetManagedCallback } from '@nangohq/types';
@@ -118,9 +118,14 @@ export const getManagedCallback = asyncWrapper<GetManagedCallback>(async (req, r
         }
 
         if (isNewTeam && flagHasUsage) {
-            const res = await linkBillingCustomer(account, user);
-            if (res.isErr()) {
-                report(res.error);
+            const linkOrbCustomerRes = await linkBillingCustomer(account, user);
+            if (linkOrbCustomerRes.isErr()) {
+                report(linkOrbCustomerRes.error);
+            } else {
+                const linkOrbSubscriptionRes = await linkBillingFreeSubscription(account);
+                if (linkOrbSubscriptionRes.isErr()) {
+                    report(linkOrbSubscriptionRes.error);
+                }
             }
         }
     }


### PR DESCRIPTION
Signing up by email not only trigger the creation of a customer in Orb but also create a subscription for it. This logic is missing when signing up via Google auth.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add missing billing subscription creation on Google-based signup**

Extends the Google OAuth signup flow so that, in addition to creating an Orb customer, it also creates an initial free subscription. The change mirrors the behaviour already present for email-based signups by invoking the new helper `linkBillingFreeSubscription()` after successfully linking the Orb customer.

<details>
<summary><strong>Key Changes</strong></summary>

• Added import of `linkBillingFreeSubscription` in `packages/server/lib/controllers/v1/account/managed/getCallback.ts`
• Replaced single call to `linkBillingCustomer()` with two-step flow: `linkBillingCustomer()` followed by `linkBillingFreeSubscription()` when the first succeeds
• Introduced separate error handling/reporting blocks for both customer and subscription linking results

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `getCallback.ts` (Google managed signup controller)
• Billing utility integration (`utils/billing.js` import)

</details>

---
*This summary was automatically generated by @propel-code-bot*