### PR TITLE
fix(webhook): fix sellsy webhook eventType mapping

### DIFF
--- a/packages/server/lib/webhook/sellsy-webhook-routing.ts
+++ b/packages/server/lib/webhook/sellsy-webhook-routing.ts
@@ -33,7 +33,16 @@ const route: WebhookHandler<SellsyWebhookPayload> = async (nango, headers, body,
         logger.info('no webhook secret configured, skipping signature validation', { configId: nango.integration.id });
     }
 
-    const webhookType = body.thirdtype ? `${body.thirdtype}.${body.event}` : body.event;
+    let webhookType: string;
+    if (body.eventType?.toLowerCase() === 'thirdlog') {
+        if (body.thirdtype) {
+            webhookType = `${body.thirdtype}.${body.event}`;
+        } else {
+            webhookType = `${body.relatedtype}.${body.eventType}.${body.event}`;
+        }
+    } else {
+        webhookType = `${body.relatedtype}.${body.event}`;
+    }
 
     const response = await nango.executeScriptForWebhooks({
         body,


### PR DESCRIPTION
## Describe the problem and your solution

-Fix Sellsy webhook eventType mapping. The webhook response is not documented, so this was implemented after consulting the team and manually testing the various webhooks events.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Correct Sellsy webhook event type composition**

Adjusts how the Sellsy webhook handler derives `webhookType` to reflect the actual payload fields returned by Sellsy. The logic now differentiates between `thirdlog` events and other event categories, concatenating the correct combination of `relatedtype`, `eventType`, `thirdtype`, and `event`.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed old `webhookType` assignment that relied only on `thirdtype` and `event`
• Introduced branch logic: when `body.eventType` equals `thirdlog`, build `webhookType` from `thirdtype` (if present) or `relatedtype.eventType.event`; otherwise use `relatedtype.event`
• Declared local variable `webhookType` with `let` to allow reassignment

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/webhook/sellsy-webhook-routing.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*