### PR TITLE
fix: remove mention of runtime records validation in prod

### DIFF
--- a/docs/guides/platform/data-validation.mdx
+++ b/docs/guides/platform/data-validation.mdx
@@ -19,6 +19,5 @@ Nango also automatically generates a [JSON Schema](https://json-schema.org/) def
 Data validation is enabled by default:
 - During local development, Nango's CLI will log type errors as warnings
     - You can optionally fail on type errors with a CLI flag
-- During production execution, type errors produce warnings in Nango's [logs](/guides/platform/logs) but do not fail the execution
 
 Refer to our [data validation implementation guide](/implementation-guides/building-integrations/data-validation) for more details.

--- a/docs/implementation-guides/building-integrations/data-validation.mdx
+++ b/docs/implementation-guides/building-integrations/data-validation.mdx
@@ -8,10 +8,9 @@ Nango automatically validates your integration inputs and outputs. It also offer
 
 ## Automatic validation
 
-The validation is available during development and production and does not require any configuration from you:
+The validation is available during development and does not require any configuration from you:
 
 - **CLI**: Dry Run validation errors are logged and will halt execution when using `--validation` command option
-- **Production**: Validation errors are logged but do not halt execution
 
 
 ## Available schema files

--- a/docs/implementation-guides/building-integrations/unified-apis.mdx
+++ b/docs/implementation-guides/building-integrations/unified-apis.mdx
@@ -95,7 +95,6 @@ In your custom functions, implement data-fetching logic and apply necessary tran
 
 - **Enforce generated types in your codebase**: Nango will leverage your unified model to [generate strongly-typed interfaces for your codebase](/implementation-guides/building-integrations/data-validation#available-schema-files), reducing errors and improving developer productivity
 - **Custom data validation**: Leverage Nango's integration with zod to define custom validation rules tailored to your unified model ([More about data validation](/guides/platform/data-validation))
-- **Runtime data validation**: Nango includes built-in runtime validation, which surfaces warnings in the **Logs** tab of the Nango UI when runtime data validation errors are detected 
 
 ### Calling the unified API from your app
 


### PR DESCRIPTION
Feature has been removed. Deleting the mention of runtime records validation in production (still enabled in the CLI)
<!-- Summary by @propel-code-bot -->

---

**Update docs to remove production runtime validation references**

Documentation updates align guidance with the current behavior where runtime record validation no longer runs in production but remains available via the CLI. References to production runtime validation are removed or reworded in the platform guide, implementation guide, and unified APIs doc.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed production runtime validation bullet from `docs/guides/platform/data-validation.mdx`
• Updated `docs/implementation-guides/building-integrations/data-validation.mdx` to describe validation availability only during development/CLI usage
• Deleted runtime validation mention from the unified APIs guide at `docs/implementation-guides/building-integrations/unified-apis.mdx`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs/guides/platform/data-validation.mdx`
• `docs/implementation-guides/building-integrations/data-validation.mdx`
• `docs/implementation-guides/building-integrations/unified-apis.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*