### PR TITLE
fix(metering): type mismatch concatenating strings instead of adding numbers

### DIFF
--- a/packages/metering/lib/crons/usage.ts
+++ b/packages/metering/lib/crons/usage.ts
@@ -121,7 +121,7 @@ const observability = {
                                 .reduce(
                                     (acc, curr) => {
                                         acc.count += curr.count;
-                                        acc.size_bytes += curr.size_bytes;
+                                        acc.size_bytes += Number(curr.size_bytes);
                                         return acc;
                                     },
                                     { count: 0, size_bytes: 0 }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Fix numeric aggregation of `size_bytes` in metering cron**

One-line bug fix converting `curr.size_bytes` to a number during the reduce step in `observability.exportRecordsMetrics`. Prevents string concatenation when `size_bytes` is received as a string, ensuring correct byte-sum calculations for billing and metrics.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced `acc.size_bytes += curr.size_bytes` with `acc.size_bytes += Number(curr.size_bytes)` in `packages/metering/lib/crons/usage.ts`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/metering/lib/crons/usage.ts` → `observability.exportRecordsMetrics` reduce logic

</details>

---
*This summary was automatically generated by @propel-code-bot*