### PR TITLE
fix(records): remove sync_id from mark_previous_generation_as_deleted index

### DIFF
--- a/packages/records/lib/db/migrations/20251211175100_records_outdated_records_indexes.ts
+++ b/packages/records/lib/db/migrations/20251211175100_records_outdated_records_indexes.ts
@@ -1,0 +1,26 @@
+import type { Knex } from 'knex';
+
+export const config = {
+    transaction: false
+};
+
+export async function up(knex: Knex): Promise<void> {
+    // adding a more specific index used by the "mark previous generation as deleted" query
+    // removing sync_id from the index as it's not used in the query filter anymore
+    // pg prevents adding index to parent table concurrently - must be done on each partition
+    for (let p = 0; p < 256; p++) {
+        await knex.raw(
+            `CREATE INDEX CONCURRENTLY IF NOT EXISTS records_p${p}_mark_previous_generation_as_deleted_v2
+                ON nango_records.records_p${p}(connection_id, model, sync_job_id)
+                INCLUDE (id)
+                WHERE deleted_at IS NULL;`
+        );
+    }
+
+    // droping existing indexes that are not being used by pg
+    for (let p = 0; p < 256; p++) {
+        await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS records_p${p}_mark_previous_generation_as_deleted;`);
+    }
+}
+
+export async function down(): Promise<void> {}


### PR DESCRIPTION
sync_id isn't a filter anymore in the `deleteOutdatedRecords` query. https://github.com/NangoHQ/nango/commit/c2e9ba4cb09d3e9d9409c5bab0fcfad209d364f8
 his commit replaces the existing index by a new one without the sync_id field

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Adjust records index to match updated filter usage**

Introduces a migration that recreates the per-partition `records_p*_mark_previous_generation_as_deleted` index without the `sync_id` column, aligning it with the current `deleteOutdatedRecords` query filters. The migration builds a new `records_p*_mark_previous_generation_as_deleted_v2` index on `(connection_id, model, sync_job_id)` with `INCLUDE (id)` while conditionally retaining only non-deleted rows, then removes the obsolete index.

<details>
<summary><strong>Key Changes</strong></summary>

• Adds `packages/records/lib/db/migrations/20251211175100_records_outdated_records_indexes.ts` to create `records_p*_mark_previous_generation_as_deleted_v2` indexes spanning partitions 0-255
• Drops the previous `records_p*_mark_previous_generation_as_deleted` indexes that still included `sync_id`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/records/lib/db/migrations/20251211175100_records_outdated_records_indexes.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*