### PR TITLE
chore: use crypto md5 hashing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15379,13 +15379,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/charenc": {
-            "version": "0.0.2",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/check-error": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
@@ -16501,13 +16494,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/crypt": {
-            "version": "0.0.2",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/crypto-browserify": {
@@ -20940,10 +20926,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-buffer": {
-            "version": "1.1.6",
-            "license": "MIT"
-        },
         "node_modules/is-builtin-module": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-5.0.0.tgz",
@@ -23140,15 +23122,6 @@
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/md5": {
-            "version": "2.3.0",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "charenc": "0.0.2",
-                "crypt": "0.0.2",
-                "is-buffer": "~1.1.6"
             }
         },
         "node_modules/md5.js": {
@@ -32518,7 +32491,6 @@
                 "@nangohq/utils": "file:../utils",
                 "dayjs": "1.11.10",
                 "knex": "3.1.0",
-                "md5": "2.3.0",
                 "pg": "8.11.3",
                 "uuid": "9.0.1"
             },

--- a/packages/records/lib/helpers/format.ts
+++ b/packages/records/lib/helpers/format.ts
@@ -1,6 +1,7 @@
+import { createHash } from 'node:crypto';
+
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc.js';
-import md5 from 'md5';
 import * as uuid from 'uuid';
 
 import { Err, Ok } from '@nangohq/utils';
@@ -34,7 +35,8 @@ export const formatRecords = ({
     const formattedRecords: FormattedRecord[] = [];
     const now = new Date();
     for (const datum of data) {
-        const data_hash = md5(JSON.stringify(datum));
+        const str = JSON.stringify(datum);
+        const data_hash = createHash('md5').update(str).digest('hex');
 
         if (!datum) {
             break;

--- a/packages/records/package.json
+++ b/packages/records/package.json
@@ -21,7 +21,6 @@
         "@nangohq/utils": "file:../utils",
         "dayjs": "1.11.10",
         "knex": "3.1.0",
-        "md5": "2.3.0",
         "pg": "8.11.3",
         "uuid": "9.0.1"
     },


### PR DESCRIPTION
crypto package md5 hashing is faster than md5 package from npm (locally almost 10x speed increase)

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Replace npm `md5` with Node built-in `crypto` MD5 hashing**

The PR removes the external `md5` dependency in the `records` package and switches to Node’s native `crypto` module for MD5 hashing inside the `formatRecords` helper. This eliminates an extra runtime dependency and claims ~10× local performance gain while keeping the hash algorithm identical.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `createHash` import from `node:crypto` in `packages/records/lib/helpers/format.ts`
• Replaced `md5(JSON.stringify(datum))` with `createHash('md5').update(str).digest('hex')` inside `formatRecords`
• Dropped `md5` from runtime dependencies in `packages/records/package.json` and pruned related entries in `package-lock.json`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/records/lib/helpers/format.ts`
• `packages/records/package.json`
• `package-lock.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*