### PR TITLE
chore(api): Retrieve DEFAULT_RATE_LIMIT_PER_MIN using zod

### DIFF
--- a/packages/server/lib/middleware/ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/ratelimit.middleware.ts
@@ -6,6 +6,8 @@ import { createClient } from 'redis';
 import { getRedisUrl } from '@nangohq/shared';
 import { flagHasAPIRateLimit, flagHasPlan, getLogger } from '@nangohq/utils';
 
+import { envs } from '../env.js';
+
 import type { RequestLocals } from '../utils/express.js';
 import type { DBPlan } from '@nangohq/types';
 import type { NextFunction, Request, Response } from 'express';
@@ -13,7 +15,7 @@ import type { RateLimiterAbstract } from 'rate-limiter-flexible';
 
 const logger = getLogger('RateLimiter');
 
-const defaultLimit = parseInt(process.env['DEFAULT_RATE_LIMIT_PER_MIN'] || '0') || 3500;
+const defaultLimit = envs.DEFAULT_RATE_LIMIT_PER_MIN;
 const rateLimiterSize: Record<DBPlan['api_rate_limit_size'], number> = {
     s: defaultLimit / 2,
     m: defaultLimit,

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -22,7 +22,7 @@ export const ENVS = z.object({
     SERVER_PORT: z.coerce.number().optional().default(3003),
     NANGO_SERVER_URL: z.url().optional(),
     NANGO_SERVER_KEEP_ALIVE_TIMEOUT: z.coerce.number().optional().default(61_000),
-    DEFAULT_RATE_LIMIT_PER_MIN: z.coerce.number().min(1).optional(),
+    DEFAULT_RATE_LIMIT_PER_MIN: z.coerce.number().min(1).optional().default(200),
     NANGO_CACHE_ENV_KEYS: z.stringbool().optional().default(false),
     NANGO_SERVER_WEBSOCKETS_PATH: z.string().optional(),
     NANGO_ADMIN_INVITE_TOKEN: z.string().optional(),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
The existing usage of `DEFAULT_RATE_LIMIT_PER_MIN` env var had 2 issues
- It didn't use zod, which is the standard way of parsing and using env vars in the codebase
- It defaulted to 3500 if it's missing, which is a lot higher than our actual current base default.

This PR addresses both of these. The default value is set to 200, which is our current base default, but only for type-safety reasons. We make sure to set this value in all services and environments that would use this variable regardless.
<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Switch rate-limit default to zod-parsed env & lower fallback value**

Replaces direct `process.env` access with typed retrieval via `envs` object and adjusts the fallback value of `DEFAULT_RATE_LIMIT_PER_MIN` from 3500 to 200. Keeps rate-limiter logic unchanged otherwise and aligns with the codebase’s standard zod-based env parsing.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed inline parsing of `process.env['DEFAULT_RATE_LIMIT_PER_MIN']` in `packages/server/lib/middleware/ratelimit.middleware.ts`
• Added `envs.DEFAULT_RATE_LIMIT_PER_MIN` import and usage
• Updated zod schema in `packages/utils/lib/environment/parse.ts` to `.default(200)` instead of leaving undefined or defaulting in code

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/middleware/ratelimit.middleware.ts`
• `packages/utils/lib/environment/parse.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*