### PR TITLE
feat(deploy): add deploy for replit

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,6 +13,7 @@ on:
                     - development
                     - staging
                     - production
+                    - replit
             service:
                 type: choice
                 description: 'Service to deploy, defaults to server'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,7 +30,7 @@ on:
                     - app_ui
 
 jobs:
-    deploy_app_ui_aws:
+    deploy_app_ui:
         if: inputs.service == 'app_ui'
         runs-on: ubuntu-latest
         environment: ${{ inputs.stage }}
@@ -49,18 +49,44 @@ jobs:
                   FILE="packages/webapp/dist/index.html"
                   sed -E -i 's#(src=")/env\.js\?hash=([^"]+)#\1${{ vars.API_DOMAIN }}/env.js?hash=\2#g' "$FILE"
             - name: configure aws credentials
+              if: inputs.stage != 'replit'
               uses: aws-actions/configure-aws-credentials@v4
               with:
                   role-to-assume: ${{ vars.DEPLOY_APP_UI_ROLE }}
                   role-session-name: GitHub_to_AWS_via_FederatedOIDC
                   aws-region: ${{ vars.AWS_REGION }}
             - name: Deploy Webapp to S3
+              if: inputs.stage != 'replit'
               run: |
                   aws s3 sync packages/webapp/dist/ s3://${{ vars.APP_UI_BUCKET }} --delete
             - name: Create invalidation
+              if: inputs.stage != 'replit'
               run: |
                   aws cloudfront create-invalidation --distribution-id ${{ vars.APP_UI_DISTRIBUTION_ID }} --paths "/*"
-    deploy_connect_ui_aws:
+            - name: Auth to GCP (OIDC)
+              if: inputs.stage == 'replit'
+              uses: google-github-actions/auth@v2
+              with:
+                  workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+                  service_account: ${{ vars.GCP_DEPLOYER_SA }}
+            - name: Setup gcloud SDK
+              if: inputs.stage == 'replit'
+              uses: google-github-actions/setup-gcloud@v2
+              with:
+                  project_id: ${{ vars.GCP_PROJECT_ID }}
+            - name: Upload Webapp to GCS
+              if: inputs.stage == 'replit'
+              run: |
+                  gcloud storage rsync --recursive --delete \
+                    packages/webapp/dist/ \
+                    gs://${{ vars.APP_UI_BUCKET }}
+            - name: Invalidate Cloud CDN cache
+              if: inputs.stage == 'replit'
+              run: |
+                  gcloud compute url-maps invalidate-cdn-cache ${{ vars.APP_UI_URL_MAP }} \
+                    --path "/*" \
+                    --project "${{ vars.GCP_PROJECT_ID }}"
+    deploy_connect_ui:
         if: inputs.service == 'connect_ui'
         runs-on: ubuntu-latest
         permissions:
@@ -75,19 +101,44 @@ jobs:
             - name: Build Connect UI
               run: npm run ts-build && npm run -w @nangohq/connect-ui build
             - name: configure aws credentials
+              if: inputs.stage != 'replit'
               uses: aws-actions/configure-aws-credentials@v4
               with:
                   role-to-assume: ${{ vars.DEPLOY_CONNECT_UI_ROLE }}
                   role-session-name: GitHub_to_AWS_via_FederatedOIDC
                   aws-region: ${{ vars.AWS_REGION }}
             - name: Deploy Connect UI to S3
+              if: inputs.stage != 'replit'
               run: |
                   aws s3 sync packages/connect-ui/dist/ s3://${{ vars.CONNECT_UI_BUCKET }} --delete
             - name: Create invalidation
+              if: inputs.stage != 'replit'
               run: |
                   aws cloudfront create-invalidation --distribution-id ${{ vars.CONNECT_UI_DISTRIBUTION_ID }} --paths "/*"
-
-    deploy_aws:
+            - name: Auth to GCP (OIDC)
+              if: inputs.stage == 'replit'
+              uses: google-github-actions/auth@v2
+              with:
+                  workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+                  service_account: ${{ vars.GCP_DEPLOYER_SA }}
+            - name: Setup gcloud SDK
+              if: inputs.stage == 'replit'
+              uses: google-github-actions/setup-gcloud@v2
+              with:
+                  project_id: ${{ vars.GCP_PROJECT_ID }}
+            - name: Upload Webapp to GCS
+              if: inputs.stage == 'replit'
+              run: |
+                  gcloud storage rsync --recursive --delete \
+                    packages/webapp/dist/ \
+                    gs://${{ vars.CONNECT_UI_BUCKET }}
+            - name: Invalidate Cloud CDN cache
+              if: inputs.stage == 'replit'
+              run: |
+                  gcloud compute url-maps invalidate-cdn-cache ${{ vars.CONNECT_UI_URL_MAP }} \
+                    --path "/*" \
+                    --project "${{ vars.GCP_PROJECT_ID }}"
+    deploy:
         if: inputs.service != 'runner' && inputs.service != 'connect_ui' && inputs.service != 'app_ui'
         runs-on: ubuntu-latest
         permissions:
@@ -102,6 +153,7 @@ jobs:
                   path: nango-environments
 
             - name: Deploy ${{ inputs.service }} (AWS)
+              if: inputs.stage != 'replit'
               run: |
                   cd nango-environments
 
@@ -116,8 +168,24 @@ jobs:
                   git add apps/${{ inputs.stage }}/nango-values.yaml
                   git commit -m "Update ${{ inputs.service }} image tag to ${{ github.sha }} in ${{ inputs.stage }}"
                   git push origin main
-    deploy_runners_aws:
-        if: inputs.service == 'runner'
+            - name: Deploy ${{ inputs.service }} (Replit)
+              if: inputs.stage == 'replit'
+              run: |
+                  cd nango-environments
+
+                  # Configure git for the commit
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+                  # Update the nango-values.yaml file for the current stage and service
+                  yq eval '.spec.values.${{ inputs.service }}.image.tag = "${{ github.sha }}"' -i apps/${{ inputs.stage }}/nango-values.yaml
+
+                  # Commit and push the changes
+                  git add apps/customers/replit/production/nango.yaml
+                  git commit -m "Update ${{ inputs.service }} image tag to ${{ github.sha }} in ${{ inputs.stage }}"
+                  git push origin main
+    deploy_runners:
+        if: inputs.service == 'runner' && inputs.stage != 'replit'
         runs-on: ubuntu-latest
         environment: ${{ inputs.stage }}
         steps:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -174,8 +174,7 @@ jobs:
                   git config user.email "github-actions[bot]@users.noreply.github.com"
 
                   # Update the nango-values.yaml file for the current stage and service
-                  yq eval '.spec.values.${{ inputs.service }}.image.tag = "${{ github.sha }}"' -i apps/${{ inputs.stage }}/nango-values.yaml
-
+                  yq eval '.spec.values.${{ inputs.service }}.image.tag = "${{ github.sha }}"' -i apps/customers/replit/production/nango.yaml
                   # Commit and push the changes
                   git add apps/customers/replit/production/nango.yaml
                   git commit -m "Update ${{ inputs.service }} image tag to ${{ github.sha }} in ${{ inputs.stage }}"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -77,9 +77,7 @@ jobs:
             - name: Upload Webapp to GCS
               if: inputs.stage == 'replit'
               run: |
-                  gcloud storage rsync --recursive --delete \
-                    packages/webapp/dist/ \
-                    gs://${{ vars.APP_UI_BUCKET }}
+                  gsutil -m rsync -r -d packages/webapp/dist/ gs://${{ vars.APP_UI_BUCKET }}
             - name: Invalidate Cloud CDN cache
               if: inputs.stage == 'replit'
               run: |
@@ -129,9 +127,7 @@ jobs:
             - name: Upload Webapp to GCS
               if: inputs.stage == 'replit'
               run: |
-                  gcloud storage rsync --recursive --delete \
-                    packages/webapp/dist/ \
-                    gs://${{ vars.CONNECT_UI_BUCKET }}
+                  gsutil -m rsync -r -d packages/connect-ui/dist/ gs://${{ vars.CONNECT_UI_BUCKET }}
             - name: Invalidate Cloud CDN cache
               if: inputs.stage == 'replit'
               run: |


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Replit stage handling to deploy workflow**

Extends `deploy.yaml` to support a `replit` stage that deploys UI artifacts to GCP (GCS + Cloud CDN) while keeping existing AWS paths for other stages. Non-UI service deployments now branch between stage-specific Helm values updates in `apps/${{ stage }}/nango-values.yaml` and the Replit-specific file `apps/customers/replit/production/nango.yaml`, and runner rollouts are explicitly limited to non-Replit stages.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `replit` to the `stage` input options and reworked `deploy_app_ui`/`deploy_connect_ui` jobs to conditionally execute AWS or GCP upload and cache invalidation steps.
• Introduced Google OIDC auth (`google-github-actions/auth@v2`) and `gsutil`/`gcloud` commands for Replit UI deployments, using `vars.GCP_*` values.
• Split the generic `deploy` job so AWS stages continue updating `apps/${{ inputs.stage }}/nango-values.yaml` while Replit updates `apps/customers/replit/production/nango.yaml`.
• Renamed jobs (`deploy_app_ui`, `deploy_connect_ui`, `deploy`, `deploy_runners`) and gated `deploy_runners` to skip when `stage == 'replit'`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• .github/workflows/deploy.yaml

</details>

---
*This summary was automatically generated by @propel-code-bot*