### PR TITLE
feat(webhooks): add webhook verification for calendly webhooks

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -2535,6 +2535,7 @@ calendly:
         - owner
     post_connection_script: calendlyPostConnection
     webhook_routing_script: calendlyWebhookRouting
+    webhook_user_defined_secret: true
     docs: https://nango.dev/docs/integrations/all/calendly
 
 callrail:

--- a/packages/server/lib/webhook/calendly-webhook-routing.ts
+++ b/packages/server/lib/webhook/calendly-webhook-routing.ts
@@ -1,8 +1,72 @@
-import { Ok } from '@nangohq/utils';
+import crypto from 'node:crypto';
+
+import { NangoError } from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
 
 import type { WebhookHandler } from './types.js';
 
-const route: WebhookHandler = async (nango, _headers, body) => {
+function parseCalendlySignature(signatureHeader: string): { timestamp: string; signature: string } | null {
+    const parts = signatureHeader.split(',');
+    let timestamp = '';
+    let signature = '';
+
+    for (const part of parts) {
+        const [key, value] = part.split('=');
+        if (key === 't' && value) {
+            timestamp = value;
+        } else if (key === 'v1' && value) {
+            signature = value;
+        }
+    }
+
+    if (!timestamp || !signature) {
+        return null;
+    }
+
+    return { timestamp, signature };
+}
+
+function validateCalendlySignature(webhookSecret: string, timestamp: string, headerSignature: string, body: any): boolean {
+    const data = timestamp + '.' + JSON.stringify(body);
+    const expectedSignature = crypto.createHmac('sha256', webhookSecret).update(data, 'utf8').digest('hex');
+
+    return crypto.timingSafeEqual(Buffer.from(expectedSignature, 'hex'), Buffer.from(headerSignature, 'hex'));
+}
+
+function validateTimestamp(timestamp: string, toleranceMs: number = 180000): boolean {
+    // 3 minutes tolerance by default
+    const timestampMilliseconds = Number(timestamp) * 1000;
+    const now = Date.now();
+    return timestampMilliseconds >= now - toleranceMs && timestampMilliseconds <= now + toleranceMs;
+}
+
+const route: WebhookHandler = async (nango, headers, body, _rawBody) => {
+    // https://developer.calendly.com/api-docs/4c305798a61d3-webhook-signatures
+    const signatureHeader = headers['calendly-webhook-signature'];
+
+    const webhookSecret = nango.integration.custom?.['webhookSecret'];
+
+    if (webhookSecret) {
+        if (!signatureHeader) {
+            return Err(new NangoError('webhook_missing_signature'));
+        }
+
+        const parsedSignature = parseCalendlySignature(signatureHeader);
+        if (!parsedSignature) {
+            return Err(new NangoError('webhook_invalid_signature'));
+        }
+
+        const { timestamp, signature } = parsedSignature;
+
+        if (!validateTimestamp(timestamp)) {
+            return Err(new NangoError('webhook_invalid_signature'));
+        }
+
+        if (!validateCalendlySignature(webhookSecret, timestamp, signature, body)) {
+            return Err(new NangoError('webhook_invalid_signature'));
+        }
+    }
+
     const response = await nango.executeScriptForWebhooks({
         body,
         webhookType: 'event',

--- a/packages/server/lib/webhook/highlevel-webhook-routing.ts
+++ b/packages/server/lib/webhook/highlevel-webhook-routing.ts
@@ -44,7 +44,7 @@ const route: WebhookHandler<HighLevelWebhookResponse> = async (nango, headers, b
 
     const response = await nango.executeScriptForWebhooks({
         body,
-        webhookType: type ?? '',
+        webhookTypeValue: type ?? '',
         connectionIdentifier,
         ...(connectionIdentifier && { propName: connectionIdentifier })
     });


### PR DESCRIPTION
## Describe the problem and your solution

- Add webhook verification for Calendly webhooks

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Calendly webhook HMAC verification and provider updates**

Adds HMAC-based verification to the `calendlyWebhookRouting` handler so Calendly webhooks are only processed when the `calendly-webhook-signature` header matches the configured shared secret. The handler now parses the signature header, enforces a three-minute timestamp tolerance, validates the digest using `crypto.timingSafeEqual`, and returns `Err(new NangoError(...))` for missing or invalid signatures prior to running `nango.executeScriptForWebhooks` with the raw request body. The Calendly provider entry is updated with `webhook_user_defined_secret: true` so users can supply the shared secret, and the HighLevel webhook handler’s call to `nango.executeScriptForWebhooks` is adjusted to pass `webhookTypeValue` instead of `webhookType`.

These changes tighten webhook security for Calendly integrations while aligning provider metadata and fixing the HighLevel webhook type parameter.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced `parseCalendlySignature`, `validateTimestamp`, and `validateCalendlySignature` helpers in `packages/server/lib/webhook/calendly-webhook-routing.ts` to enforce signature validation using `crypto.createHmac` and `crypto.timingSafeEqual` before executing webhook scripts.
• Updated the Calendly webhook route to require signatures whenever `nango.integration.custom['webhookSecret']` is configured, emitting `NangoError('webhook_missing_signature')` or `NangoError('webhook_invalid_signature')` on failure while preserving the existing success response.
• Set `webhook_user_defined_secret: true` for Calendly within `packages/providers/providers.yaml` so the shared secret can be persisted with the integration configuration.
• Corrected the HighLevel webhook handler to pass `webhookTypeValue` in `packages/server/lib/webhook/highlevel-webhook-routing.ts`, matching the expected argument name for `nango.executeScriptForWebhooks`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/webhook/calendly-webhook-routing.ts
• packages/server/lib/webhook/highlevel-webhook-routing.ts
• packages/providers/providers.yaml

</details>

---
*This summary was automatically generated by @propel-code-bot*