### PR TITLE
feat: add docs page for DELETE /records

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1019,6 +1019,7 @@
                     "group": "Syncs",
                     "pages": [
                       "reference/api/sync/records-list",
+                      "reference/api/sync/delete-records",
                       "reference/api/sync/trigger",
                       "reference/api/sync/start",
                       "reference/api/sync/pause",

--- a/docs/reference/api/sync/delete-records.mdx
+++ b/docs/reference/api/sync/delete-records.mdx
@@ -1,0 +1,29 @@
+---
+title: 'Delete records'
+sidebarTitle: 'Delete records'
+openapi: 'DELETE /records'
+---
+
+Deletes synced records for a given connection and model using cursor-based pagination.
+
+## Deletion modes
+
+- **`soft`**: Empties the record payload and marks as deleted. The record metadata is preserved, including `_nango_metadata` fields.
+- **`hard`**: Permanently removes the record entries from Nango.
+
+## Cursor behavior
+
+Records are deleted up to and including the specified `until_cursor` value. Use the `_nango_metadata.cursor` value from the record you want to delete up to.
+
+## Response
+
+<Tip>
+The `has_more` field indicates whether there are potentially more records to delete. When `true`, make another request with the same `until_cursor` to continue deletion. When `false`, all records up to the cursor have been deleted.
+</Tip>
+
+```json
+{
+  "count": 150,
+  "has_more": true
+}
+```


### PR DESCRIPTION

<!-- Summary by @propel-code-bot -->

---

**Document `DELETE /records` sync endpoint**

Adds a new reference page `docs/reference/api/sync/delete-records.mdx` explaining how the `DELETE /records` sync endpoint operates, including deletion modes, cursor handling, and response fields. Updates `docs/docs.json` so the page appears under the Syncs reference navigation.

<details>
<summary><strong>Key Changes</strong></summary>

• Created `docs/reference/api/sync/delete-records.mdx` describing soft vs hard deletions, cursor usage, and the response payload for `DELETE /records`.
• Inserted `reference/api/sync/delete-records` into the Syncs group in `docs/docs.json` to expose the page in navigation.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs/reference/api/sync/delete-records.mdx`
• `docs/docs.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*