### PR TITLE
chore(runner-sdk): remove records validation

### DIFF
--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -1,5 +1,5 @@
 import { Nango } from '@nangohq/node';
-import { InvalidRecordSDKError, NangoActionBase, NangoSyncBase } from '@nangohq/runner-sdk';
+import { NangoActionBase, NangoSyncBase } from '@nangohq/runner-sdk';
 import { ProxyRequest, getProxyConfiguration } from '@nangohq/shared';
 import { MAX_LOG_PAYLOAD, isTest, metrics, redactHeaders, redactURL, stringifyAndTruncateValue, stringifyObject, truncateJson } from '@nangohq/utils';
 
@@ -22,7 +22,6 @@ export const oldLevelToNewLevel = {
     http: 'info'
 } as const;
 
-const RECORDS_VALIDATION_SAMPLE = 1;
 const HTTP_LOG_MIN_CALLS = 5;
 const HTTP_LOG_SAMPLE_PCT = envs.RUNNER_HTTP_LOG_SAMPLE_PCT; // set to empty to disable sampling
 
@@ -377,41 +376,8 @@ export class NangoSyncRunner extends NangoSyncBase {
         }
 
         const resultsWithoutMetadata = this.removeMetadata(results);
-
-        // Validate records
-        const hasErrors = this.validateRecords(model, resultsWithoutMetadata);
-
-        if (hasErrors.length > 0) {
-            metrics.increment(metrics.Types.RUNNER_INVALID_SYNCS_RECORDS, hasErrors.length);
-            if (this.runnerFlags?.validateSyncRecords) {
-                throw new InvalidRecordSDKError({ ...hasErrors[0], model });
-            }
-
-            const sampled = hasErrors.length > RECORDS_VALIDATION_SAMPLE;
-            const sample = sampled ? hasErrors.slice(0, RECORDS_VALIDATION_SAMPLE) : hasErrors;
-            if (sampled) {
-                await this.sendLogToPersist({
-                    type: 'log',
-                    message: `Invalid records: ${hasErrors.length} failed ${sampled ? `(sampled to ${RECORDS_VALIDATION_SAMPLE})` : ''}`,
-                    source: 'internal',
-                    level: 'warn',
-                    createdAt: new Date().toISOString()
-                });
-            }
-            await Promise.all(
-                sample.map((log) => {
-                    return this.sendLogToPersist({
-                        type: 'log',
-                        message: `Invalid record payload`,
-                        meta: { ...log, model },
-                        level: 'warn',
-                        createdAt: new Date().toISOString()
-                    });
-                })
-            );
-        }
-
         const modelFullName = this.modelFullName(model);
+
         for (let i = 0; i < resultsWithoutMetadata.length; i += this.batchSize) {
             const batch = resultsWithoutMetadata.slice(i, i + this.batchSize);
             const res = await this.persistClient.saveRecords({

--- a/packages/runner/lib/sdk/sdk.unit.test.ts
+++ b/packages/runner/lib/sdk/sdk.unit.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Nango } from '@nangohq/node';
-import { AbortedSDKError, InvalidRecordSDKError } from '@nangohq/runner-sdk';
+import { AbortedSDKError } from '@nangohq/runner-sdk';
 import { ProxyRequest } from '@nangohq/shared';
 import { Ok } from '@nangohq/utils';
 
@@ -401,52 +401,6 @@ describe('Pagination', () => {
             docs: ''
         };
     };
-});
-
-describe('batchSave', () => {
-    it('should validate records with json schema', async () => {
-        const nango = new NangoSyncRunner(
-            {
-                ...nangoProps,
-                runnerFlags: { validateSyncRecords: true } as any,
-                syncConfig: {
-                    models_json_schema: {
-                        definitions: { Test: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'], additionalProperties: false } }
-                    }
-                } as any
-            },
-            { locks }
-        );
-
-        await expect(async () => await nango.batchSave([{ foo: 'bar' }], 'Test')).rejects.toThrow(
-            new InvalidRecordSDKError({
-                data: {
-                    foo: 'bar'
-                },
-                model: 'Test',
-                validation: [
-                    {
-                        instancePath: '',
-                        keyword: 'required',
-                        message: "must have required property 'id'",
-                        params: {
-                            missingProperty: 'id'
-                        },
-                        schemaPath: '#/required'
-                    },
-                    {
-                        instancePath: '',
-                        keyword: 'additionalProperties',
-                        message: 'must NOT have additional properties',
-                        params: {
-                            additionalProperty: 'foo'
-                        },
-                        schemaPath: '#/additionalProperties'
-                    }
-                ]
-            })
-        );
-    });
 });
 
 describe('Log', () => {


### PR DESCRIPTION
Records validation has never been fully enabled. Nowadays it creates more issues than values. For now we have decided to remove records validation in the runner.

Note: Records validation has not been removed from the CLI where it can still be useful. Let me know if you disagree

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Remove runner-side record validation logic**

This PR strips the runner SDK of its schema validation path during `batchSave`, removing the `InvalidRecordSDKError` dependency and associated sampling/metric reporting. The unit test covering the validation failure path has been deleted to reflect the new behavior, leaving the CLI as the only place where record validation remains enforced.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed the `InvalidRecordSDKError` import and all record-validation branches from `packages/runner/lib/sdk/sdk.ts`.
• Deleted the `RECORDS_VALIDATION_SAMPLE` constant and the `metrics.increment(metrics.Types.RUNNER_INVALID_SYNCS_RECORDS, ...)` invocation.
• Eliminated the `batchSave` validation test case and its error expectation from `packages/runner/lib/sdk/sdk.unit.test.ts`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/runner/lib/sdk/sdk.ts`
• `packages/runner/lib/sdk/sdk.unit.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*