### PR TITLE
feat(webhook): add endUserEmail

### DIFF
--- a/docs/getting-started/quickstart/embed-in-your-app.mdx
+++ b/docs/getting-started/quickstart/embed-in-your-app.mdx
@@ -139,6 +139,7 @@ description: '⏱️ 1 hour to complete'
         "connectionId": "<CONNECTION-ID>",
         "endUser": {
           "endUserId": "<END-USER-ID>",
+          "endUserEmail": "<END-USER-EMAIL>",
           "tags": { "organizationId": "<ORGANIZATION-ID>" }
         },
         ...

--- a/docs/implementation-guides/api-auth/implement-api-auth.mdx
+++ b/docs/implementation-guides/api-auth/implement-api-auth.mdx
@@ -180,6 +180,7 @@ Successful authorization webhooks sent by Nango are `POST` requests with the fol
     "connectionId": "<CONNECTION-ID>",
     "endUser": {
       "endUserId": "<END-USER-ID>",
+      "endUserEmail": "<END-USER-EMAIL>",
       "tags": { "organizationId": "<ORGANIZATION-ID>" }
     },
     ...

--- a/docs/implementation-guides/platform/webhooks-from-nango.mdx
+++ b/docs/implementation-guides/platform/webhooks-from-nango.mdx
@@ -170,8 +170,9 @@ Payload received following a connection creation:
     "provider": "<your-provider-key>",
     "environment": "DEV | PROD | ...",
     "success": true,
-    "endUser": { 
-        "endUserId": "<your-end-user-id>", 
+    "endUser": {
+        "endUserId": "<your-end-user-id>",
+        "endUserEmail": "<your-end-user-email>",
         "tags": { "organizationId": "<your-organization-id>" }
     }
 }
@@ -203,8 +204,9 @@ Payload received following a refresh token error:
     "provider": "<your-provider-key>",
     "environment": "DEV | PROD | ...",
     "success": false,
-    "endUser": { 
-        "endUserId": "<your-end-user-id>", 
+    "endUser": {
+        "endUserId": "<your-end-user-id>",
+        "endUserEmail": "<your-end-user-email>",
         "tags": { "organizationId": "<your-organization-id>" }
     },
     "error": {

--- a/packages/types/lib/webhooks/api.ts
+++ b/packages/types/lib/webhooks/api.ts
@@ -56,7 +56,7 @@ export interface NangoAuthWebhookBodyBase extends NangoWebhookBase {
     /**
      * Only presents if the connection happened with a session token
      */
-    endUser?: { endUserId: string; organizationId?: string | undefined; tags: Record<string, string> } | undefined;
+    endUser?: { endUserId: string; organizationId?: string | undefined; endUserEmail?: string | undefined | null; tags: Record<string, string> } | undefined;
 }
 
 export interface NangoAuthWebhookBodySuccess extends NangoAuthWebhookBodyBase {

--- a/packages/webhooks/lib/auth.ts
+++ b/packages/webhooks/lib/auth.ts
@@ -71,7 +71,14 @@ export async function sendAuth({
         provider: providerConfig?.provider || 'unknown',
         environment: environment.name,
         operation,
-        endUser: endUser ? { endUserId: endUser.endUserId, organizationId: endUser.organization?.organizationId, tags: endUser.tags || {} } : undefined
+        endUser: endUser
+            ? {
+                  endUserId: endUser.endUserId,
+                  endUserEmail: endUser.email,
+                  organizationId: endUser.organization?.organizationId,
+                  tags: endUser.tags || {}
+              }
+            : undefined
     };
 
     if (success) {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Expose end-user email in auth webhook payloads**

This PR adds the optional `endUserEmail` field to the auth webhook payload generated by `sendAuth`, updates the shared webhook type definition to reflect the new property, and documents its presence across relevant guides. The change is additive and keeps existing webhook consumers compatible while surfacing the extra metadata when available.

<details>
<summary><strong>Key Changes</strong></summary>

• Populate `endUserEmail` from `endUser.email` when constructing the auth webhook payload in `packages/webhooks/lib/auth.ts`
• Extend `NangoAuthWebhookBodyBase.endUser` in `packages/types/lib/webhooks/api.ts` to include optional `endUserEmail`
• Update webhook, API auth, and quickstart documentation examples to show the new `endUserEmail` field

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webhooks/lib/auth.ts`
• `packages/types/lib/webhooks/api.ts`
• `docs/implementation-guides/platform/webhooks-from-nango.mdx`
• `docs/implementation-guides/api-auth/implement-api-auth.mdx`
• `docs/getting-started/quickstart/embed-in-your-app.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*