### PR TITLE
fix(runners): use https call instead of a direct db call

### DIFF
--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -1,6 +1,6 @@
 import { Nango } from '@nangohq/node';
 import { NangoActionBase, NangoSyncBase } from '@nangohq/runner-sdk';
-import { ProxyRequest, configService, getProxyConfiguration } from '@nangohq/shared';
+import { ProxyRequest, getProxyConfiguration } from '@nangohq/shared';
 import { MAX_LOG_PAYLOAD, isTest, metrics, redactHeaders, redactURL, stringifyAndTruncateValue, stringifyObject, truncateJson } from '@nangohq/utils';
 
 import { PersistClient } from './persist.js';
@@ -116,11 +116,14 @@ export class NangoActionRunner extends NangoActionBase<never, Record<string, str
                 return connection;
             },
             getIntegrationConfig: async () => {
-                const integration = await configService.getProviderConfig(this.providerConfigKey, this.environmentId);
-                if (integration) {
+                const integration = await this.getIntegration({ include: ['credentials'] });
+                if (
+                    integration.credentials &&
+                    (integration.credentials.type === 'OAUTH1' || integration.credentials.type === 'OAUTH2' || integration.credentials.type === 'TBA')
+                ) {
                     return {
-                        oauth_client_id: integration.oauth_client_id,
-                        oauth_client_secret: integration.oauth_client_secret
+                        oauth_client_id: integration.credentials.client_id,
+                        oauth_client_secret: integration.credentials.client_secret
                     };
                 }
                 return { oauth_client_id: null, oauth_client_secret: null };


### PR DESCRIPTION
## Describe the problem and your solution

- use https call instead of a direct db call to get credentials

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Runner credential retrieval now uses integration fetch with credentials**

This PR updates the runner SDK to stop pulling OAuth client credentials directly via `configService.getProviderConfig` and instead rely on `this.getIntegration({ include: ['credentials'] })`, ensuring credentials are retrieved via the HTTPS integration endpoint. Correspondingly, the integration credentials response is constrained to OAuth-backed credential types before returning the client ID/secret tuple.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced `configService.getProviderConfig` usage with `this.getIntegration({ include: ['credentials'] })` in `packages/runner/lib/sdk/sdk.ts` to obtain integration credentials via HTTPS
• Scoped returned integration credentials to OAuth-based types and mapped fields to `client_id`/`client_secret`
• Removed unused `configService` import from `packages/runner/lib/sdk/sdk.ts`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/runner/lib/sdk/sdk.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*