### PR TITLE
fix(self-hosted): allow env variable to change the deprecation date

### DIFF
--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -32,10 +32,6 @@ const logger = getLogger('AccessMiddleware');
 const keyRegex = /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
 const ignoreEnvPaths = ['/api/v1/environments', '/api/v1/meta', '/api/v1/user', '/api/v1/user/name', '/api/v1/signin', '/api/v1/invite/:id'];
 
-const deprecatedPublicAuthenticationCutoffDate = envs.PUBLIC_AUTHENTICATION_DEPRECATION_DATE
-    ? new Date(envs.PUBLIC_AUTHENTICATION_DEPRECATION_DATE)
-    : new Date('2025-08-25');
-
 export class AccessMiddleware {
     private async validateSecretKey(secret: string): Promise<
         Result<{
@@ -438,7 +434,7 @@ export class AccessMiddleware {
                     return;
                 }
 
-                if (result.value.account.created_at > deprecatedPublicAuthenticationCutoffDate) {
+                if (result.value.account.created_at > envs.PUBLIC_AUTHENTICATION_DEPRECATION_DATE) {
                     res.status(401).send({
                         error: {
                             code: 'deprecated_authentication',

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -32,7 +32,9 @@ const logger = getLogger('AccessMiddleware');
 const keyRegex = /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
 const ignoreEnvPaths = ['/api/v1/environments', '/api/v1/meta', '/api/v1/user', '/api/v1/user/name', '/api/v1/signin', '/api/v1/invite/:id'];
 
-const deprecatedPublicAuthenticationCutoffDate = new Date('2025-08-25');
+const deprecatedPublicAuthenticationCutoffDate = envs.PUBLIC_AUTHENTICATION_DEPRECATION_DATE
+    ? new Date(envs.PUBLIC_AUTHENTICATION_DEPRECATION_DATE)
+    : new Date('2025-08-25');
 
 export class AccessMiddleware {
     private async validateSecretKey(secret: string): Promise<

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -32,7 +32,19 @@ export const ENVS = z.object({
     // Connect
     NANGO_PUBLIC_CONNECT_URL: z.url().optional(),
     NANGO_CONNECT_UI_PORT: z.coerce.number().optional().default(3009),
-    PUBLIC_AUTHENTICATION_DEPRECATION_DATE: z.coerce.date().default(new Date('2025-08-25')),
+    PUBLIC_AUTHENTICATION_DEPRECATION_DATE: z
+        .string()
+        .optional()
+        .transform((val) => {
+            if (!val) {
+                return new Date('2025-08-25');
+            }
+            const parsed = new Date(val);
+            if (isNaN(parsed.getTime())) {
+                return new Date('2025-08-25');
+            }
+            return parsed;
+        }),
 
     // Crons
     CRON_EXPORT_USAGE_MINUTES: z.coerce.number().optional().default(60),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -32,7 +32,7 @@ export const ENVS = z.object({
     // Connect
     NANGO_PUBLIC_CONNECT_URL: z.url().optional(),
     NANGO_CONNECT_UI_PORT: z.coerce.number().optional().default(3009),
-    PUBLIC_AUTHENTICATION_DEPRECATION_DATE: z.string().optional(),
+    PUBLIC_AUTHENTICATION_DEPRECATION_DATE: z.coerce.date().default(new Date('2025-08-25')),
 
     // Crons
     CRON_EXPORT_USAGE_MINUTES: z.coerce.number().optional().default(60),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -32,6 +32,7 @@ export const ENVS = z.object({
     // Connect
     NANGO_PUBLIC_CONNECT_URL: z.url().optional(),
     NANGO_CONNECT_UI_PORT: z.coerce.number().optional().default(3009),
+    PUBLIC_AUTHENTICATION_DEPRECATION_DATE: z.string().optional(),
 
     // Crons
     CRON_EXPORT_USAGE_MINUTES: z.coerce.number().optional().default(60),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -32,19 +32,7 @@ export const ENVS = z.object({
     // Connect
     NANGO_PUBLIC_CONNECT_URL: z.url().optional(),
     NANGO_CONNECT_UI_PORT: z.coerce.number().optional().default(3009),
-    PUBLIC_AUTHENTICATION_DEPRECATION_DATE: z
-        .string()
-        .optional()
-        .transform((val) => {
-            if (!val) {
-                return new Date('2025-08-25');
-            }
-            const parsed = new Date(val);
-            if (isNaN(parsed.getTime())) {
-                return new Date('2025-08-25');
-            }
-            return parsed;
-        }),
+    PUBLIC_AUTHENTICATION_DEPRECATION_DATE: z.coerce.date().catch(new Date('2025-08-25')),
 
     // Crons
     CRON_EXPORT_USAGE_MINUTES: z.coerce.number().optional().default(60),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Self hosted customers need to be able to use the deprecated method to set dynamic params

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Configurable Public-Key Auth Deprecation Date**

Replaces the hard-coded cutoff date for deprecated public-key authentication with a new environment variable so self-hosted users can postpone enforcement. The date is now validated and defaulted in `packages/utils/lib/environment/parse.ts`, and all runtime checks in `packages/server/lib/middleware/access.middleware.ts` point to the parsed env value.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `PUBLIC_AUTHENTICATION_DEPRECATION_DATE` to `ENVS` schema with `z.coerce.date().catch(new Date('2025-08-25'))`
• Removed constant `deprecatedPublicAuthenticationCutoffDate` from `packages/server/lib/middleware/access.middleware.ts`
• Replaced comparisons against the removed constant with `envs.PUBLIC_AUTHENTICATION_DEPRECATION_DATE`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/utils/lib/environment/parse.ts`
• `packages/server/lib/middleware/access.middleware.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*