### PR TITLE
docs: Add Vercel AI SDK implementation guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -192,13 +192,14 @@
             "pages": [
               "implementation-guides/ai-tool-calling/openai-sdk",
               "implementation-guides/ai-tool-calling/anthropic-sdk",
+              "implementation-guides/ai-tool-calling/vercel-sdk",
               "implementation-guides/ai-tool-calling/mastra-sdk",
-              "implementation-guides/ai-tool-calling/any-llm-sdk",
+              "implementation-guides/ai-tool-calling/any-llm",
               "implementation-guides/ai-tool-calling/implement-mcp-server"
             ]
           },
           {
-            "group": "Requests Proxy",
+            "group": "Proxy",
             "pages": [
               "implementation-guides/requests-proxy/implement-requests-proxy"
             ]

--- a/docs/guides/use-cases/ai-tool-calling.mdx
+++ b/docs/guides/use-cases/ai-tool-calling.mdx
@@ -64,5 +64,5 @@ Nango works with any framework or SDK that supports tool calling. Here are some 
 - [Anthropic](/implementation-guides/ai-tool-calling/anthropic-sdk) SDK
 - [Vercel](/implementation-guides/ai-tool-calling/vercel-sdk) SDK
 - [Mastra](/implementation-guides/ai-tool-calling/mastra-sdk) SDK
-- [Any LLM](/implementation-guides/ai-tool-calling/any-llm-sdk)
+- [Any LLM](/implementation-guides/ai-tool-calling/any-llm)
 - [MCP](/implementation-guides/ai-tool-calling/implement-mcp-server)

--- a/docs/guides/use-cases/ai-tool-calling.mdx
+++ b/docs/guides/use-cases/ai-tool-calling.mdx
@@ -62,6 +62,7 @@ For RAG-style use cases where data must be replicated locally, use [Syncs](/guid
 Nango works with any framework or SDK that supports tool calling. Here are some example guides to perform tool calling with:
 - [OpenAI](/implementation-guides/ai-tool-calling/openai-sdk) SDK
 - [Anthropic](/implementation-guides/ai-tool-calling/anthropic-sdk) SDK
+- [Vercel](/implementation-guides/ai-tool-calling/vercel-sdk) SDK
 - [Mastra](/implementation-guides/ai-tool-calling/mastra-sdk) SDK
-- [any LLM SDK](/implementation-guides/ai-tool-calling/any-llm-sdk)
+- [Any LLM](/implementation-guides/ai-tool-calling/any-llm-sdk)
 - [MCP](/implementation-guides/ai-tool-calling/implement-mcp-server)

--- a/docs/implementation-guides/ai-tool-calling/any-llm.mdx
+++ b/docs/implementation-guides/ai-tool-calling/any-llm.mdx
@@ -43,10 +43,8 @@ export async function runLLMAgent(modelClient: any) {
     const session = await nango.createConnectSession({
       allowed_integrations: [integrationId],
       end_user: { id: userId },
-    }); // Handle API auth via Nango.
+    });
 
-    // Redirect the user to a page to authorize Hubspot. 
-    // Alternatively, you can embed Nango's Frontend SDK in your app.
     console.log(`Please authorize Hubspot here: ${session.data.connect_link}`);
 
     const connection = await nango.waitForConnection(integrationId, userId);
@@ -73,17 +71,10 @@ export async function runLLMAgent(modelClient: any) {
   const toolCall = response?.toolCalls?.[0] || response?.tool_call || null;
 
   if (toolCall?.name === "who_am_i") {
-    console.log("🧩 Model decided to call the 'who_am_i' tool...");
-
-    try {
-      // Step 4: Execute the requested tool with Nango.
-      const userInfo = await nango.triggerAction("hubspot", connectionId, "whoami");
-      console.log("✅ Retrieved Hubspot user info:", userInfo);
-    } catch (error: any) {
-      console.error("❌ Nango API error:", error.response?.data?.error || error);
-    }
+    // Step 4: Execute the requested tool with Nango.
+    const userInfo = await nango.triggerAction("hubspot", connectionId, "whoami");
+    console.log("✅ Retrieved Hubspot user info:", userInfo);
   } else {
-    // Handle plain text or other model responses
     const textOutput = response?.text || response?.output_text || JSON.stringify(response);
     console.log("🗣️ Model response:", textOutput);
   }

--- a/docs/implementation-guides/ai-tool-calling/implement-mcp-server.mdx
+++ b/docs/implementation-guides/ai-tool-calling/implement-mcp-server.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Implement the MCP server'
-sidebarTitle: 'Implement the MCP server'
+title: 'MCP'
+sidebarTitle: 'MCP'
 description: 'How to use the built-in MCP server from Nango'
 ---
 

--- a/docs/implementation-guides/ai-tool-calling/mastra-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/mastra-sdk.mdx
@@ -45,7 +45,7 @@ export async function runMastraAgent() {
     const session = await nango.createConnectSession({
       allowed_integrations: [integrationId],
       end_user: { id: userId },
-    }); // Handle API auth via Nango.
+    });
 
     console.log(`Please authorize the app by visiting this URL: ${session.data.connect_link}`);
 
@@ -64,7 +64,7 @@ export async function runMastraAgent() {
         description: "Get the current user info.",
         execute: async () => {
           // Step 4: Execute the requested tool with Nango.
-          return await nango.triggerAction(integrationId, connectionId, "whoami"); // Call tool via Nango.
+          return await nango.triggerAction(integrationId, connectionId, "whoami");
         },
       }),
     },

--- a/docs/implementation-guides/ai-tool-calling/openai-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/openai-sdk.mdx
@@ -30,7 +30,7 @@ export async function runOpenAIAgent() {
   const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
   const nango = new Nango({ secretKey: process.env.NANGO_SECRET_KEY! });
 
-  const userId = "user1", integrationId = "Hubspot";
+  const userId = "user1", integrationId = "hubspot";
 
   // Step 1: Ensure the user is authorized
   console.log("🔒 Checking API authorization...")
@@ -41,7 +41,7 @@ export async function runOpenAIAgent() {
     const session = await nango.createConnectSession({
       allowed_integrations: [integrationId],
       end_user: { id: userId },
-    }); // Handle API auth via Nango.
+    });
 
     console.log(`Please authorize the app by visiting this URL: ${session.data.connect_link}`);
 
@@ -65,19 +65,13 @@ export async function runOpenAIAgent() {
     ],
   });
 
-  // Check if the model requested a tool call.
   const functionCall = response.output.find((item) => item.type === "function_call") as any;
 
   if (functionCall?.name === "who_am_i") {
-    try {
-      // Step 4: Execute the requested tool with Nango.
-      const userInfo = await nango.triggerAction("Hubspot", connectionId, "whoami"); // Call tools via Nango.
-      console.log("✅ Agent retrieved your Hubspot user info:", userInfo);
-    } catch (error: any) {
-      console.error("Nango API error:", error.response?.data?.error || error);
-    }
+    // Step 4: Execute the requested tool with Nango.
+    const userInfo = await nango.triggerAction(integrationId, connectionId, "whoami"); // Call tool via Nango.
+    console.log("✅ Agent retrieved your Hubspot user info:", userInfo);
   } else {
-    // Handle plain text or other model responses
     console.log(response.output_text);
   }
 }

--- a/docs/implementation-guides/ai-tool-calling/vercel-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/vercel-sdk.mdx
@@ -1,13 +1,13 @@
 ---
-title: "Anthropic"
-sidebarTitle: "Anthropic"
-description: "End-to-end example of calling external tools with the Anthropic SDK."
+title: "Vercel"
+sidebarTitle: "Vercel"
+description: "End-to-end example of calling external tools with the Vercel AI SDK."
 ---
 
 ## Setup
 
 ```bash
-npm i @anthropic-ai/sdk @nangohq/node
+npm i ai @ai-sdk/openai @nangohq/node
 ```
 
 <Tip>
@@ -16,24 +16,30 @@ This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. T
 
 **Requirements:** 
 - A Nango account with a Hubspot integration configured and the `whoami` action enabled.
-- An Anthropic account.
+- An OpenAI account (or another LLM provider).
 
 ## Usage
 
 Example of a basic tool that calls an external API (Hubspot):
 
 ```ts
-import Anthropic from '@anthropic-ai/sdk';
+import { generateText } from "ai";
+import { openai } from "@ai-sdk/openai";
 import { Nango } from "@nangohq/node";
+import { tool } from "ai";
+import { z } from "zod";
 
-export async function runAnthropicAgent() {
-  const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+export async function runVercelAgent() {
+  if (!process.env.OPENAI_API_KEY) {
+    console.log("Missing environment variable: OPENAI_API_KEY.");
+  }
+
   const nango = new Nango({ secretKey: process.env.NANGO_SECRET_KEY! });
 
   const userId = "user1", integrationId = "hubspot";
 
   // Step 1: Ensure the user is authorized
-  console.log("🔒 Checking API authorization...")
+  console.log("🔒 Checking API authorization...");
   let connectionId = (await nango.listConnections({ integrationId, userId })).connections[0]?.connection_id;
 
   // Step 2: If the user is not authorized, redirect to the auth flow.
@@ -50,39 +56,23 @@ export async function runAnthropicAgent() {
   }
 
   // Step 3: Send a prompt to your model with tool definitions
-  console.log("🤖 Agent running...")
-  const message = await client.messages.create({
-    model: "claude-sonnet-4-5",
-    max_tokens: 1024,
-    messages: [
-      {
-        role: "user",
-        content: "Using the who_am_i tool, provide the current user info."
-      }
-    ],
-    tools: [
-      {
-        name: "who_am_i",
+  console.log("🤖 Agent running...");
+  const response = await generateText({
+    model: openai("gpt-4o"),
+    prompt: "Using the who_am_i tool, provide the current user info.",
+    tools: {
+      who_am_i: tool({
         description: "Get the current user info.",
-        input_schema: {
-          type: "object",
-          properties: {},
-          required: []
-        }
-      }
-    ],
-    tool_choice: { type: "auto" }
+        inputSchema: z.object({}),
+        execute: async () => {
+          // Step 4: Execute the requested tool with Nango.
+          return await nango.triggerAction(integrationId, connectionId, "whoami");
+        },
+      }),
+    },
   });
-  
-  const toolUse = message.content.find((content) => content.type === "tool_use");
-  
-  if (toolUse && toolUse.type === "tool_use" && toolUse.name === "who_am_i") {
-    // Step 4: Execute the requested tool with Nango
-    const userInfo = await nango.triggerAction(integrationId, connectionId, "whoami");
-    console.log("✅ Agent retrieved your Hubspot user info:", userInfo);
-  } else {
-    console.log(message.content.find((c) => c.type === "text")?.text);
-  }
+
+  console.log("✅ Agent retrieved your Hubspot user info:", response.toolResults[0].output);
 }
 ```
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add `Vercel AI SDK` implementation guide & doc navigation tweaks**

Adds a new implementation guide demonstrating how to use Nango tool-calling with the `Vercel AI SDK` and refactors surrounding documentation to reference it consistently. The PR only touches `.mdx` content and the `docs/docs.json` navigation manifest; no application/runtime code is modified.

<details>
<summary><strong>Key Changes</strong></summary>

• Created new guide `docs/implementation-guides/ai-tool-calling/vercel-sdk.mdx` (~80 LoC) including full setup & usage example
• Updated navigation in `docs/docs.json`: added `vercel-sdk`, renamed `any-llm-sdk` → `any-llm`, and re-labelled "Requests Proxy" group to "Proxy"
• Fixed/cleaned links and comment text in existing guides (`any-llm.mdx`, `openai-sdk.mdx`, `anthropic-sdk.mdx`, `mastra-sdk.mdx`)
• Retitled `implement-mcp-server.mdx` front-matter to shorter `MCP`
• Updated AI tool-calling use-case index to list Vercel & new "Any LLM" link

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs/implementation-guides/ai-tool-calling/*` guides
• `docs/docs.json` site navigation
• `docs/guides/use-cases/ai-tool-calling.mdx` index page

</details>

---
*This summary was automatically generated by @propel-code-bot*