### PR TITLE
fix(webhooks): use local server in tests

### DIFF
--- a/packages/webhooks/lib/asyncAction.unit.test.ts
+++ b/packages/webhooks/lib/asyncAction.unit.test.ts
@@ -1,19 +1,22 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { logContextGetter } from '@nangohq/logs';
 import { axiosInstance, stringifyStable } from '@nangohq/utils';
 
 import { sendAsyncActionWebhook } from './asyncAction.js';
+import { TestWebhookServer } from './helpers/test.js';
 
 import type { DBEnvironment, DBExternalWebhook } from '@nangohq/types';
 
 const spy = vi.spyOn(axiosInstance, 'post');
 
+const testServer = new TestWebhookServer(4100);
+
 const webhookSettings: DBExternalWebhook = {
     id: 1,
     environment_id: 1,
-    primary_url: 'http://example.com/webhook',
-    secondary_url: 'http://example.com/webhook-secondary',
+    primary_url: testServer.primaryUrl,
+    secondary_url: testServer.secondaryUrl,
     on_sync_completion_always: true,
     on_auth_creation: true,
     on_auth_refresh_error: true,
@@ -29,6 +32,14 @@ const environment = {
 } as DBEnvironment;
 
 describe('AsyncAction webhookds', () => {
+    beforeAll(async () => {
+        await testServer.start();
+    });
+
+    afterAll(async () => {
+        await testServer.stop();
+    });
+
     beforeEach(() => {
         vi.resetAllMocks();
     });

--- a/packages/webhooks/lib/forward.unit.test.ts
+++ b/packages/webhooks/lib/forward.unit.test.ts
@@ -1,13 +1,16 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { logContextGetter } from '@nangohq/logs';
 import { axiosInstance } from '@nangohq/utils';
 
 import { forwardWebhook } from './forward.js';
+import { TestWebhookServer } from './helpers/test.js';
 
 import type { DBEnvironment, DBExternalWebhook, DBTeam, IntegrationConfig } from '@nangohq/types';
 
 const spy = vi.spyOn(axiosInstance, 'post');
+
+const testServer = new TestWebhookServer(4102);
 
 const account: DBTeam = {
     id: 1,
@@ -21,8 +24,8 @@ const account: DBTeam = {
 const webhookSettings: DBExternalWebhook = {
     id: 1,
     environment_id: 1,
-    primary_url: 'http://example.com/webhook',
-    secondary_url: 'http://example.com/webhook-secondary',
+    primary_url: testServer.primaryUrl,
+    secondary_url: testServer.secondaryUrl,
     on_sync_completion_always: true,
     on_auth_creation: true,
     on_auth_refresh_error: true,
@@ -40,6 +43,14 @@ const integration = {
 } as IntegrationConfig;
 
 describe('Webhooks: forward notification tests', () => {
+    beforeAll(async () => {
+        await testServer.start();
+    });
+
+    afterAll(async () => {
+        await testServer.stop();
+    });
+
     beforeEach(() => {
         vi.resetAllMocks();
     });

--- a/packages/webhooks/lib/helpers/test.ts
+++ b/packages/webhooks/lib/helpers/test.ts
@@ -1,0 +1,40 @@
+import http from 'http';
+
+/**
+ * A simple HTTP server for testing webhook delivery.
+ * The server responds with 200 OK to all requests.
+ */
+export class TestWebhookServer {
+    private server: http.Server | null = null;
+    public readonly primaryUrl: string;
+    public readonly secondaryUrl: string;
+
+    constructor(private readonly port: number) {
+        this.primaryUrl = `http://localhost:${port}/webhook`;
+        this.secondaryUrl = `http://localhost:${port}/webhook-secondary`;
+    }
+
+    async start(): Promise<void> {
+        this.server = http.createServer((_, res) => {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ success: true }));
+        });
+
+        await new Promise<void>((resolve) => {
+            this.server!.listen(this.port, () => resolve());
+        });
+    }
+
+    async stop(): Promise<void> {
+        if (!this.server) {
+            return;
+        }
+
+        await new Promise<void>((resolve, reject) => {
+            this.server!.close((err) => {
+                if (err) reject(err);
+                else resolve();
+            });
+        });
+    }
+}


### PR DESCRIPTION
The webhooks tests have been flacky lately.
Tests in `webhooks` package are sending requests over the internet. Starting a local server to be used in the tests and avoid making requests over the network

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Local HTTP server replaces external endpoints in webhook tests**

Introduces a reusable `TestWebhookServer` helper that spins up a local HTTP endpoint responding with 200/JSON to eliminate real network calls from the webhook unit tests. All webhook-related test suites now create and tear down a dedicated server instance, update fixture URLs to use `TestWebhookServer` endpoints, and assert against the resolved URLs instead of hard-coded internet addresses.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `TestWebhookServer` helper in `packages/webhooks/lib/helpers/test.ts` to provide local webhook endpoints for tests.
• Updated `auth`, `sync`, `asyncAction`, and `forward` webhook unit tests to manage helper lifecycles with `beforeAll`/`afterAll` and reset mocks pre-test.
• Replaced hard-coded external URLs in expectations with `webhookSettings.primary_url`/`webhookSettings.secondary_url` drawn from the test server.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webhooks/lib/helpers/test.ts`
• `packages/webhooks/lib/auth.unit.test.ts`
• `packages/webhooks/lib/sync.unit.test.ts`
• `packages/webhooks/lib/asyncAction.unit.test.ts`
• `packages/webhooks/lib/forward.unit.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*