### PR TITLE
fix(mcp-generic): metadata discovery

### DIFF
--- a/packages/shared/lib/clients/mcpGeneric.client.ts
+++ b/packages/shared/lib/clients/mcpGeneric.client.ts
@@ -75,7 +75,7 @@ export async function discoverMcpMetadata(
 
         // RFC9728 - Protected Resource Metadata Discovery
         let resourceMetadata: OAuthProtectedResourceMetadata | null = null;
-        let authServerUrl = new URL(mcpServerUrl);
+        let authServerUrl = new URL('/', mcpServerUrl);
 
         try {
             resourceMetadata = await discoverOAuthProtectedResourceMetadata(mcpServerUrl);


### PR DESCRIPTION
## Problem

MCP Generic OAuth metadata discovery was failing for MCP servers with paths in their URLs (e.g., Linear's `https://mcp.linear.app/mcp`).

## Solution

Fixed the authorization server URL initialization to use the origin instead of the full URL path. This aligns with RFC 8414 and matches the [MCP Inspector implementation](https://github.com/modelcontextprotocol/inspector/blob/main/client/src/lib/oauth-state-machine.ts).

```typescript
// Before
let authServerUrl = new URL(mcpServerUrl);

// After  
let authServerUrl = new URL("/", mcpServerUrl);
```

This ensures metadata discovery looks at `https://mcp.linear.app/.well-known/oauth-authorization-server` instead of `https://mcp.linear.app/mcp/.well-known/oauth-authorization-server`.

---

Issue: N/A

<!-- Summary by @propel-code-bot -->

---

**Fix MCP generic OAuth metadata discovery base URL**

Updates the MCP generic OAuth metadata discovery flow so the initial `authServerUrl` uses the MCP server origin rather than the full path. This targets scenarios where the MCP server URL includes additional path segments and aligns the lookup with RFC 8414 expectations.

<details>
<summary><strong>Key Changes</strong></summary>

• Initialize `authServerUrl` with `new URL('/', mcpServerUrl)` so discovery targets the server origin's `.well-known` endpoint

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/shared/lib/clients/mcpGeneric.client.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*