### PR TITLE
feat(records): add pruned_at column to records table

### DIFF
--- a/docs/reference/sdks/node.mdx
+++ b/docs/reference/sdks/node.mdx
@@ -1262,6 +1262,72 @@ This endpoint returns a list of records, ordered by modification date ascending.
 ```
 </Expandable>
 
+### Prune records
+
+Prunes record payloads from Nango's cache for a given model and connection up to a specified cursor. The payload is emptied but record metadata is retained. Payload can be restored by re-syncing the data.
+
+```ts
+const result = await nango.pruneRecords({
+    providerConfigKey: '<INTEGRATION-ID>',
+    connectionId: '<CONNECTION-ID>',
+    model: '<MODEL-NAME>',
+    untilCursor: '<CURSOR>'
+});
+
+console.log(`Pruned ${result.count} records. More records available: ${result.has_more}`);
+```
+
+**Parameters**
+
+<Expandable>
+  <ResponseField name="config" type="object" required>
+    <Expandable title="config" defaultOpen>
+      <ResponseField name="providerConfigKey" type="string" required>
+        The integration ID.
+      </ResponseField>
+
+      <ResponseField name="connectionId" type="string" required>
+        The connection ID.
+      </ResponseField>
+
+      <ResponseField name="model" type="string" required>
+        The name of the model from which to prune records.
+      </ResponseField>
+
+      <ResponseField name="variant" type="string">
+        The variant of the model. When omitted, the default base variant is used.
+      </ResponseField>
+
+      <ResponseField name="untilCursor" type="string" required>
+        The cursor up to which records should be pruned. Only records with a cursor less than or equal to this value will be pruned.
+      </ResponseField>
+
+      <ResponseField name="limit" type="number">
+        The maximum number of records to prune in this operation.
+      </ResponseField>
+    </Expandable>
+  </ResponseField>
+</Expandable>
+
+**Response**
+
+<Expandable>
+```json
+{
+    "count": 150,
+    "has_more": true
+}
+```
+
+<ResponseField name="count" type="number">
+  The number of records that were pruned in this operation.
+</ResponseField>
+
+<ResponseField name="has_more" type="boolean">
+  Indicates whether there are more records available for pruning that match the criteria. If `true`, you must call the method again to continue pruning records.
+</ResponseField>
+</Expandable>
+
 ### Trigger sync(s)
 
 Triggers an additional, one-off execution of specified sync(s) for a given connection or all applicable connections if no connection is specified.

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -1376,6 +1376,12 @@ paths:
                                                             type: string
                                                             description: The current cursor of the record. Use this to fetch records updated after this record
                                                             example: 'MjAyNC0wMy0wNFQwNjo1OTo1MS40NzE0NDEtMDU6MDB8fDE1Y2NjODA1LTY0ZDUtNDk0MC1hN2UwLTQ1ZmM3MDQ5OTdhMQ=='
+                                                        pruned_at:
+                                                            anyOf:
+                                                                - type: string
+                                                                  format: date-time
+                                                                - type: 'null'
+                                                            description: The timestamp at which the record payload was pruned (emptied)
                                     next_cursor:
                                         type: string
                                         description: The base64-encoded cursor for pagination
@@ -1385,51 +1391,18 @@ paths:
                 '401':
                     $ref: '#/components/responses/Unauthorized'
 
-        delete:
-            summary: Delete records
+    /records/prune:
+        patch:
+            summary: Prune records
             description: |-
-                Deletes synced records for a given connection and model using cursor-based pagination.
+                Prunes synced records for a given connection and model using cursor-based pagination.
 
-                **Deletion modes:**
-                - `soft`: Empties the record payload and marks as deleted. The record metadata is preserved.
-                - `hard`: Permanently removes the record entries.
+                **What is pruning:**
+                Pruning empties the record payload while preserving the record metadata.
 
                 **Cursor behavior:**
-                Records are deleted up to and including the specified cursor.
+                Records are pruned up to and including the specified cursor.
             parameters:
-                - name: model
-                  in: query
-                  required: true
-                  schema:
-                      type: string
-                  description: The data model to delete records from
-                - name: variant
-                  in: query
-                  required: false
-                  schema:
-                      type: string
-                  description: The variant of the model
-                - name: mode
-                  in: query
-                  required: true
-                  schema:
-                      type: string
-                      enum: [soft, hard]
-                  description: The deletion mode - 'soft' empties the payload, 'hard' permanently deletes the records
-                - name: until_cursor
-                  in: query
-                  required: true
-                  schema:
-                      type: string
-                  description: Delete all records up to and including this cursor. Use the cursor value from _nango_metadata.cursor of the record you want to delete up to.
-                - name: limit
-                  in: query
-                  required: false
-                  schema:
-                      type: integer
-                      minimum: 1
-                      maximum: 10000
-                  description: The maximum number of records to delete in this request. Defaults to 1000.
                 - name: Connection-Id
                   in: header
                   required: true
@@ -1442,10 +1415,34 @@ paths:
                   description: The integration ID used to create the connection (aka Unique Key).
                   schema:
                       type: string
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            required:
+                                - model
+                                - until_cursor
+                            properties:
+                                model:
+                                    type: string
+                                    description: The data model to prune records from
+                                variant:
+                                    type: string
+                                    description: The variant of the model
+                                until_cursor:
+                                    type: string
+                                    description: Prune all records up to and including this cursor. Use the cursor value from _nango_metadata.cursor of the record you want to prune up to.
+                                limit:
+                                    type: integer
+                                    minimum: 1
+                                    maximum: 10000
+                                    description: The maximum number of records to prune in this request. Defaults to 1000.
 
             responses:
                 '200':
-                    description: Successfully deleted records
+                    description: Successfully pruned records
                     content:
                         application/json:
                             schema:
@@ -1456,14 +1453,14 @@ paths:
                                 properties:
                                     count:
                                         type: integer
-                                        description: The number of records deleted in this request
+                                        description: The number of records pruned in this request
                                         example: 150
                                     has_more:
                                         type: boolean
                                         description: |-
-                                            Indicates if there are potentially more records to delete.
-                                            - `true`: There may be more records that need deletion
-                                            - `false`: All records up to the cursor have been deleted
+                                            Indicates if there are potentially more records to prune.
+                                            - `true`: There may be more records that need pruning
+                                            - `false`: All records up to the cursor have been pruned
                                         example: true
                 '400':
                     $ref: '#/components/responses/BadRequest'

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -538,6 +538,7 @@ export class Nango {
      * =======
      * SYNCS
      *      GET RECORDS
+     *      DELETE RECORDS
      *      TRIGGER
      *      START
      *      PAUSE
@@ -592,6 +593,47 @@ export class Nango {
 
         const response = await this.http.get(url, options);
 
+        return response.data;
+    }
+
+    /**
+     * Prunes records payload from Nango’s cache only, for a given model and connection, up to a specified cursor
+     * Payload is emptied but record metadata is retained. Payload can be restored by re-syncing the data.
+     * @param providerConfigKey - The key identifying the provider configuration on Nango
+     * @param connectionId - The ID of the connection for which to prune records
+     * @param model - The model from which to prune records
+     * @param variant - An optional variant of the model from which to prune records
+     * @param untilCursor - The cursor up to which records should be prune
+     * @param limit - An optional limit on the number of records to prune in this operation
+     * @returns A promise that resolves with an object containing the count of pruned records and a flag indicating if more records are available for pruning
+     */
+    public async pruneRecords({
+        providerConfigKey,
+        connectionId,
+        model,
+        variant,
+        untilCursor,
+        limit
+    }: {
+        providerConfigKey: string;
+        connectionId: string;
+        model: string;
+        variant?: string;
+        untilCursor: string;
+        limit?: number;
+    }): Promise<{ count: number; has_more: boolean }> {
+        const url = `${this.serverUrl}/records/prune`;
+        const headers = this.enrichHeaders({
+            'Connection-Id': connectionId,
+            'Provider-Config-Key': providerConfigKey
+        });
+        const body = {
+            model,
+            until_cursor: untilCursor,
+            ...(limit ? { limit } : {}),
+            ...(variant ? { variant } : {})
+        };
+        const response = await this.http.patch(url, body, { headers });
         return response.data;
     }
 

--- a/packages/records/lib/db/migrations/20251215191200_records_pruned_at.ts
+++ b/packages/records/lib/db/migrations/20251215191200_records_pruned_at.ts
@@ -1,0 +1,12 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.transaction(async (trx) => {
+        await trx.raw(`
+            ALTER TABLE "records"
+            ADD COLUMN IF NOT EXISTS pruned_at timestamp with time zone NULL;
+        `);
+    });
+}
+
+export async function down(): Promise<void> {}

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -181,6 +181,7 @@ export async function getRecords({
                 to_json(created_at) as first_seen_at,
                 to_json(updated_at) as last_modified_at,
                 to_json(deleted_at) as deleted_at,
+                to_json(pruned_at) as pruned_at,
                 CASE
                     WHEN deleted_at IS NOT NULL THEN 'DELETED'
                     WHEN created_at = updated_at THEN 'ADDED'
@@ -206,6 +207,7 @@ export async function getRecords({
                     last_modified_at: item.last_modified_at,
                     last_action: item.last_action,
                     deleted_at: item.deleted_at,
+                    pruned_at: item.pruned_at,
                     cursor: Cursor.new(item)
                 }
             });
@@ -703,39 +705,39 @@ export async function update({
  * @param environmentId - The id of the environment.
  * @param connectionId - The id of the connection.
  * @param model - The model name.
+ * @param mode - The deletion mode: 'hard' (permanent deletion), 'soft' (empty payload and set deleted_at) or 'prune' (empty payload only).
  * @param limit - The maximum number of records to delete.
  * @param toCursorIncluded - The cursor up to which records should be deleted (inclusive. ordered by updated_at, id).
  * @param batchSize - The number of records to delete in each batch (default is 1000).
- * @param mode - The deletion mode: 'hard' (permanent deletion) or 'soft' (empty payload and set deleted_at). Default is 'hard'.
  */
 export async function deleteRecords({
     connectionId,
     environmentId,
     model,
+    mode,
     limit,
     toCursorIncluded,
-    batchSize = 1000,
-    mode = 'hard'
+    batchSize = 1000
 }: {
     connectionId: number;
     environmentId: number;
     model: string;
+    mode: 'hard' | 'soft' | 'prune';
     limit?: number;
     toCursorIncluded?: string;
     batchSize?: number;
-    mode?: 'hard' | 'soft';
-}): Promise<Result<{ totalDeletedRecords: number; lastDeletedCursor: string | null }>> {
+}): Promise<Result<{ count: number; lastCursor: string | null }>> {
     const activeSpan = tracer.scope().active();
     const span = tracer.startSpan('nango.records.deletedRecords', {
         ...(activeSpan ? { childOf: activeSpan } : {}),
-        tags: { 'nango.connectionId': connectionId, 'nango.model': model }
+        tags: { 'nango.environmentId': environmentId, 'nango.connectionId': connectionId, 'nango.model': model, 'nango.deletionMode': mode }
     });
 
     let partition: string | undefined = undefined;
-    let totalDeletedRecords = 0;
-    let totalDeletedSizeInBytes = 0;
-    let deletedRecords = 0;
-    let lastDeletedCursor: string | null = null;
+    let totalRecords = 0;
+    let totalSizeInBytes = 0;
+    let paginatedRecords = 0;
+    let lastCursor: string | null = null;
 
     try {
         if (limit !== undefined && limit <= 0) {
@@ -756,12 +758,13 @@ export async function deleteRecords({
             await trx.raw(`SELECT pg_advisory_xact_lock(?) as lock_records_delete`, [newLockId(connectionId, model)]);
 
             do {
-                const toDelete = limit ? Math.min(batchSize, limit - totalDeletedRecords) : batchSize;
+                const toDelete = limit ? Math.min(batchSize, limit - totalRecords) : batchSize;
                 if (toDelete <= 0) {
                     break;
                 }
-                // if soft mode, we update the deleted_at/updated_at fields and empty the payload
                 // if hard mode, we permanently delete the records
+                // if soft mode, we update the deleted_at/updated_at fields
+                // if prune mode, we empty the record payload
                 const query = trx
                     .from(RECORDS_TABLE)
                     .where({ connection_id: connectionId, model })
@@ -780,7 +783,11 @@ export async function deleteRecords({
                             subQuery.whereRaw('(updated_at, id) <= (?, ?)', [decodedCursor.sort, decodedCursor.id]);
                         }
                         if (mode === 'soft') {
+                            // only soft delete non-deleted records
                             subQuery.whereNull('deleted_at');
+                        } else if (mode === 'prune') {
+                            // only prune non-pruned records
+                            subQuery.whereNull('pruned_at');
                         }
                     })
                     .returning<{ id: string; size_bytes: number; partition: string; updated_at: string }[]>([
@@ -789,12 +796,19 @@ export async function deleteRecords({
                         trx.raw('tableoid::regclass as partition'),
                         trx.raw('to_json(updated_at) as updated_at')
                     ]);
+
                 switch (mode) {
+                    case 'prune':
+                        query.update({
+                            pruned_at: now,
+                            json: {} // empty the record payload
+                            // IMPORTANT: updated_at isn't updated because it would cause the record cursor to also change
+                        });
+                        break;
                     case 'soft':
                         query.update({
                             deleted_at: now,
-                            json: {}
-                            // IMPORTANT: updated_at isn't updated because it would cause the record cursor to also change
+                            updated_at: now
                         });
                         break;
                     case 'hard':
@@ -804,25 +818,27 @@ export async function deleteRecords({
 
                 const res = await query;
 
-                deletedRecords = res.length;
-                totalDeletedRecords += deletedRecords;
-                totalDeletedSizeInBytes += res.reduce((acc, r) => acc + r.size_bytes, 0);
+                paginatedRecords = res.length;
+                totalRecords += paginatedRecords;
+                totalSizeInBytes += res.reduce((acc, r) => acc + r.size_bytes, 0);
                 if (!partition && res[0]?.partition) {
                     partition = res[0].partition;
                 }
 
                 const lastDeletedRecord = res[res.length - 1];
                 if (lastDeletedRecord) {
-                    lastDeletedCursor = Cursor.new({ id: lastDeletedRecord.id, last_modified_at: lastDeletedRecord.updated_at });
+                    lastCursor = Cursor.new({ id: lastDeletedRecord.id, last_modified_at: lastDeletedRecord.updated_at });
                 }
-            } while (deletedRecords > 0);
+            } while (paginatedRecords > 0);
 
+            // Update counts
+            const delta = mode === 'prune' ? 0 : -totalRecords; // pruning doesn't affect the records count
             const newCount = await incrCount(trx, {
                 environmentId,
                 connectionId,
                 model,
-                delta: -totalDeletedRecords,
-                deltaSizeInBytes: -totalDeletedSizeInBytes
+                delta,
+                deltaSizeInBytes: -totalSizeInBytes
             });
 
             // If all records are deleted, clean up the count entry
@@ -839,7 +855,7 @@ export async function deleteRecords({
             span.setTag('nango.partition', partition);
         }
 
-        return Ok({ totalDeletedRecords, lastDeletedCursor });
+        return Ok({ count: totalRecords, lastCursor });
     } catch (err) {
         span.setTag('error', err);
         return Err(new Error(`Failed to delete records connection ${connectionId}, model ${model}`, { cause: err }));

--- a/packages/records/lib/types.ts
+++ b/packages/records/lib/types.ts
@@ -45,6 +45,7 @@ interface RecordMetadata {
     last_modified_at: string;
     last_action: LastAction;
     deleted_at: string | null;
+    pruned_at: string | null;
     cursor: string;
 }
 

--- a/packages/server/lib/controllers/records/getRecords.integration.test.ts
+++ b/packages/server/lib/controllers/records/getRecords.integration.test.ts
@@ -136,6 +136,7 @@ describe(`GET ${route}`, () => {
                     _nango_metadata: {
                         cursor: expect.any(String),
                         deleted_at: null,
+                        pruned_at: null,
                         first_seen_at: expect.toBeIsoDateTimezone(),
                         last_action: 'ADDED',
                         last_modified_at: expect.toBeIsoDateTimezone()
@@ -147,6 +148,7 @@ describe(`GET ${route}`, () => {
                     _nango_metadata: {
                         cursor: expect.any(String),
                         deleted_at: null,
+                        pruned_at: null,
                         first_seen_at: expect.toBeIsoDateTimezone(),
                         last_action: 'ADDED',
                         last_modified_at: expect.toBeIsoDateTimezone()
@@ -173,6 +175,7 @@ describe(`GET ${route}`, () => {
                     _nango_metadata: {
                         cursor: expect.any(String),
                         deleted_at: null,
+                        pruned_at: null,
                         first_seen_at: expect.toBeIsoDateTimezone(),
                         last_action: 'ADDED',
                         last_modified_at: expect.toBeIsoDateTimezone()

--- a/packages/server/lib/crons/delete/deleteSyncData.ts
+++ b/packages/server/lib/crons/delete/deleteSyncData.ts
@@ -47,11 +47,12 @@ export async function deleteSyncData(sync: Sync, syncConfig: DBSyncConfig, opts:
                     connectionId: sync.nango_connection_id,
                     environmentId: syncConfig.environment_id,
                     model,
+                    mode: 'hard',
                     batchSize: limit
                 });
-                if (res.isOk() && res.value.totalDeletedRecords) {
-                    logger.info('deleted', res.value.totalDeletedRecords, 'records for model', model);
-                    return res.value.totalDeletedRecords;
+                if (res.isOk() && res.value.count) {
+                    logger.info('deleted', res.value.count, 'records for model', model);
+                    return res.value.count;
                 }
 
                 return 0;

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -43,8 +43,8 @@ import oauthController from './controllers/oauth.controller.js';
 import { getPublicProvider } from './controllers/providers/getProvider.js';
 import { getPublicProviders } from './controllers/providers/getProviders.js';
 import { allPublicProxy } from './controllers/proxy/allProxy.js';
-import { deletePublicRecords } from './controllers/records/deleteRecords.js';
 import { getPublicRecords } from './controllers/records/getRecords.js';
+import { patchPublicPruneRecords } from './controllers/records/patchPruneRecords.js';
 import { getPublicScriptsConfig } from './controllers/scripts/config/getScriptsConfig.js';
 import { deleteSyncVariant } from './controllers/sync/deleteSyncVariant.js';
 import { postDeployConfirmation } from './controllers/sync/deploy/postConfirmation.js';
@@ -199,7 +199,7 @@ publicAPI.route('/sync/update-connection-frequency').put(apiAuth, putSyncConnect
 
 publicAPI.use('/records', jsonContentTypeMiddleware);
 publicAPI.route('/records').get(apiAuth, getPublicRecords);
-publicAPI.route('/records').delete(apiAuth, deletePublicRecords);
+publicAPI.route('/records/prune').patch(apiAuth, patchPublicPruneRecords);
 
 publicAPI.use('/sync', jsonContentTypeMiddleware);
 publicAPI.route('/sync/trigger').post(apiAuth, postPublicTrigger);

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -48,12 +48,14 @@ export interface RecordsServiceInterface {
     deleteRecords({
         environmentId,
         connectionId,
-        model
+        model,
+        mode
     }: {
         environmentId: number;
         connectionId: number;
         model: string;
-    }): Promise<Result<{ totalDeletedRecords: number }>>;
+        mode: 'hard' | 'soft' | 'prune';
+    }): Promise<Result<{ count: number; lastCursor: string | null }>>;
     getCountsByModel({ connectionId, environmentId }: { connectionId: number; environmentId: number }): Promise<Result<Record<string, RecordCount>>>;
 }
 
@@ -592,7 +594,7 @@ export class Orchestrator {
                             if (syncVariant !== 'base') {
                                 model = `${model}::${syncVariant}`;
                             }
-                            const deletion = await recordsService.deleteRecords({ environmentId, connectionId, model });
+                            const deletion = await recordsService.deleteRecords({ environmentId, connectionId, model, mode: 'hard' });
                             if (deletion.isErr()) {
                                 void logCtx.error(`Records for model ${model} failed to be deleted`, { error: deletion.error });
                                 return Err(deletion.error);

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -68,7 +68,7 @@ import type { GetMeta } from './meta/api.js';
 import type { PostPlanExtendTrial } from './plans/http.api.js';
 import type { GetProvider, GetProviders, GetPublicProvider, GetPublicProviders } from './providers/api.js';
 import type { AllPublicProxy } from './proxy/http.api.js';
-import type { DeletePublicRecords, GetPublicRecords } from './record/api.js';
+import type { GetPublicRecords, PatchPublicPruneRecords } from './record/api.js';
 import type { GetPublicScriptsConfig } from './scripts/http.api.js';
 import type {
     GetSharedCredentialsProvider,
@@ -111,7 +111,7 @@ export type PublicApiEndpoints =
     | PostPublicTwoStepAuthorization
     | PostPublicWebhook
     | GetPublicRecords
-    | DeletePublicRecords
+    | PatchPublicPruneRecords
     | GetPublicScriptsConfig
     | PostPublicConnectTelemetry
     | PutPublicSyncConnectionFrequency

--- a/packages/types/lib/record/api.ts
+++ b/packages/types/lib/record/api.ts
@@ -8,6 +8,7 @@ export interface RecordMetadata {
     last_modified_at: string;
     last_action: RecordLastAction;
     deleted_at: string | null;
+    pruned_at: string | null;
     cursor: string;
 }
 
@@ -45,18 +46,17 @@ export type GetPublicRecords = Endpoint<{
     };
 }>;
 
-export type DeletePublicRecords = Endpoint<{
-    Method: 'DELETE';
-    Path: `/records`;
+export type PatchPublicPruneRecords = Endpoint<{
+    Method: 'PATCH';
+    Path: `/records/prune`;
     Headers: {
         'connection-id': string;
         'provider-config-key': string;
     };
     Error: ApiError<'unknown_connection'>;
-    Querystring: {
+    Body: {
         model: string;
         variant?: string | undefined;
-        mode: 'soft' | 'hard';
         until_cursor: string;
         limit?: number | undefined;
     };


### PR DESCRIPTION
companion PR (Read it first): https://github.com/NangoHQ/nango/pull/5152

<!-- Summary by @propel-code-bot -->

---

**Introduce record pruning API and metadata support**

Adds a nullable `pruned_at` column to records, exposes it via the records API and types, and replaces the former delete endpoint with a dedicated prune workflow. The records model now supports three deletion modes (hard/soft/prune), client SDKs and orchestrator callers are updated to consume the new PATCH `/records/prune` route, and documentation/tests reflect the revised metadata and request format.

<details>
<summary><strong>Key Changes</strong></summary>

• Added migration `packages/records/lib/db/migrations/20251215191200_records_pruned_at.ts` introducing nullable timestamp column `pruned_at` on `records`.
• Extended `packages/records/lib/models/records.ts` deletion logic to accept `mode: 'hard' | 'soft' | 'prune'`, emit `{ count, lastCursor }`, and track `pruned_at`/size deltas without adjusting counts for prune operations.
• Replaced the public DELETE `/records` route with PATCH `/records/prune` (`packages/server/lib/controllers/records/patchPruneRecords.ts`) including validation, response shape, and routing updates.
• Exposed pruning in clients and docs: added `pruneRecords` helper in `packages/node-client/lib/index.ts`, updated OpenAPI (`docs/spec.yaml`) and Node SDK docs.
• Updated orchestrator/cron consumers and tests to pass explicit deletion modes and expect the new `{ count, lastCursor }` structure.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `records` service deletion logic
• `/records` public API contract
• `node-client` SDK
• `docs/spec.yaml` and Node SDK docs
• Orchestrator cleanup flows and related tests

</details>

---
*This summary was automatically generated by @propel-code-bot*