### PR TITLE
fix(proxy): Disable JSON validation entirely

### DIFF
--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -309,7 +309,6 @@ export async function handleResponse({ res, responseStream, logCtx }: { res: Res
     const transferEncoding = responseStream.headers['transfer-encoding'] || '';
     const contentEncoding = responseStream.headers['content-encoding'] || '';
 
-    const isJsonResponse = contentType.includes('application/json');
     const isChunked = transferEncoding === 'chunked';
     const isEncoded = Boolean(contentEncoding);
     const isAttachmentOrInline = /^(attachment|inline)(;|\s|$)/i.test(contentDisposition);
@@ -345,8 +344,8 @@ export async function handleResponse({ res, responseStream, logCtx }: { res: Res
             return;
         }
 
-        if (isJsonResponse) {
-            res.setHeader('Content-Type', 'application/json');
+        if (typeof contentType === 'string' && contentType !== '') {
+            res.setHeader('Content-Type', contentType);
         }
 
         try {

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -346,18 +346,6 @@ export async function handleResponse({ res, responseStream, logCtx }: { res: Res
         }
 
         if (isJsonResponse) {
-            // Validate JSON structure without re-serializing to avoid JSON.parse limitations (ex: precision loss with big integers).
-            // TODO: consider removing validation and forwarding upstream response as-is (even if invalid JSON) to avoid performance overhead.
-            try {
-                JSON.parse(Buffer.concat(responseData).toString());
-            } catch (err) {
-                res.writeHead(502, { 'Content-Type': 'application/json' });
-                res.end(JSON.stringify({ error: 'Failed to parse JSON response from upstream service' }));
-                void logCtx.error('Failed to parse JSON response from upstream service', { error: err });
-                await logCtx.failed();
-                metrics.increment(metrics.Types.PROXY_FAILURE);
-                return;
-            }
             res.setHeader('Content-Type', 'application/json');
         }
 

--- a/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
@@ -126,19 +126,6 @@ describe('handleResponse', () => {
         expect(mockLogCtx.error).not.toHaveBeenCalled();
     });
 
-    it('should handle invalid JSON in response', async () => {
-        const invalidJson = '{invalid json content}';
-        const mockRes = createMockResponse();
-        const mockResponseStream = createMockResponseStream(invalidJson);
-
-        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
-        await mockRes.waitForSend();
-
-        expect(mockRes.res.writeHead).toHaveBeenCalledWith(502, { 'Content-Type': 'application/json' });
-        expect(mockRes.res.end).toHaveBeenCalledWith(JSON.stringify({ error: 'Failed to parse JSON response from upstream service' }));
-        expect(mockLogCtx.failed).toHaveBeenCalled();
-    });
-
     it('should preserve BigInt values in JSON response without precision loss', async () => {
         const jsonWithBigInt = `{"id": 7584781588001541408, "name": "test", "count": 42, "list": [12345678901234567890, 98765432109876543210]}`;
 


### PR DESCRIPTION
As discussed in https://github.com/NangoHQ/nango/pull/5188#pullrequestreview-3627019229

This change removes JSON validation entirely from our proxy.

Chances of rollback are not high but not negligible.

Best to deploy this during European hours (before peak load)
<!-- Summary by @propel-code-bot -->

---

The proxy now simply passes through upstream JSON payloads, forwarding both the response body and any non-empty Content-Type header, and the prior safeguard test that enforced a 502 on malformed JSON has been removed to align with this new behavior.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/proxy/allProxy.ts`
• `packages/server/lib/controllers/proxy/allProxy.unit.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*