### PR TITLE
fix(webhook): use event-type header and minor clean up

### DIFF
--- a/packages/server/lib/webhook/github-app-oauth-webhook-routing.ts
+++ b/packages/server/lib/webhook/github-app-oauth-webhook-routing.ts
@@ -51,8 +51,7 @@ const route: WebhookHandler = async (nango, headers, body, rawBody) => {
 
     const response = await nango.executeScriptForWebhooks({
         body,
-        headers,
-        webhookHeader: headers['x-github-event'] as string,
+        webhookHeaderValue: headers['x-github-event'] as string,
         connectionIdentifier: 'installation.id',
         propName: 'installation_id'
     });

--- a/packages/server/lib/webhook/github-app-oauth-webhook-routing.ts
+++ b/packages/server/lib/webhook/github-app-oauth-webhook-routing.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import get from 'lodash-es/get.js';
 
@@ -51,7 +51,8 @@ const route: WebhookHandler = async (nango, headers, body, rawBody) => {
 
     const response = await nango.executeScriptForWebhooks({
         body,
-        webhookType: 'action',
+        headers,
+        webhookHeader: headers['x-github-event'] as string,
         connectionIdentifier: 'installation.id',
         propName: 'installation_id'
     });
@@ -90,7 +91,7 @@ async function handleCreateWebhook(nango: InternalNango, body: any): Promise<Res
         const [connection] = connections;
 
         // if there is no matching connection or if the connection config already has an installation_id, exit
-        if (!connection || connection.connection_config['installation_id']) {
+        if (!connection || (connection.connection_config['installation_id'] !== undefined && connection.connection_config['installation_id'] !== null)) {
             logger.error('no connection or existing installation_id');
             return Err(new NangoError('webhook_no_connection_or_existing_installation_id'));
         }

--- a/packages/server/lib/webhook/github-app-oauth-webhook-routing.ts
+++ b/packages/server/lib/webhook/github-app-oauth-webhook-routing.ts
@@ -90,7 +90,7 @@ async function handleCreateWebhook(nango: InternalNango, body: any): Promise<Res
         const [connection] = connections;
 
         // if there is no matching connection or if the connection config already has an installation_id, exit
-        if (!connection || (connection.connection_config['installation_id'] !== undefined && connection.connection_config['installation_id'] !== null)) {
+        if (!connection || connection.connection_config['installation_id']) {
             logger.error('no connection or existing installation_id');
             return Err(new NangoError('webhook_no_connection_or_existing_installation_id'));
         }

--- a/packages/server/lib/webhook/github-app-webhook-routing.ts
+++ b/packages/server/lib/webhook/github-app-webhook-routing.ts
@@ -34,8 +34,7 @@ const route: WebhookHandler = async (nango, headers, body) => {
 
     const response = await nango.executeScriptForWebhooks({
         body,
-        headers,
-        webhookHeader: headers['x-github-event'] as string,
+        webhookHeaderValue: headers['x-github-event'] as string,
         connectionIdentifier: 'installation.id',
         propName: 'installation_id'
     });

--- a/packages/server/lib/webhook/github-app-webhook-routing.ts
+++ b/packages/server/lib/webhook/github-app-webhook-routing.ts
@@ -25,7 +25,6 @@ const route: WebhookHandler = async (nango, headers, body) => {
 
     if (signature) {
         const valid = validate(nango.integration, signature, body);
-        const valid = validate(nango.integration, signature, rawBody);
 
         if (!valid) {
             logger.error('Github App webhook signature invalid');

--- a/packages/server/lib/webhook/github-app-webhook-routing.ts
+++ b/packages/server/lib/webhook/github-app-webhook-routing.ts
@@ -25,6 +25,7 @@ const route: WebhookHandler = async (nango, headers, body) => {
 
     if (signature) {
         const valid = validate(nango.integration, signature, body);
+        const valid = validate(nango.integration, signature, rawBody);
 
         if (!valid) {
             logger.error('Github App webhook signature invalid');
@@ -34,7 +35,8 @@ const route: WebhookHandler = async (nango, headers, body) => {
 
     const response = await nango.executeScriptForWebhooks({
         body,
-        webhookType: 'action',
+        headers,
+        webhookHeader: headers['x-github-event'] as string,
         connectionIdentifier: 'installation.id',
         propName: 'installation_id'
     });

--- a/packages/server/lib/webhook/internal-nango.ts
+++ b/packages/server/lib/webhook/internal-nango.ts
@@ -36,18 +36,16 @@ export class InternalNango {
 
     async executeScriptForWebhooks({
         body,
-        headers,
         webhookType,
-        webhookHeader,
+        webhookHeaderValue,
         webhookTypeValue,
         connectionIdentifier,
         connectionIdentifierValue,
         propName
     }: {
         body: Record<string, any>;
-        headers?: Record<string, string>;
         webhookType?: string;
-        webhookHeader?: string;
+        webhookHeaderValue?: string;
         webhookTypeValue?: string;
         connectionIdentifier?: string;
         connectionIdentifierValue?: string;
@@ -108,7 +106,6 @@ export class InternalNango {
 
         // use webhookTypeValue if provided (direct value from headers), otherwise extract from body
         const type = webhookTypeValue || (webhookType ? get(body, webhookType) : undefined);
-        const webhookHeaderValue = webhookHeader && headers ? headers[webhookHeader] : undefined;
 
         const orchestrator = getOrchestrator();
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Route GitHub webhooks by `x-github-event` header & prevent duplicate script execution**

This patch switches GitHub webhook routing from relying on the body’s `action` field to the `x-github-event` request header. The change is threaded through `executeScriptForWebhooks()` and both GitHub routing files. While only ~22 LOC are touched, the execution path for all GitHub-App webhooks is affected. Additional tidy-ups include stricter connection-lookup logic, a safeguard against double triggers, and use of the modern `node:crypto` import.

<details>
<summary><strong>Key Changes</strong></summary>

• Extended `executeScriptForWebhooks()` signature with `webhookHeaderValue` and matched it against `webhook_subscriptions`
• Added local `triggered` flag to avoid multiple `orchestrator.triggerWebhook()` calls when `webhook_subscriptions` contains overlapping entries (e.g., `'*'` and specific events)
• Relaxed connection lookup condition from `(!connectionIdentifier || connectionIdentifier === '')` to `!connectionIdentifier`
• Returned early with `connections.map(...)` in plan-restricted branch to avoid optional chaining on possibly null list
• Replaced legacy `crypto` import with `node:crypto`
• Updated `github-app-webhook-routing.ts` & `github-app-oauth-webhook-routing.ts` to pass `headers['x-github-event']` instead of `webhookType:'action'`
• Guard change for installation-ID check now allows `0` but still blocks `undefined|null`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/webhook/internal-nango.ts` (core webhook execution logic)
• `packages/server/lib/webhook/github-app-webhook-routing.ts`
• `packages/server/lib/webhook/github-app-oauth-webhook-routing.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*