### PR TITLE
fix(zero-yaml): allow type imports

### DIFF
--- a/packages/cli/lib/zeroYaml/compile.ts
+++ b/packages/cli/lib/zeroYaml/compile.ts
@@ -401,7 +401,7 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
                         }
 
                         // Check if the imported package is in the allowed list, but allow types since this is compile time only
-                        if (!allowedPackages.includes(source) && kind?.toString() !== 'type') {
+                        if (!allowedPackages.includes(source) && kind !== 'type') {
                             throw new CompileError(
                                 'disallowed_import',
                                 lineNumber,

--- a/packages/cli/lib/zeroYaml/compile.ts
+++ b/packages/cli/lib/zeroYaml/compile.ts
@@ -279,9 +279,9 @@ export async function bundleFile({ entryPoint, projectRootPath }: { entryPoint: 
             // Babel is wrapping our own custom error but I couldn't find a way to access the original error easily
             // So we serialize it and hope for the best
             const obj = serializeError(err) as Record<string, any>;
-            if ('errors' in obj) {
-                const custom = obj['errors'][0]['detail'];
-                if (custom['type']) {
+            if ('errors' in obj && Array.isArray(obj['errors']) && obj['errors'].length > 0) {
+                const custom = obj['errors'][0]?.['detail'];
+                if (custom && custom['type']) {
                     return Err(new CompileError(custom['type'], custom['lineNumber'], custom['customMessage'], friendlyPath));
                 }
             }
@@ -390,6 +390,7 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
                     ImportDeclaration(path) {
                         const lineNumber = path.node.loc?.start.line || 0;
                         const source = path.node.source.value;
+                        const kind = path.node.importKind;
                         if (typeof source !== 'string') {
                             return;
                         }
@@ -399,8 +400,8 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
                             return;
                         }
 
-                        // Check if the imported package is in the allowed list
-                        if (!allowedPackages.includes(source)) {
+                        // Check if the imported package is in the allowed list, but allow types since this is compile time only
+                        if (!allowedPackages.includes(source) && kind?.toString() !== 'type') {
                             throw new CompileError(
                                 'disallowed_import',
                                 lineNumber,


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
If a nango-integration had a type import for example:

```
import type { RecordMetadata } from '@nangohq/types';
```
We would throw an error:
```err - ./hubspot/syncs/deals.ts 
  Import of package '@nangohq/types' is not allowed. Allowed packages are: url, node:url, crypto, node:crypto, nango, zod, unzipper, soap, botbuilder
```

but this is a legitimate use case. This updates the compilation to allow it
<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Zero-yaml compiler: permit `import type` statements & harden error unwrapping**

Small change in `packages/cli/lib/zeroYaml/compile.ts` to allow type-only imports from external packages during compile time and to make the error-deserialization guard more robust. This prevents false "disallowed import" errors for legitimate `import type …` lines and avoids runtime crashes when the wrapped error object does not contain the expected `errors` array.

<details>
<summary><strong>Key Changes</strong></summary>

• Captured `const kind = path.node.importKind` in `ImportDeclaration` visitor
• Skipped disallowed-package check when `kind === 'type'` (`!allowedPackages.includes(source) && kind !== 'type')`)
• Strengthened custom-error extraction: now checks `Array.isArray(obj['errors']) && obj['errors'].length > 0` and uses optional chaining on nested access

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/cli/lib/zeroYaml/compile.ts` (Babel `nangoPlugin` import validation & error handling paths)

</details>

---
*This summary was automatically generated by @propel-code-bot*