### PR TITLE
fix(cli): don't generate for sync if an action is passed in

### DIFF
--- a/packages/cli/lib/services/test.service.ts
+++ b/packages/cli/lib/services/test.service.ts
@@ -88,7 +88,15 @@ export function validateAndFilterIntegrations({
  * When actionName is specified, syncs should be skipped (user only wants action tests).
  * When syncName is specified, only the matching sync should be processed.
  */
-export function shouldProcessSync({ currentSyncName, syncName, actionName }: { currentSyncName: string; syncName?: string; actionName?: string }): boolean {
+export function shouldProcessSync({
+    currentSyncName,
+    syncName,
+    actionName
+}: {
+    currentSyncName: string;
+    syncName: string | undefined;
+    actionName: string | undefined;
+}): boolean {
     // Skip all syncs if actionName is specified (user only wants action tests)
     if (actionName) {
         return false;
@@ -111,8 +119,8 @@ export function shouldProcessAction({
     actionName
 }: {
     currentActionName: string;
-    syncName?: string;
-    actionName?: string;
+    syncName: string | undefined;
+    actionName: string | undefined;
 }): boolean {
     // Skip all actions if syncName is specified (user only wants sync tests)
     if (syncName) {

--- a/packages/cli/lib/services/test.service.unit.cli-test.ts
+++ b/packages/cli/lib/services/test.service.unit.cli-test.ts
@@ -382,22 +382,22 @@ describe('validateAndFilterIntegrations', () => {
 describe('shouldProcessSync', () => {
     describe('when no filters are provided', () => {
         it('should return true for any sync', () => {
-            expect(shouldProcessSync({ currentSyncName: 'fetch-users' })).toBe(true);
-            expect(shouldProcessSync({ currentSyncName: 'fetch-repos' })).toBe(true);
+            expect(shouldProcessSync({ currentSyncName: 'fetch-users', syncName: undefined, actionName: undefined })).toBe(true);
+            expect(shouldProcessSync({ currentSyncName: 'fetch-repos', syncName: undefined, actionName: undefined })).toBe(true);
         });
     });
 
     describe('when actionName is provided', () => {
         it('should return false for all syncs (user only wants action tests)', () => {
-            expect(shouldProcessSync({ currentSyncName: 'fetch-users', actionName: 'create-user' })).toBe(false);
-            expect(shouldProcessSync({ currentSyncName: 'fetch-repos', actionName: 'create-user' })).toBe(false);
+            expect(shouldProcessSync({ currentSyncName: 'fetch-users', syncName: undefined, actionName: 'create-user' })).toBe(false);
+            expect(shouldProcessSync({ currentSyncName: 'fetch-repos', syncName: undefined, actionName: 'create-user' })).toBe(false);
         });
     });
 
     describe('when syncName is provided', () => {
         it('should return true only for the matching sync', () => {
-            expect(shouldProcessSync({ currentSyncName: 'fetch-users', syncName: 'fetch-users' })).toBe(true);
-            expect(shouldProcessSync({ currentSyncName: 'fetch-repos', syncName: 'fetch-users' })).toBe(false);
+            expect(shouldProcessSync({ currentSyncName: 'fetch-users', syncName: 'fetch-users', actionName: undefined })).toBe(true);
+            expect(shouldProcessSync({ currentSyncName: 'fetch-repos', syncName: 'fetch-users', actionName: undefined })).toBe(false);
         });
     });
 
@@ -411,22 +411,22 @@ describe('shouldProcessSync', () => {
 describe('shouldProcessAction', () => {
     describe('when no filters are provided', () => {
         it('should return true for any action', () => {
-            expect(shouldProcessAction({ currentActionName: 'create-user' })).toBe(true);
-            expect(shouldProcessAction({ currentActionName: 'delete-user' })).toBe(true);
+            expect(shouldProcessAction({ currentActionName: 'create-user', syncName: undefined, actionName: undefined })).toBe(true);
+            expect(shouldProcessAction({ currentActionName: 'delete-user', syncName: undefined, actionName: undefined })).toBe(true);
         });
     });
 
     describe('when syncName is provided', () => {
         it('should return false for all actions (user only wants sync tests)', () => {
-            expect(shouldProcessAction({ currentActionName: 'create-user', syncName: 'fetch-users' })).toBe(false);
-            expect(shouldProcessAction({ currentActionName: 'delete-user', syncName: 'fetch-users' })).toBe(false);
+            expect(shouldProcessAction({ currentActionName: 'create-user', syncName: 'fetch-users', actionName: undefined })).toBe(false);
+            expect(shouldProcessAction({ currentActionName: 'delete-user', syncName: 'fetch-users', actionName: undefined })).toBe(false);
         });
     });
 
     describe('when actionName is provided', () => {
         it('should return true only for the matching action', () => {
-            expect(shouldProcessAction({ currentActionName: 'create-user', actionName: 'create-user' })).toBe(true);
-            expect(shouldProcessAction({ currentActionName: 'delete-user', actionName: 'create-user' })).toBe(false);
+            expect(shouldProcessAction({ currentActionName: 'create-user', syncName: undefined, actionName: 'create-user' })).toBe(true);
+            expect(shouldProcessAction({ currentActionName: 'delete-user', syncName: undefined, actionName: 'create-user' })).toBe(false);
         });
     });
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Ensure CLI test generation respects sync/action filters**

Introduces helper predicates `shouldProcessSync` and `shouldProcessAction` to clarify filter precedence within `generateTests` and prevent sync tests from being generated when an `actionName` filter is supplied. Unit tests have been expanded to cover permutations of `syncName` and `actionName` inputs, validating the new branching logic.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `shouldProcessSync` and `shouldProcessAction` helpers in `packages/cli/lib/services/test.service.ts` to encapsulate filter precedence rules.
• Updated `generateTests` to rely on the new helpers when iterating syncs/actions, skipping sync generation whenever `actionName` is provided and vice versa.
• Extended `packages/cli/lib/services/test.service.unit.cli-test.ts` with targeted coverage for the helper logic and its treatment of combined filters.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/cli/lib/services/test.service.ts
• packages/cli/lib/services/test.service.unit.cli-test.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*