### PR TITLE
docs(microsoft-business-central): add .default scope configuration example

### DIFF
--- a/docs/integrations/all/microsoft-business-central.mdx
+++ b/docs/integrations/all/microsoft-business-central.mdx
@@ -57,12 +57,27 @@ _No setup guide yet._
 ## API gotchas
 -   See particularly the `tenantId` parameter under [Get a token](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow#get-a-token).
 -   When requesting **Application Permissions** that require admin consent, an Microsoft Entra ID administrator must pre-authorize the permissions. Without admin consent, the app cannot obtain tokens for those scopes.
--   For multitenant applications, each tenant administrator must grant consent to the app’s required permissions before access is granted in their tenant.
+-   For multitenant applications, each tenant administrator must grant consent to the app's required permissions before access is granted in their tenant.
 -  The [.default scope](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#default-when-the-user-gives-consent) is a special scope that tells Azure AD to issue a token containing all the **Application Permissions** that have already been granted (consented) for your app on that resource. Using `.default` ensures your app receives permissions consistent with those configured and consented at the tenant or organization level.
 -   The `.default` scope can't be combined with the scopes registered in the Azure portal. So either just use the `.default` scope or remove it to list out explicit parameters that are required. If you attempt to combine them you'll receive the following error
 ```
 .default scope can't be combined with resource-specific scopes
 ```
+-   To add the `.default` scope when creating a connection, use the `integrations_config_defaults` parameter in `createConnectSession`:
+
+```typescript
+const { data } = await nango.createConnectSession({
+  end_user: {...},
+  integrations_config_defaults: {
+    "microsoft-business-central": {
+      connection_config: {
+        oauth_scopes: ".default",
+      },
+    },
+  },
+});
+```
+
 -   No user interaction is involved when using the Microsoft Business Central provider. Therefore, a Microsoft Entra ID administrator must grant consent for the required **Application Permissions** ahead of time. This can be done through the [Azure Portal](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent?pivots=portal) or by using the [admin consent endpoint](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent?pivots=ms-graph).
 <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/microsoft-business-central.mdx)</Note>
 


### PR DESCRIPTION
Add code example showing how to configure the .default OAuth scope using integrations_config_defaults parameter in createConnectSession for Microsoft Business Central integration.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Document `.default` scope example for Microsoft Business Central**

Adds guidance in `docs/integrations/all/microsoft-business-central.mdx` on how to supply the `.default` OAuth scope for Microsoft Business Central by setting `integrations_config_defaults` in a `createConnectSession` call. Restores the multitenant consent reminder with consistent apostrophe usage and embeds a TypeScript snippet illustrating the configuration.

<details>
<summary><strong>Key Changes</strong></summary>

• Reintroduced multitenant consent note using straight apostrophe
• Documented use of `integrations_config_defaults` to pass the `.default` scope in `createConnectSession`
• Inserted TypeScript example showing `oauth_scopes: ".default"` configuration

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• docs/integrations/all/microsoft-business-central.mdx

</details>

---
*This summary was automatically generated by @propel-code-bot*