### PR TITLE
fix: remove always null this.win.modal.window check in auth flows.

### DIFF
--- a/packages/frontend/lib/index.ts
+++ b/packages/frontend/lib/index.ts
@@ -225,7 +225,7 @@ export default class Nango {
                     return;
                 }
 
-                if (this.win.modal.window && !this.win.modal.closed) {
+                if (!this.win.modal.closed) {
                     return;
                 }
 


### PR DESCRIPTION
Fixes #4964 

<!-- Describe the problem and your solution --> 

Logical bug which can cause auth to error when an auth window is actually opened. Stems from a lingering window option that is `null` and confirmed to be `null` by issue author.

<!-- Issue ticket number and link (if applicable) -->

#4964 

<!-- Testing instructions (skip if just adding/editing providers) -->

Pretty safe to remove since that seems to be the intention from https://github.com/NangoHQ/nango/commit/32b771e1207642b292d544594786accd17b5c11b
<!-- Summary by @propel-code-bot -->

---

This update streamlines the auth popup polling loop by eliminating the redundant guard that always evaluated to false, allowing the authorization flow to continue while the legitimate modal remains open.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced the guard `if (this.win.modal.window && !this.win.modal.closed)` with `if (!this.win.modal.closed)` in `packages/frontend/lib/index.ts` to stop returning early when the popup is open.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/frontend/lib/index.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*