### PR TITLE
fix: remove close button from popup

### DIFF
--- a/packages/server/lib/utils/html.ts
+++ b/packages/server/lib/utils/html.ts
@@ -22,7 +22,7 @@ Nango OAuth flow callback. Read more about how to use it at: https://github.com/
 
     <div id="content" style="display: flex; width: 100vw; height: 100vh; align-items: center; justify-content: center; font-size: 14px; opacity: 0">
       <div style="text-align: center">
-        ${error ? `<p style="color: #ef665b;">An error occurred during authorization, please reach out to the support (code: ${error}).</p>` : '<p>You are now connected.</p>'}
+        ${error ? `<p style="color: #ef665b;">An error occurred during authorization, please reach out to support (code: ${error}).</p>` : '<p>You are now connected.</p>'}
         <p>You can close this window.</p>
       </div>
     </div>

--- a/packages/server/lib/utils/html.ts
+++ b/packages/server/lib/utils/html.ts
@@ -21,11 +21,9 @@ Nango OAuth flow callback. Read more about how to use it at: https://github.com/
     <noscript>JavaScript is required to proceed with the authentication.</noscript>
 
     <div id="content" style="display: flex; width: 100vw; height: 100vh; align-items: center; justify-content: center; font-size: 14px; opacity: 0">
-      <div>
-        ${error ? `<div style="color: #ef665b;">An error occurred during authorization, please reach out to the support (code: ${error}).</div>` : '<div>You are now connected</div>'}
-        <button id="closeButton" style="padding: 8px 16px; background-color: #161616; color: white; border: none; border-radius: 4px; cursor: pointer; margin-top: 10px;">
-          You can close this window
-        </button>
+      <div style="text-align: center">
+        ${error ? `<p style="color: #ef665b;">An error occurred during authorization, please reach out to the support (code: ${error}).</p>` : '<p>You are now connected.</p>'}
+        <p>You can close this window.</p>
       </div>
     </div>
 


### PR DESCRIPTION
Removes close button from popup that eventually doesn't self-close after authenticating a provider. The button doesn't work.
Before:
<img width="359" height="220" alt="image" src="https://github.com/user-attachments/assets/bf6f5f0f-8b8e-4af2-9f2d-7848c0186db1" />
> Screenshot from customer

After: 
<img width="500" height="625" alt="image" src="https://github.com/user-attachments/assets/f2dbed01-12dd-4dae-a006-ee6ccdf84ee3" />

<!-- Summary by @propel-code-bot -->

---

**Remove non-functional close button in OAuth callback popup**

Eliminates the visually rendered “close” button from the OAuth callback HTML template. The popup now only shows text messages, aligning markup semantics and centering content via inline CSS.

<details>
<summary><strong>Key Changes</strong></summary>

• Deleted inline `button#closeButton` markup from `packages/server/lib/utils/html.ts`
• Replaced success/error `div` elements with `p` tags for better semantics
• Added `text-align: center` to wrapper `div` and kept static message `You can close this window.`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/utils/html.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*