### PR TITLE
feat(providers-logo): add logo_url

### DIFF
--- a/docs/reference/api/providers/get.mdx
+++ b/docs/reference/api/providers/get.mdx
@@ -8,6 +8,7 @@ openapi: 'GET /providers/{provider}'
 {
   "data": {
     "name": "hubspot",
+    "logo_url": "https://app.nango.dev/images/template-logos/hubspot.svg",
     "display_name": "HubSpot",
     "categories": ["marketing","support","crm"],
     "auth_mode": "OAUTH2",

--- a/docs/reference/api/providers/list.mdx
+++ b/docs/reference/api/providers/list.mdx
@@ -9,6 +9,7 @@ openapi: 'GET /providers'
   "data": [
     {
       "name": "hubspot",
+      "logo_url": "https://app.nango.dev/images/template-logos/hubspot.svg",
       "display_name": "HubSpot",
       "categories": ["marketing","support","crm"],
       "auth_mode": "OAUTH2",
@@ -32,6 +33,7 @@ openapi: 'GET /providers'
     },
     {
       "name": "posthog",
+      "logo_url": "https://app.nango.dev/images/template-logos/posthog.svg",
       "display_name": "PostHog",
       "categories": ["dev-tools"],
       "auth_mode": "API_KEY",

--- a/packages/server/lib/controllers/providers/getProvider.integration.test.ts
+++ b/packages/server/lib/controllers/providers/getProvider.integration.test.ts
@@ -32,7 +32,7 @@ describe(`GET ${route}`, () => {
             data: {
                 display_name: 'HubSpot',
                 docs: 'https://nango.dev/docs/api-integrations/hubspot',
-                logoUrl: 'https://app.nango.dev/images/template-logos/hubspot.svg',
+                logo_url: 'https://app.nango.dev/images/template-logos/hubspot.svg',
                 name: 'hubspot',
                 auth_mode: 'OAUTH2'
             }

--- a/packages/server/lib/controllers/providers/getProvider.integration.test.ts
+++ b/packages/server/lib/controllers/providers/getProvider.integration.test.ts
@@ -32,6 +32,7 @@ describe(`GET ${route}`, () => {
             data: {
                 display_name: 'HubSpot',
                 docs: 'https://nango.dev/docs/api-integrations/hubspot',
+                logoUrl: 'https://app.nango.dev/images/template-logos/hubspot.svg',
                 name: 'hubspot',
                 auth_mode: 'OAUTH2'
             }

--- a/packages/server/lib/controllers/providers/getProvider.integration.test.ts
+++ b/packages/server/lib/controllers/providers/getProvider.integration.test.ts
@@ -32,7 +32,7 @@ describe(`GET ${route}`, () => {
             data: {
                 display_name: 'HubSpot',
                 docs: 'https://nango.dev/docs/api-integrations/hubspot',
-                logo_url: 'https://app.nango.dev/images/template-logos/hubspot.svg',
+                logo_url: 'http://localhost:3003/images/template-logos/hubspot.svg',
                 name: 'hubspot',
                 auth_mode: 'OAUTH2'
             }

--- a/packages/server/lib/controllers/providers/getProvider.ts
+++ b/packages/server/lib/controllers/providers/getProvider.ts
@@ -36,5 +36,5 @@ export const getPublicProvider = asyncWrapper<GetPublicProvider>((req, res) => {
         return;
     }
 
-    res.status(200).send({ data: { ...provider, name: params.provider, logoUrl: `${basePublicUrl}/images/template-logos/${params.provider}.svg` } });
+    res.status(200).send({ data: { ...provider, name: params.provider, logo_url: `${basePublicUrl}/images/template-logos/${params.provider}.svg` } });
 });

--- a/packages/server/lib/controllers/providers/getProvider.ts
+++ b/packages/server/lib/controllers/providers/getProvider.ts
@@ -1,7 +1,7 @@
 import * as z from 'zod';
 
 import { getProvider } from '@nangohq/shared';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { basePublicUrl, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { providerNameSchema } from '../../helpers/validation.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
@@ -36,5 +36,5 @@ export const getPublicProvider = asyncWrapper<GetPublicProvider>((req, res) => {
         return;
     }
 
-    res.status(200).send({ data: { ...provider, name: params.provider } });
+    res.status(200).send({ data: { ...provider, name: params.provider, logoUrl: `${basePublicUrl}/images/template-logos/${params.provider}.svg` } });
 });

--- a/packages/server/lib/controllers/providers/getProviders.integration.test.ts
+++ b/packages/server/lib/controllers/providers/getProviders.integration.test.ts
@@ -62,7 +62,7 @@ describe(`GET ${route}`, () => {
                 {
                     display_name: 'HubSpot',
                     docs: 'https://nango.dev/docs/api-integrations/hubspot',
-                    logoUrl: 'https://app.nango.dev/images/template-logos/hubspot.svg',
+                    logo_url: 'https://app.nango.dev/images/template-logos/hubspot.svg',
                     name: 'hubspot',
                     auth_mode: 'OAUTH2'
                 }

--- a/packages/server/lib/controllers/providers/getProviders.integration.test.ts
+++ b/packages/server/lib/controllers/providers/getProviders.integration.test.ts
@@ -62,6 +62,7 @@ describe(`GET ${route}`, () => {
                 {
                     display_name: 'HubSpot',
                     docs: 'https://nango.dev/docs/api-integrations/hubspot',
+                    logoUrl: 'https://app.nango.dev/images/template-logos/hubspot.svg',
                     name: 'hubspot',
                     auth_mode: 'OAUTH2'
                 }

--- a/packages/server/lib/controllers/providers/getProviders.integration.test.ts
+++ b/packages/server/lib/controllers/providers/getProviders.integration.test.ts
@@ -62,7 +62,7 @@ describe(`GET ${route}`, () => {
                 {
                     display_name: 'HubSpot',
                     docs: 'https://nango.dev/docs/api-integrations/hubspot',
-                    logo_url: 'https://app.nango.dev/images/template-logos/hubspot.svg',
+                    logo_url: 'http://localhost:3003/images/template-logos/hubspot.svg',
                     name: 'hubspot',
                     auth_mode: 'OAUTH2'
                 }

--- a/packages/server/lib/controllers/providers/getProviders.ts
+++ b/packages/server/lib/controllers/providers/getProviders.ts
@@ -1,7 +1,7 @@
 import * as z from 'zod';
 
 import { getProviders } from '@nangohq/shared';
-import { zodErrorToHTTP } from '@nangohq/utils';
+import { basePublicUrl, zodErrorToHTTP } from '@nangohq/utils';
 
 import { providerConfigKeySchema } from '../../helpers/validation.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
@@ -35,12 +35,16 @@ export const getPublicProviders = asyncWrapper<GetPublicProviders>((req, res) =>
         const reg = new RegExp(queries.search, 'i');
         for (const providerName of Object.keys(providers)) {
             if (reg.test(providerName)) {
-                filtered.push({ ...providers[providerName]!, name: providerName });
+                filtered.push({
+                    ...providers[providerName]!,
+                    name: providerName,
+                    logoUrl: `${basePublicUrl}/images/template-logos/${providerName}.svg`
+                });
             }
         }
     } else {
         filtered = Object.entries(providers).map(([name, provider]) => {
-            return { ...provider, name };
+            return { ...provider, name, logoUrl: `${basePublicUrl}/images/template-logos/${name}.svg` };
         });
     }
 

--- a/packages/server/lib/controllers/providers/getProviders.ts
+++ b/packages/server/lib/controllers/providers/getProviders.ts
@@ -38,13 +38,13 @@ export const getPublicProviders = asyncWrapper<GetPublicProviders>((req, res) =>
                 filtered.push({
                     ...providers[providerName]!,
                     name: providerName,
-                    logoUrl: `${basePublicUrl}/images/template-logos/${providerName}.svg`
+                    logo_url: `${basePublicUrl}/images/template-logos/${providerName}.svg`
                 });
             }
         }
     } else {
         filtered = Object.entries(providers).map(([name, provider]) => {
-            return { ...provider, name, logoUrl: `${basePublicUrl}/images/template-logos/${name}.svg` };
+            return { ...provider, name, logo_url: `${basePublicUrl}/images/template-logos/${name}.svg` };
         });
     }
 

--- a/packages/types/lib/providers/api.ts
+++ b/packages/types/lib/providers/api.ts
@@ -10,7 +10,7 @@ export type GetPublicProviders = Endpoint<{
         data: ApiProvider[];
     };
 }>;
-export type ApiProvider = Provider & { name: string; logoUrl: string };
+export type ApiProvider = Provider & { name: string; logo_url: string };
 
 export type GetPublicProvider = Endpoint<{
     Method: 'GET';

--- a/packages/types/lib/providers/api.ts
+++ b/packages/types/lib/providers/api.ts
@@ -10,7 +10,7 @@ export type GetPublicProviders = Endpoint<{
         data: ApiProvider[];
     };
 }>;
-export type ApiProvider = Provider & { name: string };
+export type ApiProvider = Provider & { name: string; logoUrl: string };
 
 export type GetPublicProvider = Endpoint<{
     Method: 'GET';


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Expose provider logo URLs via public provider endpoints**

Adds computed `logo_url` values to the `GET /providers` and `GET /providers/:provider` responses by deriving image paths from `basePublicUrl`. Aligns the `ApiProvider` type, integration tests, and API reference examples with the new response property.

<details>
<summary><strong>Key Changes</strong></summary>

• Computed `logo_url` using `basePublicUrl` in `getPublicProviders` and `getPublicProvider` responses
• Extended the `ApiProvider` type definition to require a `logo_url` string
• Updated integration tests and provider API docs to assert and illustrate the `logo_url` field

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/controllers/providers/getProviders.ts
• packages/server/lib/controllers/providers/getProvider.ts
• packages/types/lib/providers/api.ts
• packages/server/lib/controllers/providers/getProviders.integration.test.ts
• packages/server/lib/controllers/providers/getProvider.integration.test.ts
• docs/reference/api/providers/list.mdx
• docs/reference/api/providers/get.mdx

</details>

---
*This summary was automatically generated by @propel-code-bot*