### PR TITLE
chore(usage): replace rate limiter by queue when throttling

### DIFF
--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -224,6 +224,7 @@ export const ENVS = z.object({
     USAGE_CAPPING_ENABLED: z.stringbool().optional().default(false),
     USAGE_REVALIDATE_AFTER_MS: z.coerce.number().optional().default(3_600_000), // 1 hour
     USAGE_BILLING_API_MAX_RPS: z.coerce.number().optional().default(5), // max requests per second to Orb API usage endpoint is 10, keeping some margin
+    USAGE_BILLING_API_MAX_QUEUE_SIZE: z.coerce.number().optional().default(100), // max queued requests by rate limiter
     USAGE_BILLING_API_CACHE_TTL_SECONDS: z.coerce
         .number()
         .optional()


### PR DESCRIPTION
Instead of failing when fetching usage hit the rate limit, queue the requests to be executed in next time interval.
It could eventually fail if we hit the queue max size but since we are gonna request a limited number of time interval and aggresivelly cache the data it is only likely to happen if lots of customers hit their billing page at the same time.
It would have the effect to make loading the usage data slower which I believe it would be a better user experience that failing and having to manage retries, etc...

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Switch rate-limit logic to queueing for usage-billing API**

Replaces the fail-fast `RateLimiterRedis.consume()` approach with a `RateLimiterQueue` wrapper so Orb usage-billing calls are queued rather than rejected once the per-second limit is reached. A new env variable defines the maximum queue length and the env schema is updated accordingly. No public API surface changes; behaviour only differs under throttled load.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `RateLimiterQueue` import and replaced the internal `throttler` type from `RateLimiterRedis` to `RateLimiterQueue` in `packages/account-usage/lib/billing.ts`
• Wrapped the existing `RateLimiterRedis` instance with `new RateLimiterQueue(limiter, { maxQueueSize: envs.USAGE_BILLING_API_MAX_QUEUE_SIZE })`
• Changed throttling helper to call `removeTokens(1, key)` instead of `consume(key)` and propagate errors via `new Error('rate_limit_exceeded', { cause: err })`
• Introduced new environment variable `USAGE_BILLING_API_MAX_QUEUE_SIZE` (default `100`) and added it to the Zod schema in `packages/utils/lib/environment/parse.ts`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/account-usage/lib/billing.ts`
• `packages/utils/lib/environment/parse.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*