### PR TITLE
fix(connect-session): add in end user for mcp generic

### DIFF
--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -2011,6 +2011,37 @@ class OAuthController {
                 environmentId: session.environmentId
             });
 
+            if (!updatedConnection) {
+                void logCtx.error('Failed to create connection');
+                await logCtx.failed();
+                await publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.UnknownError('failed to create connection'));
+                return;
+            }
+
+            let connectSession: ConnectSessionAndEndUser | undefined;
+
+            if (session.connectSessionId) {
+                const connectSessionRes = await getConnectSession(db.knex, {
+                    id: session.connectSessionId,
+                    accountId: account.id,
+                    environmentId: environment.id
+                });
+                if (connectSessionRes.isErr()) {
+                    void logCtx.error('Failed to get session');
+                    await logCtx.failed();
+                    await publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.UnknownError('failed to get session'));
+                    return;
+                }
+
+                connectSession = connectSessionRes.value;
+                await syncEndUserToConnection(db.knex, {
+                    connectSession: connectSession.connectSession,
+                    connection: updatedConnection.connection,
+                    account,
+                    environment
+                });
+            }
+
             if (updatedConnection) {
                 void connectionCreatedHook(
                     {
@@ -2019,7 +2050,7 @@ class OAuthController {
                         account,
                         auth_mode: provider.auth_mode,
                         operation: updatedConnection.operation || 'unknown',
-                        endUser: undefined
+                        endUser: connectSession?.connectSession.endUser ?? undefined
                     },
                     account,
                     config,


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Propagate `endUser` info & improve error handling in `oauth.controller.ts`**

Small patch that makes sure `endUser` data coming from a `connectSession` is synced to the created connection and is forwarded to `connectionCreatedHook` for MCP generic OAuth flows. Also hardens error-handling paths when a connection or session retrieval fails.

<details>
<summary><strong>Key Changes</strong></summary>

• Added null-check & early return when `updatedConnection` is falsy with log + websocket error notification
• Fetched `ConnectSession` when `session.connectSessionId` exists and invoked `syncEndUserToConnection` to tie `endUser` to the new connection
• Passed `endUser` (if any) into `connectionCreatedHook` call (replaces previous hard-coded `undefined`)

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/oauth.controller.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*