### PR TITLE
fix(docs): correct typo in action implementation guide (#5183)

### DIFF
--- a/docs/implementation-guides/actions/implement-an-action.mdx
+++ b/docs/implementation-guides/actions/implement-an-action.mdx
@@ -215,7 +215,7 @@ You can trigger actions from your backend with the [REST API](/reference/api/act
         const result = await nango.triggerAction({
         connectionId: '<CONNECTION-ID>',
         providerConfigKey: '<INTEGRATION-ID>',
-        action: '<ATION-NAME>',
+        action: '<ACTION-NAME>',
         input: { ... }
         });
         ```


### PR DESCRIPTION
Updated the action implementation guide to fix a typo in the code example, changing '<ATION-NAME>' to '<ACTION-NAME>''

It's just a typo in the docs that was bugging me for days.