### PR TITLE
fix(mcp): filter disabled actions

### DIFF
--- a/packages/server/lib/controllers/mcp/server.ts
+++ b/packages/server/lib/controllers/mcp/server.ts
@@ -43,12 +43,14 @@ export async function createMcpServerForConnection(
 
     server.setRequestHandler(ListToolsRequestSchema, () => {
         return {
-            tools: actions
-                .filter((action) => action.enabled)
-                .flatMap((action) => {
-                    const tool = actionToTool(action);
-                    return tool ? [tool] : [];
-                })
+            tools: actions.flatMap((action) => {
+                if (!action.enabled) {
+                    return [];
+                }
+
+                const tool = actionToTool(action);
+                return tool ? [tool] : [];
+            })
         };
     });
 

--- a/packages/server/lib/controllers/mcp/server.ts
+++ b/packages/server/lib/controllers/mcp/server.ts
@@ -43,10 +43,12 @@ export async function createMcpServerForConnection(
 
     server.setRequestHandler(ListToolsRequestSchema, () => {
         return {
-            tools: actions.flatMap((action) => {
-                const tool = actionToTool(action);
-                return tool ? [tool] : [];
-            })
+            tools: actions
+                .filter((action) => action.enabled)
+                .flatMap((action) => {
+                    const tool = actionToTool(action);
+                    return tool ? [tool] : [];
+                })
         };
     });
 


### PR DESCRIPTION
https://nangohq.slack.com/archives/C09TCKP2XFB/p1765916367791799

<!-- Summary by @propel-code-bot -->

---

**Filter out disabled MCP actions from tool listings**

Updates the MCP server `ListTools` handler to stop returning disabled actions. The handler now short-circuits within the existing `flatMap` so that only actions where `action.enabled` is truthy proceed to `actionToTool` conversion.

<details>
<summary><strong>Key Changes</strong></summary>

• Short-circuited the `actions.flatMap` logic in `packages/server/lib/controllers/mcp/server.ts` to return an empty array when `action.enabled` is falsy.
• Preserved the existing `actionToTool` conversion flow for enabled actions.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/mcp/server.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*