### PR TITLE
fix: npm also carries the vulnerable glob version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN true \
 FROM node:22.21.1-bookworm-slim AS web
 
 # Install a more recent npm
-RUN npm install -g npm@10.9.2
+RUN npm install -g npm@11.6.4
 
 # - Bash is just to be able to log inside the image and have a decent shell
 RUN true \


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Update npm version in Docker build stage**

Updates the `Dockerfile` web stage to install `npm@11.6.4`, ensuring the image no longer includes the vulnerable `glob` dependency that shipped with the older `npm@10.9.2` release. No other build steps or runtime configuration are modified.

<details>
<summary><strong>Key Changes</strong></summary>

• Bumped the global `npm` installation in `Dockerfile` from `npm@10.9.2` to `npm@11.6.4`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `Dockerfile` (web stage tooling)

</details>

---
*This summary was automatically generated by @propel-code-bot*