### PR TITLE
fix(webapp): force UTC timezone in usage page

### DIFF
--- a/packages/webapp/src/pages/Team/Billing/components/MonthSelector.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/MonthSelector.tsx
@@ -19,14 +19,14 @@ export const MonthSelector: React.FC<MonthSelectorProps> = ({ onMonthChange }) =
     const selectedMonth = useMemo(() => {
         if (!monthParam) {
             const now = new Date();
-            return new Date(now.getUTCFullYear(), now.getUTCMonth(), 1);
+            return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
         }
         const [year, month] = monthParam.split('-').map(Number);
         if (isNaN(year) || isNaN(month) || month < 1 || month > 12) {
             const now = new Date();
-            return new Date(now.getUTCFullYear(), now.getUTCMonth(), 1);
+            return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
         }
-        return new Date(year, month - 1, 1, 0, 0, 0, 0);
+        return new Date(Date.UTC(year, month - 1, 1));
     }, [monthParam]);
 
     // Notify parent when month changes
@@ -42,7 +42,7 @@ export const MonthSelector: React.FC<MonthSelectorProps> = ({ onMonthChange }) =
     };
 
     const monthDisplay = useMemo(() => {
-        return selectedMonth.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+        return selectedMonth.toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' });
     }, [selectedMonth]);
 
     const handlePreviousMonth = () => {
@@ -60,7 +60,7 @@ export const MonthSelector: React.FC<MonthSelectorProps> = ({ onMonthChange }) =
     // Disable next button if trying to go to future months
     const canGoNext = useMemo(() => {
         const now = new Date();
-        const currentMonth = new Date(now.getUTCFullYear(), now.getUTCMonth(), 1);
+        const currentMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
         return selectedMonth < currentMonth;
     }, [selectedMonth]);
 

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -19,8 +19,8 @@ export const Usage: React.FC<UsageProps> = ({ selectedMonth }) => {
 
     // Calculate timeframe for the selected month
     const timeframe = useMemo(() => {
-        const start = new Date(selectedMonth.getUTCFullYear(), selectedMonth.getUTCMonth(), 1);
-        const end = new Date(selectedMonth.getUTCFullYear(), selectedMonth.getUTCMonth() + 1, 0, 23, 59, 59, 999);
+        const start = new Date(Date.UTC(selectedMonth.getUTCFullYear(), selectedMonth.getUTCMonth(), 1));
+        const end = new Date(Date.UTC(selectedMonth.getUTCFullYear(), selectedMonth.getUTCMonth() + 1, 1));
         return {
             start: start.toISOString(),
             end: end.toISOString()


### PR DESCRIPTION
`new Date()` defaults to your timezone, so we have to be MORE explicit.

<!-- Summary by @propel-code-bot -->

---

**Force UTC handling in billing usage components**

Updates date construction and formatting in the billing *MonthSelector* and *Usage* components to always use UTC. This eliminates discrepancies caused by the browser’s local timezone when calculating month boundaries and displaying the current period.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced `new Date(year, month, …)` calls with `new Date(Date.UTC(year, month, …))` in `packages/webapp/src/pages/Team/Billing/components/MonthSelector.tsx` and `packages/webapp/src/pages/Team/Billing/components/Usage.tsx`
• Added `{ timeZone: 'UTC' }` to `selectedMonth.toLocaleDateString` so the visible month label is rendered in UTC
• Adjusted end-of-month calculation in `Usage.tsx` to `new Date(Date.UTC(year, month + 1, 1))` (start of next month) instead of last millisecond of the current month

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/pages/Team/Billing/components/MonthSelector.tsx`
• `packages/webapp/src/pages/Team/Billing/components/Usage.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*