### PR TITLE
fix(server): /ready endpoint checks for db connectivity at startup

### DIFF
--- a/packages/server/lib/ready.ts
+++ b/packages/server/lib/ready.ts
@@ -1,0 +1,42 @@
+import db from '@nangohq/database';
+
+import { asyncWrapper } from './utils/asyncWrapper.js';
+
+const state = {
+    isReady: false,
+    isShuttingDown: false
+};
+
+async function isReady(): Promise<boolean> {
+    // Once shutdown has begun, always report unready.
+    if (state.isShuttingDown) {
+        return false;
+    }
+
+    // Check database connectivity once at startup.
+    // After the first successful check, assume continued readiness
+    // and ignore transient DB or network issues.
+    if (!state.isReady) {
+        try {
+            const res = await db.knex.raw('SELECT 1');
+            state.isReady = res.rowCount === 1;
+        } catch {
+            return false;
+        }
+    }
+
+    return state.isReady;
+}
+
+export function beginShutdown(): void {
+    state.isShuttingDown = true;
+    state.isReady = false;
+}
+
+export const getReady = asyncWrapper<any, any>(async (_, res) => {
+    if (await isReady()) {
+        res.status(200).send({ result: 'ok' });
+        return;
+    }
+    res.status(503).send({ result: 'not ready' });
+});

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -8,10 +8,10 @@ import { getEnvJs } from './controllers/v1/getEnvJs.js';
 import { getProvidersJSON } from './controllers/v1/getProvidersJSON.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
 import { securityMiddlewares } from './middleware/security.js';
+import { getReady } from './ready.js';
 import { internalApi } from './routes.internal.js';
 import { privateApi } from './routes.private.js';
 import { publicAPI } from './routes.public.js';
-import { isShuttingDown } from './utils/state.js';
 import { dirname } from './utils/utils.js';
 
 import type { ApiError } from '@nangohq/types';
@@ -26,13 +26,7 @@ router.use(...securityMiddlewares());
 router.get('/health', (_, res) => {
     res.status(200).send({ result: 'ok' });
 });
-router.get('/ready', (_, res) => {
-    if (isShuttingDown()) {
-        res.status(500).send({ result: 'shutting down' });
-        return;
-    }
-    res.status(200).send({ result: 'ok' });
-});
+router.get('/ready', getReady);
 router.get('/env.js', getEnvJs);
 router.get('/providers.json', rateLimiterMiddleware, getProvidersJSON);
 

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -24,9 +24,9 @@ import { trialCron } from './crons/trial.js';
 import { envs } from './env.js';
 import { runnersFleet } from './fleet.js';
 import { pubsub } from './pubsub.js';
+import { beginShutdown } from './ready.js';
 import { router } from './routes.js';
 import migrate from './utils/migrate.js';
-import { setShuttingDown } from './utils/state.js';
 
 import type { WebSocket } from 'ws';
 
@@ -138,6 +138,6 @@ process.on('SIGINT', () => {
 
 process.on('SIGTERM', () => {
     logger.info('Received SIGTERM...');
-    setShuttingDown(true);
+    beginShutdown();
     setTimeout(close, envs.SERVER_SHUTDOWN_DELAY_MS);
 });

--- a/packages/server/lib/utils/state.ts
+++ b/packages/server/lib/utils/state.ts
@@ -1,9 +1,0 @@
-let shuttingDown = false;
-
-export function setShuttingDown(value: boolean) {
-    shuttingDown = value;
-}
-
-export function isShuttingDown() {
-    return shuttingDown;
-}


### PR DESCRIPTION
once db has been reached, readiness is assumed until `beginShutdown` isCalled

<!-- Summary by @propel-code-bot -->

---

**Connection-aware `/ready` endpoint with graceful shutdown handling**

This PR replaces the previous flag-based readiness logic with a helper that performs a single database connectivity probe on startup, caches the result, and automatically turns the service to an "un-ready" state when the process begins shutdown. The change simplifies readiness checks, removes the legacy `utils/state.ts`, and ensures Kubernetes (or similar orchestrators) stop sending traffic after `SIGTERM` but before the actual shutdown delay elapses.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `packages/server/lib/ready.ts` containing `isReady()`, `beginShutdown()`, and `getReady` Express handler
• Updated `packages/server/lib/routes.ts` to register `/ready` route via `getReady` and drop previous `isShuttingDown` checks
• Hooked `beginShutdown()` into `SIGTERM` handling in `packages/server/lib/server.ts` replacing `setShuttingDown(true)`
• Deleted obsolete file `packages/server/lib/utils/state.ts` and its imports

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• HTTP readiness endpoint `/ready`
• Process signal handling (`SIGTERM`)
• Routing configuration
• Global shutdown flow

</details>

---
*This summary was automatically generated by @propel-code-bot*