### PR TITLE
feat(server): cumulative usage metrics

### DIFF
--- a/packages/billing/lib/clients/orb.ts
+++ b/packages/billing/lib/clients/orb.ts
@@ -204,7 +204,8 @@ export class OrbClient implements BillingClient {
                                 timeframeEnd: new Date(u.timeframe_end),
                                 quantity: u.quantity
                             };
-                        })
+                        }),
+                        view_mode: 'periodic'
                     };
                 })
             );

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -61,6 +61,7 @@ export interface BillingUsageMetric {
         timeframeEnd: Date;
         quantity: number;
     }[];
+    cumulative: boolean;
 }
 
 export interface BillingPlan {

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -61,7 +61,7 @@ export interface BillingUsageMetric {
         timeframeEnd: Date;
         quantity: number;
     }[];
-    cumulative: boolean;
+    view_mode: 'cumulative' | 'periodic';
 }
 
 export interface BillingPlan {


### PR DESCRIPTION
We want to show cumulative line charts for records and connections. But the usage query to orb returns everything as periodic (you can get some as periodic, some as cumulative). So we must create a cumulative chart from the periodic data, and flag it for the frontend to know.

<!-- Summary by @propel-code-bot -->

---

**Add server-side generation of cumulative usage metrics for `connections` and `records`**

Orb returns usage data as periodic time-slices only. This PR post-processes that data on the server, converting selected metrics (`connections`, `records`) to a running total so the front-end can directly render cumulative charts. A new discriminator `view_mode` (`'periodic' | 'cumulative'`) is carried on every `BillingUsageMetric` so clients can choose the correct visualisation.

<details>
<summary><strong>Key Changes</strong></summary>

• Extended `UsageTracker.getBillingUsage()` to wrap Orb data and call new helper `toCumulativeUsage()` when the metric maps to `connections` or `records`.
• Introduced helper `toCumulativeUsage()` in `packages/account-usage/lib/usage.ts` that: sorts `usage` chronologically, accumulates quantities, sets `view_mode: 'cumulative'` and returns transformed structure.
• Enhanced metric name mapping in `billingMetricToUsageMetric()` to recognise `connections` and `records`.
• Updated `OrbClient.fetchUsage()` to annotate raw results with `view_mode: 'periodic'` so downstream code can rely on the field’s presence.
• Augmented `BillingUsageMetric` type in `packages/types/lib/billing/types.ts` with `view_mode: 'cumulative' | 'periodic'` (replacing earlier `cumulative` boolean).

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/account-usage/lib/usage.ts`
• `packages/billing/lib/clients/orb.ts`
• `packages/types/lib/billing/types.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*