### PR TITLE
fix: allow webhooks for free plans

### DIFF
--- a/packages/database/lib/migrations/20251110180000_allow_webhooks_on_free_plans.cjs
+++ b/packages/database/lib/migrations/20251110180000_allow_webhooks_on_free_plans.cjs
@@ -1,0 +1,16 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex('plans').where('name', 'free').update({
+        has_webhooks_script: true,
+        has_webhooks_forward: true
+    });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -24,8 +24,8 @@ export const freePlan: PlanDefinition = {
         auto_idle: true,
         monthly_actions_max: 1000,
         monthly_active_records_max: 5000,
-        has_webhooks_script: false,
-        has_webhooks_forward: false,
+        has_webhooks_script: true,
+        has_webhooks_forward: true,
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: false,
         can_disable_connect_ui_watermark: false


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Enable webhooks for `free` plan**

This PR lifts the webhook restrictions on the `free` pricing tier. It introduces one Knex migration that updates existing `plans` records and aligns the in-memory `freePlan` definition so that new accounts are provisioned with webhook capabilities.

<details>
<summary><strong>Key Changes</strong></summary>

• Added migration `packages/database/lib/migrations/20251110180000_allow_webhooks_on_free_plans.cjs` to set `has_webhooks_script` and `has_webhooks_forward` to `true` where `name = 'free'`
• Modified `packages/shared/lib/services/plans/definitions.ts` to set `freePlan.flags.has_webhooks_script` and `freePlan.flags.has_webhooks_forward` to `true`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `plans` table data
• `packages/shared/lib/services/plans/definitions.ts`
• Any logic that checks plan feature flags

</details>

---
*This summary was automatically generated by @propel-code-bot*