### PR TITLE
feat(webapp): warning for legacy plans in usage

### DIFF
--- a/packages/webapp/src/components-v2/StyledLink.tsx
+++ b/packages/webapp/src/components-v2/StyledLink.tsx
@@ -12,6 +12,7 @@ const styledLinkVariants = cva(
             variant: {
                 default:
                     'text-link-default [&_svg]:text-link-disabled hover:text-link-hover hover:[&_svg]:text-link-hover active:text-link-press active:[&_svg]:text-link-press disabled:text-link-disabled disabled:[&_svg]:text-link-disabled',
+                info: 'text-feedback-info-fg [&_svg]:text-feedback-info-fg',
                 error: 'text-feedback-error-fg [&_svg]:text-feedback-error-fg'
             },
             type: {

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -1,8 +1,11 @@
+import { Info } from 'lucide-react';
 import { useMemo } from 'react';
 
 import { ChartCard } from '@/components-v2/ChartCard';
 import { CriticalErrorAlert } from '@/components-v2/CriticalErrorAlert';
 import { StyledLink } from '@/components-v2/StyledLink';
+import { Alert, AlertDescription, AlertTitle } from '@/components-v2/ui/alert';
+import { useEnvironment } from '@/hooks/useEnvironment';
 import { useApiGetBillingUsage } from '@/hooks/usePlan';
 import { useStore } from '@/store';
 
@@ -12,6 +15,7 @@ interface UsageProps {
 
 export const Usage: React.FC<UsageProps> = ({ selectedMonth }) => {
     const env = useStore((state) => state.env);
+    const { plan } = useEnvironment(env);
 
     // Calculate timeframe for the selected month
     const timeframe = useMemo(() => {
@@ -28,8 +32,29 @@ export const Usage: React.FC<UsageProps> = ({ selectedMonth }) => {
     if (usageError) {
         return <CriticalErrorAlert message="Error loading usage" />;
     }
+
+    const isLegacyPlan = plan && !['free', 'starter-v2', 'growth-v2'].includes(plan.name);
     return (
         <div className="w-full flex flex-col gap-6">
+            {isLegacyPlan && (
+                <Alert variant="info">
+                    <Info />
+                    <AlertTitle>You&apos;re on a legacy plan</AlertTitle>
+                    <AlertDescription>
+                        Legacy plans have different usage metrics.
+                        {usage?.data.customer.portalUrl && (
+                            <>
+                                {' '}
+                                You can see your usage in the{' '}
+                                <StyledLink icon to={usage?.data.customer.portalUrl} type="external" variant="info">
+                                    billing portal
+                                </StyledLink>
+                            </>
+                        )}
+                    </AlertDescription>
+                </Alert>
+            )}
+
             <ChartCard data={usage?.data.usage.connections} isLoading={isLoading} timeframe={timeframe} />
             <ChartCard data={usage?.data.usage.proxy} isLoading={isLoading} timeframe={timeframe} />
             <ChartCard data={usage?.data.usage.function_compute_gbms} isLoading={isLoading} timeframe={timeframe} />


### PR DESCRIPTION
Customers on legacy plans currently just see empty charts with no further disclaimer. 

<!-- Summary by @propel-code-bot -->

---

**Add legacy-plan info banner to billing usage page**

Adds a conditional `Alert` on the `Team › Billing › Usage` page that warns users on legacy plans and links them to the Stripe billing portal. A new `'info'` color variant is introduced in `StyledLink` so in-alert links use the info palette.

<details>
<summary><strong>Key Changes</strong></summary>

• Compute `isLegacyPlan` via `useEnvironment` and plan name check in `Usage.tsx`
• Render `Alert` with `Info` icon, title, description, and optional `StyledLink` when `isLegacyPlan` is true
• Extend `StyledLink` variants object with `'info'` mapping to `text-feedback-info-fg` classes

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/pages/Team/Billing/components/Usage.tsx`
• `packages/webapp/src/components-v2/StyledLink.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*