### PR TITLE
feat: add docs for records pruning feature

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1027,6 +1027,7 @@
                     "group": "Syncs",
                     "pages": [
                       "reference/api/sync/records-list",
+                      "reference/api/sync/prune-records",
                       "reference/api/sync/trigger",
                       "reference/api/sync/start",
                       "reference/api/sync/pause",

--- a/docs/reference/api/sync/prune-records.mdx
+++ b/docs/reference/api/sync/prune-records.mdx
@@ -1,0 +1,36 @@
+---
+title: 'Prune records'
+sidebarTitle: 'Prune records'
+openapi: 'PATCH /records/prune'
+---
+
+Prunes synced records for a given connection and model using cursor-based pagination.
+
+## What is pruning?
+
+Pruning empties the record payload while preserving the record metadata.
+This is useful for compliance requirements, ensuring Nango doesn't hold onto your records data while maintaining the ability to track record state. The payload can be restored by re-syncing the data.
+
+<Tip>
+Pruning is not the same as marking a record as deleted from the external API.
+This endpoint prunes data from Nango’s cache only. It does not delete anything on the external API, and it is not the same as [detecting a deletion from the source](/guides/use-cases/syncs#deletion-detection).
+
+If you need to tell your customers that a record was deleted on the external API while keeping its last-known payload in cache, use `batchDelete` or `deleteRecordsFromPreviousExecutions` in your sync functions instead.
+</Tip>
+
+## Cursor behavior
+
+Records are pruned up to and including the specified `until_cursor` value. Use the `_nango_metadata.cursor` value from the record you want to prune up to.
+
+## Response
+
+<Tip>
+The `has_more` field indicates whether there are potentially more records to prune. When `true`, make another request with the same `until_cursor` to continue pruning. When `false`, all records up to the cursor have been pruned.
+</Tip>
+
+```json
+{
+  "count": 150,
+  "has_more": true
+}
+```

--- a/docs/reference/functions.mdx
+++ b/docs/reference/functions.mdx
@@ -785,6 +785,14 @@ await nango.batchSave(githubIssues, 'GitHubIssue');
 
 Marks records as deleted in the Nango cache. Deleted records are still returned when you fetch them, but they are marked as deleted in the record's metadata (i.e. soft delete).
 
+<Tip>
+This does not remove cached payloads.
+
+`nango.batchDelete()` is used to mark records as deleted in Nango because they were deleted on the external API. Nango may still keep the last-known payload so your customer can react to the deletion event.
+
+If you want to permanently remove data from Nango storage for cost or compliance reasons, use [record pruning instead](/reference/api/sync/prune-records).
+</Tip>
+
 To implement deletion detection in your syncs, [follow this guide](/implementation-guides/syncs/deletion-detection).
 
 The only field that needs to be present in each record when calling `batchDelete` is the unique `id`; the other fields are ignored.
@@ -809,6 +817,14 @@ await nango.batchDelete(githubIssuesToDelete, 'GitHubIssue');
 ### Detect deletions automatically
 
 Automatically detects and marks records as deleted by comparing the current sync execution with the previous one.
+
+<Tip>
+This does not remove cached payloads.
+
+`nango.deleteRecordsFromPreviousExecutions()` is used to mark records as deleted in Nango because they were not returned by the external API. Nango may still keep the last-known payload so your customer can react to the deletion event.
+
+If you want to permanently remove data from Nango storage for cost or compliance reasons, use [record pruning instead](/reference/api/sync/prune-records).
+</Tip>
 
 ```js
 await nango.deleteRecordsFromPreviousExecutions('ModelName');


### PR DESCRIPTION
adding the `reference/api/sync/prune-records` page and callouts in `functions` page to mention the difference between records deletion and pruning

<!-- Summary by @propel-code-bot -->

---

**Document `PATCH /records/prune` endpoint and clarify deletion helpers**

Adds a new reference page for the `PATCH /records/prune` endpoint, describing pruning semantics, cursor handling, and response fields. Updates the `docs/reference/functions.mdx` tips to distinguish `nango.batchDelete()` and `nango.deleteRecordsFromPreviousExecutions()` from pruning, and registers the new page in `docs/docs.json` navigation.

<details>
<summary><strong>Key Changes</strong></summary>

• Created `docs/reference/api/sync/prune-records.mdx` covering pruning behavior, cursor usage, and the response contract for `PATCH /records/prune`.
• Inserted tips in `docs/reference/functions.mdx` to clarify that `nango.batchDelete()` and `nango.deleteRecordsFromPreviousExecutions()` perform soft deletes and link to pruning docs for payload removal.
• Added `reference/api/sync/prune-records` to the Syncs group in `docs/docs.json` so the new page appears in navigation.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Documentation site navigation (`docs/docs.json`)
• Sync API reference docs (`docs/reference/api/sync/prune-records.mdx`)
• Functions reference tips (`docs/reference/functions.mdx`)

</details>

---
*This summary was automatically generated by @propel-code-bot*