### PR TITLE
feat(runners): pass OAuth credentials via NangoProps instead of making an API call

### DIFF
--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -136,8 +136,10 @@ export async function startAction(task: TaskAction): Promise<Result<void>> {
             startedAt: now,
             endUser,
             heartbeatTimeoutSecs: task.heartbeatTimeoutSecs,
-            oauth_client_id: providerConfig.oauth_client_id,
-            oauth_client_secret: providerConfig.oauth_client_secret
+            integrationConfig: {
+                oauth_client_id: providerConfig.oauth_client_id,
+                oauth_client_secret: providerConfig.oauth_client_secret
+            }
         };
 
         const res = await startScript({

--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -135,7 +135,9 @@ export async function startAction(task: TaskAction): Promise<Result<void>> {
             runnerFlags: await getRunnerFlags(),
             startedAt: now,
             endUser,
-            heartbeatTimeoutSecs: task.heartbeatTimeoutSecs
+            heartbeatTimeoutSecs: task.heartbeatTimeoutSecs,
+            oauth_client_id: providerConfig.oauth_client_id,
+            oauth_client_secret: providerConfig.oauth_client_secret
         };
 
         const res = await startScript({

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -181,8 +181,10 @@ export async function startSync(task: TaskSync, startScriptFn = startScript): Pr
             ...(lastSyncDate ? { lastSyncDate } : {}),
             endUser,
             heartbeatTimeoutSecs: task.heartbeatTimeoutSecs,
-            oauth_client_id: providerConfig.oauth_client_id,
-            oauth_client_secret: providerConfig.oauth_client_secret
+            integrationConfig: {
+                oauth_client_id: providerConfig.oauth_client_id,
+                oauth_client_secret: providerConfig.oauth_client_secret
+            }
         };
 
         if (task.debug) {

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -180,7 +180,9 @@ export async function startSync(task: TaskSync, startScriptFn = startScript): Pr
             startedAt,
             ...(lastSyncDate ? { lastSyncDate } : {}),
             endUser,
-            heartbeatTimeoutSecs: task.heartbeatTimeoutSecs
+            heartbeatTimeoutSecs: task.heartbeatTimeoutSecs,
+            oauth_client_id: providerConfig.oauth_client_id,
+            oauth_client_secret: providerConfig.oauth_client_secret
         };
 
         if (task.debug) {

--- a/packages/runner-sdk/lib/action.ts
+++ b/packages/runner-sdk/lib/action.ts
@@ -69,8 +69,7 @@ export abstract class NangoActionBase<
     public connectionId: string;
     public providerConfigKey: string;
     public provider?: string;
-    public oauth_client_id?: string;
-    public oauth_client_secret?: string;
+    public integrationConfig?: NangoProps['integrationConfig'];
 
     public ActionError = ActionError;
 
@@ -126,11 +125,8 @@ export abstract class NangoActionBase<
             this.syncConfig = config.syncConfig;
         }
 
-        if (config.oauth_client_id) {
-            this.oauth_client_id = config.oauth_client_id;
-        }
-        if (config.oauth_client_secret) {
-            this.oauth_client_secret = config.oauth_client_secret;
+        if (config.integrationConfig) {
+            this.integrationConfig = config.integrationConfig;
         }
 
         this.logger = config.logger || {

--- a/packages/runner-sdk/lib/action.ts
+++ b/packages/runner-sdk/lib/action.ts
@@ -69,6 +69,8 @@ export abstract class NangoActionBase<
     public connectionId: string;
     public providerConfigKey: string;
     public provider?: string;
+    public oauth_client_id?: string;
+    public oauth_client_secret?: string;
 
     public ActionError = ActionError;
 
@@ -122,6 +124,13 @@ export abstract class NangoActionBase<
 
         if (config.syncConfig) {
             this.syncConfig = config.syncConfig;
+        }
+
+        if (config.oauth_client_id) {
+            this.oauth_client_id = config.oauth_client_id;
+        }
+        if (config.oauth_client_secret) {
+            this.oauth_client_secret = config.oauth_client_secret;
         }
 
         this.logger = config.logger || {

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -115,18 +115,11 @@ export class NangoActionRunner extends NangoActionBase<never, Record<string, str
                 }
                 return connection;
             },
-            getIntegrationConfig: async () => {
-                const integration = await this.getIntegration({ include: ['credentials'] });
-                if (
-                    integration.credentials &&
-                    (integration.credentials.type === 'OAUTH1' || integration.credentials.type === 'OAUTH2' || integration.credentials.type === 'TBA')
-                ) {
-                    return {
-                        oauth_client_id: integration.credentials.client_id,
-                        oauth_client_secret: integration.credentials.client_secret
-                    };
-                }
-                return { oauth_client_id: null, oauth_client_secret: null };
+            getIntegrationConfig: () => {
+                return {
+                    oauth_client_id: this.oauth_client_id ?? null,
+                    oauth_client_secret: this.oauth_client_secret ?? null
+                };
             }
         });
         const response = (await proxy.request()).unwrap();

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -116,10 +116,7 @@ export class NangoActionRunner extends NangoActionBase<never, Record<string, str
                 return connection;
             },
             getIntegrationConfig: () => {
-                return {
-                    oauth_client_id: this.oauth_client_id ?? null,
-                    oauth_client_secret: this.oauth_client_secret ?? null
-                };
+                return this.integrationConfig ?? { oauth_client_id: null, oauth_client_secret: null };
             }
         });
         const response = (await proxy.request()).unwrap();

--- a/packages/types/lib/runner/sdk.ts
+++ b/packages/types/lib/runner/sdk.ts
@@ -1,5 +1,6 @@
 import type { RunnerFlags } from './index.js';
 import type { LogLevel } from '../logs/messages.js';
+import type { IntegrationConfigForProxy } from '../proxy/api.js';
 import type { DBSyncConfig } from '../syncConfigs/db.js';
 import type { DBTeam } from '../team/db.js';
 import type { AxiosError, AxiosInterceptorManager, AxiosRequestConfig, AxiosResponse } from 'axios';
@@ -38,8 +39,7 @@ export interface NangoProps {
     endUser: { id: number; endUserId: string | null; orgId: string | null } | null;
     heartbeatTimeoutSecs?: number | undefined;
     isCLI?: boolean | undefined;
-    oauth_client_id?: string;
-    oauth_client_secret?: string;
+    integrationConfig?: IntegrationConfigForProxy;
 
     axios?: {
         request?: AxiosInterceptorManager<AxiosRequestConfig>;

--- a/packages/types/lib/runner/sdk.ts
+++ b/packages/types/lib/runner/sdk.ts
@@ -38,6 +38,8 @@ export interface NangoProps {
     endUser: { id: number; endUserId: string | null; orgId: string | null } | null;
     heartbeatTimeoutSecs?: number | undefined;
     isCLI?: boolean | undefined;
+    oauth_client_id?: string;
+    oauth_client_secret?: string;
 
     axios?: {
         request?: AxiosInterceptorManager<AxiosRequestConfig>;


### PR DESCRIPTION
## Describe the problem and your solution

- pass OAuth credentials via NangoProps instead of making an API call

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Inject OAuth credentials into runner props**

Populates `NangoProps` with an `integrationConfig` object carrying `oauth_client_id` and `oauth_client_secret`, allowing runners to access OAuth credentials without issuing an integration lookup. Runner bootstrap code for actions and syncs now hydrates these fields from the resolved `providerConfig`, and the SDK’s `getIntegrationConfig()` simply returns the pre-supplied props with a null fallback when unavailable.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `integrationConfig` to `NangoProps` via `packages/types/lib/runner/sdk.ts`, backed by `IntegrationConfigForProxy` typing.
• Hydrated `integrationConfig` in `startAction()` and `startSync()` payload construction using `providerConfig.oauth_client_id` and `providerConfig.oauth_client_secret`.
• Adjusted `NangoActionRunner.getIntegrationConfig()` in `packages/runner/lib/sdk/sdk.ts` to return the injected props instead of calling `getIntegration()`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Runner SDK proxy credential retrieval (`packages/runner/lib/sdk/sdk.ts`)
• Job execution payload construction for actions and syncs (`packages/jobs/lib/execution/action.ts`, `packages/jobs/lib/execution/sync.ts`)
• Runner SDK base class and shared types (`packages/runner-sdk/lib/action.ts`, `packages/types/lib/runner/sdk.ts`)

</details>

---
*This summary was automatically generated by @propel-code-bot*