### PR TITLE
fix(connectUI): allow integrations_config_defaults to flow through

### DIFF
--- a/packages/server/lib/controllers/v1/connect/sessions/postConnectSessions.ts
+++ b/packages/server/lib/controllers/v1/connect/sessions/postConnectSessions.ts
@@ -11,7 +11,8 @@ const bodySchema = z
     .object({
         allowed_integrations: originalBodySchema.shape.allowed_integrations,
         end_user: originalBodySchema.shape.end_user,
-        organization: originalBodySchema.shape.organization
+        organization: originalBodySchema.shape.organization,
+        integrations_config_defaults: originalBodySchema.shape.integrations_config_defaults
     })
     .strict();
 
@@ -35,7 +36,8 @@ export const postInternalConnectSessions = asyncWrapper<PostInternalConnectSessi
     const emulatedBody = {
         allowed_integrations: body.allowed_integrations,
         end_user: { ...body.end_user, tags: { origin: 'nango_dashboard' } },
-        organization: body.organization
+        organization: body.organization,
+        integrations_config_defaults: body.integrations_config_defaults
     } satisfies PostConnectSessions['Body'];
 
     await generateSession(res, emulatedBody);


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
A customer wants to override the connectUI settings to not show a setting. For instance
```
allowed_integrations: integration ? [integration.unique_key] : undefined,
                end_user: testUser,
                organization: undefined,
                integrations_config_defaults: {
                    'mcp-generic': {
                        connection_config: {
                            mcp_server_url: 'https://mcp.notion.com/mcpc'
                        }
                    }
                }
```
but we're not allowing that `integrations_config_defaults` [setting](https://nango.dev/docs/reference/sdks/node#create-a-connect-session) to flow through at the moment

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Allow `integrations_config_defaults` to pass through internal connect sessions**

Extends the internal connect session controller to accept and forward the `integrations_config_defaults` field. The schema now mirrors the public session schema for this property before invoking `generateSession`.

<details>
<summary><strong>Key Changes</strong></summary>

• Extended `bodySchema` in `postConnectSessions.ts` to include `originalBodySchema.shape.integrations_config_defaults`
• Propagated `body.integrations_config_defaults` in the emulated request passed to `generateSession`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/controllers/v1/connect/sessions/postConnectSessions.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*