### PR TITLE
feat(proxy): add authentication header for `OAuth1.0`

### DIFF
--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -1,6 +1,6 @@
 import { Nango } from '@nangohq/node';
 import { NangoActionBase, NangoSyncBase } from '@nangohq/runner-sdk';
-import { ProxyRequest, getProxyConfiguration } from '@nangohq/shared';
+import { ProxyRequest, getProvider, getProxyConfiguration } from '@nangohq/shared';
 import { MAX_LOG_PAYLOAD, isTest, metrics, redactHeaders, redactURL, stringifyAndTruncateValue, stringifyObject, truncateJson } from '@nangohq/utils';
 
 import { PersistClient } from './persist.js';
@@ -114,7 +114,12 @@ export class NangoActionRunner extends NangoActionBase<never, Record<string, str
                     prevConnection = connection;
                 }
                 return connection;
-            }
+            },
+            getIntegrationConfig: () => ({
+                oauth_client_id: null,
+                oauth_client_secret: null
+            }),
+            getProvider: () => getProvider(this.provider!)
         });
         const response = (await proxy.request()).unwrap();
         this.telemetryBag.proxyCalls += 1;

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -1,6 +1,6 @@
 import { Nango } from '@nangohq/node';
 import { NangoActionBase, NangoSyncBase } from '@nangohq/runner-sdk';
-import { ProxyRequest, getProvider, getProxyConfiguration } from '@nangohq/shared';
+import { ProxyRequest, getProxyConfiguration } from '@nangohq/shared';
 import { MAX_LOG_PAYLOAD, isTest, metrics, redactHeaders, redactURL, stringifyAndTruncateValue, stringifyObject, truncateJson } from '@nangohq/utils';
 
 import { PersistClient } from './persist.js';
@@ -118,8 +118,7 @@ export class NangoActionRunner extends NangoActionBase<never, Record<string, str
             getIntegrationConfig: () => ({
                 oauth_client_id: null,
                 oauth_client_secret: null
-            }),
-            getProvider: () => getProvider(this.provider!)
+            })
         });
         const response = (await proxy.request()).unwrap();
         this.telemetryBag.proxyCalls += 1;

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -12,7 +12,6 @@ import {
     configService,
     connectionService,
     errorManager,
-    getProvider,
     getProxyConfiguration,
     refreshOrTestCredentials
 } from '@nangohq/shared';
@@ -218,8 +217,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
             getIntegrationConfig: () => ({
                 oauth_client_id: integration.oauth_client_id,
                 oauth_client_secret: integration.oauth_client_secret
-            }),
-            getProvider: () => getProvider(integration.provider)
+            })
         });
 
         let success = false;

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -12,6 +12,7 @@ import {
     configService,
     connectionService,
     errorManager,
+    getProvider,
     getProxyConfiguration,
     refreshOrTestCredentials
 } from '@nangohq/shared';
@@ -213,7 +214,12 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
 
                 freshConnection = credentialResponse.value;
                 return freshConnection;
-            }
+            },
+            getIntegrationConfig: () => ({
+                oauth_client_id: integration.oauth_client_id,
+                oauth_client_secret: integration.oauth_client_secret
+            }),
+            getProvider: () => getProvider(integration.provider)
         });
 
         let success = false;

--- a/packages/server/lib/hooks/connection/credentials-verification-script.ts
+++ b/packages/server/lib/hooks/connection/credentials-verification-script.ts
@@ -107,7 +107,12 @@ async function execute(
                     proxyConfig,
                     getConnection: () => {
                         return connection;
-                    }
+                    },
+                    getIntegrationConfig: () => ({
+                        oauth_client_id: null,
+                        oauth_client_secret: null
+                    }),
+                    getProvider: () => getProvider(providerName)
                 });
                 return (await proxy.request()).unwrap();
             }

--- a/packages/server/lib/hooks/connection/credentials-verification-script.ts
+++ b/packages/server/lib/hooks/connection/credentials-verification-script.ts
@@ -111,8 +111,7 @@ async function execute(
                     getIntegrationConfig: () => ({
                         oauth_client_id: null,
                         oauth_client_secret: null
-                    }),
-                    getProvider: () => getProvider(providerName)
+                    })
                 });
                 return (await proxy.request()).unwrap();
             }

--- a/packages/server/lib/hooks/connection/internal-nango.ts
+++ b/packages/server/lib/hooks/connection/internal-nango.ts
@@ -1,4 +1,4 @@
-import { ProxyRequest, configService, connectionService, getProxyConfiguration } from '@nangohq/shared';
+import { ProxyRequest, configService, connectionService, getProvider, getProxyConfiguration } from '@nangohq/shared';
 
 import type { Config } from '@nangohq/shared';
 import type { ConnectionConfig, DBConnectionDecrypted, InternalProxyConfiguration, Provider, UserProvidedProxyConfiguration } from '@nangohq/types';
@@ -41,7 +41,18 @@ export function getInternalNango(connection: DBConnectionDecrypted, providerName
                     /* TODO: structured logging here if needed */
                 },
                 proxyConfig: proxyConfigUnwrapped,
-                getConnection: () => connection
+                getConnection: () => connection,
+                getIntegrationConfig: async () => {
+                    const integration = await configService.getProviderConfig(connection.provider_config_key, connection.environment_id);
+                    if (!integration) {
+                        return { oauth_client_id: null, oauth_client_secret: null };
+                    }
+                    return {
+                        oauth_client_id: integration.oauth_client_id,
+                        oauth_client_secret: integration.oauth_client_secret
+                    };
+                },
+                getProvider: () => getProvider(providerName)
             });
             const response = (await proxyInstance.request()).unwrap();
             return response;

--- a/packages/server/lib/hooks/connection/internal-nango.ts
+++ b/packages/server/lib/hooks/connection/internal-nango.ts
@@ -1,4 +1,4 @@
-import { ProxyRequest, configService, connectionService, getProvider, getProxyConfiguration } from '@nangohq/shared';
+import { ProxyRequest, configService, connectionService, getProxyConfiguration } from '@nangohq/shared';
 
 import type { Config } from '@nangohq/shared';
 import type { ConnectionConfig, DBConnectionDecrypted, InternalProxyConfiguration, Provider, UserProvidedProxyConfiguration } from '@nangohq/types';
@@ -44,15 +44,14 @@ export function getInternalNango(connection: DBConnectionDecrypted, providerName
                 getConnection: () => connection,
                 getIntegrationConfig: async () => {
                     const integration = await configService.getProviderConfig(connection.provider_config_key, connection.environment_id);
-                    if (!integration) {
-                        return { oauth_client_id: null, oauth_client_secret: null };
+                    if (integration) {
+                        return {
+                            oauth_client_id: integration.oauth_client_id,
+                            oauth_client_secret: integration.oauth_client_secret
+                        };
                     }
-                    return {
-                        oauth_client_id: integration.oauth_client_id,
-                        oauth_client_secret: integration.oauth_client_secret
-                    };
-                },
-                getProvider: () => getProvider(providerName)
+                    return { oauth_client_id: null, oauth_client_secret: null };
+                }
             });
             const response = (await proxyInstance.request()).unwrap();
             return response;

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -6,6 +6,7 @@ import {
     connectionService,
     errorNotificationService,
     externalWebhookService,
+    getProvider,
     getProxyConfiguration,
     productTracking,
     syncManager
@@ -374,7 +375,12 @@ export async function credentialsTest({
                 proxyConfig,
                 getConnection: () => {
                     return connection;
-                }
+                },
+                getIntegrationConfig: () => ({
+                    oauth_client_id: config.oauth_client_id,
+                    oauth_client_secret: config.oauth_client_secret
+                }),
+                getProvider: () => getProvider(config.provider)
             });
 
             const response = (await proxy.request()).unwrap();

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -6,7 +6,6 @@ import {
     connectionService,
     errorNotificationService,
     externalWebhookService,
-    getProvider,
     getProxyConfiguration,
     productTracking,
     syncManager
@@ -379,8 +378,7 @@ export async function credentialsTest({
                 getIntegrationConfig: () => ({
                     oauth_client_id: config.oauth_client_id,
                     oauth_client_secret: config.oauth_client_secret
-                }),
-                getProvider: () => getProvider(config.provider)
+                })
             });
 
             const response = (await proxy.request()).unwrap();

--- a/packages/shared/lib/services/notification/slack.service.ts
+++ b/packages/shared/lib/services/notification/slack.service.ts
@@ -6,6 +6,7 @@ import configService from '../config.service.js';
 import connectionService from '../connection.service.js';
 import { refreshOrTestCredentials } from '../connections/credentials/refresh.js';
 import environmentService from '../environment.service.js';
+import { getProvider } from '../providers.js';
 import { ProxyRequest } from '../proxy/request.js';
 import { getProxyConfiguration } from '../proxy/utils.js';
 
@@ -711,7 +712,12 @@ export class SlackService {
             const proxy = new ProxyRequest({
                 logger: () => {},
                 proxyConfig: proxyConfig.value,
-                getConnection: () => slackConnection
+                getConnection: () => slackConnection,
+                getIntegrationConfig: () => ({
+                    oauth_client_id: integration.oauth_client_id,
+                    oauth_client_secret: integration.oauth_client_secret
+                }),
+                getProvider: () => getProvider(integration.provider)
             });
             const join = await proxy.request();
             if (join.isErr()) {
@@ -780,7 +786,12 @@ export class SlackService {
             const proxy = new ProxyRequest({
                 logger: () => {},
                 proxyConfig: proxyConfig.value,
-                getConnection: () => slackConnection
+                getConnection: () => slackConnection,
+                getIntegrationConfig: () => ({
+                    oauth_client_id: integration.oauth_client_id,
+                    oauth_client_secret: integration.oauth_client_secret
+                }),
+                getProvider: () => getProvider(integration.provider)
             });
             const slackMessage = await proxy.request();
 

--- a/packages/shared/lib/services/notification/slack.service.ts
+++ b/packages/shared/lib/services/notification/slack.service.ts
@@ -6,7 +6,6 @@ import configService from '../config.service.js';
 import connectionService from '../connection.service.js';
 import { refreshOrTestCredentials } from '../connections/credentials/refresh.js';
 import environmentService from '../environment.service.js';
-import { getProvider } from '../providers.js';
 import { ProxyRequest } from '../proxy/request.js';
 import { getProxyConfiguration } from '../proxy/utils.js';
 
@@ -716,8 +715,7 @@ export class SlackService {
                 getIntegrationConfig: () => ({
                     oauth_client_id: integration.oauth_client_id,
                     oauth_client_secret: integration.oauth_client_secret
-                }),
-                getProvider: () => getProvider(integration.provider)
+                })
             });
             const join = await proxy.request();
             if (join.isErr()) {
@@ -790,8 +788,7 @@ export class SlackService {
                 getIntegrationConfig: () => ({
                     oauth_client_id: integration.oauth_client_id,
                     oauth_client_secret: integration.oauth_client_secret
-                }),
-                getProvider: () => getProvider(integration.provider)
+                })
             });
             const slackMessage = await proxy.request();
 

--- a/packages/shared/lib/services/proxy/request.ts
+++ b/packages/shared/lib/services/proxy/request.ts
@@ -6,14 +6,7 @@ import { getProxyRetryFromErr } from './retry.js';
 import { ProxyError, getAxiosConfiguration } from './utils.js';
 
 import type { RetryReason } from './utils.js';
-import type {
-    ApplicationConstructedProxyConfiguration,
-    ConnectionForProxy,
-    IntegrationConfigForProxy,
-    MaybePromise,
-    MessageRowInsert,
-    Provider
-} from '@nangohq/types';
+import type { ApplicationConstructedProxyConfiguration, ConnectionForProxy, IntegrationConfigForProxy, MaybePromise, MessageRowInsert } from '@nangohq/types';
 import type { Result, RetryAttemptArgument } from '@nangohq/utils';
 import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 
@@ -23,7 +16,6 @@ interface Props {
     onError?: (args: { err: unknown; max: number; attempt: number; retry: RetryReason }) => RetryReason;
     getConnection: () => MaybePromise<ConnectionForProxy>;
     getIntegrationConfig: () => MaybePromise<IntegrationConfigForProxy>;
-    getProvider: () => Provider | null;
 }
 
 /**
@@ -48,11 +40,6 @@ export class ProxyRequest {
     getIntegrationConfig: Props['getIntegrationConfig'];
 
     /**
-     * Called to get provider config only for Oauth1
-     */
-    getProvider: Props['getProvider'];
-
-    /**
      * Called on error, gives the ability to control the retry and wait time
      */
     onError?: Props['onError'];
@@ -72,18 +59,12 @@ export class ProxyRequest {
      */
     integrationConfig?: IntegrationConfigForProxy | undefined;
 
-    /**
-     * Provider config only for Oauth1
-     */
-    provider?: Provider | null;
-
     constructor(props: Props) {
         this.config = props.proxyConfig;
         this.logger = props.logger;
         this.onError = props.onError;
         this.getConnection = props.getConnection;
         this.getIntegrationConfig = props.getIntegrationConfig;
-        this.getProvider = props.getProvider;
     }
 
     /**
@@ -99,14 +80,12 @@ export class ProxyRequest {
 
                     if (this.connection.credentials.type === 'OAUTH1') {
                         this.integrationConfig = await this.getIntegrationConfig();
-                        this.provider = this.getProvider();
                     }
 
                     this.axiosConfig = getAxiosConfiguration({
                         integrationConfig: this.integrationConfig,
                         proxyConfig: this.config,
-                        connection: this.connection,
-                        provider: this.provider ?? null
+                        connection: this.connection
                     });
 
                     const start = new Date();

--- a/packages/shared/lib/services/proxy/request.unit.test.ts
+++ b/packages/shared/lib/services/proxy/request.unit.test.ts
@@ -10,7 +10,9 @@ describe('call', () => {
         const proxy = new ProxyRequest({
             logger: fn,
             proxyConfig: getDefaultProxy({ provider: { proxy: { base_url: 'https://httpstatuses.maor.io' } }, endpoint: '/200' }),
-            getConnection: () => getTestConnection()
+            getConnection: () => getTestConnection(),
+            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            getProvider: () => null
         });
         const res = (await proxy.request()).unwrap();
         expect(res).toMatchObject({ status: 200 });
@@ -32,7 +34,9 @@ describe('call', () => {
         const proxy = new ProxyRequest({
             logger: fn,
             proxyConfig: getDefaultProxy({ provider: { proxy: { base_url: 'https://httpstatuses.maor.io' } }, endpoint: '/400', retries: 1 }),
-            getConnection: () => getTestConnection()
+            getConnection: () => getTestConnection(),
+            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            getProvider: () => null
         });
         await expect(async () => (await proxy.request()).unwrap()).rejects.toThrowError();
         expect(fn).toHaveBeenNthCalledWith(
@@ -64,7 +68,9 @@ describe('call', () => {
         const proxy = new ProxyRequest({
             logger: fn,
             proxyConfig: getDefaultProxy({ provider: { proxy: { base_url: 'https://httpstatuses.maor.io' } }, endpoint: '/500', retries: 1 }),
-            getConnection
+            getConnection,
+            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            getProvider: () => null
         });
         await expect(async () => (await proxy.request()).unwrap()).rejects.toThrowError();
         expect(fn).toHaveBeenNthCalledWith(

--- a/packages/shared/lib/services/proxy/request.unit.test.ts
+++ b/packages/shared/lib/services/proxy/request.unit.test.ts
@@ -11,8 +11,7 @@ describe('call', () => {
             logger: fn,
             proxyConfig: getDefaultProxy({ provider: { proxy: { base_url: 'https://httpstatuses.maor.io' } }, endpoint: '/200' }),
             getConnection: () => getTestConnection(),
-            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
-            getProvider: () => null
+            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null })
         });
         const res = (await proxy.request()).unwrap();
         expect(res).toMatchObject({ status: 200 });
@@ -35,8 +34,7 @@ describe('call', () => {
             logger: fn,
             proxyConfig: getDefaultProxy({ provider: { proxy: { base_url: 'https://httpstatuses.maor.io' } }, endpoint: '/400', retries: 1 }),
             getConnection: () => getTestConnection(),
-            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
-            getProvider: () => null
+            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null })
         });
         await expect(async () => (await proxy.request()).unwrap()).rejects.toThrowError();
         expect(fn).toHaveBeenNthCalledWith(
@@ -69,8 +67,7 @@ describe('call', () => {
             logger: fn,
             proxyConfig: getDefaultProxy({ provider: { proxy: { base_url: 'https://httpstatuses.maor.io' } }, endpoint: '/500', retries: 1 }),
             getConnection,
-            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
-            getProvider: () => null
+            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null })
         });
         await expect(async () => (await proxy.request()).unwrap()).rejects.toThrowError();
         expect(fn).toHaveBeenNthCalledWith(

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -13,8 +13,11 @@ import type {
     ApplicationConstructedProxyConfiguration,
     ConnectionForProxy,
     HTTP_METHOD,
+    IntegrationConfigForProxy,
     InternalProxyConfiguration,
     OAuth2ClientCredentials,
+    Provider,
+    ProviderOAuth1,
     UserProvidedProxyConfiguration
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
@@ -50,13 +53,17 @@ const providedHeaders: Lowercase<string>[] = ['user-agent'];
 
 export function getAxiosConfiguration({
     proxyConfig,
-    connection
+    connection,
+    integrationConfig,
+    provider
 }: {
     proxyConfig: ApplicationConstructedProxyConfiguration;
     connection: ConnectionForProxy;
+    integrationConfig?: IntegrationConfigForProxy | undefined;
+    provider?: Provider | null;
 }): AxiosRequestConfig {
     const url = buildProxyURL({ config: proxyConfig, connection });
-    const headers = buildProxyHeaders({ config: proxyConfig, url, connection });
+    const headers = buildProxyHeaders({ config: proxyConfig, url, connection, integrationConfig, provider: provider ?? null });
 
     const axiosConfig: AxiosRequestConfig = {
         method: proxyConfig.method,
@@ -267,11 +274,15 @@ export function buildProxyURL({ config, connection }: { config: ApplicationConst
 export function buildProxyHeaders({
     config,
     url,
-    connection
+    connection,
+    integrationConfig,
+    provider
 }: {
     config: ApplicationConstructedProxyConfiguration;
     url: string;
     connection: ConnectionForProxy;
+    integrationConfig?: IntegrationConfigForProxy | undefined;
+    provider?: Provider | null;
 }): Record<string, string> {
     let headers: Record<Lowercase<string>, string> = {};
 
@@ -349,7 +360,36 @@ export function buildProxyHeaders({
             break;
         }
         case 'OAUTH1': {
-            throw new ProxyError('unsupported_auth', 'OAuth1 is not supported');
+            const credentials = connection.credentials;
+            const consumerKey = integrationConfig?.oauth_client_id;
+            const consumerSecret = integrationConfig?.oauth_client_secret;
+
+            if (!consumerKey || !consumerSecret) {
+                throw new ProxyError('unsupported_auth', 'OAuth1 requires oauth_client_id and oauth_client_secret in integration config');
+            }
+
+            const accessToken = credentials.oauth_token;
+            const accessTokenSecret = credentials.oauth_token_secret;
+
+            const oauth = new OAuth({
+                consumer: { key: consumerKey, secret: consumerSecret },
+                signature_method: provider ? (provider as ProviderOAuth1).signature_method : SIGNATURE_METHOD,
+                hash_function(baseString: string, key: string) {
+                    return crypto.createHmac('sha1', key).update(baseString).digest('base64');
+                }
+            });
+
+            const requestData = {
+                url,
+                method: config.method
+            };
+
+            const token = { key: accessToken, secret: accessTokenSecret };
+
+            const authHeaders = oauth.toHeader(oauth.authorize(requestData, token));
+
+            headers['authorization'] = authHeaders.Authorization;
+            break;
         }
         default: {
             throw new ProxyError('unsupported_auth', `Auth "${(connection.credentials as any).type}" is not supported`);

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -16,7 +16,6 @@ import type {
     IntegrationConfigForProxy,
     InternalProxyConfiguration,
     OAuth2ClientCredentials,
-    Provider,
     ProviderOAuth1,
     UserProvidedProxyConfiguration
 } from '@nangohq/types';
@@ -54,16 +53,14 @@ const providedHeaders: Lowercase<string>[] = ['user-agent'];
 export function getAxiosConfiguration({
     proxyConfig,
     connection,
-    integrationConfig,
-    provider
+    integrationConfig
 }: {
     proxyConfig: ApplicationConstructedProxyConfiguration;
     connection: ConnectionForProxy;
     integrationConfig?: IntegrationConfigForProxy | undefined;
-    provider?: Provider | null;
 }): AxiosRequestConfig {
     const url = buildProxyURL({ config: proxyConfig, connection });
-    const headers = buildProxyHeaders({ config: proxyConfig, url, connection, integrationConfig, provider: provider ?? null });
+    const headers = buildProxyHeaders({ config: proxyConfig, url, connection, integrationConfig });
 
     const axiosConfig: AxiosRequestConfig = {
         method: proxyConfig.method,
@@ -275,14 +272,12 @@ export function buildProxyHeaders({
     config,
     url,
     connection,
-    integrationConfig,
-    provider
+    integrationConfig
 }: {
     config: ApplicationConstructedProxyConfiguration;
     url: string;
     connection: ConnectionForProxy;
     integrationConfig?: IntegrationConfigForProxy | undefined;
-    provider?: Provider | null;
 }): Record<string, string> {
     let headers: Record<Lowercase<string>, string> = {};
 
@@ -373,7 +368,7 @@ export function buildProxyHeaders({
 
             const oauth = new OAuth({
                 consumer: { key: consumerKey, secret: consumerSecret },
-                signature_method: provider ? (provider as ProviderOAuth1).signature_method : SIGNATURE_METHOD,
+                signature_method: config.provider ? (config.provider as ProviderOAuth1).signature_method : SIGNATURE_METHOD,
                 hash_function(baseString: string, key: string) {
                     return crypto.createHmac('sha1', key).update(baseString).digest('base64');
                 }

--- a/packages/types/lib/proxy/api.ts
+++ b/packages/types/lib/proxy/api.ts
@@ -1,4 +1,5 @@
 import type { DBConnectionDecrypted } from '../connection/db.js';
+import type { DBIntegrationDecrypted } from '../integration/db.js';
 import type { HTTP_METHOD } from '../nangoYaml/index.js';
 import type { Provider } from '../providers/provider.js';
 import type { AxiosResponse } from 'axios';
@@ -36,6 +37,7 @@ export interface UserProvidedProxyConfiguration extends BaseProxyConfiguration {
 }
 
 export type ConnectionForProxy = Pick<DBConnectionDecrypted, 'connection_id' | 'connection_config' | 'credentials' | 'metadata'>;
+export type IntegrationConfigForProxy = Pick<DBIntegrationDecrypted, 'oauth_client_id' | 'oauth_client_secret'>;
 
 export interface ApplicationConstructedProxyConfiguration extends BaseProxyConfiguration {
     decompress: boolean;


### PR DESCRIPTION
Describe the problem and your solution

- add authentication headers for `OAuth1.0`, tested with trello.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add OAuth1 signing support to proxy pipeline**

Extends the proxy request flow to generate OAuth 1.0 Authorization headers by retrieving integration consumer credentials when a connection uses `OAUTH1`. `ProxyRequest` now requires a `getIntegrationConfig` callback and all call sites (server proxy controller, hooks, Slack notifications, internal scripts, SDK, and unit tests) have been updated to supply integration metadata or null defaults. The proxy utilities build the Authorization header via `oauth-1.0a`, enforce the presence of `oauth_client_id`/`oauth_client_secret`, and surface errors when credentials are missing.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `buildProxyHeaders` in `packages/shared/lib/services/proxy/utils.ts` to sign `OAUTH1` requests using consumer credentials from `IntegrationConfigForProxy` and generate the Authorization header via `oauth-1.0a`.
• Extended `getAxiosConfiguration` and `ProxyRequest` to accept `integrationConfig`, fetching it lazily through the new `getIntegrationConfig` hook only when the connection credentials type is `OAUTH1`.
• Propagated `getIntegrationConfig` implementations across server controllers, hooks, Slack notifications, runner SDK, and verification scripts to supply integration consumer key/secret values or null placeholders.
• Introduced `IntegrationConfigForProxy` type in `packages/types/lib/proxy/api.ts` and refreshed unit tests in `packages/shared/lib/services/proxy/request.unit.test.ts` to reflect the new dependency.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Proxy utilities (`packages/shared/lib/services/proxy/utils.ts`)
• Proxy request execution (`packages/shared/lib/services/proxy/request.ts`)
• Server proxy controller and hooks
• Slack notification service
• Runner SDK proxy wrapper
• Proxy-related type definitions and unit tests

</details>

---
*This summary was automatically generated by @propel-code-bot*