### PR TITLE
feat(webapp): integrations screen feedback

### DIFF
--- a/packages/webapp/src/pages/Integrations/components/AuthBadge.tsx
+++ b/packages/webapp/src/pages/Integrations/components/AuthBadge.tsx
@@ -1,7 +1,5 @@
-import { KeyRound, Lock, LockOpen, RectangleEllipsis, Shield, Signature, Sparkles } from 'lucide-react';
-
 import { getDisplayName } from '../utils';
-import { Badge } from '@/components-v2/ui/badge';
+import { CatalogBadge } from './CatalogBadge';
 
 import type { AuthModeType } from '@nangohq/types';
 
@@ -10,36 +8,10 @@ interface AuthBadgeProps {
     className?: string;
 }
 
-/**
- * Returns the appropriate icon for each auth mode type
- */
-const getIcon = (authMode: AuthModeType) => {
-    switch (authMode) {
-        case 'API_KEY':
-            return <KeyRound />;
-        case 'BASIC':
-            return <RectangleEllipsis />;
-        case 'SIGNATURE':
-            return <Signature />;
-        case 'TWO_STEP':
-            return <Shield />;
-        case 'MCP_OAUTH2':
-        case 'MCP_OAUTH2_GENERIC':
-            return <Sparkles />;
-        case 'OAUTH2_CC':
-            return <KeyRound />;
-        case 'NONE':
-            return <LockOpen />;
-        // Fallback for any unknown auth modes
-        default:
-            return <Lock />;
-    }
-};
-
 export const AuthBadge: React.FC<AuthBadgeProps> = ({ authMode, className }) => {
     return (
-        <Badge variant="gray" className={className}>
-            {getIcon(authMode)} {getDisplayName(authMode)}
-        </Badge>
+        <CatalogBadge variant="light" className={className}>
+            {getDisplayName(authMode)}
+        </CatalogBadge>
     );
 };

--- a/packages/webapp/src/pages/Integrations/components/AutoIdlingBanner.tsx
+++ b/packages/webapp/src/pages/Integrations/components/AutoIdlingBanner.tsx
@@ -39,7 +39,7 @@ export const AutoIdlingBanner: React.FC = () => {
         return (
             <Alert variant="warning">
                 <TriangleAlert />
-                <AlertTitle>Endpoints paused</AlertTitle>
+                <AlertTitle>Functions paused</AlertTitle>
                 <AlertDescription>Functions are paused every 2 weeks on the free plan.</AlertDescription>
                 <AlertActions>
                     <AlertButton variant={'warning-secondary'} onClick={onClickExtend} disabled={trialLoading}>

--- a/packages/webapp/src/pages/Integrations/components/CatalogBadge.tsx
+++ b/packages/webapp/src/pages/Integrations/components/CatalogBadge.tsx
@@ -4,11 +4,11 @@ import { cn } from '@/utils/utils';
 
 import type { VariantProps } from 'class-variance-authority';
 
-const badgeVariants = cva('font-mono px-2 py-0.5 rounded-xs bg-bg-surface text-text-secondary !text-body-extra-small-semi', {
+const badgeVariants = cva('w-fit font-mono px-2 py-0.5 rounded bg-bg-surface !text-body-extra-small-semi', {
     variants: {
         variant: {
-            dark: 'bg-bg-surface',
-            light: 'bg-bg-subtle',
+            dark: 'bg-bg-surface  text-text-secondary',
+            light: 'bg-bg-subtle  text-text-primary',
             red: 'bg-feedback-error-fg/30 text-red-300'
         }
     },

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/Tab.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/Tab.tsx
@@ -108,8 +108,7 @@ const GroupedFunctionsTable: React.FC<{
                 <Fragment key={groupName}>
                     <TableHeader className="h-8">
                         <TableRow className="h-8">
-                            <TableHead className="w-1/3 h-8">{groupName}</TableHead>
-                            <TableHead className="h-8">{index === 0 && 'Name'}</TableHead>
+                            <TableHead className="h-8">{groupName}</TableHead>
                             <TableHead className="h-8">{index === 0 && 'Type'}</TableHead>
                             <TableHead className="h-8 text-center">{index === 0 && 'Enabled'}</TableHead>
                         </TableRow>
@@ -126,10 +125,8 @@ const GroupedFunctionsTable: React.FC<{
                                             </TooltipTrigger>
                                             <TooltipContent>{func.description}</TooltipContent>
                                         </Tooltip>
+                                        <CopyButton text={func.name} />
                                     </div>
-                                </TableCell>
-                                <TableCell>
-                                    <CopyButton text={func.name} />
                                 </TableCell>
                                 <TableCell>
                                     {func.pre_built ? (

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/components/IntegrationSideInfo.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/components/IntegrationSideInfo.tsx
@@ -35,7 +35,7 @@ export const IntegrationSideInfo: React.FC<{ integration: ApiIntegration; provid
                     </StyledLink>
                 </span>
             </InfoRow>
-            {apiStatus?.status && (
+            {apiStatus?.status && apiStatus?.status !== 'unknown' && (
                 <InfoRow label="API status">
                     <div className="flex">
                         <StatusWidget className="text-text-primary" status={apiStatus?.status} />


### PR DESCRIPTION
Fixes assorted feedback received from integrations redesign:
- Hide API status when it's unknown
- Move copy button to besides name in functions table
- Update AuthBadge design in integrations list page (remove icon and use `CatalogBadge` component)

<!-- Summary by @propel-code-bot -->

---

It also aligns the auto-idling banner terminology from “Endpoints” to “Functions” to keep the integrations experience consistent.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/pages/Integrations/components/AuthBadge.tsx`
• `packages/webapp/src/pages/Integrations/components/CatalogBadge.tsx`
• `packages/webapp/src/pages/Integrations/providerConfigKey/Functions/Tab.tsx`
• `packages/webapp/src/pages/Integrations/providerConfigKey/components/IntegrationSideInfo.tsx`
• `packages/webapp/src/pages/Integrations/components/AutoIdlingBanner.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*