### PR TITLE
fix(proxy): Proxy JSON validation from remote

### DIFF
--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -347,23 +347,24 @@ export async function handleResponse({ res, responseStream, logCtx }: { res: Res
 
         try {
             if (isJsonResponse) {
-                // Validate JSON structure without re-serializing to avoid JSON.parse limitations (ex: precision loss with big integers)
-                // TODO: consider removing validation and forwarding upstream response as-is (even if invalid JSON) to avoid performance overhead
-                JSON.parse(Buffer.concat(responseData).toString());
-                res.setHeader('Content-Type', 'application/json');
+                // Validate JSON structure without re-serializing to avoid JSON.parse limitations (ex: precision loss with big integers).
+                // TODO: consider removing validation and forwarding upstream response as-is (even if invalid JSON) to avoid performance overhead.
+                try {
+                    JSON.parse(Buffer.concat(responseData).toString());
+                    res.setHeader('Content-Type', 'application/json');
+                } catch (err) {
+                    res.writeHead(502, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ error: 'Failed to parse JSON response from upstream service' }));
+                    void logCtx.error('Failed to parse JSON response from upstream service', { error: err });
+                    await logCtx.failed();
+                    metrics.increment(metrics.Types.PROXY_FAILURE);
+                    return;
+                }
             }
 
             res.send(Buffer.concat(responseData));
             metrics.increment(metrics.Types.PROXY_SUCCESS);
             await logCtx.success();
-        } catch (err) {
-            logger.error(err);
-            res.writeHead(500, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ error: 'Failed to parse JSON response' }));
-
-            void logCtx.error('Failed to parse JSON response', { error: err });
-            await logCtx.failed();
-            metrics.increment(metrics.Types.PROXY_FAILURE);
         } finally {
             metrics.increment(metrics.Types.PROXY_OUTGOING_PAYLOAD_SIZE_BYTES, responseLen, { accountId: logCtx.accountId });
         }

--- a/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
@@ -134,8 +134,8 @@ describe('handleResponse', () => {
         handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
         await mockRes.waitForSend();
 
-        expect(mockRes.res.writeHead).toHaveBeenCalledWith(500, { 'Content-Type': 'application/json' });
-        expect(mockRes.res.end).toHaveBeenCalledWith(JSON.stringify({ error: 'Failed to parse JSON response' }));
+        expect(mockRes.res.writeHead).toHaveBeenCalledWith(502, { 'Content-Type': 'application/json' });
+        expect(mockRes.res.end).toHaveBeenCalledWith(JSON.stringify({ error: 'Failed to parse JSON response from upstream service' }));
         expect(mockLogCtx.failed).toHaveBeenCalled();
     });
 
@@ -151,6 +151,20 @@ describe('handleResponse', () => {
         const sentData = mockRes.getSentData();
         expect(sentData).toBeDefined();
         expect(sentData!.toString()).toBe(jsonWithBigInt);
+        expect(mockLogCtx.success).toHaveBeenCalled();
+    });
+
+    it('should pass-thru non-json payload', async () => {
+        const nonJsonPayload = `<foobar>`;
+        const mockRes = createMockResponse();
+        const mockResponseStream = createMockResponseStream(nonJsonPayload, 'text/xml');
+
+        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
+        await mockRes.waitForSend();
+
+        const sentData = mockRes.getSentData();
+        expect(sentData).toBeDefined();
+        expect(sentData!.toString()).toBe(nonJsonPayload);
         expect(mockLogCtx.success).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
 - On failure, emit HTTP status 502 (Bad Gateway) instead of 500.
 - In error message, mention that this is in parsing upstream data.
 - Work for non-json payloads.
 - Avoid logging SyntaxError to stderr in tests.

<!-- Summary by @propel-code-bot -->

---

The update refactors the response handler to separate JSON validation from delivery, adjusts metrics and logging so failures are recorded before returning, and guards against downstream send errors being misclassified as upstream parse issues.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/proxy/allProxy.ts`
• `packages/server/lib/controllers/proxy/allProxy.unit.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*