### PR TITLE
fix: upgrade js-yaml in nango-yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21719,8 +21719,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "license": "MIT",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -31678,18 +31679,6 @@
                 "node": ">= 6"
             }
         },
-        "packages/cli/node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
         "packages/cli/node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "license": "MIT"
@@ -31938,7 +31927,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@nangohq/utils": "file:../utils",
-                "js-yaml": "4.1.0",
+                "js-yaml": "4.1.1",
                 "knex": "3.1.0",
                 "pg": "8.11.3",
                 "tarn": "3.0.2"
@@ -32363,7 +32352,7 @@
             "name": "@nangohq/nango-yaml",
             "version": "0.69.14",
             "dependencies": {
-                "js-yaml": "4.1.0",
+                "js-yaml": "4.1.1",
                 "ms": "3.0.0-canary.1"
             },
             "devDependencies": {
@@ -32479,18 +32468,6 @@
             "devDependencies": {
                 "@nangohq/types": "0.69.14",
                 "vitest": "3.2.4"
-            }
-        },
-        "packages/providers/node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "packages/pubsub": {
@@ -32961,18 +32938,6 @@
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
-            }
-        },
-        "packages/shared/node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "packages/shared/node_modules/json-schema-traverse": {
@@ -33710,19 +33675,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "scripts/node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "scripts/node_modules/json-schema-traverse": {

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -16,7 +16,7 @@
     "keywords": [],
     "dependencies": {
         "@nangohq/utils": "file:../utils",
-        "js-yaml": "4.1.0",
+        "js-yaml": "4.1.1",
         "knex": "3.1.0",
         "pg": "8.11.3",
         "tarn": "3.0.2"

--- a/packages/nango-yaml/package.json
+++ b/packages/nango-yaml/package.json
@@ -13,7 +13,7 @@
         "directory": "packages/nango-yaml"
     },
     "dependencies": {
-        "js-yaml": "4.1.0",
+        "js-yaml": "4.1.1",
         "ms": "3.0.0-canary.1"
     },
     "devDependencies": {


### PR DESCRIPTION
in #5027 not all packages were updated so dependabot is still complaining in our project.

<!-- Summary by @propel-code-bot -->

---

**Upgrade `js-yaml` to `4.1.1` across workspaces**

Updates the `js-yaml` dependency to `4.1.1` in `packages/database/package.json` and `packages/nango-yaml/package.json`, then regenerates `package-lock.json` so the workspace resolves to the patched release and removes redundant nested `js-yaml` entries.

<details>
<summary><strong>Key Changes</strong></summary>

• Bumped `js-yaml` to `4.1.1` in `packages/database/package.json`.
• Bumped `js-yaml` to `4.1.1` in `packages/nango-yaml/package.json`.
• Regenerated `package-lock.json` to reflect the new version and deduplicate workspace installs.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/database/package.json`
• `packages/nango-yaml/package.json`
• `package-lock.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*