### PR TITLE
chore(webapp): use text utilities from figma

### DIFF
--- a/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
@@ -60,8 +60,8 @@ export const EnvironmentDropdown: React.FC = () => {
                         <div className="flex gap-2 items-center">
                             <LogoInverted className="h-6 w-6 text-text-primary" />
                             <div className="flex flex-col items-start">
-                                <span className="text-s leading-3 text-text-secondary">Environment</span>
-                                <span className="text-sm leading-4 text-text-primary font-semibold truncate max-w-28">{env}</span>
+                                <span className="text-body-small-regular leading-3 text-text-secondary">Environment</span>
+                                <span className="text-body-medium-semi leading-4 text-text-primary font-semibold truncate max-w-28">{env}</span>
                             </div>
                         </div>
                         <ChevronsUpDown className="w-4.5 h-4.5 text-text-primary" />

--- a/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
@@ -78,13 +78,13 @@ export const ProfileDropdown: React.FC = () => {
             <SidebarMenuItem>
                 <DropdownMenu modal={false}>
                     <DropdownMenuTrigger className="group/profile cursor-pointer h-fit w-full p-3 inline-flex items-center justify-between bg-dropdown-bg-default hover:bg-dropdown-bg-hover active:bg-dropdown-bg-press border-t-[0.5px] border-border-muted">
-                        <div className="inline-flex gap-2">
+                        <div className="inline-flex gap-2 items-center">
                             <div className="size-10 flex items-center justify-center rounded bg-bg-surface border border-border-muted text-text-primary leading-5">
                                 {initials}
                             </div>
                             <div className="flex flex-col gap-1 items-start">
-                                <span className="text-sm font-semibold text-text-primary truncate max-w-28 ">{user?.name}</span>
-                                <span className="text-text-secondary text-s leading-3 pb-px truncate max-w-28">{user?.email}</span>
+                                <span className="text-body-medium-semi leading-4 text-text-primary truncate max-w-28 ">{user?.name}</span>
+                                <span className="text-body-small-regular leading-3 text-text-secondary pb-px truncate max-w-28">{user?.email}</span>
                             </div>
                         </div>
                         <ChevronsUpDown className="size-4.5 text-text-tertiary group-hover/profile:text-text-secondary group-active/profile:text-text-primary" />

--- a/packages/webapp/src/components-v2/Navigation.tsx
+++ b/packages/webapp/src/components-v2/Navigation.tsx
@@ -11,7 +11,7 @@ export const NavigationList: React.FC<React.ComponentProps<typeof TabsPrimitive.
 export const NavigationTrigger: React.FC<React.ComponentProps<typeof TabsPrimitive.Trigger>> = (props) => {
     return (
         <TabsPrimitive.Trigger
-            className="w-full p-2.5 cursor-pointer text-text-secondary text-sm font-medium text-start rounded hover:bg-bg-surface hover:text-text-primary data-[state=active]:bg-bg-subtle data-[state=active]:text-text-primary focus-default"
+            className="w-full p-2.5 cursor-pointer text-text-secondary text-body-medium-medium text-start rounded hover:bg-bg-surface hover:text-text-primary data-[state=active]:bg-bg-subtle data-[state=active]:text-text-primary focus-default"
             {...props}
         />
     );

--- a/packages/webapp/src/components-v2/StyledLink.tsx
+++ b/packages/webapp/src/components-v2/StyledLink.tsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom';
 import type { VariantProps } from 'class-variance-authority';
 
 const styledLinkVariants = cva(
-    'w-fit text-sm underline inline-flex items-center cursor-pointer focus-default disabled:text-link-disabled disabled:[&_svg]:text-link-disabled',
+    'w-fit text-body-medium-medium underline inline-flex items-center cursor-pointer focus-default disabled:text-link-disabled disabled:[&_svg]:text-link-disabled',
     {
         variants: {
             variant: {

--- a/packages/webapp/src/components-v2/ui/alert.tsx
+++ b/packages/webapp/src/components-v2/ui/alert.tsx
@@ -34,7 +34,7 @@ function AlertDescription({ className, ...props }: React.ComponentProps<'div'>) 
     return (
         <div
             data-slot="alert-description"
-            className={cn('col-start-2 self-start inline-flex justify-items-start gap-1 text-sm leading-5', className)}
+            className={cn('col-start-2 self-start inline-flex justify-items-start gap-1 text-body-medium-regular', className)}
             {...props}
         />
     );

--- a/packages/webapp/src/components-v2/ui/button.tsx
+++ b/packages/webapp/src/components-v2/ui/button.tsx
@@ -9,7 +9,7 @@ import type { VariantProps } from 'class-variance-authority';
 import type { LinkProps } from 'react-router-dom';
 
 const buttonVariants = cva(
-    "w-fit inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm transition-all cursor-pointer disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-default",
+    "w-fit inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md !text-body-medium-medium transition-all cursor-pointer disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-default",
     {
         variants: {
             variant: {
@@ -22,8 +22,8 @@ const buttonVariants = cva(
                 ghost: 'bg-transparent text-text-tertiary hover:text-text-primary'
             },
             size: {
-                sm: 'h-8 rounded gap-1.5 px-3 py-2 text-sm',
-                lg: 'h-10 rounded gap-2 px-4 py-2 font-medium',
+                sm: 'h-8 rounded gap-1.5 px-3 py-2',
+                lg: 'h-10 rounded gap-2 px-4 py-2',
                 icon: 'size-5 p-1'
             }
         },

--- a/packages/webapp/src/components-v2/ui/dialog.tsx
+++ b/packages/webapp/src/components-v2/ui/dialog.tsx
@@ -80,7 +80,7 @@ function DialogTitle({ className, ...props }: React.ComponentProps<typeof Dialog
 }
 
 function DialogDescription({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Description>) {
-    return <DialogPrimitive.Description data-slot="dialog-description" className={cn('text-text-secondary text-sm', className)} {...props} />;
+    return <DialogPrimitive.Description data-slot="dialog-description" className={cn('text-text-secondary text-body-medium-regular', className)} {...props} />;
 }
 
 export { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger };

--- a/packages/webapp/src/components-v2/ui/dropdown-menu.tsx
+++ b/packages/webapp/src/components-v2/ui/dropdown-menu.tsx
@@ -51,7 +51,7 @@ function DropdownMenuItem({
             data-inset={inset}
             data-variant={variant}
             className={cn(
-                "focus:bg-dropdown-bg-hover focus:text-text-primary data-[variant=destructive]:text-red-500 data-[variant=destructive]:focus:bg-red-500/10 data-[variant=destructive]:focus:text-red-500 data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-neutral-500 relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+                "focus:bg-dropdown-bg-hover focus:text-text-primary data-[variant=destructive]:text-red-500 data-[variant=destructive]:focus:bg-red-500/10 data-[variant=destructive]:focus:text-red-500 data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-neutral-500 relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-body-medium-medium outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
                 className
             )}
             {...props}
@@ -64,7 +64,7 @@ function DropdownMenuCheckboxItem({ className, children, checked, ...props }: Re
         <DropdownMenuPrimitive.CheckboxItem
             data-slot="dropdown-menu-checkbox-item"
             className={cn(
-                "focus:bg-neutral-100 focus:text-neutral-900 relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 dark:focus:bg-neutral-800 dark:focus:text-neutral-50",
+                "focus:bg-neutral-100 focus:text-neutral-900 relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-body-medium-medium outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 dark:focus:bg-neutral-800 dark:focus:text-neutral-50",
                 className
             )}
             checked={checked}
@@ -89,7 +89,7 @@ function DropdownMenuRadioItem({ className, children, ...props }: React.Componen
         <DropdownMenuPrimitive.RadioItem
             data-slot="dropdown-menu-radio-item"
             className={cn(
-                "focus:bg-neutral-100 focus:text-neutral-900 relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 dark:focus:bg-neutral-800 dark:focus:text-neutral-50",
+                "focus:bg-neutral-100 focus:text-neutral-900 relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-body-medium-medium outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 dark:focus:bg-neutral-800 dark:focus:text-neutral-50",
                 className
             )}
             {...props}

--- a/packages/webapp/src/components-v2/ui/form.tsx
+++ b/packages/webapp/src/components-v2/ui/form.tsx
@@ -90,7 +90,7 @@ function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
 function FormDescription({ className, ...props }: React.ComponentProps<'p'>) {
     const { formDescriptionId } = useFormField();
 
-    return <p data-slot="form-description" id={formDescriptionId} className={cn('text-text-tertiary text-s leading-4', className)} {...props} />;
+    return <p data-slot="form-description" id={formDescriptionId} className={cn('!text-text-tertiary text-body-small-regular', className)} {...props} />;
 }
 
 function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
@@ -102,7 +102,7 @@ function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
     }
 
     return (
-        <p data-slot="form-message" id={formMessageId} className={cn('text-feedback-error-fg text-s leading-4', className)} {...props}>
+        <p data-slot="form-message" id={formMessageId} className={cn('!text-feedback-error-fg text-body-small-regular', className)} {...props}>
             {body}
         </p>
     );

--- a/packages/webapp/src/components-v2/ui/input.tsx
+++ b/packages/webapp/src/components-v2/ui/input.tsx
@@ -9,8 +9,8 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
             data-slot="input"
             data-filled={props.value !== ''}
             className={cn(
-                'bg-bg-surface border border-border-muted text-text-primary placeholder:text-text-tertiary focus-shadow focus:border-border-default data-[filled=true]:not-aria-invalid:border-border-strong',
-                'file:text-neutral-950  flex h-9 w-full min-w-0 rounded px-3 py-1 shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+                'bg-bg-surface border border-border-muted text-text-primary !text-body-medium-regular placeholder:text-text-tertiary focus-shadow focus:border-border-default data-[filled=true]:not-aria-invalid:border-border-strong',
+                'file:text-neutral-950  flex h-9 w-full min-w-0 rounded px-3 py-1 shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-body-medium-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
                 'aria-invalid:focus-error aria-invalid:border-feedback-error-border',
                 className
             )}

--- a/packages/webapp/src/components-v2/ui/label.tsx
+++ b/packages/webapp/src/components-v2/ui/label.tsx
@@ -8,7 +8,7 @@ function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimiti
         <LabelPrimitive.Root
             data-slot="label"
             className={cn(
-                'flex items-center gap-2 text-text-primary text-sm font-medium select-none group-data-[disabled=true]:pointer-events-none peer-disabled:cursor-not-allowed',
+                'flex items-center gap-2 text-text-primary text-body-medium-medium select-none group-data-[disabled=true]:pointer-events-none peer-disabled:cursor-not-allowed',
                 className
             )}
             {...props}

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -554,12 +554,6 @@
     font-weight: 400;
 }
 
-@utility body-small-regular {
-    font-size: 12px;
-    line-height: 16px;
-    font-weight: 400;
-}
-
 @utility text-body-small-semi {
     font-size: 12px;
     line-height: 16px;

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -488,6 +488,90 @@
     }
 }
 
+@utility text-title-screen {
+    font-size: 40px;
+    line-height: 48px;
+    font-weight: 700;
+}
+
+@utility text-title-section {
+    font-size: 32px;
+    line-height: 40px;
+    font-weight: 700;
+}
+
+@utility text-title-subsection {
+    font-size: 24px;
+    line-height: 32px;
+    font-weight: 700;
+}
+
+@utility text-title-group {
+    font-size: 20px;
+    line-height: 28px;
+    font-weight: 600;
+}
+
+@utility text-title-body {
+    font-size: 18px;
+    line-height: 24px;
+    font-weight: 600;
+}
+
+@utility text-body-large-regular {
+    font-size: 16px;
+    line-height: 24px;
+    font-weight: 400;
+}
+
+@utility text-body-large-semi {
+    font-size: 16px;
+    line-height: 24px;
+    font-weight: 600;
+}
+
+@utility text-body-medium-regular {
+    font-size: 14px;
+    line-height: 20px;
+    font-weight: 400;
+}
+
+@utility text-body-medium-medium {
+    font-size: 14px;
+    line-height: 20px;
+    font-weight: 500;
+}
+
+@utility text-body-medium-semi {
+    font-size: 14px;
+    line-height: 20px;
+    font-weight: 600;
+}
+
+@utility text-body-small-regular {
+    font-size: 12px;
+    line-height: 16px;
+    font-weight: 400;
+}
+
+@utility body-small-regular {
+    font-size: 12px;
+    line-height: 16px;
+    font-weight: 400;
+}
+
+@utility text-body-small-semi {
+    font-size: 12px;
+    line-height: 16px;
+    font-weight: 600;
+}
+
+@utility text-body-extra-small-semi {
+    font-size: 12px;
+    line-height: 14px;
+    font-weight: 600;
+}
+
 /*
   The default border color has changed to `currentcolor` in Tailwind CSS v4,
   so we've added these compatibility styles to make sure everything still


### PR DESCRIPTION
We have clear text utilities in figma, but I've copying text styles manually. I should have done this from the start, as it helps with consistency and dev speed. This is not an exhaustive replacement, but it allows me to use these in new things, and to replace as I go from now on.

<!-- Summary by @propel-code-bot -->

---

**Standardize typography with Figma-based text utilities**

Introduces a set of 18 Figma-aligned `@utility` typography classes in `packages/webapp/src/index.css` and refactors multiple React components to consume these classes instead of ad-hoc Tailwind font/size utilities. The goal is to drive UI consistency, simplify further styling work, and accelerate adoption of the design system across the webapp.

<details>
<summary><strong>Key Changes</strong></summary>

• Added 18 new text utility classes (e.g., `text-title-screen`, `text-body-medium-semi`) under `@utility` in `index.css`
• Removed duplicate utility and fixed naming collision (`body-small-regular` ➜ `text-body-small-regular`)
• Replaced hard-coded Tailwind text classes with new utilities in `ProfileDropdown`, `EnvironmentDropdown`, `Navigation`, and several design-system components (`button.tsx`, `input.tsx`, `label.tsx`, `alert.tsx`, `dialog.tsx`, `dropdown-menu.tsx`, `form.tsx`, `StyledLink.tsx`)
• Updated default variants in `buttonVariants` and `styledLinkVariants` to apply `!text-body-medium-medium`
• Minor spacing/flex tweaks where structure changed (e.g., added `items-center` in `ProfileDropdown`)

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/index.css`
• `components-v2/ui/*` (button, input, dropdown-menu, alert, dialog, form, label)
• `components-v2/AppSidebar/*` (ProfileDropdown, EnvironmentDropdown)
• `components-v2/Navigation.tsx`
• `components-v2/StyledLink.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*