### PR TITLE
fix: avoid excessive locking when updating connection last_fetched_at

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -842,8 +842,17 @@ class ConnectionService {
         return del;
     }
 
-    public async updateLastFetched(id: number) {
-        await db.knex.from<DBConnection>(`_nango_connections`).where({ id, deleted: false }).update({ last_fetched_at: new Date() });
+    public async updateLastFetched(id: number): Promise<void> {
+        // the query can be called concurrently
+        // we therefore first attempt to lock the row
+        // if lock can't be acquired, the update is skipped without waiting
+        // in order to avoid excessive db locking/waiting
+        await db
+            .knex('_nango_connections')
+            .whereIn('id', function () {
+                this.select('id').from('_nango_connections').where({ id, deleted: false }).forUpdate().skipLocked();
+            })
+            .update({ last_fetched_at: db.knex.fn.now() });
     }
 
     // Parses and arbitrary object (e.g. a server response or a user provided auth object) into AuthCredentials.

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -80,7 +80,6 @@ export async function refreshOrTestCredentials(props: RefreshProps): Promise<Res
 
         span.setTag('connectionId', props.connection.connection_id).setTag('authType', props.connection.credentials.type);
 
-        // TODO: remove this when cron is using other columns
         await connectionService.updateLastFetched(props.connection.id);
         props.connection = { ...props.connection, last_fetched_at: new Date() };
 


### PR DESCRIPTION
The TODO comment state that calling `updateLastFetched` could be removed. However it is still used in `getStaleConnections` https://github.com/NangoHQ/nango/blob/cc93b91b3bc4445c70c8cf84783cb0e0c26d34fb/packages/shared/lib/services/connection.service.ts#L572
so not sure removing is safe. 
pinging @bodinsamuel in case you remember (feel free to ignore if you are too busy enjoying köttbullar) 

In the meantime, this commit is making the query more concurrency-safe by skipping the update if another transaction is locking the row.

<!-- Summary by @propel-code-bot -->

---

**Make `updateLastFetched()` non-blocking under concurrent access**

Rewrites the `updateLastFetched()` query so that it *attempts* to acquire a row-level lock and immediately skips the update if the row is already locked.  This prevents connection-refresh workers that run in parallel from piling up on the same row and keeps overall DB latency low.  Call-sites remain unchanged except that an outdated TODO comment was removed.

<details>
<summary><strong>Key Changes</strong></summary>

• Refactored `updateLastFetched(id)` in `packages/shared/lib/services/connection.service.ts` to: (1) sub-select the row with `forUpdate().skipLocked()`, (2) update with `db.knex.fn.now()` instead of `new Date()`
• Deleted stale TODO line in `packages/shared/lib/services/connections/credentials/refresh.ts` (functional behaviour unchanged)

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/services/connection.service.ts`
• `packages/shared/lib/services/connections/credentials/refresh.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*