### PR TITLE
docs: Document Nango webhook retries and timeouts

### DIFF
--- a/docs/changelog/dev-updates.mdx
+++ b/docs/changelog/dev-updates.mdx
@@ -8,7 +8,36 @@ description: "Updates and breaking changes for developers."
 [Full technical changelog on <Icon icon="github" />](https://github.com/NangoHQ/nango/releases)
 </Info>
 
-<Update label="Oct 29, 2025" description="Function custom logs" tags={["Breaking changes", "Functions"]}>
+<Update label="November 27, 2025">
+
+  ## Behavior change of webhooks from Nango to your app
+
+  New behavior: 
+  - Timeout: 20s (instead of 60s)
+  - Retries: 2 (instead of 7)
+
+  ### 🗓️ Timeline
+
+  - New behavior will go like on **December 3, 2025**. 
+
+  ### 🧐 Am I impacted?
+
+  Most likely. In particular, if you consume webhooks for auth, syncs, async actions, webhook forwards.
+
+  ### 💡 What should I do?
+
+  No action to take.
+
+  ### Why are we making this change?
+
+  The long timeout and many retries created incidents when webhook endpoints where unavailable. The new behavior is in line with other popular APIs (e.g. Stripe, Hubspot).
+
+
+  ---
+
+</Update>
+
+<Update label="October 29, 2025">
 
   ## Function custom logs won't be ingested by default for remote environments
 
@@ -71,7 +100,7 @@ description: "Updates and breaking changes for developers."
 
 </Update>
 
-<Update label="Sep 1, 2025"  tags={["Breaking changes", "API"]}>
+<Update label="September 1, 2025">
 
   ## End-user info is no longer shared between connections
 
@@ -114,7 +143,7 @@ Currently, if multiple connections share the same `end_user_id`, they also share
 
 </Update>
 
-<Update label="August 22, 2025" description="Action output limit" tags={["Breaking changes"]}>
+<Update label="August 22, 2025">
 
   ## Action payload output limit
 
@@ -149,7 +178,7 @@ Currently, if multiple connections share the same `end_user_id`, they also share
 </Update>
 
 
-<Update label="August 20, 2025" description="v0.66.2" tags={["Breaking changes", "API", "CLI"]}>
+<Update label="August 20, 2025">
 
   ## Deprecation of `/connection` endpoints
 
@@ -219,7 +248,7 @@ Currently, if multiple connections share the same `end_user_id`, they also share
 </Update>
 
 
-<Update label="July 21, 2025" description="v0.64.0" tags={["Breaking changes","CLI", "Scripts"]}>
+<Update label="July 21, 2025">
 
   ## Deprecation of `nango.yaml` configuration file
 

--- a/docs/changelog/dev-updates.mdx
+++ b/docs/changelog/dev-updates.mdx
@@ -18,7 +18,7 @@ description: "Updates and breaking changes for developers."
 
   ### 🗓️ Timeline
 
-  - New behavior will go like on **December 3, 2025**. 
+  - New behavior will go live on **December 3, 2025**.
 
   ### 🧐 Am I impacted?
 

--- a/docs/changelog/dev-updates.mdx
+++ b/docs/changelog/dev-updates.mdx
@@ -30,7 +30,7 @@ description: "Updates and breaking changes for developers."
 
   ### Why are we making this change?
 
-  The long timeout and many retries created incidents when webhook endpoints where unavailable. The new behavior is in line with other popular APIs (e.g. Stripe, Hubspot).
+  The long timeout and many retries created incidents when webhook endpoints were unavailable. The new behavior is in line with other popular APIs (e.g. Stripe, Hubspot).
 
 
   ---

--- a/docs/implementation-guides/platform/webhooks-from-nango.mdx
+++ b/docs/implementation-guides/platform/webhooks-from-nango.mdx
@@ -282,7 +282,9 @@ Webhooks forward from external APIs have the following JSON body:
 
 ## Webhook retries & debugging
 
-Nango retries each webhook with non-2xx responses 7 times with exponential backoff (starting delay: 100ms, time multiple: 2, view details in the [code](https://github.com/NangoHQ/nango/blob/master/packages/webhooks/lib/utils.ts)).
+Nango retries each webhook with non-2xx responses 2 times with exponential backoff (starting delay: 100ms, time multiple: 2, view details in the [code](https://github.com/NangoHQ/nango/blob/master/packages/webhooks/lib/utils.ts)).
+
+Webhooks time out after 20 seconds.
 
 Each webhook attempt is logged in Nango's [logs](/guides/platform/logs).
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Docs: Update webhook timeout & retry policy**

Updates documentation to reflect the new webhook behavior (20 s timeout, 2 retries) and logs the change in the developer changelog. No source code is modified; only `.mdx` content under `docs/` is touched.

<details>
<summary><strong>Key Changes</strong></summary>

• Added new update block dated November 27 2025 in `docs/changelog/dev-updates.mdx` documenting the webhook timeout reduction to 20 s and retry count reduction to 2
• Replaced legacy values (60 s / 7 retries) with new values (20 s / 2 retries) in `docs/implementation-guides/platform/webhooks-from-nango.mdx`
• Standardized date-label formatting for several existing changelog entries (e.g., `Sep 1, 2025` ➜ `September 1, 2025`)

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs/changelog/dev-updates.mdx`
• `docs/implementation-guides/platform/webhooks-from-nango.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*