### PR TITLE
feat: add /DELETE records endpoint

### DIFF
--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -1385,6 +1385,91 @@ paths:
                 '401':
                     $ref: '#/components/responses/Unauthorized'
 
+        delete:
+            summary: Delete records
+            description: |-
+                Deletes synced records for a given connection and model using cursor-based pagination.
+
+                **Deletion modes:**
+                - `soft`: Empties the record payload and marks as deleted. The record metadata is preserved.
+                - `hard`: Permanently removes the record entries.
+
+                **Cursor behavior:**
+                Records are deleted up to and including the specified cursor.
+            parameters:
+                - name: model
+                  in: query
+                  required: true
+                  schema:
+                      type: string
+                  description: The data model to delete records from
+                - name: variant
+                  in: query
+                  required: false
+                  schema:
+                      type: string
+                  description: The variant of the model
+                - name: mode
+                  in: query
+                  required: true
+                  schema:
+                      type: string
+                      enum: [soft, hard]
+                  description: The deletion mode - 'soft' empties the payload, 'hard' permanently deletes the records
+                - name: until_cursor
+                  in: query
+                  required: true
+                  schema:
+                      type: string
+                  description: Delete all records up to and including this cursor. Use the cursor value from _nango_metadata.cursor of the record you want to delete up to.
+                - name: limit
+                  in: query
+                  required: false
+                  schema:
+                      type: integer
+                      minimum: 1
+                      maximum: 10000
+                  description: The maximum number of records to delete in this request. Defaults to 1000.
+                - name: Connection-Id
+                  in: header
+                  required: true
+                  description: The connection ID used to create the connection.
+                  schema:
+                      type: string
+                - name: Provider-Config-Key
+                  in: header
+                  required: true
+                  description: The integration ID used to create the connection (aka Unique Key).
+                  schema:
+                      type: string
+
+            responses:
+                '200':
+                    description: Successfully deleted records
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                required:
+                                    - count
+                                    - has_more
+                                properties:
+                                    count:
+                                        type: integer
+                                        description: The number of records deleted in this request
+                                        example: 150
+                                    has_more:
+                                        type: boolean
+                                        description: |-
+                                            Indicates if there are potentially more records to delete.
+                                            - `true`: There may be more records that need deletion
+                                            - `false`: All records up to the cursor have been deleted
+                                        example: true
+                '400':
+                    $ref: '#/components/responses/BadRequest'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+
     /sync/trigger:
         post:
             summary: Trigger a sync

--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -1210,18 +1210,37 @@ describe('Records service', () => {
             ];
             await upsertRecords({ records, connectionId, environmentId, model, syncId });
 
-            const prune = (await Records.deleteRecords({ connectionId, environmentId, model, mode: 'soft' })).unwrap();
+            const recs = (await Records.getRecords({ connectionId, model })).unwrap();
+            const last = recs.records[recs.records.length - 1]!;
+            const cursor = last._nango_metadata.cursor;
 
-            expect(prune.totalDeletedRecords).toBe(3);
+            // update last record to ensure it is not deleted and correct cursor is returned
+            await upsertRecords({ records: [{ id: last.id, name: 'Maxwell Doe' }], connectionId, environmentId, model, syncId });
+
+            // prune all records but the last one that was just updated
+            const prune = (await Records.deleteRecords({ connectionId, environmentId, model, mode: 'soft', toCursorIncluded: cursor })).unwrap();
+            expect(prune.totalDeletedRecords).toBe(2);
+            expect(prune.lastDeletedCursor).toBe(recs.records[recs.records.length - 2]!._nango_metadata.cursor); // second last record's cursor since last record was updated and not deleted
+
+            // try to prune again, should not delete any records
+            const prune2 = (await Records.deleteRecords({ connectionId, environmentId, model, mode: 'soft', toCursorIncluded: cursor })).unwrap();
+            expect(prune2.totalDeletedRecords).toBe(0);
+            expect(prune2.lastDeletedCursor).toBeNull();
 
             const stats = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
-            expect(stats[model]).toBeUndefined();
+            expect(stats[model]?.count).toBe(1);
 
             const res = (await Records.getRecords({ connectionId, model })).unwrap();
             expect(res.records.length).toBe(3);
             res.records.forEach((r) => {
-                expect(r._nango_metadata.last_action).toBe('DELETED');
-                expect(r._nango_metadata.deleted_at).not.toBeNull();
+                if (r.id === last.id) {
+                    expect(r._nango_metadata.last_action).toBe('UPDATED');
+                    expect(r._nango_metadata.deleted_at).toBeNull();
+                } else {
+                    expect(r.id).toBeDefined();
+                    expect(r._nango_metadata.last_action).toBe('DELETED');
+                    expect(r._nango_metadata.deleted_at).not.toBeNull();
+                }
             });
         });
     });

--- a/packages/server/lib/controllers/records/deleteRecords.integration.test.ts
+++ b/packages/server/lib/controllers/records/deleteRecords.integration.test.ts
@@ -1,0 +1,285 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { format, migrate as migrateRecords, records } from '@nangohq/records';
+import { seeders } from '@nangohq/shared';
+
+import { isError, isSuccess, runServer, shouldBeProtected } from '../../utils/tests.js';
+
+const route = '/records';
+let api: Awaited<ReturnType<typeof runServer>>;
+describe(`DELETE ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+        await migrateRecords();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(route, {
+            method: 'DELETE',
+            query: { model: 'Ticket', mode: 'soft', until_cursor: 'abc' },
+            headers: { 'connection-id': 't', 'provider-config-key': '' }
+        });
+
+        shouldBeProtected(res);
+    });
+
+    it('should require all mandatory parameters', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        // @ts-expect-error on purpose
+        const res = await api.fetch(route, {
+            method: 'DELETE',
+            token: env.secret_key,
+            query: {} as { model: string; mode: 'soft' | 'hard'; until_cursor: string }
+        });
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'invalid_query_params',
+                errors: [
+                    { code: 'invalid_type', message: 'Invalid input: expected string, received undefined', path: ['model'] },
+                    { code: 'invalid_value', message: 'Invalid option: expected one of "soft"|"hard"', path: ['mode'] },
+                    { code: 'invalid_type', message: 'Invalid input: expected string, received undefined', path: ['until_cursor'] }
+                ]
+            }
+        });
+    });
+
+    it('should require headers', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        // @ts-expect-error on purpose
+        const res = await api.fetch(route, {
+            method: 'DELETE',
+            token: env.secret_key,
+            query: { model: 'Ticket', mode: 'soft', until_cursor: 'abc' }
+        });
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'invalid_headers',
+                errors: [
+                    { code: 'invalid_type', message: 'Invalid input: expected string, received undefined', path: ['connection-id'] },
+                    { code: 'invalid_type', message: 'Invalid input: expected string, received undefined', path: ['provider-config-key'] }
+                ]
+            }
+        });
+    });
+
+    it('should complain about unknown connection', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(route, {
+            method: 'DELETE',
+            token: env.secret_key,
+            query: { model: 'Ticket', mode: 'soft', until_cursor: 'abc' },
+            headers: { 'connection-id': 't', 'provider-config-key': 'a' }
+        });
+        isError(res.json);
+        expect(res.json).toStrictEqual({
+            error: { code: 'unknown_connection', message: 'Provided ConnectionId and ProviderConfigKey does not match a valid connection' }
+        });
+        expect(res.res.status).toBe(400);
+    });
+
+    it('should delete page of records', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+        await records.upsert({
+            records: format
+                .formatRecords({
+                    data: [
+                        { id: 'record1', foo: 'bar' },
+                        { id: 'record2', foo: 'bar' },
+                        { id: 'record3', foo: 'bar' }
+                    ],
+                    syncId: '00000000-0000-0000-0000-000000000001',
+                    syncJobId: 1,
+                    connectionId: conn.id,
+                    model: 'Ticket'
+                })
+                .unwrap(),
+            connectionId: conn.id,
+            environmentId: env.id,
+            model: 'Ticket'
+        });
+        const recs = (
+            await records.getRecords({
+                connectionId: conn.id,
+                model: 'Ticket'
+            })
+        ).unwrap();
+        expect(recs.records.length).toBe(3);
+
+        const cursor = recs.records[1]?._nango_metadata.cursor;
+        const cursorLast = recs.records[recs.records.length - 1]?._nango_metadata.cursor;
+
+        // Delete one record (limit 1)
+        const res1 = await api.fetch(route, {
+            method: 'DELETE',
+            token: env.secret_key,
+            query: {
+                model: 'Ticket',
+                mode: 'soft',
+                until_cursor: cursor!,
+                limit: 1
+            },
+            headers: { 'connection-id': conn.connection_id, 'provider-config-key': 'github' }
+        });
+        isSuccess(res1.json);
+        expect(res1.json).toStrictEqual<typeof res1.json>({
+            count: 1,
+            has_more: true
+        });
+        expect(res1.res.status).toBe(200);
+
+        // Delete until the cursor (2nd record - inclusive)
+        const res2 = await api.fetch(route, {
+            method: 'DELETE',
+            token: env.secret_key,
+            query: {
+                model: 'Ticket',
+                mode: 'soft',
+                until_cursor: cursor!
+            },
+            headers: { 'connection-id': conn.connection_id, 'provider-config-key': 'github' }
+        });
+        isSuccess(res2.json);
+        expect(res2.json).toStrictEqual<typeof res2.json>({
+            count: 1,
+            has_more: false
+        });
+        expect(res2.res.status).toBe(200);
+
+        // Delete the last record
+        const res3 = await api.fetch(route, {
+            method: 'DELETE',
+            token: env.secret_key,
+            query: {
+                model: 'Ticket',
+                mode: 'soft',
+                until_cursor: cursorLast!
+            },
+            headers: { 'connection-id': conn.connection_id, 'provider-config-key': 'github' }
+        });
+
+        isSuccess(res3.json);
+        expect(res3.json).toStrictEqual<typeof res3.json>({
+            count: 1,
+            has_more: false
+        });
+        expect(res3.res.status).toBe(200);
+
+        // Try to delete more records (none left)
+        const res4 = await api.fetch(route, {
+            method: 'DELETE',
+            token: env.secret_key,
+            query: {
+                model: 'Ticket',
+                mode: 'soft',
+                until_cursor: cursorLast!
+            },
+            headers: { 'connection-id': conn.connection_id, 'provider-config-key': 'github' }
+        });
+
+        isSuccess(res4.json);
+        expect(res4.json).toStrictEqual<typeof res4.json>({
+            count: 0,
+            has_more: false
+        });
+        expect(res4.res.status).toBe(200);
+    });
+
+    it('should handle updated records', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+        await records.upsert({
+            records: format
+                .formatRecords({
+                    data: [
+                        { id: '1', foo: 'bar' },
+                        { id: '2', foo: 'bar' },
+                        { id: '3', foo: 'bar' }
+                    ],
+                    syncId: '00000000-0000-0000-0000-000000000002',
+                    syncJobId: 1,
+                    connectionId: conn.id,
+                    model: 'Ticket'
+                })
+                .unwrap(),
+            connectionId: conn.id,
+            environmentId: env.id,
+            model: 'Ticket'
+        });
+
+        const recs = (
+            await records.getRecords({
+                connectionId: conn.id,
+                model: 'Ticket'
+            })
+        ).unwrap();
+        expect(recs.records.length).toBe(3);
+
+        const cursorLast = recs.records[recs.records.length - 1]?._nango_metadata.cursor;
+
+        // Update all but first record to have new cursors
+        // This simulates records being updated after the initial fetch
+        await records.upsert({
+            records: format
+                .formatRecords({
+                    data: recs.records.slice(1).map((r) => {
+                        return { id: r.id, foo: 'baz' };
+                    }),
+                    syncId: '00000000-0000-0000-0000-000000000003',
+                    syncJobId: 2,
+                    connectionId: conn.id,
+                    model: 'Ticket'
+                })
+                .unwrap(),
+            connectionId: conn.id,
+            environmentId: env.id,
+            model: 'Ticket'
+        });
+
+        const res1 = await api.fetch(route, {
+            method: 'DELETE',
+            token: env.secret_key,
+            query: {
+                model: 'Ticket',
+                mode: 'soft',
+                until_cursor: cursorLast!,
+                limit: 1
+            },
+            headers: { 'connection-id': conn.connection_id, 'provider-config-key': 'github' }
+        });
+        isSuccess(res1.json);
+        expect(res1.json).toStrictEqual<typeof res1.json>({
+            count: 1,
+            has_more: true
+        });
+        expect(res1.res.status).toBe(200);
+
+        // Try to delete more records (none left)
+        const res2 = await api.fetch(route, {
+            method: 'DELETE',
+            token: env.secret_key,
+            query: {
+                model: 'Ticket',
+                mode: 'soft',
+                until_cursor: cursorLast!
+            },
+            headers: { 'connection-id': conn.connection_id, 'provider-config-key': 'github' }
+        });
+
+        isSuccess(res2.json);
+        expect(res2.json).toStrictEqual<typeof res2.json>({
+            count: 0,
+            has_more: false
+        });
+        expect(res2.res.status).toBe(200);
+    });
+});

--- a/packages/server/lib/controllers/records/deleteRecords.ts
+++ b/packages/server/lib/controllers/records/deleteRecords.ts
@@ -1,0 +1,83 @@
+import * as z from 'zod';
+
+import { records } from '@nangohq/records';
+import { connectionService } from '@nangohq/shared';
+import { zodErrorToHTTP } from '@nangohq/utils';
+
+import { connectionIdSchema, modelSchema, providerConfigKeySchema, variantSchema } from '../../helpers/validation.js';
+import { asyncWrapper } from '../../utils/asyncWrapper.js';
+
+import type { DeletePublicRecords } from '@nangohq/types';
+
+export const validationQuery = z
+    .object({
+        model: modelSchema,
+        variant: variantSchema.optional(),
+        mode: z.enum(['soft', 'hard']),
+        until_cursor: z.string().min(1).max(1000),
+        limit: z.coerce.number().min(1).max(10_000).optional()
+    })
+    .strict();
+export const validationHeaders = z
+    .object({
+        'connection-id': connectionIdSchema,
+        'provider-config-key': providerConfigKeySchema
+    })
+    .strict();
+
+export const deletePublicRecords = asyncWrapper<DeletePublicRecords>(async (req, res) => {
+    const valQuery = validationQuery.safeParse(req.query);
+    if (!valQuery.success) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valQuery.error) } });
+        return;
+    }
+
+    const valHeaders = validationHeaders.safeParse({ 'connection-id': req.get('connection-id'), 'provider-config-key': req.get('provider-config-key') });
+    if (!valHeaders.success) {
+        res.status(400).send({ error: { code: 'invalid_headers', errors: zodErrorToHTTP(valHeaders.error) } });
+        return;
+    }
+
+    const { environment } = res.locals;
+    const headers: DeletePublicRecords['Headers'] = valHeaders.data;
+    const query: DeletePublicRecords['Querystring'] = valQuery.data;
+
+    const { error, response: connection } = await connectionService.getConnection(headers['connection-id'], headers['provider-config-key'], environment.id);
+
+    if (error || !connection) {
+        res.status(400).send({
+            error: { code: 'unknown_connection', message: 'Provided ConnectionId and ProviderConfigKey does not match a valid connection' }
+        });
+        return;
+    }
+
+    const model = query.variant && query.variant !== 'base' ? `${query.model}::${query.variant}` : query.model;
+    const result = await records.deleteRecords({
+        environmentId: environment.id,
+        connectionId: connection.id,
+        model,
+        mode: query.mode,
+        limit: query.limit || 1000,
+        batchSize: 1000,
+        toCursorIncluded: query.until_cursor
+    });
+
+    if (result.isErr()) {
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to delete records' } });
+        return;
+    }
+
+    // IMPORTANT:
+    // if until_cursor doesn't exist anymore (e.g. records was updated or deleted)
+    // we can't be sure if there are more records to delete
+    // so we optimistically return has_more = true in that case
+    // This may lead to one extra call to this endpoint
+    // but ensures all records are deleted as expected
+    // without extra code/query to maintain and execute on every request
+    const hasMore = result.value.totalDeletedRecords > 0 && query.until_cursor !== result.value.lastDeletedCursor;
+
+    res.send({
+        count: result.value.totalDeletedRecords,
+        has_more: hasMore
+    });
+});

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -43,6 +43,7 @@ import oauthController from './controllers/oauth.controller.js';
 import { getPublicProvider } from './controllers/providers/getProvider.js';
 import { getPublicProviders } from './controllers/providers/getProviders.js';
 import { allPublicProxy } from './controllers/proxy/allProxy.js';
+import { deletePublicRecords } from './controllers/records/deleteRecords.js';
 import { getPublicRecords } from './controllers/records/getRecords.js';
 import { getPublicScriptsConfig } from './controllers/scripts/config/getScriptsConfig.js';
 import { deleteSyncVariant } from './controllers/sync/deleteSyncVariant.js';
@@ -198,6 +199,7 @@ publicAPI.route('/sync/update-connection-frequency').put(apiAuth, putSyncConnect
 
 publicAPI.use('/records', jsonContentTypeMiddleware);
 publicAPI.route('/records').get(apiAuth, getPublicRecords);
+publicAPI.route('/records').delete(apiAuth, deletePublicRecords);
 
 publicAPI.use('/sync', jsonContentTypeMiddleware);
 publicAPI.route('/sync/trigger').post(apiAuth, postPublicTrigger);

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -68,7 +68,7 @@ import type { GetMeta } from './meta/api.js';
 import type { PostPlanExtendTrial } from './plans/http.api.js';
 import type { GetProvider, GetProviders, GetPublicProvider, GetPublicProviders } from './providers/api.js';
 import type { AllPublicProxy } from './proxy/http.api.js';
-import type { GetPublicRecords } from './record/api.js';
+import type { DeletePublicRecords, GetPublicRecords } from './record/api.js';
 import type { GetPublicScriptsConfig } from './scripts/http.api.js';
 import type {
     GetSharedCredentialsProvider,
@@ -111,6 +111,7 @@ export type PublicApiEndpoints =
     | PostPublicTwoStepAuthorization
     | PostPublicWebhook
     | GetPublicRecords
+    | DeletePublicRecords
     | GetPublicScriptsConfig
     | PostPublicConnectTelemetry
     | PutPublicSyncConnectionFrequency

--- a/packages/types/lib/record/api.ts
+++ b/packages/types/lib/record/api.ts
@@ -44,3 +44,24 @@ export type GetPublicRecords = Endpoint<{
         records: NangoRecord[];
     };
 }>;
+
+export type DeletePublicRecords = Endpoint<{
+    Method: 'DELETE';
+    Path: `/records`;
+    Headers: {
+        'connection-id': string;
+        'provider-config-key': string;
+    };
+    Error: ApiError<'unknown_connection'>;
+    Querystring: {
+        model: string;
+        variant?: string | undefined;
+        mode: 'soft' | 'hard';
+        until_cursor: string;
+        limit?: number | undefined;
+    };
+    Success: {
+        count: number;
+        has_more: boolean;
+    };
+}>;


### PR DESCRIPTION
API endpoint to delete records for a given connection/model
Parameters:
- hard (deletes entries) or soft (empties payload)
- until_cursor (deletes all records until cursor)
- limit (optional - limit the number of deleted records)

# How to test

```
curl --request DELETE \  
  --url http://localhost:3003/records\?model\=YOUR_MODEL\&until_cursor\=CURSOR\&mode\=soft \
  --header 'Authorization: Bearer ...' \
  --header 'Connection-Id: ...' \
  --header 'Provider-Config-Key: ...'

```

<!-- Summary by @propel-code-bot -->

---

**Add cursor-aware `DELETE /records` API with backend pruning refinements**

Introduces a new public `DELETE /records` endpoint with `soft` and `hard` deletion modes, cursor-bounded pagination, header/query validation via Zod, and integration into the public route/auth pipeline. The controller relies on `connectionService.getConnection`, applies a default page size of 1000 records, and reports `{ count, has_more }` based on the last deleted cursor.

Underlying record store changes ensure `records.deleteRecords` supports both deletion modes without mutating `updated_at` during soft deletes, always echoes the external identifier in the response `id`, and prevents updates to already-deleted rows. Types, OpenAPI docs, and extensive integration tests were updated to cover the new behaviors and edge cases (limits, cursor drift, protection, and updated records).

<details>
<summary><strong>Key Changes</strong></summary>

• Added `deletePublicRecords` controller with Zod-based validation, connection lookup, `records.deleteRecords` invocation, and `has_more` computation, exposed through the public router.
• Enhanced `records.deleteRecords` implementation to handle soft vs. hard modes, iterate in batches up to the requested cursor/limit, return the last deleted cursor, and keep soft-deleted records' `updated_at` stable while recording `deleted_at`.
• Adjusted `getRecords` to set response `id` from `external_id`, blocked updates on already-deleted rows via `getRecordsToUpdate`, and refreshed OpenAPI spec/types and integration tests for deletion scenarios.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/controllers/records
• packages/server/lib/routes.public.ts
• packages/records/lib/models/records.ts
• packages/types/lib/record/api.ts
• docs/spec.yaml
• packages/records/lib/models/records.integration.test.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*