### PR TITLE
fix(providers): add pennylane rate limit header to check

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -9876,6 +9876,9 @@ pennylane:
     token_url: https://app.pennylane.com/oauth/token
     proxy:
         base_url: https://app.pennylane.com
+        retry:
+            at:
+                - 'ratelimit-reset'
     scope_separator: '+'
     authorization_params:
         response_type: code
@@ -9905,6 +9908,9 @@ pennylane-company-api:
                 accept: application/json
             endpoints:
                 - /api/external/v2/me
+        retry:
+            at:
+                - 'ratelimit-reset'
     docs: https://docs.nango.dev/integrations/all/pennylane-company-api
     docs_connect: https://docs.nango.dev/integrations/all/pennylane-company-api/connect
     credentials:


### PR DESCRIPTION
## Describe the problem and your solution

- Add pennylane rate limit header, I couldn’t find this header in the docs, but it seems to be returned when the API gets rate limited.

```
{
  "date": "Fri, 11 Nov 2024 00:00:00 GMT",
  "content-length": "45",
  "ratelimit-limit": "25",
  "ratelimit-remaining": "0",
  "cache-control": "no-cache",
  "ratelimit-limitname": "external APIs",
  "ratelimit-reset": "1763161432"
}
```
<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add `ratelimit-reset` retry header for Pennylane providers**

This PR augments the Pennylane provider definitions so that Nango automatically schedules retries when the Pennylane API returns its proprietary `ratelimit-reset` header. Two sections in `packages/providers/providers.yaml` (`pennylane` OAuth provider and `pennylane-company-api` API-key provider) now contain a `proxy.retry.at` list with this header.

<details>
<summary><strong>Key Changes</strong></summary>

• Inserted `retry.at` configuration with `- 'ratelimit-reset'` under `pennylane.proxy`
• Inserted identical `retry.at` block under `pennylane-company-api.proxy`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/providers/providers.yaml`

</details>

---
*This summary was automatically generated by @propel-code-bot*