### PR TITLE
fix(logs): global search bar not working consistently

### DIFF
--- a/packages/logs/lib/es/client.ts
+++ b/packages/logs/lib/es/client.ts
@@ -5,8 +5,8 @@ import { CircuitBreaker } from './circuitBreaker.js';
 
 const rawClient = new Client({
     nodes: envs.NANGO_LOGS_ES_URL || 'http://localhost:0',
-    requestTimeout: 5000,
-    maxRetries: 1,
+    requestTimeout: envs.NANGO_LOGS_ES_REQUEST_TIMEOUT_MS,
+    maxRetries: envs.NANGO_LOGS_ES_MAX_RETRIES,
     auth: {
         username: envs.NANGO_LOGS_ES_USER!, // ggignore
         password: envs.NANGO_LOGS_ES_PWD! // ggignore

--- a/packages/logs/lib/models/messages.ts
+++ b/packages/logs/lib/models/messages.ts
@@ -148,7 +148,7 @@ export async function searchForMessagesInsideOperations(opts: { search: string; 
         query,
         aggs: {
             // We aggregate because we can have N match per operation
-            parentIdAgg: { terms: { size: opts.operationsIds.length + 1, field: 'parentId' } }
+            parentIdAgg: { terms: { size: opts.operationsIds.length + 1, field: 'parentId', execution_hint: 'map' } }
         }
     });
 

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -241,6 +241,8 @@ export const ENVS = z.object({
 
     // Elasticsearch
     NANGO_LOGS_ES_URL: z.url().optional(),
+    NANGO_LOGS_ES_REQUEST_TIMEOUT_MS: z.coerce.number().optional().default(5000),
+    NANGO_LOGS_ES_MAX_RETRIES: z.coerce.number().optional().default(1),
     NANGO_LOGS_ES_USER: z.string().optional(),
     NANGO_LOGS_ES_PWD: z.string().optional(),
     NANGO_LOGS_ENABLED: z.stringbool().optional().default(false),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Make Elasticsearch client timeout/retries configurable & optimize aggregation execution**

The PR introduces environment-based configuration for Elasticsearch request timeout and retry count, replacing hard-coded values, and adds an aggregation performance hint. It also extends the environment schema to validate and provide defaults for the new variables.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced hard-coded `requestTimeout` and `maxRetries` in `packages/logs/lib/es/client.ts` with `envs.NANGO_LOGS_ES_REQUEST_TIMEOUT_MS` and `envs.NANGO_LOGS_ES_MAX_RETRIES`
• Added `execution_hint: 'map'` to the `parentIdAgg` terms aggregation in `packages/logs/lib/models/messages.ts`
• Extended `packages/utils/lib/environment/parse.ts` with `NANGO_LOGS_ES_REQUEST_TIMEOUT_MS` and `NANGO_LOGS_ES_MAX_RETRIES` (defaults: 5000ms, 1 retry)

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/logs/lib/es/client.ts`
• `packages/logs/lib/models/messages.ts`
• `packages/utils/lib/environment/parse.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*