### PR TITLE
chore(billing): refactor getUsage

### DIFF
--- a/packages/account-usage/lib/usage.ts
+++ b/packages/account-usage/lib/usage.ts
@@ -253,7 +253,7 @@ export class UsageTracker implements IUsageTracker {
         for (const billingMetric of billingUsage.value) {
             const usageMetric = billingMetricToUsageMetric(billingMetric.name);
             if (usageMetric) {
-                res[usageMetric] = billingMetric.quantity;
+                res[usageMetric] = billingMetric.total;
             }
         }
         return Ok(res);

--- a/packages/billing/lib/billing.ts
+++ b/packages/billing/lib/billing.ts
@@ -5,7 +5,17 @@ import { envs } from './envs.js';
 import { BillingEventGrouping } from './grouping.js';
 import { logger } from './logger.js';
 
-import type { BillingClient, BillingCustomer, BillingEvent, BillingPlan, BillingSubscription, BillingUsageMetric, DBTeam, DBUser } from '@nangohq/types';
+import type {
+    BillingClient,
+    BillingCustomer,
+    BillingEvent,
+    BillingPlan,
+    BillingSubscription,
+    BillingUsageMetric,
+    DBTeam,
+    DBUser,
+    GetBillingUsageOpts
+} from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 export class Billing {
@@ -82,8 +92,8 @@ export class Billing {
         return await this.client.getSubscription(accountId);
     }
 
-    async getUsage(subscriptionId: string, period?: 'previous'): Promise<Result<BillingUsageMetric[]>> {
-        return await this.client.getUsage(subscriptionId, period);
+    async getUsage(subscriptionId: string, opts?: GetBillingUsageOpts): Promise<Result<BillingUsageMetric[]>> {
+        return await this.client.getUsage(subscriptionId, opts);
     }
 
     async upgrade(opts: { subscriptionId: string; planExternalId: string }): Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>> {

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -10,7 +10,7 @@ export interface BillingClient {
     getCustomer: (accountId: number) => Promise<Result<BillingCustomer>>;
     getSubscription: (accountId: number) => Promise<Result<BillingSubscription | null>>;
     createSubscription: (team: DBTeam, planExternalId: string) => Promise<Result<BillingSubscription>>;
-    getUsage: (subscriptionId: string, period?: 'previous') => Promise<Result<BillingUsageMetric[]>>;
+    getUsage: (subscriptionId: string, opts?: GetBillingUsageOpts) => Promise<Result<BillingUsageMetric[]>>;
     upgrade: (opts: { subscriptionId: string; planExternalId: string }) => Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>>;
     downgrade: (opts: { subscriptionId: string; planExternalId: string }) => Promise<Result<void>>;
     applyPendingChanges: (opts: {
@@ -36,10 +36,31 @@ export interface BillingSubscription {
     planExternalId: string;
 }
 
+export interface GetBillingUsageOpts {
+    timeframe?: {
+        start: Date;
+        end: Date;
+    };
+    granularity?: 'day';
+    billingMetric?: {
+        id: string;
+        group_by?: 'environmentId' | 'provider' | 'providerConfigKey' | 'connectionId' | 'type' | 'functionName' | 'model';
+    };
+}
+
 export interface BillingUsageMetric {
     id: string;
     name: string;
-    quantity: number;
+    group?: {
+        key: string;
+        value: string;
+    };
+    total: number;
+    usage: {
+        timeframeStart: Date;
+        timeframeEnd: Date;
+        quantity: number;
+    }[];
 }
 
 export interface BillingPlan {

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -23,14 +23,14 @@ export const UsageTable: React.FC<{ data: GetBillingUsage['Success'] | undefined
 
         // Create the merged list
         return Array.from(allIds).map((id) => {
-            const currentItem = data.data.current.find((item) => item.id === id);
-            const previousItem = data.data.previous.find((item) => item.id === id);
+            const currentUsage = data.data.current.find((item) => item.id === id);
+            const previousUsage = data.data.previous.find((item) => item.id === id);
 
             return {
                 id,
-                name: currentItem?.name || previousItem?.name || 'Unknown',
-                current: currentItem?.quantity || 0,
-                previous: previousItem?.quantity || 0
+                name: currentUsage?.name || previousUsage?.name || 'Unknown',
+                current: currentUsage?.total,
+                previous: previousUsage?.total
             };
         });
     }, [data]);


### PR DESCRIPTION
in preparation for the cost explorer feature, refactoring `billing.getUsage(`) to be able to pass additional parameters (timeframe, granularity, metricId and groupBy) and return a list of values to support daily granularity.
No behavior is being modified in this commit

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Refactor `billing.getUsage` to accept filter options and return granular data**

The PR introduces `GetBillingUsageOpts`, expands the `BillingUsageMetric` payload, and updates all call-sites so `billing.getUsage()` can receive optional `timeframe`, `granularity`, and `billingMetric` parameters. The Orb client now aggregates usage and optionally returns daily buckets plus total, while downstream layers (core billing wrapper, server controller, account-usage tracker, and web UI) are realigned to the new return shape.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `GetBillingUsageOpts` and extended `BillingUsageMetric` in `packages/types/lib/billing/types.ts`
• Changed `BillingClient.getUsage()` signature to `(subscriptionId, opts?)` throughout codebase
• Refactored `packages/billing/lib/clients/orb.ts#getUsage` to map new opts to Orb SDK params, calculate `total`, and expose `usage[]` + optional `group`
• Updated billing façade `packages/billing/lib/billing.ts` and server controller `packages/server/lib/controllers/v1/plans/usage/getBillingUsage.ts` to build previous/current month date ranges manually
• Adjusted usage tracker (`packages/account-usage/lib/usage.ts`) to rely on `metric.total` instead of deprecated `quantity`
• Modified web component `UsageTable.tsx` to display `total` values and handle merged metric sets

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/types`
• `packages/billing/lib/clients/orb.ts`
• `packages/billing/lib/billing.ts`
• `packages/server/lib/controllers/v1/plans/usage/getBillingUsage.ts`
• `packages/account-usage`
• `packages/webapp`

</details>

---
*This summary was automatically generated by @propel-code-bot*