### PR TITLE
docs: Add tool calling implementation guides for 4 providers

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -194,6 +194,10 @@
               "implementation-guides/ai-tool-calling/anthropic-sdk",
               "implementation-guides/ai-tool-calling/vercel-sdk",
               "implementation-guides/ai-tool-calling/mastra-sdk",
+              "implementation-guides/ai-tool-calling/google-sdk",
+              "implementation-guides/ai-tool-calling/langchain-sdk",
+              "implementation-guides/ai-tool-calling/llamaindex-sdk",
+              "implementation-guides/ai-tool-calling/openai-agents-sdk",
               "implementation-guides/ai-tool-calling/any-llm",
               "implementation-guides/ai-tool-calling/implement-mcp-server"
             ]

--- a/docs/guides/use-cases/ai-tool-calling.mdx
+++ b/docs/guides/use-cases/ai-tool-calling.mdx
@@ -64,5 +64,9 @@ Nango works with any framework or SDK that supports tool calling. Here are some 
 - [Anthropic](/implementation-guides/ai-tool-calling/anthropic-sdk) SDK
 - [Vercel](/implementation-guides/ai-tool-calling/vercel-sdk) SDK
 - [Mastra](/implementation-guides/ai-tool-calling/mastra-sdk) SDK
+- [Google](/implementation-guides/ai-tool-calling/google-sdk) SDK
+- [LangChain](/implementation-guides/ai-tool-calling/langchain-sdk) SDK
+- [LlamaIndex](/implementation-guides/ai-tool-calling/llamaindex-sdk) SDK
+- [OpenAI Agents](/implementation-guides/ai-tool-calling/openai-agents-sdk) SDK
 - [Any LLM](/implementation-guides/ai-tool-calling/any-llm)
 - [MCP](/implementation-guides/ai-tool-calling/implement-mcp-server)

--- a/docs/implementation-guides/ai-tool-calling/google-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/google-sdk.mdx
@@ -1,0 +1,100 @@
+---
+title: "Google"
+sidebarTitle: "Google"
+description: "End-to-end example of calling external tools with the Google SDK."
+---
+
+## Setup
+
+```bash
+npm i ai @google/genai @nangohq/node
+```
+
+<Tip>
+This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](https://nango.dev/docs/reference/api/authentication).
+</Tip>
+
+**Requirements:** 
+- A Nango account with a Hubspot integration configured and the `whoami` action enabled.
+- An Google Gemini account.
+
+## Usage
+
+Example of a basic tool that calls an external API (Hubspot):
+
+```ts
+import { GoogleGenAI, FunctionCallingConfigMode, Type } from "@google/genai";
+import { Nango } from "@nangohq/node";
+
+export async function runGoogleAgent() {
+  if (!process.env.GOOGLE_API_KEY) {
+    console.log("Missing environment variable: GOOGLE_API_KEY.");
+  }
+
+  const ai = new GoogleGenAI({ apiKey: process.env.GOOGLE_API_KEY! });
+  const nango = new Nango({ secretKey: process.env.NANGO_SECRET_KEY! });
+
+  const userId = "user1", integrationId = "hubspot";
+
+  // Step 1: Ensure the user is authorized
+  console.log("🔒 Checking API authorization...");
+  let connectionId = (await nango.listConnections({ integrationId, userId })).connections[0]?.connection_id;
+
+  // Step 2: If the user is not authorized, redirect to the auth flow.
+  if (!connectionId) {
+    const session = await nango.createConnectSession({
+      allowed_integrations: [integrationId],
+      end_user: { id: userId },
+    });
+
+    console.log(`Please authorize the app by visiting this URL: ${session.data.connect_link}`);
+
+    const connection = await nango.waitForConnection(integrationId, userId);
+    connectionId = connection!.connection_id;
+  }
+
+  // Step 3: Send a prompt to your model with tool definitions
+  console.log("🤖 Agent running...");
+  const response = await ai.models.generateContent({
+    model: "gemini-2.5-flash",
+    contents: "Using the who_am_i tool, provide the current user info.",
+    config: {
+      toolConfig: {
+        functionCallingConfig: {
+          mode: FunctionCallingConfigMode.ANY,
+          allowedFunctionNames: ["who_am_i"],
+        },
+      },
+      tools: [
+        {
+          functionDeclarations: [
+            {
+              name: "who_am_i",
+              description: "Get the current user info.",
+              parameters: {
+                type: Type.OBJECT,
+                properties: {},
+                required: [],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  const functionCall = response.functionCalls?.[0];
+
+  if (functionCall?.name === "who_am_i") {
+    // Step 4: Execute the requested tool with Nango.
+    const userInfo = await nango.triggerAction(integrationId, connectionId, "whoami");
+    console.log("✅ Agent retrieved your Hubspot user info:", userInfo);
+  } else {
+    console.log(response.text);
+  }
+}
+```
+
+<Tip>
+You can let agents or models introspect available tools and their specifications by calling this [endpoint](/reference/api/scripts/config). Your model can then automatically decide which tool to call.
+</Tip>

--- a/docs/implementation-guides/ai-tool-calling/google-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/google-sdk.mdx
@@ -16,7 +16,7 @@ This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. T
 
 **Requirements:** 
 - A Nango account with a Hubspot integration configured and the `whoami` action enabled.
-- An Google Gemini account.
+- A Google Gemini account.
 
 ## Usage
 

--- a/docs/implementation-guides/ai-tool-calling/langchain-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/langchain-sdk.mdx
@@ -1,0 +1,85 @@
+---
+title: "LangChain"
+sidebarTitle: "LangChain"
+description: "End-to-end example of calling external tools with the LangChain SDK."
+---
+
+## Setup
+
+```bash
+npm i ai langchain @langchain/core/tools @nangohq/node zod
+```
+
+<Tip>
+This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](https://nango.dev/docs/reference/api/authentication).
+</Tip>
+
+**Requirements:** 
+- A Nango account with a Hubspot integration configured and the `whoami` action enabled.
+- An OpenAI account (or another LLM provider).
+
+## Usage
+
+Example of a basic tool that calls an external API (Hubspot):
+
+```ts
+import { createAgent } from "langchain";
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { Nango } from "@nangohq/node";
+import { z } from "zod";
+
+export async function runLangChainAgent() {
+    if (!process.env.OPENAI_API_KEY) {
+        console.log("Missing environment variable: OPENAI_API_KEY.");
+    }
+
+    const nango = new Nango({ secretKey: process.env.NANGO_SECRET_KEY! });
+
+    const userId = "user1", integrationId = "hubspot";
+
+    // Step 1: Ensure the user is authorized
+    console.log("🔒 Checking API authorization...");
+    let connectionId = (await nango.listConnections({ integrationId, userId })).connections[0]?.connection_id;
+
+    // Step 2: If the user is not authorized, redirect to the auth flow.
+    if (!connectionId) {
+        const session = await nango.createConnectSession({
+            allowed_integrations: [integrationId],
+            end_user: { id: userId },
+        });
+
+        console.log(`Please authorize the app by visiting this URL: ${session.data.connect_link}`);
+
+        const connection = await nango.waitForConnection(integrationId, userId);
+        connectionId = connection!.connection_id;
+    }
+
+    // Step 3: Define the tool
+    const whoAmITool = new DynamicStructuredTool({
+        name: "who_am_i",
+        description: "Get the current user info.",
+        schema: z.object({}),
+        func: async () => {
+            // Step 4: Execute the requested tool with Nango.
+            const result = await nango.triggerAction(integrationId, connectionId, "whoami");
+            return JSON.stringify(result);
+        },
+    });
+
+    const agent = createAgent({
+        model: "openai:gpt-4",
+        tools: [whoAmITool],
+    });
+
+    console.log("🤖 Agent running...");
+    const result = await agent.invoke({
+        messages: [{ role: "user", content: "Using the who_am_i tool, provide the current user info." }],
+    });
+
+    console.log("✅ Agent retrieved your Hubspot user info:", result.messages[result.messages.length - 1].content);
+}
+```
+
+<Tip>
+You can let agents or models introspect available tools and their specifications by calling this [endpoint](/reference/api/scripts/config). Your model can then automatically decide which tool to call.
+</Tip>

--- a/docs/implementation-guides/ai-tool-calling/llamaindex-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/llamaindex-sdk.mdx
@@ -1,0 +1,90 @@
+---
+title: "LlamaIndex"
+sidebarTitle: "LlamaIndex"
+description: "End-to-end example of calling external tools with the LlamaIndex SDK."
+---
+
+## Setup
+
+```bash
+npm i llamaindex @llamaindex/openai @nangohq/node
+```
+
+<Tip>
+This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](https://nango.dev/docs/reference/api/authentication).
+</Tip>
+
+**Requirements:** 
+- A Nango account with a Hubspot integration configured and the `whoami` action enabled.
+- An OpenAI account (or another LLM provider).
+
+## Usage
+
+Example of a basic tool that calls an external API (Hubspot):
+
+```ts
+import { ReActAgent, FunctionTool } from "llamaindex";
+import { OpenAI } from "@llamaindex/openai";
+import { Nango } from "@nangohq/node";
+
+export async function runLlamaIndexAgent() {
+    if (!process.env.OPENAI_API_KEY) {
+        console.log("Missing environment variable: OPENAI_API_KEY.");
+    }
+
+    const nango = new Nango({ secretKey: process.env.NANGO_SECRET_KEY! });
+
+    const userId = "user1", integrationId = "hubspot";
+
+    // Step 1: Ensure the user is authorized
+    console.log("🔒 Checking API authorization...");
+    let connectionId = (await nango.listConnections({ integrationId, userId })).connections[0]?.connection_id;
+
+    // Step 2: If the user is not authorized, redirect to the auth flow.
+    if (!connectionId) {
+        const session = await nango.createConnectSession({
+            allowed_integrations: [integrationId],
+            end_user: { id: userId },
+        });
+
+        console.log(`Please authorize the app by visiting this URL: ${session.data.connect_link}`);
+
+        const connection = await nango.waitForConnection(integrationId, userId);
+        connectionId = connection!.connection_id;
+    }
+
+    // Step 3: Define the tool
+    const whoAmITool = FunctionTool.from(
+        async () => {
+            // Step 4: Execute the requested tool with Nango.
+            const result = await nango.triggerAction(integrationId, connectionId, "whoami");
+            return JSON.stringify(result);
+        },
+        {
+            name: "who_am_i",
+            description: "Get the current user info.",
+            parameters: {
+                type: "object",
+                properties: {},
+                required: [],
+            },
+        }
+    );
+
+    const agent = new ReActAgent({
+        tools: [whoAmITool],
+        llm: new OpenAI({ model: "gpt-4" }),
+    });
+
+    console.log("🤖 Agent running...");
+    const response = await agent.chat({
+        message: "Using the who_am_i tool, provide the current user info.",
+    });
+
+    console.log("✅ Agent retrieved your Hubspot user info:", response.response);
+}
+```
+
+<Tip>
+You can let agents or models introspect available tools and their specifications by calling this [endpoint](/reference/api/scripts/config). Your model can then automatically decide which tool to call.
+</Tip>

--- a/docs/implementation-guides/ai-tool-calling/openai-agents-sdk.mdx
+++ b/docs/implementation-guides/ai-tool-calling/openai-agents-sdk.mdx
@@ -1,0 +1,87 @@
+---
+title: "OpenAI Agents SDK"
+sidebarTitle: "OpenAI Agents SDK"
+description: "End-to-end example of calling external tools with the OpenAI Agents SDK."
+---
+
+## Setup
+
+```bash
+npm i ai @openai/agents @nangohq/node
+```
+
+<Tip>
+This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](https://nango.dev/docs/reference/api/authentication).
+</Tip>
+
+**Requirements:** 
+- A Nango account with a Hubspot integration configured and the `whoami` action enabled.
+- An OpenAI account.
+
+## Usage
+
+Example of a basic tool that calls an external API (Hubspot):
+
+```ts
+import { Agent, run, tool } from "@openai/agents";
+import { Nango } from "@nangohq/node";
+
+export async function runOpenAIAgentsAgent() {
+  if (!process.env.OPENAI_API_KEY) {
+    console.log("Missing environment variable: OPENAI_API_KEY.");
+  }
+
+  const nango = new Nango({ secretKey: process.env.NANGO_SECRET_KEY! });
+
+  const userId = "user1", integrationId = "hubspot";
+
+  // Step 1: Ensure the user is authorized
+  console.log("🔒 Checking API authorization...");
+  let connectionId = (await nango.listConnections({ integrationId, userId })).connections[0]?.connection_id;
+
+  // Step 2: If the user is not authorized, redirect to the auth flow.
+  if (!connectionId) {
+    const session = await nango.createConnectSession({
+      allowed_integrations: [integrationId],
+      end_user: { id: userId },
+    });
+
+    console.log(`Please authorize the app by visiting this URL: ${session.data.connect_link}`);
+
+    const connection = await nango.waitForConnection(integrationId, userId);
+    connectionId = connection!.connection_id;
+  }
+
+  // Step 3: Send a prompt to your model with tool definitions
+  const agent = new Agent({
+    name: "Hubspot Agent",
+    instructions: "You are a helpful assistant that can access Hubspot data.",
+    tools: [
+      tool({
+        name: "who_am_i",
+        description: "Get the current user info.",
+        strict: true,
+        parameters: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+        async execute() {
+          // Step 4: Execute the requested tool with Nango.
+          return await nango.triggerAction(integrationId, connectionId, "whoami");
+        },
+      }),
+    ],
+  });
+
+  console.log("🤖 Agent running...");
+  const result = await run(agent, "Using the who_am_i tool, provide the current user info.");
+
+  console.log("✅ Agent retrieved your Hubspot user info:", result.finalOutput);
+}
+```
+
+<Tip>
+You can let agents or models introspect available tools and their specifications by calling this [endpoint](/reference/api/scripts/config). Your model can then automatically decide which tool to call.
+</Tip>


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add AI-tool-calling documentation for Google, LangChain, LlamaIndex, and OpenAI Agents**

Adds four new implementation guides that demonstrate how to call Nango-hosted tools from the `GoogleGenAI`, `LangChain`, `LlamaIndex`, and `@openai/agents` SDKs. Also updates site navigation (`docs/docs.json`) and the main AI-tool-calling use-case page so these guides are discoverable.

<details>
<summary><strong>Key Changes</strong></summary>

• Created `docs/implementation-guides/ai-tool-calling/google-sdk.mdx`
• Created `docs/implementation-guides/ai-tool-calling/langchain-sdk.mdx`
• Created `docs/implementation-guides/ai-tool-calling/llamaindex-sdk.mdx`
• Created `docs/implementation-guides/ai-tool-calling/openai-agents-sdk.mdx`
• Inserted four new slugs into navigation arrays in `docs/docs.json`
• Extended SDK list in `docs/guides/use-cases/ai-tool-calling.mdx`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Documentation content under `docs/implementation-guides/ai-tool-calling`
• Site navigation file `docs/docs.json`
• Use-case overview `docs/guides/use-cases/ai-tool-calling.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*