### PR TITLE
fix: scopes deletion logic

### DIFF
--- a/packages/webapp/src/components-v2/ScopesInput.tsx
+++ b/packages/webapp/src/components-v2/ScopesInput.tsx
@@ -28,8 +28,9 @@ export const ScopesInput: React.FC<ScopesInputProps> = ({ scopesString, onChange
     }, [scopesString]);
 
     const onDelete = (index: number) => {
-        setScopes((prev) => prev.filter((_, i) => i !== index));
-        onChange?.(scopes.join(','), -1);
+        const newScopes = scopes.filter((_, i) => i !== index);
+        setScopes(newScopes);
+        onChange?.(newScopes.join(','), -1);
     };
 
     const onSubmit = async () => {


### PR DESCRIPTION
It was passing forward the outdated list of scopes

<!-- Summary by @propel-code-bot -->

---

The update refines the deletion workflow so the component derives the refreshed scope list before mutating local state and invoking its change callback, ensuring consumers receive the current scopes after a removal.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced `newScopes` in `onDelete` to filter out the removed scope before state update
• Calls `setScopes(newScopes)` and `onChange?.(newScopes.join(','), -1)` to ensure the callback receives the latest data

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/components-v2/ScopesInput.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*