### PR TITLE
fix: do not await slack when handling function success

### DIFF
--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -230,7 +230,7 @@ export async function handleActionSuccess({
         environment_id: nangoProps.environmentId,
         provider_config_key: nangoProps.providerConfigKey
     };
-    await slackService.removeFailingConnection({
+    void slackService.removeFailingConnection({
         connection,
         name: nangoProps.syncConfig.sync_name,
         type: 'action',

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -473,7 +473,7 @@ export async function handleSyncSuccess({
         }
         await setTaskSuccess({ taskId, output: null });
 
-        await slackService.removeFailingConnection({
+        void slackService.removeFailingConnection({
             connection,
             name: nangoProps.syncVariant === 'base' ? nangoProps.syncConfig.sync_name : `${nangoProps.syncConfig.sync_name}::${nangoProps.syncVariant}`,
             type: 'sync',


### PR DESCRIPTION
Some calls to slackService were still being awaited. We don't want to await SlackService function to prevent delaying the functions result processing when Slack is slow/ratelimiting/unresponsive. Other call to SlackService in the same files were already not awaited

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Avoid awaiting Slack cleanup during success handlers**

Updates `handleActionSuccess` and the sync success flow to fire-and-forget `slackService.removeFailingConnection` so Slack latency does not delay job completion. Aligns these success paths with other non-blocking Slack invocations already present in the codebase.

<details>
<summary><strong>Key Changes</strong></summary>

• Switched `slackService.removeFailingConnection` to run via `void` in `packages/jobs/lib/execution/action.ts` success handler
• Applied the same non-blocking pattern in `packages/jobs/lib/execution/sync.ts` success handler

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/jobs/lib/execution/action.ts
• packages/jobs/lib/execution/sync.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*