### PR TITLE
chore: fixedSizedMap utilt

### DIFF
--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -1,5 +1,5 @@
 import db from '@nangohq/database';
-import { flagHasPlan, isCloud, metrics, report } from '@nangohq/utils';
+import { FixedSizeMap, flagHasPlan, isCloud, metrics, report } from '@nangohq/utils';
 
 import environmentService, { hashSecretKey } from './environment.service.js';
 import { LogActionEnum } from '../models/Telemetry.js';
@@ -11,7 +11,7 @@ import encryptionManager from '../utils/encryption.manager.js';
 import type { Knex } from '@nangohq/database';
 import type { DBEnvironment, DBPlan, DBTeam } from '@nangohq/types';
 
-const hashLocalCache = new Map<string, string>();
+const hashLocalCache = new FixedSizeMap<string, string>(10_000);
 
 const freeEmailDomains = new Set([
     'gmail.com',

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -2,7 +2,7 @@ import tracer from 'dd-trace';
 
 import { getLocking } from '@nangohq/kvstore';
 import { getProvider } from '@nangohq/providers';
-import { Err, Ok, getLogger, metrics } from '@nangohq/utils';
+import { Err, FixedSizeMap, Ok, getLogger, metrics } from '@nangohq/utils';
 
 import { decode as decodeJwt } from '../../../auth/jwt.js';
 import providerClient from '../../../clients/provider.client.js';
@@ -63,10 +63,10 @@ interface RefreshProps {
 const logger = getLogger('connectionRefresh');
 
 // In-memory cache for in-flight refresh operations to collapse concurrent requests
-const inFlightRefreshes = new Map<
+const inFlightRefreshes = new FixedSizeMap<
     string,
     Promise<Result<{ connection: DBConnectionDecrypted; refreshed: boolean; credentials: RefreshableCredentials }, NangoInternalError>>
->();
+>(5_000);
 
 /**
  * Take a connection and try to refresh or test based on it's type

--- a/packages/utils/lib/index.ts
+++ b/packages/utils/lib/index.ts
@@ -25,3 +25,4 @@ export * from './version.js';
 export * from './wait.js';
 export * from './date.js';
 export * from './frequency.js';
+export * from './map.js';

--- a/packages/utils/lib/map.ts
+++ b/packages/utils/lib/map.ts
@@ -1,0 +1,71 @@
+/**
+ * A Fixed-Size Map implementation with write-based eviction policy.
+ *
+ * This class maintains a map with a maximum size. When the size limit is reached,
+ * the least recently written entry is automatically evicted upon adding a new entry.
+ *
+ * Important: Only write operations (set) update an entry's position, NOT read operations (get).
+ * This means entries are evicted based on when they were last written, not when they were last accessed.
+ * This is intentional to avoid the performance overhead of reordering on every read.
+ *
+ * @example
+ * ```typescript
+ * const cache = new FixedSizeMap<string, number>(1000);
+ * cache.set('key1', 100);    // Marks key1 as most recent
+ * cache.get('key1');         // Does NOT update position
+ * cache.set('key1', 200);    // Updates position again
+ * ```
+ *
+ * Performance characteristics:
+ * - get: O(1) - simple lookup, no reordering
+ * - set: O(1) - may delete and re-add to maintain write order
+ * - Memory: O(maxSize) bounded
+ */
+export class FixedSizeMap<K, V> {
+    private map: Map<K, V>;
+    private maxSize: number;
+
+    constructor(maxSize: number) {
+        if (maxSize <= 0) {
+            throw new Error('maxSize must be a positive integer.');
+        }
+        this.map = new Map<K, V>();
+        this.maxSize = maxSize;
+    }
+
+    get(key: K): V | undefined {
+        return this.map.get(key);
+    }
+
+    set(key: K, value: V): void {
+        // If key already exists, delete it first to maintain insertion order
+        // We are paying a small price in performance for this
+        // in order to keep frequently updated entries in the cache.
+        if (this.map.has(key)) {
+            this.map.delete(key);
+        }
+        // If at capacity, remove oldest entry (ie: first item in Map)
+        else if (this.map.size >= this.maxSize) {
+            const firstKey = this.map.keys().next().value as K;
+            this.map.delete(firstKey);
+        }
+
+        this.map.set(key, value);
+    }
+
+    has(key: K): boolean {
+        return this.map.has(key);
+    }
+
+    delete(key: K): boolean {
+        return this.map.delete(key);
+    }
+
+    clear(): void {
+        this.map.clear();
+    }
+
+    get size(): number {
+        return this.map.size;
+    }
+}

--- a/packages/utils/lib/map.unit.test.ts
+++ b/packages/utils/lib/map.unit.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+
+import { FixedSizeMap } from './map.js';
+
+describe('FixedSizeMap', () => {
+    describe('basic operations', () => {
+        it('should throw if maxSize is <= 0', () => {
+            expect(() => new FixedSizeMap<string, number>(0)).toThrow('maxSize must be a positive integer.');
+            expect(() => new FixedSizeMap<string, number>(-1)).toThrow('maxSize must be a positive integer.');
+        });
+        it('should set and get values', () => {
+            const map = new FixedSizeMap<string, number>(10);
+
+            map.set('key1', 100);
+            map.set('key2', 200);
+
+            expect(map.get('key1')).toBe(100);
+            expect(map.get('key2')).toBe(200);
+        });
+
+        it('should return undefined for non-existent keys', () => {
+            const map = new FixedSizeMap<string, number>(10);
+
+            expect(map.get('nonexistent')).toBeUndefined();
+        });
+
+        it('should check if key exists with has()', () => {
+            const map = new FixedSizeMap<string, number>(10);
+
+            map.set('key1', 100);
+
+            expect(map.has('key1')).toBe(true);
+            expect(map.has('key2')).toBe(false);
+        });
+
+        it('should delete entries', () => {
+            const map = new FixedSizeMap<string, number>(10);
+
+            map.set('key1', 100);
+            expect(map.has('key1')).toBe(true);
+
+            const deleted = map.delete('key1');
+
+            expect(deleted).toBe(true);
+            expect(map.has('key1')).toBe(false);
+            expect(map.get('key1')).toBeUndefined();
+        });
+
+        it('should return false when deleting non-existent key', () => {
+            const map = new FixedSizeMap<string, number>(10);
+
+            const deleted = map.delete('nonexistent');
+
+            expect(deleted).toBe(false);
+        });
+
+        it('should clear all entries', () => {
+            const map = new FixedSizeMap<string, number>(10);
+
+            map.set('key1', 100);
+            map.set('key2', 200);
+            map.set('key3', 300);
+
+            expect(map.size).toBe(3);
+
+            map.clear();
+
+            expect(map.size).toBe(0);
+            expect(map.has('key1')).toBe(false);
+            expect(map.has('key2')).toBe(false);
+            expect(map.has('key3')).toBe(false);
+        });
+
+        it('should track size correctly', () => {
+            const map = new FixedSizeMap<string, number>(10);
+
+            expect(map.size).toBe(0);
+
+            map.set('key1', 100);
+            expect(map.size).toBe(1);
+
+            map.set('key2', 200);
+            expect(map.size).toBe(2);
+
+            map.delete('key1');
+            expect(map.size).toBe(1);
+
+            map.clear();
+            expect(map.size).toBe(0);
+        });
+    });
+
+    describe('size limit enforcement', () => {
+        it('should not exceed max size', () => {
+            const map = new FixedSizeMap<string, number>(3);
+
+            map.set('key1', 1);
+            map.set('key2', 2);
+            map.set('key3', 3);
+
+            expect(map.size).toBe(3);
+
+            map.set('key4', 4);
+
+            expect(map.size).toBe(3);
+        });
+
+        it('should evict oldest entry when at capacity', () => {
+            const map = new FixedSizeMap<string, number>(3);
+
+            map.set('key1', 1);
+            map.set('key2', 2);
+            map.set('key3', 3);
+            map.set('key4', 4);
+
+            expect(map.has('key1')).toBe(false);
+            expect(map.has('key2')).toBe(true);
+            expect(map.has('key3')).toBe(true);
+            expect(map.has('key4')).toBe(true);
+            expect(map.size).toBe(3);
+        });
+
+        it('should evict in FIFO order when at capacity', () => {
+            const map = new FixedSizeMap<string, number>(3);
+
+            map.set('key1', 1);
+            map.set('key2', 2);
+            map.set('key3', 3);
+            map.set('key4', 4); // evicts key1
+            map.set('key5', 5); // evicts key2
+
+            expect(map.has('key1')).toBe(false);
+            expect(map.has('key2')).toBe(false);
+            expect(map.has('key3')).toBe(true);
+            expect(map.has('key4')).toBe(true);
+            expect(map.has('key5')).toBe(true);
+        });
+    });
+
+    describe('LRU behavior on writes', () => {
+        it('should update existing key without changing size', () => {
+            const map = new FixedSizeMap<string, number>(3);
+
+            map.set('key1', 1);
+            map.set('key2', 2);
+
+            expect(map.size).toBe(2);
+
+            map.set('key1', 100);
+
+            expect(map.size).toBe(2);
+            expect(map.get('key1')).toBe(100);
+        });
+
+        it('should move re-inserted key to most recent position', () => {
+            const map = new FixedSizeMap<string, number>(3);
+
+            map.set('key1', 1);
+            map.set('key2', 2);
+            map.set('key3', 3);
+
+            // Re-insert key1, making it most recent
+            map.set('key1', 100);
+
+            // Adding key4 should now evict key2 (oldest), not key1
+            map.set('key4', 4);
+
+            expect(map.has('key1')).toBe(true);
+            expect(map.has('key2')).toBe(false);
+            expect(map.has('key3')).toBe(true);
+            expect(map.has('key4')).toBe(true);
+        });
+
+        it('should handle multiple re-insertions correctly', () => {
+            const map = new FixedSizeMap<string, number>(3);
+
+            map.set('key1', 1);
+            map.set('key2', 2);
+            map.set('key3', 3);
+
+            // Re-insert
+            map.set('key1', 10);
+            map.set('key2', 20);
+            map.set('key1', 100);
+
+            // Order should now be: key3 (oldest), key2, key1 (newest)
+            // Adding key4 should evict key3
+            map.set('key4', 4);
+
+            expect(map.has('key1')).toBe(true);
+            expect(map.has('key2')).toBe(true);
+            expect(map.has('key3')).toBe(false); // evicted
+            expect(map.has('key4')).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
Long time due.

Implement a FixedSizeMap util class to use as bounded local cache. 
We are using `Map` in a few places as local caches. 
Even though their size under normal operations is likely to be very reasonable it is safer to be defensive to prevent high memory usage under extraordinary circumstances.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Introduce bounded `FixedSizeMap` utility and apply to caches**

Adds a reusable `FixedSizeMap` utility that enforces capacity-checked, write-ordered eviction and integrates it into existing in-memory caches.

Updates the credential refresh and account hashing services to cap cache entries, preventing unbounded growth while preserving current behavior, and supplies comprehensive unit coverage for the new utility.

<details>
<summary><strong>Key Changes</strong></summary>

• Implemented `FixedSizeMap` in `packages/utils/lib/map.ts` with O(1) `get`/`set`, FIFO eviction on writes, and input validation.
• Added exhaustive unit tests in `packages/utils/lib/map.unit.test.ts` covering basic CRUD usage, capacity enforcement, and write-order eviction semantics.
• Swapped unbounded `Map` usage for `FixedSizeMap` in `packages/shared/lib/services/connections/credentials/refresh.ts` (capacity `5_000`) and `packages/shared/lib/services/account.service.ts` (capacity `10_000`).
• Re-exported the new utility via `packages/utils/lib/index.ts` for downstream consumers.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/utils/lib/map.ts`
• `packages/utils/lib/map.unit.test.ts`
• `packages/shared/lib/services/connections/credentials/refresh.ts`
• `packages/shared/lib/services/account.service.ts`
• `packages/utils/lib/index.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*