### PR TITLE
feat(webapp): minor transition polish

### DIFF
--- a/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
@@ -53,7 +53,7 @@ export default function UsageCard() {
     return (
         <Link
             to={`/${env}/team/billing#usage`}
-            className="flex flex-col gap-4.5 px-3 py-3.5 text-xs rounded-sm bg-bg-surface border-[0.5px] border-border-muted cursor-pointer hover:bg-bg-elevated hover:border-transparent"
+            className="flex flex-col gap-4.5 px-3 py-3.5 text-xs rounded-sm bg-bg-surface border-[0.5px] border-border-muted cursor-pointer transition-colors hover:bg-bg-elevated hover:border-transparent"
         >
             {isLoading ? (
                 <>

--- a/packages/webapp/src/components-v2/Navigation.tsx
+++ b/packages/webapp/src/components-v2/Navigation.tsx
@@ -11,7 +11,7 @@ export const NavigationList: React.FC<React.ComponentProps<typeof TabsPrimitive.
 export const NavigationTrigger: React.FC<React.ComponentProps<typeof TabsPrimitive.Trigger>> = (props) => {
     return (
         <TabsPrimitive.Trigger
-            className="w-full p-2.5 cursor-pointer text-text-secondary text-body-medium-medium text-start rounded hover:bg-bg-surface hover:text-text-primary data-[state=active]:bg-bg-subtle data-[state=active]:text-text-primary focus-default"
+            className="w-full p-2.5 cursor-pointer text-text-secondary text-body-medium-medium text-start rounded transition-colors hover:bg-bg-surface hover:text-text-primary data-[state=active]:bg-bg-subtle data-[state=active]:text-text-primary focus-default"
             {...props}
         />
     );

--- a/packages/webapp/src/components-v2/ui/button.tsx
+++ b/packages/webapp/src/components-v2/ui/button.tsx
@@ -9,7 +9,7 @@ import type { VariantProps } from 'class-variance-authority';
 import type { LinkProps } from 'react-router-dom';
 
 const buttonVariants = cva(
-    "w-fit inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md !text-body-medium-medium transition-all cursor-pointer disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-default",
+    "w-fit inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md !text-body-medium-medium transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-default",
     {
         variants: {
             variant: {

--- a/packages/webapp/src/components-v2/ui/dropdown-menu.tsx
+++ b/packages/webapp/src/components-v2/ui/dropdown-menu.tsx
@@ -51,7 +51,7 @@ function DropdownMenuItem({
             data-inset={inset}
             data-variant={variant}
             className={cn(
-                "focus:bg-dropdown-bg-hover focus:text-text-primary data-[variant=destructive]:text-red-500 data-[variant=destructive]:focus:bg-red-500/10 data-[variant=destructive]:focus:text-red-500 data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-neutral-500 relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-body-medium-medium outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+                "transition-colors focus:bg-dropdown-bg-hover focus:text-text-primary data-[variant=destructive]:text-red-500 data-[variant=destructive]:focus:bg-red-500/10 data-[variant=destructive]:focus:text-red-500 data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-neutral-500 relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-body-medium-medium outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:transition-colors [&_svg:not([class*='size-'])]:size-4",
                 className
             )}
             {...props}
@@ -115,7 +115,7 @@ function DropdownMenuLabel({
         <DropdownMenuPrimitive.Label
             data-slot="dropdown-menu-label"
             data-inset={inset}
-            className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
+            className={cn('px-2 py-1.5 text-body-medium-medium transition-colors data-[inset]:pl-8', className)}
             {...props}
         />
     );

--- a/packages/webapp/src/components-v2/ui/sidebar.tsx
+++ b/packages/webapp/src/components-v2/ui/sidebar.tsx
@@ -364,11 +364,11 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
 }
 
 const sidebarMenuButtonVariants = cva(
-    'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded p-2 text-left text-sm outline-hidden focus-default transition-[width,height,padding] hover:bg-nav-bg-hover hover:text-text-primary focus-visible:bg-nav-bg-hover focus-visible:text-text-primary active:bg-nav-bg-press disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-nav-bg-press data-[active=true]:text-text-primary data-[state=open]:hover:bg-nav-bg-hover data-[state=open]:hover:text-text-primary group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0',
+    'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded p-2 text-left text-body-medium-medium outline-hidden focus-default transition-[width,height,padding] hover:bg-nav-bg-hover hover:text-text-primary focus-visible:bg-nav-bg-hover focus-visible:text-text-primary active:bg-nav-bg-press disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-nav-bg-press data-[active=true]:text-text-primary data-[state=open]:hover:bg-nav-bg-hover data-[state=open]:hover:text-text-primary group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0',
     {
         variants: {
             variant: {
-                default: 'hover:bg-nav-bg-hover hover:text-text-primary',
+                default: 'transition-colors hover:bg-nav-bg-hover hover:text-text-primary',
                 outline:
                     'bg-white shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-nav-bg-hover hover:text-text-primary hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))] dark:bg-neutral-950'
             },

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -222,6 +222,8 @@
     }
 
     /* Start of design system v2 */
+    --default-transition-duration: 100ms;
+
     /* Primitive colors */
     --color-black: #0b0b0c;
     --color-white: #ffffff;


### PR DESCRIPTION
Adding a color transition time to dropdowns and menus in general (for hover color changes). Reduced default transition time from 200ms to 100ms, so it's smooth but still snappy. We had these in some places, but it was inconsistent. Trying to make it more consistent.

<!-- Summary by @propel-code-bot -->

---

**Standardize color-hover transitions across webapp UI components**

This PR unifies hover/active color transition behaviour by ensuring all affected UI components use a consistent `transition-colors` utility and by defining the global CSS variable `--default-transition-duration` as 100 ms (previous default was effectively 200 ms or absent). Only class-name level changes were made; no TypeScript/JS logic was altered.

<details>
<summary><strong>Key Changes</strong></summary>

• Added CSS variable `--default-transition-duration: 100ms` in `packages/webapp/src/index.css`
• Prepended `transition-colors` to component class strings in `dropdown-menu.tsx`, `sidebar.tsx`, `UsageCard.tsx`, `Navigation.tsx`, and `button.tsx`
• Updated variant defaults in `sidebarMenuButtonVariants` to include `transition-colors` and ensured text size utility consistency (`text-body-medium-medium`)
• Minor modifier tweaks (e.g., `text-body-medium-medium`) to keep typography consistent when transitions are applied

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/components-v2/ui/dropdown-menu.tsx`
• `packages/webapp/src/components-v2/ui/sidebar.tsx`
• `packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx`
• `packages/webapp/src/components-v2/Navigation.tsx`
• `packages/webapp/src/components-v2/ui/button.tsx`
• `packages/webapp/src/index.css`

</details>

---
*This summary was automatically generated by @propel-code-bot*