### PR TITLE
fix(scopes): allow spaces in scopes

### DIFF
--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.integration.test.ts
@@ -86,4 +86,21 @@ describe(`PATCH ${endpoint}`, () => {
             error: { code: 'invalid_body', message: "Can't rename an integration with active connections" }
         });
     });
+
+    it('should allow scopes with spaces', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            query: { env: 'dev' },
+            token: env.secret_key,
+            params: { providerConfigKey: 'github' },
+            body: { authType: 'OAUTH2', clientId: 'test-client', clientSecret: 'test-secret', scopes: 'read write,admin access' }
+        });
+
+        isSuccess(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            data: { success: true }
+        });
+    });
 });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
@@ -32,7 +32,7 @@ const validationBody = z
                         authType: z.enum(['OAUTH1', 'OAUTH2', 'TBA']),
                         clientId: z.string().min(1).max(255),
                         clientSecret: z.string().min(1),
-                        scopes: z.union([z.string().regex(/^[0-9a-zA-Z:/_.-]+(,[0-9a-zA-Z:/_.-]+)*$/), z.string().max(0)])
+                        scopes: z.union([z.string().regex(/^[0-9a-zA-Z:/_. -]+(,[0-9a-zA-Z:/_. -]+)*$/), z.string().max(0)])
                     })
                     .strict(),
                 z
@@ -56,7 +56,7 @@ const validationBody = z
                 z
                     .object({
                         authType: z.enum(['MCP_OAUTH2']),
-                        scopes: z.union([z.string().regex(/^[0-9a-zA-Z:/_.-]+(,[0-9a-zA-Z:/_.-]+)*$/), z.string().max(0)])
+                        scopes: z.union([z.string().regex(/^[0-9a-zA-Z:/_. -]+(,[0-9a-zA-Z:/_. -]+)*$/), z.string().max(0)])
                     })
                     .strict(),
                 z


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Allow spaces in scope validation**

Updates the OAuth credential validation in `patchIntegration.ts` so that `scopes` values can include space characters within each comma-delimited token. Adds an integration test covering a PATCH request with scopes containing spaces to ensure the controller accepts the updated format.

<details>
<summary><strong>Key Changes</strong></summary>

• Expanded the `scopes` regex in `patchIntegration.ts` to include space characters in each token.
• Added an integration test validating that PATCHing an integration with `scopes` value `read write,admin access` succeeds.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/v1/integrations/providerConfigKey`

</details>

---
*This summary was automatically generated by @propel-code-bot*