### PR TITLE
chore: Upgrade dependencies that use jws to patch security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15123,6 +15123,8 @@
         },
         "node_modules/buffer-equal-constant-time": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
             "license": "BSD-3-Clause"
         },
         "node_modules/buffer-from": {
@@ -20276,27 +20278,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/google-auth-library/node_modules/jwa": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-            "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-            "license": "MIT",
-            "dependencies": {
-                "buffer-equal-constant-time": "^1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/google-auth-library/node_modules/jws": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-            "license": "MIT",
-            "dependencies": {
-                "jwa": "^2.0.0",
-                "safe-buffer": "^5.0.1"
-            }
-        },
         "node_modules/google-logging-utils": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
@@ -20337,27 +20318,6 @@
             },
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/gtoken/node_modules/jwa": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-            "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-            "license": "MIT",
-            "dependencies": {
-                "buffer-equal-constant-time": "^1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/gtoken/node_modules/jws": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-            "license": "MIT",
-            "dependencies": {
-                "jwa": "^2.0.0",
-                "safe-buffer": "^5.0.1"
             }
         },
         "node_modules/guess-json-indent": {
@@ -21995,10 +21955,12 @@
             }
         },
         "node_modules/jsonwebtoken": {
-            "version": "9.0.2",
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+            "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
             "license": "MIT",
             "dependencies": {
-                "jws": "^3.2.2",
+                "jws": "^4.0.1",
                 "lodash.includes": "^4.3.0",
                 "lodash.isboolean": "^3.0.3",
                 "lodash.isinteger": "^4.0.4",
@@ -22029,19 +21991,23 @@
             }
         },
         "node_modules/jwa": {
-            "version": "1.4.1",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+            "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
             "license": "MIT",
             "dependencies": {
-                "buffer-equal-constant-time": "1.0.1",
+                "buffer-equal-constant-time": "^1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
                 "safe-buffer": "^5.0.1"
             }
         },
         "node_modules/jws": {
-            "version": "3.2.2",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+            "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
             "license": "MIT",
             "dependencies": {
-                "jwa": "^1.4.1",
+                "jwa": "^2.0.1",
                 "safe-buffer": "^5.0.1"
             }
         },
@@ -32732,7 +32698,7 @@
                 "express-session": "1.18.2",
                 "he": "^1.2.0",
                 "helmet": "7.1.0",
-                "jsonwebtoken": "9.0.2",
+                "jsonwebtoken": "9.0.3",
                 "lodash-es": "4.17.21",
                 "multer": "2.0.2",
                 "node-cron": "3.0.2",
@@ -32847,7 +32813,8 @@
                 "form-data": "4.0.4",
                 "he": "^1.2.0",
                 "js-yaml": "4.1.1",
-                "jsonwebtoken": "9.0.2",
+                "jsonwebtoken": "9.0.3",
+                "jws": "^4.0.1",
                 "lodash-es": "4.17.21",
                 "ms": "3.0.0-canary.1",
                 "oauth-1.0a": "2.2.6",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -49,7 +49,7 @@
         "express-session": "1.18.2",
         "he": "^1.2.0",
         "helmet": "7.1.0",
-        "jsonwebtoken": "9.0.2",
+        "jsonwebtoken": "9.0.3",
         "lodash-es": "4.17.21",
         "multer": "2.0.2",
         "node-cron": "3.0.2",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -37,7 +37,7 @@
         "form-data": "4.0.4",
         "he": "^1.2.0",
         "js-yaml": "4.1.1",
-        "jsonwebtoken": "9.0.2",
+        "jsonwebtoken": "9.0.3",
         "lodash-es": "4.17.21",
         "ms": "3.0.0-canary.1",
         "oauth-1.0a": "2.2.6",


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Upgrade dependencies that use jws to patch security vulnerability present in <4.0.1

<!-- Issue ticket number and link (if applicable) -->

https://github.com/NangoHQ/nango/security/dependabot/254
https://github.com/NangoHQ/nango/security/dependabot/255


<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Patch upgrade of `jsonwebtoken` dependencies**

Bumps `jsonwebtoken` from `9.0.2` to `9.0.3` in the `packages/server` and `packages/shared` workspaces and refreshes `package-lock.json` to resolve the `jws` `<4.0.1` security advisory. The lockfile now pulls in `jws` `4.0.1` and `jwa` `2.0.1`, removing older transitive copies in sub-packages.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `packages/server/package.json` and `packages/shared/package.json` to require `jsonwebtoken` `9.0.3`
• Regenerated `package-lock.json` so the root dependency tree now resolves `jsonwebtoken` `9.0.3`, `jws` `4.0.1`, and `jwa` `2.0.1`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/package.json`
• `packages/shared/package.json`
• `package-lock.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*