### PR TITLE
fix(webapp): profile dropdown alignment and open state

### DIFF
--- a/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
@@ -77,7 +77,7 @@ export const ProfileDropdown: React.FC = () => {
         <SidebarMenu>
             <SidebarMenuItem>
                 <DropdownMenu modal={false}>
-                    <DropdownMenuTrigger className="group/profile cursor-pointer h-fit w-full p-3 inline-flex items-center justify-between bg-dropdown-bg-default hover:bg-dropdown-bg-hover active:bg-dropdown-bg-press border-t-[0.5px] border-border-muted">
+                    <DropdownMenuTrigger className="group/profile cursor-pointer h-fit w-full p-3 inline-flex items-center justify-between bg-dropdown-bg-default hover:bg-dropdown-bg-hover data-[state=open]:bg-dropdown-bg-press border-t-[0.5px] border-border-muted">
                         <div className="inline-flex gap-2 items-center">
                             <div className="size-10 flex items-center justify-center rounded bg-bg-surface border border-border-muted text-text-primary leading-5">
                                 {initials}
@@ -89,7 +89,7 @@ export const ProfileDropdown: React.FC = () => {
                         </div>
                         <ChevronsUpDown className="size-4.5 text-text-tertiary group-hover/profile:text-text-secondary group-active/profile:text-text-primary" />
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" alignOffset={0} side="right" className="w-50 p-2">
+                    <DropdownMenuContent align="end" alignOffset={0} side="right" sideOffset={0} className="w-50 p-2">
                         {items.map((item, index) => (
                             <DropdownMenuItem
                                 key={index}


### PR DESCRIPTION
Fixing incorrect spacing on popup, and incorrect open state colors.

Before:
<img width="450" height="188" alt="image" src="https://github.com/user-attachments/assets/fa0288c2-942a-44f4-a2bf-848dad3285b3" />

After:
<img width="462" height="176" alt="image" src="https://github.com/user-attachments/assets/c92d65fb-c584-4d60-9609-214ea86aeab4" />
<!-- Summary by @propel-code-bot -->

---

**Adjust profile dropdown trigger and menu alignment**

Updates the profile dropdown trigger styling to use the pressed background color only when the menu is open and sets the dropdown content side offset to zero for improved alignment. These changes address spacing and open-state color issues described in the PR context.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced `active:bg-dropdown-bg-press` with `data-[state=open]:bg-dropdown-bg-press` on `DropdownMenuTrigger` to scope the pressed background to the open state
• Added `sideOffset={0}` to `DropdownMenuContent` to align the menu flush with the trigger

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*