### PR TITLE
fix: account activation toasts

### DIFF
--- a/packages/server/lib/controllers/v1/account/validateEmailAndLogin.ts
+++ b/packages/server/lib/controllers/v1/account/validateEmailAndLogin.ts
@@ -46,8 +46,15 @@ export const validateEmailAndLogin = asyncWrapper<ValidateEmailAndLogin>(async (
                     message: 'The token has expired. An email has been sent with a new token.'
                 }
             });
+        } else if (error.message === 'user_not_found') {
+            res.status(400).send({
+                error: {
+                    code: 'invalid_token',
+                    message: 'The token is invalid.'
+                }
+            });
         } else {
-            logger.error('Error validating user');
+            logger.error('Error validating user', error);
             res.status(500).send({
                 error: { code: 'error_validating_user', message: 'There was a problem validating the user. Please reach out to support.' }
             });

--- a/packages/types/lib/account/api.ts
+++ b/packages/types/lib/account/api.ts
@@ -32,7 +32,12 @@ export type ValidateEmailAndLogin = Endpoint<{
     Body: {
         token: string;
     };
-    Error: ApiError<'error_logging_in'> | ApiError<'error_validating_user'> | ApiError<'token_expired'> | ApiError<'error_refreshing_token'>;
+    Error:
+        | ApiError<'error_logging_in'>
+        | ApiError<'error_validating_user'>
+        | ApiError<'invalid_token'>
+        | ApiError<'token_expired'>
+        | ApiError<'error_refreshing_token'>;
     Success: {
         user: ApiUser;
     };

--- a/packages/webapp/src/pages/Account/EmailVerified.tsx
+++ b/packages/webapp/src/pages/Account/EmailVerified.tsx
@@ -1,25 +1,28 @@
-import { Loading } from '@geist-ui/core';
-import { useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'react-toastify';
+import { useEffectOnce } from 'react-use';
 
 import { useStore } from '../../store';
 import { useAnalyticsTrack } from '../../utils/analytics';
 import { apiFetch } from '../../utils/api';
 import { useSignin } from '../../utils/user';
+import { useToast } from '@/hooks/useToast';
+import DefaultLayout from '@/layout/DefaultLayout';
 
 import type { ValidateEmailAndLogin } from '@nangohq/types';
 
 export const EmailVerified: React.FC = () => {
-    const [loaded, setLoaded] = useState(false);
+    const [errorMessage, setErrorMessage] = useState('');
     const { token } = useParams<{ token: string }>();
     const signin = useSignin();
     const navigate = useNavigate();
+    const { toast } = useToast();
     const analyticsTrack = useAnalyticsTrack();
 
     const env = useStore((state) => state.env);
 
-    useEffect(() => {
+    useEffectOnce(() => {
         if (!token) return;
 
         const verifyEmail = async () => {
@@ -35,33 +38,40 @@ export const EmailVerified: React.FC = () => {
                     const errorResponse: ValidateEmailAndLogin['Errors'] = response;
 
                     if (errorResponse.error.code === 'token_expired') {
-                        toast.error(errorResponse.error.message, { position: toast.POSITION.BOTTOM_CENTER });
+                        toast({ title: errorResponse.error.message, variant: 'error' });
                         navigate(`/verify-email/expired/${token}`);
                         return;
                     }
-                    toast.error(response.error.message || 'Issue verifying email. Please try again.', { position: toast.POSITION.BOTTOM_CENTER });
-                } else {
-                    const user: ValidateEmailAndLogin['Success']['user'] = response['user'];
-                    analyticsTrack('web:account_signup', {
-                        user_id: user.id,
-                        email: user.email,
-                        name: user.name,
-                        accountId: user.accountId
-                    });
 
-                    signin(user);
-                    toast.success('Email verified successfully!', { position: toast.POSITION.BOTTOM_CENTER });
-                    navigate(`/${env}/getting-started`);
+                    setErrorMessage(errorResponse.error.message || 'Issue verifying email. Please try again.');
+                    return;
                 }
+
+                const user: ValidateEmailAndLogin['Success']['user'] = response['user'];
+                analyticsTrack('web:account_signup', {
+                    user_id: user.id,
+                    email: user.email,
+                    name: user.name,
+                    accountId: user.accountId
+                });
+
+                signin(user);
+                toast({ title: 'Email verified successfully!', variant: 'success' });
+                navigate(`/${env}/getting-started`);
             } catch {
-                toast.error('An error occurred while verifying the email. Please try again.', { position: toast.POSITION.BOTTOM_CENTER });
-            } finally {
-                setLoaded(true);
+                setErrorMessage('An error occurred while verifying the email. Please try again.');
             }
         };
 
         void verifyEmail();
-    }, [token, navigate, env, signin, analyticsTrack]);
+    });
 
-    return !loaded ? <Loading spaceRatio={2.5} className="-top-36" /> : null;
+    return (
+        <DefaultLayout>
+            <div className="mt-4 flex flex-col justify-center items-center gap-8">
+                <h2 className="text-text-primary text-title-group">{errorMessage ? 'Something went wrong' : 'Verifying your email'}</h2>
+                {errorMessage ? <p className="text-text-light-gray text-body-small">{errorMessage}</p> : <Loader2 className="w-10 h-10 animate-spin" />}
+            </div>
+        </DefaultLayout>
+    );
 };


### PR DESCRIPTION
Currently, when verifying the email (by clicking the url sent to the user's email), they get 2 toast messages: a successful one, and a failed one. It looks like the request to `/verify/code` happens twice, so the second one fails, and despite being irrelevant, it's still shown. This is not the easiest thing to debug, because react has different behaviors for a dev build and a production build when it comes to rendering. I'm trying to mitigate this without wasting too much time:
- Using `useEffectOnce` from the `react-use` library to see if it does a better job at actually only executing once.
- Displaying the error message in the page instead of in toasts when there's no redirect. The design isn't final by any means, just pulled over the structure from the verify email screen.
- Sending an invalid token should not result in a 500 code.
- Updated to use correct toasts (they were un-styled react-toasts)

<img width="688" height="448" alt="image" src="https://github.com/user-attachments/assets/5a99e6e9-d9c2-44d6-9d86-b145c610988a" />
