### PR TITLE
fix: cache zod schema when possible

### DIFF
--- a/packages/jobs/lib/routes/runners/postIdle.ts
+++ b/packages/jobs/lib/routes/runners/postIdle.ts
@@ -7,8 +7,10 @@ import { runnersFleet } from '../../runner/fleet.js';
 import type { PostIdle } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, RouteHandler } from '@nangohq/utils';
 
+const paramsSchema = z.object({ nodeId: z.coerce.number().positive() }).strict();
+
 const validate = validateRequest<PostIdle>({
-    parseParams: (data) => z.object({ nodeId: z.coerce.number().positive() }).strict().parse(data)
+    parseParams: (data) => paramsSchema.parse(data)
 });
 
 const handler = async (_req: EndpointRequest, res: EndpointResponse<PostIdle>) => {

--- a/packages/jobs/lib/routes/runners/postRegister.ts
+++ b/packages/jobs/lib/routes/runners/postRegister.ts
@@ -7,13 +7,12 @@ import { runnersFleet } from '../../runner/fleet.js';
 import type { PostRegister } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, RouteHandler } from '@nangohq/utils';
 
+const paramsSchema = z.object({ nodeId: z.coerce.number().positive() }).strict();
+const bodySchema = z.object({ url: z.string().min(1) }).strict();
+
 const validate = validateRequest<PostRegister>({
-    parseParams: (data) => z.object({ nodeId: z.coerce.number().positive() }).strict().parse(data),
-    parseBody: (data) =>
-        z
-            .object({ url: z.string().min(1) })
-            .strict()
-            .parse(data)
+    parseParams: (data) => paramsSchema.parse(data),
+    parseBody: (data) => bodySchema.parse(data)
 });
 
 const handler = async (_req: EndpointRequest, res: EndpointResponse<PostRegister>) => {

--- a/packages/jobs/lib/routes/tasks/putTask.ts
+++ b/packages/jobs/lib/routes/tasks/putTask.ts
@@ -76,26 +76,26 @@ const nangoPropsSchema = z.looseObject({
         .default({ level: 'info' })
 });
 
+const bodySchema = z.object({
+    nangoProps: nangoPropsSchema,
+    error: z
+        .object({
+            type: z.string(),
+            payload: z.record(z.string(), z.unknown()).or(z.unknown().transform((v) => ({ message: v }))),
+            status: z.number(),
+            additional_properties: z.record(z.string(), z.unknown()).optional()
+        })
+        .optional(),
+    output: jsonSchema.default(null),
+    telemetryBag: z
+        .object({ customLogs: z.number(), proxyCalls: z.number(), durationMs: z.number().default(0), memoryGb: z.number().default(1) })
+        .default({ customLogs: 0, proxyCalls: 0, durationMs: 0, memoryGb: 1 })
+});
+const paramsSchema = z.object({ taskId: z.string().uuid() }).strict();
+
 const validate = validateRequest<PutTask>({
-    parseBody: (data) =>
-        z
-            .object({
-                nangoProps: nangoPropsSchema,
-                error: z
-                    .object({
-                        type: z.string(),
-                        payload: z.record(z.string(), z.unknown()).or(z.unknown().transform((v) => ({ message: v }))),
-                        status: z.number(),
-                        additional_properties: z.record(z.string(), z.unknown()).optional()
-                    })
-                    .optional(),
-                output: jsonSchema.default(null),
-                telemetryBag: z
-                    .object({ customLogs: z.number(), proxyCalls: z.number(), durationMs: z.number().default(0), memoryGb: z.number().default(1) })
-                    .default({ customLogs: 0, proxyCalls: 0, durationMs: 0, memoryGb: 1 })
-            })
-            .parse(data),
-    parseParams: (data) => z.object({ taskId: z.string().uuid() }).strict().parse(data)
+    parseBody: (data) => bodySchema.parse(data),
+    parseParams: (data) => paramsSchema.parse(data)
 });
 
 const handler = async (_req: EndpointRequest, res: EndpointResponse<PutTask>) => {

--- a/packages/jobs/lib/routes/tasks/taskId/postHeartbeat.ts
+++ b/packages/jobs/lib/routes/tasks/taskId/postHeartbeat.ts
@@ -7,8 +7,10 @@ import { orchestratorClient } from '../../../clients.js';
 import type { PostHeartbeat } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, RouteHandler } from '@nangohq/utils';
 
+const paramsSchema = z.object({ taskId: z.string().uuid() }).strict();
+
 const validate = validateRequest<PostHeartbeat>({
-    parseParams: (data) => z.object({ taskId: z.string().uuid() }).strict().parse(data)
+    parseParams: (data) => paramsSchema.parse(data)
 });
 
 const handler = async (_req: EndpointRequest, res: EndpointResponse<PostHeartbeat>) => {

--- a/packages/orchestrator/lib/routes/v1/postDequeue.ts
+++ b/packages/orchestrator/lib/routes/v1/postDequeue.ts
@@ -24,16 +24,16 @@ type PostDequeue = Endpoint<{
     Success: Task[];
 }>;
 
+const bodySchema = z
+    .object({
+        limit: z.coerce.number().positive(),
+        longPolling: z.coerce.boolean(),
+        groupKeyPattern: z.string().min(1)
+    })
+    .strict();
+
 const validate = validateRequest<PostDequeue>({
-    parseBody: (data) =>
-        z
-            .object({
-                limit: z.coerce.number().positive(),
-                longPolling: z.coerce.boolean(),
-                groupKeyPattern: z.string().min(1)
-            })
-            .strict()
-            .parse(data)
+    parseBody: (data) => bodySchema.parse(data)
 });
 
 export const route: Route<PostDequeue> = { path, method };

--- a/packages/orchestrator/lib/routes/v1/postImmediate.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediate.ts
@@ -38,30 +38,31 @@ export type PostImmediate = Endpoint<{
     Success: { taskId: string; retryKey: string };
 }>;
 
+function argsSchema(data: any) {
+    if ('args' in data && 'type' in data.args) {
+        const taskType = data.args.type as TaskType;
+        switch (taskType) {
+            case 'sync':
+                return syncArgsSchema;
+            case 'action':
+                return actionArgsSchema;
+            case 'webhook':
+                return webhookArgsSchema;
+            case 'on-event':
+                return onEventArgsSchema;
+            case 'abort':
+                return syncAbortArgsSchema;
+            default:
+                ((_exhaustiveCheck: never) => {
+                    z.never();
+                })(taskType);
+        }
+    }
+    return z.never();
+}
+
 const validate = validateRequest<PostImmediate>({
     parseBody: (data: any) => {
-        function argsSchema(data: any) {
-            if ('args' in data && 'type' in data.args) {
-                const taskType = data.args.type as TaskType;
-                switch (taskType) {
-                    case 'sync':
-                        return syncArgsSchema;
-                    case 'action':
-                        return actionArgsSchema;
-                    case 'webhook':
-                        return webhookArgsSchema;
-                    case 'on-event':
-                        return onEventArgsSchema;
-                    case 'abort':
-                        return syncAbortArgsSchema;
-                    default:
-                        ((_exhaustiveCheck: never) => {
-                            z.never();
-                        })(taskType);
-                }
-            }
-            return z.never();
-        }
         const schema = z
             .object({
                 name: z.string().min(1),

--- a/packages/orchestrator/lib/routes/v1/putRecurring.ts
+++ b/packages/orchestrator/lib/routes/v1/putRecurring.ts
@@ -19,24 +19,23 @@ export type PutRecurring = Endpoint<{
     Success: { scheduleId: string };
 }>;
 
-const validate = validateRequest<PutRecurring>({
-    parseBody: (data: any) => {
-        return z
-            .object({
-                schedule: z.union([
-                    z.object({
-                        name: z.string().min(1),
-                        state: z.union([z.literal('STARTED'), z.literal('PAUSED'), z.literal('DELETED')])
-                    }),
-                    z.object({
-                        name: z.string().min(1),
-                        frequencyMs: z.number().int().positive()
-                    })
-                ])
+const bodySchema = z
+    .object({
+        schedule: z.union([
+            z.object({
+                name: z.string().min(1),
+                state: z.union([z.literal('STARTED'), z.literal('PAUSED'), z.literal('DELETED')])
+            }),
+            z.object({
+                name: z.string().min(1),
+                frequencyMs: z.number().int().positive()
             })
-            .strict()
-            .parse(data);
-    }
+        ])
+    })
+    .strict();
+
+const validate = validateRequest<PutRecurring>({
+    parseBody: (data: any) => bodySchema.parse(data)
 });
 
 const handler = (scheduler: Scheduler) => {

--- a/packages/orchestrator/lib/routes/v1/retries/retryKey/getOutput.ts
+++ b/packages/orchestrator/lib/routes/v1/retries/retryKey/getOutput.ts
@@ -22,13 +22,12 @@ type GetRetryOutput = Endpoint<{
 const path = '/v1/retries/:retryKey/output';
 const method = 'GET';
 
+const querySchema = z.object({ ownerKey: z.string().min(1) }).strict();
+const paramsSchema = z.object({ retryKey: z.string().uuid() }).strict();
+
 const validate = validateRequest<GetRetryOutput>({
-    parseQuery: (data) =>
-        z
-            .object({ ownerKey: z.string().min(1) })
-            .strict()
-            .parse(data),
-    parseParams: (data) => z.object({ retryKey: z.string().uuid() }).strict().parse(data)
+    parseQuery: (data) => querySchema.parse(data),
+    parseParams: (data) => paramsSchema.parse(data)
 });
 
 const handler = (scheduler: Scheduler) => {

--- a/packages/orchestrator/lib/routes/v1/schedules/postRun.ts
+++ b/packages/orchestrator/lib/routes/v1/schedules/postRun.ts
@@ -19,13 +19,10 @@ export type PostScheduleRun = Endpoint<{
     Success: { scheduleId: string };
 }>;
 
+const bodySchema = z.object({ scheduleName: z.string().min(1) }).strict();
+
 const validate = validateRequest<PostScheduleRun>({
-    parseBody: (data: any) => {
-        return z
-            .object({ scheduleName: z.string().min(1) })
-            .strict()
-            .parse(data);
-    }
+    parseBody: (data: any) => bodySchema.parse(data)
 });
 
 const handler = (scheduler: Scheduler) => {

--- a/packages/orchestrator/lib/routes/v1/schedules/postSearch.ts
+++ b/packages/orchestrator/lib/routes/v1/schedules/postSearch.ts
@@ -20,15 +20,15 @@ type PostSearch = Endpoint<{
     Success: Schedule[];
 }>;
 
+const bodySchema = z
+    .object({
+        names: z.array(z.string().min(1)).optional(),
+        limit: z.number().int()
+    })
+    .strict();
+
 const validate = validateRequest<PostSearch>({
-    parseBody: (data) =>
-        z
-            .object({
-                names: z.array(z.string().min(1)).optional(),
-                limit: z.number().int()
-            })
-            .strict()
-            .parse(data)
+    parseBody: (data) => bodySchema.parse(data)
 });
 
 const handler = (scheduler: Scheduler) => {

--- a/packages/orchestrator/lib/routes/v1/tasks/postSearch.ts
+++ b/packages/orchestrator/lib/routes/v1/tasks/postSearch.ts
@@ -21,16 +21,16 @@ type PostSearch = Endpoint<{
     Success: Task[];
 }>;
 
+const bodySchema = z
+    .object({
+        groupKey: z.string().min(1).optional(),
+        limit: z.coerce.number().positive().optional(),
+        ids: z.array(z.string().uuid()).optional()
+    })
+    .strict();
+
 const validate = validateRequest<PostSearch>({
-    parseBody: (data) =>
-        z
-            .object({
-                groupKey: z.string().min(1).optional(),
-                limit: z.coerce.number().positive().optional(),
-                ids: z.array(z.string().uuid()).optional()
-            })
-            .strict()
-            .parse(data)
+    parseBody: (data) => bodySchema.parse(data)
 });
 
 const handler = (scheduler: Scheduler) => {

--- a/packages/orchestrator/lib/routes/v1/tasks/putTaskId.ts
+++ b/packages/orchestrator/lib/routes/v1/tasks/putTaskId.ts
@@ -26,13 +26,12 @@ type PutTask = Endpoint<{
 const path = '/v1/tasks/:taskId';
 const method = 'PUT';
 
+const bodySchema = z.object({ output: jsonSchema, state: z.enum(['SUCCEEDED', 'FAILED', 'CANCELLED']) }).strict();
+const paramsSchema = z.object({ taskId: z.string().uuid() }).strict();
+
 const validate = validateRequest<PutTask>({
-    parseBody: (data) =>
-        z
-            .object({ output: jsonSchema, state: z.enum(['SUCCEEDED', 'FAILED', 'CANCELLED']) })
-            .strict()
-            .parse(data),
-    parseParams: (data) => z.object({ taskId: z.string().uuid() }).strict().parse(data)
+    parseBody: (data) => bodySchema.parse(data),
+    parseParams: (data) => paramsSchema.parse(data)
 });
 
 const handler = (scheduler: Scheduler) => {

--- a/packages/orchestrator/lib/routes/v1/tasks/taskId/getOutput.ts
+++ b/packages/orchestrator/lib/routes/v1/tasks/taskId/getOutput.ts
@@ -26,14 +26,14 @@ type GetOutput = Endpoint<{
 const path = '/v1/tasks/:taskId/output';
 const method = 'GET';
 
+const querySchema = z.object({
+    longPolling: z.coerce.number().optional()
+});
+const paramsSchema = z.object({ taskId: z.string().uuid() }).strict();
+
 const validate = validateRequest<GetOutput>({
-    parseQuery: (data) =>
-        z
-            .object({
-                longPolling: z.coerce.number().optional()
-            })
-            .parse(data),
-    parseParams: (data) => z.object({ taskId: z.string().uuid() }).strict().parse(data)
+    parseQuery: (data) => querySchema.parse(data),
+    parseParams: (data) => paramsSchema.parse(data)
 });
 
 const handler = (scheduler: Scheduler, eventEmitter: EventEmitter) => {

--- a/packages/orchestrator/lib/routes/v1/tasks/taskId/postHeartbeat.ts
+++ b/packages/orchestrator/lib/routes/v1/tasks/taskId/postHeartbeat.ts
@@ -19,8 +19,10 @@ type PostHeartbeat = Endpoint<{
     Success: never;
 }>;
 
+const paramsSchema = z.object({ taskId: z.string().uuid() }).strict();
+
 const validate = validateRequest<PostHeartbeat>({
-    parseParams: (data) => z.object({ taskId: z.string().uuid() }).strict().parse(data)
+    parseParams: (data) => paramsSchema.parse(data)
 });
 
 const handler = (scheduler: Scheduler) => {


### PR DESCRIPTION
building zod schema on the fly can be costly at scale. This commit builds the endpoint zod schema once at module load time Follow up of 8ee042e31 (persist)

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Hoist reusable Zod schemas to avoid per-request rebuilds**

Moves all inline Zod schemas used by orchestrator and jobs HTTP routes into module-level constants, so validation schemas are created once at load time instead of on every request. The functional behavior of each endpoint remains unchanged; only schema construction has been refactored for reuse.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced top-level `bodySchema`, `paramsSchema`, and `querySchema` constants across 15 route handlers to replace per-request inline Zod builders
• Preserved preprocessing logic (e.g., `bodySchema` with `z.preprocess` in `postRecurring` and dynamic `argsSchema` selection in `postImmediate`) while reusing the cached base schema
• Standardized usage of `validateRequest` to parse data via the new cached schemas for tasks, schedules, retries, runners, and heartbeat endpoints

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/orchestrator/lib/routes/v1/*` validation logic
• `packages/jobs/lib/routes/*` validation logic

</details>

---
*This summary was automatically generated by @propel-code-bot*