### PR TITLE
fix(persist): caching zod schemas

### DIFF
--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts
@@ -31,25 +31,24 @@ type DeleteOutdatedRecords = Endpoint<{
 const path = '/environment/:environmentId/connection/:nangoConnectionId/sync/:syncId/job/:syncJobId/outdated';
 const method = 'DELETE';
 
+const bodySchema = z
+    .object({
+        model: z.string(),
+        activityLogId: operationIdRegex
+    })
+    .strict();
+const paramsSchema = z
+    .object({
+        environmentId: z.coerce.number().int().positive(),
+        nangoConnectionId: z.coerce.number().int().positive(),
+        syncId: z.string(),
+        syncJobId: z.coerce.number().int().positive()
+    })
+    .strict();
+
 const validate = validateRequest<DeleteOutdatedRecords>({
-    parseBody: (data: unknown) =>
-        z
-            .object({
-                model: z.string(),
-                activityLogId: operationIdRegex
-            })
-            .strict()
-            .parse(data),
-    parseParams: (data: unknown) =>
-        z
-            .object({
-                environmentId: z.coerce.number().int().positive(),
-                nangoConnectionId: z.coerce.number().int().positive(),
-                syncId: z.string(),
-                syncJobId: z.coerce.number().int().positive()
-            })
-            .strict()
-            .parse(data)
+    parseBody: (data: unknown) => bodySchema.parse(data),
+    parseParams: (data: unknown) => paramsSchema.parse(data)
 });
 
 const handler = async (_req: EndpointRequest, res: EndpointResponse<DeleteOutdatedRecords, AuthLocals>) => {

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/validate.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/validate.ts
@@ -12,27 +12,27 @@ const mergingStrategySchema = z.discriminatedUnion('strategy', [
     })
 ]);
 
+const recordsBodySchema = z
+    .object({
+        model: z.string(),
+        records: z.array(z.object({ id: z.union([z.string().max(255).min(1), z.number()]) }).catchall(z.unknown())).nonempty(),
+        providerConfigKey: z.string(),
+        connectionId: z.string(),
+        activityLogId: operationIdRegex,
+        merging: mergingStrategySchema.default({ strategy: 'override' })
+    })
+    .strict();
+
+const recordsParamsSchema = z
+    .object({
+        environmentId: z.coerce.number().int().positive(),
+        nangoConnectionId: z.coerce.number().int().positive(),
+        syncId: z.string(),
+        syncJobId: z.coerce.number().int().positive()
+    })
+    .strict();
+
 export const recordsRequestParser = {
-    parseBody: (data: unknown) =>
-        z
-            .object({
-                model: z.string(),
-                records: z.array(z.object({ id: z.union([z.string().max(255).min(1), z.number()]) }).catchall(z.unknown())).nonempty(),
-                providerConfigKey: z.string(),
-                connectionId: z.string(),
-                activityLogId: operationIdRegex,
-                merging: mergingStrategySchema.default({ strategy: 'override' })
-            })
-            .strict()
-            .parse(data),
-    parseParams: (data: unknown) =>
-        z
-            .object({
-                environmentId: z.coerce.number().int().positive(),
-                nangoConnectionId: z.coerce.number().int().positive(),
-                syncId: z.string(),
-                syncJobId: z.coerce.number().int().positive()
-            })
-            .strict()
-            .parse(data)
+    parseBody: (data: unknown) => recordsBodySchema.parse(data),
+    parseParams: (data: unknown) => recordsParamsSchema.parse(data)
 };

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/validate.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/validate.ts
@@ -2,49 +2,48 @@ import * as z from 'zod';
 
 import { operationIdRegex } from '@nangohq/logs';
 
+const getCursorQuerySchema = z
+    .object({
+        model: z.string(),
+        offset: z.union([z.literal('first'), z.literal('last')])
+    })
+    .strict();
+
+const getCursorParamsSchema = z
+    .object({
+        environmentId: z.coerce.number().int().positive(),
+        nangoConnectionId: z.coerce.number().int().positive()
+    })
+    .strict();
+
 export const getCursorRequestParser = {
-    parseQuery: (data: unknown) =>
-        z
-            .object({
-                model: z.string(),
-                offset: z.union([z.literal('first'), z.literal('last')])
-            })
-            .strict()
-            .parse(data),
-    parseParams: (data: unknown) =>
-        z
-            .object({
-                environmentId: z.coerce.number().int().positive(),
-                nangoConnectionId: z.coerce.number().int().positive()
-            })
-            .strict()
-            .parse(data)
+    parseQuery: (data: unknown) => getCursorQuerySchema.parse(data),
+    parseParams: (data: unknown) => getCursorParamsSchema.parse(data)
 };
 
+const getRecordsQuerySchema = z
+    .object({
+        model: z.string(),
+        cursor: z.string().optional(),
+        limit: z.coerce.number().int().positive().default(100),
+        activityLogId: operationIdRegex.optional(),
+        externalIds: z
+            .union([
+                z.string().min(1).max(256), // There is no diff between a normal query param and an array with one item
+                z.array(z.string().min(1).max(256)).max(100)
+            ])
+            .transform((val) => (Array.isArray(val) ? val : [val]))
+            .optional()
+    })
+    .strict();
+const getRecordsParamsSchema = z
+    .object({
+        environmentId: z.coerce.number().int().positive(),
+        nangoConnectionId: z.coerce.number().int().positive()
+    })
+    .strict();
+
 export const getRecordsRequestParser = {
-    parseQuery: (data: unknown) =>
-        z
-            .object({
-                model: z.string(),
-                cursor: z.string().optional(),
-                limit: z.coerce.number().int().positive().default(100),
-                activityLogId: operationIdRegex.optional(),
-                externalIds: z
-                    .union([
-                        z.string().min(1).max(256), // There is no diff between a normal query param and an array with one item
-                        z.array(z.string().min(1).max(256)).max(100)
-                    ])
-                    .transform((val) => (Array.isArray(val) ? val : [val]))
-                    .optional()
-            })
-            .strict()
-            .parse(data),
-    parseParams: (data: unknown) =>
-        z
-            .object({
-                environmentId: z.coerce.number().int().positive(),
-                nangoConnectionId: z.coerce.number().int().positive()
-            })
-            .strict()
-            .parse(data)
+    parseQuery: (data: unknown) => getRecordsQuerySchema.parse(data),
+    parseParams: (data: unknown) => getRecordsParamsSchema.parse(data)
 };

--- a/packages/persist/lib/routes/environment/environmentId/postLog.ts
+++ b/packages/persist/lib/routes/environment/environmentId/postLog.ts
@@ -9,54 +9,54 @@ import type { EndpointRequest, EndpointResponse, Route, RouteHandler } from '@na
 
 const MAX_LOG_CHAR = 10000;
 
-export const logBodySchema = z.object({
-    activityLogId: operationIdRegex,
-    log: z.object({
-        type: z.enum(['log', 'http']),
-        message: z.string(),
-        source: z.enum(['internal', 'user']).optional().default('internal'),
-        level: z.enum(['debug', 'info', 'warn', 'error']),
-        error: z
-            .object({
-                name: z.string(),
-                message: z.string(),
-                type: z.string().optional(),
-                payload: z.any().optional()
-            })
-            .optional(),
-        request: z
-            .object({
-                url: z.string(),
-                method: z.string(),
-                headers: z.record(z.string(), z.string())
-            })
-            .optional(),
-        response: z
-            .object({
-                code: z.number(),
-                headers: z.record(z.string(), z.string())
-            })
-            .optional(),
-        meta: z.record(z.string(), z.any()).optional().nullable(),
-        createdAt: z.string(),
-        endedAt: z.string().optional(),
-        durationMs: z.number().optional(),
-        context: z.enum(['script', 'proxy']).optional(),
-        retry: z.object({ max: z.number(), waited: z.number(), attempt: z.number() }).optional()
+const logBodySchema = z
+    .object({
+        activityLogId: operationIdRegex,
+        log: z.object({
+            type: z.enum(['log', 'http']),
+            message: z.string(),
+            source: z.enum(['internal', 'user']).optional().default('internal'),
+            level: z.enum(['debug', 'info', 'warn', 'error']),
+            error: z
+                .object({
+                    name: z.string(),
+                    message: z.string(),
+                    type: z.string().optional(),
+                    payload: z.any().optional()
+                })
+                .optional(),
+            request: z
+                .object({
+                    url: z.string(),
+                    method: z.string(),
+                    headers: z.record(z.string(), z.string())
+                })
+                .optional(),
+            response: z
+                .object({
+                    code: z.number(),
+                    headers: z.record(z.string(), z.string())
+                })
+                .optional(),
+            meta: z.record(z.string(), z.any()).optional().nullable(),
+            createdAt: z.string(),
+            endedAt: z.string().optional(),
+            durationMs: z.number().optional(),
+            context: z.enum(['script', 'proxy']).optional(),
+            retry: z.object({ max: z.number(), waited: z.number(), attempt: z.number() }).optional()
+        })
     })
-});
+    .strict();
+
+const logParamsSchema = z
+    .object({
+        environmentId: z.coerce.number().int().positive()
+    })
+    .strict();
 
 const validate = validateRequest<PostLog>({
-    parseBody: (data) => {
-        return logBodySchema.strict().parse(data);
-    },
-    parseParams: (data) =>
-        z
-            .object({
-                environmentId: z.coerce.number().int().positive()
-            })
-            .strict()
-            .parse(data)
+    parseBody: (data) => logBodySchema.parse(data),
+    parseParams: (data) => logParamsSchema.parse(data)
 });
 
 const handler = (_req: EndpointRequest, res: EndpointResponse<PostLog, AuthLocals>) => {


### PR DESCRIPTION
building zod schema on the fly can be costly at scale. This commit builds the endpoint zod schema once. 
Quick testing showed 10x-100x parsing improvement

<!-- Summary by @propel-code-bot -->

---

**Persist layer: reuse cached `zod` schemas instead of constructing per-request**

The PR refactors four Persist route files so that request/response validation schemas are created once at module load time and then reused. Previous code regenerated the schema objects inside every `parse*` callback, incurring significant per-request cost. No functional behaviour is intended to change; only construction location of the schemas.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced top-level constants `logBodySchema`, `logParamsSchema`, `getCursorQuerySchema`, `getRecordsQuerySchema`, `recordsBodySchema`, etc. that already include `.strict()`.
• Updated each `validateRequest` call to reference the pre-built schemas via `schema.parse(data)`.
• Removed inline `z.object(...).strict()` constructions inside every `parseBody/parseParams/parseQuery` implementation.
• Commit message documents a measured 10x–100x parsing speed-up.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/persist/lib/routes/environment/environmentId/postLog.ts`
• `packages/persist/lib/routes/environment/environmentId/connection/connectionId/validate.ts`
• `packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/validate.ts`
• `packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*