### PR TITLE
chore(records): syncId not necessary to delete records

### DIFF
--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -306,7 +306,6 @@ export async function handleSyncSuccess({
                 const res = await records.deleteOutdatedRecords({
                     connectionId: nangoProps.nangoConnectionId,
                     model,
-                    syncId: nangoProps.syncId,
                     generation: nangoProps.syncJobId
                 });
                 if (res.isErr()) {

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts
@@ -58,9 +58,8 @@ const handler = async (_req: EndpointRequest, res: EndpointResponse<DeleteOutdat
     const logCtx = logContextGetter.getStateLess({ id: String(activityLogId), accountId: account.id });
     const result = await records.deleteOutdatedRecords({
         connectionId: nangoConnectionId,
-        syncId,
-        generation: syncJobId,
-        model
+        model,
+        generation: syncJobId
     });
     if (result.isOk()) {
         const deleted = result.value.length;

--- a/packages/server/lib/crons/delete/deleteSyncData.ts
+++ b/packages/server/lib/crons/delete/deleteSyncData.ts
@@ -43,11 +43,10 @@ export async function deleteSyncData(sync: Sync, syncConfig: DBSyncConfig, opts:
             limit,
             logger,
             deleteFn: async () => {
-                const res = await records.deleteRecordsBySyncId({
+                const res = await records.deleteRecords({
                     connectionId: sync.nango_connection_id,
                     environmentId: syncConfig.environment_id,
                     model,
-                    syncId: sync.id,
                     batchSize: limit
                 });
                 if (res.isOk() && res.value.totalDeletedRecords) {

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -45,16 +45,14 @@ import type { Result } from '@nangohq/utils';
 import type { JsonValue } from 'type-fest';
 
 export interface RecordsServiceInterface {
-    deleteRecordsBySyncId({
-        connectionId,
+    deleteRecords({
         environmentId,
-        model,
-        syncId
+        connectionId,
+        model
     }: {
-        connectionId: number;
         environmentId: number;
+        connectionId: number;
         model: string;
-        syncId: string;
     }): Promise<Result<{ totalDeletedRecords: number }>>;
     getRecordStatsByModel({ connectionId, environmentId }: { connectionId: number; environmentId: number }): Promise<Result<Record<string, RecordCount>>>;
 }
@@ -594,7 +592,7 @@ export class Orchestrator {
                             if (syncVariant !== 'base') {
                                 model = `${model}::${syncVariant}`;
                             }
-                            const deletion = await recordsService.deleteRecordsBySyncId({ syncId, connectionId, environmentId, model });
+                            const deletion = await recordsService.deleteRecords({ environmentId, connectionId, model });
                             if (deletion.isErr()) {
                                 void logCtx.error(`Records for model ${model} failed to be deleted`, { error: deletion.error });
                                 return Err(deletion.error);


### PR DESCRIPTION
`record.syncId` is a legacy field. I don't remember why it was ported from the old data model but I imagine it was required for the transition
It is currently inserted but also used for deletion. However since a given connection/model is already unique (variant is part of the model name), filtering deletion by syncId is unecessary.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Remove `syncId` dependency from record deletion logic**

This PR refactors record deletion helpers to rely solely on the `connectionId`/`model` key instead of the legacy `syncId`. The `deleteRecordsBySyncId` helper is replaced with `deleteRecords`, callers across orchestrator flows, job execution, cron cleanup, and HTTP routes are updated, and the record service integration tests are realigned with the simplified API.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced `deleteRecordsBySyncId` with `deleteRecords` in `packages/records/lib/models/records.ts`, removing the `syncId` filter from hard-delete queries and adjusting error handling
• Simplified `deleteOutdatedRecords` in `packages/records/lib/models/records.ts` to drop the `syncId` predicate, relying on generation and `connectionId`/`model` to soft-delete legacy rows
• Updated all call sites (`packages/shared/lib/clients/orchestrator.ts`, `packages/jobs/lib/execution/sync.ts`, `packages/server/lib/crons/delete/deleteSyncData.ts`, HTTP routes) to use the new signature without `syncId`
• Refreshed `packages/records/lib/models/records.integration.test.ts` to remove `syncId` arguments and add coverage for the renamed `deleteRecords` helper

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/records/lib/models/records.ts`
• `packages/records/lib/models/records.integration.test.ts`
• `packages/shared/lib/clients/orchestrator.ts`
• `packages/jobs/lib/execution/sync.ts`
• `packages/server/lib/crons/delete/deleteSyncData.ts`
• `packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*