### PR TITLE
feat(webapp): redesign integrations catalog

### DIFF
--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -25,7 +25,7 @@ import { EnvironmentSettings } from './pages/Environment/Settings/Show';
 import { ClassicGettingStarted } from './pages/GettingStarted/ClassicGettingStarted';
 import { GettingStarted } from './pages/GettingStarted/Show';
 import { Homepage } from './pages/Homepage/Show';
-import CreateIntegration from './pages/Integrations/Create';
+import { CreateIntegration } from './pages/Integrations/Create';
 import { IntegrationsList } from './pages/Integrations/Show';
 import { ShowIntegration } from './pages/Integrations/providerConfigKey/Show';
 import { LogsShow } from './pages/Logs/Show';

--- a/packages/webapp/src/components-v2/ui/badge.tsx
+++ b/packages/webapp/src/components-v2/ui/badge.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/utils/utils';
 import type { VariantProps } from 'class-variance-authority';
 
 const badgeVariants = cva(
-    'inline-flex items-center justify-center uppercase rounded px-2 py-0.5 text-body-extra-small-semi w-fit whitespace-nowrap shrink-0 [&>svg]:size-3.5 gap-1 [&>svg]:pointer-events-none',
+    'inline-flex items-center justify-center uppercase rounded px-2 py-0.5 !text-body-extra-small-semi w-fit whitespace-nowrap shrink-0 [&>svg]:size-3.5 gap-1 [&>svg]:pointer-events-none',
     {
         variants: {
             variant: {
@@ -15,7 +15,8 @@ const badgeVariants = cva(
                 mint: 'bg-badge-bg-mint text-badge-fg-mint',
                 pink: 'bg-badge-bg-pink text-badge-fg-pink',
                 yellow: 'bg-badge-bg-yellow text-badge-fg-yellow',
-                green: 'bg-badge-bg-green text-badge-fg-green'
+                green: 'bg-badge-bg-green text-badge-fg-green',
+                ghost: 'bg-transparent text-text-secondary border border-border-default'
             }
         },
         defaultVariants: {

--- a/packages/webapp/src/components-v2/ui/input-group.tsx
+++ b/packages/webapp/src/components-v2/ui/input-group.tsx
@@ -1,0 +1,129 @@
+import { cva } from 'class-variance-authority';
+import * as React from 'react';
+
+import { Button } from '@/components-v2/ui/button';
+import { Input } from '@/components-v2/ui/input';
+import { Textarea } from '@/components-v2/ui/textarea';
+import { cn } from '@/utils/utils';
+
+import type { VariantProps } from 'class-variance-authority';
+
+function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
+    return (
+        <div
+            data-slot="input-group"
+            role="group"
+            className={cn(
+                'group/input-group bg-bg-surface border border-border-muted text-text-primary placeholder:text-text-tertiary !text-body-medium-regular relative flex w-full items-center rounded transition-[color,box-shadow] outline-none focus-shadow',
+                'h-9 min-w-0 has-[>textarea]:h-auto',
+
+                // Variants based on alignment.
+                'has-[>[data-align=inline-start]]:[&>input]:pl-2',
+                'has-[>[data-align=inline-end]]:[&>input]:pr-2',
+                'has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3',
+                'has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3',
+
+                // Focus state.
+                'has-[[data-slot=input-group-control]:focus-visible]:shadow-focus has-[[data-slot=input-group-control]:focus-visible]:border-border-default',
+                // Filled state - different border when input has text (works for both controlled and uncontrolled inputs)
+                'has-[[data-slot=input-group-control]:not(:placeholder-shown)]:border-border-strong',
+
+                // Error state.
+                'has-[[data-slot][aria-invalid=true]]:focus-error has-[[data-slot][aria-invalid=true]]:border-feedback-error-border',
+
+                className
+            )}
+            {...props}
+        />
+    );
+}
+
+const inputGroupAddonVariants = cva(
+    "text-neutral-500 flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium select-none [&>svg:not([class*='size-'])]:size-4 [&>kbd]:rounded-[calc(var(--radius)-5px)] group-data-[disabled=true]/input-group:opacity-50 dark:text-neutral-400",
+    {
+        variants: {
+            align: {
+                'inline-start': 'order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]',
+                'inline-end': 'order-last pr-3 has-[>button]:mr-[-0.45rem] has-[>kbd]:mr-[-0.35rem]',
+                'block-start': 'order-first w-full justify-start px-3 pt-3 [.border-b]:pb-3 group-has-[>input]/input-group:pt-2.5',
+                'block-end': 'order-last w-full justify-start px-3 pb-3 [.border-t]:pt-3 group-has-[>input]/input-group:pb-2.5'
+            }
+        },
+        defaultVariants: {
+            align: 'inline-start'
+        }
+    }
+);
+
+function InputGroupAddon({ className, align = 'inline-start', ...props }: React.ComponentProps<'div'> & VariantProps<typeof inputGroupAddonVariants>) {
+    return (
+        <div
+            role="group"
+            data-slot="input-group-addon"
+            data-align={align}
+            className={cn(inputGroupAddonVariants({ align }), className)}
+            onClick={(e) => {
+                if ((e.target as HTMLElement).closest('button')) {
+                    return;
+                }
+                e.currentTarget.parentElement?.querySelector('input')?.focus();
+            }}
+            {...props}
+        />
+    );
+}
+
+const inputGroupButtonVariants = cva('text-sm shadow-none flex gap-2 items-center', {
+    variants: {
+        size: {
+            xs: "h-6 gap-1 px-2 rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-3.5 has-[>svg]:px-2",
+            sm: 'h-8 px-2.5 gap-1.5 rounded-md has-[>svg]:px-2.5',
+            'icon-xs': 'size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0',
+            'icon-sm': 'size-8 p-0 has-[>svg]:p-0'
+        }
+    },
+    defaultVariants: {
+        size: 'xs'
+    }
+});
+
+function InputGroupButton({
+    className,
+    type = 'button',
+    variant = 'ghost',
+    size = 'xs',
+    ...props
+}: Omit<React.ComponentProps<typeof Button>, 'size'> & VariantProps<typeof inputGroupButtonVariants>) {
+    return <Button type={type} data-size={size} variant={variant} className={cn(inputGroupButtonVariants({ size }), className)} {...props} />;
+}
+
+function InputGroupText({ className, ...props }: React.ComponentProps<'span'>) {
+    return (
+        <span
+            className={cn("text-neutral-500 flex items-center gap-2 text-sm [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4", className)}
+            {...props}
+        />
+    );
+}
+
+function InputGroupInput({ className, ...props }: React.ComponentProps<'input'>) {
+    return (
+        <Input
+            data-slot="input-group-control"
+            className={cn('flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0', className)}
+            {...props}
+        />
+    );
+}
+
+function InputGroupTextarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+    return (
+        <Textarea
+            data-slot="input-group-control"
+            className={cn('flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus-visible:ring-0', className)}
+            {...props}
+        />
+    );
+}
+
+export { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupText, InputGroupTextarea };

--- a/packages/webapp/src/components-v2/ui/textarea.tsx
+++ b/packages/webapp/src/components-v2/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import { cn } from '@/utils/utils';
+
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+    return (
+        <textarea
+            data-slot="textarea"
+            className={cn(
+                'border-neutral-200 placeholder:text-neutral-500 focus-visible:border-neutral-950 focus-visible:ring-neutral-950/50 aria-invalid:ring-red-500/20 dark:aria-invalid:ring-red-500/40 aria-invalid:border-red-500 dark:bg-neutral-200/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:border-neutral-800 dark:placeholder:text-neutral-400 dark:focus-visible:border-neutral-300 dark:focus-visible:ring-neutral-300/50 dark:aria-invalid:ring-red-900/20 dark:dark:aria-invalid:ring-red-900/40 dark:aria-invalid:border-red-900 dark:dark:bg-neutral-800/30',
+                className
+            )}
+            {...props}
+        />
+    );
+}
+
+export { Textarea };

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -351,6 +351,7 @@
     --color-badge-fg-yellow: var(--color-yellow-700);
 
     --color-focus-ring: var(--color-brand-500);
+    --shadow-focus: 0 0 0 3px rgba(0, 178, 227, 0.2);
 
     /* Feedback */
     --color-feedback-success-fg: var(--color-green-700);
@@ -602,7 +603,7 @@
 }
 
 @utility text-body-extra-small-semi {
-    font-size: 12px;
+    font-size: 10px;
     line-height: 14px;
     font-weight: 600;
 }

--- a/packages/webapp/src/pages/Integrations/Create.tsx
+++ b/packages/webapp/src/pages/Integrations/Create.tsx
@@ -1,18 +1,22 @@
-import { BookOpenIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import debounce from 'lodash/debounce';
+import { Info, Loader2, Search } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { useNavigate } from 'react-router-dom';
 import { useSWRConfig } from 'swr';
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../components/ui/Dialog';
-import IntegrationLogo from '../../components/ui/IntegrationLogo';
-import { Button } from '../../components/ui/button/Button';
+import { AuthBadge } from './components/AuthBadge';
 import { apiPostIntegration, clearIntegrationsCache } from '../../hooks/useIntegration';
 import { useToast } from '../../hooks/useToast';
 import DashboardLayout from '../../layout/DashboardLayout';
 import { useStore } from '../../store';
 import { useGetProvidersAPI } from '../../utils/api';
+import { IntegrationLogo } from '@/components-v2/IntegrationLogo';
+import { Alert, AlertDescription } from '@/components-v2/ui/alert';
+import { Badge } from '@/components-v2/ui/badge';
+import { Button } from '@/components-v2/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components-v2/ui/dialog';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components-v2/ui/input-group';
 
 import type { AuthModeType } from '@nangohq/types';
 
@@ -27,7 +31,7 @@ interface Provider {
     preConfiguredScopes: string[];
 }
 
-export default function Create() {
+export const CreateIntegration = () => {
     const { mutate, cache } = useSWRConfig();
     const { toast } = useToast();
     const env = useStore((state) => state.env);
@@ -85,12 +89,6 @@ export default function Create() {
         }
     };
 
-    const showDocs = (e: React.MouseEvent<SVGSVGElement>, provider: Provider) => {
-        e.stopPropagation();
-        const documentationUrl = provider.docs ?? `https://nango.dev/docs/integrations/all/${provider.name}`;
-        window.open(documentationUrl, '_blank');
-    };
-
     const filterProviders = useCallback(
         (value: string) => {
             if (!value.trim()) {
@@ -145,47 +143,28 @@ export default function Create() {
     };
 
     return (
-        <DashboardLayout>
+        <DashboardLayout fullWidth className="flex flex-col gap-8">
             <Helmet>
-                <title>Integrations Create - Nango</title>
+                <title>Create integration - Nango</title>
             </Helmet>
-            {providers && (
-                <div className="w-full">
-                    <h2 className="text-left text-3xl font-semibold tracking-tight text-white mb-8">Create Integration</h2>
-                    <div className="relative">
-                        <div className="h-fit rounded-md text-white text-sm">
-                            <MagnifyingGlassIcon className="absolute top-2 left-4 h-5 w-5 text-gray-400" />
-                            <input
-                                id="search"
-                                name="search"
-                                type="text"
-                                placeholder="Search APIs or category"
-                                className="border-border-gray bg-active-gray indent-8 text-white block w-full appearance-none rounded-md border px-3 py-2 text-sm placeholder-gray-400 shadow-xs focus:outline-hidden"
-                                onChange={handleInputChange}
-                                onKeyUp={handleInputChange}
-                            />
-                        </div>
-                    </div>
-                    <div className="flex flex-wrap text-white w-full">
-                        {providers.map((provider) => (
-                            <div
-                                key={provider.name}
-                                className="flex justify-between px-2 p-2 mr-2 mt-4 mb-5 w-[14.7rem] border border-transparent rounded-sm cursor-pointer items-center text-sm hover:bg-hover-gray"
-                                onClick={() => onSelectProvider(provider)}
-                            >
-                                <div className="flex items-center">
-                                    <IntegrationLogo provider={provider.name} height={12} width={12} classNames="mr-2" />
-                                    <div className="flex flex-col flex-start">
-                                        <span className="flex">{provider.displayName}</span>
-                                        {provider.categories && <span className="flex text-xs text-gray-400">{provider.categories.join(', ')}</span>}
-                                    </div>
-                                </div>
-                                <BookOpenIcon onClick={(e) => showDocs(e, provider)} className="h-5 w-5 text-gray-400 hover:text-white hover:bg-hover-gray" />
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            )}
+
+            <header>
+                <h2 className="text-text-primary text-title-subsection">Set up new integration</h2>
+            </header>
+
+            <InputGroup className="bg-bg-subtle">
+                <InputGroupInput type="text" placeholder="Github, accounting, oauth..." onChange={handleInputChange} onKeyUp={handleInputChange} />
+                <InputGroupAddon>
+                    <Search />
+                </InputGroupAddon>
+            </InputGroup>
+
+            <div className="flex flex-col gap-2">
+                {providers?.map((provider) => (
+                    <Provider key={provider.name} provider={provider} onClick={() => onSelectProvider(provider)} />
+                ))}
+            </div>
+
             <Dialog open={showConfigModal} onOpenChange={setShowConfigModal}>
                 <DialogContent className="w-[570px] max-w-[570px]">
                     <DialogHeader>
@@ -193,34 +172,30 @@ export default function Create() {
                     </DialogHeader>
 
                     {selectedProvider && (
-                        <div className="space-y-8">
-                            <div className="flex items-center justify-between p-3 bg-gray-900 rounded-lg">
-                                <div className="flex items-center">
-                                    <IntegrationLogo provider={selectedProvider.name} height={10} width={10} classNames="mr-2" />
+                        <div className="flex flex-col gap-4">
+                            <div className="flex items-center justify-between p-3 bg-bg-subtle rounded">
+                                <div className="flex items-center gap-2">
+                                    <IntegrationLogo provider={selectedProvider.name} size={10} />
                                     <span className="text-white font-medium">{selectedProvider.displayName}</span>
                                 </div>
-                                <div className="bg-gray-700 px-2 py-1 rounded-sm text-sm">
-                                    <span className="text-gray-500">Type: </span>
-                                    <span className="text-gray-300">{selectedProvider.authMode}</span>
-                                </div>
+                                <AuthBadge authMode={selectedProvider.authMode} className="py-2 px-4 !text-body-small-semi gap-2" />
                             </div>
-                            <div className="relative w-full rounded-lg border px-2 py-2 text-sm flex gap-2.5 items-center min-h-10 bg-blue-base-35 border-blue-base text-blue-base">
-                                <svg className="w-4 h-4 shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                                    <path
-                                        fillRule="evenodd"
-                                        d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-                                        clipRule="evenodd"
-                                    />
-                                </svg>
-                                <div className="flex flex-col gap-2">
-                                    <div className="text-sm">
-                                        Nango provides a developer app for testing. They may get reset occasionally. Always use your own developer app for
-                                        production.
-                                    </div>
-                                </div>
-                            </div>
-                            <div className="flex justify-between">
-                                <Button type="button" onClick={() => handleIntegrationCreation(env !== 'prod')} isLoading={isCreatingShared} variant="primary">
+                            <Alert variant="info">
+                                <Info />
+                                <AlertDescription>
+                                    Nango provides a developer app for testing. They may get reset occasionally. Always use your own developer app for
+                                    production.
+                                </AlertDescription>
+                            </Alert>
+                            <div className="flex justify-between gap-2">
+                                <Button
+                                    type="button"
+                                    size="lg"
+                                    onClick={() => handleIntegrationCreation(env !== 'prod')}
+                                    disabled={isCreatingShared}
+                                    variant="primary"
+                                >
+                                    {isCreatingShared && <Loader2 />}
                                     {isCreatingShared && env !== 'prod'
                                         ? 'Creating...'
                                         : env !== 'prod'
@@ -229,10 +204,12 @@ export default function Create() {
                                 </Button>
                                 <Button
                                     type="button"
+                                    size="lg"
                                     onClick={() => handleIntegrationCreation(env === 'prod')}
-                                    isLoading={isCreatingShared}
+                                    disabled={isCreatingShared}
                                     variant="secondary"
                                 >
+                                    {isCreatingShared && <Loader2 />}
                                     {isCreatingShared && env === 'prod'
                                         ? 'Creating...'
                                         : env === 'prod'
@@ -246,4 +223,26 @@ export default function Create() {
             </Dialog>
         </DashboardLayout>
     );
-}
+};
+
+const Provider = ({ provider, onClick }: { provider: Provider; onClick: () => void }) => {
+    return (
+        <div
+            onClick={onClick}
+            className="p-4 w-full inline-flex items-center justify-between bg-bg-elevated rounded border border-transparent cursor-pointer transition-colors hover:bg-bg-surface hover:border-border-disabled"
+        >
+            <div className="inline-flex gap-1.5 items-center">
+                <IntegrationLogo provider={provider.name} />
+                <span className="text-text-primary text-body-medium-semi">{provider.displayName}</span>
+            </div>
+            <div className="inline-flex gap-1.5 items-center justify-end">
+                <AuthBadge authMode={provider.authMode} />
+                {provider.categories?.map((category) => (
+                    <Badge key={category} variant="ghost">
+                        {category}
+                    </Badge>
+                ))}
+            </div>
+        </div>
+    );
+};

--- a/packages/webapp/src/pages/Integrations/components/AuthBadge.tsx
+++ b/packages/webapp/src/pages/Integrations/components/AuthBadge.tsx
@@ -6,6 +6,7 @@ import type { AuthModeType } from '@nangohq/types';
 
 interface AuthBadgeProps {
     authMode: AuthModeType;
+    className?: string;
 }
 
 /**
@@ -60,9 +61,9 @@ const getIcon = (authMode: AuthModeType) => {
     }
 };
 
-export const AuthBadge: React.FC<AuthBadgeProps> = ({ authMode }) => {
+export const AuthBadge: React.FC<AuthBadgeProps> = ({ authMode, className }) => {
     return (
-        <Badge variant="gray">
+        <Badge variant="gray" className={className}>
             {getIcon(authMode)} {getDisplayName(authMode)}
         </Badge>
     );


### PR DESCRIPTION
Redesign of the integrations catalog (the page where you select the new integration you want to create).
Eventually, this flow will be different and selecting an integration won't immediately create the integration. But for now, we're just redesigning with no significant changes to the flow.
The ƒull provider list is loaded and rendered. I haven't changed that, but I've added list virtualization to improve performance.

Before:
<img width="1510" height="802" alt="image" src="https://github.com/user-attachments/assets/70394ba2-ef22-4fef-990a-19e736e56a9f" />

After: 
<img width="1512" height="801" alt="image" src="https://github.com/user-attachments/assets/60b1d5b3-4ccb-460c-b290-173f220cf6df" />
<!-- Summary by @propel-code-bot -->

---

**Web-app integrations catalog – UI redesign + virtualized list**

Replaces the legacy `CreateIntegration` screen with a new implementation that uses design-system v2 primitives, refreshed typography/colors, and introduces list virtualization via `@tanstack/react-virtual`. Functional flow (search → select provider → optional config modal → create integration) remains unchanged, but routing now exports the component as a named `CreateIntegration`. Several reusable UI primitives (`InputGroup`, `Textarea`, extended `Badge` variants) and new CSS tokens/focus shadows are added.

<details>
<summary><strong>Key Changes</strong></summary>

• Refactored `packages/webapp/src/pages/Integrations/Create.tsx` → new component `CreateIntegration` with virtualized provider list (`ProviderList` + `useVirtualizer`) and updated modal layout
• Added new UI primitives: `InputGroup`, `InputGroupAddon`, `InputGroupInput`, `InputGroupTextarea`, `InputGroupButton` in `components-v2/ui/input-group.tsx`
• Extended `Badge` component with `ghost` variant and typography tweak; updated `AuthBadge` to accept `className` and use new badge variant
• Introduced generic `Textarea` component (`components-v2/ui/textarea.tsx`)
• Global design-system updates in `index.css`: new `--shadow-focus`, smaller `text-body-extra-small-semi` font-size, focus utility rules
• Routing change in `App.tsx` to use named export `CreateIntegration`; legacy `CreateOld.tsx` kept temporarily (should be deleted before merge)
• Performance: provider list now virtualized (overscan 5, estimated row height 74px) to avoid rendering hundreds of DOM nodes

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `src/pages/Integrations/Create.tsx`
• `src/components-v2/ui/*` (badge, input-group, textarea)
• `src/pages/Integrations/components/AuthBadge.tsx`
• `src/index.css` theme tokens & utilities
• `src/App.tsx` routing

</details>

---
*This summary was automatically generated by @propel-code-bot*