### PR TITLE
feat: records pruning

### DIFF
--- a/docs/reference/sdks/node.mdx
+++ b/docs/reference/sdks/node.mdx
@@ -1262,6 +1262,72 @@ This endpoint returns a list of records, ordered by modification date ascending.
 ```
 </Expandable>
 
+### Prune records
+
+Prunes record payloads from Nango's cache for a given model and connection up to a specified cursor. The payload is emptied but record metadata is retained. Payload can be restored by re-syncing the data.
+
+```ts
+const result = await nango.pruneRecords({
+    providerConfigKey: '<INTEGRATION-ID>',
+    connectionId: '<CONNECTION-ID>',
+    model: '<MODEL-NAME>',
+    untilCursor: '<CURSOR>'
+});
+
+console.log(`Pruned ${result.count} records. More records available: ${result.has_more}`);
+```
+
+**Parameters**
+
+<Expandable>
+  <ResponseField name="config" type="object" required>
+    <Expandable title="config" defaultOpen>
+      <ResponseField name="providerConfigKey" type="string" required>
+        The integration ID.
+      </ResponseField>
+
+      <ResponseField name="connectionId" type="string" required>
+        The connection ID.
+      </ResponseField>
+
+      <ResponseField name="model" type="string" required>
+        The name of the model from which to prune records.
+      </ResponseField>
+
+      <ResponseField name="variant" type="string">
+        The variant of the model. When omitted, the default base variant is used.
+      </ResponseField>
+
+      <ResponseField name="untilCursor" type="string" required>
+        The cursor up to which records should be pruned. Only records with a cursor less than or equal to this value will be pruned.
+      </ResponseField>
+
+      <ResponseField name="limit" type="number">
+        The maximum number of records to prune in this operation.
+      </ResponseField>
+    </Expandable>
+  </ResponseField>
+</Expandable>
+
+**Response**
+
+<Expandable>
+```json
+{
+    "count": 150,
+    "has_more": true
+}
+```
+
+<ResponseField name="count" type="number">
+  The number of records that were pruned in this operation.
+</ResponseField>
+
+<ResponseField name="has_more" type="boolean">
+  Indicates whether there are more records available for pruning that match the criteria. If `true`, you must call the method again to continue pruning records.
+</ResponseField>
+</Expandable>
+
 ### Trigger sync(s)
 
 Triggers an additional, one-off execution of specified sync(s) for a given connection or all applicable connections if no connection is specified.

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -1376,6 +1376,12 @@ paths:
                                                             type: string
                                                             description: The current cursor of the record. Use this to fetch records updated after this record
                                                             example: 'MjAyNC0wMy0wNFQwNjo1OTo1MS40NzE0NDEtMDU6MDB8fDE1Y2NjODA1LTY0ZDUtNDk0MC1hN2UwLTQ1ZmM3MDQ5OTdhMQ=='
+                                                        pruned_at:
+                                                            anyOf:
+                                                                - type: string
+                                                                  format: date-time
+                                                                - type: 'null'
+                                                            description: The timestamp at which the record payload was pruned (emptied)
                                     next_cursor:
                                         type: string
                                         description: The base64-encoded cursor for pagination
@@ -1385,51 +1391,18 @@ paths:
                 '401':
                     $ref: '#/components/responses/Unauthorized'
 
-        delete:
-            summary: Delete records
+    /records/prune:
+        patch:
+            summary: Prune records
             description: |-
-                Deletes synced records for a given connection and model using cursor-based pagination.
+                Prunes synced records for a given connection and model using cursor-based pagination.
 
-                **Deletion modes:**
-                - `soft`: Empties the record payload and marks as deleted. The record metadata is preserved.
-                - `hard`: Permanently removes the record entries.
+                **What is pruning:**
+                Pruning empties the record payload while preserving the record metadata.
 
                 **Cursor behavior:**
-                Records are deleted up to and including the specified cursor.
+                Records are pruned up to and including the specified cursor.
             parameters:
-                - name: model
-                  in: query
-                  required: true
-                  schema:
-                      type: string
-                  description: The data model to delete records from
-                - name: variant
-                  in: query
-                  required: false
-                  schema:
-                      type: string
-                  description: The variant of the model
-                - name: mode
-                  in: query
-                  required: true
-                  schema:
-                      type: string
-                      enum: [soft, hard]
-                  description: The deletion mode - 'soft' empties the payload, 'hard' permanently deletes the records
-                - name: until_cursor
-                  in: query
-                  required: true
-                  schema:
-                      type: string
-                  description: Delete all records up to and including this cursor. Use the cursor value from _nango_metadata.cursor of the record you want to delete up to.
-                - name: limit
-                  in: query
-                  required: false
-                  schema:
-                      type: integer
-                      minimum: 1
-                      maximum: 10000
-                  description: The maximum number of records to delete in this request. Defaults to 1000.
                 - name: Connection-Id
                   in: header
                   required: true
@@ -1442,10 +1415,34 @@ paths:
                   description: The integration ID used to create the connection (aka Unique Key).
                   schema:
                       type: string
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            required:
+                                - model
+                                - until_cursor
+                            properties:
+                                model:
+                                    type: string
+                                    description: The data model to prune records from
+                                variant:
+                                    type: string
+                                    description: The variant of the model
+                                until_cursor:
+                                    type: string
+                                    description: Prune all records up to and including this cursor. Use the cursor value from _nango_metadata.cursor of the record you want to prune up to.
+                                limit:
+                                    type: integer
+                                    minimum: 1
+                                    maximum: 10000
+                                    description: The maximum number of records to prune in this request. Defaults to 1000.
 
             responses:
                 '200':
-                    description: Successfully deleted records
+                    description: Successfully pruned records
                     content:
                         application/json:
                             schema:
@@ -1456,14 +1453,14 @@ paths:
                                 properties:
                                     count:
                                         type: integer
-                                        description: The number of records deleted in this request
+                                        description: The number of records pruned in this request
                                         example: 150
                                     has_more:
                                         type: boolean
                                         description: |-
-                                            Indicates if there are potentially more records to delete.
-                                            - `true`: There may be more records that need deletion
-                                            - `false`: All records up to the cursor have been deleted
+                                            Indicates if there are potentially more records to prune.
+                                            - `true`: There may be more records that need pruning
+                                            - `false`: All records up to the cursor have been pruned
                                         example: true
                 '400':
                     $ref: '#/components/responses/BadRequest'

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -538,6 +538,7 @@ export class Nango {
      * =======
      * SYNCS
      *      GET RECORDS
+     *      DELETE RECORDS
      *      TRIGGER
      *      START
      *      PAUSE
@@ -592,6 +593,47 @@ export class Nango {
 
         const response = await this.http.get(url, options);
 
+        return response.data;
+    }
+
+    /**
+     * Prunes records payload from Nango’s cache only, for a given model and connection, up to a specified cursor
+     * Payload is emptied but record metadata is retained. Payload can be restored by re-syncing the data.
+     * @param providerConfigKey - The key identifying the provider configuration on Nango
+     * @param connectionId - The ID of the connection for which to prune records
+     * @param model - The model from which to prune records
+     * @param variant - An optional variant of the model from which to prune records
+     * @param untilCursor - The cursor up to which records should be prune
+     * @param limit - An optional limit on the number of records to prune in this operation
+     * @returns A promise that resolves with an object containing the count of pruned records and a flag indicating if more records are available for pruning
+     */
+    public async pruneRecords({
+        providerConfigKey,
+        connectionId,
+        model,
+        variant,
+        untilCursor,
+        limit
+    }: {
+        providerConfigKey: string;
+        connectionId: string;
+        model: string;
+        variant?: string;
+        untilCursor: string;
+        limit?: number;
+    }): Promise<{ count: number; has_more: boolean }> {
+        const url = `${this.serverUrl}/records/prune`;
+        const headers = this.enrichHeaders({
+            'Connection-Id': connectionId,
+            'Provider-Config-Key': providerConfigKey
+        });
+        const body = {
+            model,
+            until_cursor: untilCursor,
+            ...(limit ? { limit } : {}),
+            ...(variant ? { variant } : {})
+        };
+        const response = await this.http.patch(url, body, { headers });
         return response.data;
     }
 

--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -1213,6 +1213,8 @@ describe('Records service', () => {
             ];
             await upsertRecords({ records, connectionId, environmentId, model, syncId });
 
+            const statsBefore = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
+
             const recs = (await Records.getRecords({ connectionId, model })).unwrap();
             const last = recs.records[recs.records.length - 1]!;
             const cursor = last._nango_metadata.cursor;
@@ -1242,6 +1244,11 @@ describe('Records service', () => {
                     expect(r._nango_metadata.pruned_at).not.toBeNull();
                 }
             });
+
+            // count should remain the same but size should be reduced
+            const stats = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
+            expect(stats[model]?.count).toBe(3);
+            expect(stats[model]?.size_bytes).toBeLessThan(statsBefore[model]?.size_bytes || 0);
         });
     });
 

--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -1009,8 +1009,8 @@ describe('Records service', () => {
             let stats = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
             expect(stats[model]?.count).toBe(records.length);
 
-            const deletedCount = (await Records.deleteRecords({ connectionId, environmentId, model, batchSize: 2 })).unwrap();
-            expect(deletedCount.totalDeletedRecords).toBe(records.length);
+            const deletedCount = (await Records.deleteRecords({ connectionId, environmentId, model, mode: 'hard', batchSize: 2 })).unwrap();
+            expect(deletedCount.count).toBe(records.length);
 
             stats = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
             expect(stats[model]).toBe(undefined);
@@ -1038,8 +1038,8 @@ describe('Records service', () => {
             expect(initialStats[model]?.count).toBe(5);
             const initialSize = initialStats[model]?.size_bytes || 0;
 
-            const deletedCount = (await Records.deleteRecords({ connectionId, environmentId, model, limit: 3 })).unwrap();
-            expect(deletedCount.totalDeletedRecords).toBe(3);
+            const deletedCount = (await Records.deleteRecords({ connectionId, environmentId, model, mode: 'hard', limit: 3 })).unwrap();
+            expect(deletedCount.count).toBe(3);
 
             const finalStats = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
             expect(finalStats[model]?.count).toBe(2);
@@ -1061,8 +1061,8 @@ describe('Records service', () => {
             ];
             await upsertRecords({ records, connectionId, environmentId, model, syncId });
 
-            const deletedCount = (await Records.deleteRecords({ connectionId, environmentId, model, limit: 2 })).unwrap();
-            expect(deletedCount.totalDeletedRecords).toBe(2);
+            const deletedCount = (await Records.deleteRecords({ connectionId, environmentId, model, mode: 'hard', limit: 2 })).unwrap();
+            expect(deletedCount.count).toBe(2);
 
             const finalStats = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
             expect(finalStats[model]).toBeUndefined();
@@ -1073,13 +1073,13 @@ describe('Records service', () => {
             const environmentId = rnd.number();
             const model = rnd.string();
 
-            const zeroResult = await Records.deleteRecords({ connectionId, environmentId, model, limit: 0 });
+            const zeroResult = await Records.deleteRecords({ connectionId, environmentId, model, mode: 'hard', limit: 0 });
             expect(zeroResult.isErr()).toBe(true);
             if (zeroResult.isErr()) {
                 expect(zeroResult.error.message).toBe('limit must be greater than 0');
             }
 
-            const negativeResult = await Records.deleteRecords({ connectionId, environmentId, model, limit: -5 });
+            const negativeResult = await Records.deleteRecords({ connectionId, environmentId, model, mode: 'hard', limit: -5 });
             expect(negativeResult.isErr()).toBe(true);
             if (negativeResult.isErr()) {
                 expect(negativeResult.error.message).toBe('limit must be greater than 0');
@@ -1118,13 +1118,14 @@ describe('Records service', () => {
                     connectionId,
                     environmentId,
                     model,
+                    mode: 'hard',
                     toCursorIncluded: someRecordCursor!,
                     limit: 100
                 })
             ).unwrap();
 
-            expect(deletion.totalDeletedRecords).toBe(toDelete);
-            expect(deletion.lastDeletedCursor).toBe(someRecordCursor);
+            expect(deletion.count).toBe(toDelete);
+            expect(deletion.lastCursor).toBe(someRecordCursor);
 
             const remaining = (await Records.getRecords({ connectionId, model })).unwrap();
             expect(remaining.records.length).toBe(records.length - toDelete);
@@ -1136,15 +1137,15 @@ describe('Records service', () => {
             expect(stats[model]?.count).toBe(records.length - toDelete);
         });
 
-        it('should return null lastDeletedCursor when no records deleted', async () => {
+        it('should return null lastCursor when no records deleted', async () => {
             const connectionId = rnd.number();
             const environmentId = rnd.number();
             const model = rnd.string();
 
-            const deleteResult = (await Records.deleteRecords({ connectionId, environmentId, model })).unwrap();
+            const deleteResult = (await Records.deleteRecords({ connectionId, environmentId, model, mode: 'hard' })).unwrap();
 
-            expect(deleteResult.totalDeletedRecords).toBe(0);
-            expect(deleteResult.lastDeletedCursor).toBeNull();
+            expect(deleteResult.count).toBe(0);
+            expect(deleteResult.lastCursor).toBeNull();
         });
 
         it('should respect cursor boundary when deleting in batches', async () => {
@@ -1168,13 +1169,14 @@ describe('Records service', () => {
                     connectionId,
                     environmentId,
                     model,
+                    mode: 'hard',
                     toCursorIncluded: twelfthRecordCursor!,
                     batchSize: 7
                 })
             ).unwrap();
 
-            expect(deleteResult.totalDeletedRecords).toBe(12);
-            expect(deleteResult.lastDeletedCursor).toBe(twelfthRecordCursor);
+            expect(deleteResult.count).toBe(12);
+            expect(deleteResult.lastCursor).toBe(twelfthRecordCursor);
 
             const remainingRecords = (await Records.getRecords({ connectionId, model })).unwrap();
             expect(remainingRecords.records.length).toBe(8);
@@ -1189,6 +1191,7 @@ describe('Records service', () => {
                 connectionId,
                 environmentId,
                 model,
+                mode: 'hard',
                 toCursorIncluded: 'invalid-cursor-value'
             });
 
@@ -1198,7 +1201,7 @@ describe('Records service', () => {
             }
         });
 
-        it('should prune records when mode = soft', async () => {
+        it('should prune records when mode = prune', async () => {
             const connectionId = rnd.number();
             const environmentId = rnd.number();
             const model = rnd.string();
@@ -1214,32 +1217,29 @@ describe('Records service', () => {
             const last = recs.records[recs.records.length - 1]!;
             const cursor = last._nango_metadata.cursor;
 
-            // update last record to ensure it is not deleted and correct cursor is returned
+            // update last record to ensure it is not pruned and correct cursor is returned
             await upsertRecords({ records: [{ id: last.id, name: 'Maxwell Doe' }], connectionId, environmentId, model, syncId });
 
             // prune all records but the last one that was just updated
-            const prune = (await Records.deleteRecords({ connectionId, environmentId, model, mode: 'soft', toCursorIncluded: cursor })).unwrap();
-            expect(prune.totalDeletedRecords).toBe(2);
-            expect(prune.lastDeletedCursor).toBe(recs.records[recs.records.length - 2]!._nango_metadata.cursor); // second last record's cursor since last record was updated and not deleted
+            const prune = (await Records.deleteRecords({ connectionId, environmentId, model, mode: 'prune', toCursorIncluded: cursor })).unwrap();
+            expect(prune.count).toBe(2);
+            expect(prune.lastCursor).toBe(recs.records[recs.records.length - 2]!._nango_metadata.cursor); // second last record's cursor since last record was updated and not deleted
 
-            // try to prune again, should not delete any records
-            const prune2 = (await Records.deleteRecords({ connectionId, environmentId, model, mode: 'soft', toCursorIncluded: cursor })).unwrap();
-            expect(prune2.totalDeletedRecords).toBe(0);
-            expect(prune2.lastDeletedCursor).toBeNull();
-
-            const stats = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
-            expect(stats[model]?.count).toBe(1);
+            // try to prune again, should not do anything
+            const prune2 = (await Records.deleteRecords({ connectionId, environmentId, model, mode: 'prune', toCursorIncluded: cursor })).unwrap();
+            expect(prune2.count).toBe(0);
+            expect(prune2.lastCursor).toBeNull();
 
             const res = (await Records.getRecords({ connectionId, model })).unwrap();
             expect(res.records.length).toBe(3);
             res.records.forEach((r) => {
                 if (r.id === last.id) {
                     expect(r._nango_metadata.last_action).toBe('UPDATED');
-                    expect(r._nango_metadata.deleted_at).toBeNull();
+                    expect(r._nango_metadata.pruned_at).toBeNull();
                 } else {
                     expect(r.id).toBeDefined();
-                    expect(r._nango_metadata.last_action).toBe('DELETED');
-                    expect(r._nango_metadata.deleted_at).not.toBeNull();
+                    expect(r._nango_metadata.last_action).toBe('ADDED');
+                    expect(r._nango_metadata.pruned_at).not.toBeNull();
                 }
             });
         });

--- a/packages/records/lib/types.ts
+++ b/packages/records/lib/types.ts
@@ -45,6 +45,7 @@ interface RecordMetadata {
     last_modified_at: string;
     last_action: LastAction;
     deleted_at: string | null;
+    pruned_at: string | null;
     cursor: string;
 }
 

--- a/packages/server/lib/controllers/records/getRecords.integration.test.ts
+++ b/packages/server/lib/controllers/records/getRecords.integration.test.ts
@@ -136,6 +136,7 @@ describe(`GET ${route}`, () => {
                     _nango_metadata: {
                         cursor: expect.any(String),
                         deleted_at: null,
+                        pruned_at: null,
                         first_seen_at: expect.toBeIsoDateTimezone(),
                         last_action: 'ADDED',
                         last_modified_at: expect.toBeIsoDateTimezone()
@@ -147,6 +148,7 @@ describe(`GET ${route}`, () => {
                     _nango_metadata: {
                         cursor: expect.any(String),
                         deleted_at: null,
+                        pruned_at: null,
                         first_seen_at: expect.toBeIsoDateTimezone(),
                         last_action: 'ADDED',
                         last_modified_at: expect.toBeIsoDateTimezone()
@@ -173,6 +175,7 @@ describe(`GET ${route}`, () => {
                     _nango_metadata: {
                         cursor: expect.any(String),
                         deleted_at: null,
+                        pruned_at: null,
                         first_seen_at: expect.toBeIsoDateTimezone(),
                         last_action: 'ADDED',
                         last_modified_at: expect.toBeIsoDateTimezone()

--- a/packages/server/lib/crons/delete/deleteSyncData.ts
+++ b/packages/server/lib/crons/delete/deleteSyncData.ts
@@ -47,11 +47,12 @@ export async function deleteSyncData(sync: Sync, syncConfig: DBSyncConfig, opts:
                     connectionId: sync.nango_connection_id,
                     environmentId: syncConfig.environment_id,
                     model,
+                    mode: 'hard',
                     batchSize: limit
                 });
-                if (res.isOk() && res.value.totalDeletedRecords) {
-                    logger.info('deleted', res.value.totalDeletedRecords, 'records for model', model);
-                    return res.value.totalDeletedRecords;
+                if (res.isOk() && res.value.count) {
+                    logger.info('deleted', res.value.count, 'records for model', model);
+                    return res.value.count;
                 }
 
                 return 0;

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -43,8 +43,8 @@ import oauthController from './controllers/oauth.controller.js';
 import { getPublicProvider } from './controllers/providers/getProvider.js';
 import { getPublicProviders } from './controllers/providers/getProviders.js';
 import { allPublicProxy } from './controllers/proxy/allProxy.js';
-import { deletePublicRecords } from './controllers/records/deleteRecords.js';
 import { getPublicRecords } from './controllers/records/getRecords.js';
+import { patchPublicPruneRecords } from './controllers/records/patchPruneRecords.js';
 import { getPublicScriptsConfig } from './controllers/scripts/config/getScriptsConfig.js';
 import { deleteSyncVariant } from './controllers/sync/deleteSyncVariant.js';
 import { postDeployConfirmation } from './controllers/sync/deploy/postConfirmation.js';
@@ -199,7 +199,7 @@ publicAPI.route('/sync/update-connection-frequency').put(apiAuth, putSyncConnect
 
 publicAPI.use('/records', jsonContentTypeMiddleware);
 publicAPI.route('/records').get(apiAuth, getPublicRecords);
-publicAPI.route('/records').delete(apiAuth, deletePublicRecords);
+publicAPI.route('/records/prune').patch(apiAuth, patchPublicPruneRecords);
 
 publicAPI.use('/sync', jsonContentTypeMiddleware);
 publicAPI.route('/sync/trigger').post(apiAuth, postPublicTrigger);

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -48,12 +48,14 @@ export interface RecordsServiceInterface {
     deleteRecords({
         environmentId,
         connectionId,
-        model
+        model,
+        mode
     }: {
         environmentId: number;
         connectionId: number;
         model: string;
-    }): Promise<Result<{ totalDeletedRecords: number }>>;
+        mode: 'hard' | 'soft' | 'prune';
+    }): Promise<Result<{ count: number; lastCursor: string | null }>>;
     getCountsByModel({ connectionId, environmentId }: { connectionId: number; environmentId: number }): Promise<Result<Record<string, RecordCount>>>;
 }
 
@@ -592,7 +594,7 @@ export class Orchestrator {
                             if (syncVariant !== 'base') {
                                 model = `${model}::${syncVariant}`;
                             }
-                            const deletion = await recordsService.deleteRecords({ environmentId, connectionId, model });
+                            const deletion = await recordsService.deleteRecords({ environmentId, connectionId, model, mode: 'hard' });
                             if (deletion.isErr()) {
                                 void logCtx.error(`Records for model ${model} failed to be deleted`, { error: deletion.error });
                                 return Err(deletion.error);

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -68,7 +68,7 @@ import type { GetMeta } from './meta/api.js';
 import type { PostPlanExtendTrial } from './plans/http.api.js';
 import type { GetProvider, GetProviders, GetPublicProvider, GetPublicProviders } from './providers/api.js';
 import type { AllPublicProxy } from './proxy/http.api.js';
-import type { DeletePublicRecords, GetPublicRecords } from './record/api.js';
+import type { GetPublicRecords, PatchPublicPruneRecords } from './record/api.js';
 import type { GetPublicScriptsConfig } from './scripts/http.api.js';
 import type {
     GetSharedCredentialsProvider,
@@ -111,7 +111,7 @@ export type PublicApiEndpoints =
     | PostPublicTwoStepAuthorization
     | PostPublicWebhook
     | GetPublicRecords
-    | DeletePublicRecords
+    | PatchPublicPruneRecords
     | GetPublicScriptsConfig
     | PostPublicConnectTelemetry
     | PutPublicSyncConnectionFrequency

--- a/packages/types/lib/record/api.ts
+++ b/packages/types/lib/record/api.ts
@@ -8,6 +8,7 @@ export interface RecordMetadata {
     last_modified_at: string;
     last_action: RecordLastAction;
     deleted_at: string | null;
+    pruned_at: string | null;
     cursor: string;
 }
 
@@ -45,18 +46,17 @@ export type GetPublicRecords = Endpoint<{
     };
 }>;
 
-export type DeletePublicRecords = Endpoint<{
-    Method: 'DELETE';
-    Path: `/records`;
+export type PatchPublicPruneRecords = Endpoint<{
+    Method: 'PATCH';
+    Path: `/records/prune`;
     Headers: {
         'connection-id': string;
         'provider-config-key': string;
     };
     Error: ApiError<'unknown_connection'>;
-    Querystring: {
+    Body: {
         model: string;
         variant?: string | undefined;
-        mode: 'soft' | 'hard';
         until_cursor: string;
         limit?: number | undefined;
     };


### PR DESCRIPTION
Prerequesite: https://github.com/NangoHQ/nango/pull/5152

I misunderstood the requirements and thought pruning was linked to records deletion but records pruning is actually its own operation, independent to the concept of deleting a record.
This commit is removing the DELETE /records endpoint and replace it by PATCH /records/prune.
Records now have a pruned_at metadata to be able to track already pruned records since payload cannot be used at query time since it is encrypted. It is also a good idea to have it as an audit trail

I have kept the internal deleteRecords function in order to take advantage of the shared logic (pagination, etc...) even though the soft delete mode isn't currently used

Documentation update to come in next PR

<!-- Summary by @propel-code-bot -->

---

**Add record pruning endpoint and metadata tracking**

This PR replaces the previous `DELETE /records` API with a dedicated `PATCH /records/prune` endpoint that empties record payloads, sets a new `pruned_at` timestamp, and leaves metadata/counts in place. The change propagates through the records service, OpenAPI spec, node SDK, orchestrator cleanup flow, and both unit and integration tests so pruning can be initiated programmatically and reported back to clients.

<details>
<summary><strong>Key Changes</strong></summary>

• Expose `pruned_at` in records metadata, OpenAPI schema, integration tests, and the node client response types.
• Extend `records.deleteRecords` to support a new `'prune'` mode (no count decrement, size reduction only) and return `{ count, lastCursor }` for all modes.
• Replace the public `DELETE /records` route with `PATCH /records/prune`, validating request bodies and wiring the new handler through routing and SDK support.
• Update orchestrator and cleanup cron callers to pass an explicit deletion mode and to adapt to the updated result shape.
• Document the pruning workflow in the public API spec and Node SDK guide.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Public records API routing
• Records service deletion logic
• Node SDK (`packages/node-client/lib/index.ts`)
• OpenAPI spec and documentation
• Orchestrator cleanup flows and cron

</details>

---
*This summary was automatically generated by @propel-code-bot*