### PR TITLE
feat(webhooks): Update docs around the new webhook verification header

### DIFF
--- a/docs/changelog/dev-updates.mdx
+++ b/docs/changelog/dev-updates.mdx
@@ -8,6 +8,40 @@ description: "Updates and breaking changes for developers."
 [Full technical changelog on <Icon icon="github" />](https://github.com/NangoHQ/nango/releases)
 </Info>
 
+<Update label="December 5, 2025">
+
+  ## New HMAC-based webhook signature header
+
+  Nango webhooks now include a new `X-Nango-Hmac-Sha256` header that uses HMAC-SHA256 for improved security. The legacy `X-Nango-Signature` header (which uses plain SHA-256 with key concatenation) is still sent for backwards compatibility but should no longer be used.
+
+  ### 🗓️ Timeline
+
+  - **Now available**: The `X-Nango-Hmac-Sha256` header is already included in all webhook requests.
+  - The `X-Nango-Signature` header will continue to be sent for backwards compatibility, with no current deprecation timeline.
+
+  ### 🧐 Am I impacted?
+
+  - If you're currently verifying webhooks using the `X-Nango-Signature` header
+  - If you're implementing webhook verification for the first time
+
+  ### 💡 What should I do?
+
+  **For new integrations:**
+  - Use the `X-Nango-Hmac-Sha256` header to verify webhook signatures
+  - See the updated [webhook documentation](/implementation-guides/platform/webhooks-from-nango#verifying-webhooks-from-nango) for code examples
+
+  **For existing integrations:**
+  - Migrate to using `X-Nango-Hmac-Sha256` when convenient
+  - The old `X-Nango-Signature` header will continue to work, but we recommend migrating for better security
+
+  ### Why are we making this change?
+
+  HMAC-SHA256 is cryptographically more secure than plain SHA-256 with concatenation. HMAC provides better protection against length extension attacks and is the industry standard for webhook signature verification.
+
+  ---
+
+</Update>
+
 <Update label="November 27, 2025">
 
   ## Behavior change of webhooks from Nango to your app

--- a/docs/implementation-guides/platform/webhooks-from-nango.mdx
+++ b/docs/implementation-guides/platform/webhooks-from-nango.mdx
@@ -20,13 +20,17 @@ To subscribe to Nango webhooks:
 
 You can configure up to two webhook URLs per environment. Nango webhooks will be sent to both.
 
-To test webhooks locally, use a webhook forwarding service like [ngrok](https://dev.to/mmascioni/testing-and-debugging-webhooks-with-ngrok-4alp, or [webhook.site](https://webhook.site/).
+To test webhooks locally, use a webhook forwarding service like [ngrok](https://dev.to/mmascioni/testing-and-debugging-webhooks-with-ngrok-4alp), or [webhook.site](https://webhook.site/).
 
 ## Verifying webhooks from Nango
 
-Validate webhooks from Nango by looking at the `X-Nango-Signature` header.
+Validate webhooks from Nango by looking at the `X-Nango-Hmac-Sha256` header.
 
-It's a SHA-256 hash of the webhook payload with the secret key, found in the _Environment Settings_ in the Nango UI, prepended.
+It's an HMAC-SHA256 hash of the webhook payload, using the secret key found in the _Environment Settings_ in the Nango UI.
+
+<Warning>
+Nango webhook requests include an `X-Nango-Hmac-Sha256` header for secure verification. A legacy `X-Nango-Signature` header (using plain SHA-256) is also sent for backwards compatibility but should not be used. If you're currently using `X-Nango-Signature`, migrate to `X-Nango-Hmac-Sha256` for improved security.
+</Warning>
 
 The webhook signature can be generated with the following code:
 
@@ -34,8 +38,7 @@ The webhook signature can be generated with the following code:
   <Tab title="Node SDK">
     ```typescript
     async (req, res) => {
-        const signature = req.headers['x-nango-signature'];
-        const isValid = nango.verifyWebhookSignature(signature, req.body);
+        const isValid = nango.verifyIncomingWebhookRequest(req.body, req.headers);
     }
     ```
   </Tab>
@@ -44,46 +47,52 @@ The webhook signature can be generated with the following code:
     import crypto from 'crypto';
     
     const secretKeyDev = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
-    const signature = `${secretKeyDev}${JSON.stringify(payload)}`;
-    const hash = crypto.createHash('sha256').update(signature).digest('hex');
+    const body = // raw request body as string
+    const hash = crypto.createHmac('sha256', secretKeyDev).update(body).digest('hex');
     ```
   </Tab>
   <Tab title="Python">
     ```python
+    import hmac
     import hashlib
     
     secret_key_dev = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
-    signature = secret_key_dev + request.body.decode("utf-8")
-    hash = hashlib.sha256(signature.encode("utf-8")).hexdigest()
+    body = # raw request body as bytes
+    hash = hmac.new(secret_key_dev.encode('utf-8'), body, hashlib.sha256).hexdigest()
     ```
   </Tab>
   <Tab title="Java">
     ```java
-    import java.security.MessageDigest;
-    import java.security.NoSuchAlgorithmException;
-    import javax.xml.bind.DatatypeConverter;
+    import javax.crypto.Mac;
+    import javax.crypto.spec.SecretKeySpec;
+    import java.nio.charset.StandardCharsets;
     
     public class Main {
-        public static void main(String[] args) throws NoSuchAlgorithmException {
+        public static void main(String[] args) throws Exception {
             String secretKeyDev = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
-            String payloadString = // convert payload to JSON string
-            String signature = secretKeyDev + payloadString;
+            String body = // raw request body as string
     
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hashBytes = digest.digest(signature.getBytes("UTF-8"));
-            String hash = DatatypeConverter.printHexBinary(hashBytes).toLowerCase();
+            Mac mac = Mac.getInstance("HmacSHA256");
+            SecretKeySpec secretKey = new SecretKeySpec(secretKeyDev.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+            mac.init(secretKey);
+            byte[] hashBytes = mac.doFinal(body.getBytes(StandardCharsets.UTF_8));
+            
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hashBytes) {
+                hexString.append(String.format("%02x", b));
+            }
+            String hash = hexString.toString();
         }
     }
     ```
   </Tab>
   <Tab title="Ruby">
     ```ruby
-    require 'json'
-    require 'digest'
+    require 'openssl'
     
     secret_key_dev = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
-    signature = "#{secret_key_dev}#{payload.to_json}"
-    hash = Digest::SHA256.hexdigest(signature)
+    body = # raw request body 
+    hash = OpenSSL::HMAC.hexdigest('SHA256', secret_key_dev, body)
     ```
   </Tab>
   <Tab title="Go">
@@ -91,45 +100,49 @@ The webhook signature can be generated with the following code:
     package main
     
     import (
+        "crypto/hmac"
         "crypto/sha256"
         "encoding/hex"
-        "encoding/json"
+        "io"
+        "net/http"
     )
     
     func main() {
         secretKeyDev := "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-        payloadString, _ := json.Marshal(payload) // Handle error in real code
-        signature := secretKeyDev + string(payloadString)
+        var body []byte // raw request body
     
-        hash := sha256.Sum256([]byte(signature))
-        hexHash := hex.EncodeToString(hash[:])
+        h := hmac.New(sha256.New, []byte(secretKeyDev))
+        h.Write(body)
+        hash := hex.EncodeToString(h.Sum(nil))
     }
     ```
   </Tab>
   <Tab title="Rust">
     ```rust
-    use sha2::{Sha256, Digest};
-    use serde_json::json; // Assuming use of serde_json for JSON serialization
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+    
+    type HmacSha256 = Hmac<Sha256>;
     
     let secret_key_dev = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
-    let signature = format!("{}{}", secret_key_dev, serde_json::to_string(&payload).unwrap());
-    let mut hasher = Sha256::new();
-    hasher.update(signature.as_bytes());
-    let hash = format!("{:x}", hasher.finalize());
+    let body = // raw request body as string or bytes
+    let mut mac = HmacSha256::new_from_slice(secret_key_dev.as_bytes()).unwrap();
+    mac.update(body.as_bytes());
+    let hash = format!("{:x}", mac.finalize().into_bytes());
     ```
   </Tab>
   <Tab title="PHP">
     ```php
     <?php
     $secretKeyDev = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
-    $signature = $secretKeyDev . json_encode($payload);
-    $hash = hash('sha256', $signature);
+    $body = // raw request body as string
+    $hash = hash_hmac('sha256', $body, $secretKeyDev);
     ?>
     ```
   </Tab>
 </Tabs>
 
-Only accept a webhook if the `X-Nango-Signature` header value matches the webhook signature.
+Only accept a webhook if the `X-Nango-Hmac-Sha256` header value matches the webhook signature.
 
 ## Types of Nango webhooks
 

--- a/docs/reference/sdks/node.mdx
+++ b/docs/reference/sdks/node.mdx
@@ -1953,8 +1953,7 @@ Asserts that a Webhook is coming from Nango's backend.
 
 ```js
 async (req, res) => {
-    const signature = req.headers['x-nango-signature'];
-    const isValid = nango.verifyWebhookSignature(signature, req.body);
+    const isValid = nango.verifyIncomingWebhookRequest(req.body, req.headers);
 }
 ```
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Update the documentation around using the new `X-Nango-Hmac-Sha256` header for webhook verification.

Pages affected:
- [Webhooks from Nango](https://nango-marcin-nan-4471-update-webhook-verification-docs.mintlify.app/implementation-guides/platform/webhooks-from-nango)
- [Dev Updates](https://nango-marcin-nan-4471-update-webhook-verification-docs.mintlify.app/changelog/dev-updates)
- [Node SDK Reference](https://nango-marcin-nan-4471-update-webhook-verification-docs.mintlify.app/reference/sdks/node#verify-webhook-signature)

Related PRs:
- https://github.com/NangoHQ/nango/pull/5093
- https://github.com/NangoHQ/nango/pull/5097
<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Document HMAC-based webhook verification header rollout**

The PR refreshes webhook verification docs to center on the new `X-Nango-Hmac-Sha256` header, replaces language-specific snippets with HMAC implementations, and warns against continued reliance on the legacy `X-Nango-Signature`. It also adds a changelog entry describing rollout expectations and updates the Node SDK reference to reference `nango.verifyIncomingWebhookRequest` for validation.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `docs/implementation-guides/platform/webhooks-from-nango.mdx` with HMAC guidance, migration warning, and refreshed code samples across Node, JavaScript/TypeScript, Python, Java, Ruby, Go, Rust, and PHP.
• Added a `December 5, 2025` entry in `docs/changelog/dev-updates.mdx` announcing the new header, timeline, impact, and migration steps.
• Replaced the Node SDK reference example in `docs/reference/sdks/node.mdx` to demonstrate `nango.verifyIncomingWebhookRequest(req.body, req.headers)`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs/implementation-guides/platform/webhooks-from-nango.mdx`
• `docs/changelog/dev-updates.mdx`
• `docs/reference/sdks/node.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*