### PR TITLE
feat(cli-nango-test): nango test implementation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -228,6 +228,7 @@
             "group": "Building integrations",
             "pages": [
               "implementation-guides/building-integrations/functions-setup",
+              "implementation-guides/building-integrations/test-functions",
               "implementation-guides/building-integrations/leverage-ai-agents",
               "implementation-guides/building-integrations/extend-reference-implementation",
               "implementation-guides/building-integrations/unified-apis",

--- a/docs/implementation-guides/actions/implement-an-action.mdx
+++ b/docs/implementation-guides/actions/implement-an-action.mdx
@@ -156,6 +156,10 @@ You can also pass input data to the action. Run `nango dryrun --help` to see all
     By default, `dryrun` retrieves connections from your `dev` environment. You can change this with a CLI flag.
 </Tip>
 
+<Tip>
+    You can also use `nango test` to run your action with output validation, or `nango test --local` for fast testing with mocked API responses. See the [Test functions guide](/implementation-guides/building-integrations/test-functions) for more details.
+</Tip>
+
 ### Step 6 - Deploy your action
 
 To run your action in Nango, you need to deploy it to an environment in your Nango account.

--- a/docs/implementation-guides/building-integrations/test-functions.mdx
+++ b/docs/implementation-guides/building-integrations/test-functions.mdx
@@ -1,0 +1,224 @@
+---
+title: 'Test functions'
+sidebarTitle: 'Test functions'
+description: 'How to test your syncs and actions locally'
+---
+
+Testing your integration functions ensures they work correctly before deploying to production. Nango provides two testing modes:
+
+- **Remote testing** (default): Tests with real API calls and validates output against your schema
+- **Local testing**: Tests with mocked API responses for fast, repeatable regression testing
+
+## Remote testing
+
+Remote testing executes your function making real API calls to verify it works end-to-end.
+
+### Run a remote test
+
+```bash
+nango test <script-name> <connection-id>
+```
+
+This command:
+1. Compiles your function
+2. Executes it against a real connection
+3. Validates output against your model schema
+4. Reports any validation errors
+
+Example:
+```bash
+nango test salesforce-contacts conn_123abc
+```
+
+<Tip>
+By default, tests use connections from your `dev` environment. Change this with the `-e` flag.
+</Tip>
+
+### Pass input to actions
+
+For actions that require input, use the `--input` flag:
+
+```bash
+nango test create-contact conn_123abc --input '{"email": "test@example.com"}'
+```
+
+You can also load input from a file:
+```bash
+nango test create-contact conn_123abc --input @fixtures/contact.json
+```
+
+## Local testing
+
+Local testing uses mocked API responses to test your functions without making real API calls. This is useful for:
+
+- Fast iteration during development
+- Regression testing in CI/CD
+- Testing without rate limits
+- Reproducible test results
+
+### Set up local testing
+
+**Step 1: Capture API responses**
+
+First, save real API responses from a working connection:
+
+```bash
+nango dryrun <script-name> <connection-id> --save-responses
+```
+
+This creates mock files in your integration directory:
+```
+nango-integrations/
+└── salesforce/
+    └── mocks/
+        └── nango/
+            └── get/
+                └── proxy/
+                    └── services/
+                        └── data/
+                            └── v53.0/
+                                └── query/
+                                    └── salesforce-contacts/
+                                        └── abc123def.json
+```
+
+<Note>
+Mock files are saved with a hash of the request parameters. This ensures different API calls use the correct mocked response.
+</Note>
+
+**Step 2: Create expected output files**
+
+For actions, create an expected output file:
+```bash
+# Create the mock directory
+mkdir -p nango-integrations/<integration>/mocks/<action-name>
+
+# Add the expected output
+echo '{"id": "123", "name": "John Doe"}' > nango-integrations/<integration>/mocks/<action-name>/output.json
+```
+
+For syncs, create expected batch save/delete files:
+```bash
+# Create the model directory
+mkdir -p nango-integrations/<integration>/mocks/<sync-name>/<ModelName>
+
+# Add expected records
+echo '[{"id": "1", "name": "Contact 1"}]' > nango-integrations/<integration>/mocks/<sync-name>/<ModelName>/batchSave.json
+```
+
+**Step 3: Run local tests**
+
+```bash
+nango test <script-name> <connection-id> --local
+```
+
+This command:
+1. Loads your compiled function
+2. Uses mocked API responses instead of real calls
+3. Compares actual output to expected output
+4. Reports any differences
+
+Example:
+```bash
+nango test salesforce-contacts conn_123abc --local
+```
+
+### Mock file structure
+
+#### For actions
+
+```
+<integration>/mocks/
+└── <action-name>/
+    ├── input.json          # Optional: input data for the action
+    └── output.json         # Required: expected output
+```
+
+#### For syncs
+
+```
+<integration>/mocks/
+└── <sync-name>/
+    └── <ModelName>/
+        ├── batchSave.json    # Expected records to save
+        └── batchDelete.json  # Expected records to delete
+```
+
+## Testing in CI/CD
+
+Local testing is ideal for CI/CD pipelines because it's fast and doesn't require API credentials.
+
+Example GitHub Actions workflow:
+
+```yaml
+name: Test Integrations
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install Nango CLI
+        run: npm install -g nango
+
+      - name: Run local tests
+        working-directory: ./nango-integrations
+        run: |
+          nango test salesforce-contacts conn_test --local
+          nango test hubspot-contacts conn_test --local
+```
+
+<Warning>
+Commit mock files to your repository so tests run consistently across environments.
+</Warning>
+
+## Best practices
+
+**Update mocks when APIs change**
+
+When external APIs change their response format, re-run `--save-responses` to update your mocks:
+
+```bash
+nango dryrun salesforce-contacts conn_123abc --save-responses
+```
+
+**Test both success and error cases**
+
+Create separate mocks for error scenarios to ensure your error handling works correctly.
+
+**Use meaningful connection IDs**
+
+In local mode, the connection ID doesn't need to be real, but use descriptive names:
+
+```bash
+nango test salesforce-contacts conn_test_pagination --local
+```
+
+**Keep mocks in version control**
+
+Mock files should be committed to your repository so your team and CI can run tests consistently.
+
+## Troubleshooting
+
+**"No mocked responses found"**
+
+Run `nango dryrun <script> <connection-id> --save-responses` first to capture API responses.
+
+**"Output does not match expected result"**
+
+Check the test output for differences between expected and actual values. Update your function or expected output file as needed.
+
+**"Unable to find compiled script file"**
+
+Make sure you've compiled your functions. Run `nango dev` or manually compile before testing.
+
+## Next steps
+
+- [Implement a sync](/implementation-guides/syncs/implement-a-sync)
+- [Implement an action](/implementation-guides/actions/implement-an-action)
+- [Data validation](/implementation-guides/building-integrations/data-validation)

--- a/packages/cli/lib/services/dryrun.service.unit.test.ts
+++ b/packages/cli/lib/services/dryrun.service.unit.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DryRunResult, DryRunServiceConfig } from './dryrun.service.js';
+
+describe('DryRunService types', () => {
+    describe('DryRunServiceConfig', () => {
+        it('should accept minimal required config', () => {
+            const config: DryRunServiceConfig = {
+                fullPath: '/path/to/project',
+                validation: true,
+                isZeroYaml: false
+            };
+
+            expect(config).toBeDefined();
+            expect(config.fullPath).toBe('/path/to/project');
+            expect(config.validation).toBe(true);
+            expect(config.isZeroYaml).toBe(false);
+        });
+
+        it('should accept config with optional environment', () => {
+            const config: DryRunServiceConfig = {
+                fullPath: '/path/to/project',
+                validation: false,
+                isZeroYaml: true,
+                environment: 'dev'
+            };
+
+            expect(config.environment).toBe('dev');
+        });
+
+        it('should accept config with optional returnOutput', () => {
+            const config: DryRunServiceConfig = {
+                fullPath: '/path/to/project',
+                validation: true,
+                isZeroYaml: false,
+                returnOutput: true
+            };
+
+            expect(config.returnOutput).toBe(true);
+        });
+    });
+
+    describe('DryRunResult discriminated union', () => {
+        it('should accept success result with output', () => {
+            const result: DryRunResult = {
+                success: true,
+                output: 'Test output'
+            };
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.output).toBe('Test output');
+            }
+        });
+
+        it('should accept failure result with error', () => {
+            const result: DryRunResult = {
+                success: false,
+                error: 'Test error'
+            };
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.error).toBe('Test error');
+            }
+        });
+
+        it('should accept failure result with errorDetails', () => {
+            const result: DryRunResult = {
+                success: false,
+                error: 'Test error',
+                errorDetails: 'Additional details'
+            };
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.error).toBe('Test error');
+                expect(result.errorDetails).toBe('Additional details');
+            }
+        });
+
+        it('should accept failure result with validationError', () => {
+            const result: DryRunResult = {
+                success: false,
+                error: 'Validation failed',
+                validationError: {
+                    type: 'invalid_action_output',
+                    code: 'invalid_action_output',
+                    payload: { data: {}, validation: [] }
+                }
+            };
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.validationError).toBeDefined();
+                if (result.validationError && 'code' in result.validationError) {
+                    expect(result.validationError.code).toBe('invalid_action_output');
+                }
+            }
+        });
+
+        it('should properly discriminate success from failure', () => {
+            const successResult: DryRunResult = {
+                success: true,
+                output: 'Success'
+            };
+
+            const failureResult: DryRunResult = {
+                success: false,
+                error: 'Failed'
+            };
+
+            // Type narrowing should work correctly
+            if (successResult.success) {
+                // TypeScript should know this is the success branch
+                const _output: string = successResult.output;
+                expect(_output).toBe('Success');
+            }
+
+            if (!failureResult.success) {
+                // TypeScript should know this is the failure branch
+                const _error: string = failureResult.error;
+                expect(_error).toBe('Failed');
+            }
+        });
+    });
+});

--- a/packages/cli/lib/services/localTest.service.ts
+++ b/packages/cli/lib/services/localTest.service.ts
@@ -1,0 +1,331 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import * as vm from 'node:vm';
+import * as url from 'url';
+
+import * as zod from 'zod';
+
+import { BASE_VARIANT } from '@nangohq/runner-sdk';
+
+import { parse } from './config.service.js';
+import { getIntegrationFile } from './dryrun.service.js';
+import * as nangoScript from '../sdkScripts.js';
+import { NangoActionMockBase, NangoSyncMockBase } from '../testMocks/utils.js';
+import { printDebug } from '../utils.js';
+import { buildDefinitions } from '../zeroYaml/definitions.js';
+import { ReadableError } from '../zeroYaml/utils.js';
+
+import type { GlobalOptions } from '../types.js';
+import type { NangoProps, NangoYamlParsed, ParsedNangoAction, ParsedNangoSync, ScriptFileType } from '@nangohq/types';
+
+interface LocalTestArgs extends GlobalOptions {
+    sync: string;
+    connectionId: string;
+    input?: string;
+    optionalEnvironment?: string;
+    optionalProviderConfigKey?: string;
+    variant?: string;
+}
+
+export type LocalTestResult =
+    | { success: true; output: string }
+    | {
+          success: false;
+          error: string;
+          errorDetails?: string;
+          details?: Record<string, unknown>;
+      };
+
+/**
+ * LocalTestService executes scripts using mocked API responses from the mocks/ directory,
+ * then validates the output against expected local data.
+ *
+ * This is useful for regression testing without making real API calls.
+ *
+ * Note: Requires mocked responses to be saved first using `dryrun --save-responses`.
+ * Mocked responses are stored in: {integration}/mocks/nango/{method}/proxy/{endpoint}/{script}/{hash}.json
+ */
+export class LocalTestService {
+    fullPath: string;
+    isZeroYaml: boolean;
+
+    constructor({ fullPath, isZeroYaml }: { fullPath: string; isZeroYaml: boolean }) {
+        this.fullPath = fullPath;
+        this.isZeroYaml = isZeroYaml;
+    }
+
+    public async run(options: LocalTestArgs, debug = false): Promise<LocalTestResult> {
+        const { sync: syncName, connectionId, variant } = options;
+
+        if (!syncName) {
+            return { success: false, error: 'Script name is required' };
+        }
+
+        const syncVariant = variant || BASE_VARIANT;
+
+        if (!connectionId) {
+            return { success: false, error: 'Connection id is required' };
+        }
+
+        // Parse config to find integration and script
+        let parsed: NangoYamlParsed;
+        if (this.isZeroYaml) {
+            const def = await buildDefinitions({ fullPath: this.fullPath, debug });
+            if (def.isErr()) {
+                return {
+                    success: false,
+                    error: def.error instanceof ReadableError ? def.error.toText() : def.error.message
+                };
+            }
+            parsed = def.value;
+        } else {
+            const parsing = parse(process.cwd(), debug);
+            if (parsing.isErr()) {
+                return { success: false, error: parsing.error.message };
+            }
+
+            parsed = parsing.value.parsed!;
+        }
+
+        if (options.optionalProviderConfigKey && !parsed.integrations.some((inte) => inte.providerConfigKey === options.optionalProviderConfigKey)) {
+            return { success: false, error: `Integration "${options.optionalProviderConfigKey}" does not exist` };
+        }
+
+        let providerConfigKey: string | undefined;
+        let isOnEventScript = false;
+
+        // Find the appropriate script to run
+        let scriptInfo: ParsedNangoSync | ParsedNangoAction | undefined;
+        for (const integration of parsed.integrations) {
+            if (options.optionalProviderConfigKey && integration.providerConfigKey !== options.optionalProviderConfigKey) {
+                continue;
+            }
+
+            // Priority for syncs and actions
+            for (const script of [...integration.syncs, ...integration.actions]) {
+                if (script.name !== syncName) {
+                    continue;
+                }
+                if (scriptInfo) {
+                    return { success: false, error: `Multiple integrations contain a script named "${syncName}". Please use "--integration-id"` };
+                }
+                scriptInfo = script;
+                providerConfigKey = integration.providerConfigKey;
+            }
+
+            // If nothing that could still be a on-event script
+            if (!scriptInfo) {
+                for (const script of Object.values(integration.onEventScripts).flat()) {
+                    if (script !== syncName) {
+                        continue;
+                    }
+                    if (isOnEventScript) {
+                        return {
+                            success: false,
+                            error: `Multiple integrations contain a post connection script named "${syncName}". Please use "--integration-id"`
+                        };
+                    }
+                    isOnEventScript = true;
+                    providerConfigKey = integration.providerConfigKey;
+                }
+            }
+        }
+
+        if ((!scriptInfo && !isOnEventScript) || !providerConfigKey) {
+            return {
+                success: false,
+                error: `No script matched "${syncName}"${options.optionalProviderConfigKey ? ` for integration "${options.optionalProviderConfigKey}"` : ''}`
+            };
+        }
+
+        if (debug && scriptInfo) {
+            printDebug(`Found integration ${providerConfigKey}, ${scriptInfo.type} ${scriptInfo.name}`);
+        }
+
+        let type: ScriptFileType = 'syncs';
+        if (scriptInfo?.type === 'action') {
+            type = 'actions';
+        } else if (isOnEventScript) {
+            type = 'on-events';
+        }
+
+        // Verify mocked responses exist
+        const mocksResponseDir = path.resolve(this.fullPath, providerConfigKey, 'mocks', 'nango');
+        if (!fs.existsSync(mocksResponseDir)) {
+            return {
+                success: false,
+                error: `No mocked responses found at ${mocksResponseDir}. Run "dryrun ${syncName} ${connectionId} --save-responses" first to capture API responses.`
+            };
+        }
+
+        // Get the compiled script using the same method as dryrun
+        // For zero yaml, build/ is at the root; for regular yaml, dist/ is per-provider
+        const loadLocation = this.isZeroYaml ? this.fullPath + '/' : path.resolve(this.fullPath, providerConfigKey) + '/';
+
+        // Create minimal syncConfig for local testing (validation not needed)
+        const syncConfig: NangoProps['syncConfig'] = {
+            id: 0,
+            sync_name: syncName,
+            nango_config_id: 0,
+            file_location: '',
+            version: '1',
+            models: scriptInfo?.output || [],
+            active: true,
+            runs: null,
+            environment_id: 1,
+            track_deletes: false,
+            type: scriptInfo?.type || 'sync',
+            auto_start: false,
+            attributes: {},
+            pre_built: false,
+            is_public: false,
+            metadata: {},
+            input: null,
+            sync_type: 'full',
+            webhook_subscriptions: null,
+            enabled: true,
+            models_json_schema: null,
+            created_at: new Date(),
+            updated_at: new Date(),
+            deleted_at: null,
+            sdk_version: null
+        };
+
+        const nangoProps: NangoProps = {
+            scriptType: type === 'syncs' ? 'sync' : type === 'actions' ? 'action' : 'on-event',
+            host: 'http://localhost',
+            secretKey: 'test-secret-key',
+            team: { id: 1, name: 'test-team' },
+            connectionId,
+            environmentId: 1,
+            environmentName: 'dev',
+            activityLogId: 'test-activity-log-id',
+            providerConfigKey,
+            provider: providerConfigKey,
+            syncVariant: syncVariant || BASE_VARIANT,
+            nangoConnectionId: 1,
+            syncConfig,
+            runnerFlags: {
+                validateActionInput: false,
+                validateActionOutput: false,
+                validateSyncRecords: false,
+                validateSyncMetadata: false
+            },
+            logger: { level: 'off' },
+            debug,
+            startedAt: new Date(),
+            endUser: null
+        };
+
+        const script = getIntegrationFile({
+            syncName,
+            nangoProps,
+            location: loadLocation,
+            isZeroYaml: this.isZeroYaml
+        });
+
+        if (!script) {
+            return {
+                success: false,
+                error: `Unable to find compiled script file for "${syncName}"`
+            };
+        }
+
+        try {
+            // Execute the compiled script using vm.Script (same as dryrun)
+            const filename = `${syncName}-${providerConfigKey}.js`;
+            const wrappedCode = `(function() { var module = { exports: {} }; var exports = module.exports; ${script}
+                return module.exports;
+            })();
+            `;
+
+            const scriptObj = new vm.Script(wrappedCode, { filename });
+
+            const sandbox = {
+                console,
+                require: (moduleName: string) => {
+                    switch (moduleName) {
+                        case 'url':
+                            return url;
+                        case 'crypto':
+                            return crypto;
+                        case 'nango':
+                            return nangoScript;
+                        case 'zod':
+                            return zod;
+                        default:
+                            throw new Error(`Module "${moduleName}" is not available in local test mode`);
+                    }
+                }
+            };
+
+            const context = vm.createContext(sandbox);
+            const scriptExports: { default?: any } = scriptObj.runInContext(context);
+
+            if (!scriptExports.default) {
+                return {
+                    success: false,
+                    error: `No default export found for "${syncName}"`
+                };
+            }
+
+            // Determine the function to call based on the export type (same logic as dryrun)
+            let scriptFunction: (nango: any, input: any) => Promise<any>;
+            if (typeof scriptExports.default !== 'function') {
+                // Zero yaml exports an object with type and exec properties
+                const payload = scriptExports.default;
+                if (!payload.exec || typeof payload.exec !== 'function') {
+                    return {
+                        success: false,
+                        error: `Invalid script export for "${syncName}". Expected exec function.`
+                    };
+                }
+                scriptFunction = payload.exec;
+            } else {
+                // Regular yaml exports a function directly
+                scriptFunction = scriptExports.default;
+            }
+
+            // Create mock instance using the base classes (no vitest dependency)
+            const integrationDir = path.resolve(this.fullPath, providerConfigKey);
+            const MockClass = type === 'syncs' ? NangoSyncMockBase : NangoActionMockBase;
+            const mockInstance = new MockClass({
+                dirname: integrationDir,
+                name: syncName,
+                Model: scriptInfo?.output?.[0] || ''
+            });
+
+            // Get input and expected output from mocked files
+            const input = await mockInstance.getInput();
+            const expectedOutput = await mockInstance.getOutput();
+
+            // Run the script
+            const actualOutput = await scriptFunction(mockInstance, input);
+
+            // Compare output
+            const outputsMatch = JSON.stringify(actualOutput) === JSON.stringify(expectedOutput);
+
+            if (outputsMatch) {
+                return {
+                    success: true,
+                    output: 'Output matches expected result'
+                };
+            } else {
+                return {
+                    success: false,
+                    error: 'Output does not match expected result',
+                    details: {
+                        expected: expectedOutput,
+                        actual: actualOutput
+                    }
+                };
+            }
+        } catch (err: any) {
+            return {
+                success: false,
+                error: `Test execution failed: ${err.message}`,
+                errorDetails: err.stack
+            };
+        }
+    }
+}

--- a/packages/cli/lib/services/localTest.service.unit.test.ts
+++ b/packages/cli/lib/services/localTest.service.unit.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+import type { LocalTestResult } from './localTest.service.js';
+
+describe('LocalTestService types', () => {
+    describe('LocalTestResult discriminated union', () => {
+        it('should accept success result with output', () => {
+            const result: LocalTestResult = {
+                success: true,
+                output: 'Output matches expected result'
+            };
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.output).toBe('Output matches expected result');
+            }
+        });
+
+        it('should accept failure result with error', () => {
+            const result: LocalTestResult = {
+                success: false,
+                error: 'Test execution failed'
+            };
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.error).toBe('Test execution failed');
+            }
+        });
+
+        it('should accept failure result with errorDetails', () => {
+            const result: LocalTestResult = {
+                success: false,
+                error: 'Script not found',
+                errorDetails: 'Stack trace or additional error information'
+            };
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.error).toBe('Script not found');
+                expect(result.errorDetails).toBe('Stack trace or additional error information');
+            }
+        });
+
+        it('should accept failure result with details containing expected and actual', () => {
+            const result: LocalTestResult = {
+                success: false,
+                error: 'Output does not match expected result',
+                details: {
+                    expected: { id: '123', name: 'test' },
+                    actual: { id: '123', name: 'different' }
+                }
+            };
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.error).toBe('Output does not match expected result');
+                expect(result.details).toBeDefined();
+                expect(result.details?.['expected']).toEqual({ id: '123', name: 'test' });
+                expect(result.details?.['actual']).toEqual({ id: '123', name: 'different' });
+            }
+        });
+
+        it('should narrow types correctly in conditionals', () => {
+            const testResult = (success: boolean): LocalTestResult => {
+                if (success) {
+                    return { success: true, output: 'Test passed' };
+                }
+                return { success: false, error: 'Test failed' };
+            };
+
+            const successResult = testResult(true);
+            const failureResult = testResult(false);
+
+            if (successResult.success) {
+                // In this branch, TypeScript knows result has output property
+                expect(successResult.output).toBe('Test passed');
+                // @ts-expect-error error property should not exist on success result
+                const _error = successResult.error;
+            }
+
+            if (!failureResult.success) {
+                // In this branch, TypeScript knows result has error property
+                expect(failureResult.error).toBe('Test failed');
+                // @ts-expect-error output property should not exist on failure result
+                const _output = failureResult.output;
+            }
+        });
+    });
+
+    describe('Mock data structure expectations', () => {
+        it('should document expected action mock structure', () => {
+            // Expected structure for actions:
+            // <integration>/mocks/<action-name>/
+            //   ├── input.json (optional)
+            //   └── output.json (required)
+
+            const mockStructure = {
+                path: 'hubspot/mocks/get-contact/output.json',
+                content: {
+                    id: '123',
+                    name: 'John Doe'
+                }
+            };
+
+            expect(mockStructure.path).toBeDefined();
+            expect(mockStructure.content).toBeDefined();
+        });
+
+        it('should document expected sync mock structure', () => {
+            // Expected structure for syncs:
+            // <integration>/mocks/<sync-name>/
+            //   └── <model>/
+            //       ├── batchSave.json (optional)
+            //       └── batchDelete.json (optional)
+
+            const mockStructure = {
+                path: 'hubspot/mocks/fetch-contacts/Contact/batchSave.json',
+                content: [
+                    { id: '1', name: 'Contact 1' },
+                    { id: '2', name: 'Contact 2' }
+                ]
+            };
+
+            expect(mockStructure.path).toBeDefined();
+            expect(mockStructure.content).toBeInstanceOf(Array);
+        });
+    });
+});

--- a/packages/cli/lib/services/response-saver.service.ts
+++ b/packages/cli/lib/services/response-saver.service.ts
@@ -82,7 +82,9 @@ export function onAxiosRequestFulfilled({
     if (!providerConfigKey) {
         return response;
     }
-    const directoryName = `${process.env['NANGO_MOCKS_RESPONSE_DIRECTORY'] ?? ''}${providerConfigKey}`;
+    // Fall back to current working directory if not explicitly set
+    const mocksBaseDir = process.env['NANGO_MOCKS_RESPONSE_DIRECTORY'] || `${process.cwd()}/`;
+    const directoryName = `${mocksBaseDir}${providerConfigKey}`;
 
     if (response.request.path.includes(`/connections/${connectionId}`)) {
         const connection = response.data as GetPublicConnection['Success'];
@@ -134,7 +136,9 @@ export function onAxiosRequestRejected({
     syncName: string;
     syncVariant: string;
 }) {
-    const directoryName = `${process.env['NANGO_MOCKS_RESPONSE_DIRECTORY'] ?? ''}${providerConfigKey}`;
+    // Fall back to current working directory if not explicitly set
+    const mocksBaseDir = process.env['NANGO_MOCKS_RESPONSE_DIRECTORY'] || `${process.cwd()}/`;
+    const directoryName = `${mocksBaseDir}${providerConfigKey}`;
 
     const response: AxiosResponse | undefined = (error as AxiosError).response;
     if (response) {

--- a/packages/cli/lib/services/sdk.ts
+++ b/packages/cli/lib/services/sdk.ts
@@ -83,19 +83,29 @@ export class NangoActionCLI extends NangoActionBase {
         }
     }
 
-    public triggerSync(
+    public async triggerSync(
         _providerConfigKey: string,
         connectionId: string,
         sync: string | { name: string; variant: string },
         _syncMode?: unknown
     ): Promise<void | string> {
         const syncArgs = typeof sync === 'string' ? { sync } : { sync: sync.name, variant: sync.variant };
-        return this.dryRunService.run({
+        const result = await this.dryRunService.run({
             ...syncArgs,
             connectionId,
             autoConfirm: true,
             debug: false
         });
+
+        // Handle the new object return type
+        if (result && typeof result === 'object' && 'success' in result) {
+            if (result.success) {
+                return result.output;
+            }
+            return '';
+        }
+
+        return result;
     }
 
     public startSync(_providerConfigKey: string, _syncs: (string | { name: string; variant: string })[], _connectionId?: string): Promise<void> {

--- a/packages/cli/lib/testMocks/utils.vitest.ts
+++ b/packages/cli/lib/testMocks/utils.vitest.ts
@@ -1,0 +1,87 @@
+import { vi } from 'vitest';
+
+import { NangoActionMockBase, NangoSyncMockBase } from './utils.js';
+
+/**
+ * Vitest-enabled version of NangoActionMock.
+ * Wraps all methods with vi.fn() for test spying.
+ * Use NangoActionMockBase if you don't need vitest functionality.
+ */
+class NangoActionMock extends NangoActionMockBase {
+    // Override method signatures to indicate they are vi.fn() mocks
+    declare setLogger: ReturnType<typeof vi.fn>;
+    declare log: ReturnType<typeof vi.fn>;
+    declare getConnection: ReturnType<typeof vi.fn>;
+    declare getMetadata: ReturnType<typeof vi.fn>;
+    declare paginate: ReturnType<typeof vi.fn>;
+    declare get: ReturnType<typeof vi.fn>;
+    declare post: ReturnType<typeof vi.fn>;
+    declare patch: ReturnType<typeof vi.fn>;
+    declare put: ReturnType<typeof vi.fn>;
+    declare delete: ReturnType<typeof vi.fn>;
+    declare proxy: ReturnType<typeof vi.fn>;
+    declare getWebhookURL: ReturnType<typeof vi.fn>;
+    declare zodValidateInput: ReturnType<typeof vi.fn>;
+
+    constructor(args: { dirname: string; name: string; Model: string }) {
+        super(args);
+        // Wrap all methods with vi.fn() for testing
+        this.setLogger = vi.fn();
+        this.log = vi.fn();
+        this.getConnection = vi.fn(this._getConnectionData);
+        this.getMetadata = vi.fn(this._getMetadataData);
+        this.paginate = vi.fn(this._getProxyPaginateData);
+        this.get = vi.fn(this._proxyGetData);
+        this.post = vi.fn(this._proxyPostData);
+        this.patch = vi.fn(this._proxyPatchData);
+        this.put = vi.fn(this._proxyPutData);
+        this.delete = vi.fn(this._proxyDeleteData);
+        this.proxy = vi.fn(this._proxyData);
+        this.getWebhookURL = vi.fn(() => 'https://example.com/webhook');
+        this.updateMetadata = vi.fn();
+        this.getToken = vi.fn();
+        this.getIntegration = vi.fn();
+        this.setMetadata = vi.fn();
+        this.setFieldMapping = vi.fn();
+        this.getFieldMapping = vi.fn();
+        this.getEnvironmentVariables = vi.fn(() => Promise.resolve({}));
+        this.getFlowAttributes = vi.fn(() => Promise.resolve({}));
+        this.triggerAction = vi.fn();
+        this.triggerSync = vi.fn();
+        this.zodValidateInput = vi.fn(({ input }) => Promise.resolve({ success: true as const, data: input }));
+        this.startSync = vi.fn();
+        this.uncontrolledFetch = vi.fn();
+        this.tryAcquireLock = vi.fn(() => Promise.resolve(true));
+        this.releaseLock = vi.fn();
+        this.releaseAllLocks = vi.fn();
+    }
+}
+
+/**
+ * Vitest-enabled version of NangoSyncMock.
+ * Wraps all methods with vi.fn() for test spying.
+ * Use NangoSyncMockBase if you don't need vitest functionality.
+ */
+class NangoSyncMock extends NangoSyncMockBase {
+    declare batchSave: ReturnType<typeof vi.fn>;
+    declare batchDelete: ReturnType<typeof vi.fn>;
+    declare batchUpdate: ReturnType<typeof vi.fn>;
+    declare getRecordsByIds: ReturnType<typeof vi.fn>;
+    declare deleteRecordsFromPreviousExecutions: ReturnType<typeof vi.fn>;
+    declare setMergingStrategy: ReturnType<typeof vi.fn>;
+    declare batchSend: ReturnType<typeof vi.fn>;
+
+    constructor(args: { dirname: string; name: string; Model: string }) {
+        super(args);
+        // Wrap sync-specific methods with vi.fn()
+        this.batchSave = vi.fn();
+        this.batchDelete = vi.fn();
+        this.batchUpdate = vi.fn();
+        this.getRecordsByIds = vi.fn();
+        this.deleteRecordsFromPreviousExecutions = vi.fn();
+        this.setMergingStrategy = vi.fn();
+        this.batchSend = vi.fn();
+    }
+}
+
+export { NangoActionMock, NangoSyncMock };

--- a/packages/cli/lib/utils/testResultFormatter.ts
+++ b/packages/cli/lib/utils/testResultFormatter.ts
@@ -1,0 +1,128 @@
+import chalk from 'chalk';
+
+import { displayValidationError } from './errors.js';
+
+import type { InvalidActionInputSDKError, InvalidActionOutputSDKError, InvalidRecordSDKError } from '@nangohq/runner-sdk';
+
+export interface TestResult {
+    success: boolean;
+    output?: string;
+    error?: string;
+    errorDetails?: string;
+    validationError?: InvalidActionInputSDKError | InvalidActionOutputSDKError | InvalidRecordSDKError | { type: string; code?: string; payload: unknown };
+    details?: Record<string, unknown>;
+}
+
+export interface TestContext {
+    scriptName: string;
+    connectionId: string;
+    environment: string;
+    mode: 'Local' | 'Remote';
+}
+
+const DISPLAY_WIDTH = 60;
+
+export function displayTestResult(result: TestResult, context: TestContext): void {
+    printHeader(result.success, context.mode);
+    printTestDetails(context);
+
+    if (result.success) {
+        printSuccess(result, context);
+    } else {
+        printFailure(result);
+    }
+
+    printFooter();
+}
+
+function printHeader(success: boolean, mode: string): void {
+    console.log('');
+    console.log(chalk.gray('═'.repeat(DISPLAY_WIDTH)));
+    if (success) {
+        console.log(chalk.green.bold(`  ✓ ${mode.toUpperCase()} TEST PASSED`));
+    } else {
+        console.log(chalk.red.bold(`  ✗ ${mode.toUpperCase()} TEST FAILED`));
+    }
+    console.log(chalk.gray('═'.repeat(DISPLAY_WIDTH)));
+}
+
+function printTestDetails(context: TestContext): void {
+    console.log('');
+    console.log(chalk.cyan.bold('Test Details:'));
+    console.log(chalk.gray('  Script:        '), chalk.white(context.scriptName));
+    console.log(chalk.gray('  Connection ID: '), chalk.white(context.connectionId));
+    console.log(chalk.gray('  Environment:   '), chalk.white(context.environment));
+    console.log(chalk.gray('  Mode:          '), chalk.white(context.mode));
+}
+
+function printSuccess(result: TestResult, context: TestContext): void {
+    // For remote tests, don't show verbose output - just pass/fail is enough
+    if (context.mode === 'Remote') {
+        return;
+    }
+
+    // For local tests, show the output
+    console.log('');
+    console.log(chalk.gray('─'.repeat(DISPLAY_WIDTH)));
+    console.log(chalk.green.bold(result.output?.includes('Output') ? 'Output:' : 'Result:'));
+
+    if (result.output) {
+        console.log('  ', result.output);
+    }
+
+    if (result.details) {
+        console.log('');
+        console.log(chalk.gray('Details:'));
+        console.log(JSON.stringify(result.details, null, 2));
+    }
+}
+
+function printFailure(result: TestResult): void {
+    console.log('');
+    console.log(chalk.gray('─'.repeat(DISPLAY_WIDTH)));
+    console.log(chalk.red.bold('Failure Reason:'));
+    console.log('');
+
+    // Display validation errors nicely
+    if (result.validationError) {
+        const err = result.validationError;
+        if ('code' in err && (err.code === 'invalid_action_output' || err.code === 'invalid_action_input')) {
+            const errorType = err.code === 'invalid_action_input' ? 'Input' : 'Output';
+            console.log(chalk.yellow(`  ${errorType} validation failed`));
+            console.log('');
+
+            if ('payload' in err && err.payload) {
+                displayValidationError(err.payload as Parameters<typeof displayValidationError>[0]);
+            }
+            return;
+        }
+        if ('type' in err && err.type === 'invalid_sync_record') {
+            console.log(chalk.yellow('  Record validation failed'));
+            console.log('');
+
+            if ('payload' in err && err.payload) {
+                displayValidationError(err.payload as Parameters<typeof displayValidationError>[0]);
+            }
+            return;
+        }
+    }
+
+    // Display regular error
+    console.log(chalk.red('  ', result.error));
+
+    if (result.details) {
+        console.log('');
+        console.log(chalk.gray('Details:'));
+        console.log(JSON.stringify(result.details, null, 2));
+    } else if (result.errorDetails) {
+        console.log('');
+        console.log(chalk.gray('Details:'));
+        console.log(result.errorDetails);
+    }
+}
+
+function printFooter(): void {
+    console.log('');
+    console.log(chalk.gray('═'.repeat(DISPLAY_WIDTH)));
+    console.log('');
+}

--- a/packages/cli/lib/utils/testResultFormatter.unit.test.ts
+++ b/packages/cli/lib/utils/testResultFormatter.unit.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { displayTestResult } from './testResultFormatter.js';
+
+import type { TestContext, TestResult } from './testResultFormatter.js';
+
+describe('testResultFormatter', () => {
+    let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleLogSpy.mockRestore();
+    });
+
+    const context: TestContext = {
+        scriptName: 'test-script',
+        connectionId: 'conn-123',
+        environment: 'dev',
+        mode: 'Local'
+    };
+
+    describe('displayTestResult', () => {
+        it('should display success result with output for local tests', () => {
+            const result: TestResult = {
+                success: true,
+                output: 'Test passed successfully'
+            };
+
+            displayTestResult(result, context);
+
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('✓'));
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('LOCAL TEST PASSED'));
+            expect(consoleLogSpy).toHaveBeenCalledWith('  ', 'Test passed successfully');
+        });
+
+        it('should not display verbose output for remote test success', () => {
+            const result: TestResult = {
+                success: true,
+                output: 'Test passed successfully'
+            };
+
+            const remoteContext: TestContext = {
+                ...context,
+                mode: 'Remote'
+            };
+
+            displayTestResult(result, remoteContext);
+
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('✓'));
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('REMOTE TEST PASSED'));
+            // Should NOT show the verbose output
+            expect(consoleLogSpy).not.toHaveBeenCalledWith('  ', 'Test passed successfully');
+        });
+
+        it('should display success result with details', () => {
+            const result: TestResult = {
+                success: true,
+                output: 'Test passed',
+                details: { foo: 'bar' }
+            };
+
+            displayTestResult(result, context);
+
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('Details:'));
+            expect(consoleLogSpy).toHaveBeenCalledWith(JSON.stringify({ foo: 'bar' }, null, 2));
+        });
+
+        it('should display failure result with error', () => {
+            const result: TestResult = {
+                success: false,
+                error: 'Test failed'
+            };
+
+            displayTestResult(result, context);
+
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('✗'));
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('LOCAL TEST FAILED'));
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('Failure Reason:'));
+        });
+
+        it('should display validation error for invalid action input', () => {
+            const result: TestResult = {
+                success: false,
+                error: 'Validation failed',
+                validationError: {
+                    type: 'invalid_action_input',
+                    code: 'invalid_action_input',
+                    payload: {
+                        data: { foo: 'bar' },
+                        validation: [],
+                        model: 'TestModel'
+                    }
+                }
+            };
+
+            displayTestResult(result, context);
+
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('Input validation failed'));
+        });
+
+        it('should display validation error for invalid action output', () => {
+            const result: TestResult = {
+                success: false,
+                error: 'Validation failed',
+                validationError: {
+                    type: 'invalid_action_output',
+                    code: 'invalid_action_output',
+                    payload: {
+                        data: { foo: 'bar' },
+                        validation: [],
+                        model: 'TestModel'
+                    }
+                }
+            };
+
+            displayTestResult(result, context);
+
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('Output validation failed'));
+        });
+
+        it('should display validation error for invalid sync record', () => {
+            const result: TestResult = {
+                success: false,
+                error: 'Validation failed',
+                validationError: {
+                    type: 'invalid_sync_record',
+                    payload: {
+                        data: { foo: 'bar' },
+                        validation: [],
+                        model: 'TestModel'
+                    }
+                }
+            };
+
+            displayTestResult(result, context);
+
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('Record validation failed'));
+        });
+
+        it('should display error details when provided', () => {
+            const result: TestResult = {
+                success: false,
+                error: 'Test failed',
+                errorDetails: 'Additional error information'
+            };
+
+            displayTestResult(result, context);
+
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('Details:'));
+            expect(consoleLogSpy).toHaveBeenCalledWith('Additional error information');
+        });
+
+        it('should display test details correctly', () => {
+            const result: TestResult = {
+                success: true,
+                output: 'Test passed'
+            };
+
+            displayTestResult(result, context);
+
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('Test Details:'));
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.anything(), expect.stringContaining('test-script'));
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.anything(), expect.stringContaining('conn-123'));
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.anything(), expect.stringContaining('dev'));
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.anything(), expect.stringContaining('Local'));
+        });
+
+        it('should handle remote mode correctly', () => {
+            const result: TestResult = {
+                success: true,
+                output: 'Test passed'
+            };
+
+            const remoteContext: TestContext = {
+                ...context,
+                mode: 'Remote'
+            };
+
+            displayTestResult(result, remoteContext);
+
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('REMOTE TEST PASSED'));
+            expect(consoleLogSpy).toHaveBeenCalledWith(expect.anything(), expect.stringContaining('Remote'));
+        });
+    });
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,9 +16,9 @@
             "default": "./dist/sdkScripts.js"
         },
         "./test": {
-            "require": "./dist/testMocks/utils.js",
-            "types": "./dist/testMocks/utils.d.ts",
-            "default": "./dist/testMocks/utils.js"
+            "require": "./dist/testMocks/utils.vitest.js",
+            "types": "./dist/testMocks/utils.vitest.d.ts",
+            "default": "./dist/testMocks/utils.vitest.js"
         },
         "./package.json": "./package.json"
     },

--- a/packages/shared/lib/services/endUser.service.ts
+++ b/packages/shared/lib/services/endUser.service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 import { Err, Ok } from '@nangohq/utils';
 
 import type { Knex } from '@nangohq/database';

--- a/scripts/validation/providers/validate.ts
+++ b/scripts/validation/providers/validate.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import Ajv from 'ajv';
-// eslint-disable-next-line import/order
 import chalk from 'chalk';
 import { dump, load } from 'js-yaml';
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**CLI: Introduce `nango test` command for local & remote integration testing with CI-ready reporting**

This PR adds a first-class end-to-end testing workflow to the Nango CLI by introducing the `nango test` command. The new command discovers and runs exported test functions in an integration workspace, either locally in the sandbox or remotely against a deployed Nango environment (via a new `/v1/tests` backend endpoint). Results are captured in a structured format, summarized in a Jest-style report, and the CLI now exits with the number of failed tests—making it immediately usable as a quality gate in CI pipelines.

Supporting work includes refactoring shared execution logic out of the dry-run and response-saver services, extending the SDK for remote test invocation, adding unit tests and dev dependencies, updating provider-validation scripts to invoke the new command, and documenting how to write and run integration tests. The change set is purely additive (no breaking API changes) but requires a backend version that exposes the new endpoint for remote execution.

---
*This summary was automatically generated by @propel-code-bot*