### PR TITLE
fix(docs): clarify Nango doesn't export otlp logs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -310,7 +310,7 @@
               "implementation-guides/platform/webhooks-from-nango",
               "implementation-guides/platform/contribute-new-api",
               "implementation-guides/platform/implement-event-handler",
-              "implementation-guides/platform/open-telemetry-logs-export",
+              "implementation-guides/platform/open-telemetry-export",
               "implementation-guides/platform/common-issues"
             ]
           },

--- a/docs/guides/platform/logs.mdx
+++ b/docs/guides/platform/logs.mdx
@@ -32,12 +32,12 @@ Nango provides detailed filtering and searching of log messages by integration, 
 
 We recommend exploring the logs in your own Nango account under **Logs**.
 
-## OpenTelemetry logs export
+## OpenTelemetry export
 
-Nango supports exporting logs with OpenTelemetry.
+Nango supports exporting OpenTelemetry traces.
 
 We recommend this for:
 - Advanced custom metrics
 - Advanced alerting and escalation paths (e.g., segment sync errors by customer account for customized escalation paths)
 
-To set up OpenTelemetry export, follow our [OpenTelemetry logs export setup guide](/implementation-guides/platform/open-telemetry-logs-export).
+To set up OpenTelemetry export, follow our [OpenTelemetry export setup guide](/implementation-guides/platform/open-telemetry-export).

--- a/docs/implementation-guides/platform/open-telemetry-export.mdx
+++ b/docs/implementation-guides/platform/open-telemetry-export.mdx
@@ -1,12 +1,12 @@
 ---
-title: 'Setup OpenTelemetry Logs Export'
+title: 'Setup OpenTelemetry Export'
 sidebarTitle: 'OpenTelemetry export setup'
-description: 'How to setup OpenTelemetry logs export in Nango'
+description: 'How to setup OpenTelemetry export in Nango'
 ---
 
 ## Overview
 
-Nango provides OpenTelemetry export to help you monitor and analyze your integration activities.
+Nango provides OpenTelemetry traces export to help you monitor and analyze your integration activities.
 
 By exporting operations as traces to your OpenTelemetry collector, you can gain valuable insights into your Nango usage and track various operations in real-time.
 

--- a/packages/webapp/src/pages/Environment/Settings/Export.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Export.tsx
@@ -109,7 +109,7 @@ export const ExportSettings: React.FC = () => {
                 <h3 className="uppercase text-sm">Export Settings</h3>
             </Link>
             <div className="px-8 flex flex-col gap-4 w-1/2">
-                <Link to="https://nango.dev/docs/implementation-guides/platform/open-telemetry-logs-export" className="flex gap-2 items-center" target="_blank">
+                <Link to="https://nango.dev/docs/implementation-guides/platform/open-telemetry-export" className="flex gap-2 items-center" target="_blank">
                     <label className="font-semibold">OpenTelemetry</label> <IconExternalLink stroke={1} size={18} />
                 </Link>
 


### PR DESCRIPTION
Making it slightly clearer that Nango doesn't support otlp logs and export the supported operations as traces

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Clarify OpenTelemetry documentation and update related links**

The PR updates OpenTelemetry documentation to clarify that Nango exports operations as OTLP traces rather than logs and aligns navigation metadata with the new wording. It also updates the dashboard help link to reference the renamed documentation slug.

<details>
<summary><strong>Key Changes</strong></summary>

• Adjusted front matter and overview text in `docs/implementation-guides/platform/open-telemetry-export.mdx` to describe OpenTelemetry trace export instead of logs.
• Updated `docs/guides/platform/logs.mdx` to refer to trace export and point to the new setup guide slug.
• Changed the navigation entry in `docs/docs.json` from `open-telemetry-logs-export` to `open-telemetry-export`.
• Pointed the OpenTelemetry help link in `packages/webapp/src/pages/Environment/Settings/Export.tsx` to the new documentation path.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• docs/implementation-guides/platform/open-telemetry-export.mdx
• docs/guides/platform/logs.mdx
• docs/docs.json
• packages/webapp/src/pages/Environment/Settings/Export.tsx

</details>

---
*This summary was automatically generated by @propel-code-bot*