### PR TITLE
fix(auth): allow/disallow regular signup based on environment variable

### DIFF
--- a/packages/server/lib/controllers/v1/account/managed/getCallback.ts
+++ b/packages/server/lib/controllers/v1/account/managed/getCallback.ts
@@ -99,7 +99,7 @@ export const getManagedCallback = asyncWrapper<GetManagedCallback>(async (req, r
         } else {
             // Regular signup
             if (!envs.AUTH_ALLOW_SIGNUP) {
-                res.status(500).send({ error: { code: 'server_error', message: 'Signup is disabled.' } });
+                res.status(403).send({ error: { code: 'forbidden', message: 'Signup is disabled.' } });
                 return;
             }
             const resAccount = await accountService.createAccount({ name, email: authorizedUser.email });

--- a/packages/server/lib/controllers/v1/account/managed/getCallback.ts
+++ b/packages/server/lib/controllers/v1/account/managed/getCallback.ts
@@ -5,6 +5,7 @@ import { acceptInvitation, accountService, expirePreviousInvitations, getInvitat
 import { basePublicUrl, flagHasUsage, getLogger, nanoid, report } from '@nangohq/utils';
 
 import { getWorkOSClient } from '../../../../clients/workos.client.js';
+import { envs } from '../../../../env.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 import { linkBillingCustomer, linkBillingFreeSubscription } from '../../../../utils/billing.js';
 
@@ -97,6 +98,10 @@ export const getManagedCallback = asyncWrapper<GetManagedCallback>(async (req, r
             account = (await accountService.getAccountById(db.knex, invitation.account_id))!;
         } else {
             // Regular signup
+            if (!envs.AUTH_ALLOW_SIGNUP) {
+                res.status(500).send({ error: { code: 'server_error', message: 'Signup is disabled.' } });
+                return;
+            }
             const resAccount = await accountService.createAccount({ name, email: authorizedUser.email });
             if (!resAccount) {
                 res.status(500).send({ error: { code: 'error_creating_account', message: 'Failed to create account' } });

--- a/packages/server/lib/controllers/v1/account/signup.ts
+++ b/packages/server/lib/controllers/v1/account/signup.ts
@@ -86,7 +86,7 @@ export const signup = asyncWrapper<PostSignup>(async (req, res) => {
         await acceptInvitation(token);
     } else {
         if (!envs.AUTH_ALLOW_SIGNUP) {
-            res.status(500).send({ error: { code: 'server_error', message: 'Signup is disabled.' } });
+            res.status(403).send({ error: { code: 'forbidden', message: 'Signup is disabled.' } });
             return;
         }
 

--- a/packages/server/lib/controllers/v1/account/signup.ts
+++ b/packages/server/lib/controllers/v1/account/signup.ts
@@ -6,6 +6,7 @@ import db from '@nangohq/database';
 import { acceptInvitation, accountService, getInvitation, pbkdf2, userService } from '@nangohq/shared';
 import { flagHasUsage, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import { envs } from '../../../env.js';
 import { sendVerificationEmail } from '../../../helpers/email.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { linkBillingCustomer, linkBillingFreeSubscription } from '../../../utils/billing.js';
@@ -84,6 +85,11 @@ export const signup = asyncWrapper<PostSignup>(async (req, res) => {
 
         await acceptInvitation(token);
     } else {
+        if (!envs.AUTH_ALLOW_SIGNUP) {
+            res.status(500).send({ error: { code: 'server_error', message: 'Signup is disabled.' } });
+            return;
+        }
+
         // Regular account
         account = await accountService.createAccount({ name, email, foundUs });
         if (!account) {

--- a/packages/server/lib/controllers/v1/getEnvJs.ts
+++ b/packages/server/lib/controllers/v1/getEnvJs.ts
@@ -36,6 +36,7 @@ export const getEnvJs = asyncWrapper<any, any>((_, res) => {
             logs: envs.NANGO_LOGS_ENABLED,
             scripts: flagHasScripts,
             auth: flagHasAuth,
+            allowSignup: envs.AUTH_ALLOW_SIGNUP,
             managedAuth: flagHasManagedAuth,
             gettingStarted: true,
             slack: flagHasSlack,

--- a/packages/types/lib/web/env.ts
+++ b/packages/types/lib/web/env.ts
@@ -16,6 +16,7 @@ export interface WindowEnv {
         logs: boolean;
         scripts: boolean;
         auth: boolean;
+        allowSignup: boolean;
         managedAuth: boolean;
         gettingStarted: boolean;
         slack: boolean;

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -16,6 +16,7 @@ export const ENVS = z.object({
     NANGO_DASHBOARD_USERNAME: z.string().optional(),
     NANGO_DASHBOARD_PASSWORD: z.string().optional(),
     LOCAL_NANGO_USER_ID: z.coerce.number().optional(),
+    AUTH_ALLOW_SIGNUP: z.stringbool().optional().default(true),
 
     // API
     NANGO_PORT: z.coerce.number().optional().default(3003), // Sync those two ports?


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Signup flow gated by new env toggle**

Introduces a configurable guard on non-invite signup flows by adding the `AUTH_ALLOW_SIGNUP` environment flag (default `true`). The flag is parsed via `packages/utils/lib/environment/parse.ts`, injected into both regular and WorkOS-managed signup controllers, and surfaced to the client configuration payload through `packages/server/lib/controllers/v1/getEnvJs.ts` and `packages/types/lib/web/env.ts`.

<details>
<summary><strong>Key Changes</strong></summary>

• Parsed new `AUTH_ALLOW_SIGNUP` flag in `packages/utils/lib/environment/parse.ts` with a default of `true`.
• Blocked regular account creation in `packages/server/lib/controllers/v1/account/signup.ts` when `envs.AUTH_ALLOW_SIGNUP` is falsy, returning `403`.
• Guarded WorkOS-managed regular signups in `packages/server/lib/controllers/v1/account/managed/getCallback.ts` using the same `envs.AUTH_ALLOW_SIGNUP` check.
• Exposed the flag to the dashboard environment payload via `packages/server/lib/controllers/v1/getEnvJs.ts` and updated the `WindowEnv` type in `packages/types/lib/web/env.ts`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/v1/account/signup.ts`
• `packages/server/lib/controllers/v1/account/managed/getCallback.ts`
• `packages/server/lib/controllers/v1/getEnvJs.ts`
• `packages/types/lib/web/env.ts`
• `packages/utils/lib/environment/parse.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*