### PR TITLE
fix: runner to auto shutdown after 30mins not 1800ms

### DIFF
--- a/packages/fleet/lib/fleet.integration.test.ts
+++ b/packages/fleet/lib/fleet.integration.test.ts
@@ -47,7 +47,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleMaxDurationMs: 1800
+                idleMaxDurationMs: 1_800_000
             };
             await nodeConfigOverrides.upsert(dbClient.db, props);
             const image = generateImage();
@@ -125,7 +125,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleMaxDurationMs: 1800
+                idleMaxDurationMs: 1_800_000
             };
             const nodeConfigOverride = (await fleet.overrideNodeConfig(props)).unwrap();
             expect(nodeConfigOverride).toStrictEqual({
@@ -151,7 +151,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: true,
                 isProfilingEnabled: true,
-                idleMaxDurationMs: 1800
+                idleMaxDurationMs: 1_800_000
             };
             await fleet.overrideNodeConfig(props);
             const updatedProps = {
@@ -162,7 +162,7 @@ describe('fleet', () => {
                 storageMb: 2000,
                 isTracingEnabled: true,
                 isProfilingEnabled: true,
-                idleMaxDurationMs: 1800
+                idleMaxDurationMs: 1_800_000
             };
             const nodeConfigOverride = (await fleet.overrideNodeConfig(updatedProps)).unwrap();
             expect(nodeConfigOverride).toStrictEqual({
@@ -188,7 +188,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleMaxDurationMs: 1800
+                idleMaxDurationMs: 1_800_000
             };
             await fleet.overrideNodeConfig(props);
 
@@ -211,7 +211,7 @@ describe('fleet', () => {
                 storageMb: 100,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleMaxDurationMs: 1800
+                idleMaxDurationMs: 1_800_000
             };
             await fleet.overrideNodeConfig(props);
 
@@ -223,7 +223,7 @@ describe('fleet', () => {
                 storageMb: null,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleMaxDurationMs: 1800
+                idleMaxDurationMs: 1_800_000
             };
             await fleet.overrideNodeConfig(defaultProps);
 
@@ -237,7 +237,7 @@ describe('fleet', () => {
                 storageMb: null,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleMaxDurationMs: 1800,
+                idleMaxDurationMs: 1_800_000,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });

--- a/packages/fleet/lib/models/helpers.test.ts
+++ b/packages/fleet/lib/models/helpers.test.ts
@@ -56,7 +56,7 @@ async function createNode(db: knex.Knex, { routingId, deploymentId }: { routingI
         storageMb: 512,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleMaxDurationMs: 1800
+        idleMaxDurationMs: 1_800_000
     });
     return node.unwrap();
 }

--- a/packages/fleet/lib/models/node_config_overrides.integration.test.ts
+++ b/packages/fleet/lib/models/node_config_overrides.integration.test.ts
@@ -22,7 +22,7 @@ describe('NodeConfgOverrides', () => {
         storageMb: 1000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleMaxDurationMs: 1800
+        idleMaxDurationMs: 1_800_000
     };
 
     it('should be successfully created', async () => {
@@ -80,7 +80,7 @@ describe('NodeConfgOverrides', () => {
             storageMb: 2000,
             isTracingEnabled: true,
             isProfilingEnabled: true,
-            idleMaxDurationMs: 1800
+            idleMaxDurationMs: 1_800_000
         };
         const updatedNodeConfigOverride = (await node_config_overrides.upsert(dbClient.db, updatedProps)).unwrap();
         expect(updatedNodeConfigOverride).toStrictEqual({

--- a/packages/fleet/lib/models/nodes.integration.test.ts
+++ b/packages/fleet/lib/models/nodes.integration.test.ts
@@ -37,7 +37,7 @@ describe('Nodes', () => {
                 storageMb: 512,
                 isTracingEnabled: false,
                 isProfilingEnabled: false,
-                idleMaxDurationMs: 1800
+                idleMaxDurationMs: 1_800_000
             })
         ).unwrap();
         expect(node).toStrictEqual({
@@ -52,7 +52,7 @@ describe('Nodes', () => {
             storageMb: 512,
             isTracingEnabled: false,
             isProfilingEnabled: false,
-            idleMaxDurationMs: 1800,
+            idleMaxDurationMs: 1_800_000,
             error: null,
             createdAt: expect.any(Date),
             lastStateTransitionAt: expect.any(Date)

--- a/packages/fleet/lib/node-providers/noop.ts
+++ b/packages/fleet/lib/node-providers/noop.ts
@@ -9,7 +9,7 @@ export const noopNodeProvider: NodeProvider = {
         storageMb: 1000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleMaxDurationMs: 1800
+        idleMaxDurationMs: 1_800_000
     },
     start: () => {
         return Promise.resolve(Ok(undefined));

--- a/packages/fleet/lib/supervisor/supervisor.integration.test.ts
+++ b/packages/fleet/lib/supervisor/supervisor.integration.test.ts
@@ -21,7 +21,7 @@ const mockNodeProvider = {
         storageMb: 1000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleMaxDurationMs: 1800
+        idleMaxDurationMs: 1_800_000
     },
     start: vi.fn().mockResolvedValue(Ok(undefined)),
     terminate: vi.fn().mockResolvedValue(Ok(undefined)),
@@ -144,7 +144,7 @@ describe('Supervisor', () => {
             memoryMb: 1234,
             storageMb: 567890,
             error: null,
-            idleMaxDurationMs: 1800
+            idleMaxDurationMs: 1_800_000
         });
     });
 

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -454,7 +454,7 @@ export const kubernetesNodeProvider: NodeProvider = {
         storageMb: 20000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleMaxDurationMs: 1800
+        idleMaxDurationMs: 1_800_000 // 30 minutes
     },
     start: async (node: Node) => {
         const kubernetes = Kubernetes.getInstance();

--- a/packages/jobs/lib/runner/local.ts
+++ b/packages/jobs/lib/runner/local.ts
@@ -20,7 +20,7 @@ export const localNodeProvider: NodeProvider = {
         storageMb: 20000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleMaxDurationMs: 1800
+        idleMaxDurationMs: 0 // No auto-shutdown for local runners
     },
     start: async (node) => {
         try {

--- a/packages/jobs/lib/runner/render.ts
+++ b/packages/jobs/lib/runner/render.ts
@@ -28,7 +28,7 @@ export const renderNodeProvider: NodeProvider = {
         storageMb: 20000,
         isTracingEnabled: false,
         isProfilingEnabled: false,
-        idleMaxDurationMs: 1800
+        idleMaxDurationMs: 1_800_000
     },
     start: async (node) => {
         if (!envs.RUNNER_OWNER_ID) {


### PR DESCRIPTION
Field was changed to hold ms and not seconds anymore but value was not updated
<!-- Summary by @propel-code-bot -->

---

**Update `idleMaxDurationMs` from seconds to milliseconds across codebase**

The PR fixes an earlier unit mismatch: `idleMaxDurationMs` fields were still set to 1800 (seconds) even though the field now expects milliseconds. Values are multiplied by 1 000 (→ 1_800_000) everywhere and test expectations are adjusted accordingly. Local runner is explicitly configured with `idleMaxDurationMs: 0` (no auto-shutdown).

<details>
<summary><strong>Key Changes</strong></summary>

• Changed hard-coded `idleMaxDurationMs` values from `1800` to `1_800_000` in tests and default node configs
• Updated default configs for `noopNodeProvider`, `localNodeProvider`, `kubernetesNodeProvider`, and `renderNodeProvider`
• Set `idleMaxDurationMs` to `0` for `localNodeProvider` to disable auto-shutdown when running locally
• Aligned integration tests (`fleet`, `nodes`, `node_config_overrides`, `supervisor`) with new millisecond values

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/fleet/lib/**/*.integration.test.ts`
• `packages/fleet/lib/node-providers/noop.ts`
• `packages/jobs/lib/runner/{local,kubernetes,render}.ts`
• `packages/fleet/lib/models/helpers.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*