### PR TITLE
feat(webhooks): add support for fathom webhook

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -4876,6 +4876,8 @@ fathom:
                 content-type: application/json
             endpoints:
                 - /external/v1/teams
+    webhook_routing_script: fathomWebhookRouting
+    webhook_user_defined_secret: true
     docs: https://nango.dev/docs/integrations/all/fathom
     docs_connect: https://nango.dev/docs/integrations/all/fathom/connect
     credentials:
@@ -4899,6 +4901,8 @@ fathom-oauth:
         grant_type: authorization_code
     refresh_params:
         grant_type: refresh_token
+    webhook_routing_script: fathomWebhookRouting
+    webhook_user_defined_secret: true
     proxy:
         base_url: https://api.fathom.ai
         retry:

--- a/packages/server/lib/webhook/fathom-webhook-routing.ts
+++ b/packages/server/lib/webhook/fathom-webhook-routing.ts
@@ -1,0 +1,81 @@
+import crypto from 'node:crypto';
+
+import { NangoError } from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
+
+import type { FathomWebhookResponse, WebhookHandler } from './types.js';
+
+// https://developers.fathom.ai/webhooks#verifying-webhooks
+// built from the Fathom sdk
+function validate(secret: string, msgId: string, msgSignature: string, msgTimestamp: string, rawBody: string | Buffer): boolean {
+    let actualSecret: Buffer;
+    if (secret.startsWith('whsec_')) {
+        actualSecret = Buffer.from(secret.substring(6), 'base64');
+    } else {
+        actualSecret = Buffer.from(secret, 'base64');
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    const timestamp = parseInt(msgTimestamp, 10);
+    const tolerance = 5 * 60;
+
+    if (isNaN(timestamp) || now - timestamp > tolerance || timestamp > now + tolerance) {
+        return false;
+    }
+
+    const payloadString = Buffer.isBuffer(rawBody) ? rawBody.toString('utf8') : rawBody;
+
+    const timestampNumber = Math.floor(timestamp);
+    const toSign = `${msgId}.${timestampNumber}.${payloadString}`;
+
+    const expected = crypto.createHmac('sha256', actualSecret).update(toSign, 'utf8').digest('base64');
+
+    const passedSignatures = msgSignature.split(' ');
+
+    for (const versionedSignature of passedSignatures) {
+        const [_version, signature] = versionedSignature.split(',');
+
+        if (!signature) {
+            return false;
+        }
+
+        if (crypto.timingSafeEqual(Buffer.from(signature, 'base64'), Buffer.from(expected, 'base64'))) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+const route: WebhookHandler<FathomWebhookResponse> = async (nango, headers, body, rawBody) => {
+    if (nango.integration.custom?.['webhookSecret']) {
+        const msgId = headers['webhook-id'] || headers['svix-id'];
+        const msgSignature = headers['webhook-signature'] || headers['svix-signature'];
+        const msgTimestamp = headers['webhook-timestamp'] || headers['svix-timestamp'];
+
+        if (!msgId || !msgSignature || !msgTimestamp) {
+            return Err(new NangoError('webhook_missing_signature'));
+        }
+
+        if (!validate(nango.integration.custom['webhookSecret'], msgId, msgSignature, msgTimestamp, rawBody)) {
+            return Err(new NangoError('webhook_invalid_signature'));
+        }
+    }
+
+    const emailAddress = body.recorded_by?.email;
+
+    const response = await nango.executeScriptForWebhooks({
+        body,
+        connectionIdentifierValue: emailAddress,
+        propName: 'metadata.emailAddress'
+    });
+
+    return Ok({
+        content: { status: 'success' },
+        statusCode: 200,
+        connectionIds: response?.connectionIds || [],
+        toForward: body
+    });
+};
+
+export default route;

--- a/packages/server/lib/webhook/index.ts
+++ b/packages/server/lib/webhook/index.ts
@@ -25,4 +25,5 @@ export { default as connectwisePsaWebhookRouting } from './connectwise-psa-webho
 export { default as shipstationWebhookRouting } from './shipstation-webhook-routing.js';
 export { default as googleCalendarWebhookRouting } from './google-calendar-webhook-routing.js';
 export { default as sellsyWebhookRouting } from './sellsy-webhook-routing.js';
+export { default as fathomWebhookRouting } from './fathom-webhook-routing.js';
 export type * from './types.js';

--- a/packages/server/lib/webhook/types.ts
+++ b/packages/server/lib/webhook/types.ts
@@ -271,3 +271,94 @@ export interface SellsyWebhookPayload {
     relatedobject: Record<string, any>;
     individual: boolean;
 }
+
+interface CalendarInvitee {
+    name: string | null;
+    email: string | null;
+    email_domain: string | null;
+    is_external: boolean;
+    matched_speaker_display_name?: string | null;
+}
+
+interface RecordedBy {
+    name: string;
+    email: string;
+    email_domain: string;
+    team: string | null;
+}
+
+interface Speaker {
+    display_name: string;
+    matched_calendar_invitee_email: string | null;
+}
+
+interface TranscriptEntry {
+    speaker: Speaker;
+    text: string;
+    timestamp: string;
+}
+
+interface DefaultSummary {
+    template_name: string | null;
+    markdown_formatted: string | null;
+}
+
+interface Assignee {
+    name: string | null;
+    email: string | null;
+    team: string | null;
+}
+
+interface ActionItem {
+    description: string;
+    user_generated: boolean;
+    completed: boolean;
+    recording_timestamp: string;
+    recording_playback_url: string;
+    assignee: Assignee;
+}
+
+interface CRMContact {
+    name: string;
+    email: string;
+    record_url: string;
+}
+
+interface CRMCompany {
+    name: string;
+    record_url: string;
+}
+
+interface CRMDeal {
+    name: string;
+    amount: number;
+    record_url: string;
+}
+
+interface CRMMatches {
+    contacts: CRMContact[];
+    companies: CRMCompany[];
+    deals: CRMDeal[];
+    error: string | null;
+}
+
+export interface FathomWebhookResponse {
+    title: string;
+    meeting_title: string | null;
+    recording_id: number;
+    url: string;
+    share_url: string;
+    created_at: string;
+    scheduled_start_time: string;
+    scheduled_end_time: string;
+    recording_start_time: string;
+    recording_end_time: string;
+    calendar_invitees_domains_type: 'only_internal' | 'one_or_more_external';
+    transcript_language: string;
+    calendar_invitees: CalendarInvitee[];
+    recorded_by: RecordedBy;
+    transcript: TranscriptEntry[] | null;
+    default_summary?: DefaultSummary;
+    action_items: ActionItem[] | null;
+    crm_matches?: CRMMatches;
+}


### PR DESCRIPTION
## Describe the problem and your solution

- add support for fathom webhook

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Fathom webhook routing support**

Introduces full webhook handling for Fathom by defining payload typings, adding a route that verifies Svix-style signatures, and wiring the handler into the webhook registry. Provider metadata now exposes the new routing script and allows customers to supply their own webhook secret for both API key and OAuth integrations.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `FathomWebhookResponse` interfaces to `packages/server/lib/webhook/types.ts` describing the inbound payload schema.
• Implemented `packages/server/lib/webhook/fathom-webhook-routing.ts` to validate webhook signatures, execute user scripts, and return forwarding metadata.
• Registered `fathomWebhookRouting` in `packages/providers/providers.yaml` for both Fathom auth modes and exported the handler via `packages/server/lib/webhook/index.ts`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/webhook/types.ts
• packages/server/lib/webhook/fathom-webhook-routing.ts
• packages/providers/providers.yaml
• packages/server/lib/webhook/index.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*