### PR TITLE
docs(client-id): update docs

### DIFF
--- a/docs/reference/sdks/node.mdx
+++ b/docs/reference/sdks/node.mdx
@@ -1907,7 +1907,18 @@ const { data } = await nango.createConnectSession({
   </ResponseField>
 
   <ResponseField name="integrations_config_defaults" type="object">
-    Default configuration for specific integrations.
+    Default configuration for specific integrations. For OAuth2 integrations, you can allow end-users to provide their own OAuth client credentials by setting empty `oauth_client_id_override` and `oauth_client_secret_override` values:
+    ```js
+    integrations_config_defaults: {
+      google: {
+        connection_config: {
+          oauth_client_id_override: '',
+          oauth_client_secret_override: ''
+        }
+      }
+    }
+    ```
+    When set to empty strings, Connect UI will display optional input fields for users to enter their own OAuth app credentials.
   </ResponseField>
 </Expandable>
 

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -2978,6 +2978,12 @@ components:
                                     oauth_scopes_override:
                                         type: string
                                         description: Override oauth scopes
+                                    oauth_client_id_override:
+                                        type: string
+                                        description: Set to empty string to allow end-users to provide their own OAuth client ID in Connect UI
+                                    oauth_client_secret_override:
+                                        type: string
+                                        description: Set to empty string to allow end-users to provide their own OAuth client secret in Connect UI
                 overrides:
                     type: object
                     additionalProperties:


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Document Connect UI OAuth client override behavior**

Updates Connect session documentation to explain how empty `oauth_client_id_override` and `oauth_client_secret_override` values in `integrations_config_defaults` prompt end-users for their own OAuth credentials. Mirrors that guidance in `docs/spec.yaml` so the OpenAPI schema includes the new field descriptions.

<details>
<summary><strong>Key Changes</strong></summary>

• Expanded `integrations_config_defaults` guidance in `docs/reference/sdks/node.mdx` with an OAuth override example and explanation of Connect UI behavior.
• Added descriptions for `oauth_client_id_override` and `oauth_client_secret_override` under the OpenAPI schema for `ConnectSessionInput` in `docs/spec.yaml`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs/reference/sdks/node.mdx`
• `docs/spec.yaml`

</details>

---
*This summary was automatically generated by @propel-code-bot*