### PR TITLE
fix(runner): reset last idle tracking date whenever track is called

### DIFF
--- a/packages/runner/lib/monitor.ts
+++ b/packages/runner/lib/monitor.ts
@@ -39,8 +39,8 @@ export class RunnerMonitor {
     }
 
     track(nangoProps: NangoProps, taskId: string): void {
+        this.lastIdleTrackingDate = Date.now();
         if (nangoProps.syncJobId) {
-            this.lastIdleTrackingDate = Date.now();
             this.tracked.set(nangoProps.syncJobId, { nangoProps, taskId });
         }
     }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Always refresh idle timer in `RunnerMonitor.track()`**

This PR makes a single-line logic tweak in `packages/runner/lib/monitor.ts`. The idle timer (`lastIdleTrackingDate`) is now updated on every invocation of `track()` *before* the conditional check on `nangoProps.syncJobId`, ensuring the runner never appears idle while work is incoming, even when no `syncJobId` is present.

<details>
<summary><strong>Key Changes</strong></summary>

• Moved assignment `this.lastIdleTrackingDate = Date.now();` outside the `if (nangoProps.syncJobId)` block in `track()`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/runner/lib/monitor.ts` (idle tracking logic)

</details>

---
*This summary was automatically generated by @propel-code-bot*