### PR TITLE
chore(webapp): Fix no hover pointer over buttons

### DIFF
--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -648,6 +648,11 @@
         width: 100%;
         height: 100%;
     }
+
+    button,
+    [role='button'] {
+        cursor: pointer;
+    }
 }
 
 .transparent-code .language-json {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
In Tailwind CSS. Starting from version 3.0, Tailwind's Preflight (base styles) intentionally does not set cursor: pointer on buttons. This is a philosophical design decision by the Tailwind team. IMO we should have the cursor pointer as it feels natural while browsing the web these days.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Ensure buttons show pointer cursor in webapp**

Adds a base CSS rule so `button` and `[role='button']` elements consistently show a pointer cursor, restoring expected hover behavior after Tailwind Preflight dropped the default.

<details>
<summary><strong>Key Changes</strong></summary>

• Added global `cursor: pointer` rule for `button` and `[role='button']` within the `@layer base` section of `packages/webapp/src/index.css`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/webapp/src/index.css

</details>

---
*This summary was automatically generated by @propel-code-bot*