### PR TITLE
fix: remove DEPRECATED functionLogs runner flag

### DIFF
--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -383,8 +383,7 @@ export class DryRunService {
                     validateActionInput: this.validation, // irrelevant for cli
                     validateActionOutput: this.validation, // irrelevant for cli
                     validateSyncRecords: this.validation,
-                    validateSyncMetadata: false,
-                    functionLogs: true
+                    validateSyncMetadata: false
                 },
                 startedAt: new Date(),
                 endUser: null,

--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -132,10 +132,7 @@ export async function startAction(task: TaskAction): Promise<Result<void>> {
             syncConfig: syncConfig,
             debug: false,
             logger: sdkLogger,
-            runnerFlags: {
-                ...(await getRunnerFlags()),
-                functionLogs: !cappingFunctionLogsStatus.isCapped
-            },
+            runnerFlags: await getRunnerFlags(),
             startedAt: now,
             endUser,
             heartbeatTimeoutSecs: task.heartbeatTimeoutSecs

--- a/packages/jobs/lib/execution/onEvent.ts
+++ b/packages/jobs/lib/execution/onEvent.ts
@@ -118,10 +118,7 @@ export async function startOnEvent(task: TaskOnEvent): Promise<Result<void>> {
             syncConfig,
             debug: false,
             logger: sdkLogger,
-            runnerFlags: {
-                ...(await getRunnerFlags()),
-                functionLogs: !cappingFunctionLogsStatus.isCapped
-            },
+            runnerFlags: await getRunnerFlags(),
             startedAt: new Date(),
             endUser,
             heartbeatTimeoutSecs: task.heartbeatTimeoutSecs

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -176,10 +176,7 @@ export async function startSync(task: TaskSync, startScriptFn = startScript): Pr
             syncConfig,
             debug: task.debug || false,
             logger: sdkLogger,
-            runnerFlags: {
-                ...(await getRunnerFlags()),
-                functionLogs: !cappingFunctionLogsStatus.isCapped
-            },
+            runnerFlags: await getRunnerFlags(),
             startedAt,
             ...(lastSyncDate ? { lastSyncDate } : {}),
             endUser,

--- a/packages/jobs/lib/execution/webhook.ts
+++ b/packages/jobs/lib/execution/webhook.ts
@@ -147,10 +147,7 @@ export async function startWebhook(task: TaskWebhook): Promise<Result<void>> {
             syncJobId: syncJob.id,
             debug: false,
             logger: sdkLogger,
-            runnerFlags: {
-                ...(await getRunnerFlags()),
-                functionLogs: !cappingFunctionLogsStatus.isCapped
-            },
+            runnerFlags: await getRunnerFlags(),
             endUser: endUser,
             startedAt: new Date(),
             heartbeatTimeoutSecs: task.heartbeatTimeoutSecs

--- a/packages/jobs/lib/routes/tasks/putTask.ts
+++ b/packages/jobs/lib/routes/tasks/putTask.ts
@@ -67,8 +67,7 @@ const nangoPropsSchema = z.looseObject({
         validateWebhookInput: z.boolean().default(false),
         validateWebhookOutput: z.boolean().default(false),
         validateSyncRecords: z.boolean().default(false),
-        validateSyncMetadata: z.boolean().default(false),
-        functionLogs: z.boolean().default(true) //TODO: DEPRECATED
+        validateSyncMetadata: z.boolean().default(false)
     }),
     logger: z
         .looseObject({

--- a/packages/jobs/lib/utils/flags.ts
+++ b/packages/jobs/lib/utils/flags.ts
@@ -1,12 +1,9 @@
 import { getFeatureFlagsClient } from '@nangohq/kvstore';
 
+import type { RunnerFlags } from '@nangohq/types';
+
 export const featureFlags = await getFeatureFlagsClient();
-export async function getRunnerFlags(): Promise<{
-    validateActionInput: boolean;
-    validateActionOutput: boolean;
-    validateSyncRecords: boolean;
-    validateSyncMetadata: boolean;
-}> {
+export async function getRunnerFlags(): Promise<RunnerFlags> {
     const [validateActionInput, validateActionOutput, validateSyncRecords, validateSyncMetadata] = await Promise.all([
         featureFlags.isSet('runner.validateActionInput'),
         featureFlags.isSet('runner.validateActionOutput'),

--- a/packages/runner/lib/exec.unit.test.ts
+++ b/packages/runner/lib/exec.unit.test.ts
@@ -31,8 +31,7 @@ function getNangoProps(): NangoProps {
             validateActionInput: false,
             validateActionOutput: false,
             validateSyncMetadata: false,
-            validateSyncRecords: false,
-            functionLogs: true
+            validateSyncRecords: false
         },
         endUser: null,
         heartbeatTimeoutSecs: 30

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -126,11 +126,6 @@ export class NangoActionRunner extends NangoActionBase<never, Record<string, str
     public override async log(...args: [...any]): Promise<void> {
         this.throwIfAborted();
 
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-boolean-literal-compare
-        if (this.runnerFlags.functionLogs === false) {
-            return;
-        }
-
         // if logging is turned off, we bail early
         if (this.logger.level === 'off') {
             return;

--- a/packages/types/lib/runner/index.ts
+++ b/packages/types/lib/runner/index.ts
@@ -20,5 +20,4 @@ export interface RunnerFlags {
     validateActionOutput: boolean;
     validateSyncRecords: boolean;
     validateSyncMetadata: boolean;
-    functionLogs: boolean; // DEPRECATED
 }


### PR DESCRIPTION
Disabling functions custom logs is now done via setting the logger level to 'off' instead of having an extra runner flag

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Remove deprecated `functionLogs` runner flag**

Deprecated runner flag `functionLogs` has been fully excised in favor of controlling log output solely through the SDK/logger `level` property. All call-sites that built or consumed `RunnerFlags` now rely on the revised `RunnerFlags` type (without `functionLogs`). Capping logic continues to set `sdkLogger.level = 'off'` when limits are reached, keeping the existing behaviour without the extra flag.

<details>
<summary><strong>Key Changes</strong></summary>

• Deleted `functionLogs` from `RunnerFlags` definition in `packages/types/lib/runner/index.ts` and updated associated zod schema in `packages/jobs/lib/routes/tasks/putTask.ts`
• Updated `getRunnerFlags()` in `packages/jobs/lib/utils/flags.ts` to return `Promise<RunnerFlags>` (no inline type) and removed object spread merging of `functionLogs` in all execution modules (`action.ts`, `onEvent.ts`, `sync.ts`, `webhook.ts`)
• Adjusted logging suppression: `packages/runner/lib/sdk/sdk.ts` now bypasses log writes solely based on `this.logger.level === 'off'`
• Refactored CLI dry-run service, unit tests, and test fixtures to drop the flag
• Removed schema/default handling of the flag in request validation and CLI input

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/jobs` execution pipeline (action/onEvent/sync/webhook)
• `packages/runner` SDK logging
• `packages/cli` dry-run service
• `packages/types` runner types
• Task API route validation

</details>

---
*This summary was automatically generated by @propel-code-bot*