### PR TITLE
fix: upgrade js-yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31517,7 +31517,7 @@
                 "figlet": "1.8.2",
                 "glob": "10.3.10",
                 "import-meta-resolve": "4.1.0",
-                "js-yaml": "4.1.0",
+                "js-yaml": "4.1.1",
                 "jscodeshift": "17.3.0",
                 "npm-package-arg": "10.1.0",
                 "ora": "8.2.0",
@@ -31657,6 +31657,18 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "packages/cli/node_modules/js-yaml": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "packages/cli/node_modules/json-schema-traverse": {
@@ -32416,11 +32428,23 @@
             "name": "@nangohq/providers",
             "version": "0.69.13",
             "dependencies": {
-                "js-yaml": "4.1.0"
+                "js-yaml": "4.1.1"
             },
             "devDependencies": {
                 "@nangohq/types": "0.69.13",
                 "vitest": "3.2.4"
+            }
+        },
+        "packages/providers/node_modules/js-yaml": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "packages/pubsub": {
@@ -32798,7 +32822,7 @@
                 "fast-xml-parser": "4.5.0",
                 "form-data": "4.0.4",
                 "he": "^1.2.0",
-                "js-yaml": "4.1.0",
+                "js-yaml": "4.1.1",
                 "jsonwebtoken": "9.0.2",
                 "lodash-es": "4.17.21",
                 "ms": "3.0.0-canary.1",
@@ -32889,6 +32913,18 @@
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
+            }
+        },
+        "packages/shared/node_modules/js-yaml": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "packages/shared/node_modules/json-schema-traverse": {
@@ -33603,7 +33639,7 @@
                 "chalk": "5.4.1",
                 "figures": "6.1.0",
                 "git-cliff": "2.10.0",
-                "js-yaml": "4.1.0",
+                "js-yaml": "4.1.1",
                 "semver": "^7.7.2",
                 "webflow-api": "3.1.3",
                 "zx": "8.7.1"
@@ -33623,6 +33659,19 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "scripts/node_modules/js-yaml": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "scripts/node_modules/json-schema-traverse": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -62,7 +62,7 @@
         "glob": "10.3.10",
         "import-meta-resolve": "4.1.0",
         "jscodeshift": "17.3.0",
-        "js-yaml": "4.1.0",
+        "js-yaml": "4.1.1",
         "npm-package-arg": "10.1.0",
         "ora": "8.2.0",
         "promptly": "3.2.0",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -8,7 +8,7 @@
     "private": false,
     "scripts": {},
     "dependencies": {
-        "js-yaml": "4.1.0"
+        "js-yaml": "4.1.1"
     },
     "devDependencies": {
         "@nangohq/types": "0.69.13",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -36,7 +36,7 @@
         "fast-xml-parser": "4.5.0",
         "form-data": "4.0.4",
         "he": "^1.2.0",
-        "js-yaml": "4.1.0",
+        "js-yaml": "4.1.1",
         "jsonwebtoken": "9.0.2",
         "lodash-es": "4.17.21",
         "ms": "3.0.0-canary.1",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,7 +8,7 @@
         "chalk": "5.4.1",
         "figures": "6.1.0",
         "git-cliff": "2.10.0",
-        "js-yaml": "4.1.0",
+        "js-yaml": "4.1.1",
         "semver": "^7.7.2",
         "webflow-api": "3.1.3",
         "zx": "8.7.1"


### PR DESCRIPTION
https://github.com/NangoHQ/nango/security/dependabot/223

<!-- Summary by @propel-code-bot -->

---

**Upgrade `js-yaml` to 4.1.1 (security patch) across all packages**

This PR bumps the `js-yaml` dependency from version `4.1.0` to `4.1.1` throughout the monorepo to address the security advisory referenced in the Dependabot alert. The update touches four `package.json` files and synchronises the corresponding entries in `package-lock.json` to remove every instance of `4.1.0` and replace it with `4.1.1`.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated dependency declaration `"js-yaml": "4.1.1"` in `packages/cli/package.json`.
• Updated dependency declaration in `packages/providers/package.json`.
• Updated dependency declaration in `packages/shared/package.json`.
• Updated dependency declaration in `scripts/package.json`.
• Regenerated sections of `package-lock.json` to reflect the new version and added new sub-tree entries for `4.1.1` including its `argparse` dependency reference.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/cli/package.json`
• `packages/providers/package.json`
• `packages/shared/package.json`
• `scripts/package.json`
• `package-lock.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*