### PR TITLE
fix: remove dimensions for records/conn billing events

### DIFF
--- a/packages/billing/lib/grouping.ts
+++ b/packages/billing/lib/grouping.ts
@@ -131,9 +131,6 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
                         timestamp: b.properties.timestamp,
                         idempotencyKey: b.properties.idempotencyKey,
                         accountId: b.properties.accountId,
-                        environmentId: b.properties.environmentId,
-                        environmentName: b.properties.environmentName,
-                        integrationId: b.properties.integrationId,
                         telemetry: {
                             sizeBytes: _a.properties.telemetry.sizeBytes + b.properties.telemetry.sizeBytes
                         },
@@ -175,9 +172,6 @@ export class BillingEventGrouping implements Grouping<BillingEvent> {
                         timestamp: b.properties.timestamp,
                         idempotencyKey: b.properties.idempotencyKey,
                         accountId: b.properties.accountId,
-                        environmentId: b.properties.environmentId,
-                        environmentName: b.properties.environmentName,
-                        integrationId: b.properties.integrationId,
                         count: a.properties.count + b.properties.count,
                         frequencyMs: b.properties.frequencyMs
                     }

--- a/packages/billing/lib/grouping.unit.test.ts
+++ b/packages/billing/lib/grouping.unit.test.ts
@@ -113,9 +113,6 @@ describe('BillingEventGrouping', () => {
                 type: 'records',
                 properties: {
                     accountId: 1,
-                    environmentId: 3,
-                    environmentName: 'env',
-                    integrationId: '4',
                     count: 100,
                     timestamp: new Date(),
                     frequencyMs: 60_000,
@@ -128,9 +125,6 @@ describe('BillingEventGrouping', () => {
                 type: 'billable_connections_v2',
                 properties: {
                     accountId: 1,
-                    environmentId: 3,
-                    environmentName: 'env',
-                    integrationId: '4',
                     count: 10,
                     timestamp: new Date(),
                     frequencyMs: 86_400_000
@@ -156,8 +150,8 @@ describe('BillingEventGrouping', () => {
             'function_executions|accountId:1|environmentId:3|environmentName:env|functionName:actionFunction|integrationId:4|type:action',
             'function_executions|accountId:1|environmentId:3|environmentName:env|frequencyMs:100|functionName:syncFunction|integrationId:4|type:sync',
             'monthly_active_records|accountId:1|environmentId:3|environmentName:env|integrationId:5|model:model1|syncId:sync1',
-            'records|accountId:1|environmentId:3|environmentName:env|integrationId:4',
-            'billable_connections_v2|accountId:1|environmentId:3|environmentName:env|integrationId:4',
+            'records|accountId:1',
+            'billable_connections_v2|accountId:1',
             'billable_connections|accountId:1|environmentId:3|environmentName:env|integrationId:4'
         ]);
     });
@@ -437,9 +431,6 @@ describe('BillingEventGrouping', () => {
                 type: 'records',
                 properties: {
                     accountId: 1,
-                    environmentId: 3,
-                    environmentName: 'env',
-                    integrationId: '4',
                     count: 6,
                     timestamp: new Date('2024-01-01T00:00:00Z'),
                     frequencyMs: 60_000,
@@ -452,9 +443,6 @@ describe('BillingEventGrouping', () => {
                 type: 'records',
                 properties: {
                     accountId: 1,
-                    environmentId: 3,
-                    environmentName: 'env',
-                    integrationId: '4',
                     count: 30,
                     timestamp: new Date('2024-01-02T00:00:00Z'),
                     frequencyMs: 60_000,
@@ -468,9 +456,6 @@ describe('BillingEventGrouping', () => {
                 type: 'records',
                 properties: {
                     accountId: 1,
-                    environmentId: 3,
-                    environmentName: 'env',
-                    integrationId: '4',
                     count: 36,
                     timestamp: new Date('2024-01-02T00:00:00Z'),
                     frequencyMs: 60_000,
@@ -485,9 +470,6 @@ describe('BillingEventGrouping', () => {
                 type: 'billable_connections_v2',
                 properties: {
                     accountId: 1,
-                    environmentId: 3,
-                    environmentName: 'env',
-                    integrationId: '4',
                     count: 7,
                     timestamp: new Date('2024-01-01T00:00:00Z'),
                     frequencyMs: 60_000
@@ -497,9 +479,6 @@ describe('BillingEventGrouping', () => {
                 type: 'billable_connections_v2',
                 properties: {
                     accountId: 1,
-                    environmentId: 3,
-                    environmentName: 'env',
-                    integrationId: '4',
                     count: 40,
                     timestamp: new Date('2024-01-02T00:00:00Z'),
                     frequencyMs: 60_000
@@ -510,9 +489,6 @@ describe('BillingEventGrouping', () => {
                 type: 'billable_connections_v2',
                 properties: {
                     accountId: 1,
-                    environmentId: 3,
-                    environmentName: 'env',
-                    integrationId: '4',
                     count: 47,
                     timestamp: new Date('2024-01-02T00:00:00Z'),
                     frequencyMs: 60_000

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1537,14 +1537,11 @@ class ConnectionService {
         return Number(res?.count || 0);
     }
 
-    // return the number of connections per account/environment/integration
+    // return the number of connections per account
     async countMetric(): Promise<
         Result<
             {
                 accountId: number;
-                environmentId: number;
-                environmentName: string;
-                integrationId: string;
                 count: number;
             }[]
         >
@@ -1556,20 +1553,11 @@ class ConnectionService {
                 .select<
                     {
                         accountId: number;
-                        environmentId: number;
-                        environmentName: string;
-                        integrationId: string;
                         count: number;
                     }[]
-                >(
-                    db.knex.raw(`_nango_environments.account_id as "accountId"`),
-                    db.knex.raw(`_nango_environments.id as "environmentId"`),
-                    db.knex.raw(`_nango_environments.name as "environmentName"`),
-                    db.knex.raw(`_nango_connections.provider_config_key as "integrationId"`),
-                    db.knex.raw(`count(DISTINCT _nango_connections.id) AS "count"`)
-                )
+                >(db.knex.raw(`_nango_environments.account_id as "accountId"`), db.knex.raw(`count(_nango_connections.id) AS "count"`))
                 .whereNull('_nango_connections.deleted_at')
-                .groupBy('_nango_environments.account_id', '_nango_environments.id', '_nango_environments.name', '_nango_connections.provider_config_key');
+                .groupBy('_nango_environments.account_id');
 
             if (res) {
                 return Ok(res);

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -95,9 +95,6 @@ export type MarBillingEvent = BillingEventBase<
 export type RecordsBillingEvent = BillingEventBase<
     'records',
     {
-        environmentId: number;
-        environmentName: string;
-        integrationId: string;
         frequencyMs: number;
         telemetry: {
             sizeBytes: number;
@@ -166,9 +163,6 @@ export type ConnectionsBillingEvent = BillingEventBase<'billable_connections'>;
 export type ConnectionsBillingEventV2 = BillingEventBase<
     'billable_connections_v2',
     {
-        environmentId: number;
-        environmentName: string;
-        integrationId: string;
         frequencyMs: number;
     }
 >;


### PR DESCRIPTION
Dimensions are not compatible with records and connections billing metrics. Reverting the changes deployed on Friday

<!-- Summary by @propel-code-bot -->

---

**Remove environment/integration dimensions from records & connection billing events**

This PR reverts last week’s dimension expansion for `records` and `billable_connections_v2` metrics. All logic now aggregates strictly at the `accountId` level, eliminating `environmentId`, `environmentName`, and `integrationId` fields. Corresponding types, grouping/aggregation logic, SQL queries, cron exporters, and unit tests are realigned to the simplified schema.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `RecordsBillingEvent` and `ConnectionsBillingEventV2` definitions in `packages/types/lib/billing/types.ts` to drop `environmentId`, `environmentName`, `integrationId`.
• Refactored `BillingEventGrouping.groupingKey()` and `aggregate()` in `packages/billing/lib/grouping.ts` to omit the removed properties.
• Simplified SQL in `ConnectionService.countMetric()` (`packages/shared/lib/services/connection.service.ts`): now `GROUP BY _nango_environments.account_id` only.
• Adjusted cron exporter `packages/metering/lib/crons/usage.ts` – aggregation maps keyed by `accountId` and payloads without the removed dimensions.
• Patched unit tests in `packages/billing/lib/grouping.unit.test.ts` to reflect the new keys.
• Net diff: +8 / −62 lines across 5 TypeScript files.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/types/lib/billing/types.ts`
• `packages/billing/lib/grouping.ts` & test
• `packages/shared/lib/services/connection.service.ts` (metric query)
• `packages/metering/lib/crons/usage.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*