### PR TITLE
docs: improve the OpenAI SDK implementation guide + add guide for any LLM provider

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -191,6 +191,7 @@
             "group": "AI tool calling",
             "pages": [
               "implementation-guides/ai-tool-calling/openai-sdk",
+              "implementation-guides/ai-tool-calling/any-llm-sdk",
               "implementation-guides/ai-tool-calling/implement-mcp-server"
             ]
           },

--- a/docs/guides/use-cases/ai-tool-calling.mdx
+++ b/docs/guides/use-cases/ai-tool-calling.mdx
@@ -59,7 +59,7 @@ For RAG-style use cases where data must be replicated locally, use [Syncs](/guid
 
 ## Implementation guides
 
-Nango works with any framework or SDK that supports tool calling. Here some example guides:
+Nango works with any framework or SDK that supports tool calling. Here are some example guides:
 - [Tool calling with the OpenAI SDK](/implementation-guides/ai-tool-calling/openai-sdk)
 - [Tool calling with any LLM SDK](/implementation-guides/ai-tool-calling/any-llm-sdk)
 - [Tool calling with MCP](/implementation-guides/ai-tool-calling/implement-mcp-server)

--- a/docs/guides/use-cases/ai-tool-calling.mdx
+++ b/docs/guides/use-cases/ai-tool-calling.mdx
@@ -61,4 +61,5 @@ For RAG-style use cases where data must be replicated locally, use [Syncs](/guid
 
 Nango works with any framework or SDK that supports tool calling. Here some example guides:
 - [Tool calling with the OpenAI SDK](/implementation-guides/ai-tool-calling/openai-sdk)
+- [Tool calling with any LLM SDK](/implementation-guides/ai-tool-calling/any-llm-sdk)
 - [Tool calling with MCP](/implementation-guides/ai-tool-calling/implement-mcp-server)

--- a/docs/implementation-guides/ai-tool-calling/any-llm-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/any-llm-sdk.mdx
@@ -8,7 +8,7 @@ This guide shows how to combine **Nango** with **any LLM provider** to consume e
 
 ## Example overview
 
-The example below uses HubSpot’s API to demonstrate how to can access a user’s external account through Nango.
+The example below uses Hubspot’s API to demonstrate how to access a user’s external account through Nango.
 <Tip>
 **Requirements**
 - A Nango account with an integration for `hubspot` and the `whoami` action enabled.
@@ -17,7 +17,7 @@ The example below uses HubSpot’s API to demonstrate how to can access a user�
 
 In this example:
 1. Check if the user is already authenticated with Hubspot.  
-2. If not, start the HubSpot OAuth flow. You can do this:
+2. If not, start the Hubspot OAuth flow. You can do this:
    - Directly in the chat session, or  
    - By embedding the [Frontend SDK](https://nango.dev/docs/implementation-guides/api-auth/implement-api-auth#2-trigger-the-auth-flow-frontend) in your app.  
 3. Send a prompt to your model.
@@ -36,12 +36,12 @@ export async function runLLMAgent(modelClient: any) {
   const integrationId = "hubspot";
 
   // Step 1: Ensure the user is authorized
-  console.log("🔒 Checking HubSpot authorization...");
+  console.log("🔒 Checking Hubspot authorization...");
   let connectionId = (await nango.listConnections({ userId })).connections[0]?.connection_id;
 
   // Step 2: If the user is not authorized, redirect to the auth flow.
   if (!connectionId) {
-    console.log("User not authorized, starting HubSpot auth flow...");
+    console.log("User not authorized, starting Hubspot auth flow...");
 
     const session = await nango.createConnectSession({
       allowed_integrations: [integrationId],
@@ -50,7 +50,7 @@ export async function runLLMAgent(modelClient: any) {
 
     // Redirect the user to a page to authorize Hubspot. 
     // Alternatively, you can embed Nango's Frontend SDK in your app.
-    console.log(`Please authorize HubSpot here: ${session.data.connect_link}`);
+    console.log(`Please authorize Hubspot here: ${session.data.connect_link}`);
 
     const connection = await nango.waitForConnection(integrationId, userId);
     connectionId = connection?.connection_id;
@@ -62,11 +62,11 @@ export async function runLLMAgent(modelClient: any) {
   console.log("🤖 Agent running...");
   const response = await modelClient.generate({
     model: "your-llm-model-id",
-    input: "Get the current HubSpot user info using the who_am_i tool.",
+    input: "Get the current Hubspot user info using the who_am_i tool.",
     tools: [
       {
         name: "who_am_i",
-        description: "Fetch the current HubSpot user profile.",
+        description: "Fetch the current Hubspot user profile.",
         parameters: { type: "object", properties: {} },
       },
     ],
@@ -81,7 +81,7 @@ export async function runLLMAgent(modelClient: any) {
     try {
       // Step 4: Execute the requested tool with Nango.
       const userInfo = await nango.triggerAction("hubspot", connectionId, "whoami");
-      console.log("✅ Retrieved HubSpot user info:", userInfo);
+      console.log("✅ Retrieved Hubspot user info:", userInfo);
     } catch (error: any) {
       console.error("❌ Nango API error:", error.response?.data?.error || error);
     }

--- a/docs/implementation-guides/ai-tool-calling/any-llm-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/any-llm-sdk.mdx
@@ -1,0 +1,103 @@
+---
+title: "Any LLM SDK example"
+sidebarTitle: "Any LLM SDK example"
+description: "End-to-end example of calling external APIs via tool calling with any LLM provider."
+---
+
+This guide shows how to combine **Nango** with **any LLM provider** to consume external APIs via tool calling.
+
+## Example overview
+
+The example below uses HubSpot’s API to demonstrate how to can access a user’s external account through Nango.
+<Tip>
+**Requirements**
+- A Nango account with an integration for `hubspot` and the `whoami` action enabled.
+- An account with your preferred LLM provider.
+</Tip>
+
+In this example:
+1. Check if the user is already authenticated with Hubspot.  
+2. If not, start the HubSpot OAuth flow. You can do this:
+   - Directly in the chat session, or  
+   - By embedding the [Frontend SDK](https://nango.dev/docs/implementation-guides/api-auth/implement-api-auth#2-trigger-the-auth-flow-frontend) in your app.  
+3. Send a prompt to your model.
+4. When the model calls a tool, trigger the corresponding Nango action.
+
+## Example code
+
+```ts
+import { Nango } from "@nangohq/node";
+
+// Initialize the Nango client
+const nango = new Nango({ secretKey: process.env.NANGO_SECRET_KEY! });
+
+export async function runLLMAgent(modelClient: any) {
+  const userId = "user1";
+  const integrationId = "hubspot";
+
+  // Step 1: Ensure the user is authorized
+  console.log("🔒 Checking HubSpot authorization...");
+  let connectionId = (await nango.listConnections({ userId })).connections[0]?.connection_id;
+
+  // Step 2: If the user is not authorized, redirect to the auth flow.
+  if (!connectionId) {
+    console.log("User not authorized, starting HubSpot auth flow...");
+
+    const session = await nango.createConnectSession({
+      allowed_integrations: [integrationId],
+      end_user: { id: userId },
+    }); // Handle API auth via Nango.
+
+    // Redirect the user to a page to authorize Hubspot. 
+    // Alternatively, you can embed Nango's Frontend SDK in your app.
+    console.log(`Please authorize HubSpot here: ${session.data.connect_link}`);
+
+    const connection = await nango.waitForConnection(integrationId, userId);
+    connectionId = connection?.connection_id;
+
+    if (!connectionId) throw new Error("Auth flow failed");
+  }
+
+  // Step 3: Send a prompt to your model.
+  console.log("🤖 Agent running...");
+  const response = await modelClient.generate({
+    model: "your-llm-model-id",
+    input: "Get the current HubSpot user info using the who_am_i tool.",
+    tools: [
+      {
+        name: "who_am_i",
+        description: "Fetch the current HubSpot user profile.",
+        parameters: { type: "object", properties: {} },
+      },
+    ],
+  });
+
+  // Check if the model requested a tool call
+  const toolCall = response?.toolCalls?.[0] || response?.tool_call || null;
+
+  if (toolCall?.name === "who_am_i") {
+    console.log("🧩 Model decided to call the 'who_am_i' tool...");
+
+    try {
+      // Step 4: Execute the requested tool with Nango.
+      const userInfo = await nango.triggerAction("hubspot", connectionId, "whoami");
+      console.log("✅ Retrieved HubSpot user info:", userInfo);
+    } catch (error: any) {
+      console.error("❌ Nango API error:", error.response?.data?.error || error);
+    }
+  } else {
+    // Handle plain text or other model responses
+    const textOutput = response?.text || response?.output_text || JSON.stringify(response);
+    console.log("🗣️ Model response:", textOutput);
+  }
+}
+```
+
+<Tip>
+This example uses the **Nango Node SDK**, which is a thin wrapper around Nango’s REST API. You can use the same flow in any language with the [API reference](https://nango.dev/docs/reference/api/authentication).
+</Tip>
+
+<Tip>
+You can let agents or models introspect available tools and their specifications by calling this  
+[endpoint](/reference/api/scripts/config). Your model can then automatically decide which tool to call.
+</Tip>

--- a/docs/implementation-guides/ai-tool-calling/openai-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/openai-sdk.mdx
@@ -38,7 +38,7 @@ export async function runOpenAIAgent() {
 
   // Step 1: Ensure the user is authorized
   console.log("🔒 Checking API authorization...")
-  let connectionId = (await nango.listConnections({ userId: userId })).connections[0]?.connection_id;
+  let connectionId = (await nango.listConnections({ userId })).connections[0]?.connection_id;
 
   // Step 2: If the user is not authorized, redirect to the auth flow.
   if (!connectionId) {

--- a/docs/implementation-guides/ai-tool-calling/openai-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/openai-sdk.mdx
@@ -8,17 +8,17 @@ This guide demonstrates how to combine **Nango** and the **OpenAI SDK** to consu
 
 ## Example overview
 
-The example below uses HubSpot's API to demonstrate how to can access a user’s external account through Nango.
+The example below uses Hubspot's API to demonstrate how to access a user’s external account through Nango.
 
 <Tip>
 **Requirements:** 
-- A Nango account with an integration for `hubspot` with the `whoami` action enabled.
-- A OpenAI account.
+- A Nango account with an integration for `Hubspot` with the `whoami` action enabled.
+- An OpenAI account.
 </Tip>
 
 In this example:
 1. Check if the user is already authenticated with Hubspot.  
-2. If not, start the HubSpot OAuth flow. You can do this:
+2. If not, start the Hubspot OAuth flow. You can do this:
    - Directly in the chat session, or  
    - By embedding the [Frontend SDK](https://nango.dev/docs/implementation-guides/api-auth/implement-api-auth#2-trigger-the-auth-flow-frontend) in your app.  
 3. Send a prompt to your model.
@@ -34,7 +34,7 @@ export async function runOpenAIAgent() {
   const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
   const nango = new Nango({ secretKey: process.env.NANGO_SECRET_KEY! });
 
-  const userId = "user1", integrationId = "hubspot";
+  const userId = "user1", integrationId = "Hubspot";
 
   // Step 1: Ensure the user is authorized
   console.log("🔒 Checking API authorization...")
@@ -80,7 +80,7 @@ export async function runOpenAIAgent() {
   if (functionCall?.name === "who_am_i") {
     try {
       // Step 4: Execute the requested tool with Nango.
-      const userInfo = await nango.triggerAction("hubspot", connectionId, "whoami"); // Call tools via Nango.
+      const userInfo = await nango.triggerAction("Hubspot", connectionId, "whoami"); // Call tools via Nango.
       console.log("✅ Agent retrieved your Hubspot user info:", userInfo);
     } catch (error: any) {
       console.error("Nango API error:", error.response?.data?.error || error);

--- a/docs/implementation-guides/ai-tool-calling/openai-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/openai-sdk.mdx
@@ -6,17 +6,25 @@ description: "End-to-end example of calling external tools with the OpenAI SDK."
 
 This guide demonstrates how to combine **Nango** and the **OpenAI SDK** to consume external APIs via tool calling.
 
-In this example:
-- The OpenAI model defines a `who_am_i` tool and sends a prompt to OpenAI.  
-- When the model calls the tool, the script uses **Nango** to ensure the user’s connection is active and, if needed, walks them through the HubSpot auth flow.  
-- Once authorized, the script executes the model’s tool call by triggering the `whoami` action on **HubSpot** through Nango.  
-- Finally, it prints the resulting HubSpot user info in the console.  
+## Example overview
+
+The example below uses HubSpot's API to demonstrate how to can access a user’s external account through Nango.
 
 <Tip>
 **Requirements:** 
 - A Nango account with an integration for `hubspot` with the `whoami` action enabled.
 - A OpenAI account.
 </Tip>
+
+In this example:
+1. Check if the user is already authenticated with Hubspot.  
+2. If not, start the HubSpot OAuth flow. You can do this:
+   - Directly in the chat session, or  
+   - By embedding the [Frontend SDK](https://nango.dev/docs/implementation-guides/api-auth/implement-api-auth#2-trigger-the-auth-flow-frontend) in your app.  
+3. Send a prompt to your model.
+4. When the model calls a tool, trigger the corresponding Nango action.
+
+## Example code
 
 ```ts
 import OpenAI from "openai";
@@ -28,9 +36,11 @@ export async function runOpenAIAgent() {
 
   const userId = "user1", integrationId = "hubspot";
 
+  // Step 1: Ensure the user is authorized
   console.log("🔒 Checking API authorization...")
   let connectionId = (await nango.listConnections({ userId: userId })).connections[0]?.connection_id;
 
+  // Step 2: If the user is not authorized, redirect to the auth flow.
   if (!connectionId) {
     const session = await nango.createConnectSession({
       allowed_integrations: [integrationId],
@@ -48,6 +58,7 @@ export async function runOpenAIAgent() {
     }
   }
 
+  // Step 3: Send a prompt to your model.
   console.log("🤖 Agent running...")
   const response = await client.responses.create({
     model: "gpt-5",
@@ -63,21 +74,29 @@ export async function runOpenAIAgent() {
     ],
   });
 
+  // Check if the model requested a tool call.
   const functionCall = response.output.find((item) => item.type === "function_call") as any;
 
   if (functionCall?.name === "who_am_i") {
     try {
+      // Step 4: Execute the requested tool with Nango.
       const userInfo = await nango.triggerAction("hubspot", connectionId, "whoami"); // Call tools via Nango.
       console.log("✅ Agent retrieved your Hubspot user info:", userInfo);
     } catch (error: any) {
       console.error("Nango API error:", error.response?.data?.error || error);
     }
   } else {
+    // Handle plain text or other model responses
     console.log(response.output_text);
   }
 }
 ```
 
 <Tip>
-  You can let agents/models introspect & select tools autonomously with this [endpoint](/reference/api/scripts/config).
+This example uses the **Nango Node SDK**, which is a thin wrapper around Nango’s REST API. You can use the same flow in any language with the [API reference](https://nango.dev/docs/reference/api/authentication).
+</Tip>
+
+<Tip>
+You can let agents or models introspect available tools and their specifications by calling this  
+[endpoint](/reference/api/scripts/config). Your model can then automatically decide which tool to call.
 </Tip>

--- a/docs/implementation-guides/ai-tool-calling/openai-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/openai-sdk.mdx
@@ -21,7 +21,6 @@ In this example:
 ```ts
 import OpenAI from "openai";
 import { Nango } from "@nangohq/node";
-import readline from "readline";
 
 export async function runOpenAIAgent() {
   const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
@@ -30,7 +29,7 @@ export async function runOpenAIAgent() {
   const userId = "user1", integrationId = "hubspot";
 
   console.log("🔒 Checking API authorization...")
-  let connectionId = (await nango.listConnections(undefined, undefined, { endUserId: userId })).connections[0]?.connection_id;
+  let connectionId = (await nango.listConnections({ userId: userId })).connections[0]?.connection_id;
 
   if (!connectionId) {
     const session = await nango.createConnectSession({
@@ -39,9 +38,10 @@ export async function runOpenAIAgent() {
     }); // Handle API auth via Nango.
 
     console.log(`Please authorize the app by visiting this URL: ${session.data.connect_link}`);
-    await waitForEnter("Press Enter once you've authorized the app...");
 
-    connectionId = (await nango.listConnections(undefined, undefined, { endUserId: userId })).connections[0]?.connection_id;
+    const connection = await nango.waitForConnection(integrationId, userId);
+    connectionId = connection?.connection_id;
+
     if (!connectionId) {
       console.log("Connect flow failed.");
       return;
@@ -75,11 +75,6 @@ export async function runOpenAIAgent() {
   } else {
     console.log(response.output_text);
   }
-}
-
-function waitForEnter(prompt: string) {
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  return new Promise<void>((resolve) => rl.question(prompt, () => { rl.close(); resolve(); }));
 }
 ```
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add universal LLM SDK implementation guide & refresh OpenAI guide**

Pure documentation PR. Introduces a new guide (`any-llm-sdk.mdx`) that shows how to call Nango Actions from any LLM client in TypeScript and refactors the existing `openai-sdk.mdx` guide for consistency. Navigation (`docs.json`) and the AI-tool-calling overview page are updated to surface the new material; no build, runtime, or application logic is touched.

<details>
<summary><strong>Key Changes</strong></summary>

• Created `docs/implementation-guides/ai-tool-calling/any-llm-sdk.mdx` with ~100 LOC of walkthrough & sample code
• Re-worked `docs/implementation-guides/ai-tool-calling/openai-sdk.mdx`: removed `readline`, uses `nango.waitForConnection`, reordered sections, tightened wording, fixed typos
• Extended `docs/docs.json`: added `implementation-guides/ai-tool-calling/any-llm-sdk` to the "AI tool calling" group
• Updated `docs/guides/use-cases/ai-tool-calling.mdx` copy and added link to the new guide

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs/implementation-guides/ai-tool-calling` guides
• `docs/guides/use-cases/ai-tool-calling.mdx` overview
• `docs/docs.json` navigation tree

</details>

---
*This summary was automatically generated by @propel-code-bot*