### PR TITLE
fix(logs): allow configurable timeouts for elasticsearch query

### DIFF
--- a/packages/logs/lib/es/client.ts
+++ b/packages/logs/lib/es/client.ts
@@ -5,8 +5,8 @@ import { CircuitBreaker } from './circuitBreaker.js';
 
 const rawClient = new Client({
     nodes: envs.NANGO_LOGS_ES_URL || 'http://localhost:0',
-    requestTimeout: 5000,
-    maxRetries: 1,
+    requestTimeout: envs.NANGO_LOGS_ES_REQUEST_TIMEOUT_MS,
+    maxRetries: envs.NANGO_LOGS_ES_MAX_RETRIES,
     auth: {
         username: envs.NANGO_LOGS_ES_USER!, // ggignore
         password: envs.NANGO_LOGS_ES_PWD! // ggignore

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -241,6 +241,8 @@ export const ENVS = z.object({
 
     // Elasticsearch
     NANGO_LOGS_ES_URL: z.url().optional(),
+    NANGO_LOGS_ES_REQUEST_TIMEOUT_MS: z.coerce.number().optional().default(5000),
+    NANGO_LOGS_ES_MAX_RETRIES: z.coerce.number().optional().default(1),
     NANGO_LOGS_ES_USER: z.string().optional(),
     NANGO_LOGS_ES_PWD: z.string().optional(),
     NANGO_LOGS_ENABLED: z.stringbool().optional().default(false),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Make Elasticsearch timeout & retry configurable via env vars**

Replaces hard-coded Elasticsearch client settings with environment-driven values, enabling operators to tune `requestTimeout` and `maxRetries` without code changes. Corresponding environment schema updates supply sane defaults (5000 ms timeout, 1 retry) and validation.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced literals `requestTimeout: 5000` and `maxRetries: 1` in `packages/logs/lib/es/client.ts` with env-driven `envs.NANGO_LOGS_ES_REQUEST_TIMEOUT_MS` and `envs.NANGO_LOGS_ES_MAX_RETRIES`.
• Extended Zod schema in `packages/utils/lib/environment/parse.ts` with `NANGO_LOGS_ES_REQUEST_TIMEOUT_MS` and `NANGO_LOGS_ES_MAX_RETRIES` (numeric, optional, default 5000 and 1).

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/logs/lib/es/client.ts`
• `packages/utils/lib/environment/parse.ts`
• Environment configuration for logs/Elasticsearch

</details>

---
*This summary was automatically generated by @propel-code-bot*