### PR TITLE
Fix Public Connect URL by passing `NANGO_PUBLIC_CONNECT_URL` env var to the server container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,6 +34,7 @@ services:
             - SERVER_PORT
             - CSP_REPORT_ONLY=true
             - NANGO_SERVER_URL=${NANGO_SERVER_URL:-http://localhost:3003}
+            - NANGO_PUBLIC_CONNECT_URL=${NANGO_PUBLIC_CONNECT_URL:-http://localhost:3009}
             - NANGO_PUBLIC_SERVER_URL=${NANGO_PUBLIC_SERVER_URL:-http://localhost:3000}
             - FLAG_AUTH_ENABLED
             - NANGO_DASHBOARD_USERNAME


### PR DESCRIPTION
The nango-server container was always falling back to `http://localhost:3009` because `NANGO_PUBLIC_CONNECT_URL` was not included in the environment list.
As a result, the Dashboard continued using localhost:3009 instead of the custom Connect UI domain.
This update passes the env var to the server container to make sure it works as expected

<!-- Summary by @propel-code-bot -->

---

**Expose `NANGO_PUBLIC_CONNECT_URL` to `nango-server` container**

Adds the missing `NANGO_PUBLIC_CONNECT_URL` environment variable to the `nango-server` service definition in `docker-compose.yaml`. Without this, the server always fell back to `http://localhost:3009`, causing the dashboard to ignore custom Connect UI domains.

<details>
<summary><strong>Key Changes</strong></summary>

• Inserted `NANGO_PUBLIC_CONNECT_URL=${NANGO_PUBLIC_CONNECT_URL:-http://localhost:3009}` into the `environment` list of the `nango-server` service in `docker-compose.yaml`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docker-compose.yaml` (service `nango-server` environment block)

</details>

---
*This summary was automatically generated by @propel-code-bot*