### PR TITLE
fix(jobs): set correct env vars for dd

### DIFF
--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -418,7 +418,8 @@ class Kubernetes {
             ...(envs.DD_SITE ? [{ name: 'DD_SITE', value: envs.DD_SITE }] : []),
             ...(envs.DD_TRACE_AGENT_URL ? [{ name: 'DD_TRACE_AGENT_URL', value: envs.DD_TRACE_AGENT_URL }] : []),
             { name: 'DD_PROFILING_ENABLED', value: String(node.isProfilingEnabled) },
-            { name: 'DD_TRACE_ENABLED', value: String(node.isTracingEnabled) },
+            { name: 'DD_APM_TRACING_ENABLED', value: String(node.isTracingEnabled) },
+            { name: 'DD_TRACE_ENABLED', value: String(node.isTracingEnabled || node.isProfilingEnabled) },
             { name: 'JOBS_SERVICE_URL', value: getJobsUrl() },
             { name: 'PROVIDERS_URL', value: getProvidersUrl() },
             { name: 'PROVIDERS_RELOAD_INTERVAL', value: envs.PROVIDERS_RELOAD_INTERVAL.toString() }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Datadog env var corrections in `kubernetes.ts` runner**

Updates the Kubernetes runner’s environment variable list to correctly expose Datadog APM and tracing switches. Adds the missing `DD_APM_TRACING_ENABLED` flag and recalculates `DD_TRACE_ENABLED` to reflect either tracing or profiling enablement, ensuring Datadog receives accurate configuration.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `DD_APM_TRACING_ENABLED` with value derived from `node.isTracingEnabled`
• Re-computed `DD_TRACE_ENABLED` to `node.isTracingEnabled || node.isProfilingEnabled`
• Removed former single use of `DD_TRACE_ENABLED` tied only to tracing

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/jobs/lib/runner/kubernetes.ts` – `getEnvironmentVariables()` output

</details>

---
*This summary was automatically generated by @propel-code-bot*