### PR TITLE
feat(persist): add records auto-pruning

### DIFF
--- a/packages/persist/lib/daemons/autopruning.daemon.ts
+++ b/packages/persist/lib/daemons/autopruning.daemon.ts
@@ -11,11 +11,11 @@ import { logger } from '../logger.js';
  * Auto-pruning daemon
  * This daemon runs in a loop and prunes old records from the database based on the defined stale period
  * each tick, a candidate connection/model is selected for pruning
- * If a candidate is found, records older than the stale period are deleted
- * Only a limited number of records are deleted per tick to avoid overwhelming the database
+ * If a candidate is found, records older than the stale period are pruned
+ * Only a limited number of records are pruned per tick to avoid overwhelming the database
  * We rely on the daemon to run periodically on each persist instance to continue pruning old records
  */
-export function autoPruningDaemon(): { abort: () => Promise<void> } {
+export function autoPruningDaemon(): Awaited<ReturnType<typeof cancellableDaemon>> {
     return cancellableDaemon({
         tickIntervalMs: envs.PERSIST_AUTO_PRUNING_INTERVAL_MS,
         tick: async (): Promise<void> => {
@@ -51,23 +51,25 @@ export function autoPruningDaemon(): { abort: () => Promise<void> } {
                 });
                 if (res.isErr()) {
                     span.addTags({ error: res.error.message }).finish();
-                    logger.error(`[Auto-pruning] error deleting records: ${res.error.message}`);
+                    logger.error(`[Auto-pruning] error pruning records: ${res.error.message}`);
                     return;
                 }
                 // lag: how far behind are we from the desired pruning point
                 // high lag means we are not keeping up with pruning
                 let lagMs: number | null = null;
-                const cursorSort = Cursor.from(candidate.value.cursor)?.sort;
-                if (cursorSort) {
-                    const cursorDate = new Date(cursorSort);
-                    lagMs = Date.now() - cursorDate.getTime() - envs.PERSIST_AUTO_PRUNING_STALE_AFTER_MS;
+                if (res.value.lastCursor) {
+                    const cursorSort = Cursor.from(res.value.lastCursor)?.sort;
+                    if (cursorSort) {
+                        const cursorDate = new Date(cursorSort);
+                        lagMs = Date.now() - cursorDate.getTime() - envs.PERSIST_AUTO_PRUNING_STALE_AFTER_MS;
+                    }
                 }
                 span.addTags({
-                    deleted: res.value.count,
+                    pruned: res.value.count,
                     ...(lagMs ? { lagMs } : {})
                 }).finish();
             }
-            span.addTags({ deleted: 0, candidate: 'none_found' }).finish();
+            span.addTags({ pruned: 0, candidate: 'none_found' }).finish();
         }
     });
 }

--- a/packages/persist/lib/daemons/autopruning.daemon.ts
+++ b/packages/persist/lib/daemons/autopruning.daemon.ts
@@ -1,0 +1,73 @@
+import tracer from 'dd-trace';
+
+import { Cursor, records } from '@nangohq/records';
+import { connectionService } from '@nangohq/shared';
+import { cancellableDaemon } from '@nangohq/utils';
+
+import { envs } from '../env.js';
+import { logger } from '../logger.js';
+
+/*
+ * Auto-pruning daemon
+ * This daemon runs in a loop and prunes old records from the database based on the defined stale period
+ * each tick, a candidate connection/model is selected for pruning
+ * If a candidate is found, records older than the stale period are deleted
+ * Only a limited number of records are deleted per tick to avoid overwhelming the database
+ * We rely on the daemon to run periodically on each persist instance to continue pruning old records
+ */
+export function autoPruningDaemon(): { abort: () => Promise<void> } {
+    return cancellableDaemon({
+        tickIntervalMs: envs.PERSIST_AUTO_PRUNING_INTERVAL_MS,
+        tick: async (): Promise<void> => {
+            const dryRun = true; // TODO: removed after grace period given to customer (Feb 8th 2026)
+            const active = tracer.scope().active();
+            const span = tracer.startSpan('nango.persist.daemon.autopruning', {
+                childOf: active as tracer.Span,
+                tags: { dryRun }
+            });
+            const candidate = await records.autoPruningCandidate({ staleAfterMs: envs.PERSIST_AUTO_PRUNING_STALE_AFTER_MS });
+            if (candidate.isErr()) {
+                span.addTags({ error: candidate.error.message }).finish();
+                logger.error(`[Auto-pruning] error getting candidate: ${candidate.error.message}`);
+                return;
+            }
+            if (candidate.value) {
+                const connection = await connectionService.getConnectionById(candidate.value.connectionId);
+                if (!connection) {
+                    span.addTags({ error: `Connection ${candidate.value.connectionId} not found` }).finish();
+                    logger.error(`[Auto-pruning] connection ${candidate.value.connectionId} not found`);
+                    return;
+                }
+                span.addTags({ environmentId: connection.environment_id, candidate: candidate.value });
+
+                const res = await records.deleteRecords({
+                    environmentId: connection.environment_id,
+                    connectionId: candidate.value.connectionId,
+                    model: candidate.value.model,
+                    mode: 'prune',
+                    toCursorIncluded: candidate.value.cursor,
+                    limit: envs.PERSIST_AUTO_PRUNING_LIMIT,
+                    dryRun
+                });
+                if (res.isErr()) {
+                    span.addTags({ error: res.error.message }).finish();
+                    logger.error(`[Auto-pruning] error deleting records: ${res.error.message}`);
+                    return;
+                }
+                // lag: how far behind are we from the desired pruning point
+                // high lag means we are not keeping up with pruning
+                let lagMs: number | null = null;
+                const cursorSort = Cursor.from(candidate.value.cursor)?.sort;
+                if (cursorSort) {
+                    const cursorDate = new Date(cursorSort);
+                    lagMs = Date.now() - cursorDate.getTime() - envs.PERSIST_AUTO_PRUNING_STALE_AFTER_MS;
+                }
+                span.addTags({
+                    deleted: res.value.count,
+                    ...(lagMs ? { lagMs } : {})
+                }).finish();
+            }
+            span.addTags({ deleted: 0, candidate: 'none_found' }).finish();
+        }
+    });
+}

--- a/packages/records/lib/index.ts
+++ b/packages/records/lib/index.ts
@@ -4,6 +4,7 @@ import { configRead } from './db/config.js';
 export * from './db/migrate.js';
 export * as records from './models/records.js';
 export * as format from './helpers/format.js';
+export { Cursor } from './cursor.js';
 export type * from './types.js';
 export { clearDb as clearDbTestsOnly } from './db/test.helpers.js';
 

--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -1,8 +1,9 @@
 import dayjs from 'dayjs';
 import * as uuid from 'uuid';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { RECORDS_TABLE, RECORD_COUNTS_TABLE } from '../constants.js';
+import { Cursor } from '../cursor.js';
 import { db } from '../db/client.js';
 import { migrate } from '../db/migrate.js';
 import { formatRecords } from '../helpers/format.js';
@@ -1250,6 +1251,128 @@ describe('Records service', () => {
             expect(stats[model]?.count).toBe(3);
             expect(stats[model]?.size_bytes).toBeLessThan(statsBefore[model]?.size_bytes || 0);
         });
+
+        it('should simulate hard deletion when dryRun = true', async () => {
+            const connectionId = rnd.number();
+            const environmentId = rnd.number();
+            const model = rnd.string();
+            const syncId = uuid.v4();
+
+            const records = [
+                { id: '1', name: 'John Doe' },
+                { id: '2', name: 'Jane Doe' },
+                { id: '3', name: 'Max Doe' },
+                { id: '4', name: 'Mike Doe' },
+                { id: '5', name: 'Alice Doe' }
+            ];
+            await upsertRecords({ records, connectionId, environmentId, model, syncId });
+
+            const statsBefore = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
+            expect(statsBefore[model]?.count).toBe(5);
+            const initialSize = statsBefore[model]?.size_bytes || 0;
+
+            const res = (
+                await Records.deleteRecords({
+                    connectionId,
+                    environmentId,
+                    model,
+                    mode: 'hard',
+                    limit: 3,
+                    dryRun: true
+                })
+            ).unwrap();
+
+            // Should report what would be deleted
+            expect(res.count).toBe(3);
+            expect(res.lastCursor).toBeDefined();
+
+            // Verify records were not actually deleted
+            const statsAfterDryRun = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
+            expect(statsAfterDryRun[model]?.count).toBe(5);
+            expect(statsAfterDryRun[model]?.size_bytes).toBe(initialSize);
+
+            const recordsAfterDryRun = (await Records.getRecords({ connectionId, model })).unwrap();
+            expect(recordsAfterDryRun.records.length).toBe(5);
+        });
+
+        it('should simulate soft deletion when dryRun = true', async () => {
+            const connectionId = rnd.number();
+            const environmentId = rnd.number();
+            const model = rnd.string();
+            const syncId = uuid.v4();
+
+            const records = [
+                { id: '1', name: 'John Doe' },
+                { id: '2', name: 'Jane Doe' },
+                { id: '3', name: 'Max Doe' }
+            ];
+            await upsertRecords({ records, connectionId, environmentId, model, syncId });
+
+            const res = (
+                await Records.deleteRecords({
+                    connectionId,
+                    environmentId,
+                    model,
+                    mode: 'soft',
+                    dryRun: true
+                })
+            ).unwrap();
+
+            // Should report what would be deleted
+            expect(res.count).toBe(3);
+            expect(res.lastCursor).toBeDefined();
+
+            // Verify records were not actually deleted
+            const recordsAfterDryRun = (await Records.getRecords({ connectionId, model, filter: 'deleted' })).unwrap();
+            expect(recordsAfterDryRun.records.length).toBe(0);
+
+            const allRecords = (await Records.getRecords({ connectionId, model })).unwrap();
+            expect(allRecords.records.length).toBe(3);
+            allRecords.records.forEach((r) => {
+                expect(r._nango_metadata.deleted_at).toBeNull();
+            });
+        });
+
+        it('should simulate pruning when dryRun = true', async () => {
+            const connectionId = rnd.number();
+            const environmentId = rnd.number();
+            const model = rnd.string();
+            const syncId = uuid.v4();
+
+            const records = [
+                { id: '1', name: 'John Doe' },
+                { id: '2', name: 'Jane Doe' }
+            ];
+            await upsertRecords({ records, connectionId, environmentId, model, syncId });
+
+            const statsBefore = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
+            const initialSize = statsBefore[model]?.size_bytes || 0;
+
+            const res = (
+                await Records.deleteRecords({
+                    connectionId,
+                    environmentId,
+                    model,
+                    mode: 'prune',
+                    dryRun: true
+                })
+            ).unwrap();
+
+            expect(res.count).toBe(2);
+            expect(res.lastCursor).toBeDefined();
+
+            // Verify records were not actually pruned
+            const recordsAfterDryRun = (await Records.getRecords({ connectionId, model })).unwrap();
+            expect(recordsAfterDryRun.records.length).toBe(2);
+            recordsAfterDryRun.records.forEach((r) => {
+                expect(r._nango_metadata.pruned_at).toBeNull();
+                expect(r['name']).toBeDefined(); // payload still exists
+            });
+
+            // Size should remain unchanged
+            const statsAfterDryRun = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
+            expect(statsAfterDryRun[model]?.size_bytes).toBe(initialSize);
+        });
     });
 
     describe('incrCount', () => {
@@ -1355,6 +1478,99 @@ describe('Records service', () => {
             });
             expect(newCount.count).toBe(initialStats[model]?.count);
             expect(newCount.size_bytes).toBe(initialStats[model]?.size_bytes);
+        });
+    });
+
+    describe('autoPruningCandidate', () => {
+        beforeEach(async () => {
+            await db(RECORDS_TABLE).truncate();
+        });
+        it('should find a stale record candidate for pruning', async () => {
+            const connectionId = rnd.number();
+            const environmentId = rnd.number();
+            const model = rnd.string();
+            const syncId = uuid.v4();
+
+            const records = [
+                { id: '1', name: 'Old Record 1' },
+                { id: '2', name: 'Old Record 2' }
+            ];
+            await upsertRecords({ records, connectionId, environmentId, model, syncId });
+
+            // Make first record stale
+            const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+            await db(RECORDS_TABLE).where({ external_id: '1', connection_id: connectionId, model }).update({ updated_at: oneDayAgo });
+
+            // Try to find a stale record
+            // Since we're picking a random partition, we might need to try multiple times
+            const staleAfterMs = 60 * 60 * 1000; // 1 hour
+            for (let i = 0; i < 1000; i++) {
+                const candidate = (await Records.autoPruningCandidate({ staleAfterMs })).unwrap();
+                if (candidate) {
+                    expect(candidate.connectionId).toBe(connectionId);
+                    expect(candidate.model).toBe(model);
+                    const decodedCursor = Cursor.from(candidate.cursor);
+                    if (!decodedCursor) {
+                        throw new Error('Failed to decode cursor');
+                    }
+                    const staleRecord = (
+                        await Records.getRecords({ connectionId: candidate.connectionId, model: candidate.model, externalIds: ['1'] })
+                    ).unwrap().records[0];
+                    expect(staleRecord?._nango_metadata.cursor).toBe(candidate.cursor);
+                    return;
+                }
+            }
+            throw new Error('No candidate found. Expecting one');
+        });
+
+        it('should return null when no stale records exist', async () => {
+            const connectionId = rnd.number();
+            const environmentId = rnd.number();
+            const model = rnd.string();
+            const syncId = uuid.v4();
+
+            const records = [
+                { id: '1', name: 'Old Record 1' },
+                { id: '2', name: 'Old Record 2' }
+            ];
+            await upsertRecords({ records, connectionId, environmentId, model, syncId });
+
+            // Since we're picking a random partition we need to try multiple times
+            const staleAfterMs = 60 * 60 * 1000; // 1 hour
+            for (let i = 0; i < 1000; i++) {
+                const candidate = (await Records.autoPruningCandidate({ staleAfterMs })).unwrap();
+                if (candidate) {
+                    throw new Error(`Expected no candidate, but found ${JSON.stringify(candidate)}`);
+                }
+            }
+        });
+
+        it('should not return already pruned records', async () => {
+            const connectionId = rnd.number();
+            const environmentId = rnd.number();
+            const model = rnd.string();
+            const syncId = uuid.v4();
+
+            // Insert records
+            const records = [
+                { id: '1', name: 'Record to be pruned' },
+                { id: '2', name: 'Another record' }
+            ];
+            await upsertRecords({ records, connectionId, environmentId, model, syncId });
+
+            // Mark the records as already pruned
+            const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+            await db(RECORDS_TABLE).where({ connection_id: connectionId, model }).update({ updated_at: oneDayAgo, pruned_at: new Date() });
+
+            // Try to find a stale record
+            // Since we're picking a random partition we need to try multiple times
+            const staleAfterMs = 60 * 60 * 1000; // 1 hour
+            for (let i = 0; i < 50; i++) {
+                const candidate = (await Records.autoPruningCandidate({ staleAfterMs })).unwrap();
+                if (candidate) {
+                    throw new Error(`Expected no candidate, but found ${JSON.stringify(candidate)}`);
+                }
+            }
         });
     });
 });

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -709,6 +709,7 @@ export async function update({
  * @param limit - The maximum number of records to delete.
  * @param toCursorIncluded - The cursor up to which records should be deleted (inclusive. ordered by updated_at, id).
  * @param batchSize - The number of records to delete in each batch (default is 1000).
+ * @param dryRun - If true, simulates the deletion without actually deleting any records (default is false).
  */
 export async function deleteRecords({
     connectionId,
@@ -717,7 +718,8 @@ export async function deleteRecords({
     mode,
     limit,
     toCursorIncluded,
-    batchSize = 1000
+    batchSize = 1000,
+    dryRun = false
 }: {
     connectionId: number;
     environmentId: number;
@@ -726,11 +728,18 @@ export async function deleteRecords({
     limit?: number;
     toCursorIncluded?: string;
     batchSize?: number;
+    dryRun?: boolean;
 }): Promise<Result<{ count: number; lastCursor: string | null }>> {
     const activeSpan = tracer.scope().active();
     const span = tracer.startSpan('nango.records.deletedRecords', {
         ...(activeSpan ? { childOf: activeSpan } : {}),
-        tags: { 'nango.environmentId': environmentId, 'nango.connectionId': connectionId, 'nango.model': model, 'nango.deletionMode': mode }
+        tags: {
+            'nango.environmentId': environmentId,
+            'nango.connectionId': connectionId,
+            'nango.model': model,
+            'nango.deletionMode': mode,
+            'nango.dryRun': dryRun
+        }
     });
 
     let partition: string | undefined = undefined;
@@ -754,8 +763,10 @@ export async function deleteRecords({
 
         await db.transaction(async (trx) => {
             const now = trx.fn.now(6);
-            // Lock to prevent concurrent deletions
-            await trx.raw(`SELECT pg_advisory_xact_lock(?) as lock_records_delete`, [newLockId(connectionId, model)]);
+            // Lock to prevent concurrent deletions (skip lock if dry run)
+            if (!dryRun) {
+                await trx.raw(`SELECT pg_advisory_xact_lock(?) as lock_records_delete`, [newLockId(connectionId, model)]);
+            }
 
             do {
                 const toDelete = limit ? Math.min(batchSize, limit - totalRecords) : batchSize;
@@ -797,23 +808,25 @@ export async function deleteRecords({
                         trx.raw('to_json(updated_at) as updated_at')
                     ]);
 
-                switch (mode) {
-                    case 'prune':
-                        query.update({
-                            pruned_at: now,
-                            json: {} // empty the record payload
-                            // IMPORTANT: updated_at isn't updated because it would cause the record cursor to also change
-                        });
-                        break;
-                    case 'soft':
-                        query.update({
-                            deleted_at: now,
-                            updated_at: now
-                        });
-                        break;
-                    case 'hard':
-                        query.del();
-                        break;
+                if (!dryRun) {
+                    switch (mode) {
+                        case 'prune':
+                            query.update({
+                                pruned_at: now,
+                                json: {} // empty the record payload
+                                // IMPORTANT: updated_at isn't updated because it would cause the record cursor to also change
+                            });
+                            break;
+                        case 'soft':
+                            query.update({
+                                deleted_at: now,
+                                updated_at: now
+                            });
+                            break;
+                        case 'hard':
+                            query.del();
+                            break;
+                    }
                 }
 
                 const res = await query;
@@ -829,25 +842,32 @@ export async function deleteRecords({
                 if (lastDeletedRecord) {
                     lastCursor = Cursor.new({ id: lastDeletedRecord.id, last_modified_at: lastDeletedRecord.updated_at });
                 }
+
+                // break if the returned page is not full
+                if (paginatedRecords < toDelete) {
+                    break;
+                }
             } while (paginatedRecords > 0);
 
             // Update counts
-            const delta = mode === 'prune' ? 0 : -totalRecords; // pruning doesn't affect the records count
-            const newCount = await incrCount(trx, {
-                environmentId,
-                connectionId,
-                model,
-                delta,
-                deltaSizeInBytes: -totalSizeInBytes
-            });
-
-            // If all records are deleted, clean up the count entry
-            if (newCount?.count === 0) {
-                await deleteCount(trx, {
+            if (!dryRun) {
+                const delta = mode === 'prune' ? 0 : -totalRecords; // pruning doesn't affect the records count
+                const newCount = await incrCount(trx, {
                     environmentId,
                     connectionId,
-                    model
+                    model,
+                    delta,
+                    deltaSizeInBytes: -totalSizeInBytes
                 });
+
+                // If all records are deleted, clean up the count entry
+                if (newCount?.count === 0) {
+                    await deleteCount(trx, {
+                        environmentId,
+                        connectionId,
+                        model
+                    });
+                }
             }
         });
 
@@ -1079,6 +1099,60 @@ export async function deleteCount(
     }
 ): Promise<void> {
     await trx.from(RECORD_COUNTS_TABLE).where({ connection_id: connectionId, environment_id: environmentId, model }).del();
+}
+
+/*
+ * autoPruningCandidate
+ * @desc finds a candidate connection/model for auto-pruning
+ * This function helps distribute the pruning load across partitions
+ * by randomly selecting a partition to search for stale records.
+ * @param staleAfterMs - milliseconds since last modification to consider a record stale
+ * @returns a Result containing either:
+ * - candidate connection and model with a cursor to the stale record
+ * - null if no candidate found
+ */
+export async function autoPruningCandidate({ staleAfterMs }: { staleAfterMs: number }): Promise<
+    Result<{
+        partition: number;
+        connectionId: number;
+        model: string;
+        cursor: string;
+    } | null>
+> {
+    // Pick a random partition
+    const partition = Math.floor(Math.random() * 256);
+
+    try {
+        // Find a record that is stale in that partition
+        const [candidate] = await db
+            .from(`${RECORDS_TABLE}_p${partition}`)
+            .select<{ id: string; connection_id: number; model: string; last_modified_at: string }[]>(
+                // PostgreSQL stores timestamp with microseconds precision
+                // however, javascript date only supports milliseconds precision
+                // we therefore convert timestamp to string (using to_json()) in order to avoid precision loss
+                db.raw(`
+                    id,
+                    connection_id,
+                    model,
+                    to_json(updated_at) as last_modified_at
+                `)
+            )
+            .whereNull('pruned_at')
+            .whereRaw(`updated_at < NOW() - INTERVAL '${staleAfterMs} milliseconds'`)
+            .limit(1);
+
+        if (candidate) {
+            return Ok({
+                partition,
+                connectionId: candidate.connection_id,
+                model: candidate.model,
+                cursor: Cursor.new(candidate)
+            });
+        }
+        return Ok(null);
+    } catch (err) {
+        return Err(new Error(`Failed to find auto-pruning candidate in partition ${partition}`, { cause: err }));
+    }
 }
 
 /**

--- a/packages/utils/lib/daemon.ts
+++ b/packages/utils/lib/daemon.ts
@@ -1,0 +1,27 @@
+import { setTimeout } from 'node:timers/promises';
+
+export function cancellableDaemon<T>({ tick, tickIntervalMs }: { tick: () => Promise<T>; tickIntervalMs: number }): {
+    abort: () => Promise<T | void>;
+} {
+    const ac = new AbortController();
+    const loop = async (): Promise<void> => {
+        if (tickIntervalMs <= 0) {
+            return;
+        }
+        while (true) {
+            if (ac.signal.aborted) {
+                return;
+            }
+            tick();
+            await setTimeout(tickIntervalMs);
+        }
+    };
+    const done = loop();
+
+    const abort = async () => {
+        ac.abort();
+        return await done;
+    };
+
+    return { abort };
+}

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -54,6 +54,12 @@ export const ENVS = z.object({
 
     // Persist
     PERSIST_SERVICE_URL: z.url().optional(),
+    PERSIST_AUTO_PRUNING_INTERVAL_MS: z.coerce.number().optional().default(5_000), // set to 0 to disable
+    PERSIST_AUTO_PRUNING_LIMIT: z.coerce.number().optional().default(1_000),
+    PERSIST_AUTO_PRUNING_STALE_AFTER_MS: z.coerce
+        .number()
+        .optional()
+        .default(30 * 24 * 3600 * 1000), // 30 days
     NANGO_PERSIST_PORT: z.coerce.number().optional().default(3007),
 
     // Orchestrator

--- a/packages/utils/lib/index.ts
+++ b/packages/utils/lib/index.ts
@@ -26,3 +26,4 @@ export * from './wait.js';
 export * from './date.js';
 export * from './frequency.js';
 export * from './map.js';
+export * from './daemon.js';

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -96,9 +96,7 @@ export enum Types {
 
     USAGE_IS_CAPPED = 'nango.capping.isCapped',
 
-    PUBSUB_PUBLISH = 'nango.pubsub.publish',
-
-    PERSIST_RECORDS_AUTO_PRUNING = 'nango.persist.daemon.autopruning'
+    PUBSUB_PUBLISH = 'nango.pubsub.publish'
 }
 
 type Dimensions = Record<string, string | number> | undefined;

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -96,7 +96,9 @@ export enum Types {
 
     USAGE_IS_CAPPED = 'nango.capping.isCapped',
 
-    PUBSUB_PUBLISH = 'nango.pubsub.publish'
+    PUBSUB_PUBLISH = 'nango.pubsub.publish',
+
+    PERSIST_RECORDS_AUTO_PRUNING = 'nango.persist.daemon.autopruning'
 }
 
 type Dimensions = Record<string, string | number> | undefined;


### PR DESCRIPTION
We want to start removing records data and finally enforce the 'cache' nature of the records data store (aka: it is not a customer-facing database but a temporary location where records are saved before the customers replicate them into their own system). 
It will help with data privacy compliance and accountability as well as scalability and storage. 
The first step is to prune the record (ie: empty the payload) when a record isn't being updated for 30 days. Pruning a record allows Nango features like changes detection to work while not storing any customer data anymore for stale records (other than the record id). Customers would have 30 days after a records is updated by a sync to replicate it.

This PR is introducing a background daemon that prunes the payload of records not updated in that last 30 days.
The daemon runs in dryrun mode for now, not pruning any records yet until after the grace period communicated to customers.
The daemon runs in a tight loop. For each iteration a candidate connection/model is being selected and up to 1000 records for it are pruned. Each loop processing is kept small (max: 1 connection / 1000 records, random partition) in order to have a minimal impact on the db.
I am not sure yet that the tick interval and limit values would be enough to keep up (or if they are too aggressive). They might need to be tweaked once running in production.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/persist` background daemons
• `packages/records` service (`deleteRecords`, new `autoPruningCandidate`)
• `packages/utils` utilities (`cancellableDaemon`, metrics enum, env parsing)`
• Integration tests for records deletion/pruning

</details>

---
*This summary was automatically generated by @propel-code-bot*

<!-- Summary by @propel-code-bot -->

---

Supporting updates add a shared cancellable daemon utility with environment-configurable intervals and limits, extend deleteRecords’ dry-run handling, and broaden integration coverage to validate dry-run execution and candidate selection.

---
*This summary was automatically generated by @propel-code-bot*