### PR TITLE
feat(server): single provider endpoint

### DIFF
--- a/packages/server/lib/controllers/v1/providers/getProvider.ts
+++ b/packages/server/lib/controllers/v1/providers/getProvider.ts
@@ -1,0 +1,52 @@
+import * as z from 'zod';
+
+import { getProvider, sharedCredentialsService } from '@nangohq/shared';
+import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { providerListItemToAPI } from '../../../formatters/provider.js';
+import { providerNameSchema } from '../../../helpers/validation.js';
+import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+
+import type { GetProvider } from '@nangohq/types';
+
+export const validationParams = z
+    .object({
+        providerConfigKey: providerNameSchema
+    })
+    .strict();
+
+export const getProviderItem = asyncWrapper<GetProvider>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req, { withEnv: true });
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valParams = validationParams.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({
+            error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) }
+        });
+        return;
+    }
+
+    const params: GetProvider['Params'] = valParams.data;
+    const provider = getProvider(params.providerConfigKey);
+    if (!provider) {
+        res.status(404).send({ error: { code: 'not_found', message: `Unknown provider ${params.providerConfigKey}` } });
+        return;
+    }
+
+    try {
+        const sharedCredentials = await sharedCredentialsService.getPreConfiguredProviderScopes();
+        const preConfiguredInfo = sharedCredentials.isOk() ? sharedCredentials.value[params.providerConfigKey] : undefined;
+        const isPreConfigured = preConfiguredInfo ? preConfiguredInfo.preConfigured : false;
+        const preConfiguredScopes = preConfiguredInfo ? preConfiguredInfo.scopes : [];
+
+        const providerListItem = providerListItemToAPI(params.providerConfigKey, provider, isPreConfigured, preConfiguredScopes);
+        res.status(200).send({ data: providerListItem });
+    } catch (err) {
+        report(err);
+        res.status(500).send({ error: { code: 'server_error' } });
+    }
+});

--- a/packages/server/lib/controllers/v1/providers/getProviders.ts
+++ b/packages/server/lib/controllers/v1/providers/getProviders.ts
@@ -1,0 +1,41 @@
+import { getProviders, sharedCredentialsService } from '@nangohq/shared';
+import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { providerListItemToAPI } from '../../../formatters/provider.js';
+import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+
+import type { GetProviders } from '@nangohq/types';
+
+export const getProvidersList = asyncWrapper<GetProviders>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req, { withEnv: true });
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const providers = getProviders();
+    if (!providers) {
+        res.status(500).send({ error: { code: 'server_error' } });
+        return;
+    }
+
+    try {
+        const sharedCredentials = await sharedCredentialsService.getPreConfiguredProviderScopes();
+
+        const list = Object.entries(providers)
+            .filter(([, properties]) => properties.auth_mode !== 'MCP_OAUTH2')
+            .map(([provider, properties]) => {
+                // check if provider has nango's preconfigured credentials
+                const preConfiguredInfo = sharedCredentials.isOk() ? sharedCredentials.value[provider] : undefined;
+                const isPreConfigured = preConfiguredInfo ? preConfiguredInfo.preConfigured : false;
+                const preConfiguredScopes = preConfiguredInfo ? preConfiguredInfo.scopes : [];
+
+                return providerListItemToAPI(provider, properties, isPreConfigured, preConfiguredScopes);
+            });
+        const sortedList = list.sort((a, b) => a.name.localeCompare(b.name));
+        res.status(200).send({ data: sortedList });
+    } catch (err) {
+        report(err);
+        res.status(500).send({ error: { code: 'server_error' } });
+    }
+});

--- a/packages/server/lib/formatters/provider.ts
+++ b/packages/server/lib/formatters/provider.ts
@@ -1,0 +1,14 @@
+import type { ApiProviderListItem, Provider } from '@nangohq/types';
+
+export function providerListItemToAPI(providerName: string, properties: Provider, preConfigured: boolean, preConfiguredScopes: string[]): ApiProviderListItem {
+    return {
+        name: providerName,
+        displayName: properties.display_name,
+        defaultScopes: properties.default_scopes,
+        authMode: properties.auth_mode,
+        categories: properties.categories,
+        docs: properties.docs,
+        preConfigured,
+        preConfiguredScopes
+    };
+}

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -71,6 +71,8 @@ import { getPlans } from './controllers/v1/plans/getPlans.js';
 import { postPlanExtendTrial } from './controllers/v1/plans/trial/postPlanExtendTrial.js';
 import { getBillingUsage } from './controllers/v1/plans/usage/getBillingUsage.js';
 import { getUsage } from './controllers/v1/plans/usage/getUsage.js';
+import { getProviderItem } from './controllers/v1/providers/getProvider.js';
+import { getProvidersList } from './controllers/v1/providers/getProviders.js';
 import { deleteStripePaymentMethod } from './controllers/v1/stripe/payment_methods/deletePaymentMethod.js';
 import { getStripePaymentMethods } from './controllers/v1/stripe/payment_methods/getPaymentMethods.js';
 import { postStripeCollectPayment } from './controllers/v1/stripe/payment_methods/postCollectPayment.js';
@@ -191,6 +193,8 @@ web.route('/integrations/:providerConfigKey').delete(webAuth, deleteIntegration)
 web.route('/integrations/:providerConfigKey/flows').get(webAuth, getIntegrationFlows);
 
 web.route('/provider').get(configController.listProvidersFromYaml.bind(configController));
+web.route('/providers').get(webAuth, getProvidersList);
+web.route('/providers/:providerConfigKey').get(webAuth, getProviderItem);
 
 web.route('/connections').get(webAuth, getConnections);
 web.route('/connections/count').get(webAuth, getConnectionsCount);

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -66,7 +66,7 @@ import type { DeleteInvite, GetInvite, PostInvite } from './invitations/api.js';
 import type { GetOperation, PostInsights, SearchFilters, SearchMessages, SearchOperations } from './logs/api.js';
 import type { GetMeta } from './meta/api.js';
 import type { PostPlanExtendTrial } from './plans/http.api.js';
-import type { GetPublicProvider, GetPublicProviders } from './providers/api.js';
+import type { GetProvider, GetProviders, GetPublicProvider, GetPublicProviders } from './providers/api.js';
 import type { AllPublicProxy } from './proxy/http.api.js';
 import type { GetPublicRecords } from './record/api.js';
 import type { GetPublicScriptsConfig } from './scripts/http.api.js';
@@ -179,7 +179,9 @@ export type PrivateApiEndpoints =
     | GetGettingStarted
     | PatchGettingStarted
     | GetConnectUISettings
-    | PutConnectUISettings;
+    | PutConnectUISettings
+    | GetProviders
+    | GetProvider;
 
 export type APIEndpoints = PrivateApiEndpoints | PublicApiEndpoints;
 

--- a/packages/types/lib/providers/api.ts
+++ b/packages/types/lib/providers/api.ts
@@ -1,5 +1,6 @@
 import type { Endpoint } from '../api.js';
 import type { Provider } from './provider.js';
+import type { AuthModeType } from '../auth/api.js';
 
 export type GetPublicProviders = Endpoint<{
     Method: 'GET';
@@ -18,5 +19,33 @@ export type GetPublicProvider = Endpoint<{
     Querystring?: { connect_session_token: string };
     Success: {
         data: ApiProvider;
+    };
+}>;
+
+export interface ApiProviderListItem {
+    name: string;
+    displayName: string;
+    defaultScopes?: string[] | undefined;
+    authMode: AuthModeType;
+    categories?: string[] | undefined;
+    docs: string;
+    preConfigured: boolean;
+    preConfiguredScopes: string[];
+}
+
+export type GetProviders = Endpoint<{
+    Method: 'GET';
+    Path: '/api/v1/providers';
+    Success: {
+        data: ApiProviderListItem[];
+    };
+}>;
+
+export type GetProvider = Endpoint<{
+    Method: 'GET';
+    Path: '/api/v1/providers/:providerConfigKey';
+    Params: { providerConfigKey: string };
+    Success: {
+        data: ApiProviderListItem;
     };
 }>;

--- a/packages/webapp/src/hooks/useProvider.tsx
+++ b/packages/webapp/src/hooks/useProvider.tsx
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { APIError, apiFetch } from '../utils/api';
+
+import type { GetProvider } from '@nangohq/types';
+
+export function useProvider(env: string, provider: string) {
+    return useQuery<GetProvider['Success'], APIError>({
+        queryKey: ['provider', env, provider],
+        queryFn: async (): Promise<GetProvider['Success']> => {
+            const res = await apiFetch(`/api/v1/providers/${encodeURIComponent(provider)}?env=${env}`, {
+                method: 'GET'
+            });
+
+            const json = (await res.json()) as GetProvider['Reply'];
+            if (!res.ok || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+
+            return json;
+        },
+        enabled: Boolean(env && provider)
+    });
+}

--- a/packages/webapp/src/hooks/useProviders.tsx
+++ b/packages/webapp/src/hooks/useProviders.tsx
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { APIError, apiFetch } from '../utils/api';
+
+import type { GetProviders } from '@nangohq/types';
+
+export function useProviders(env: string) {
+    return useQuery<GetProviders['Success'], APIError>({
+        queryKey: ['providers', env],
+        queryFn: async (): Promise<GetProviders['Success']> => {
+            const res = await apiFetch(`/api/v1/providers?env=${env}`, {
+                method: 'GET'
+            });
+
+            const json = (await res.json()) as GetProviders['Reply'];
+            if (!res.ok || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+
+            return json;
+        },
+        enabled: Boolean(env)
+    });
+}

--- a/packages/webapp/src/utils/api.tsx
+++ b/packages/webapp/src/utils/api.tsx
@@ -1,7 +1,6 @@
 import { toast } from 'react-toastify';
 
 import { globalEnv } from './env';
-import { useSignout } from './user';
 
 import type { ApiError, PostSignup } from '@nangohq/types';
 
@@ -119,29 +118,6 @@ export function useHostedSigninAPI() {
             if (res.status !== 200 && res.status !== 401) {
                 serverErrorToast();
                 return;
-            }
-
-            return res;
-        } catch {
-            requestErrorToast();
-        }
-    };
-}
-
-export function useGetProvidersAPI(env: string) {
-    const signout = useSignout();
-
-    return async () => {
-        try {
-            const res = await apiFetch(`/api/v1/provider?env=${env}`);
-
-            if (res.status === 401) {
-                await signout();
-                return;
-            }
-
-            if (res.status !== 200) {
-                serverErrorToast();
             }
 
             return res;


### PR DESCRIPTION
Change `/api/v1/provider` to `/api/v1/providers` and refactor to new style.
Add `/api/v1/providers/:providerConfigKey` to get a single provider.

<!-- Summary by @propel-code-bot -->

---

**Introduce typed provider endpoints and React Query integrations**

Server-side provider routes now expose typed payloads via `/api/v1/providers` and `/api/v1/providers/:providerConfigKey`, including validation, error handling, and shared-credential metadata. The web app consumes these endpoints through new React Query hooks, updates the integrations creation flow to use the typed responses, and removes the legacy `useGetProvidersAPI` helper in favor of centralized fetch utilities.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `getProvidersList` and `getProviderItem` controllers under `packages/server/lib/controllers/v1/providers` that validate requests, load shared credential metadata, and format responses with `providerListItemToAPI`.
• Introduced `ApiProviderListItem`, `GetProviders`, and `GetProvider` types in `packages/types/lib/providers/api.ts` and registered them in the consolidated endpoint registry.
• Created `useProviders` and `useProvider` React Query hooks and refactored `CreateIntegration` to consume the typed provider data while dropping `useGetProvidersAPI`.
• Updated `packages/server/lib/routes.private.ts` to expose the new provider routes alongside the legacy `/provider` handler for backward compatibility.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/controllers/v1/providers/getProviders.ts
• packages/server/lib/controllers/v1/providers/getProvider.ts
• packages/server/lib/formatters/provider.ts
• packages/server/lib/routes.private.ts
• packages/types/lib/providers/api.ts
• packages/types/lib/api.endpoints.ts
• packages/webapp/src/hooks/useProviders.tsx
• packages/webapp/src/hooks/useProvider.tsx
• packages/webapp/src/pages/Integrations/Create.tsx
• packages/webapp/src/utils/api.tsx

</details>

---
*This summary was automatically generated by @propel-code-bot*