### PR TITLE
fix(providers): remove scope param in `drchrono` if its empty

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -4215,6 +4215,7 @@ drchrono:
     auth_mode: OAUTH2
     authorization_url: https://app.drchrono.com/o/authorize/
     token_url: https://app.drchrono.com/o/token/
+    authorization_url_skip_empty: true
     authorization_params:
         response_type: code
     token_params:


### PR DESCRIPTION
## Describe the problem and your solution

- Remove the scope parameter for DrChrono in the `authorization_url` if it’s empty, granting all scopes.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add `authorization_url_skip_empty` flag for `drchrono` provider**

Single-line provider configuration tweak. The change instructs the platform to omit the `scope` query parameter from the DrChrono OAuth2 `authorization_url` when no scopes are configured, which causes DrChrono to grant all scopes by default.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `authorization_url_skip_empty: true` to the `drchrono` block in `packages/providers/providers.yaml`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/providers/providers.yaml` (DrChrono provider configuration)

</details>

---
*This summary was automatically generated by @propel-code-bot*