### PR TITLE
fix(proxy): preserve BigInt precision in JSON responses

### DIFF
--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -303,7 +303,7 @@ export function parseHeaders(req: Pick<Request, 'rawHeaders'>) {
     return forwardedHeaders;
 }
 
-async function handleResponse({ res, responseStream, logCtx }: { res: Response; responseStream: AxiosResponse; logCtx: LogContext }) {
+export async function handleResponse({ res, responseStream, logCtx }: { res: Response; responseStream: AxiosResponse; logCtx: LogContext }) {
     const contentType = responseStream.headers['content-type'] || '';
     const contentDisposition = responseStream.headers['content-disposition'] || '';
     const transferEncoding = responseStream.headers['transfer-encoding'] || '';
@@ -345,17 +345,15 @@ async function handleResponse({ res, responseStream, logCtx }: { res: Response; 
             return;
         }
 
-        if (!isJsonResponse) {
-            res.send(Buffer.concat(responseData));
-            await logCtx.success();
-            metrics.increment(metrics.Types.PROXY_SUCCESS);
-            return;
-        }
-
         try {
-            const parsedResponse = JSON.parse(Buffer.concat(responseData).toString());
+            if (isJsonResponse) {
+                // Validate JSON structure without re-serializing to avoid JSON.parse limitations (ex: precision loss with big integers)
+                // TODO: consider removing validation and forwarding upstream response as-is (even if invalid JSON) to avoid performance overhead
+                JSON.parse(Buffer.concat(responseData).toString());
+                res.setHeader('Content-Type', 'application/json');
+            }
 
-            res.json(parsedResponse);
+            res.send(Buffer.concat(responseData));
             metrics.increment(metrics.Types.PROXY_SUCCESS);
             await logCtx.success();
         } catch (err) {

--- a/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { Readable } from 'node:stream';
 
-import { parseHeaders } from './allProxy.js';
+import { describe, expect, it, vi } from 'vitest';
 
-import type { Request } from 'express';
+import { handleResponse, parseHeaders } from './allProxy.js';
+
+import type { LogContext } from '@nangohq/logs';
+import type { AxiosResponse } from 'axios';
+import type { Request, Response } from 'express';
 
 describe('parseHeaders', () => {
     it('should parse headers that starts with Nango-Proxy or nango-proxy', () => {
@@ -36,3 +40,118 @@ describe('parseHeaders', () => {
         expect(parsedHeaders).toEqual({});
     });
 });
+
+/* eslint-disable @typescript-eslint/unbound-method */
+describe('handleResponse', () => {
+    const mockLogCtx = {
+        success: vi.fn(),
+        failed: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn(),
+        accountId: 1
+    } as unknown as LogContext;
+    const createMockResponse = () => {
+        let sentData: Buffer | undefined;
+        const headers: Record<string, string> = {};
+        let statusCode = 200;
+        let sendResolve: (() => void) | undefined;
+        const sendPromise = new Promise<void>((resolve) => {
+            sendResolve = resolve;
+        });
+
+        return {
+            res: {
+                setHeader: vi.fn((name: string, value: string) => {
+                    headers[name] = value;
+                }),
+                send: vi.fn((data: Buffer) => {
+                    sentData = data;
+                    if (sendResolve) sendResolve();
+                }),
+                status: vi.fn((code: number) => {
+                    statusCode = code;
+                    return {
+                        end: vi.fn(() => {
+                            if (sendResolve) sendResolve();
+                        })
+                    };
+                }),
+                writeHead: vi.fn(),
+                end: vi.fn(() => {
+                    if (sendResolve) sendResolve();
+                })
+            } as unknown as Response,
+            getSentData: () => sentData,
+            getHeaders: () => headers,
+            getStatusCode: () => statusCode,
+            waitForSend: () => sendPromise
+        };
+    };
+
+    const createMockResponseStream = (data: string, contentType = 'application/json', status = 200): AxiosResponse => {
+        const stream = new Readable();
+        stream.push(data);
+        stream.push(null);
+
+        return {
+            status,
+            headers: {
+                'content-type': contentType
+            },
+            data: stream
+        } as unknown as AxiosResponse;
+    };
+
+    it('should handle 204 No Content response', async () => {
+        const mockRes = createMockResponse();
+        const mockResponseStream = createMockResponseStream('', 'application/json', 204);
+
+        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
+        await mockRes.waitForSend();
+
+        expect(mockRes.res.status).toHaveBeenCalledWith(204);
+        expect(mockLogCtx.success).toHaveBeenCalled();
+    });
+
+    it('should validate that response is valid JSON', async () => {
+        const validJson = '{"id": 123, "name": "test"}';
+        const mockRes = createMockResponse();
+        const mockResponseStream = createMockResponseStream(validJson);
+
+        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
+        await mockRes.waitForSend();
+
+        expect(mockRes.getSentData()!.toString()).toBe(validJson);
+        expect(mockLogCtx.success).toHaveBeenCalled();
+        expect(mockLogCtx.error).not.toHaveBeenCalled();
+    });
+
+    it('should handle invalid JSON in response', async () => {
+        const invalidJson = '{invalid json content}';
+        const mockRes = createMockResponse();
+        const mockResponseStream = createMockResponseStream(invalidJson);
+
+        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
+        await mockRes.waitForSend();
+
+        expect(mockRes.res.writeHead).toHaveBeenCalledWith(500, { 'Content-Type': 'application/json' });
+        expect(mockRes.res.end).toHaveBeenCalledWith(JSON.stringify({ error: 'Failed to parse JSON response' }));
+        expect(mockLogCtx.failed).toHaveBeenCalled();
+    });
+
+    it('should preserve BigInt values in JSON response without precision loss', async () => {
+        const jsonWithBigInt = `{"id": 7584781588001541408, "name": "test", "count": 42, "list": [12345678901234567890, 98765432109876543210]}`;
+
+        const mockRes = createMockResponse();
+        const mockResponseStream = createMockResponseStream(jsonWithBigInt);
+
+        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
+        await mockRes.waitForSend();
+
+        const sentData = mockRes.getSentData();
+        expect(sentData).toBeDefined();
+        expect(sentData!.toString()).toBe(jsonWithBigInt);
+        expect(mockLogCtx.success).toHaveBeenCalled();
+    });
+});
+/* eslint-enable @typescript-eslint/unbound-method */


### PR DESCRIPTION
Avoid precision loss with big integers by forwarding JSON responses as raw buffers instead of re-parsing/re-serializing.

Keeping the JSON validation behavior for now but we could revisit it at some point. The objective here is to unblock customers and fix the bigInt precision loss bug

<!-- Summary by @propel-code-bot -->

---

**Preserve BigInt precision in proxy JSON responses**

Exports `handleResponse` from `packages/server/lib/controllers/proxy/allProxy.ts` and changes JSON proxy handling so the upstream buffer is returned directly. JSON payloads are still validated by parsing a copy, while the response headers and logging/metrics flows remain intact. Unit coverage in `packages/server/lib/controllers/proxy/allProxy.unit.test.ts` now exercises 204 responses, invalid JSON handling, and a BigInt regression case.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `handleResponse` to stream non-buffered payloads unchanged and forward buffered responses using `res.send(Buffer.concat(responseData))` while setting `Content-Type` explicitly for JSON responses.
• Retained JSON validation by parsing a cloned buffer to detect invalid payloads without mutating the original stream, preserving BigInt precision.
• Exported `handleResponse` and expanded Vitest coverage to include BigInt, invalid JSON, and 204 No Content scenarios with mock `Response` objects.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/controllers/proxy/allProxy.ts
• packages/server/lib/controllers/proxy/allProxy.unit.test.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*