### PR TITLE
fix(docs): add diagnostics info

### DIFF
--- a/docs/implementation-guides/syncs/implement-a-sync.mdx
+++ b/docs/implementation-guides/syncs/implement-a-sync.mdx
@@ -183,12 +183,20 @@ Easily test your integration functions locally as you develop them with the `dry
 nango dryrun salesforce-contacts '<CONNECTION-ID>'
 ```
 
-To learn more about all the options for dryrun, run: `nango dryrun --help`
+You can also enable performance diagnostics to monitor memory usage and CPU metrics:
+
+```bash
+nango dryrun salesforce-contacts '<CONNECTION-ID>' --diagnostics
+```
+
+The `--diagnostics` flag displays detailed performance metrics including average and peak memory usage (RSS, heap, external) and CPU utilization, which is useful for performance tuning and identifying memory leaks.
+
+To learn more about all the options for the dryrun, run: `nango dryun --help`.
 
 Because this is a dry run, syncs won't persist data in Nango. Instead, the retrieved data is printed to the console.
 
 <Tip>
-    By default, `dryrun` retrieves connections from your `dev` environment. You can change this with a CLI flag.
+    By default, `dryrun` retrieves connections from your `dev` environment. You can change this with the `-e` flag.
 </Tip>
 
 ### Step 6 - Deploy your sync

--- a/docs/implementation-guides/syncs/implement-a-sync.mdx
+++ b/docs/implementation-guides/syncs/implement-a-sync.mdx
@@ -191,7 +191,7 @@ nango dryrun salesforce-contacts '<CONNECTION-ID>' --diagnostics
 
 The `--diagnostics` flag displays detailed performance metrics including average and peak memory usage (RSS, heap, external) and CPU utilization, which is useful for performance tuning and identifying memory leaks.
 
-To learn more about all the options for the dryrun, run: `nango dryun --help`.
+To learn more about all the options for the dryrun, run: `nango dryrun --help`.
 
 Because this is a dry run, syncs won't persist data in Nango. Instead, the retrieved data is printed to the console.
 

--- a/docs/implementation-guides/syncs/implement-a-sync.mdx
+++ b/docs/implementation-guides/syncs/implement-a-sync.mdx
@@ -191,6 +191,10 @@ nango dryrun salesforce-contacts '<CONNECTION-ID>' --diagnostics
 
 The `--diagnostics` flag displays detailed performance metrics including average and peak memory usage (RSS, heap, external) and CPU utilization, which is useful for performance tuning and identifying memory leaks.
 
+<Warning>
+Local diagnostics are indicative only and do not fully represent CPU/memory consumption when run by Nango Cloud. Performance characteristics may differ between local and cloud environments.
+</Warning>
+
 To learn more about all the options for the dryrun, run: `nango dryrun --help`.
 
 Because this is a dry run, syncs won't persist data in Nango. Instead, the retrieved data is printed to the console.


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Docs: document `--diagnostics` flag in `nango dryrun` guide**

Updates the sync implementation guide to show how to invoke `nango dryrun` with the `--diagnostics` flag, explains reported metrics, adds a cloud-vs-local disclaimer, and fixes minor wording/typos. No application or library code is touched; change is strictly in markdown documentation.

<details>
<summary><strong>Key Changes</strong></summary>

• Inserted new example command `nango dryrun <CONNECTION-ID> --diagnostics`
• Added paragraph describing metrics returned by the `--diagnostics` flag (RSS, heap, external memory, CPU)
• Added `<Warning>` block clarifying that local diagnostics may differ from Nango Cloud behaviour
• Replaced generic environment tip with explicit reference to the `-e` flag
• Restored previously missing list item in cursor-based sync section and corrected minor typos

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs/implementation-guides/syncs/implement-a-sync.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*