### PR TITLE
chore: pubsub.publish metrics on failure

### DIFF
--- a/packages/pubsub/lib/publisher.ts
+++ b/packages/pubsub/lib/publisher.ts
@@ -1,5 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
+import { metrics } from '@nangohq/utils';
+
 import type { Event } from './event.js';
 import type { Transport } from './transport/transport.js';
 import type { Result } from '@nangohq/utils';
@@ -13,10 +15,14 @@ export class Publisher {
     }
 
     public async publish(event: SetOptional<Event, 'idempotencyKey' | 'createdAt'>): Promise<Result<void>> {
-        return this.transport.publish({
+        const res = await this.transport.publish({
             ...event,
             idempotencyKey: event.idempotencyKey ?? uuidv4(),
             createdAt: event.createdAt ?? new Date()
         });
+        if (res.isErr()) {
+            metrics.increment(metrics.Types.PUBSUB_PUBLISH, 1, { subject: event.subject, success: 'false' });
+        }
+        return res;
     }
 }

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -94,7 +94,9 @@ export enum Types {
 
     ORB_BILLING_EVENTS_INGESTED = 'nango.billing.orb.ingested',
 
-    USAGE_IS_CAPPED = 'nango.capping.isCapped'
+    USAGE_IS_CAPPED = 'nango.capping.isCapped',
+
+    PUBSUB_PUBLISH = 'nango.pubsub.publish'
 }
 
 type Dimensions = Record<string, string | number> | undefined;


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add `PUBSUB_PUBLISH` failure metric**

Adds Datadog metric emission when `Publisher.publish()` fails and registers the new metric key in the shared `metrics` enum. No functional behavior changes, only observability improvements.

<details>
<summary><strong>Key Changes</strong></summary>

• Imported `metrics` utility in `packages/pubsub/lib/publisher.ts`
• Wrapped transport call result in `res` and incremented `metrics.increment(metrics.Types.PUBSUB_PUBLISH, 1, { subject: event.subject, success: 'false' })` on `Err`
• Appended `PUBSUB_PUBLISH = 'nango.pubsub.publish'` to `packages/utils/lib/telemetry/metrics.ts` enum
• Kept previous `USAGE_IS_CAPPED` entry while ensuring trailing comma for enum syntax

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/pubsub/lib/publisher.ts`
• `packages/utils/lib/telemetry/metrics.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*