### PR TITLE
docs: add missing NANGO_SERVER_URL in env variables for nango-jobs co…

### DIFF
--- a/docs/guides/self-hosting/enterprise-self-hosting/ecs.mdx
+++ b/docs/guides/self-hosting/enterprise-self-hosting/ecs.mdx
@@ -419,6 +419,10 @@ Define the container configurations for each Nango service using Fargate.
                             "value": "postgresql://USER:PWD@HOST:PORT/DB_NAME"
                         },
                         {
+                            "name": "NANGO_SERVER_URL",
+                            "value": "http://YOUR.ALB.DNS"
+                        },
+                        {
                             "name": "AWS_ACCESS_KEY_ID",
                             "value": "YOUR_AWS_ACCESS_KEY_ID"
                         },


### PR DESCRIPTION
NANGO_SERVER_URL was missing causing syncs to connect to `api.nango.dev` cloud instance instead of self-hosted enterprise instance.

<!-- Summary by @propel-code-bot -->

---

**docs: add missing `NANGO_SERVER_URL` to jobs container example**

Adds the previously omitted `NANGO_SERVER_URL` environment variable to the ECS self-hosting guide. This prevents `nango-jobs` containers deployed via the documented task definition from defaulting to the cloud endpoint `api.nango.dev` and ensures they target the intended self-hosted server.

<details>
<summary><strong>Key Changes</strong></summary>

• Inserted `NANGO_SERVER_URL` with placeholder value `http://YOUR.ALB.DNS` in `docs/guides/self-hosting/enterprise-self-hosting/ecs.mdx` under the `nango-jobs` container env list

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs/guides/self-hosting/enterprise-self-hosting/ecs.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*