### PR TITLE
feat(webhooks): Add X-Nango-Hmac-Sha256 header to webhook requests

### DIFF
--- a/packages/webhooks/lib/asyncAction.unit.test.ts
+++ b/packages/webhooks/lib/asyncAction.unit.test.ts
@@ -81,11 +81,21 @@ describe('AsyncAction webhookds', () => {
         };
         const bodyString = stringifyStable(body).unwrap();
         expect(spy).toHaveBeenNthCalledWith(1, webhookSettings.primary_url, bodyString, {
-            headers: { 'X-Nango-Signature': expect.any(String), 'content-type': 'application/json', 'user-agent': expect.stringContaining('nango/') },
+            headers: {
+                'X-Nango-Signature': expect.toBeSha256(),
+                'X-Nango-Hmac-Sha256': expect.toBeSha256(),
+                'content-type': 'application/json',
+                'user-agent': expect.stringContaining('nango/')
+            },
             timeout: expect.any(Number)
         });
         expect(spy).toHaveBeenNthCalledWith(2, webhookSettings.secondary_url, bodyString, {
-            headers: { 'X-Nango-Signature': expect.any(String), 'content-type': 'application/json', 'user-agent': expect.stringContaining('nango/') },
+            headers: {
+                'X-Nango-Signature': expect.toBeSha256(),
+                'X-Nango-Hmac-Sha256': expect.toBeSha256(),
+                'content-type': 'application/json',
+                'user-agent': expect.stringContaining('nango/')
+            },
             timeout: expect.any(Number)
         });
     });

--- a/packages/webhooks/lib/auth.unit.test.ts
+++ b/packages/webhooks/lib/auth.unit.test.ts
@@ -296,6 +296,7 @@ describe('Webhooks: auth notification tests', () => {
             expect.objectContaining({
                 headers: {
                     'X-Nango-Signature': expect.toBeSha256(),
+                    'X-Nango-Hmac-Sha256': expect.toBeSha256(),
                     'content-type': 'application/json',
                     'user-agent': expect.stringContaining('nango/')
                 }
@@ -309,6 +310,7 @@ describe('Webhooks: auth notification tests', () => {
             expect.objectContaining({
                 headers: {
                     'X-Nango-Signature': expect.toBeSha256(),
+                    'X-Nango-Hmac-Sha256': expect.toBeSha256(),
                     'content-type': 'application/json',
                     'user-agent': expect.stringContaining('nango/')
                 }

--- a/packages/webhooks/lib/sync.unit.test.ts
+++ b/packages/webhooks/lib/sync.unit.test.ts
@@ -293,6 +293,7 @@ describe('Webhooks: sync notification tests', () => {
             expect.objectContaining({
                 headers: {
                     'X-Nango-Signature': expect.toBeSha256(),
+                    'X-Nango-Hmac-Sha256': expect.toBeSha256(),
                     'content-type': 'application/json',
                     'user-agent': expect.stringContaining('nango/')
                 }
@@ -306,6 +307,7 @@ describe('Webhooks: sync notification tests', () => {
             expect.objectContaining({
                 headers: {
                     'X-Nango-Signature': expect.toBeSha256(),
+                    'X-Nango-Hmac-Sha256': expect.toBeSha256(),
                     'content-type': 'application/json',
                     'user-agent': expect.stringContaining('nango/')
                 }

--- a/packages/webhooks/lib/utils.unit.test.ts
+++ b/packages/webhooks/lib/utils.unit.test.ts
@@ -2,20 +2,44 @@ import { describe, expect, it } from 'vitest';
 
 import { stringifyStable } from '@nangohq/utils';
 
-import { getSignatureHeader } from './utils.js';
+import { getHmacSignatureHeader, getSignatureHeaderUnsafe } from './utils.js';
 
-describe('getSignatureHeader', () => {
+describe('getSignatureHeaderUnsafe', () => {
     it('should return a string', () => {
         const secret = 'secret';
         const payload = 'payload';
-        const signature = getSignatureHeader(secret, payload);
+        const signature = getSignatureHeaderUnsafe(secret, payload);
         expect(signature).toBe('22439a879b090cd05e5b51c5b5d7e4a205830e6ab4f54b90f5a822b7c7110934');
     });
 
     it('should return the same signature for the same payload but different order', () => {
         const secret = 'secret';
-        const signature1 = getSignatureHeader(secret, stringifyStable({ a: 1, b: 2 }).unwrap());
-        const signature2 = getSignatureHeader(secret, stringifyStable({ b: 2, a: 1 }).unwrap());
+        const signature1 = getSignatureHeaderUnsafe(secret, stringifyStable({ a: 1, b: 2 }).unwrap());
+        const signature2 = getSignatureHeaderUnsafe(secret, stringifyStable({ b: 2, a: 1 }).unwrap());
         expect(signature1).toBe(signature2);
+    });
+});
+
+describe('getHmacSignatureHeader', () => {
+    it('should return a string', () => {
+        const secret = 'secret';
+        const payload = 'payload';
+        const signature = getHmacSignatureHeader(secret, payload);
+        expect(signature).toBe('b82fcb791acec57859b989b430a826488ce2e479fdf92326bd0a2e8375a42ba4');
+    });
+
+    it('should return the same signature for the same payload but different order', () => {
+        const secret = 'secret';
+        const signature1 = getHmacSignatureHeader(secret, stringifyStable({ a: 1, b: 2 }).unwrap());
+        const signature2 = getHmacSignatureHeader(secret, stringifyStable({ b: 2, a: 1 }).unwrap());
+        expect(signature1).toBe(signature2);
+    });
+
+    it('should return a different signature from getSignatureHeaderUnsafe', () => {
+        const secret = 'secret';
+        const payload = 'payload';
+        const safeSignature = getHmacSignatureHeader(secret, payload);
+        const unsafeSignature = getSignatureHeaderUnsafe(secret, payload);
+        expect(safeSignature).not.toEqual(unsafeSignature);
     });
 });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Add X-Nango-Signature-Hmac-Sha256 header to webhook requests which uses HMAC-SHA256 to create the signature. This new header will be used by the updated Node SDK and will be the recommended way of verifying the payloads coming via webhooks from Nango.

<!-- Issue ticket number and link (if applicable) -->
Fix https://github.com/NangoHQ/nango/issues/4886

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add HMAC-SHA256 webhook signature header**

Introduces a secure HMAC-based webhook signature helper while leaving the legacy SHA256 hash path available under a new `getSignatureHeaderUnsafe` name. Webhook delivery now emits both the legacy `X-Nango-Signature` header and the new `X-Nango-Hmac-Sha256` header, with unit tests updated to validate both headers across async action, auth, and sync webhook flows.

<details>
<summary><strong>Key Changes</strong></summary>

• Renamed `getSignatureHeader` to `getSignatureHeaderUnsafe` and documented its insecurity in `packages/webhooks/lib/utils.ts`
• Added HMAC-based helper `getHmacSignatureHeader` and used it to populate a new `X-Nango-Hmac-Sha256` webhook header
• Updated webhook delivery logic to include both legacy and HMAC headers
• Extended unit tests in webhook utility, async action, auth, and sync suites to assert the presence/format of the dual headers

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/webhooks/lib/utils.ts
• packages/webhooks/lib/utils.unit.test.ts
• packages/webhooks/lib/asyncAction.unit.test.ts
• packages/webhooks/lib/auth.unit.test.ts
• packages/webhooks/lib/sync.unit.test.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*