### PR TITLE
docs: Add Mastra example and improve other examples

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -192,6 +192,7 @@
             "pages": [
               "implementation-guides/ai-tool-calling/openai-sdk",
               "implementation-guides/ai-tool-calling/anthropic-sdk",
+              "implementation-guides/ai-tool-calling/mastra-sdk",
               "implementation-guides/ai-tool-calling/any-llm-sdk",
               "implementation-guides/ai-tool-calling/implement-mcp-server"
             ]

--- a/docs/guides/use-cases/ai-tool-calling.mdx
+++ b/docs/guides/use-cases/ai-tool-calling.mdx
@@ -62,6 +62,6 @@ For RAG-style use cases where data must be replicated locally, use [Syncs](/guid
 Nango works with any framework or SDK that supports tool calling. Here are some example guides to perform tool calling with:
 - [OpenAI](/implementation-guides/ai-tool-calling/openai-sdk) SDK
 - [Anthropic](/implementation-guides/ai-tool-calling/anthropic-sdk) SDK
-- [Mastra](/implementation-guides/ai-tool-calling/anthropic-sdk) SDK
+- [Mastra](/implementation-guides/ai-tool-calling/mastra-sdk) SDK
 - [any LLM SDK](/implementation-guides/ai-tool-calling/any-llm-sdk)
 - [MCP](/implementation-guides/ai-tool-calling/implement-mcp-server)

--- a/docs/guides/use-cases/ai-tool-calling.mdx
+++ b/docs/guides/use-cases/ai-tool-calling.mdx
@@ -59,8 +59,9 @@ For RAG-style use cases where data must be replicated locally, use [Syncs](/guid
 
 ## Implementation guides
 
-Nango works with any framework or SDK that supports tool calling. Here are some example guides:
-- [Tool calling with the OpenAI SDK](/implementation-guides/ai-tool-calling/openai-sdk)
-- [Tool calling with the Anthropic SDK](/implementation-guides/ai-tool-calling/anthropic-sdk)
-- [Tool calling with any LLM SDK](/implementation-guides/ai-tool-calling/any-llm-sdk)
-- [Tool calling with MCP](/implementation-guides/ai-tool-calling/implement-mcp-server)
+Nango works with any framework or SDK that supports tool calling. Here are some example guides to perform tool calling with:
+- [OpenAI](/implementation-guides/ai-tool-calling/openai-sdk) SDK
+- [Anthropic](/implementation-guides/ai-tool-calling/anthropic-sdk) SDK
+- [Mastra](/implementation-guides/ai-tool-calling/anthropic-sdk) SDK
+- [any LLM SDK](/implementation-guides/ai-tool-calling/any-llm-sdk)
+- [MCP](/implementation-guides/ai-tool-calling/implement-mcp-server)

--- a/docs/implementation-guides/ai-tool-calling/anthropic-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/anthropic-sdk.mdx
@@ -15,7 +15,7 @@ This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. T
 </Tip>
 
 **Requirements:** 
-- A Nango account with an Hubspot integration configured and the `whoami` action enabled.
+- A Nango account with a Hubspot integration configured and the `whoami` action enabled.
 - An Anthropic account.
 
 ## Usage

--- a/docs/implementation-guides/ai-tool-calling/any-llm-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/any-llm-sdk.mdx
@@ -15,7 +15,7 @@ This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. T
 </Tip>
 
 **Requirements:** 
-- A Nango account with an Hubspot integration configured and the `whoami` action enabled.
+- A Nango account with a Hubspot integration configured and the `whoami` action enabled.
 - An account with your preferred LLM provider.
 
 ## Usage

--- a/docs/implementation-guides/ai-tool-calling/any-llm-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/any-llm-sdk.mdx
@@ -1,29 +1,26 @@
 ---
-title: "Any LLM SDK example"
-sidebarTitle: "Any LLM SDK example"
+title: "Any LLM"
+sidebarTitle: "Any LLM"
 description: "End-to-end example of calling external APIs via tool calling with any LLM provider."
 ---
 
-This guide shows how to combine **Nango** with **any LLM provider** to consume external APIs via tool calling.
+## Setup
 
-## Example overview
+```bash
+npm i @nangohq/node
+```
 
-The example below uses Hubspot’s API to demonstrate how to access a user’s external account through Nango.
 <Tip>
-**Requirements**
-- A Nango account with an integration for `hubspot` and the `whoami` action enabled.
-- An account with your preferred LLM provider.
+This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](https://nango.dev/docs/reference/api/authentication).
 </Tip>
 
-In this example:
-1. Check if the user is already authenticated with Hubspot.  
-2. If not, start the Hubspot OAuth flow. You can do this:
-   - Directly in the chat session, or  
-   - By embedding the [Frontend SDK](https://nango.dev/docs/implementation-guides/api-auth/implement-api-auth#2-trigger-the-auth-flow-frontend) in your app.  
-3. Send a prompt to your model.
-4. When the model calls a tool, trigger the corresponding Nango action.
+**Requirements:** 
+- A Nango account with an Hubspot integration configured and the `whoami` action enabled.
+- An account with your preferred LLM provider.
 
-## Example code
+## Usage
+
+Example of a basic tool that calls an external API (Hubspot):
 
 ```ts
 import { Nango } from "@nangohq/node";
@@ -94,10 +91,5 @@ export async function runLLMAgent(modelClient: any) {
 ```
 
 <Tip>
-This example uses the **Nango Node SDK**, which is a thin wrapper around Nango’s REST API. You can use the same flow in any language with the [API reference](https://nango.dev/docs/reference/api/authentication).
-</Tip>
-
-<Tip>
-You can let agents or models introspect available tools and their specifications by calling this  
-[endpoint](/reference/api/scripts/config). Your model can then automatically decide which tool to call.
+You can let agents or models introspect available tools and their specifications by calling this [endpoint](/reference/api/scripts/config). Your model can then automatically decide which tool to call.
 </Tip>

--- a/docs/implementation-guides/ai-tool-calling/mastra-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/mastra-sdk.mdx
@@ -15,7 +15,7 @@ This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. T
 </Tip>
 
 **Requirements:** 
-- A Nango account with an Hubspot integration configured and the `whoami` action enabled.
+- A Nango account with a Hubspot integration configured and the `whoami` action enabled.
 - An OpenAI account (or another LLM provider).
 
 ## Usage

--- a/docs/implementation-guides/ai-tool-calling/mastra-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/mastra-sdk.mdx
@@ -1,13 +1,13 @@
 ---
-title: "Anthropic"
-sidebarTitle: "Anthropic"
-description: "End-to-end example of calling external tools with the Anthropic SDK."
+title: "Mastra"
+sidebarTitle: "Mastra"
+description: "End-to-end example of calling external tools with the Mastra SDK."
 ---
 
 ## Setup
 
 ```bash
-npm i @anthropic-ai/sdk @nangohq/node
+npm i @mastra/core @nangohq/node
 ```
 
 <Tip>
@@ -16,18 +16,22 @@ This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. T
 
 **Requirements:** 
 - A Nango account with an Hubspot integration configured and the `whoami` action enabled.
-- An Anthropic account.
+- An OpenAI account (or another LLM provider).
 
 ## Usage
 
 Example of a basic tool that calls an external API (Hubspot):
 
 ```ts
-import Anthropic from '@anthropic-ai/sdk';
+import { Agent } from "@mastra/core/agent";
+import { createTool } from "@mastra/core/tools";
 import { Nango } from "@nangohq/node";
 
-export async function runAnthropicAgent() {
-  const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+export async function runMastraAgent() {
+  if (!process.env.OPENAI_API_KEY) {
+    console.log("Missing environment variable: OPENAI_API_KEY.")
+  }
+
   const nango = new Nango({ secretKey: process.env.NANGO_SECRET_KEY! });
 
   const userId = "user1", integrationId = "hubspot";
@@ -49,45 +53,27 @@ export async function runAnthropicAgent() {
     connectionId = connection!.connection_id;
   }
 
-  // Step 3: Send a prompt to your model with tool definitions
-  console.log("🤖 Agent running...")
-  const message = await client.messages.create({
-    model: "claude-sonnet-4-5",
-    max_tokens: 1024,
-    messages: [
-      {
-        role: "user",
-        content: "Using the who_am_i tool, provide the current user info."
-      }
-    ],
-    tools: [
-      {
-        name: "who_am_i",
+  // Step 3: Send a prompt to your model.
+  const agent = new Agent({
+    name: "Hubspot Agent",
+    instructions: "You are a helpful assistant that can access Hubspot data.",
+    model: "openai/gpt-4o",
+    tools: {
+      who_am_i: createTool({
+        id: "who_am_i",
         description: "Get the current user info.",
-        input_schema: {
-          type: "object",
-          properties: {},
-          required: []
-        }
-      }
-    ],
-    tool_choice: { type: "auto" }
+        execute: async () => {
+          // Step 4: Execute the requested tool with Nango.
+          return await nango.triggerAction(integrationId, connectionId, "whoami"); // Call tool via Nango.
+        },
+      }),
+    },
   });
-  
-  // Check if Claude requested a tool call
-  const toolUse = message.content.find((content) => content.type === "tool_use");
-  
-  if (toolUse && toolUse.type === "tool_use" && toolUse.name === "who_am_i") {
-    try {
-      // Step 4: Execute the requested tool with Nango
-      const userInfo = await nango.triggerAction(integrationId, connectionId, "whoami"); // Call tools via Nango
-      console.log("✅ Agent retrieved your Hubspot user info:", userInfo);
-    } catch (error: any) {
-      console.error("Nango API error:", error.response?.data?.error || error);
-    }
-  } else {
-    console.log(message.content.find((c) => c.type === "text")?.text);
-  }
+
+  console.log("🤖 Agent running...")
+  const response = await agent.generate("Using the who_am_i tool, provide the current user info.");
+
+  console.log("✅ Agent retrieved your Hubspot user info:", response.text);
 }
 ```
 

--- a/docs/implementation-guides/ai-tool-calling/openai-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/openai-sdk.mdx
@@ -1,30 +1,26 @@
 ---
-title: "OpenAI SDK example"
-sidebarTitle: "OpenAI SDK example"
+title: "OpenAI"
+sidebarTitle: "OpenAI"
 description: "End-to-end example of calling external tools with the OpenAI SDK."
 ---
 
-This guide demonstrates how to combine **Nango** and the **OpenAI SDK** to consume external APIs via tool calling.
+## Setup
 
-## Example overview
-
-The example below uses Hubspot's API to demonstrate how to access a user’s external account through Nango.
+```bash
+npm i openai @nangohq/node
+```
 
 <Tip>
-**Requirements:** 
-- A Nango account with an integration for `Hubspot` with the `whoami` action enabled.
-- An OpenAI account.
+This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](https://nango.dev/docs/reference/api/authentication).
 </Tip>
 
-In this example:
-1. Check if the user is already authenticated with Hubspot.  
-2. If not, start the Hubspot OAuth flow. You can do this:
-   - Directly in the chat session, or  
-   - By embedding the [Frontend SDK](https://nango.dev/docs/implementation-guides/api-auth/implement-api-auth#2-trigger-the-auth-flow-frontend) in your app.  
-3. Send a prompt to your model.
-4. When the model calls a tool, trigger the corresponding Nango action.
+**Requirements:** 
+- A Nango account with an Hubspot integration configured and the `whoami` action enabled.
+- An OpenAI account.
 
-## Example code
+## Usage
+
+Example of a basic tool that calls an external API (Hubspot):
 
 ```ts
 import OpenAI from "openai";
@@ -88,10 +84,5 @@ export async function runOpenAIAgent() {
 ```
 
 <Tip>
-This example uses the **Nango Node SDK**, which is a thin wrapper around Nango’s REST API. You can use the same flow in any language with the [API reference](https://nango.dev/docs/reference/api/authentication).
-</Tip>
-
-<Tip>
-You can let agents or models introspect available tools and their specifications by calling this  
-[endpoint](/reference/api/scripts/config). Your model can then automatically decide which tool to call.
+You can let agents or models introspect available tools and their specifications by calling this [endpoint](/reference/api/scripts/config). Your model can then automatically decide which tool to call.
 </Tip>

--- a/docs/implementation-guides/ai-tool-calling/openai-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/openai-sdk.mdx
@@ -15,7 +15,7 @@ This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. T
 </Tip>
 
 **Requirements:** 
-- A Nango account with an Hubspot integration configured and the `whoami` action enabled.
+- A Nango account with a Hubspot integration configured and the `whoami` action enabled.
 - An OpenAI account.
 
 ## Usage


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add `mastra-sdk` guide and align AI tool-calling docs**

Adds a new `docs/implementation-guides/ai-tool-calling/mastra-sdk.mdx` page and refactors existing OpenAI, Anthropic, and Any-LLM examples to share a unified "Setup / Requirements / Usage / Tips" structure. Updates `docs/guides/use-cases/ai-tool-calling.mdx` and `docs/docs.json` navigation to surface the new guide and rename side-bar titles for consistency. All changes are documentation-only; no runtime code is affected.

<details>
<summary><strong>Key Changes</strong></summary>

• New guide `docs/implementation-guides/ai-tool-calling/mastra-sdk.mdx` with full TypeScript example
• Retitled existing guides (`openai-sdk.mdx`, `anthropic-sdk.mdx`, `any-llm-sdk.mdx`) to concise names and re-organised content sections
• Harmonised Tip blocks, removed duplicated explanations, and corrected heading hierarchy across all AI tool-calling guides
• Updated implementation-guide list in `docs/guides/use-cases/ai-tool-calling.mdx` to include `Mastra` and re-phrased intro sentence
• Extended `docs/docs.json` navigation arrays to reference `implementation-guides/ai-tool-calling/mastra-sdk`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs/implementation-guides/ai-tool-calling/*`
• `docs/guides/use-cases/ai-tool-calling.mdx`
• `docs/docs.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*