### PR TITLE
fix(docs): docs update

### DIFF
--- a/docs/reference/sdks/node.mdx
+++ b/docs/reference/sdks/node.mdx
@@ -474,7 +474,26 @@ await nango.patchConnection({
 
 <Expandable>
     <ResponseField name="body" type="PatchPublicConnection['Body']" required>
-        The body of the connection (see [API Reference](/reference/api/connections/patch))
+        <Expandable title="body" defaultOpen>
+            The body of the connection.
+
+            <ResponseField name="end_user" type="object">
+                <Expandable title="end_user">
+                    <ResponseField name="id" type="string">
+                        Uniquely identifies the end user.
+                    </ResponseField>
+                    <ResponseField name="email" type="string">
+                        The email address of the end user.
+                    </ResponseField>
+                    <ResponseField name="display_name" type="string">
+                        The display name of the end user.
+                    </ResponseField>
+                    <ResponseField name="tags" type="object">
+                        Tags associated with the end user. Only accepts string values, up to 64 keys.
+                    </ResponseField>
+                </Expandable>
+            </ResponseField>
+        </Expandable>
     </ResponseField>
 </Expandable>
 
@@ -1814,7 +1833,7 @@ const { data } = await nango.createConnectSession({
   <ResponseField name="end_user" type="object" required>
     <Expandable title="end_user" defaultOpen>
       <ResponseField name="id" type="string" required>
-        The unique identifier for the end user.
+        Uniquely identifies the end user.
       </ResponseField>
       <ResponseField name="email" type="string">
         The email address of the end user.
@@ -1822,26 +1841,57 @@ const { data } = await nango.createConnectSession({
       <ResponseField name="display_name" type="string">
         The display name of the end user.
       </ResponseField>
+      <ResponseField name="tags" type="object">
+        Tags associated with the end user. Only accepts string values, up to 64 keys.
+      </ResponseField>
     </Expandable>
   </ResponseField>
 
   <ResponseField name="organization" type="object">
     <Expandable title="organization" defaultOpen>
       <ResponseField name="id" type="string" required>
-        The unique identifier for the organization.
+        Uniquely identifies the organization the end user belongs to. (Deprecated)
       </ResponseField>
       <ResponseField name="display_name" type="string">
-        The display name of the organization.
+        The display name of the organization. (Deprecated)
       </ResponseField>
     </Expandable>
   </ResponseField>
 
   <ResponseField name="allowed_integrations" type="string[]">
-    An array of integration IDs that are allowed for this session.
+    Filters which integrations the end user can interact with.
   </ResponseField>
 
   <ResponseField name="integrations_config_defaults" type="object">
-    Default configuration for specific integrations.
+    <Expandable title="integrations_config_defaults" defaultOpen>
+      Default configuration for specific integrations. Keyed by integration ID.
+
+      <ResponseField name="user_scopes" type="string">
+        For Slack only.
+      </ResponseField>
+
+      <ResponseField name="authorization_params" type="object">
+        Query params passed to the OAuth flow (for OAuth2 only).
+      </ResponseField>
+
+      <ResponseField name="connection_config" type="object">
+        <Expandable title="connection_config">
+          <ResponseField name="oauth_scopes_override" type="string[]">
+            Override OAuth scopes for this integration.
+          </ResponseField>
+        </Expandable>
+      </ResponseField>
+    </Expandable>
+  </ResponseField>
+
+  <ResponseField name="overrides" type="object">
+    <Expandable title="overrides" defaultOpen>
+      Override configuration for specific integrations. Keyed by integration ID.
+
+      <ResponseField name="docs_connect" type="string">
+        Override the URL of the docs we point to in the connect flow.
+      </ResponseField>
+    </Expandable>
   </ResponseField>
 </Expandable>
 
@@ -1904,7 +1954,7 @@ const { data } = await nango.createReconnectSession({
   <ResponseField name="end_user" type="object">
     <Expandable title="end_user">
       <ResponseField name="id" type="string" required>
-        The unique identifier for the end user.
+        Uniquely identifies the end user.
       </ResponseField>
       <ResponseField name="email" type="string">
         The email address of the end user.
@@ -1912,22 +1962,53 @@ const { data } = await nango.createReconnectSession({
       <ResponseField name="display_name" type="string">
         The display name of the end user.
       </ResponseField>
+      <ResponseField name="tags" type="object">
+        Tags associated with the end user. Only accepts string values, up to 64 keys.
+      </ResponseField>
     </Expandable>
   </ResponseField>
 
   <ResponseField name="organization" type="object">
     <Expandable title="organization">
       <ResponseField name="id" type="string" required>
-        The unique identifier for the organization.
+        Uniquely identifies the organization the end user belongs to. (Deprecated)
       </ResponseField>
       <ResponseField name="display_name" type="string">
-        The display name of the organization.
+        The display name of the organization. (Deprecated)
       </ResponseField>
     </Expandable>
   </ResponseField>
 
   <ResponseField name="integrations_config_defaults" type="object">
-    Default configuration for specific integrations.
+    <Expandable title="integrations_config_defaults" defaultOpen>
+      Default configuration for specific integrations. Keyed by integration ID.
+
+      <ResponseField name="user_scopes" type="string">
+        For Slack only.
+      </ResponseField>
+
+      <ResponseField name="authorization_params" type="object">
+        Query params passed to the OAuth flow (for OAuth2 only).
+      </ResponseField>
+
+      <ResponseField name="connection_config" type="object">
+        <Expandable title="connection_config">
+          <ResponseField name="oauth_scopes_override" type="string[]">
+            Override OAuth scopes for this integration.
+          </ResponseField>
+        </Expandable>
+      </ResponseField>
+    </Expandable>
+  </ResponseField>
+
+  <ResponseField name="overrides" type="object">
+    <Expandable title="overrides" defaultOpen>
+      Override configuration for specific integrations. Keyed by integration ID.
+
+      <ResponseField name="docs_connect" type="string">
+        Override the URL of the docs we point to in the connect flow.
+      </ResponseField>
+    </Expandable>
   </ResponseField>
 </Expandable>
 

--- a/docs/reference/sdks/node.mdx
+++ b/docs/reference/sdks/node.mdx
@@ -474,26 +474,7 @@ await nango.patchConnection({
 
 <Expandable>
     <ResponseField name="body" type="PatchPublicConnection['Body']" required>
-        <Expandable title="body" defaultOpen>
-            The body of the connection.
-
-            <ResponseField name="end_user" type="object">
-                <Expandable title="end_user">
-                    <ResponseField name="id" type="string">
-                        Uniquely identifies the end user.
-                    </ResponseField>
-                    <ResponseField name="email" type="string">
-                        The email address of the end user.
-                    </ResponseField>
-                    <ResponseField name="display_name" type="string">
-                        The display name of the end user.
-                    </ResponseField>
-                    <ResponseField name="tags" type="object">
-                        Tags associated with the end user. Only accepts string values, up to 64 keys.
-                    </ResponseField>
-                </Expandable>
-            </ResponseField>
-        </Expandable>
+      The body of the connection (see [API Reference](/reference/api/connections/patch))
     </ResponseField>
 </Expandable>
 

--- a/docs/reference/sdks/node.mdx
+++ b/docs/reference/sdks/node.mdx
@@ -474,7 +474,7 @@ await nango.patchConnection({
 
 <Expandable>
     <ResponseField name="body" type="PatchPublicConnection['Body']" required>
-       The body of the connection (see [API Reference](/reference/api/connections/patch))
+        The body of the connection (see [API Reference](/reference/api/connections/patch))
     </ResponseField>
 </Expandable>
 
@@ -1814,7 +1814,7 @@ const { data } = await nango.createConnectSession({
   <ResponseField name="end_user" type="object" required>
     <Expandable title="end_user" defaultOpen>
       <ResponseField name="id" type="string" required>
-        Uniquely identifies the end user.
+        The unique identifier for the end user.
       </ResponseField>
       <ResponseField name="email" type="string">
         The email address of the end user.
@@ -1831,7 +1831,7 @@ const { data } = await nango.createConnectSession({
   <ResponseField name="organization" type="object">
     <Expandable title="organization" defaultOpen>
       <ResponseField name="id" type="string" required>
-        Uniquely identifies the organization the end user belongs to. (Deprecated)
+        The unique identifier for the organization. (Deprecated)
       </ResponseField>
       <ResponseField name="display_name" type="string">
         The display name of the organization. (Deprecated)
@@ -1840,7 +1840,7 @@ const { data } = await nango.createConnectSession({
   </ResponseField>
 
   <ResponseField name="allowed_integrations" type="string[]">
-    Filters which integrations the end user can interact with.
+    An array of integration IDs that are allowed for this session.
   </ResponseField>
 
   <ResponseField name="integrations_config_defaults" type="object">
@@ -1935,7 +1935,7 @@ const { data } = await nango.createReconnectSession({
   <ResponseField name="end_user" type="object">
     <Expandable title="end_user">
       <ResponseField name="id" type="string" required>
-        Uniquely identifies the end user.
+        The unique identifier for the end user.
       </ResponseField>
       <ResponseField name="email" type="string">
         The email address of the end user.
@@ -1952,7 +1952,7 @@ const { data } = await nango.createReconnectSession({
   <ResponseField name="organization" type="object">
     <Expandable title="organization">
       <ResponseField name="id" type="string" required>
-        Uniquely identifies the organization the end user belongs to. (Deprecated)
+        The unique identifier for the organization. (Deprecated)
       </ResponseField>
       <ResponseField name="display_name" type="string">
         The display name of the organization. (Deprecated)

--- a/docs/reference/sdks/node.mdx
+++ b/docs/reference/sdks/node.mdx
@@ -474,7 +474,7 @@ await nango.patchConnection({
 
 <Expandable>
     <ResponseField name="body" type="PatchPublicConnection['Body']" required>
-      The body of the connection (see [API Reference](/reference/api/connections/patch))
+       The body of the connection (see [API Reference](/reference/api/connections/patch))
     </ResponseField>
 </Expandable>
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Expand Node SDK reference docs with new config fields & deprecation flags**

This PR updates the Node SDK reference (`docs/reference/sdks/node.mdx`) by documenting newly-supported request/response fields (`tags`, `overrides`, `integrations_config_defaults`) and adding deprecation annotations for the `organization` object fields. No source code, runtime behaviour or build logic are modified.

<details>
<summary><strong>Key Changes</strong></summary>

• Added detailed sections for `tags`, `overrides`, `integrations_config_defaults` objects, including sub-fields such as `user_scopes`, `authorization_params`, and `oauth_scopes_override`
• Flagged `organization.id` and `organization.display_name` as **(Deprecated)** in two places
• Grammar/wording clarifications for `allowed_integrations`, `end_user.id`, etc.
• Net diff: +68 / ‑6 lines, single file touched

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs/reference/sdks/node.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*