### PR TITLE
refactor(records): centralize count management with incrCount helper

### DIFF
--- a/packages/account-usage/lib/usage.ts
+++ b/packages/account-usage/lib/usage.ts
@@ -269,7 +269,7 @@ export class UsageTracker implements IUsageTracker {
         let count = 0;
         if (envs.length > 0) {
             const envIds = envs.map((e) => e.id);
-            for await (const recordCounts of records.paginateRecordCounts({ environmentIds: envIds })) {
+            for await (const recordCounts of records.paginateCounts({ environmentIds: envIds })) {
                 if (recordCounts.isErr()) {
                     return Err(recordCounts.error);
                 }

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -304,6 +304,7 @@ export async function handleSyncSuccess({
                     `'track_deletes' is deprecated and will be removed in future versions. To detect deletions please call 'nango.deleteRecordsFromPreviousExecutions()' in your sync script.`
                 );
                 const res = await records.deleteOutdatedRecords({
+                    environmentId: nangoProps.environmentId,
                     connectionId: nangoProps.nangoConnectionId,
                     model,
                     generation: nangoProps.syncJobId

--- a/packages/metering/lib/crons/usage.ts
+++ b/packages/metering/lib/crons/usage.ts
@@ -101,7 +101,7 @@ const observability = {
                 // Performance note: This nested pagination approach is necessary because records and connections
                 // are stored in separate databases, making SQL JOINs impossible.
                 // To reconsider when record counts table becomes very large
-                for await (const recordCounts of records.paginateRecordCounts()) {
+                for await (const recordCounts of records.paginateCounts()) {
                     if (recordCounts.isErr()) {
                         throw recordCounts.error;
                     }

--- a/packages/persist/lib/records.ts
+++ b/packages/persist/lib/records.ts
@@ -81,7 +81,7 @@ export async function persistRecords({
         case 'update':
             softDelete = false;
             persistFunction = async (records: FormattedRecord[]) => {
-                return recordsService.update({ records, connectionId, model, merging });
+                return recordsService.update({ records, environmentId: environment.id, connectionId, model, merging });
             };
             break;
     }

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts
@@ -52,11 +52,12 @@ const validate = validateRequest<DeleteOutdatedRecords>({
 });
 
 const handler = async (_req: EndpointRequest, res: EndpointResponse<DeleteOutdatedRecords, AuthLocals>) => {
-    const { nangoConnectionId, syncId, syncJobId } = res.locals.parsedParams;
+    const { nangoConnectionId, syncId, syncJobId, environmentId } = res.locals.parsedParams;
     const { model, activityLogId } = res.locals.parsedBody;
     const { account, environment } = res.locals;
     const logCtx = logContextGetter.getStateLess({ id: String(activityLogId), accountId: account.id });
     const result = await records.deleteOutdatedRecords({
+        environmentId,
         connectionId: nangoConnectionId,
         model,
         generation: syncJobId

--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -850,6 +850,11 @@ describe('Records service', () => {
 
             const records = Array.from({ length: count }, (_, i) => ({ id: `${i}`, name: `record ${i}` }));
             await upsertRecords({ records, connectionId, environmentId, model, syncId, syncJobId: 1 });
+            // Insert an additional record to ensure total count is correct
+            await upsertRecords({ records: [{ id: '99', name: '99' }], connectionId, environmentId, model, syncId, syncJobId: 2 });
+
+            const initialStats = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
+            expect(initialStats[model]?.count).toBe(11);
 
             const deletedIds = (
                 await Records.deleteOutdatedRecords({
@@ -861,6 +866,9 @@ describe('Records service', () => {
                 })
             ).unwrap();
             expect(deletedIds).toHaveLength(count);
+
+            const finalStats = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
+            expect(finalStats[model]?.count).toBe(1); // only the last record should remain
         });
 
         it('should update record counts correctly', async () => {

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -820,7 +820,7 @@ export async function deleteOutdatedRecords({
                 deletedIds.push(...res.map((r) => r.external_id));
 
                 // update records count and size
-                const deleted = deletedIds.length;
+                const deleted = res.length;
                 const sizeInBytes = res.reduce((acc, r) => acc + r.size_bytes, 0);
                 if (deleted > 0) {
                     await incrCount(trx, {

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -60,7 +60,7 @@ class SyncController {
     }
 
     private async addRecordCount(syncs: (Sync & { models: string[] })[], connectionId: number, environmentId: number) {
-        const byModel = await recordsService.getRecordStatsByModel({ connectionId, environmentId });
+        const byModel = await recordsService.getCountsByModel({ connectionId, environmentId });
         if (byModel.isOk()) {
             return syncs.map((sync) => ({
                 ...sync,

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -54,7 +54,7 @@ export interface RecordsServiceInterface {
         connectionId: number;
         model: string;
     }): Promise<Result<{ totalDeletedRecords: number }>>;
-    getRecordStatsByModel({ connectionId, environmentId }: { connectionId: number; environmentId: number }): Promise<Result<Record<string, RecordCount>>>;
+    getCountsByModel({ connectionId, environmentId }: { connectionId: number; environmentId: number }): Promise<Result<Record<string, RecordCount>>>;
 }
 
 // TODO: move to @nangohq/types (with the rest of the ochestrator public types)

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -522,7 +522,7 @@ export class SyncManagerService {
             throw new Error(`Schedule for sync ${sync.id} and environment ${environmentId} not found`);
         }
 
-        const countRes = await recordsService.getRecordStatsByModel({ connectionId: sync.nango_connection_id, environmentId }); // TODO: handle sync's variant
+        const countRes = await recordsService.getCountsByModel({ connectionId: sync.nango_connection_id, environmentId }); // TODO: handle sync's variant
         if (countRes.isErr()) {
             throw new Error(`Failed to get records count for sync ${sync.id} in environment ${environmentId}: ${stringifyError(countRes.error)}`);
         }


### PR DESCRIPTION
In preparation of the refactoring of the `deleteRecords` function required for `pruning v1` feature, this commit refactor the record count increment/decrement by extracting it into a helper function.

<!-- Summary by @propel-code-bot -->

---

**Centralize record count updates with shared helpers**

This PR refactors the records subsystem so that every increment/decrement of `record_counts` is funneled through the new `incrCount`/`deleteCount` helpers. The helpers enforce non-negative totals and consolidate the previously duplicated SQL used during upsert, update, soft-delete, pruning, and hard-delete flows. Public record count APIs have been renamed (`getCountsByModel`, `paginateCounts`), and downstream consumers across orchestrator, persistence, usage, and metering have been updated to the new signatures (including passing `environmentId` into writes).
Integration tests now cover the helper behaviours, renamed APIs, and the various delete paths to ensure counts and `size_bytes` stay in sync after the refactor.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced `incrCount` and `deleteCount` in `packages/records/lib/models/records.ts` and rewired upsert/update/delete/pruning flows to route count mutations through the helper with `GREATEST(0, …)` guards.
• Renamed `getRecordStatsByModel`→`getCountsByModel` and `paginateRecordCounts`→`paginateCounts`, updating orchestrator interfaces, server controllers, account usage, and metering cron consumers.
• Required `environmentId` for `update`, `deleteOutdatedRecords`, and related call sites (e.g., persistence layer, job execution) to support the new helper signature and advisory locking during deletes.
• Augmented integration tests with scenarios that validate helper semantics (insert, increment, decrement, zero-delta), renamed APIs, soft/hard deletes, and pruning count/size bookkeeping.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/records/lib/models/records.ts
• packages/records/lib/models/records.integration.test.ts
• packages/shared/lib/clients/orchestrator.ts
• packages/shared/lib/services/sync/manager.service.ts
• packages/persist/lib/records.ts
• packages/jobs/lib/execution/sync.ts
• packages/account-usage/lib/usage.ts
• packages/metering/lib/crons/usage.ts
• packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts
• packages/server/lib/controllers/sync.controller.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*