### PR TITLE
fix(runners): keep track of pending actions

### DIFF
--- a/packages/runner/lib/abort.ts
+++ b/packages/runner/lib/abort.ts
@@ -6,7 +6,7 @@ export const abort = (taskId: string): boolean => {
     if (ac) {
         ac.abort();
         abortControllers.delete(taskId);
-        usage.untrackByTaskId(taskId);
+        usage.untrack(taskId);
         logger.info('Aborted task', { taskId });
         return true;
     } else {

--- a/packages/runner/lib/monitor.ts
+++ b/packages/runner/lib/monitor.ts
@@ -13,7 +13,7 @@ import type { NangoProps } from '@nangohq/types';
 const regexRunnerUrl = /^http:\/\/(production|staging)-runner-account-(\d+|default)-\d+/;
 export class RunnerMonitor {
     private runnerId: number;
-    private tracked = new Map<number, { nangoProps: NangoProps; taskId: string }>();
+    private tracked = new Map<string, { nangoProps: NangoProps }>();
     private idleMaxDurationMs = envs.IDLE_MAX_DURATION_MS;
     private lastIdleTrackingDate = Date.now();
     private lastMemoryReportDate: Date | null = null;
@@ -40,24 +40,11 @@ export class RunnerMonitor {
 
     track(nangoProps: NangoProps, taskId: string): void {
         this.lastIdleTrackingDate = Date.now();
-        if (nangoProps.syncJobId) {
-            this.tracked.set(nangoProps.syncJobId, { nangoProps, taskId });
-        }
+        this.tracked.set(taskId, { nangoProps });
     }
 
-    untrack(nangoProps: NangoProps): void {
-        if (nangoProps.syncJobId) {
-            this.tracked.delete(nangoProps.syncJobId);
-        }
-    }
-
-    untrackByTaskId(taskId: string): void {
-        for (const [syncJobId, value] of this.tracked.entries()) {
-            if (value.taskId === taskId) {
-                this.tracked.delete(syncJobId);
-                break;
-            }
-        }
+    untrack(taskId: string): void {
+        this.tracked.delete(taskId);
     }
 
     resetIdleMaxDurationMs(): void {
@@ -151,6 +138,7 @@ export class RunnerMonitor {
     }
 }
 
+// TODO: revisit memory monitoring since runners are not running in Render anymore
 function getRenderTotalMemoryInBytes(): number {
     const memoryMaxFile = '/sys/fs/cgroup/memory.max';
     try {

--- a/packages/runner/lib/server.ts
+++ b/packages/runner/lib/server.ts
@@ -107,7 +107,7 @@ function startProcedure() {
                 } finally {
                     clearInterval(heartbeat);
                     abortControllers.delete(taskId);
-                    usage.untrack(nangoProps);
+                    usage.untrack(taskId);
                     logger.info(`Task ${taskId} completed`);
                 }
             });


### PR DESCRIPTION
Runner idling logic depends on keeping track of ongoing task executions.
We used to not keep track of actions, relying on the fact that actions are usually short running and runner idling time was 24h 
We recently dropped the idling time to 30mins which made it possible for runners doing only actions to always idle after 30mins, requiring a cold start.

This commit modifies the tasks tracking logic on runner, tracking all pending tasks (including actions). It is gonna increase the memory consumption of actions heavy runners but will make the idling logic less brittle and timing dependent

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Track all pending tasks (incl. actions) to stabilize runner idle logic**

The PR changes how a runner decides whether it is idle. Previously, the runner only tracked long-running sync jobs via `syncJobId`, so runners executing *only* short-lived actions appeared idle and were shut down after the new 30-minute idle threshold. The fix switches the tracking key to `taskId`, stores every incoming task in the `RunnerMonitor.tracked` map, and updates all call-sites to use the new `track(taskId)` / `untrack(taskId)` API.

The change impacts `monitor.ts`, `abort.ts`, and `server.ts`, removes now-obsolete helpers, and adds a TODO about outdated Render-specific memory monitoring. Functional surface area is small (≈30 LoC touched) but affects core lifecycle logic, so the PR is classified as MODERATE.

<details>
<summary><strong>Key Changes</strong></summary>

• Changed `RunnerMonitor.tracked` map key from `number` (syncJobId) to `string` (taskId)
• Unified untracking logic: removed `untrackByTaskId()` and `untrack(nangoProps)` in favor of `untrack(taskId)`
• Updated all call sites in `abort.ts` and `server.ts` to reflect the new API
• Added TODO comment about memory monitoring no longer running on Render
• Minor refactor: deleted ~20 lines of obsolete code, net +7/-19

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/runner/lib/monitor.ts`
• `packages/runner/lib/abort.ts`
• `packages/runner/lib/server.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*