### PR TITLE
fix: NAN-4493: Wrap create account DB write with transaction

### DIFF
--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -456,7 +456,7 @@ describe('Persist API', () => {
 
 const initDb = async () => {
     const now = new Date();
-    const env = await environmentService.createEnvironment(0, 'testEnv');
+    const env = await environmentService.createEnvironment(db.knex, { accountId: 0, name: 'testEnv' });
     if (!env) throw new Error('Environment not created');
 
     const plan = (await createPlan(db.knex, { account_id: 0, name: 'free' })).unwrap();

--- a/packages/server/lib/controllers/sync/deploy/postDeployInternal.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeployInternal.ts
@@ -1,5 +1,6 @@
 import * as z from 'zod';
 
+import db from '@nangohq/database';
 import { logContextGetter } from '@nangohq/logs';
 import { cleanIncomingFlow, configService, connectionService, deploy, environmentService, errorManager, getAndReconcileDifferences } from '@nangohq/shared';
 import { zodErrorToHTTP } from '@nangohq/utils';
@@ -48,7 +49,7 @@ export const postDeployInternal = asyncWrapper<PostDeployInternal>(async (req, r
     let environment = await environmentService.getByEnvironmentName(account.id, environmentName);
 
     if (!environment) {
-        environment = await environmentService.createEnvironment(account.id, environmentName);
+        environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: environmentName });
 
         if (!environment) {
             res.status(500).send({

--- a/packages/server/lib/controllers/v1/environment/deleteEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/deleteEnvironment.integration.test.ts
@@ -33,7 +33,7 @@ describe(`DELETE ${endpoint}`, () => {
 
     it('should not allow deleting prod environment', async () => {
         const { account } = await seeders.seedAccountEnvAndUser();
-        const prodEnv = await environmentService.createEnvironment(account.id, PROD_ENVIRONMENT_NAME);
+        const prodEnv = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: PROD_ENVIRONMENT_NAME });
         if (!prodEnv) {
             throw new Error('Failed to create prod environment');
         }
@@ -57,7 +57,7 @@ describe(`DELETE ${endpoint}`, () => {
 
     it('should successfully delete a non-prod environment', async () => {
         const { account } = await seeders.seedAccountEnvAndUser();
-        const testEnv = await environmentService.createEnvironment(account.id, 'test-delete');
+        const testEnv = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: 'test-delete' });
         if (!testEnv) {
             throw new Error('Failed to create test environment');
         }
@@ -79,7 +79,7 @@ describe(`DELETE ${endpoint}`, () => {
     it('should soft delete configs, syncConfigs and syncs when environment is deleted', async () => {
         // Seed account, environment, and user
         const { account } = await seeders.seedAccountEnvAndUser();
-        const testEnv = await environmentService.createEnvironment(account.id, 'test-delete-related');
+        const testEnv = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: 'test-delete-related' });
         if (!testEnv) {
             throw new Error('Failed to create test environment');
         }

--- a/packages/server/lib/controllers/v1/environment/patchEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/patchEnvironment.integration.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import db from '@nangohq/database';
 import { environmentService, seeders } from '@nangohq/shared';
 
 import { isError, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
@@ -54,7 +55,7 @@ describe(`PATCH ${endpoint}`, () => {
 
     it('should not allow renaming to an existing environment name', async () => {
         const { env, account } = await seeders.seedAccountEnvAndUser();
-        await environmentService.createEnvironment(account.id, 'existing');
+        await environmentService.createEnvironment(db.knex, { accountId: account.id, name: 'existing' });
 
         const res = await api.fetch(endpoint, {
             method: 'PATCH',

--- a/packages/server/lib/controllers/v1/environment/postEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/postEnvironment.integration.test.ts
@@ -29,7 +29,7 @@ describe(`POST ${endpoint}`, () => {
     it('should not allow environment name to be the same as an existing environment', async () => {
         const { env, plan } = await seeders.seedAccountEnvAndUser();
         await updatePlan(db.knex, { id: plan.id, environments_max: 10 });
-        await environmentService.createEnvironment(env.account_id, 'existing');
+        await environmentService.createEnvironment(db.knex, { accountId: env.account_id, name: 'existing' });
 
         const res = await api.fetch(endpoint, {
             method: 'POST',

--- a/packages/server/lib/controllers/v1/environment/postEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/postEnvironment.ts
@@ -58,17 +58,20 @@ export const postEnvironment = asyncWrapper<PostEnvironment>(async (req, res) =>
         return;
     }
 
-    const created = await environmentService.createEnvironment(accountId, body.name);
+    const created = await environmentService.createEnvironment(db.knex, { accountId: accountId, name: body.name });
     if (!created) {
         res.status(500).send({ error: { code: 'server_error', message: 'Failed to create environment' } });
         return;
     }
 
-    await externalWebhookService.update(created.id, {
-        on_auth_creation: true,
-        on_auth_refresh_error: true,
-        on_sync_completion_always: true,
-        on_sync_error: true
+    await externalWebhookService.update(db.knex, {
+        environment_id: created.id,
+        data: {
+            on_auth_creation: true,
+            on_auth_refresh_error: true,
+            on_sync_completion_always: true,
+            on_sync_error: true
+        }
     });
 
     res.status(200).send({ data: { id: created.id, name: created.name } });

--- a/packages/server/lib/controllers/v1/environment/webhook/patchWebhook.ts
+++ b/packages/server/lib/controllers/v1/environment/webhook/patchWebhook.ts
@@ -2,6 +2,7 @@ import { URL } from 'url';
 
 import * as z from 'zod';
 
+import db from '@nangohq/database';
 import { externalWebhookService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
@@ -78,7 +79,7 @@ export const patchWebhook = asyncWrapper<PatchWebhook>(async (req, res) => {
         return;
     }
 
-    await externalWebhookService.update(environment.id, data);
+    await externalWebhookService.update(db.knex, { environment_id: environment.id, data: data });
 
     res.status(200).send({ success: true });
 });

--- a/packages/shared/lib/seeders/environment.seeder.ts
+++ b/packages/shared/lib/seeders/environment.seeder.ts
@@ -1,9 +1,11 @@
+import db from '@nangohq/database';
+
 import environmentService from '../services/environment.service.js';
 
 import type { DBEnvironment } from '@nangohq/types';
 
 export async function createEnvironmentSeed(accountId: number = 0, envName: string = 'test'): Promise<DBEnvironment> {
-    const env = await environmentService.createEnvironment(accountId, envName);
+    const env = await environmentService.createEnvironment(db.knex, { accountId: accountId, name: envName });
     if (!env) {
         throw new Error('Failed to create environment');
     }

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -45,7 +45,7 @@ describe('Account service', () => {
 
     it('should retrieve account context by secretKey', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(account.id, uuid(), db.knex);
+        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
 
         const bySecretKey = await accountService.getAccountContext({ secretKey: environment!.secret_key });
@@ -71,7 +71,7 @@ describe('Account service', () => {
 
     it('should retrieve account context by publicKey', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(account.id, uuid(), db.knex);
+        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
 
         const byPublicKey = await accountService.getAccountContext({ publicKey: environment!.public_key });
@@ -97,7 +97,7 @@ describe('Account service', () => {
 
     it('should retrieve account context by environment uuid', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(account.id, uuid(), db.knex);
+        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
 
         const byUuid = await accountService.getAccountContext({ environmentUuid: environment!.uuid });
@@ -123,7 +123,7 @@ describe('Account service', () => {
 
     it('should retrieve account context by account uuid', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(account.id, uuid(), db.knex);
+        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
 
         const byAccountUuid = await accountService.getAccountContext({ accountUuid: account.uuid, envName: environment!.name });
@@ -149,7 +149,7 @@ describe('Account service', () => {
 
     it('should retrieve account context by accountId and envName', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(account.id, uuid(), db.knex);
+        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
 
         const byAccountId = await accountService.getAccountContext({ accountId: account.id, envName: environment!.name });
@@ -175,7 +175,7 @@ describe('Account service', () => {
 
     it('should retrieve account context by environmentId', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(account.id, uuid(), db.knex);
+        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
 
         const byEnvironmentId = await accountService.getAccountContext({ environmentId: environment!.id });

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -1,22 +1,52 @@
 import { v4 as uuid } from 'uuid';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import db, { multipleMigrations } from '@nangohq/database';
 
 import accountService from './account.service.js';
-import environmentService from './environment.service.js';
-import { createPlan } from './plans/plans.js';
-import { createAccount } from '../seeders/account.seeder.js';
+import environmentService, { defaultEnvironments } from './environment.service.js';
+import * as plans from './plans/plans.js';
+import { createAccount as createTestAccount } from '../seeders/account.seeder.js';
 
 describe('Account service', () => {
     beforeAll(async () => {
         await multipleMigrations();
     });
 
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should create an account with default environments and a free plan', async () => {
+        const accountName = uuid();
+        const account = await accountService.createAccount({ name: accountName });
+        expect(account).toBeDefined();
+        expect(account!.name).toBe(`${accountName}'s Team`);
+
+        const environments = await environmentService.getEnvironmentsByAccountId(account!.id);
+        expect(environments).toHaveLength(defaultEnvironments.length);
+
+        const plan = await db.knex.select('*').from('plans').where({ account_id: account!.id }).first();
+        expect(plan).toBeDefined();
+        expect(plan.name).toBe('free');
+    });
+
+    it('should rollback the transaction if creating the plan fails', async () => {
+        vi.spyOn(plans, 'createPlan').mockRejectedValueOnce(new Error('PLAN_CREATION_FAILED'));
+
+        const accountName = uuid();
+        const teamName = `${accountName}'s Team`;
+
+        await expect(accountService.createAccount({ name: accountName })).rejects.toThrow('PLAN_CREATION_FAILED');
+
+        const account = await db.knex.select('*').from('_nango_accounts').where({ name: teamName }).first();
+        expect(account).toBeUndefined();
+    });
+
     it('should retrieve account context by secretKey', async () => {
-        const account = await createAccount();
-        const environment = await environmentService.createEnvironment(account.id, uuid());
-        const plan = (await createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
+        const account = await createTestAccount();
+        const environment = await environmentService.createEnvironment(account.id, uuid(), db.knex);
+        const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
 
         const bySecretKey = await accountService.getAccountContext({ secretKey: environment!.secret_key });
 
@@ -40,9 +70,9 @@ describe('Account service', () => {
     });
 
     it('should retrieve account context by publicKey', async () => {
-        const account = await createAccount();
-        const environment = await environmentService.createEnvironment(account.id, uuid());
-        const plan = (await createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
+        const account = await createTestAccount();
+        const environment = await environmentService.createEnvironment(account.id, uuid(), db.knex);
+        const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
 
         const byPublicKey = await accountService.getAccountContext({ publicKey: environment!.public_key });
 
@@ -66,9 +96,9 @@ describe('Account service', () => {
     });
 
     it('should retrieve account context by environment uuid', async () => {
-        const account = await createAccount();
-        const environment = await environmentService.createEnvironment(account.id, uuid());
-        const plan = (await createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
+        const account = await createTestAccount();
+        const environment = await environmentService.createEnvironment(account.id, uuid(), db.knex);
+        const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
 
         const byUuid = await accountService.getAccountContext({ environmentUuid: environment!.uuid });
 
@@ -92,9 +122,9 @@ describe('Account service', () => {
     });
 
     it('should retrieve account context by account uuid', async () => {
-        const account = await createAccount();
-        const environment = await environmentService.createEnvironment(account.id, uuid());
-        const plan = (await createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
+        const account = await createTestAccount();
+        const environment = await environmentService.createEnvironment(account.id, uuid(), db.knex);
+        const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
 
         const byAccountUuid = await accountService.getAccountContext({ accountUuid: account.uuid, envName: environment!.name });
 
@@ -118,9 +148,9 @@ describe('Account service', () => {
     });
 
     it('should retrieve account context by accountId and envName', async () => {
-        const account = await createAccount();
-        const environment = await environmentService.createEnvironment(account.id, uuid());
-        const plan = (await createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
+        const account = await createTestAccount();
+        const environment = await environmentService.createEnvironment(account.id, uuid(), db.knex);
+        const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
 
         const byAccountId = await accountService.getAccountContext({ accountId: account.id, envName: environment!.name });
 
@@ -144,9 +174,9 @@ describe('Account service', () => {
     });
 
     it('should retrieve account context by environmentId', async () => {
-        const account = await createAccount();
-        const environment = await environmentService.createEnvironment(account.id, uuid());
-        const plan = (await createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
+        const account = await createTestAccount();
+        const environment = await environmentService.createEnvironment(account.id, uuid(), db.knex);
+        const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
 
         const byEnvironmentId = await accountService.getAccountContext({ environmentId: environment!.id });
 

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -139,7 +139,7 @@ class AccountService {
                 return null;
             }
 
-            await environmentService.createDefaultEnvironments(result[0].id, trx);
+            await environmentService.createDefaultEnvironments(trx, { accountId: result[0].id });
             if (flagHasPlan) {
                 const freePlan = plansList.find((plan) => plan.code === 'free');
                 const res = await createPlan(trx, { account_id: result[0].id, name: 'free', ...freePlan?.flags });

--- a/packages/shared/lib/services/environment.service.integration.test.ts
+++ b/packages/shared/lib/services/environment.service.integration.test.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from 'uuid';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { multipleMigrations } from '@nangohq/database';
+import db, { multipleMigrations } from '@nangohq/database';
 
 import environmentService, { hashSecretKey } from './environment.service.js';
 import { createAccount } from '../seeders/account.seeder.js';
@@ -14,7 +14,7 @@ describe('Environment service', () => {
     it('should create a service with secrets', async () => {
         const account = await createAccount();
         const envName = uuid();
-        const env = await environmentService.createEnvironment(account.id, envName);
+        const env = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: envName });
         if (!env) {
             throw new Error('failed_to_create_env');
         }
@@ -53,7 +53,7 @@ describe('Environment service', () => {
 
     it('should rotate secretKey', async () => {
         const account = await createAccount();
-        const env = (await environmentService.createEnvironment(account.id, uuid()))!;
+        const env = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() }))!;
         expect(env.secret_key).toBeUUID();
 
         // Rotate

--- a/packages/shared/lib/services/external-webhook.service.ts
+++ b/packages/shared/lib/services/external-webhook.service.ts
@@ -10,23 +10,28 @@ export async function get(id: number): Promise<DBExternalWebhook | null> {
 }
 
 export async function update(
-    environment_id: number,
-    data: Partial<
-        Pick<
-            DBExternalWebhook,
-            | 'primary_url'
-            | 'secondary_url'
-            | 'on_auth_creation'
-            | 'on_auth_refresh_error'
-            | 'on_sync_completion_always'
-            | 'on_sync_error'
-            | 'on_async_action_completion'
-        >
-    >,
-    trx?: Knex
+    trx: Knex,
+    {
+        environment_id,
+        data
+    }: {
+        trx?: Knex;
+        environment_id: number;
+        data: Partial<
+            Pick<
+                DBExternalWebhook,
+                | 'primary_url'
+                | 'secondary_url'
+                | 'on_auth_creation'
+                | 'on_auth_refresh_error'
+                | 'on_sync_completion_always'
+                | 'on_sync_error'
+                | 'on_async_action_completion'
+            >
+        >;
+    }
 ): Promise<void> {
-    const q = trx || db.knex;
-    await q
+    await trx
         .from<DBExternalWebhook>('_nango_external_webhooks')
         .insert({
             environment_id,

--- a/packages/shared/lib/services/external-webhook.service.ts
+++ b/packages/shared/lib/services/external-webhook.service.ts
@@ -1,6 +1,7 @@
 import db from '@nangohq/database';
 
 import type { DBExternalWebhook } from '@nangohq/types';
+import type { Knex } from 'knex';
 
 export async function get(id: number): Promise<DBExternalWebhook | null> {
     const result = await db.knex.select('*').from<DBExternalWebhook>('_nango_external_webhooks').where({ environment_id: id }).first();
@@ -21,9 +22,11 @@ export async function update(
             | 'on_sync_error'
             | 'on_async_action_completion'
         >
-    >
+    >,
+    trx?: Knex
 ): Promise<void> {
-    await db.knex
+    const q = trx || db.knex;
+    await q
         .from<DBExternalWebhook>('_nango_external_webhooks')
         .insert({
             environment_id,


### PR DESCRIPTION
Goal: wrap the logic of the create account function into a db transaction
Why: ensure data integrity and atomicity 

Description:
Wraps `packages/shared/lib/services/account.service.ts:createAccount` with a DB transaction.

- Wrap db calls with transaction
- Pipe transaction to downstream calls
- Implement integration tests to test trx and implementation
- Trx is optional on downstream calls to be backwards compatible

NAN-4493

<!-- Summary by @propel-code-bot -->

---

**Wrap account creation in DB transaction and propagate optional trx usage**

The PR wraps `accountService.createAccount` in a `db.knex.transaction`, ensuring that account, default environment creation, webhook seeding, and plan provisioning succeed or fail atomically. To support this flow, downstream services (environment creation, default environment seeding, webhook updates) now accept an optional transaction and all controllers, seeders, and integration tests have been realigned with the new signatures.
Additional integration coverage verifies the happy path for default environment and plan creation plus rollback behaviour when plan provisioning fails, while existing tests and seed data have been updated to inject the new transactional parameters.

<details>
<summary><strong>Key Changes</strong></summary>

• Wrap `accountService.createAccount` with `db.knex.transaction`, propagate `trx` to `environmentService.createDefaultEnvironments` and `createPlan`, and throw on plan provisioning failures to trigger rollback
• Refactor `environmentService.createEnvironment`/`createDefaultEnvironments` to accept an optional `Knex` argument (defaulting to `db.knex`) and use it for encryption updates and webhook seeding
• Update `externalWebhookService.update` to require a `trx` instance for inserts/updates and adjust all call sites (controllers, services, tests, seeders) to pass either a transaction or `db.knex`
• Revise environment/account service integration tests and controller integration tests to use the new signatures and add coverage for transactional rollback when `plans.createPlan` rejects

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/shared/lib/services/account.service.ts
• packages/shared/lib/services/environment.service.ts
• packages/shared/lib/services/external-webhook.service.ts
• packages/server/lib/controllers/v1/environment/*
• packages/shared/lib/services/account.service.integration.test.ts
• packages/shared/lib/services/environment.service.integration.test.ts
• packages/persist/lib/server.integration.test.ts
• packages/shared/lib/seeders/environment.seeder.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*