### PR TITLE
chore(webhooks): add circuit breaker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33627,6 +33627,7 @@
             "name": "@nangohq/webhooks",
             "version": "1.0.0",
             "dependencies": {
+                "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/logs": "file:../logs",
                 "@nangohq/utils": "file:../utils",
                 "axios": "1.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33632,7 +33632,8 @@
                 "@nangohq/utils": "file:../utils",
                 "axios": "1.12.0",
                 "dayjs": "1.11.7",
-                "dayjs-plugin-utc": "0.1.2"
+                "dayjs-plugin-utc": "0.1.2",
+                "rate-limiter-flexible": "5.0.3"
             },
             "devDependencies": {
                 "@nangohq/types": "file:../types",

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -349,6 +349,14 @@ export const ENVS = z.object({
     NANGO_ACTIVEMQ_PASSWORD: z.string().optional().default('admin'),
     NANGO_ACTIVEMQ_CONNECT_TIMEOUT_MS: z.coerce.number().optional().default(10_000),
 
+    // WEBHOOK DELIVERY CIRCUIT BREAKER
+    NANGO_WEBHOOK_TIMEOUT_MS: z.coerce.number().optional().default(20_000),
+    NANGO_WEBHOOK_RETRY_ATTEMPTS: z.coerce.number().optional().default(2),
+    NANGO_WEBHOOK_CIRCUIT_BREAKER_FAILURE_THRESHOLD: z.coerce.number().optional().default(5),
+    NANGO_WEBHOOK_CIRCUIT_BREAKER_WINDOW_SECS: z.coerce.number().optional().default(10),
+    NANGO_WEBHOOK_CIRCUIT_BREAKER_COOLDOWN_DURATION_SECS: z.coerce.number().optional().default(60),
+    NANGO_WEBHOOK_CIRCUIT_BREAKER_AUTO_RESET_SECS: z.coerce.number().optional().default(3600),
+
     // ----- Others
     SERVER_RUN_MODE: z.enum(['DOCKERIZED', '']).optional(),
     NANGO_CLOUD: z.stringbool().optional().default(false),

--- a/packages/webhooks/lib/asyncAction.unit.test.ts
+++ b/packages/webhooks/lib/asyncAction.unit.test.ts
@@ -81,10 +81,12 @@ describe('AsyncAction webhookds', () => {
         };
         const bodyString = stringifyStable(body).unwrap();
         expect(spy).toHaveBeenNthCalledWith(1, webhookSettings.primary_url, bodyString, {
-            headers: { 'X-Nango-Signature': expect.any(String), 'content-type': 'application/json', 'user-agent': expect.stringContaining('nango/') }
+            headers: { 'X-Nango-Signature': expect.any(String), 'content-type': 'application/json', 'user-agent': expect.stringContaining('nango/') },
+            timeout: expect.any(Number)
         });
         expect(spy).toHaveBeenNthCalledWith(2, webhookSettings.secondary_url, bodyString, {
-            headers: { 'X-Nango-Signature': expect.any(String), 'content-type': 'application/json', 'user-agent': expect.stringContaining('nango/') }
+            headers: { 'X-Nango-Signature': expect.any(String), 'content-type': 'application/json', 'user-agent': expect.stringContaining('nango/') },
+            timeout: expect.any(Number)
         });
     });
 });

--- a/packages/webhooks/lib/circuitBreaker.integration.test.ts
+++ b/packages/webhooks/lib/circuitBreaker.integration.test.ts
@@ -1,0 +1,287 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { getRedis } from '@nangohq/kvstore';
+import { Err, Ok } from '@nangohq/utils';
+
+import { CircuitBreakerRedis } from './circuitBreaker.js';
+
+import type { CircuitBreaker } from './circuitBreaker.js';
+import type { RedisClientType } from 'redis';
+
+describe('Circuit breaker', () => {
+    let redis: RedisClientType;
+    let circuitBreaker: CircuitBreaker;
+
+    const failureThreshold = 3;
+    const cooldownDurationSecs = 2;
+    const windowSecs = 1;
+
+    const executeNFailures = async (key: string, n: number) => {
+        for (let i = 0; i < n; i++) {
+            await circuitBreaker.execute(key, () => Promise.resolve(Err('test-error')));
+        }
+    };
+    const waitForCooldown = () => {
+        return new Promise((resolve) => setTimeout(resolve, cooldownDurationSecs * 1001));
+    };
+    const waitForWindow = () => {
+        return new Promise((resolve) => setTimeout(resolve, windowSecs * 1001));
+    };
+
+    beforeAll(async () => {
+        const url = process.env['NANGO_REDIS_URL'];
+        if (!url) {
+            throw new Error('NANGO_REDIS_URL environment variable is not set.');
+        }
+        redis = await getRedis(url);
+    });
+
+    beforeEach(() => {
+        circuitBreaker = new CircuitBreakerRedis({
+            id: 'circuitC',
+            redis,
+            options: {
+                failureThreshold,
+                windowSecs,
+                cooldownDurationSecs,
+                autoResetSecs: 600
+            }
+        });
+    });
+
+    afterEach(async () => {
+        await redis.flushAll();
+    });
+
+    afterAll(async () => {
+        await redis.disconnect();
+    });
+
+    describe('when CLOSED', () => {
+        it('should allow execution', async () => {
+            const res = await circuitBreaker.execute('keyK', () => Promise.resolve(Ok('success')));
+            expect(res.unwrap()).toBe('success');
+        });
+
+        it('should not count failures outside the time window', async () => {
+            const key = 'keyK';
+
+            // Record 2 failures within the window
+            await executeNFailures(key, failureThreshold - 1);
+
+            // Wait for window to expire
+            await waitForWindow();
+
+            // Record 2 more failures - should NOT open circuit since old failures expired
+            await executeNFailures(key, 2);
+
+            // Circuit should still be CLOSED (only 2 recent failures, threshold is 3)
+            const res = await circuitBreaker.execute(key, () => Promise.resolve(Ok('success')));
+            expect(res.unwrap()).toBe('success');
+        });
+        it('should isolate circuit state per key', async () => {
+            const key1 = 'endpoint-1';
+            const key2 = 'endpoint-2';
+
+            // Open circuit for key1
+            await executeNFailures(key1, failureThreshold + 1);
+
+            // key2 should still work
+            const res = await circuitBreaker.execute(key2, () => Promise.resolve(Ok('success')));
+            expect(res.unwrap()).toBe('success');
+
+            // key1 should be blocked
+            const res2 = await circuitBreaker.execute(key1, () => Promise.resolve(Ok('success')));
+            expect(res2.isErr()).toBe(true);
+        });
+    });
+
+    describe('when OPEN', () => {
+        it('should reject execution', async () => {
+            const key = 'keyK';
+
+            // Trigger failures to open the circuit
+            await executeNFailures(key, failureThreshold + 1);
+
+            // Circuit should now be OPEN and reject execution
+            const res = await circuitBreaker.execute(key, () => Promise.resolve(Ok('success')));
+
+            expect(res.isErr()).toBe(true);
+            if (res.isErr()) {
+                expect(res.error.message).toEqual('circuit_breaker_open_circuitC_keyK');
+            }
+        });
+
+        it('should transition to HALF_OPEN after cooldown', async () => {
+            const key = 'keyK';
+
+            // Trigger failures to open the circuit
+            await executeNFailures(key, failureThreshold + 1);
+
+            // Wait for cooldown to expire
+            await waitForCooldown();
+
+            // Next execution should be a recovery attempt (HALF_OPEN)
+            const res = await circuitBreaker.execute(key, async () => Promise.resolve(Ok('recovery-success')));
+            expect(res.unwrap()).toBe('recovery-success');
+        });
+
+        it('should reopen circuit if recovery attempt fails in HALF_OPEN state', async () => {
+            const key = 'keyK';
+
+            // Trigger failures to open the circuit
+            await executeNFailures(key, failureThreshold + 1);
+
+            // Wait for cooldown to expire
+            await waitForCooldown();
+
+            // Recovery attempt fails (HALF_OPEN → OPEN)
+            const recoveryRes = await circuitBreaker.execute(key, () => Promise.resolve(Err('recovery-failed')));
+            expect(recoveryRes.isErr()).toBe(true);
+
+            // Circuit should be OPEN again and reject subsequent executions
+            const res = await circuitBreaker.execute(key, () => Promise.resolve(Ok('success')));
+            expect(res.isErr()).toBe(true);
+            if (res.isErr()) {
+                expect(res.error.message).toEqual('circuit_breaker_open_circuitC_keyK');
+            }
+        });
+
+        it('should close circuit if recovery attempt succeeds in HALF_OPEN state', async () => {
+            const key = 'keyK';
+
+            // Trigger failures to open the circuit
+            await executeNFailures(key, failureThreshold + 1);
+
+            // Wait for cooldown to expire
+            await waitForCooldown();
+
+            // Recovery attempt succeeds (HALF_OPEN → CLOSED)
+            const recoveryRes = await circuitBreaker.execute(key, () => Promise.resolve(Ok('recovery-success')));
+            expect(recoveryRes.unwrap()).toBe('recovery-success');
+
+            // Circuit should be CLOSED and allow normal execution
+            const res = await circuitBreaker.execute(key, () => Promise.resolve(Ok('normal-success')));
+            expect(res.unwrap()).toBe('normal-success');
+        });
+    });
+
+    describe('when HALF_OPEN', () => {
+        it('should allow some executions', async () => {
+            const key = 'keyK';
+            // Trigger failures to open the circuit
+            await executeNFailures(key, failureThreshold + 1);
+            // Wait for cooldown to expire
+            await waitForCooldown();
+
+            // First recovery attempt to transition to HALF_OPEN
+            const exec1 = circuitBreaker.execute(key, async () => {
+                await new Promise((resolve) => setTimeout(resolve, 100)); // slight delay
+                return Ok('recovery-success');
+            });
+            // try another execution before the first one completes
+            await new Promise((resolve) => setTimeout(resolve, 20)); // ensure overlap
+            const exec2 = circuitBreaker.execute(key, () => Promise.resolve(Ok('should-fail')));
+
+            // wait for both executions
+            await exec1;
+            const res = await exec2;
+            expect(res.isErr()).toBe(true);
+            if (res.isErr()) {
+                expect(res.error.message).toEqual('circuit_breaker_halfopen_circuitC_keyK');
+            }
+        });
+
+        it('should reopen circuit if execution fails', async () => {
+            const key = 'keyK';
+
+            // Trigger failures to open the circuit
+            await executeNFailures(key, failureThreshold + 1);
+
+            // Wait for cooldown to expire
+            await waitForCooldown();
+
+            // In HALF_OPEN, execution fails → re-open circuit
+            const res = await circuitBreaker.execute(key, () => Promise.resolve(Err('half-open-failed')));
+            expect(res.isErr()).toBe(true);
+
+            // Circuit should be OPEN again and reject subsequent executions
+            const res2 = await circuitBreaker.execute(key, () => Promise.resolve(Ok('success')));
+            expect(res2.isErr()).toBe(true);
+            if (res2.isErr()) {
+                expect(res2.error.message).toEqual('circuit_breaker_open_circuitC_keyK');
+            }
+        });
+
+        it('should close circuit if execution succeeds', async () => {
+            const key = 'keyK';
+
+            // Trigger failures to open the circuit
+            await executeNFailures(key, failureThreshold + 1);
+
+            // Wait for cooldown to expire
+            await waitForCooldown();
+
+            // In HALF_OPEN, execution succeeds → close circuit
+            const res = await circuitBreaker.execute(key, async () => Promise.resolve(Ok('half-open-success')));
+            expect(res.unwrap()).toBe('half-open-success');
+
+            // Circuit should be CLOSED and allow normal execution
+            const res2 = await circuitBreaker.execute(key, () => Promise.resolve(Ok('normal-success')));
+            expect(res2.unwrap()).toBe('normal-success');
+        });
+        it('can allow multiple attempts recovery', async () => {
+            const key = 'keyK';
+
+            // Trigger failures to open the circuit
+            await executeNFailures(key, failureThreshold + 1);
+
+            // Wait for cooldown to expire
+            await waitForCooldown();
+
+            // Start multiple recovery attempts simultaneously
+            const results = await Promise.all([
+                circuitBreaker.execute(key, () => Promise.resolve(Ok(`recovery-success-1`))),
+                circuitBreaker.execute(key, () => Promise.resolve(Ok(`recovery-success-2`))),
+                circuitBreaker.execute(key, () => Promise.resolve(Ok(`recovery-success-3`)))
+            ]);
+
+            // All attempts should succeed
+            expect(results.filter((res) => res.isOk()).length).toBe(3);
+        });
+    });
+    describe('auto reset', () => {
+        it('should reset circuit after auto reset duration', async () => {
+            const circuitBreaker = new CircuitBreakerRedis({
+                id: 'circuitC',
+                redis,
+                options: {
+                    failureThreshold: 2,
+                    windowSecs: 1,
+                    cooldownDurationSecs: 1,
+                    autoResetSecs: 2
+                }
+            });
+
+            const key = 'KeyK';
+            // Trigger failures to open the circuit
+            for (let i = 0; i < 3; i++) {
+                await circuitBreaker.execute(key, () => Promise.resolve(Err('test-error')));
+            }
+
+            // Circuit should now be OPEN and reject execution
+            const resOpen = await circuitBreaker.execute(key, () => Promise.resolve(Ok('success')));
+            expect(resOpen.isErr()).toBe(true);
+            if (resOpen.isErr()) {
+                expect(resOpen.error.message).toEqual('circuit_breaker_open_circuitC_KeyK');
+            }
+
+            // Wait for auto reset duration to expired
+            await new Promise((resolve) => setTimeout(resolve, 2500));
+
+            // Circuit should be reset to CLOSED and allow execution
+            const resClosed = await circuitBreaker.execute(key, () => Promise.resolve(Ok('success')));
+            expect(resClosed.unwrap()).toBe('success');
+        });
+    });
+});

--- a/packages/webhooks/lib/circuitBreaker.ts
+++ b/packages/webhooks/lib/circuitBreaker.ts
@@ -1,0 +1,153 @@
+import { RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible';
+
+import { Err } from '@nangohq/utils';
+
+import type { Result } from '@nangohq/types';
+
+type CircuitState = 'CLOSED' | 'OPEN' | 'HALF_OPEN';
+
+interface CircuitStateData {
+    state: CircuitState;
+    untilMs: number;
+}
+
+interface CircuitBreakerOptions {
+    failureThreshold: number;
+    windowSecs: number;
+    cooldownDurationSecs: number;
+    autoResetSecs: number;
+}
+
+export interface CircuitBreaker {
+    execute<T>(key: string, fn: () => Promise<Result<T>>): Promise<Result<T>>;
+}
+
+export class CircuitBreakerPassThrough implements CircuitBreaker {
+    async execute<T>(_key: string, fn: () => Promise<Result<T>>): Promise<Result<T>> {
+        return fn();
+    }
+}
+
+export class CircuitBreakerRedis implements CircuitBreaker {
+    private readonly id: string;
+    private readonly redis: any; //TODO
+    private readonly failureLimiter: RateLimiterRedis;
+    private readonly cooldownDurationMs: number;
+    private readonly autoResetSecs: number;
+    private readonly keyPrefix: string;
+
+    constructor({ id, redis, options }: { id: string; redis: any; options: CircuitBreakerOptions }) {
+        this.id = id;
+        this.cooldownDurationMs = options.cooldownDurationSecs * 1000;
+        this.redis = redis;
+        this.autoResetSecs = options.autoResetSecs;
+        this.keyPrefix = `circuitbreaker:${id}`;
+
+        // Rate limiter for tracking failures
+        this.failureLimiter = new RateLimiterRedis({
+            storeClient: redis,
+            keyPrefix: `${this.keyPrefix}:failures`,
+            points: options.failureThreshold,
+            duration: options.windowSecs
+        });
+    }
+
+    async execute<T>(key: string, fn: () => Promise<Result<T>>): Promise<Result<T>> {
+        const stateData = await this.getState(key);
+        const now = Date.now();
+
+        // No state = CLOSED (normal operation)
+        if (!stateData) {
+            return this.executeClosed(key, fn);
+        }
+
+        if (stateData.state === 'OPEN') {
+            if (now < stateData.untilMs) {
+                // OPEN and now < untilMs => error
+                return Err(`circuit_breaker_open_${this.id}_${key}`);
+            } else {
+                // OPEN and now >= untilMs => Recovery attempt
+                return this.executeWithRecovery(key, fn);
+            }
+        }
+
+        if (stateData.state === 'HALF_OPEN') {
+            if (now < stateData.untilMs) {
+                // HALF_OPEN and now < untilMs => error
+                return Err(`circuit_breaker_halfopen_${this.id}_${key}`);
+            } else {
+                // HALF_OPEN after untilMs => recovery attempt
+                return await this.executeWithRecovery(key, fn);
+            }
+        }
+
+        // CLOSED state (shouldn't reach here if no key, but handle it)
+        return this.executeClosed(key, fn);
+    }
+
+    // Execute function in CLOSED state
+    // If it fails, record the failure
+    // If failures exceed threshold, open the circuit
+    private async executeClosed<T>(key: string, fn: () => Promise<Result<T>>): Promise<Result<T>> {
+        const res = await fn();
+        if (res.isErr()) {
+            try {
+                await this.failureLimiter.consume(key, 1);
+            } catch (err) {
+                // too many failures => open circuit
+                if (err instanceof RateLimiterRes) {
+                    const now = Date.now();
+                    await this.setState(key, {
+                        state: 'OPEN',
+                        untilMs: now + this.cooldownDurationMs
+                    });
+                }
+            }
+        }
+        return res;
+    }
+
+    // Execute function and attempt recovery
+    // If it fails, re-open the circuit
+    // If it succeeds, close the circuit
+    private async executeWithRecovery<T>(key: string, fn: () => Promise<Result<T>>): Promise<Result<T>> {
+        const now = Date.now();
+        // Move to HALF_OPEN state before executing the function
+        await this.setState(key, {
+            state: 'HALF_OPEN',
+            untilMs: now + this.cooldownDurationMs
+        });
+        // At least one execution is allowed in HALF_OPEN to check if the underlying issue is resolved
+        // We accept that multiple concurrent calls may enter HALF_OPEN state for simplicity
+        const res = await fn();
+        if (res.isErr()) {
+            // Failure in half-open = re-open the circuit
+            await this.setState(key, {
+                state: 'OPEN',
+                untilMs: now + this.cooldownDurationMs
+            });
+        } else {
+            // Success in half-open = remove the key (back to closed/normal)
+            await this.removeState(key);
+            await this.failureLimiter.delete(key);
+        }
+        return res;
+    }
+
+    private async getState(key: string): Promise<CircuitStateData | null> {
+        const data = await this.redis.get(`${this.keyPrefix}:${key}`);
+        if (!data) {
+            return null;
+        }
+        return JSON.parse(data);
+    }
+
+    private async setState(key: string, state: CircuitStateData): Promise<void> {
+        const ttlMs = this.autoResetSecs * 1000;
+        await this.redis.set(`${this.keyPrefix}:${key}`, JSON.stringify(state), 'PX', ttlMs);
+    }
+
+    private async removeState(key: string): Promise<void> {
+        await this.redis.del(`${this.keyPrefix}:${key}`);
+    }
+}

--- a/packages/webhooks/lib/envs.ts
+++ b/packages/webhooks/lib/envs.ts
@@ -1,0 +1,3 @@
+import { ENVS, parseEnvs } from '@nangohq/utils';
+
+export const envs = parseEnvs(ENVS);

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -2,14 +2,18 @@ import crypto from 'crypto';
 
 import { isAxiosError } from 'axios';
 
+import { getRedis } from '@nangohq/kvstore';
 import { Err, Ok, axiosInstance as axios, networkError, redactHeaders, retryFlexible, stringifyStable, userAgent } from '@nangohq/utils';
+
+import { CircuitBreakerPassThrough, CircuitBreakerRedis } from './circuitBreaker.js';
+import { envs } from './envs.js';
 
 import type { LogContext } from '@nangohq/logs';
 import type { DBEnvironment, DBExternalWebhook, MessageHTTPResponse, MessageRow, WebhookTypes } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { AxiosError, AxiosResponse } from 'axios';
 
-export const RETRY_ATTEMPTS = 7;
+export const RETRY_ATTEMPTS = envs.NANGO_WEBHOOK_RETRY_ATTEMPTS;
 
 export const NON_FORWARDABLE_HEADERS = [
     'host',
@@ -28,6 +32,23 @@ export const NON_FORWARDABLE_HEADERS = [
     'www-authenticate',
     'server'
 ];
+
+const circuitBreaker = await (async () => {
+    if (envs.NANGO_REDIS_URL) {
+        const redis = await getRedis(envs.NANGO_REDIS_URL);
+        return new CircuitBreakerRedis({
+            id: 'webhooks',
+            redis,
+            options: {
+                failureThreshold: envs.NANGO_WEBHOOK_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+                windowSecs: envs.NANGO_WEBHOOK_CIRCUIT_BREAKER_WINDOW_SECS,
+                cooldownDurationSecs: envs.NANGO_WEBHOOK_CIRCUIT_BREAKER_COOLDOWN_DURATION_SECS,
+                autoResetSecs: envs.NANGO_WEBHOOK_CIRCUIT_BREAKER_AUTO_RESET_SECS
+            }
+        });
+    }
+    return new CircuitBreakerPassThrough();
+})();
 
 function formatLogResponse(response: AxiosResponse): MessageHTTPResponse {
     return {
@@ -157,42 +178,50 @@ export const deliver = async ({
         try {
             await retryFlexible(
                 async () => {
-                    const createdAt = new Date();
-                    try {
-                        const res = await axios.post(url, bodyString.value, { headers });
+                    const result = await circuitBreaker.execute(url, async () => {
+                        const createdAt = new Date();
+                        try {
+                            const res = await axios.post(url, bodyString.value, { headers, timeout: envs.NANGO_WEBHOOK_TIMEOUT_MS });
 
-                        void logCtx?.http(`POST ${url}`, { request: logRequest, response: formatLogResponse(res), context: 'webhook', createdAt });
-                        if (res.status >= 200 && res.status < 300) {
-                            void logCtx?.info(`Webhook "${webhookType}" sent successfully (${type} URL) ${endingMessage ? ` ${endingMessage}` : ''}`);
-                        } else {
-                            void logCtx?.warn(
-                                `Webhook "${webhookType}" sent successfully (${type} URL) but received a "${res.status}" response code${endingMessage ? ` ${endingMessage}` : ''}. Please send a 2xx on successful receipt.`
-                            );
-                            success = false;
+                            void logCtx?.http(`POST ${url}`, { request: logRequest, response: formatLogResponse(res), context: 'webhook', createdAt });
+                            if (res.status >= 200 && res.status < 300) {
+                                void logCtx?.info(`Webhook "${webhookType}" sent successfully (${type} URL) ${endingMessage ? ` ${endingMessage}` : ''}`);
+                                return Ok(res);
+                            } else {
+                                void logCtx?.warn(
+                                    `Webhook "${webhookType}" sent successfully (${type} URL) but received a "${res.status}" response code${endingMessage ? ` ${endingMessage}` : ''}. Please send a 2xx on successful receipt.`
+                                );
+                                return Err(`non_2xx_status_${res.status}`);
+                            }
+                        } catch (err) {
+                            if (isAxiosError(err)) {
+                                void logCtx?.http(`POST ${logRequest.url}`, {
+                                    response: err.response ? formatLogResponse(err.response) : undefined,
+                                    request: logRequest,
+                                    context: 'webhook',
+                                    error: !err.response ? err : null,
+                                    level: 'error',
+                                    createdAt
+                                });
+                                return Err(err);
+                            } else {
+                                void logCtx?.http(`POST ${logRequest?.url}`, {
+                                    request: logRequest,
+                                    response: undefined,
+                                    context: 'webhook',
+                                    error: err,
+                                    level: 'error',
+                                    createdAt
+                                });
+                                return Err(new Error('unknown_error', { cause: err }));
+                            }
                         }
-                        return res;
-                    } catch (err) {
-                        if (isAxiosError(err)) {
-                            void logCtx?.http(`POST ${logRequest.url}`, {
-                                response: err.response ? formatLogResponse(err.response) : undefined,
-                                request: logRequest,
-                                context: 'webhook',
-                                error: !err.response ? err : null,
-                                level: 'error',
-                                createdAt
-                            });
-                        } else {
-                            void logCtx?.http(`POST ${logRequest?.url}`, {
-                                request: logRequest,
-                                response: undefined,
-                                context: 'webhook',
-                                error: err,
-                                level: 'error',
-                                createdAt
-                            });
-                        }
-                        throw err;
+                    });
+
+                    if (result.isErr()) {
+                        throw result.error;
                     }
+                    return result.value;
                 },
                 {
                     max: RETRY_ATTEMPTS,
@@ -219,7 +248,11 @@ export const deliver = async ({
 
 export function shouldRetry(err: unknown): { retry: boolean; reason: string } {
     if (!isAxiosError(err)) {
-        return { retry: false, reason: 'unknown_error' };
+        let reason = 'unknown_error';
+        if (err instanceof Error && err.message.startsWith('circuit_breaker')) {
+            reason = 'circuit_breaker_open';
+        }
+        return { retry: false, reason };
     }
 
     if (err.code && networkError.includes(err.code)) {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -17,9 +17,11 @@
     "dependencies": {
         "@nangohq/logs": "file:../logs",
         "@nangohq/utils": "file:../utils",
+        "@nangohq/kvstore": "file:../kvstore",
         "axios": "1.12.0",
         "dayjs": "1.11.7",
-        "dayjs-plugin-utc": "0.1.2"
+        "dayjs-plugin-utc": "0.1.2",
+        "rate-limiter-flexible": "5.0.3"
     },
     "devDependencies": {
         "@nangohq/types": "file:../types",

--- a/packages/webhooks/tsconfig.json
+++ b/packages/webhooks/tsconfig.json
@@ -13,6 +13,9 @@
         },
         {
             "path": "../types"
+        },
+        {
+            "path": "../kvstore"
         }
     ],
     "include": ["lib/**/*", "../utils/lib/vitest.d.ts"]


### PR DESCRIPTION
Adding a circuit breaker mechanism to fail quickly when a customer webhook endpoint is unresponsive (timeouts/errors). The goal is to protect Nango services when a customer webhook endpoint is down. It affects all webhooks delivered to customers, including sync webhooks, not just webhook forwarding.

Using `rate-limiter-flexible` library and redis, which is used in other part of the stack, to keep track of the failure rate for each endpoint. 

When requests for a given endpoint fail beyond the threshold, Nango will skip making the requests and fail the webhook delivery quickly. After a cooldown period Nango will let at least one request go through. If recovery requests are successful, the circuit breaker will be closed and delivering the webhook will be attempted again for the url. 
If recovery requests failed, delivery of webhooks for this url will be stopped again until a new cooldown period ends. 

This commit is also lowering the timeout of the webhook delivery requests to 20s (from 60s) and the number of retry attempt to 2 (previously 7)

This is not introducing any queuing mechanism and a large amount of webhook deliveries might still be attempted before the circuit breaker open. (if for example the customer endpoint is slow to respond). It would still provide some protection by stopping outgoing requests once the 20s timeouts elapsed and won't allow a large amount of requests until the endpoint responds with success again). It could however introduce a seesaw behavior if the heavy loads is sustained and the customer endpoints slow down under load but recover quickly. Not perfect but better than no protection at at like we have today

<!-- Summary by @propel-code-bot -->

---

**Webhook delivery circuit-breaker with Redis + timeout/retry tuning**

Introduces a Redis-backed circuit breaker that halts outbound webhook calls after repeated failures and automatically probes for recovery. The breaker is injected into the existing webhook delivery flow, lowers default request timeout to 20 s, reduces retry attempts from 7 to 2, and makes all thresholds configurable through new environment variables. Extensive vitest coverage validates CLOSED/OPEN/HALF_OPEN transitions and auto-reset behavior. Supporting changes span env parsing, dependency graph, and test updates.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `packages/webhooks/lib/circuitBreaker.ts` implementing `CircuitBreakerRedis` and `CircuitBreakerPassThrough` with failure counting via `rate-limiter-flexible` and Redis TTL-backed state
• Integrated breaker into `packages/webhooks/lib/utils.ts` (`deliver()`): calls now wrapped in `circuitBreaker.execute()`; new timeout and adjusted retry logic
• Added env schema knobs (`NANGO_WEBHOOK_TIMEOUT_MS`, `NANGO_WEBHOOK_RETRY_ATTEMPTS`, `NANGO_WEBHOOK_CIRCUIT_BREAKER_*`) in `packages/utils/lib/environment/parse.ts`
• Lazy breaker instantiation with Redis fallback to pass-through when `NANGO_REDIS_URL` is undefined
• Extensive integration test `packages/webhooks/lib/circuitBreaker.integration.test.ts` (≈280 LOC) covering all state transitions incl. auto-reset and key isolation
• Updated unit tests (`asyncAction.unit.test.ts`) to reflect new timeout param
• Dependency additions: `rate-limiter-flexible`, `@nangohq/kvstore`; tsconfig path updates; lockfile regeneration

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webhooks/lib/circuitBreaker.ts`
• `packages/webhooks/lib/utils.ts`
• `packages/utils/lib/environment/parse.ts`
• `packages/webhooks/lib/envs.ts`
• Webhook integration/unit tests
• Package manifests and `tsconfig` references

</details>

---
*This summary was automatically generated by @propel-code-bot*