### PR TITLE
fix(records): smaller batch size for records deletion

### DIFF
--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -714,18 +714,46 @@ export async function deleteRecordsBySyncId({
 }): Promise<{ totalDeletedRecords: number }> {
     let totalDeletedRecords = 0;
     let deletedRecords = 0;
+    let minBatchSize = 100; // minimum batch size we allow
+    let currentBatchSize = batchSize;
     do {
-        // records table is partitioned by connection_id and model
-        // to avoid table scan, we must filter by connection_id and model
-        deletedRecords = await db
-            .from(RECORDS_TABLE)
-            .where({ connection_id: connectionId, model })
-            .whereIn('id', function (sub) {
-                sub.select('id').from(RECORDS_TABLE).where({ connection_id: connectionId, model, sync_id: syncId }).limit(batchSize);
-            })
-            .del();
-        totalDeletedRecords += deletedRecords;
-    } while (deletedRecords >= batchSize);
+        try {
+            deletedRecords = await db
+                .from(RECORDS_TABLE)
+                .where({ connection_id: connectionId, model })
+                .whereIn('id', function (sub: any) {
+                    sub.select('id').from(RECORDS_TABLE).where({ connection_id: connectionId, model, sync_id: syncId }).limit(currentBatchSize);
+                })
+                .del();
+            totalDeletedRecords += deletedRecords;
+            // On success reset batch size in case it was lowered before
+            currentBatchSize = batchSize;
+        } catch (err: any) {
+            // Check for statement timeout error and lower batch size if so
+            const message = typeof err?.message === 'string' ? err.message : '';
+            if (
+                message.includes('canceling statement due to statement timeout') ||
+                message.includes('statement timeout') ||
+                message.includes('QueryCanceledError')
+            ) {
+                if (currentBatchSize > minBatchSize) {
+                    currentBatchSize = Math.floor(currentBatchSize / 2);
+                    if (currentBatchSize < minBatchSize) {
+                        currentBatchSize = minBatchSize;
+                    }
+                    // If batch is too small to make progress, throw
+                } else {
+                    throw new Error(
+                        `Failed to delete records for model '${model}' and syncId '${syncId}': repeatedly hit statement timeout at minimal batch size (${minBatchSize}).`
+                    );
+                }
+            } else {
+                throw err;
+            }
+            // retry the loop with reduced batch size
+            deletedRecords = 0;
+        }
+    } while (deletedRecords >= currentBatchSize);
     await deleteRecordCount({ connectionId, environmentId, model });
 
     return { totalDeletedRecords };

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -594,12 +594,8 @@ export class Orchestrator {
                             if (syncVariant !== 'base') {
                                 model = `${model}::${syncVariant}`;
                             }
-                            try {
-                                const del = await recordsService.deleteRecordsBySyncId({ syncId, connectionId, environmentId, model });
-                                void logCtx.info(`Records for model ${model} were deleted successfully`, del);
-                            } catch (err) {
-                                void logCtx.error(`Failed to delete records for model ${model}`, { error: err, model });
-                            }
+                            const del = await recordsService.deleteRecordsBySyncId({ syncId, connectionId, environmentId, model });
+                            void logCtx.info(`Records for model ${model} were deleted successfully`, del);
                         }
                     }
 

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -594,8 +594,12 @@ export class Orchestrator {
                             if (syncVariant !== 'base') {
                                 model = `${model}::${syncVariant}`;
                             }
-                            const del = await recordsService.deleteRecordsBySyncId({ syncId, connectionId, environmentId, model });
-                            void logCtx.info(`Records for model ${model} were deleted successfully`, del);
+                            try {
+                                const del = await recordsService.deleteRecordsBySyncId({ syncId, connectionId, environmentId, model });
+                                void logCtx.info(`Records for model ${model} were deleted successfully`, del);
+                            } catch (err) {
+                                void logCtx.error(`Failed to delete records for model ${model}`, { error: err, model });
+                            }
                         }
                     }
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
https://github.com/NangoHQ/nango/issues/4992

Smaller batch size in `deleteRecordsBySyncId` to avoid db timeout

[NAN-4347](https://linear.app/nango/issue/NAN-4347/delete-data-when-doing-a-full-refresh)
<!-- Summary by @propel-code-bot -->

---

**Paginate & wrap `deleteRecordsBySyncId` in a DB transaction to prevent time-outs**

The PR refactors record-deletion logic to break large `DELETE` operations into smaller batches (default 1 000 rows) executed inside a single Knex transaction.  This guarantees atomic removal of both the record rows and their associated stats in `nango_record_counts`, eliminating long-running queries that previously timed out.  An accompanying integration test validates end-to-end behaviour.

<details>
<summary><strong>Key Changes</strong></summary>

• Changed default `batchSize` from 5 000 to 1 000 in `deleteRecordsBySyncId`
• Re-implemented deletion loop inside `db.transaction`, deleting until `deletedRecords === 0`
• Updated call-site to invoke new `deleteRecordCount(trx, …)`; helper now requires an explicit `Knex` transaction
• Added integration test block in `packages/records/lib/models/records.integration.test.ts` covering paginated deletion & stats cleanup

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/records/lib/models/records.ts`
• `packages/records/lib/models/records.integration.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*