### PR TITLE
fix(webflow): fix docs paths to recognized migrated ones

### DIFF
--- a/scripts/webflow-api-sync.ts
+++ b/scripts/webflow-api-sync.ts
@@ -33,8 +33,12 @@ const providersPath = 'packages/providers/providers.yaml';
 // eslint-disable-next-line import/no-named-as-default-member
 const providers = yaml.load(await fs.readFile(providersPath, 'utf8')) as Record<string, Provider>;
 
-const docsPath = 'docs/integrations/all';
-const files = await fs.readdir(docsPath);
+const docsPaths = ['docs/integrations/all', 'docs/api-integrations'];
+const files: string[] = [];
+for (const docsPath of docsPaths) {
+    const dirFiles = await fs.readdir(docsPath);
+    files.push(...dirFiles);
+}
 
 // we only need a subset of providers based on how our docs are written
 const neededProviders: Record<string, Provider> = {};


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Update Webflow sync script to read migrated docs directories**

Updates `scripts/webflow-api-sync.ts` so the Webflow sync script collects markdown files from both `docs/integrations/all` and `docs/api-integrations`. It aggregates filenames from both locations before deriving provider metadata.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaces single `docsPath` with `docsPaths` array including `docs/integrations/all` and `docs/api-integrations`
• Accumulates directory listings from each docs path into a unified `files` array prior to provider filtering

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• scripts/webflow-api-sync.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*