### PR TITLE
feat(integrations): add support for fathom oauth

### DIFF
--- a/docs/api-integrations/fathom-oauth.mdx
+++ b/docs/api-integrations/fathom-oauth.mdx
@@ -1,0 +1,81 @@
+---
+title: 'Fathom (OAuth)'
+sidebarTitle: 'Fathom (OAuth)'
+description: 'Integrate your application with the Fathom API'
+---
+
+## 🚀 Quickstart
+
+Connect to Fathom with Nango and see data flow in 2 minutes.
+
+<Steps>
+    <Step title="Create the integration">
+    In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Fathom_.
+    </Step>
+    <Step title="Authorize Fathom">
+    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then log in to Fathom. Later, you'll let your users do the same directly from your app.
+    </Step>
+    <Step title="Call the Fathom API">
+    Let's make your first request to the Fathom API (fetch a list of meetings). Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+    <Tabs>
+        <Tab title="cURL">
+
+            ```bash
+            curl "https://api.nango.dev/proxy/external/v1/meetings" \
+              -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+              -H "Provider-Config-Key: <INTEGRATION-ID>" \
+              -H "Connection-Id: <CONNECTION-ID>"
+            ```
+
+        </Tab>
+
+        <Tab title="Node">
+
+        Install Nango's backend SDK with `npm i @nangohq/node`. Then run:
+
+        ```typescript
+        import { Nango } from '@nangohq/node';
+
+        const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+
+        const res = await nango.get({
+            endpoint: '/external/v1/meetings',
+            providerConfigKey: '<INTEGRATION-ID>',
+            connectionId: '<CONNECTION-ID>'
+        });
+
+        console.log(res.data);
+        ```
+        </Tab>
+
+    </Tabs>
+    Or fetch credentials with the [Node SDK](/reference/sdks/node#get-a-connection-with-credentials) or [API](/reference/api/connection/get).
+
+    ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+    </Step>
+
+    <Step title="Implement Nango in your app">
+        Follow our [quickstart](/getting-started/quickstart/embed-in-your-app) to integrate Nango in your app.
+
+        To obtain your own production credentials, follow the setup guide linked below.
+    </Step>
+</Steps>
+
+## 📚 Fathom Integration Guides
+
+Nango-maintained guides for common use cases.
+
+- [How to register your own Fathom OAuth app](/api-integrations/fathom-oauth/how-to-register-your-own-fathom-oauth-app)  
+Register an OAuth app with Fathom and obtain credentials to connect it to Nango
+
+Official docs: [Fathom API Documentation](https://developers.fathom.ai/api-overview)
+
+## 🧩 Pre-built syncs & actions for Fathom
+
+Enable them in your dashboard. [Extend and customize](/implementation-guides/building-integrations/extend-reference-implementation) to fit your needs.
+
+import PreBuiltUseCases from "/snippets/generated/fathom/PreBuiltUseCases.mdx"
+
+<PreBuiltUseCases />
+
+---

--- a/docs/api-integrations/fathom-oauth/how-to-register-your-own-fathom-oauth-app.mdx
+++ b/docs/api-integrations/fathom-oauth/how-to-register-your-own-fathom-oauth-app.mdx
@@ -1,0 +1,29 @@
+---
+title: 'How to register your own Fathom OAuth app'
+sidebarTitle: 'Fathom Setup'
+description: 'Register an OAuth app with Fathom and connect it to Nango'
+---
+
+This guide shows you how to register your own app with Fathom to obtain your OAuth credentials (client ID & secret). These are required to let your users grant your app access to their Fathom account.
+
+<Steps>
+  <Step title="Create a Fathom account">
+    If you don't have a Fathom account, sign up for free account at [fathom.ai](https://www.fathom.ai/).
+  </Step>
+  <Step title="Register your application">
+    1. Navigate to the [create app form](https://fathom.video/marketplace_applications/new).
+    2. Fill in all the required details for your application.
+    3. For the **Redirect URLs** field, add: `https://api.nango.dev/oauth/callback`
+    4. Submit the form to create your application.
+    5. After creation, note your **Client ID** and **Client Secret** for both production and development environments. You'll need these when configuring the integration in Nango.
+    
+    <Note>Currently, the only available OAuth scope is `public_api`.</Note>
+  </Step>
+  <Step title="Next">
+    Follow the [_Quickstart_](/getting-started/quickstart) to connect your first account.
+  </Step>
+</Steps>
+
+For more details, see [Fathom's OAuth documentation](https://developers.fathom.ai/sdks/oauth).
+
+---

--- a/docs/api-integrations/fathom-oauth/how-to-register-your-own-fathom-oauth-app.mdx
+++ b/docs/api-integrations/fathom-oauth/how-to-register-your-own-fathom-oauth-app.mdx
@@ -8,7 +8,7 @@ This guide shows you how to register your own app with Fathom to obtain your OAu
 
 <Steps>
   <Step title="Create a Fathom account">
-    If you don't have a Fathom account, sign up for free account at [fathom.ai](https://www.fathom.ai/).
+    If you don't have a Fathom account, sign up for a free account at [fathom.ai](https://www.fathom.ai/).
   </Step>
   <Step title="Register your application">
     1. Navigate to the [create app form](https://fathom.video/marketplace_applications/new).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -525,6 +525,7 @@
               "integrations/all/falai",
               "integrations/all/fairing",
               "integrations/all/fathom",
+              "api-integrations/fathom-oauth",
               "integrations/all/figjam",
               "integrations/all/figma",
               "integrations/all/figma-scim",

--- a/docs/snippets/generated/fathom-oauth/PreBuiltTooling.mdx
+++ b/docs/snippets/generated/fathom-oauth/PreBuiltTooling.mdx
@@ -1,0 +1,41 @@
+## Pre-built tooling
+<AccordionGroup>
+<Accordion title="✅ Authorization">
+| Tools | Status |
+| - | - |
+| Pre-built authorization (OAuth) | ✅ |
+| Credentials auto-refresh | ✅ |
+| Auth parameters validation | ✅ |
+| Pre-built authorization UI | ✅ |
+| Custom authorization UI | ✅ |
+| Expired credentials detection | ✅ |
+</Accordion>
+<Accordion title="✅ Read & write data">
+| Tools | Status |
+| - | - |
+| Pre-built integrations | 🚫 (time to contribute: &lt;48h) |
+| API unification | ✅ |
+| 2-way sync | ✅ |
+| Webhooks from Nango on data modifications | ✅ |
+| Real-time webhooks from 3rd-party API | 🚫 (time to contribute: &lt;48h) |
+| Proxy requests | ✅ |
+</Accordion>
+<Accordion title="✅ Observability & data quality">
+| Tools | Status |
+| - | - |
+| HTTP request logging | ✅ |
+| End-to-type type safety | ✅ |
+| Data runtime validation | ✅ |
+| OpenTelemetry export | ✅ |
+| Slack alerts on errors | ✅ |
+| Integration status API | ✅ |
+</Accordion>
+<Accordion title="✅ Customization">
+| Tools | Status |
+| - | - |
+| Create or customize use-cases | ✅ |
+| Pre-configured pagination | 🚫 (time to contribute: &lt;48h) |
+| Pre-configured rate-limit handling | ✅ |
+| Per-customer configurations | ✅ |
+</Accordion>
+</AccordionGroup>

--- a/docs/snippets/generated/fathom-oauth/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/fathom-oauth/PreBuiltUseCases.mdx
@@ -1,0 +1,3 @@
+_No pre-built syncs or actions available yet._
+
+<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/platform/functions) independently.</Tip>

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -4848,6 +4848,29 @@ fathom:
             title: API Key
             description: The API key for your Fathom account
 
+fathom-oauth:
+    display_name: Fathom (OAuth)
+    categories:
+        - communication
+        - video
+    auth_mode: OAUTH2
+    authorization_url: https://fathom.video/external/v1/oauth2/authorize
+    token_url: https://fathom.video/external/v1/oauth2/token
+    disable_pkce: true
+    authorization_params:
+        response_type: code
+    token_params:
+        grant_type: authorization_code
+    refresh_params:
+        grant_type: refresh_token
+    proxy:
+        base_url: https://api.fathom.ai
+        retry:
+            at:
+                - 'ratelimit-reset'
+    docs: https://nango.dev/docs/api-integrations/fathom-oauth
+    setup_guide_url: https://nango.dev/docs/api-integrations/fathom-oauth/how-to-register-your-own-fathom-oauth-app
+
 fellow:
     display_name: Fellow
     categories:

--- a/packages/webapp/public/images/template-logos/fathom-oauth.svg
+++ b/packages/webapp/public/images/template-logos/fathom-oauth.svg
@@ -1,0 +1,1 @@
+fathom.svg

--- a/snippets/generated/fathom/PreBuiltUseCases.mdx
+++ b/snippets/generated/fathom/PreBuiltUseCases.mdx
@@ -1,0 +1,3 @@
+_No pre-built syncs or actions available yet._
+
+<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/platform/functions) independently.</Tip>


### PR DESCRIPTION
## Describe the problem and your solution

- add support for fathom oauth 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Fathom OAuth provider configuration and docs**

Registers the new `fathom-oauth` provider in `packages/providers/providers.yaml` and wires associated assets (logo alias) and documentation. Adds a quickstart, setup guide, generated snippets, and navigation updates so the integration appears alongside existing Fathom materials.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `fathom-oauth` entry to `packages/providers/providers.yaml` with OAuth endpoints, retry headers, and documentation links.
• Published `docs/api-integrations/fathom-oauth.mdx` quickstart, setup guide at `docs/api-integrations/fathom-oauth/how-to-register-your-own-fathom-oauth-app.mdx`, and generated snippets under `docs/snippets/generated/fathom-oauth/`.
• Updated `docs/docs.json` navigation to surface the new integration documentation and linked an SVG alias via `packages/webapp/public/images/template-logos/fathom-oauth.svg`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/providers/providers.yaml
• docs/api-integrations/fathom-oauth.mdx
• docs/api-integrations/fathom-oauth/how-to-register-your-own-fathom-oauth-app.mdx
• docs/snippets/generated/fathom-oauth/PreBuiltTooling.mdx
• docs/docs.json
• packages/webapp/public/images/template-logos/fathom-oauth.svg

</details>

---
*This summary was automatically generated by @propel-code-bot*