### PR TITLE
feat(records): add cursor-based deletion to deleteRecords

### DIFF
--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 import * as uuid from 'uuid';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { RECORDS_TABLE, RECORD_COUNTS_TABLE } from '../constants.js';
 import { db } from '../db/client.js';
@@ -12,11 +12,11 @@ import type { FormattedRecord, UnencryptedRecordData, UpsertSummary } from '../t
 import type { MergingStrategy, Result } from '@nangohq/types';
 
 describe('Records service', () => {
-    beforeEach(async () => {
+    beforeAll(async () => {
         await migrate();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
         await db(RECORDS_TABLE).truncate();
         await db(RECORD_COUNTS_TABLE).truncate();
     });
@@ -905,6 +905,10 @@ describe('Records service', () => {
 
     describe('paginateCounts', () => {
         it('should paginate through record counts', async () => {
+            // Clear existing records and counts
+            await db(RECORDS_TABLE).truncate();
+            await db(RECORD_COUNTS_TABLE).truncate();
+
             const res1 = await upsertNRecords(15);
             const res2 = await upsertNRecords(25);
             const res3 = await upsertNRecords(35);
@@ -987,7 +991,7 @@ describe('Records service', () => {
     });
 
     describe('deleteRecords', () => {
-        it('should delete records for given connection/model', async () => {
+        it('should delete all records for given connection/model', async () => {
             const connectionId = rnd.number();
             const environmentId = rnd.number();
             const model = rnd.string();
@@ -1013,6 +1017,166 @@ describe('Records service', () => {
 
             const res = (await Records.getRecords({ connectionId, model })).unwrap();
             expect(res.records.length).toBe(0);
+        });
+
+        it('should delete only specified limit and update count/size correctly', async () => {
+            const connectionId = rnd.number();
+            const environmentId = rnd.number();
+            const model = rnd.string();
+            const syncId = uuid.v4();
+
+            const records = [
+                { id: '1', name: 'John Doe' },
+                { id: '2', name: 'Jane Doe' },
+                { id: '3', name: 'Max Doe' },
+                { id: '4', name: 'Mike Doe' },
+                { id: '5', name: 'Alice Doe' }
+            ];
+            await upsertRecords({ records, connectionId, environmentId, model, syncId });
+
+            const initialStats = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
+            expect(initialStats[model]?.count).toBe(5);
+            const initialSize = initialStats[model]?.size_bytes || 0;
+
+            const deletedCount = (await Records.deleteRecords({ connectionId, environmentId, model, limit: 3 })).unwrap();
+            expect(deletedCount.totalDeletedRecords).toBe(3);
+
+            const finalStats = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
+            expect(finalStats[model]?.count).toBe(2);
+            expect(finalStats[model]?.size_bytes).toBeLessThan(initialSize);
+
+            const res = (await Records.getRecords({ connectionId, model })).unwrap();
+            expect(res.records.length).toBe(2);
+        });
+
+        it('should return error for invalid limit values', async () => {
+            const connectionId = rnd.number();
+            const environmentId = rnd.number();
+            const model = rnd.string();
+
+            const zeroResult = await Records.deleteRecords({ connectionId, environmentId, model, limit: 0 });
+            expect(zeroResult.isErr()).toBe(true);
+            if (zeroResult.isErr()) {
+                expect(zeroResult.error.message).toBe('limit must be greater than 0');
+            }
+
+            const negativeResult = await Records.deleteRecords({ connectionId, environmentId, model, limit: -5 });
+            expect(negativeResult.isErr()).toBe(true);
+            if (negativeResult.isErr()) {
+                expect(negativeResult.error.message).toBe('limit must be greater than 0');
+            }
+        });
+
+        it('should delete records up to specified cursor', async () => {
+            const connectionId = rnd.number();
+            const environmentId = rnd.number();
+            const model = rnd.string();
+            const syncId = uuid.v4();
+
+            const records = [
+                { id: '1', name: 'John Doe' },
+                { id: '2', name: 'Jane Doe' },
+                { id: '3', name: 'Max Doe' },
+                { id: '4', name: 'Mike Doe' },
+                { id: '5', name: 'Alice Doe' },
+                { id: '6', name: 'Bob Doe' },
+                { id: '7', name: 'Charlie Doe' },
+                { id: '8', name: 'David Doe' },
+                { id: '9', name: 'Eve Doe' },
+                { id: '10', name: 'Frank Doe' }
+            ];
+            await upsertRecords({ records, connectionId, environmentId, model, syncId });
+
+            const inserted = (await Records.getRecords({ connectionId, model })).unwrap();
+            expect(inserted.records.length).toBe(records.length);
+
+            const toDelete = 4;
+            const someRecordCursor = inserted.records[toDelete - 1]?._nango_metadata.cursor;
+            expect(someRecordCursor).toBeDefined();
+
+            const deletion = (
+                await Records.deleteRecords({
+                    connectionId,
+                    environmentId,
+                    model,
+                    toCursorIncluded: someRecordCursor!,
+                    limit: 100
+                })
+            ).unwrap();
+
+            expect(deletion.totalDeletedRecords).toBe(toDelete);
+            expect(deletion.lastDeletedCursor).toBe(someRecordCursor);
+
+            const remaining = (await Records.getRecords({ connectionId, model })).unwrap();
+            expect(remaining.records.length).toBe(records.length - toDelete);
+
+            const remainingIds = remaining.records.map((r) => r.id);
+            expect(remainingIds).toEqual(expect.arrayContaining(inserted.records.slice(toDelete).map((r) => r.id)));
+
+            const stats = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
+            expect(stats[model]?.count).toBe(records.length - toDelete);
+        });
+
+        it('should return null lastDeletedCursor when no records deleted', async () => {
+            const connectionId = rnd.number();
+            const environmentId = rnd.number();
+            const model = rnd.string();
+
+            const deleteResult = (await Records.deleteRecords({ connectionId, environmentId, model })).unwrap();
+
+            expect(deleteResult.totalDeletedRecords).toBe(0);
+            expect(deleteResult.lastDeletedCursor).toBeNull();
+        });
+
+        it('should respect cursor boundary when deleting in batches', async () => {
+            const connectionId = rnd.number();
+            const environmentId = rnd.number();
+            const model = rnd.string();
+            const syncId = uuid.v4();
+
+            const records = Array.from({ length: 20 }, (_, i) => ({
+                id: `${i + 1}`,
+                name: `Record ${i + 1}`
+            }));
+            await upsertRecords({ records, connectionId, environmentId, model, syncId });
+
+            const allRecords = (await Records.getRecords({ connectionId, model })).unwrap();
+            const twelfthRecordCursor = allRecords.records[11]?._nango_metadata.cursor;
+            expect(twelfthRecordCursor).toBeDefined();
+
+            const deleteResult = (
+                await Records.deleteRecords({
+                    connectionId,
+                    environmentId,
+                    model,
+                    toCursorIncluded: twelfthRecordCursor!,
+                    batchSize: 3
+                })
+            ).unwrap();
+
+            expect(deleteResult.totalDeletedRecords).toBe(12);
+            expect(deleteResult.lastDeletedCursor).toBe(twelfthRecordCursor);
+
+            const remainingRecords = (await Records.getRecords({ connectionId, model })).unwrap();
+            expect(remainingRecords.records.length).toBe(8);
+        });
+
+        it('should return error for invalid cursor', async () => {
+            const connectionId = rnd.number();
+            const environmentId = rnd.number();
+            const model = rnd.string();
+
+            const invalidCursorResult = await Records.deleteRecords({
+                connectionId,
+                environmentId,
+                model,
+                toCursorIncluded: 'invalid-cursor-value'
+            });
+
+            expect(invalidCursorResult.isErr()).toBe(true);
+            if (invalidCursorResult.isErr()) {
+                expect(invalidCursorResult.error.message).toBe('invalid_cursor_value');
+            }
         });
     });
 


### PR DESCRIPTION
Add support for bounded record deletion:
- Add `toCursorIncluded` parameter to delete records up to a cursor (inclusive)
- Add `limit` parameter to limit number of records deleted
- Return `lastDeletedCursor`

The cursor logic will be used by the DELETE /records endpoint so
customers can explicitely prune records until a specific record/cursor

<!-- Summary by @propel-code-bot -->

---

**Cursor- and limit-aware record deletion with count updates**

Extends `deleteRecords` in `packages/records/lib/models/records.ts` to support bounded deletions via optional `limit` and `toCursorIncluded`, returning both the total deleted row count and the `lastDeletedCursor`. The update now tracks deleted byte totals, reuses `incrCount` to adjust `record_counts`, and prunes the count row when the remaining total reaches zero. Integration coverage in `packages/records/lib/models/records.integration.test.ts` has been expanded to exercise the new deletion pathways (limits, cursors, batch execution, validation) while consolidating setup/teardown to a single migration run per suite. The `incrCount` helper now returns the updated `RecordCount`, enabling callers to check whether counts hit zero.

<details>
<summary><strong>Key Changes</strong></summary>

• Augmented `deleteRecords` to accept `limit`, `toCursorIncluded`, and return `{ totalDeletedRecords, lastDeletedCursor }`, with advisory locking and ordered batched deletions that respect cursor boundaries.
• Accumulates deleted row counts and byte sizes, invokes `incrCount` for deltas, and removes the record-count row when totals reach zero.
• Reworked `incrCount` to always upsert counts, clamp at zero via `GREATEST`, and return the new `RecordCount` (with `size_bytes` normalized to number).
• Expanded `records.integration.test.ts` with cursor/limit deletion scenarios, invalid input checks, and updated expectations for count bookkeeping while switching to `beforeAll`/`afterAll` migration control.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/records/lib/models/records.ts`
• `packages/records/lib/models/records.integration.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*