### PR TITLE
chore: manually fixing the managed-manifest - commit failed in workflow

### DIFF
--- a/managed-manifest.json
+++ b/managed-manifest.json
@@ -1,67 +1,74 @@
 {
-  "latest": {
-    "imageVersion": "1.4.3",
-    "appVersion": "0.69.14",
-    "commitHash": "c0ad94b62f94bc123407f290a5de50b61f088c3e",
-    "releaseDate": "2025-12-09T12:27:30.165Z",
-    "comparisonUrl": "https://github.com/NangoHQ/nango/compare/4dace800e5d3d9f24f745d6a7f294c55fbe7a9cd...c0ad94b62f94bc123407f290a5de50b61f088c3e"
-  },
-  "history": [
-    {
-      "imageVersion": "1.0.0",
-      "appVersion": "0.61.2",
-      "commitHash": "",
-      "releaseDate": "",
-      "comparisonUrl": null
+    "latest": {
+        "imageVersion": "1.4.4",
+        "appVersion": "0.69.14",
+        "commitHash": "4b516136c879310ce3f603d2f96b7a2b958b30bd",
+        "releaseDate": "2025-12-10T15:43:00.000Z",
+        "comparisonUrl": "https://github.com/NangoHQ/nango/compare/c0ad94b62f94bc123407f290a5de50b61f088c3e...4b516136c879310ce3f603d2f96b7a2b958b30bd"
     },
-    {
-      "imageVersion": "1.0.1",
-      "appVersion": "0.61.3",
-      "commitHash": "b107a94354a65358ea9c96579023d85ce8486a7d",
-      "releaseDate": "2025-06-23T17:19:13.183Z",
-      "comparisonUrl": null
-    },
-    {
-      "imageVersion": "1.1.0",
-      "appVersion": "0.65.0",
-      "commitHash": "0e82ec7811ffb939367a543e386353d06bde499a",
-      "releaseDate": "2025-08-11T10:33:37.622Z",
-      "comparisonUrl": "https://github.com/NangoHQ/nango/compare/b107a94354a65358ea9c96579023d85ce8486a7d...0e82ec7811ffb939367a543e386353d06bde499a"
-    },
-    {
-      "imageVersion": "1.2.0",
-      "appVersion": "0.66.0",
-      "commitHash": "1dcbc7b2863a977924c8574082abcba147a14bd1",
-      "releaseDate": "2025-08-13T17:37:31.955Z",
-      "comparisonUrl": "https://github.com/NangoHQ/nango/compare/0e82ec7811ffb939367a543e386353d06bde499a...1dcbc7b2863a977924c8574082abcba147a14bd1"
-    },
-    {
-      "imageVersion": "1.3.0",
-      "appVersion": "0.67.6",
-      "commitHash": "a82bdf7e3ac317dc126c580af9445052ede5003b",
-      "releaseDate": "2025-09-15T13:07:49.057Z",
-      "comparisonUrl": "https://github.com/NangoHQ/nango/compare/1dcbc7b2863a977924c8574082abcba147a14bd1...a82bdf7e3ac317dc126c580af9445052ede5003b"
-    },
-    {
-      "imageVersion": "1.4.0",
-      "appVersion": "0.69.2",
-      "commitHash": "6b0de8723a877ce2da8380be4cbaa10b98011c8c",
-      "releaseDate": "2025-10-08T10:16:53.505Z",
-      "comparisonUrl": "https://github.com/NangoHQ/nango/compare/a82bdf7e3ac317dc126c580af9445052ede5003b...6b0de8723a877ce2da8380be4cbaa10b98011c8c"
-    },
-    {
-      "imageVersion": "1.4.1",
-      "appVersion": "0.69.3",
-      "commitHash": "a2d8563901e0a2d11d31bf7d69c178a191ac3cf8",
-      "releaseDate": "2025-10-15T14:00:30.594Z",
-      "comparisonUrl": "https://github.com/NangoHQ/nango/compare/6b0de8723a877ce2da8380be4cbaa10b98011c8c...a2d8563901e0a2d11d31bf7d69c178a191ac3cf8"
-    },
-    {
-      "imageVersion": "1.4.2",
-      "appVersion": "0.69.5",
-      "commitHash": "4dace800e5d3d9f24f745d6a7f294c55fbe7a9cd",
-      "releaseDate": "2025-10-29T14:21:59.189Z",
-      "comparisonUrl": "https://github.com/NangoHQ/nango/compare/a2d8563901e0a2d11d31bf7d69c178a191ac3cf8...4dace800e5d3d9f24f745d6a7f294c55fbe7a9cd"
-    }
-  ]
+    "history": [
+        {
+            "imageVersion": "1.0.0",
+            "appVersion": "0.61.2",
+            "commitHash": "",
+            "releaseDate": "",
+            "comparisonUrl": null
+        },
+        {
+            "imageVersion": "1.0.1",
+            "appVersion": "0.61.3",
+            "commitHash": "b107a94354a65358ea9c96579023d85ce8486a7d",
+            "releaseDate": "2025-06-23T17:19:13.183Z",
+            "comparisonUrl": null
+        },
+        {
+            "imageVersion": "1.1.0",
+            "appVersion": "0.65.0",
+            "commitHash": "0e82ec7811ffb939367a543e386353d06bde499a",
+            "releaseDate": "2025-08-11T10:33:37.622Z",
+            "comparisonUrl": "https://github.com/NangoHQ/nango/compare/b107a94354a65358ea9c96579023d85ce8486a7d...0e82ec7811ffb939367a543e386353d06bde499a"
+        },
+        {
+            "imageVersion": "1.2.0",
+            "appVersion": "0.66.0",
+            "commitHash": "1dcbc7b2863a977924c8574082abcba147a14bd1",
+            "releaseDate": "2025-08-13T17:37:31.955Z",
+            "comparisonUrl": "https://github.com/NangoHQ/nango/compare/0e82ec7811ffb939367a543e386353d06bde499a...1dcbc7b2863a977924c8574082abcba147a14bd1"
+        },
+        {
+            "imageVersion": "1.3.0",
+            "appVersion": "0.67.6",
+            "commitHash": "a82bdf7e3ac317dc126c580af9445052ede5003b",
+            "releaseDate": "2025-09-15T13:07:49.057Z",
+            "comparisonUrl": "https://github.com/NangoHQ/nango/compare/1dcbc7b2863a977924c8574082abcba147a14bd1...a82bdf7e3ac317dc126c580af9445052ede5003b"
+        },
+        {
+            "imageVersion": "1.4.0",
+            "appVersion": "0.69.2",
+            "commitHash": "6b0de8723a877ce2da8380be4cbaa10b98011c8c",
+            "releaseDate": "2025-10-08T10:16:53.505Z",
+            "comparisonUrl": "https://github.com/NangoHQ/nango/compare/a82bdf7e3ac317dc126c580af9445052ede5003b...6b0de8723a877ce2da8380be4cbaa10b98011c8c"
+        },
+        {
+            "imageVersion": "1.4.1",
+            "appVersion": "0.69.3",
+            "commitHash": "a2d8563901e0a2d11d31bf7d69c178a191ac3cf8",
+            "releaseDate": "2025-10-15T14:00:30.594Z",
+            "comparisonUrl": "https://github.com/NangoHQ/nango/compare/6b0de8723a877ce2da8380be4cbaa10b98011c8c...a2d8563901e0a2d11d31bf7d69c178a191ac3cf8"
+        },
+        {
+            "imageVersion": "1.4.2",
+            "appVersion": "0.69.5",
+            "commitHash": "4dace800e5d3d9f24f745d6a7f294c55fbe7a9cd",
+            "releaseDate": "2025-10-29T14:21:59.189Z",
+            "comparisonUrl": "https://github.com/NangoHQ/nango/compare/a2d8563901e0a2d11d31bf7d69c178a191ac3cf8...4dace800e5d3d9f24f745d6a7f294c55fbe7a9cd"
+        },
+        {
+            "imageVersion": "1.4.3",
+            "appVersion": "0.69.14",
+            "commitHash": "c0ad94b62f94bc123407f290a5de50b61f088c3e",
+            "releaseDate": "2025-12-09T12:27:30.165Z",
+            "comparisonUrl": "https://github.com/NangoHQ/nango/compare/4dace800e5d3d9f24f745d6a7f294c55fbe7a9cd...c0ad94b62f94bc123407f290a5de50b61f088c3e"
+        }
+    ]
 }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Update managed manifest to reflect release 1.4.4**

This PR refreshes `managed-manifest.json` after an automated workflow failed, ensuring the manifest now advertises version `1.4.4` as the latest release. The previous `latest` entry for version `1.4.3` has been preserved in the `history` array, and the file has been re-indented with four-space nesting.

<details>
<summary><strong>Key Changes</strong></summary>

• Set `latest` metadata to version `1.4.4` with commit `4b516136c879310ce3f603d2f96b7a2b958b30bd` and the corresponding release timestamp and comparison URL
• Appended the former `latest` entry for version `1.4.3` to the `history` array to maintain release chronology
• Reformatted `managed-manifest.json` with four-space indentation throughout

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `managed-manifest.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*