### PR TITLE
fix: Stop rate limiting orb webhooks

### DIFF
--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -229,7 +229,11 @@ if (flagHasUsage) {
     web.route('/stripe/payment_methods').delete(webAuth, deleteStripePaymentMethod);
     web.route('/stripe/webhooks').post(rateLimiterMiddleware, postStripeWebhooks);
 
-    web.route('/orb/webhooks').post(rateLimiterMiddleware, postOrbWebhooks);
+    web.route('/orb/webhooks').post((_req, _res, next) => {
+        // Skip rate limiting of Orb webhooks. Rate limit errors can accidentally disable the Orb
+        // webhook and there is no way to control the type or frequency of the webhooks from within Orb.
+        next();
+    }, postOrbWebhooks);
 }
 
 web.route('/admin/impersonate').post(webAuth, postImpersonate);


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Orb has a policy to automatically disable a webhook if 99% of their requests fail within a certain time period. At the start of the month, they issue a lot of `invoice.created` events which we don't care about but there is no way to filter them in the Orb platform. As a result, at some point, their webhook requests start failing due to rate limits, the webhook gets disabled and we stop receiving events that we actually care about.

The events that we don't care about we just let pass-through anyways. The compute spent is just on deserializing and verifying the signature of the message. If that fails during a load test, we can consider filtering out even earlier, before the signature is verified.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Remove rate limiting from Orb webhook route**

The PR removes the `rateLimiterMiddleware` from the `web.route('/orb/webhooks')` handler in `packages/server/lib/routes.private.ts`. An inline middleware now short-circuits to `next()` with a comment documenting the rationale for exempting Orb webhook traffic from throttling to avoid unwanted disablement on Orb’s side.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced the `rateLimiterMiddleware` on `web.route('/orb/webhooks')` with a no-op inline middleware that immediately invokes `next()`
• Added explanatory comment about bypassing rate limiting for Orb webhooks

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/routes.private.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*