### PR TITLE
fix(runner): only label pods when trace or profiling enabled

### DIFF
--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -208,6 +208,9 @@ class Kubernetes {
                 }
             }
         };
+        if (node.isProfilingEnabled || node.isTracingEnabled) {
+            deploymentManifest.spec!.template.metadata!.labels!['nango.dev/apm'] = 'enabled';
+        }
 
         try {
             await this.appsApi.createNamespacedDeployment({


### PR DESCRIPTION
This change works together with changes that are coming to the datadog-agent configuration to only instrument pods that are labelled correctly. 

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Conditionally label runner pods for APM**

Adds a guard so the Kubernetes runner deployment is only labeled with `nango.dev/apm=enabled` when the node configuration explicitly enables either profiling or tracing. This prevents unnecessary pod labeling when APM features are disabled.

<details>
<summary><strong>Key Changes</strong></summary>

• Inserted conditional check `if (node.isProfilingEnabled || node.isTracingEnabled)` in `createDeployment()`
• Only sets `deploymentManifest.spec!.template.metadata!.labels!['nango.dev/apm'] = 'enabled'` when condition is true

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/jobs/lib/runner/kubernetes.ts` – `Kubernetes.createDeployment()` logic

</details>

---
*This summary was automatically generated by @propel-code-bot*