### PR TITLE
feat(webapp): improve number formatting in usage card

### DIFF
--- a/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
@@ -5,44 +5,45 @@ import { useApiGetUsage } from '../../hooks/usePlan.js';
 import { useStore } from '../../store.js';
 import { cn } from '../../utils/utils.js';
 
+const numberFormatter = Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
 /**
  * Formats multiples of 1000 to K, M, B, or T
  * @example 1000 -> 1K
  * @example 2000 -> 2K
- * @example 2025 -> 2025
+ * @example 2025 -> 2,025
  * @example 1000000 -> 1M
- * @example 1234000 -> 1234K
+ * @example 1234000 -> 1,234K
  */
 function formatLimit(limit: number) {
     if (limit >= 1_000_000_000_000 && limit % 1_000_000_000_000 === 0) {
-        return `${(limit / 1_000_000_000_000).toLocaleString('en-US', { maximumFractionDigits: 0 })}T`;
+        return `${numberFormatter.format(limit / 1_000_000_000_000)}T`;
     }
     if (limit >= 1_000_000_000 && limit % 1_000_000_000 === 0) {
-        return `${(limit / 1_000_000_000).toLocaleString('en-US', { maximumFractionDigits: 0 })}B`;
+        return `${numberFormatter.format(limit / 1_000_000_000)}B`;
     }
     if (limit >= 1_000_000 && limit % 1_000_000 === 0) {
-        return `${(limit / 1_000_000).toLocaleString('en-US', { maximumFractionDigits: 0 })}M`;
+        return `${numberFormatter.format(limit / 1_000_000)}M`;
     }
     if (limit >= 1000 && limit % 1000 === 0) {
-        return `${(limit / 1000).toLocaleString('en-US', { maximumFractionDigits: 0 })}K`;
+        return `${numberFormatter.format(limit / 1000)}K`;
     }
-    return limit.toLocaleString('en-US');
+    return numberFormatter.format(limit);
 }
 
 function formatUsage(usage: number) {
     if (usage >= 1_000_000_000_000) {
-        return `${(usage / 1_000_000_000_000).toLocaleString('en-US', { maximumFractionDigits: 0 })}T`;
+        return `${numberFormatter.format(usage / 1_000_000_000_000)}T`;
     }
     if (usage >= 1_000_000_000) {
-        return `${(usage / 1_000_000_000).toLocaleString('en-US', { maximumFractionDigits: 0 })}B`;
+        return `${numberFormatter.format(usage / 1_000_000_000)}B`;
     }
     if (usage >= 1_000_000) {
-        return `${(usage / 1_000_000).toLocaleString('en-US', { maximumFractionDigits: 0 })}M`;
+        return `${numberFormatter.format(usage / 1_000_000)}M`;
     }
     if (usage >= 1000) {
-        return `${(usage / 1000).toLocaleString('en-US', { maximumFractionDigits: 0 })}K`;
+        return `${numberFormatter.format(usage / 1000)}K`;
     }
-    return usage.toLocaleString('en-US');
+    return numberFormatter.format(usage);
 }
 
 export default function UsageCard() {

--- a/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
@@ -6,7 +6,7 @@ import { useStore } from '../../store.js';
 import { cn } from '../../utils/utils.js';
 
 /**
- * Formats multiples of 1000 to K or M
+ * Formats multiples of 1000 to K, M, B, or T
  * @example 1000 -> 1K
  * @example 2000 -> 2K
  * @example 2025 -> 2025
@@ -14,23 +14,35 @@ import { cn } from '../../utils/utils.js';
  * @example 1234000 -> 1234K
  */
 function formatLimit(limit: number) {
+    if (limit >= 1_000_000_000_000 && limit % 1_000_000_000_000 === 0) {
+        return `${(limit / 1_000_000_000_000).toLocaleString('en-US', { maximumFractionDigits: 0 })}T`;
+    }
+    if (limit >= 1_000_000_000 && limit % 1_000_000_000 === 0) {
+        return `${(limit / 1_000_000_000).toLocaleString('en-US', { maximumFractionDigits: 0 })}B`;
+    }
     if (limit >= 1_000_000 && limit % 1_000_000 === 0) {
-        return `${(limit / 1_000_000).toFixed(0)}M`;
+        return `${(limit / 1_000_000).toLocaleString('en-US', { maximumFractionDigits: 0 })}M`;
     }
     if (limit >= 1000 && limit % 1000 === 0) {
-        return `${(limit / 1000).toFixed(0)}K`;
+        return `${(limit / 1000).toLocaleString('en-US', { maximumFractionDigits: 0 })}K`;
     }
-    return limit;
+    return limit.toLocaleString('en-US');
 }
 
 function formatUsage(usage: number) {
+    if (usage >= 1_000_000_000_000) {
+        return `${(usage / 1_000_000_000_000).toLocaleString('en-US', { maximumFractionDigits: 0 })}T`;
+    }
+    if (usage >= 1_000_000_000) {
+        return `${(usage / 1_000_000_000).toLocaleString('en-US', { maximumFractionDigits: 0 })}B`;
+    }
     if (usage >= 1_000_000) {
-        return `${(usage / 1_000_000).toFixed(0)}M`;
+        return `${(usage / 1_000_000).toLocaleString('en-US', { maximumFractionDigits: 0 })}M`;
     }
     if (usage >= 1000) {
-        return `${(usage / 1000).toFixed(0)}K`;
+        return `${(usage / 1000).toLocaleString('en-US', { maximumFractionDigits: 0 })}K`;
     }
-    return usage;
+    return usage.toLocaleString('en-US');
 }
 
 export default function UsageCard() {


### PR DESCRIPTION
Add `B` and `T` for billions and trillions. Also, comma-separate big numbers (with localeString) (`10000` -> `10,000`)

<!-- Summary by @propel-code-bot -->

---

**Add `B`/`T` suffixes and comma formatting to `UsageCard` numbers**

The PR extends number-formatting helpers in `UsageCard.tsx` to support billions (`B`) and trillions (`T`) and to apply thousands separators using `Intl.NumberFormat('en-US')`. Only presentation logic is modified; no API contracts or state handling are touched.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced reusable formatter `const numberFormatter = Intl.NumberFormat('en-US', { maximumFractionDigits: 0 })`
• Updated `formatLimit` and `formatUsage` to handle 1e9 (`B`) and 1e12 (`T`) plus locale-based comma separation fallback
• Replaced `.toFixed(0)` calls with `numberFormatter.format(...)`
• Refreshed JSDoc examples to cover new behaviour

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*