### PR TITLE
fix(server): include _MS in shutdown delay env var name

### DIFF
--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -139,5 +139,5 @@ process.on('SIGINT', () => {
 process.on('SIGTERM', () => {
     logger.info('Received SIGTERM...');
     setShuttingDown(true);
-    setTimeout(close, envs.SERVER_SHUTDOWN_DELAY);
+    setTimeout(close, envs.SERVER_SHUTDOWN_DELAY_MS);
 });

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -27,7 +27,7 @@ export const ENVS = z.object({
     NANGO_SERVER_WEBSOCKETS_PATH: z.string().optional(),
     NANGO_ADMIN_INVITE_TOKEN: z.string().optional(),
     NANGO_SERVER_PUBLIC_BODY_LIMIT: z.string().optional().default('75mb'),
-    SERVER_SHUTDOWN_DELAY: z.coerce.number().optional().default(0),
+    SERVER_SHUTDOWN_DELAY_MS: z.coerce.number().optional().default(0),
 
     // Connect
     NANGO_PUBLIC_CONNECT_URL: z.url().optional(),


### PR DESCRIPTION
Renaming the shutdown delay environment variable to include `_MS` to indicate the value is expressed in milliseconds.