### PR TITLE
fix(webapp): chart improvements

### DIFF
--- a/packages/webapp/src/components-v2/ChartCard.tsx
+++ b/packages/webapp/src/components-v2/ChartCard.tsx
@@ -82,7 +82,7 @@ export const ChartCard: React.FC<ChartCardProps> = ({ isLoading, data, timeframe
     const ChartComponent = data?.view_mode === 'cumulative' ? AreaChart : BarChart;
     const ChartElement =
         data?.view_mode === 'cumulative' ? (
-            <Area dataKey="total" fill="var(--color-total)" type="natural" strokeWidth={2} dot={false} />
+            <Area dataKey="total" fill="var(--color-total)" type="basis" strokeWidth={2} dot={false} />
         ) : (
             <Bar dataKey="total" fill="var(--color-total)" />
         );
@@ -104,7 +104,7 @@ export const ChartCard: React.FC<ChartCardProps> = ({ isLoading, data, timeframe
             <main className="px-6 py-4 flex-1 min-h-0 overflow-hidden">
                 {!isEmpty && (
                     <ChartContainer config={chartConfig} className="h-full w-full">
-                        <ChartComponent accessibilityLayer data={chartData} barCategoryGap={4}>
+                        <ChartComponent accessibilityLayer data={chartData} margin={{ top: 0, right: 0, bottom: 0, left: 0 }} barCategoryGap={4}>
                             <CartesianGrid vertical={false} strokeDasharray="3 3" stroke="var(--color-border-muted)" />
                             <XAxis
                                 dataKey="date"

--- a/packages/webapp/src/components-v2/ChartCard.tsx
+++ b/packages/webapp/src/components-v2/ChartCard.tsx
@@ -113,7 +113,7 @@ export const ChartCard: React.FC<ChartCardProps> = ({ isLoading, data, timeframe
                                 stroke="var(--color-bg-muted)"
                                 tickFormatter={(value: string) => new Date(value).getUTCDate().toString()}
                             />
-                            <YAxis tickLine={false} axisLine={false} tickFormatter={(value) => formatQuantity(value)} />
+                            <YAxis tickLine={false} axisLine={false} tickFormatter={(value) => formatQuantity(value)} padding={{ top: 20 }} />
                             {showTodayLine && <ReferenceLine x={todayDateKey} stroke="var(--color-border-muted)" strokeDasharray="3 3" strokeWidth={1} />}
                             <ChartTooltip
                                 content={


### PR DESCRIPTION
`type="natural"` would cause overshooting in some cases. Also added some top padding in YAxis so that bars/lines don't touch the top.
Before:
<img width="847" height="447" alt="image" src="https://github.com/user-attachments/assets/8bed6f71-23a6-4ac6-a130-75df5aba3221" />

After:
<img width="852" height="444" alt="image" src="https://github.com/user-attachments/assets/3fcc76c4-d960-423b-99c6-b07c3adcf1e2" />

<!-- Summary by @propel-code-bot -->

---

**Adjust chart smoothing curve and add Y-axis padding**

Replaces Recharts `Area` curve type from `natural` to `basis` to prevent overshooting on cumulative charts and adds vertical padding so bars/lines no longer touch the top of the plot area. Minor prop tweaks are confined to `ChartCard.tsx` with no behavioral or data-handling changes.

<details>
<summary><strong>Key Changes</strong></summary>

• Changed `type` prop on `Area` from `natural` to `basis`
• Added `margin={{ top: 0, right: 0, bottom: 0, left: 0 }}` to `ChartComponent`
• Added `padding={{ top: 20 }}` to `YAxis` to create visual spacing

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/components-v2/ChartCard.tsx` (chart rendering props)

</details>

---
*This summary was automatically generated by @propel-code-bot*