### PR TITLE
feat(integrations): add support for tiktok personal

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -770,6 +770,7 @@
               "integrations/all/thrivecart-oauth",
               "integrations/all/ticktick",
               "integrations/all/tiktok-accounts",
+              "integrations/all/tiktok-personal",
               "integrations/all/tiktok-ads",
               "integrations/all/timely",
               "integrations/all/todoist",

--- a/docs/integrations/all/tiktok-personal.mdx
+++ b/docs/integrations/all/tiktok-personal.mdx
@@ -1,0 +1,114 @@
+---
+title: 'TikTok Personal'
+sidebarTitle: 'TikTok Personal'
+description: 'Access the TikTok Personal API in 2 minutes 💨'
+---
+
+
+<Tabs>
+  <Tab title="🚀 Quickstart">
+    <Steps>
+      <Step title="Create an integration">
+        In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _TikTok Personal_.  Nango doesn't provide a test OAuth app for TikTok Personal yet. You’ll need to set up your own by following these [instructions](#🧑%E2%80%8D💻-oauth-app-setup). After that, make sure to add the OAuth client ID, secret, and scopes in the integration settings in Nango.
+      </Step>
+      <Step title="Authorize TikTok Personal">
+        Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then log in to TikTok. Later, you'll let your users do the same directly from your app.
+      </Step>
+      <Step title="Call the TikTok Personal API">
+        Let's make your first request to the TikTok Personal API (fetch user info). Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+        <Tabs>
+            <Tab title="cURL">
+
+                ```bash
+                curl "https://api.nango.dev/proxy/v2/user/info/?fields=open_id,union_id,avatar_url" \
+                  -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+                  -H "Provider-Config-Key: <INTEGRATION-ID>" \
+                  -H "Connection-Id: <CONNECTION-ID>"
+                ```
+
+            </Tab>
+
+            <Tab title="Node">
+
+            Install Nango's backend SDK with `npm i @nangohq/node`. Then run:
+
+            ```typescript
+            import { Nango } from '@nangohq/node';
+
+            const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+
+            const res = await nango.get({
+                endpoint: '/v2/user/info/',
+                providerConfigKey: '<INTEGRATION-ID>',
+                connectionId: '<CONNECTION-ID>',
+                params: {
+                  fields: 'open_id,union_id,avatar_url'
+                }
+            });
+
+            console.log(res.data.data);
+            ```
+            </Tab>
+
+
+        </Tabs>
+
+        Or fetch credentials dynamically via the [Node SDK](/reference/sdks/node#get-a-connection-with-credentials) or [API](/reference/api/connection/get).
+
+      </Step>
+    </Steps>
+
+    ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+
+    <Tip>
+    Next step: [Embed the auth flow](/getting-started/quickstart/embed-in-your-app) in your app to let your users connect their TikTok accounts.
+    </Tip>
+  </Tab>
+  <Tab title="🧑‍💻 OAuth app setup">
+   <Steps>
+  <Step title="Create a TikTok Developer account">
+    Go to [TikTok for Developers](https://developers.tiktok.com/) and sign in with your TikTok account. If you don't have a TikTok account, create one first.
+  </Step>
+  <Step title="Create & configure a TikTok app">
+    1. Navigate to [My Apps](https://developers.tiktok.com/apps/) and click _Create an app_. 
+    2. Select the app **Ownership**, enter a name, and select the **App Type**. Then click the **Create app** button.
+    3. Fill in all your app details:
+       - For **Platforms**, select **Web**
+       - For **Products**, make sure you select **Login Kit**
+       - In the Web **Login Kit** field, add `https://api.nango.dev/oauth/callback` as the **Redirect URL**
+       -  In the **Scopes** field, select the scopes your integration requires (e.g., `user.info.basic`, `video.list`, etc.). Copy these scopes as you will need them when configuring the integration in Nango.
+    4. After creating the app, go to the _Basic Information_ tab and note your **Client Key** and **Client Secret**. You will need these to configure the integration in Nango.
+    
+  </Step>
+  <Step title="Next">
+    Follow the [_Quickstart_](/getting-started/quickstart).
+  </Step>
+</Steps>
+  </Tab>
+  <Tab title="🔗 Useful links">
+    | Topic | Links |
+    | - | - |
+    | General | [Website](https://www.tiktok.com/) |
+    | | [TikTok for Developers](https://developers.tiktok.com/) |
+    | Developer | [API documentation](https://developers.tiktok.com/doc/overview) |
+    | | [My Apps](https://developers.tiktok.com/apps/) |
+    | | [How to register your Application](https://developers.tiktok.com/doc/getting-started-create-an-app) |
+    | | [How to add a Sandbox](https://developers.tiktok.com/doc/add-a-sandbox) |
+    | | [Authorization documentation](https://developers.tiktok.com/doc/login-kit-web) |
+    | | [Access Token exchange](https://developers.tiktok.com/doc/oauth-user-access-token-management) |
+    | | [OAuth scopes](https://developers.tiktok.com/doc/scopes-overview) |
+    | | [API Rate limiting](https://developers.tiktok.com/doc/tiktok-api-v2-rate-limit) |
+
+    <Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/tiktok-personal.mdx)</Note>
+  </Tab>
+  <Tab title="🚨 API gotchas">
+    _None yet, add yours!_
+
+    <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/tiktok-personal.mdx)</Note>
+  </Tab>
+</Tabs>
+
+<Info>
+    Questions? Join us in the [Slack community](https://nango.dev/slack).
+</Info>
+

--- a/docs/integrations/all/tiktok-personal.mdx
+++ b/docs/integrations/all/tiktok-personal.mdx
@@ -67,7 +67,7 @@ description: 'Access the TikTok Personal API in 2 minutes 💨'
   <Tab title="🧑‍💻 OAuth app setup">
    <Steps>
   <Step title="Create a TikTok Developer account">
-    Go to [TikTok for Developers](https://developers.tiktok.com/) and sign in with your TikTok account. If you don't have a TikTok account, create one first.
+    Go to [TikTok for Developers](https://developers.tiktok.com/) and sign in with your TikTok Developer's account. If you don't have a TikTok account, create one first.
   </Step>
   <Step title="Create & configure a TikTok app">
     1. Navigate to [My Apps](https://developers.tiktok.com/apps/) and click _Create an app_. 

--- a/docs/snippets/generated/tiktok-personal/PreBuiltTooling.mdx
+++ b/docs/snippets/generated/tiktok-personal/PreBuiltTooling.mdx
@@ -1,0 +1,41 @@
+## Pre-built tooling
+<AccordionGroup>
+<Accordion title="✅ Authorization">
+| Tools | Status |
+| - | - |
+| Pre-built authorization (OAuth) | ✅ |
+| Credentials auto-refresh | ✅ |
+| Auth parameters validation | ✅ |
+| Pre-built authorization UI | ✅ |
+| Custom authorization UI | ✅ |
+| Expired credentials detection | ✅ |
+</Accordion>
+<Accordion title="✅ Read & write data">
+| Tools | Status |
+| - | - |
+| Pre-built integrations | 🚫 (time to contribute: &lt;48h) |
+| API unification | ✅ |
+| 2-way sync | ✅ |
+| Webhooks from Nango on data modifications | ✅ |
+| Real-time webhooks from 3rd-party API | 🚫 (time to contribute: &lt;48h) |
+| Proxy requests | ✅ |
+</Accordion>
+<Accordion title="✅ Observability & data quality">
+| Tools | Status |
+| - | - |
+| HTTP request logging | ✅ |
+| End-to-type type safety | ✅ |
+| Data runtime validation | ✅ |
+| OpenTelemetry export | ✅ |
+| Slack alerts on errors | ✅ |
+| Integration status API | ✅ |
+</Accordion>
+<Accordion title="✅ Customization">
+| Tools | Status |
+| - | - |
+| Create or customize use-cases | ✅ |
+| Pre-configured pagination | 🚫 (time to contribute: &lt;48h) |
+| Pre-configured rate-limit handling | ✅ |
+| Per-customer configurations | ✅ |
+</Accordion>
+</AccordionGroup>

--- a/docs/snippets/generated/tiktok-personal/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/tiktok-personal/PreBuiltUseCases.mdx
@@ -1,0 +1,5 @@
+## Pre-built integrations
+
+_No pre-built integration yet (time to contribute: &lt;48h)_
+
+<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/platform/functions) independently.</Tip>

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -12845,6 +12845,30 @@ tiktok-ads:
         client_id: app_id
     docs: https://nango.dev/docs/integrations/all/tiktok-ads
 
+tiktok-personal:
+    display_name: TikTok Personal
+    categories:
+        - social
+    auth_mode: OAUTH2
+    authorization_url: https://www.tiktok.com/v2/auth/authorize/
+    token_url: https://open.tiktokapis.com/v2/oauth/token/
+    proxy:
+        base_url: https://open.tiktokapis.com
+        retry:
+            at:
+                - 'x-ratelimit-reset'
+    authorization_params:
+        response_type: code
+    token_params:
+        grant_type: authorization_code
+    refresh_params:
+        grant_type: refresh_token
+    body_format: form
+    scope_separator: ','
+    authorization_url_replacements:
+        client_id: client_key
+    docs: https://nango.dev/docs/integrations/all/tiktok-personal
+
 timely:
     display_name: Timely
     categories:

--- a/packages/shared/lib/clients/provider.client.ts
+++ b/packages/shared/lib/clients/provider.client.ts
@@ -35,6 +35,7 @@ class ProviderClient {
             case 'sharepoint-online':
             case 'tiktok-ads':
             case 'tiktok-accounts':
+            case 'tiktok-personal':
             case 'sentry-oauth':
             case 'stripe-app':
             case 'stripe-app-sandbox':
@@ -87,6 +88,8 @@ class ProviderClient {
                 return this.createStripeAppToken(tokenUrl, code, config.oauth_client_secret, callBackUrl);
             case 'tiktok-accounts':
                 return this.createTiktokAccountsToken(tokenUrl, code, config.oauth_client_id, config.oauth_client_secret, callBackUrl);
+            case 'tiktok-personal':
+                return this.createTiktokPersonalToken(tokenUrl, code, config.oauth_client_id, config.oauth_client_secret, callBackUrl);
             case 'workday-oauth':
                 return this.createWorkdayOauthAccessToken(tokenUrl, code, config.oauth_client_id, config.oauth_client_secret, callBackUrl, codeVerifier);
             default:
@@ -149,6 +152,13 @@ class ProviderClient {
             case 'tiktok-accounts':
                 return this.refreshTiktokAccountsToken(
                     provider.refresh_url as string,
+                    credentials.refresh_token as string,
+                    config.oauth_client_id,
+                    config.oauth_client_secret
+                );
+            case 'tiktok-personal':
+                return this.refreshTiktokPersonalToken(
+                    provider.token_url as string,
                     credentials.refresh_token as string,
                     config.oauth_client_id,
                     config.oauth_client_secret
@@ -593,6 +603,61 @@ class ProviderClient {
             throw new NangoError('tiktok_token_refresh_request_error');
         } catch (err: any) {
             throw new NangoError('tiktok_token_refresh_request_error', err.message);
+        }
+    }
+
+    private async createTiktokPersonalToken(tokenUrl: string, code: string, clientKey: string, clientSecret: string, redirectUri: string): Promise<object> {
+        try {
+            const headers = {
+                'Content-Type': 'application/x-www-form-urlencoded'
+            };
+
+            const body = {
+                client_key: clientKey,
+                client_secret: clientSecret,
+                code,
+                grant_type: 'authorization_code',
+                redirect_uri: redirectUri
+            };
+
+            const response = await axios.post(tokenUrl, body, { headers });
+
+            if (response.status === 200 && response.data) {
+                return {
+                    ...response.data
+                };
+            }
+
+            throw new NangoError('tiktok_personal_token_request_error', response.data);
+        } catch (err: any) {
+            throw new NangoError('tiktok_personal_token_request_error', err.message);
+        }
+    }
+
+    private async refreshTiktokPersonalToken(tokenUrl: string, refreshToken: string, clientKey: string, clientSecret: string): Promise<object> {
+        try {
+            const headers = {
+                'Content-Type': 'application/x-www-form-urlencoded'
+            };
+
+            const body = {
+                client_key: clientKey,
+                client_secret: clientSecret,
+                grant_type: 'refresh_token',
+                refresh_token: refreshToken
+            };
+
+            const response = await axios.post(tokenUrl, body, { headers });
+
+            if (response.status === 200 && response.data) {
+                return {
+                    ...response.data
+                };
+            }
+
+            throw new NangoError('tiktok_personal_refresh_token_request_error', response.data);
+        } catch (err: any) {
+            throw new NangoError('tiktok_personal_refresh_token_request_error', err.message);
         }
     }
 

--- a/packages/webapp/public/images/template-logos/tiktok-personal.svg
+++ b/packages/webapp/public/images/template-logos/tiktok-personal.svg
@@ -1,0 +1,1 @@
+tiktok-ads.svg


### PR DESCRIPTION
## Describe the problem and your solution
Add support for tiktok personal

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add first-class support for TikTok Personal accounts**

This PR introduces a brand-new "tiktok-personal" provider that lets customers connect and interact with non-business TikTok accounts. The work registers the provider (OAuth metadata, default scopes), extends the TypeScript SDK so `client.tiktokPersonal.*` is typed, adds end-user documentation and quick-start snippets, and ships branded assets for the dashboard. All changes are additive—no existing APIs or schemas are modified—making the release safe for a minor version bump while significantly widening the platform’s addressable creator base.

<details>
<summary><strong>Key Changes</strong></summary>

• Registered `tiktok-personal` provider in providers.yaml with OAuth settings and metadata
• Extended ProviderClient type map to expose typed `tiktokPersonal` client methods
• Added comprehensive docs page and auto-generated snippets for the new provider
• Included TikTok Personal SVG logo in the webapp asset pipeline

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/providers/providers.yaml
• packages/shared/lib/clients/provider.client.ts
• docs/integrations/all/tiktok-personal.mdx
• docs/snippets/generated/tiktok-personal/*
• packages/webapp/public/images/template-logos/

</details>

---
*This summary was automatically generated by @propel-code-bot*