### PR TITLE
fix(cli-generate-tests): filtering follow up

### DIFF
--- a/packages/cli/lib/services/test.service.ts
+++ b/packages/cli/lib/services/test.service.ts
@@ -52,20 +52,32 @@ export function validateAndFilterIntegrations({
         filtered = { [integrationId]: filtered[integrationId] };
     }
 
-    // Validate sync name exists
+    // Filter by sync name - only keep integrations that have this sync
     if (syncName) {
-        const allSyncs = Object.values(filtered).flatMap((i) => Object.keys(i.syncs || {}));
-        if (!allSyncs.includes(syncName)) {
+        const integrationsWithSync: Record<string, IntegrationDefinition> = {};
+        for (const [key, integration] of Object.entries(filtered)) {
+            if (integration.syncs && syncName in integration.syncs) {
+                integrationsWithSync[key] = integration;
+            }
+        }
+        if (Object.keys(integrationsWithSync).length === 0) {
             return { valid: false, error: `Sync "${syncName}" not found`, filteredIntegrations: {} };
         }
+        filtered = integrationsWithSync;
     }
 
-    // Validate action name exists
+    // Filter by action name - only keep integrations that have this action
     if (actionName) {
-        const allActions = Object.values(filtered).flatMap((i) => Object.keys(i.actions || {}));
-        if (!allActions.includes(actionName)) {
+        const integrationsWithAction: Record<string, IntegrationDefinition> = {};
+        for (const [key, integration] of Object.entries(filtered)) {
+            if (integration.actions && actionName in integration.actions) {
+                integrationsWithAction[key] = integration;
+            }
+        }
+        if (Object.keys(integrationsWithAction).length === 0) {
             return { valid: false, error: `Action "${actionName}" not found`, filteredIntegrations: {} };
         }
+        filtered = integrationsWithAction;
     }
 
     return { valid: true, filteredIntegrations: filtered };

--- a/packages/cli/lib/services/test.service.unit.cli-test.ts
+++ b/packages/cli/lib/services/test.service.unit.cli-test.ts
@@ -92,7 +92,7 @@ describe('validateAndFilterIntegrations', () => {
             expect(result.error).toBe('Sync "fetch-messages" not found');
         });
 
-        it('should succeed when sync name exists across all integrations', () => {
+        it('should filter to only integrations containing the sync when no integrationId provided', () => {
             const integrations = createMockIntegrations();
             const result = validateAndFilterIntegrations({
                 integrations,
@@ -100,7 +100,8 @@ describe('validateAndFilterIntegrations', () => {
             });
 
             expect(result.valid).toBe(true);
-            expect(Object.keys(result.filteredIntegrations)).toEqual(['github', 'slack']);
+            // Should only include github, not slack (which doesn't have fetch-repos)
+            expect(Object.keys(result.filteredIntegrations)).toEqual(['github']);
         });
 
         it('should succeed when sync name exists within specified integration', () => {
@@ -142,7 +143,7 @@ describe('validateAndFilterIntegrations', () => {
             expect(result.error).toBe('Action "send-message" not found');
         });
 
-        it('should succeed when action name exists across all integrations', () => {
+        it('should filter to only integrations containing the action when no integrationId provided', () => {
             const integrations = createMockIntegrations();
             const result = validateAndFilterIntegrations({
                 integrations,
@@ -150,7 +151,8 @@ describe('validateAndFilterIntegrations', () => {
             });
 
             expect(result.valid).toBe(true);
-            expect(Object.keys(result.filteredIntegrations)).toEqual(['github', 'slack']);
+            // Should only include github, not slack (which doesn't have create-issue)
+            expect(Object.keys(result.filteredIntegrations)).toEqual(['github']);
         });
 
         it('should succeed when action name exists within specified integration', () => {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Adjust CLI test generation filtering logic**

Updates `validateAndFilterIntegrations` so sync and action filters now narrow the result set to integrations that actually contain the requested resource, rather than allowing unrelated integrations to pass validation. Corresponding unit tests were updated to verify that filtering excludes integrations lacking the requested sync or action.

<details>
<summary><strong>Key Changes</strong></summary>

• Reworked `validateAndFilterIntegrations` to rebuild `filtered` with only integrations that include the requested `syncName` or `actionName` before returning success
• Ensured sync/action lookups return an error when no integrations contain the requested resource after filtering
• Updated unit tests in `test.service.unit.cli-test.ts` to assert the filtered integration keys match the new behavior

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/cli/lib/services/test.service.ts`
• `packages/cli/lib/services/test.service.unit.cli-test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*