### PR TITLE
fix(providers): add amazon selling partner `redirect_uri_metadata` config

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -696,6 +696,8 @@ amazon-selling-partner:
         grant_type: authorization_code
     refresh_params:
         grant_type: refresh_token
+    redirect_uri_metadata:
+        - selling_partner_id
     proxy:
         base_url: https://sellingpartnerapi-${connectionConfig.region}.amazon.com
         headers:
@@ -745,6 +747,8 @@ amazon-selling-partner-beta:
         grant_type: authorization_code
     refresh_params:
         grant_type: refresh_token
+    redirect_uri_metadata:
+        - selling_partner_id
     proxy:
         base_url: https://sandbox.sellingpartnerapi-${connectionConfig.region}.amazon.com
         headers:
@@ -9915,7 +9919,7 @@ pandadoc-api-key:
             headers:
                 content-type: application/json
             endpoints:
-                - /public/v1/logs
+                - /public/v1/members
         headers:
             authorization: API-Key ${apiKey}
     docs: https://nango.dev/docs/integrations/all/pandadoc-api-key

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -9919,7 +9919,7 @@ pandadoc-api-key:
             headers:
                 content-type: application/json
             endpoints:
-                - /public/v1/members
+                - /public/v1/members/current
         headers:
             authorization: API-Key ${apiKey}
     docs: https://nango.dev/docs/integrations/all/pandadoc-api-key


### PR DESCRIPTION
## Describe the problem and your solution

-  add amazon selling partner redirect_uri_metadata to extract the `selling_partner_id` from the callback url.
-  Update `pandadoc` verification endpoint to one that works even after the free trial expires. This was tested during the free trial period.

 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Amazon SP metadata capture and Pandadoc verification endpoint update**

Adds `redirect_uri_metadata` for the Amazon Selling Partner (production and beta) provider entries so the callback can capture `selling_partner_id`. Updates the Pandadoc API-key verification to use `/public/v1/members/current`, an endpoint that remains accessible beyond the free-trial period.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `redirect_uri_metadata` with `selling_partner_id` for both `amazon-selling-partner` and `amazon-selling-partner-beta` definitions in `packages/providers/providers.yaml`.
• Replaced the Pandadoc verification endpoint with `/public/v1/members/current` to avoid trial-only access.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/providers/providers.yaml

</details>

---
*This summary was automatically generated by @propel-code-bot*