### PR TITLE
feat: switch getting started to Github

### DIFF
--- a/packages/database/lib/migrations/20251110180000_reset_getting_started_progress.cjs
+++ b/packages/database/lib/migrations/20251110180000_reset_getting_started_progress.cjs
@@ -1,0 +1,13 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw('TRUNCATE TABLE getting_started_progress, getting_started_meta RESTART IDENTITY');
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};

--- a/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.integration.test.ts
@@ -40,7 +40,7 @@ describe(`DELETE ${endpoint}`, () => {
         const { env, account } = await seeders.seedAccountEnvAndUser();
 
         // Getting started meta expects a preprovisioned provider config
-        await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar', {
+        await seeders.createPreprovisionedProviderConfigSeed(env, 'github-getting-started', 'github', 'github-getting-started', {
             oauth_client_id: 'foo',
             oauth_client_secret: 'bar',
             oauth_scopes: 'hello, world'
@@ -49,7 +49,7 @@ describe(`DELETE ${endpoint}`, () => {
         const metaResult = await gettingStartedService.getOrCreateMeta(db.knex, account.id, env.id);
         expect(metaResult.isOk()).toBe(true);
 
-        const res = await api.fetch(endpoint, { method: 'DELETE', token: env.secret_key, params: { uniqueKey: 'google-calendar-getting-started' } });
+        const res = await api.fetch(endpoint, { method: 'DELETE', token: env.secret_key, params: { uniqueKey: 'github-getting-started' } });
         isSuccess(res.json);
 
         const metaAfter = await gettingStartedService.getMetaByAccountId(db.knex, account.id);

--- a/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
@@ -24,7 +24,7 @@ describe(`GET ${endpoint}`, () => {
 
     it("creates meta+integration when they don't exist", async () => {
         const { env, user } = await seeders.seedAccountEnvAndUser();
-        await seeders.createSharedCredentialsSeed('google-calendar');
+        await seeders.createSharedCredentialsSeed('github-getting-started');
         const session = await authenticateUser(api, user);
 
         const res = await api.fetch(endpoint, { method: 'GET', query: { env: 'dev' }, session });
@@ -37,9 +37,9 @@ describe(`GET ${endpoint}`, () => {
                     environment: { id: env.id, name: env.name },
                     integration: {
                         id: expect.any(Number),
-                        unique_key: 'google-calendar-getting-started',
-                        provider: 'google-calendar',
-                        display_name: 'Google Calendar (Getting Started)'
+                        unique_key: 'github-getting-started',
+                        provider: 'github',
+                        display_name: 'Github (Getting Started)'
                     }
                 },
                 connection: null,
@@ -53,10 +53,10 @@ describe(`GET ${endpoint}`, () => {
         const session = await authenticateUser(api, user);
 
         // Ensure pre-provisioned integration exists
-        const provider = getProvider('google-calendar');
+        const provider = getProvider('github');
         expect(provider).toBeTruthy();
-        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar', {
-            display_name: 'Google Calendar (Getting Started)'
+        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'github-getting-started', 'github', 'github-getting-started', {
+            display_name: 'Github (Getting Started)'
         });
 
         // Create meta without progress
@@ -93,8 +93,8 @@ describe(`GET ${endpoint}`, () => {
         const session = await authenticateUser(api, user);
 
         // Create integration
-        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'google-calendar-getting-started', 'google-calendar', {
-            display_name: 'Google Calendar (Getting Started)'
+        const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'github-getting-started', 'github', 'github-getting-started', {
+            display_name: 'Github (Getting Started)'
         });
 
         // Create meta and and progress
@@ -108,7 +108,7 @@ describe(`GET ${endpoint}`, () => {
         // Connection to link to progress
         const connection = await seeders.createConnectionSeed({
             env,
-            provider: 'google-calendar-getting-started',
+            provider: 'github-getting-started',
             connectionId: 'demo-conn-id'
         });
 
@@ -150,7 +150,7 @@ describe(`GET ${endpoint}`, () => {
         // Create a connection and link it to the progress
         const connection = await seeders.createConnectionSeed({
             env,
-            provider: 'google-calendar-getting-started',
+            provider: 'github-getting-started',
             connectionId: 'test-conn-id'
         });
 

--- a/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.ts
@@ -8,7 +8,7 @@ import type { GetGettingStarted } from '@nangohq/types';
 
 /**
  * Getting started should always be available, so if it doesn't already exist, we create it,
- * including setting up a new google-calendar-getting-started integration using the preprovisioned provider if needed.
+ * including setting up a new github-getting-started integration using the preprovisioned provider if needed.
  */
 export const getGettingStarted = asyncWrapper<GetGettingStarted>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });

--- a/packages/shared/lib/seeders/config.seeder.ts
+++ b/packages/shared/lib/seeders/config.seeder.ts
@@ -83,6 +83,7 @@ export async function createPreprovisionedProviderConfigSeed(
     env: DBEnvironment,
     unique_key: string,
     providerName: string,
+    shared_credentials_name?: string,
     rest?: Partial<IntegrationConfig>
 ): Promise<IntegrationConfig> {
     const provider = getProvider(providerName);
@@ -90,7 +91,7 @@ export async function createPreprovisionedProviderConfigSeed(
         throw new Error(`createPreprovisionedProviderSeed: ${providerName} provider not found`);
     }
 
-    const sharedCredentials = await createSharedCredentialsSeed(providerName);
+    const sharedCredentials = await createSharedCredentialsSeed(shared_credentials_name ?? providerName);
 
     const created = await configService.createProviderConfig(
         {

--- a/packages/shared/lib/services/getting-started.service.ts
+++ b/packages/shared/lib/services/getting-started.service.ts
@@ -215,16 +215,16 @@ export async function getOrCreateMeta(db: Knex, accountId: number, currentEnviro
             return Ok(existingMeta.value);
         }
 
-        const googleCalendarIntegrationId = await getOrCreateGoogleCalendarIntegration(currentEnvironmentId);
+        const githubIntegrationId = await getOrCreateGithubIntegration(currentEnvironmentId);
 
-        if (googleCalendarIntegrationId.isErr()) {
-            return Err(googleCalendarIntegrationId.error);
+        if (githubIntegrationId.isErr()) {
+            return Err(githubIntegrationId.error);
         }
 
         const newMeta = await createMeta(trx, {
             account_id: accountId,
             environment_id: currentEnvironmentId,
-            integration_id: googleCalendarIntegrationId.value
+            integration_id: githubIntegrationId.value
         });
 
         if (newMeta.isErr()) {
@@ -235,27 +235,28 @@ export async function getOrCreateMeta(db: Knex, accountId: number, currentEnviro
     });
 }
 
-async function getOrCreateGoogleCalendarIntegration(environmentId: number): Promise<Result<number>> {
+async function getOrCreateGithubIntegration(environmentId: number): Promise<Result<number>> {
     try {
-        const existingIntegrationId = await configService.getIdByProviderConfigKey(environmentId, 'google-calendar-getting-started');
+        const existingIntegrationId = await configService.getIdByProviderConfigKey(environmentId, 'github-getting-started');
 
         if (existingIntegrationId) {
             return Ok(existingIntegrationId);
         }
 
-        const PROVIDER_NAME = 'google-calendar';
+        const PROVIDER_NAME = 'github';
 
         const provider = getProvider(PROVIDER_NAME);
         if (!provider) {
-            return Err('google_calendar_provider_not_found');
+            return Err('github_provider_not_found');
         }
 
         const newIntegration = await sharedCredentialsService.createPreprovisionedProvider({
             providerName: PROVIDER_NAME,
+            shared_credentials_name: 'github-getting-started',
             environment_id: environmentId,
             provider,
-            display_name: 'Google Calendar (Getting Started)',
-            unique_key: 'google-calendar-getting-started'
+            display_name: 'Github (Getting Started)',
+            unique_key: 'github-getting-started'
         });
 
         if (newIntegration.isErr()) {
@@ -265,12 +266,12 @@ async function getOrCreateGoogleCalendarIntegration(environmentId: number): Prom
         const id = newIntegration.value.id ?? null;
 
         if (!id) {
-            return Err('failed_to_create_google_calendar_integration');
+            return Err('failed_to_create_github_integration');
         }
 
         return Ok(id);
     } catch (err) {
-        return Err(new Error('failed_to_get_or_create_google_calendar_integration', { cause: err }));
+        return Err(new Error('failed_to_get_or_create_github_integration', { cause: err }));
     }
 }
 

--- a/packages/shared/lib/services/shared-credentials.service.ts
+++ b/packages/shared/lib/services/shared-credentials.service.ts
@@ -20,17 +20,23 @@ class SharedCredentialsService {
         environment_id,
         provider,
         display_name,
-        unique_key
+        unique_key,
+        shared_credentials_name
     }: {
         providerName: string;
         environment_id: number;
         provider: Provider;
         display_name?: string;
         unique_key?: string;
+        shared_credentials_name?: string;
     }): Promise<Result<IntegrationConfig>> {
         try {
             const config = await db.knex.transaction(async (trx) => {
-                const sharedCredentials = await trx.select('*').from<DBSharedCredentials>('providers_shared_credentials').where('name', providerName).first();
+                const sharedCredentials = await trx
+                    .select('*')
+                    .from<DBSharedCredentials>('providers_shared_credentials')
+                    .where('name', shared_credentials_name ?? providerName)
+                    .first();
 
                 if (!sharedCredentials) {
                     throw new Error('shared_credentials_not_found');

--- a/packages/webapp/src/pages/GettingStarted/FirstStep.tsx
+++ b/packages/webapp/src/pages/GettingStarted/FirstStep.tsx
@@ -1,4 +1,4 @@
-import { IconBrandGoogleFilled } from '@tabler/icons-react';
+import { IconBrandGithub } from '@tabler/icons-react';
 import { useCallback, useRef } from 'react';
 import { useUnmount } from 'react-use';
 
@@ -111,11 +111,11 @@ export const FirstStep: React.FC<FirstStepProps> = ({ connection, integration, o
         return (
             <div className="flex flex-col gap-4">
                 <div className="flex flex-col gap-1.5">
-                    <h3 className="text-brand-500 text-sm font-semibold">Google Calendar connection authorized!</h3>
+                    <h3 className="text-brand-500 text-sm font-semibold">Github connection authorized!</h3>
                 </div>
                 <Button variant="tertiary" size="lg" onClick={onClickDisconnect} className="w-fit">
-                    <IconBrandGoogleFilled className="size-5 mr-2" />
-                    Disconnect from Google Calendar
+                    <IconBrandGithub className="size-5 mr-2" />
+                    Disconnect from Github
                 </Button>
             </div>
         );
@@ -129,14 +129,14 @@ export const FirstStep: React.FC<FirstStepProps> = ({ connection, integration, o
                     Connect your account just like your users would in your app. <br />
                     This will create a connection for your{' '}
                     <StyledLink to={`/${env}/integrations/${integration?.unique_key}`} icon>
-                        Google Calendar integration
+                        Github integration
                     </StyledLink>
                     .
                 </p>
             </div>
             <Button variant="primary" size="lg" onClick={onClickConnect} className="w-fit">
-                <IconBrandGoogleFilled className="size-5" />
-                Connect to Google Calendar
+                <IconBrandGithub className="size-5" />
+                Connect to Github
             </Button>
         </div>
     );

--- a/packages/webapp/src/pages/GettingStarted/SecondStep.tsx
+++ b/packages/webapp/src/pages/GettingStarted/SecondStep.tsx
@@ -12,71 +12,30 @@ import { StyledLink } from '@/components-v2/StyledLink';
 import { Button } from '@/components-v2/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components-v2/ui/tooltip';
 
-interface CalendarEvent {
-    summary: string;
-    description: string;
-    start: {
-        dateTime: Date;
-    };
-    end: {
-        dateTime: Date;
-    };
-}
-
-function getNodeClientCode(calendarEvent: CalendarEvent, connectionId?: string, providerConfigKey?: string) {
+function getNodeClientCode(connectionId?: string, providerConfigKey?: string) {
     return `
 import { Nango } from "@nangohq/node";
 
 const nango = new Nango({ secretKey: "<NANGO-SECRET-KEY>" });
 
-await nango.post({
-    endpoint: "/calendar/v3/calendars/primary/events",
+await nango.put({
+    endpoint: "/user/starred/nangohq/nango",
     connectionId: "${connectionId ?? '<CONNECTION-ID>'}",
-    providerConfigKey: "${providerConfigKey ?? '<PROVIDER-CONFIG-KEY>'}",
-    data: {
-        summary: "Getting started with Nango",
-        description: "Created with Nango from the getting started page!",
-        start: {
-            dateTime: "${calendarEvent.start.dateTime.toISOString()}"
-        },
-        end: {
-            dateTime: "${calendarEvent.end.dateTime.toISOString()}"
-        }
-    }
+    providerConfigKey: "${providerConfigKey ?? '<PROVIDER-CONFIG-KEY>'}"
 });
 
-console.log("Created calendar event!");
+console.log("Starred Nango's Github repository!");
 `.trim();
 }
 
-function getCurlCode(calendarEvent: CalendarEvent, connectionId?: string, providerConfigKey?: string) {
+function getCurlCode(connectionId?: string, providerConfigKey?: string) {
     return `
-curl -X POST https://api.nango.dev/proxy/calendar/v3/calendars/primary/events \\
+curl -X PUT https://api.nango.dev/proxy/user/starred/nangohq/nango \\
     -H "Authorization: Bearer <NANGO-SECRET-KEY>" \\
     -H "Content-Type: application/json" \\
     -H "Connection-Id: ${connectionId ?? '<CONNECTION-ID>'}" \\
-    -H "Provider-Config-Key: ${providerConfigKey ?? '<PROVIDER-CONFIG-KEY>'}" \\
-    -d '${JSON.stringify(calendarEvent)}'
+    -H "Provider-Config-Key: ${providerConfigKey ?? '<PROVIDER-CONFIG-KEY>'}"
 `.trim();
-}
-
-/**
- * Returns the next 15-minute interval from the current time
- * @returns A Date object representing the next 15-minute interval
- * @example now: 12:08 -> 12:15
- */
-function dateNext15Minutes() {
-    const now = new Date();
-    const minutes = now.getMinutes();
-    const roundedMinutes = Math.ceil(minutes / 15) * 15;
-    if (roundedMinutes === 60) {
-        now.setHours(now.getHours() + 1);
-        now.setMinutes(0, 0, 0);
-    } else {
-        now.setMinutes(roundedMinutes, 0, 0);
-    }
-
-    return now;
 }
 
 interface SecondStepProps {
@@ -95,28 +54,13 @@ export const SecondStep: React.FC<SecondStepProps> = ({ connectionId, providerCo
     const [isExecuting, setIsExecuting] = useState(false);
     const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 
-    const calendarEvent: CalendarEvent = useMemo(() => {
-        const next15Minutes = dateNext15Minutes();
-
-        return {
-            summary: 'Getting started with Nango',
-            description: 'Created with Nango from the getting started page!',
-            start: {
-                dateTime: next15Minutes
-            },
-            end: {
-                dateTime: new Date(next15Minutes.getTime() + 15 * 60 * 1000)
-            }
-        };
-    }, []);
-
     const nodeClientCode = useMemo(() => {
-        return getNodeClientCode(calendarEvent, connectionId, providerConfigKey);
-    }, [calendarEvent, connectionId, providerConfigKey]);
+        return getNodeClientCode(connectionId, providerConfigKey);
+    }, [connectionId, providerConfigKey]);
 
     const curlCode = useMemo(() => {
-        return getCurlCode(calendarEvent, connectionId, providerConfigKey);
-    }, [calendarEvent, connectionId, providerConfigKey]);
+        return getCurlCode(connectionId, providerConfigKey);
+    }, [connectionId, providerConfigKey]);
 
     const onExecute = async () => {
         if (!connectionId || !providerConfigKey || !environmentAndAccount) {
@@ -126,15 +70,14 @@ export const SecondStep: React.FC<SecondStepProps> = ({ connectionId, providerCo
         setIsExecuting(true);
         try {
             const res = await publicApiFetch(
-                '/proxy/calendar/v3/calendars/primary/events',
+                '/proxy/user/starred/nangohq/nango',
                 {
                     connectionId: connectionId,
                     providerConfigKey: providerConfigKey,
                     secretKey: environmentAndAccount?.environment.secret_key
                 },
                 {
-                    method: 'POST',
-                    body: JSON.stringify(calendarEvent)
+                    method: 'PUT'
                 }
             );
 
@@ -147,10 +90,7 @@ export const SecondStep: React.FC<SecondStepProps> = ({ connectionId, providerCo
             }
 
             toast({
-                title: `Created calendar event at ${calendarEvent.start.dateTime.toLocaleTimeString('en-US', {
-                    hour: '2-digit',
-                    minute: '2-digit'
-                })}. Check your calendar!`,
+                title: `Starred Nango's Github repository!`,
                 variant: 'success'
             });
         } catch {
@@ -167,7 +107,7 @@ export const SecondStep: React.FC<SecondStepProps> = ({ connectionId, providerCo
     return (
         <div className="flex flex-col gap-5 w-full min-w-0">
             <div className="flex flex-col gap-1.5">
-                <h3 className="text-text-primary text-sm font-semibold">Use Nango as a proxy to make requests to Google Calendar</h3>
+                <h3 className="text-text-primary text-sm font-semibold">Use Nango as a proxy to make requests to Github</h3>
                 {!connectionId && (
                     <p className="text-text-tertiary text-sm">
                         Nango will handle API credentials for you. <br />
@@ -187,7 +127,7 @@ export const SecondStep: React.FC<SecondStepProps> = ({ connectionId, providerCo
                                 <TooltipContent side="bottom">{connectionId}</TooltipContent>
                             </Tooltip>
                         </p>
-                        <p className="text-text-tertiary text-sm">You can use it to make requests to Google Calendar.</p>
+                        <p className="text-text-tertiary text-sm">You can use it to make requests to Github.</p>
                     </div>
                 )}
             </div>
@@ -207,7 +147,8 @@ export const SecondStep: React.FC<SecondStepProps> = ({ connectionId, providerCo
                                     displayLanguage: 'cURL',
                                     icon: <IconTerminal2 className="w-4 h-4" />,
                                     language: 'bash',
-                                    code: curlCode
+                                    code: curlCode,
+                                    highlightedLines: isTooltipOpen ? [4] : undefined
                                 }
                             ]}
                             className="w-full"
@@ -232,8 +173,8 @@ export const SecondStep: React.FC<SecondStepProps> = ({ connectionId, providerCo
                                 <StyledLink to={`/${env}/logs?integrations=${providerConfigKey}&connections=${connectionId}`} icon>
                                     Explore the logs from this demo
                                 </StyledLink>
-                                <StyledLink to="https://calendar.google.com/calendar/r/day" type="external" icon>
-                                    Open Google Calendar to see the event
+                                <StyledLink to="https://github.com/nangohq/nango" type="external" icon>
+                                    Open Nango&apos;s Github repository to see the star
                                 </StyledLink>
                             </>
                         )}

--- a/packages/webapp/src/pages/GettingStarted/Show.tsx
+++ b/packages/webapp/src/pages/GettingStarted/Show.tsx
@@ -48,7 +48,7 @@ export const GettingStarted: React.FC = () => {
             </Helmet>
             <header className="flex flex-col gap-3.5">
                 <h2 className="flex text-left text-2xl font-semibold tracking-tight text-text-primary">Getting started</h2>
-                <p className="text-text-secondary text-sm">Try connecting Nango with Google Calendar to see how integrations work.</p>
+                <p className="text-text-secondary text-sm">Try connecting Nango with Github to see how integrations work.</p>
             </header>
             <div className="flex flex-row gap-10 min-w-0">
                 <VerticalSteps
@@ -87,7 +87,7 @@ export const GettingStarted: React.FC = () => {
                             )
                         },
                         {
-                            id: 'access-google-calendar-api',
+                            id: 'access-github-api',
                             icon: LockOpen,
                             content: (
                                 <SecondStep


### PR DESCRIPTION
Switches getting started from google calendar to github. The script stars nango's repo.

<!-- Summary by @propel-code-bot -->

---

**Switch Getting-Started Demo from Google Calendar to Github**

The onboarding demo has been re-oriented from posting a Google Calendar event to starring Nango’s Github repository. All backend, frontend, tests and seed data that referenced `google-calendar-getting-started` have been migrated to `github-getting-started`. A one-off migration resets existing onboarding metadata so users can rerun the flow with the new provider.

<details>
<summary><strong>Key Changes</strong></summary>

• Frontend: Replaced Google-specific UI, icons and code snippets in `packages/webapp/src/pages/GettingStarted/*Step.tsx` to use Github endpoints (`/user/starred/nangohq/nango`) with `PUT` semantics
• Backend service: Refactored `getOrCreateMeta()` and helpers in `packages/shared/lib/services/getting-started.service.ts` to create `github-getting-started` integrations via new helper `getOrCreateGithubIntegration()`
• Controller update: `packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.ts` and associated tests now reference Github provider and unique key
• Shared credentials service (`shared-credentials.service.ts`): accepts optional `shared_credentials_name` and ensures correct lookup when creating pre-provisioned configs
• DB migration `20251110180000_reset_getting_started_progress.cjs`: truncates `getting_started_meta` and `getting_started_progress` to discard Calendar data
• Test & seeder updates across server and shared packages to align with new provider keys
• Seed helper enhanced to pass `shared_credentials_name` and avoid collisions

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `webapp` GettingStarted pages
• `shared` getting-started service
• `shared-credentials` service
• REST controller `getGettingStarted`
• Integration & unit tests
• Database migration & seeders

</details>

---
*This summary was automatically generated by @propel-code-bot*