### PR TITLE
fix(webflow): fix check on webhflow sync

### DIFF
--- a/scripts/webflow-api-sync.ts
+++ b/scripts/webflow-api-sync.ts
@@ -116,8 +116,8 @@ for (const [slug, provider] of Object.entries(neededProviders)) {
     const logo = `https://raw.githubusercontent.com/NangoHQ/nango/refs/heads/master/${logoPath}`;
 
     let preBuiltCount = 0;
-    if (flowProviderKeys.integrations[slug]) {
-        const flowProviderIndex = flowProviderKeys.indexOf(slug);
+    const flowProviderIndex = flowProviderKeys.indexOf(slug);
+    if (flowProviderIndex !== -1) {
         if (flowsJson[flowProviderIndex]['actions']) {
             preBuiltCount += flowsJson[flowProviderIndex]['actions'].length;
         }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Fix Webflow sync flow provider index guard**

Updates the Webflow sync script to compute the provider index first and guard against a missing slug before accessing `flowsJson`. This prevents lookups on `flowProviderKeys.integrations` and avoids computing prebuilt counts when the provider slug is absent.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaces the `flowProviderKeys.integrations[slug]` existence check with a direct `flowProviderKeys.indexOf(slug)` lookup.
• Adds a `flowProviderIndex !== -1` guard before counting `actions` and `syncs` in `flowsJson`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• scripts/webflow-api-sync.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*