### PR TITLE
feat(webapp): (proposal) improve fuzzy search in integrations catalog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19751,6 +19751,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/fuse.js": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+            "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/gaxios": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.1.tgz",
@@ -33141,6 +33151,7 @@
                 "cmdk": "1.0.4",
                 "date-fns": "4.1.0",
                 "env-cmd": "10.1.0",
+                "fuse.js": "7.1.0",
                 "httpsnippet-lite": "3.0.5",
                 "json-schema": "^0.4.0",
                 "lodash": "4.17.21",

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -72,6 +72,7 @@
         "cmdk": "1.0.4",
         "date-fns": "4.1.0",
         "env-cmd": "10.1.0",
+        "fuse.js": "7.1.0",
         "httpsnippet-lite": "3.0.5",
         "json-schema": "^0.4.0",
         "lodash": "4.17.21",


### PR DESCRIPTION
We currently do a simple `.includes` on the name and categories. I think having fuzzy search including weighted auth mode and categories here is valuable. Using `fuse.js` it makes this pretty easy and efficient.

<!-- Summary by @propel-code-bot -->

---

**Integrations Catalog: switch to weighted fuzzy search via `fuse.js`**

Replaces the previous case-insensitive substring filter in the integrations catalog with a weighted fuzzy search powered by `fuse.js`. The new logic considers `displayName`, `name`, `authMode`, and `categories`, each with configurable weights, and keeps the existing 300 ms debounce. A new runtime dependency (`fuse.js@7.1.0`) is added to `package.json`/`package-lock.json`.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `Fuse` import and created memoised `fuse` instance in `packages/webapp/src/pages/Integrations/Create.tsx`
• Re-implemented `filterProviders` to use `fuse.search()` and rank results
• Preserved debounced search with `debounce` (300 ms) in `debouncedFilterProviders`
• Added dependency `fuse.js@7.1.0` in `packages/webapp/package.json` and lockfile

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/pages/Integrations/Create.tsx` (search logic, hooks, memoisation)
• `packages/webapp/package.json` / `package-lock.json` (dependencies)

</details>

---
*This summary was automatically generated by @propel-code-bot*