### PR TITLE
fix: upgrade mcp sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3525,12 +3525,13 @@
             }
         },
         "node_modules/@modelcontextprotocol/sdk": {
-            "version": "1.19.1",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.19.1.tgz",
-            "integrity": "sha512-3Y2h3MZKjec1eAqSTBclATlX+AbC6n1LgfVzRMJLt3v6w0RCYgwLrjbxPDbhsYHt6Wdqc/aCceNJYgj448ELQQ==",
+            "version": "1.24.3",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.3.tgz",
+            "integrity": "sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==",
             "license": "MIT",
             "dependencies": {
-                "ajv": "^6.12.6",
+                "ajv": "^8.17.1",
+                "ajv-formats": "^3.0.1",
                 "content-type": "^1.0.5",
                 "cors": "^2.8.5",
                 "cross-spawn": "^7.0.5",
@@ -3538,14 +3539,66 @@
                 "eventsource-parser": "^3.0.0",
                 "express": "^5.0.1",
                 "express-rate-limit": "^7.5.0",
+                "jose": "^6.1.1",
                 "pkce-challenge": "^5.0.0",
                 "raw-body": "^3.0.0",
-                "zod": "^3.23.8",
-                "zod-to-json-schema": "^3.24.1"
+                "zod": "^3.25 || ^4.0",
+                "zod-to-json-schema": "^3.25.0"
             },
             "engines": {
                 "node": ">=18"
+            },
+            "peerDependencies": {
+                "@cfworker/json-schema": "^4.1.1",
+                "zod": "^3.25 || ^4.0"
+            },
+            "peerDependenciesMeta": {
+                "@cfworker/json-schema": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": false
+                }
             }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT"
         },
         "node_modules/@nangohq/account-usage": {
             "resolved": "packages/account-usage",
@@ -13637,6 +13690,7 @@
         },
         "node_modules/ajv": {
             "version": "6.12.6",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -19203,6 +19257,7 @@
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
@@ -21657,9 +21712,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/jose": {
-            "version": "6.0.11",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.11.tgz",
-            "integrity": "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==",
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+            "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
@@ -21925,6 +21980,7 @@
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/json-schema-typed": {
@@ -31386,12 +31442,12 @@
             }
         },
         "node_modules/zod-to-json-schema": {
-            "version": "3.24.5",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-            "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+            "version": "3.25.0",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
+            "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
             "license": "ISC",
             "peerDependencies": {
-                "zod": "^3.24.1"
+                "zod": "^3.25 || ^4"
             }
         },
         "node_modules/zustand": {
@@ -32702,7 +32758,7 @@
             "version": "1.0.0",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@modelcontextprotocol/sdk": "1.19.1",
+                "@modelcontextprotocol/sdk": "1.24.3",
                 "@nangohq/account-usage": "file:../account-usage",
                 "@nangohq/billing": "file:../billing",
                 "@nangohq/database": "file:../database",
@@ -32830,7 +32886,7 @@
             "dependencies": {
                 "@aws-sdk/client-s3": "3.796.0",
                 "@hapi/boom": "10.0.1",
-                "@modelcontextprotocol/sdk": "1.19.1",
+                "@modelcontextprotocol/sdk": "1.24.3",
                 "@nangohq/database": "file:../database",
                 "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/nango-yaml": "file:../nango-yaml",

--- a/packages/server/lib/controllers/mcp/server.ts
+++ b/packages/server/lib/controllers/mcp/server.ts
@@ -77,7 +77,7 @@ function actionToTool(action: DBSyncConfig): Tool | null {
         name: action.sync_name,
         inputSchema: {
             type: 'object',
-            properties: inputSchema?.properties,
+            properties: inputSchema?.properties as Record<string, object>,
             required: inputSchema?.required
         },
         description

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,7 +19,7 @@
     },
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
-        "@modelcontextprotocol/sdk": "1.19.1",
+        "@modelcontextprotocol/sdk": "1.24.3",
         "@nangohq/account-usage": "file:../account-usage",
         "@nangohq/billing": "file:../billing",
         "@nangohq/database": "file:../database",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,7 +20,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "3.796.0",
         "@hapi/boom": "10.0.1",
-        "@modelcontextprotocol/sdk": "1.19.1",
+        "@modelcontextprotocol/sdk": "1.24.3",
         "@nangohq/database": "file:../database",
         "@nangohq/kvstore": "file:../kvstore",
         "@nangohq/nango-yaml": "file:../nango-yaml",


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Upgrade `@modelcontextprotocol/sdk` to 1.24.3**

Upgrades `@modelcontextprotocol/sdk` to `1.24.3` in `packages/server` and `packages/shared`, regenerating `package-lock.json` to capture new transitive dependencies such as `ajv` v8, `ajv-formats`, `jose` v6.1.3, and updated `zod`/`zod-to-json-schema` ranges. Updates `packages/server/lib/controllers/mcp/server.ts` to align with revised SDK typings by asserting `inputSchema.properties` to a `Record<string, object>`.

<details>
<summary><strong>Key Changes</strong></summary>

• Bumped `@modelcontextprotocol/sdk` to `1.24.3` in `packages/server/package.json` and `packages/shared/package.json`.
• Regenerated `package-lock.json` to reflect new dependency graph (e.g., `ajv` v8, `ajv-formats`, `jose` v6.1.3, `zod-to-json-schema` v3.25.0).
• Added a type assertion for `inputSchema.properties` in `packages/server/lib/controllers/mcp/server.ts` to satisfy updated SDK typings.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/mcp/server.ts`
• `packages/server/package.json`
• `packages/shared/package.json`
• `package-lock.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*