### PR TITLE
feat(docs): docs migration iteration 3

### DIFF
--- a/docs/api-integrations/atlassian.mdx
+++ b/docs/api-integrations/atlassian.mdx
@@ -1,0 +1,82 @@
+---
+title: 'Atlassian'
+sidebarTitle: 'Atlassian'
+description: 'Integrate your application with the Atlassian API'
+---
+
+## 🚀 Quickstart
+
+Connect to Atlassian with Nango and see data flow in 2 minutes.
+
+<Steps>
+    <Step title="Create the integration">
+    In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Atlassian_.
+    </Step>
+    <Step title="Authorize Atlassian">
+    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then log in to Atlassian. Later, you'll let your users do the same directly from your app.
+    </Step>
+    <Step title="Call the Atlassian API">
+    Let's make your first request to the Atlassian API (fetch accessible resources). Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+    <Tabs>
+        <Tab title="cURL">
+
+            ```bash
+            curl "https://api.nango.dev/proxy/oauth/token/accessible-resources" \
+              -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+              -H "Provider-Config-Key: <INTEGRATION-ID>" \
+              -H "Connection-Id: <CONNECTION-ID>"
+            ```
+
+        </Tab>
+
+        <Tab title="Node">
+
+        Install Nango's backend SDK with `npm i @nangohq/node`. Then run:
+
+        ```typescript
+        import { Nango } from '@nangohq/node';
+
+        const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+
+        const res = await nango.get({
+            endpoint: '/oauth/token/accessible-resources',
+            providerConfigKey: '<INTEGRATION-ID>',
+            connectionId: '<CONNECTION-ID>'
+        });
+
+        console.log(JSON.stringify(res.data, null, 2));
+        ```
+        </Tab>
+
+
+    </Tabs>
+    Or fetch credentials with the [Node SDK](/reference/sdks/node#get-a-connection-with-credentials) or [API](/reference/api/connection/get).
+
+    ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+    </Step>
+
+    <Step title="Implement Nango in your app">
+        Follow our [quickstart](/getting-started/quickstart/embed-in-your-app) to integrate Nango in your app.
+
+        To obtain your own production credentials, follow the setup guide linked below.
+    </Step>
+</Steps>
+
+## 📚 Atlassian Integration Guides
+
+Nango maintained guides for common use cases.
+
+- [How to register your own Atlassian API OAuth app](/api-integrations/atlassian/how-to-register-your-own-atlassian-api-oauth-app)
+Register an OAuth app with Atlassian and obtain credentials to connect it to Nango
+
+Official docs: [Atlassian Developer Portal](https://developer.atlassian.com/)
+
+## 🧩 Pre-built syncs & actions for Atlassian
+
+Enable them in your dashboard. [Extend and customize](/implementation-guides/building-integrations/extend-reference-implementation) to fit your needs.
+
+import PreBuiltUseCases from "/snippets/generated/atlassian/PreBuiltUseCases.mdx"
+
+<PreBuiltUseCases />
+
+---

--- a/docs/api-integrations/atlassian/how-to-register-your-own-atlassian-api-oauth-app.mdx
+++ b/docs/api-integrations/atlassian/how-to-register-your-own-atlassian-api-oauth-app.mdx
@@ -1,0 +1,64 @@
+---
+title: 'How to register your own Atlassian API OAuth app'
+sidebarTitle: 'Atlassian Setup'
+description: 'Register an OAuth app with Atlassian and connect it to Nango'
+---
+
+This guide shows you how to register your own app with Atlassian to obtain your OAuth credentials (client ID & secret). These are required to let your users grant your app access to their Atlassian account.
+
+## Creating an OAuth 2.0 (3LO) App
+
+<Steps>
+  <Step title="Create an Atlassian developer account">
+    If you don't already have one, sign up for an [Atlassian developer account](https://id.atlassian.com/signup/).
+  </Step>
+  <Step title="Create a new OAuth 2.0 (3LO) app">
+    1. Go to the [Atlassian Developer Console](https://developer.atlassian.com/console/myapps/).
+    2. Click **Create** and select **OAuth 2.0 integration**.
+    3. Enter a name, agree to Atlassian's developer terms by checking the agreement checkbox for your app and click **Create**.
+    4. Your app will be created and you'll be taken to the app management page.
+  </Step>
+  <Step title="Configure OAuth 2.0 (3LO)">
+    1. In the left sidebar, select **Authorization**.
+    2. Next to OAuth 2.0 (3LO), click **Add**.
+    3. Enter `https://api.nango.dev/oauth/callback` as the **Callback URL**.
+    4. Click **Save Changes** to save your changes.
+  </Step>
+  <Step title="Add API permissions">
+    1. In the left sidebar, select **Permissions**.
+    2. Find the APIs you want to use (Jira, Confluence, etc.) and click **Add**, then click **Configure**.
+    3. Click **Edit Scopes** then select the [scopes](https://developer.atlassian.com/cloud/jira/platform/scopes-for-oauth-2-3LO-and-forge-apps/#scopes) your application requires.
+    4. Click **Save Changes** to save your changes.
+
+    Common scopes include:
+    - `read:jira-user` - Read user information
+    - `read:jira-work` - Read Jira work items (issues, projects, etc.)
+    - `write:jira-work` - Create and update Jira work items
+    - `offline_access` - Access to refresh tokens for offline access
+
+    See the full list of scopes in [Atlassian's Jira scopes documentation](https://developer.atlassian.com/cloud/jira/platform/scopes-for-oauth-2-3LO-and-forge-apps/) and [Confluence scopes documentation](https://developer.atlassian.com/cloud/confluence/scopes-for-oauth-2-3LO-and-forge-apps/).
+  </Step>
+  <Step title="Obtain your client credentials">
+    1. In the left sidebar, select **Settings**.
+    2. Copy both the **Client ID** and **Secret** by clicking the copy buttons next to them, as you'll need them when configuring your integration in Nango.
+  </Step>
+  <Step title="Make your app available to users">
+    1. In the left sidebar, select **Distribution**.
+    2. In **Distribution controls**, click the **Edit** button, select the **Sharing** radio button, enter a **Privacy Policy URL** and then click the **Save changes** button.
+
+    <Note>By default, your app is private and can only be used by you. Making it public allows other users to authorize your app.</Note>
+  </Step>
+  <Step title="Next">
+    Follow the [_Quickstart_](/getting-started/quickstart).
+  </Step>
+</Steps>
+
+## Important API Considerations
+
+**Refresh token expiration:** Refresh tokens will expire after 365 days of non-use and will expire by 90 days if the resource owner is inactive for 90 days. Make sure you call `nango.getConnection()` at least every 365 days to trigger a refresh. See [Atlassian's OAuth documentation](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/#how-do-i-get-a-new-access-token--if-my-access-token-expires-or-is-revoked-) for more details.
+
+**Using the Nango proxy:** When using the proxy for Atlassian, it is important to know that Jira apps will use `/jira/{cloudid}/{api}` for Jira apps and `/confluence/{cloudid}/{api}` for Confluence apps.
+
+For more information on Atlassian's OAuth implementation, see the [OAuth-related documentation](https://developer.atlassian.com/cloud/confluence/oauth-2-3lo-apps).
+
+---

--- a/docs/api-integrations/docusign.mdx
+++ b/docs/api-integrations/docusign.mdx
@@ -1,0 +1,82 @@
+---
+title: 'DocuSign'
+sidebarTitle: 'DocuSign'
+description: 'Integrate your application with the DocuSign API'
+---
+
+## 🚀 Quickstart
+
+Connect to DocuSign with Nango and see data flow in 2 minutes.
+
+<Steps>
+    <Step title="Create the integration">
+    In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _DocuSign_.
+    </Step>
+    <Step title="Authorize DocuSign">
+    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then log in to DocuSign. Later, you'll let your users do the same directly from your app.
+    </Step>
+    <Step title="Call the DocuSign API">
+    Let's make your first request to the DocuSign API (fetch user info). Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+    <Tabs>
+        <Tab title="cURL">
+
+            ```bash
+            curl "https://api.nango.dev/proxy/oauth/userinfo" \
+              -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+              -H "Provider-Config-Key: <INTEGRATION-ID>" \
+              -H "Connection-Id: <CONNECTION-ID>"
+            ```
+
+        </Tab>
+
+        <Tab title="Node">
+
+        Install Nango's backend SDK with `npm i @nangohq/node`. Then run:
+
+        ```typescript
+        import { Nango } from '@nangohq/node';
+
+        const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+
+        const res = await nango.get({
+            endpoint: '/oauth/userinfo',
+            providerConfigKey: '<INTEGRATION-ID>',
+            connectionId: '<CONNECTION-ID>'
+        });
+
+        console.log(res.data);
+        ```
+        </Tab>
+
+
+    </Tabs>
+    Or fetch credentials with the [Node SDK](/reference/sdks/node#get-a-connection-with-credentials) or [API](/reference/api/connection/get).
+
+    ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+    </Step>
+
+    <Step title="Implement Nango in your app">
+        Follow our [quickstart](/getting-started/quickstart/embed-in-your-app) to integrate Nango in your app.
+
+        To obtain your own production credentials, follow the setup guide linked below.
+    </Step>
+</Steps>
+
+## 📚 DocuSign Integration Guides
+
+Nango maintained guides for common use cases.
+
+- [How to register your own DocuSign API OAuth app](/api-integrations/docusign/how-to-register-your-own-docusign-api-oauth-app)
+Register an OAuth app with DocuSign and obtain credentials to connect it to Nango
+
+Official docs: [DocuSign API docs](https://developers.docusign.com/docs)
+
+## 🧩 Pre-built syncs & actions for DocuSign
+
+Enable them in your dashboard. [Extend and customize](/implementation-guides/building-integrations/extend-reference-implementation) to fit your needs.
+
+import PreBuiltUseCases from "/snippets/generated/docusign/PreBuiltUseCases.mdx"
+
+<PreBuiltUseCases />
+
+---

--- a/docs/api-integrations/docusign/how-to-register-your-own-docusign-api-oauth-app.mdx
+++ b/docs/api-integrations/docusign/how-to-register-your-own-docusign-api-oauth-app.mdx
@@ -1,0 +1,42 @@
+---
+title: 'How to register your own DocuSign API OAuth app'
+sidebarTitle: 'DocuSign Setup'
+description: 'Register an OAuth app with DocuSign and connect it to Nango'
+---
+
+This guide shows you how to register your own app with DocuSign to obtain your OAuth credentials (client ID & secret). These are required to let your users grant your app access to their DocuSign account.
+
+## Before you begin
+
+To test your integration during development, use the `docusign-sandbox` configuration in Nango. This lets you test with the [DocuSign Developer account](https://developers.docusign.com/platform/account/).
+
+## Registering your OAuth app
+
+<Steps>
+  <Step title="Sign up for a developer account">
+    If you don't already have one, sign up for a [DocuSign Developer account](https://developers.docusign.com/).
+  </Step>
+  <Step title="Create and configure an integration">
+    1. Navigate to [Build Integration](https://developers.docusign.com/platform/build-integration/).
+    2. Click **Create App & Get Keys** or similar button to start creating your integration.
+    3. Fill in all the required information for your application.
+    4. In the OAuth redirect URIs section, add `https://api.nango.dev/oauth/callback` as your redirect URL.
+    5. Under the permission scopes section, select the various scopes you will need. See [DocuSign's OAuth scopes documentation](https://developers.docusign.com/platform/auth/reference/scopes) for the full list.
+  </Step>
+  <Step title="Obtain OAuth credentials">
+    On your app's configuration page, copy your **Integration Key** (this is your client ID) and **Secret Key** (this is your client secret).
+
+    <Note>
+    The DocuSign **Integration Key** is actually the 'client ID'. You'll also need to add a **Secret Key** when creating your app.
+    </Note>
+
+    <img src="/integrations/all/docusign/docusign_secret.png" style={{maxWidth: "450px" }} />
+  </Step>
+  <Step title="Next">
+    Follow the [_Quickstart_](/getting-started/quickstart) to configure your integration in Nango using these credentials.
+  </Step>
+</Steps>
+
+For more details on DocuSign's OAuth implementation, see [DocuSign's OAuth documentation](https://developers.docusign.com/platform/auth/authcode).
+
+---

--- a/docs/api-integrations/greenhouse.mdx
+++ b/docs/api-integrations/greenhouse.mdx
@@ -1,0 +1,85 @@
+---
+title: 'Greenhouse'
+sidebarTitle: 'Greenhouse'
+description: 'Integrate your application with the Greenhouse API'
+---
+
+## 🚀 Quickstart
+
+Connect to Greenhouse with Nango and see data flow in 2 minutes.
+
+<Steps>
+    <Step title="Create the integration">
+    In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Greenhouse (OAuth)_.
+    </Step>
+    <Step title="Authorize Greenhouse">
+    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then log in to Greenhouse. Later, you'll let your users do the same directly from your app.
+    </Step>
+    <Step title="Call the Greenhouse API">
+    Let's make your first request to the Greenhouse API. Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+    <Tabs>
+        <Tab title="cURL">
+
+            ```bash
+            curl -X GET "https://api.nango.dev/proxy/v1/partner/current_user" \
+              -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+              -H "Provider-Config-Key: <INTEGRATION-ID>" \
+              -H "Connection-Id: <CONNECTION-ID>"
+            ```
+
+        </Tab>
+
+        <Tab title="Node">
+
+        Install Nango's backend SDK with `npm i @nangohq/node`. Then run:
+
+        ```typescript
+        import { Nango } from '@nangohq/node';
+
+        const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+
+        const res = await nango.get({
+            endpoint: '/v1/partner/current_user',
+            providerConfigKey: '<INTEGRATION-ID>',
+            connectionId: '<CONNECTION-ID>'
+        });
+
+        console.log(JSON.stringify(res.data, null, 2));
+        ```
+        </Tab>
+
+
+    </Tabs>
+    Or fetch credentials with the [Node SDK](/reference/sdks/node#get-a-connection-with-credentials) or [API](/reference/api/connection/get).
+
+    ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+    </Step>
+
+    <Step title="Implement Nango in your app">
+        Follow our [quickstart](/getting-started/quickstart/embed-in-your-app) to integrate Nango in your app.
+
+        To obtain your own production credentials, follow the setup guide linked below.
+    </Step>
+</Steps>
+
+## 📚 Greenhouse Integration Guides
+
+Nango maintained guides for common use cases.
+
+- [How to register your own Greenhouse API OAuth app](/api-integrations/greenhouse/how-to-register-your-own-greenhouse-api-oauth-app)
+Register an OAuth app with Greenhouse and obtain credentials to connect it to Nango
+
+- [How do I link my Greenhouse account?](/api-integrations/greenhouse/connect)
+Learn how to authenticate with Greenhouse and link your account
+
+Official docs: [Greenhouse API docs](https://developers.greenhouse.io/candidate-ingestion.html)
+
+## 🧩 Pre-built syncs & actions for Greenhouse
+
+Enable them in your dashboard. [Extend and customize](/implementation-guides/building-integrations/extend-reference-implementation) to fit your needs.
+
+import PreBuiltUseCases from "/snippets/generated/greenhouse/PreBuiltUseCases.mdx"
+
+<PreBuiltUseCases />
+
+---

--- a/docs/api-integrations/greenhouse/connect.mdx
+++ b/docs/api-integrations/greenhouse/connect.mdx
@@ -1,0 +1,28 @@
+---
+title: Greenhouse (OAuth) - How do I link my account?
+sidebarTitle: Greenhouse (OAuth)
+---
+
+# Overview
+
+To authenticate with Greenhouse (OAuth), you need:
+1. **Greenhouse API Domain** - This is the domain to the Greenhouse API product you would wish to connect to.
+
+This guide will walk you through finding this within Greenhouse.
+
+### Prerequisites:
+
+- You must have an account with Greenhouse.
+
+#### Step 1: Finding your Greenhouse API Domain
+- Your **Greenhouse API Domain** refers to the base domain for the specific Greenhouse API product you're using. For the Ingestion API, this is `api`.
+
+#### Step 2: Connect Your Greenhouse Account
+Once you have your **Greenhouse API Domain**:
+1. Open the form where you need to authenticate with Greenhouse (OAuth).
+2. Enter your **Greenhouse API Domain** in its respective field.
+3. Submit the form, and you should be successfully authenticated.
+
+<img src="/integrations/all/greenhouse/form.png" />
+
+You are now connected to Greenhouse (OAuth).

--- a/docs/api-integrations/greenhouse/how-to-register-your-own-greenhouse-api-oauth-app.mdx
+++ b/docs/api-integrations/greenhouse/how-to-register-your-own-greenhouse-api-oauth-app.mdx
@@ -1,0 +1,43 @@
+---
+title: 'How to register your own Greenhouse API OAuth app'
+sidebarTitle: 'Greenhouse Setup'
+description: 'Register an OAuth app with Greenhouse and connect it to Nango'
+---
+
+This guide shows you how to register your own app with Greenhouse to obtain your OAuth credentials (consumer key & consumer secret). These are required to let your users grant your app access to their Greenhouse account.
+
+## Registering your OAuth application
+
+<Steps>
+  <Step title="Submit application information to Greenhouse">
+    Contact Greenhouse to register your OAuth application. You'll need to provide:
+    - **Application Name**: The name of your application as it will appear in Greenhouse.
+    - **Application URL**: The URL of your application.
+    - **Callback URL**: Use `https://api.nango.dev/oauth/callback`
+    - **Logo Image**: A 128x128 pixel image that Greenhouse will include in their permissions modal.
+  </Step>
+  <Step title="Receive OAuth credentials from Greenhouse">
+    After submitting your application information, Greenhouse will provide:
+    - **Consumer Key**: Uniquely identifies your application.
+    - **Consumer Secret**: Acts as proof of your application's identity (will be encrypted when emailed).
+
+    <Note>The consumer secret is confidential and will be encrypted by Greenhouse for security. They'll provide decryption instructions.</Note>
+
+    After decrypting the consumer secret, copy both the **Consumer Key** (which serves as the Client ID) and **Consumer Secret** (which serves as the Client Secret) as you'll need them when configuring your integration in Nango.
+  </Step>
+  <Step title="Next">
+    Follow the [_Quickstart_](/getting-started/quickstart).
+  </Step>
+</Steps>
+
+## Common Scopes
+
+| Scope | Description |
+| ----- | ----------- |
+| `candidates.create` | Create new candidates or prospects |
+| `candidates.view` | View candidates imported via this partner |
+| `jobs.view` | View my jobs |
+
+For more details on Greenhouse's OAuth implementation, see [Greenhouse's OAuth documentation](https://developers.greenhouse.io/candidate-ingestion.html#authentication).
+
+---

--- a/docs/api-integrations/lever.mdx
+++ b/docs/api-integrations/lever.mdx
@@ -1,0 +1,82 @@
+---
+title: 'Lever'
+sidebarTitle: 'Lever'
+description: 'Integrate your application with the Lever API'
+---
+
+## 🚀 Quickstart
+
+Connect to Lever with Nango and see data flow in 2 minutes.
+
+<Steps>
+    <Step title="Create the integration">
+    In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Lever_.
+    </Step>
+    <Step title="Authorize Lever">
+    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then log in to Lever. Later, you'll let your users do the same directly from your app.
+    </Step>
+    <Step title="Call the Lever API">
+    Let's make your first request to the Lever API (fetch opportunities). Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+    <Tabs>
+        <Tab title="cURL">
+
+            ```bash
+            curl "https://api.nango.dev/proxy/v1/opportunities" \
+              -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+              -H "Provider-Config-Key: <INTEGRATION-ID>" \
+              -H "Connection-Id: <CONNECTION-ID>"
+            ```
+
+        </Tab>
+
+        <Tab title="Node">
+
+        Install Nango's backend SDK with `npm i @nangohq/node`. Then run:
+
+        ```typescript
+        import { Nango } from '@nangohq/node';
+
+        const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+
+        const res = await nango.get({
+            endpoint: '/v1/opportunities',
+            providerConfigKey: '<INTEGRATION-ID>',
+            connectionId: '<CONNECTION-ID>'
+        });
+
+        console.log(res.data);
+        ```
+        </Tab>
+
+
+    </Tabs>
+    Or fetch credentials with the [Node SDK](/reference/sdks/node#get-a-connection-with-credentials) or [API](/reference/api/connection/get).
+
+    ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+    </Step>
+
+    <Step title="Implement Nango in your app">
+        Follow our [quickstart](/getting-started/quickstart/embed-in-your-app) to integrate Nango in your app.
+
+        To obtain your own production credentials, follow the setup guide linked below.
+    </Step>
+</Steps>
+
+## 📚 Lever Integration Guides
+
+Nango maintained guides for common use cases.
+
+- [How to register your own Lever API OAuth app](/api-integrations/lever/how-to-register-your-own-lever-api-oauth-app)
+Register an OAuth app with Lever and obtain credentials to connect it to Nango
+
+Official docs: [Lever API docs](https://hire.lever.co/developer/documentation)
+
+## 🧩 Pre-built syncs & actions for Lever
+
+Enable them in your dashboard. [Extend and customize](/implementation-guides/building-integrations/extend-reference-implementation) to fit your needs.
+
+import PreBuiltUseCases from "/snippets/generated/lever/PreBuiltUseCases.mdx"
+
+<PreBuiltUseCases />
+
+---

--- a/docs/api-integrations/lever/how-to-register-your-own-lever-api-oauth-app.mdx
+++ b/docs/api-integrations/lever/how-to-register-your-own-lever-api-oauth-app.mdx
@@ -1,0 +1,47 @@
+---
+title: 'How to register your own Lever API OAuth app'
+sidebarTitle: 'Lever Setup'
+description: 'Register an OAuth app with Lever and connect it to Nango'
+---
+
+This guide shows you how to register your own app with Lever to obtain your OAuth credentials (client ID & secret). These are required to let your users grant your app access to their Lever account.
+
+## Registering your OAuth application
+
+<Steps>
+  <Step title="Sign in to Lever">
+    Go to your Lever account and navigate to the [Lever Settings](https://hire.lever.co/settings/integrations?tab=api) -> Integrations & API section.
+  </Step>
+  <Step title="Request OAuth credentials">
+    Contact Lever to request OAuth credentials for your application. You'll need to provide:
+    - **Application Name**: The name of your application
+    - **Redirect URI**: Use `https://api.nango.dev/oauth/callback`
+    - **Description**: Brief description of what your application does
+  </Step>
+  <Step title="Receive OAuth credentials">
+    After approval, Lever will provide you with:
+    - **Client ID**: Your application's unique identifier
+    - **Client Secret**: Your application's secret key
+
+    Copy these credentials as you'll need them when configuring your integration in Nango.
+  </Step>
+  <Step title="Configure in Nango">
+    In your [Nango dashboard](https://app.nango.dev/dev/integrations), go to the Lever integration and enter your Client ID and Client Secret.
+  </Step>
+  <Step title="Next">
+    Follow the [_Quickstart_](/getting-started/quickstart).
+  </Step>
+</Steps>
+
+## Production vs Sandbox Environments
+
+You should create different integrations in Nango for using the Lever production vs. sandbox API:
+
+- **Lever (OAuth)** - For production use with the live Lever API
+- **Lever (OAuth Sandbox)** - For testing with Lever's sandbox environment
+
+Each environment requires separate OAuth credentials.
+
+For more details on Lever's OAuth implementation, see [Lever's OAuth documentation](https://hire.lever.co/developer/oauth).
+
+---

--- a/docs/api-integrations/monday.mdx
+++ b/docs/api-integrations/monday.mdx
@@ -1,0 +1,87 @@
+---
+title: 'Monday'
+sidebarTitle: 'Monday'
+description: 'Integrate your application with the Monday API'
+---
+
+## 🚀 Quickstart
+
+Connect to Monday with Nango and see data flow in 2 minutes.
+
+<Steps>
+    <Step title="Create the integration">
+    In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Monday_.
+    </Step>
+    <Step title="Authorize Monday">
+    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then log in to Monday. Later, you'll let your users do the same directly from your app.
+    </Step>
+    <Step title="Call the Monday API">
+    Let's make your first request to the Monday API (GraphQL). Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+    <Tabs>
+        <Tab title="cURL">
+
+            ```bash
+            curl "https://api.nango.dev/proxy/v2" \
+              -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+              -H "Provider-Config-Key: <INTEGRATION-ID>" \
+              -H "Connection-Id: <CONNECTION-ID>" \
+              -H "Content-Type: application/json" \
+              -d '{"query": "query { me { id name email } }"}'
+            ```
+
+        </Tab>
+
+        <Tab title="Node">
+
+        Install Nango's backend SDK with `npm i @nangohq/node`. Then run:
+
+        ```typescript
+        import { Nango } from '@nangohq/node';
+
+        const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+
+        const res = await nango.post({
+            endpoint: '/v2',
+            providerConfigKey: '<INTEGRATION-ID>',
+            connectionId: '<CONNECTION-ID>',
+            data: {
+                query: 'query { me { id name email } }'
+            }
+        });
+
+        console.log(res.data);
+        ```
+        </Tab>
+
+
+    </Tabs>
+    Or fetch credentials with the [Node SDK](/reference/sdks/node#get-a-connection-with-credentials) or [API](/reference/api/connection/get).
+
+    ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+    </Step>
+
+    <Step title="Implement Nango in your app">
+        Follow our [quickstart](/getting-started/quickstart/embed-in-your-app) to integrate Nango in your app.
+
+        To obtain your own production credentials, follow the setup guide linked below.
+    </Step>
+</Steps>
+
+## 📚 Monday Integration Guides
+
+Nango maintained guides for common use cases.
+
+- [How to register your own Monday API OAuth app](/api-integrations/monday/how-to-register-your-own-monday-api-oauth-app)
+Register an OAuth app with Monday and obtain credentials to connect it to Nango
+
+Official docs: [Monday API docs](https://developer.monday.com/api-reference/reference/about-the-api-reference)
+
+## 🧩 Pre-built syncs & actions for Monday
+
+Enable them in your dashboard. [Extend and customize](/implementation-guides/building-integrations/extend-reference-implementation) to fit your needs.
+
+import PreBuiltUseCases from "/snippets/generated/monday/PreBuiltUseCases.mdx"
+
+<PreBuiltUseCases />
+
+---

--- a/docs/api-integrations/monday/how-to-register-your-own-monday-api-oauth-app.mdx
+++ b/docs/api-integrations/monday/how-to-register-your-own-monday-api-oauth-app.mdx
@@ -1,0 +1,45 @@
+---
+title: 'How to register your own Monday API OAuth app'
+sidebarTitle: 'Monday Setup'
+description: 'Register an OAuth app with Monday and connect it to Nango'
+---
+
+This guide shows you how to register your own app with Monday to obtain your OAuth credentials (client ID & secret). These are required to let your users grant your app access to their Monday account.
+
+## Registering your Monday OAuth app
+
+<Steps>
+    <Step title="Access the Monday Developers section">
+        Log in to your Monday account.
+        Click on the profile icon in the top right corner and select _Developers_.
+    </Step>
+    <Step title="Create an OAuth application">
+        On the _Developers_ section, click on the _Create App_ button.
+        Select the newly created app from the list.
+        Scroll down to the _App Credentials_ section.
+        Copy the _Client ID_ and _Client Secret_.
+        You will need them when configuring Nango.
+    </Step>
+    <Step title="Configure the redirect URL">
+        On the created app page, select the _Build_ dropdown at the right side of the page.
+        Select _OAuth and Permissions_
+        At the top of the page, select the _Redirect URLs_ tab.
+        Add the following Redirect URL: `https://api.nango.dev/oauth/callback`.
+        Click on _Save Scopes_.
+    </Step>
+    <Step title="Promote the Monday app to live">
+        At the top right of the page, click on the _Promote to Live_ button.
+        Click on the confirmation button.
+    </Step>
+    <Step title="Next">
+        Follow the [_Quickstart_](/getting-started/quickstart) to set up your Monday integration in Nango.
+    </Step>
+</Steps>
+
+## Important API Considerations
+
+**Access tokens do not expire:** Access tokens will be valid until the user uninstalls your app. Monday's OAuth flow does not support refresh tokens at the moment.
+
+For more details on Monday's OAuth implementation, see [Monday's OAuth documentation](https://developer.monday.com/apps/docs/oauth).
+
+---

--- a/docs/api-integrations/servicenow.mdx
+++ b/docs/api-integrations/servicenow.mdx
@@ -1,0 +1,82 @@
+---
+title: 'ServiceNow'
+sidebarTitle: 'ServiceNow'
+description: 'Integrate your application with the ServiceNow API'
+---
+
+## 🚀 Quickstart
+
+Connect to ServiceNow with Nango and see data flow in 2 minutes.
+
+<Steps>
+    <Step title="Create the integration">
+    In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _ServiceNow_.
+    </Step>
+    <Step title="Authorize ServiceNow">
+    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then log in to ServiceNow. Later, you'll let your users do the same directly from your app.
+    </Step>
+    <Step title="Call the ServiceNow API">
+    Let's make your first request to the ServiceNow API (fetch incidents). Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+    <Tabs>
+        <Tab title="cURL">
+
+            ```bash
+            curl "https://api.nango.dev/proxy/api/now/table/incident" \
+              -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+              -H "Provider-Config-Key: <INTEGRATION-ID>" \
+              -H "Connection-Id: <CONNECTION-ID>"
+            ```
+
+        </Tab>
+
+        <Tab title="Node">
+
+        Install Nango's backend SDK with `npm i @nangohq/node`. Then run:
+
+        ```typescript
+        import { Nango } from '@nangohq/node';
+
+        const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+
+        const res = await nango.get({
+            endpoint: '/api/now/table/incident',
+            providerConfigKey: '<INTEGRATION-ID>',
+            connectionId: '<CONNECTION-ID>'
+        });
+
+        console.log(res.data);
+        ```
+        </Tab>
+
+
+    </Tabs>
+    Or fetch credentials with the [Node SDK](/reference/sdks/node#get-a-connection-with-credentials) or [API](/reference/api/connection/get).
+
+    ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+    </Step>
+
+    <Step title="Implement Nango in your app">
+        Follow our [quickstart](/getting-started/quickstart/embed-in-your-app) to integrate Nango in your app.
+
+        To obtain your own production credentials, follow the setup guide linked below.
+    </Step>
+</Steps>
+
+## 📚 ServiceNow Integration Guides
+
+Nango maintained guides for common use cases.
+
+- [How to register your own ServiceNow API OAuth app](/api-integrations/servicenow/how-to-register-your-own-servicenow-api-oauth-app)
+Register an OAuth app with ServiceNow and obtain credentials to connect it to Nango
+
+Official docs: [ServiceNow REST API docs](https://developer.servicenow.com/dev.do#!/reference/api/vancouver/rest/c_TableAPI)
+
+## 🧩 Pre-built syncs & actions for ServiceNow
+
+Enable them in your dashboard. [Extend and customize](/implementation-guides/building-integrations/extend-reference-implementation) to fit your needs.
+
+import PreBuiltUseCases from "/snippets/generated/servicenow/PreBuiltUseCases.mdx"
+
+<PreBuiltUseCases />
+
+---

--- a/docs/api-integrations/servicenow/how-to-register-your-own-servicenow-api-oauth-app.mdx
+++ b/docs/api-integrations/servicenow/how-to-register-your-own-servicenow-api-oauth-app.mdx
@@ -1,0 +1,81 @@
+---
+title: 'How to register your own ServiceNow API OAuth app'
+sidebarTitle: 'ServiceNow Setup'
+description: 'Register an OAuth app with ServiceNow and connect it to Nango'
+---
+
+This guide shows you how to register your own OAuth application with ServiceNow to obtain your OAuth credentials (client ID & secret). These are required to let your users grant your app access to their ServiceNow account.
+
+<Note>
+A [ServiceNow Developer Instance](https://developer.servicenow.com/dev.do) is free, but production instances require a paid subscription.
+</Note>
+
+## Creating an OAuth application
+
+<Steps>
+  <Step title="Create a ServiceNow Developer Account">
+    1. Go to the [ServiceNow Developer Portal](https://developer.servicenow.com/dev.do).
+    2. Click **Sign up and Start Building** to create a new account if you don't already have one.
+    3. Complete the registration process.
+  </Step>
+  <Step title="Request a Personal Developer Instance (PDI)">
+    1. After logging in to the Developer Portal, navigate to **Start Building**.
+    2. Click **Request Instance**.
+    3. Select the latest ServiceNow release version.
+    4. Wait for your instance to be provisioned (this usually takes a few minutes).
+    5. Once provisioned, you'll receive an email with your instance details, including the URL, admin username, and password.
+  </Step>
+  <Step title="Log in to your ServiceNow instance">
+    1. Navigate to your instance URL (typically in the format `https://[your-instance-name].service-now.com/`).
+    2. Log in with the admin credentials provided in the email.
+  </Step>
+  <Step title="Create an OAuth API endpoint for external clients">
+    1. In your ServiceNow instance, navigate to **System OAuth** > **Application Registry**.
+    2. Click **New** to create a new OAuth application.
+    3. Select **Create an OAuth API endpoint for external clients**.
+    4. Fill in the following fields:
+       - **Name**: Enter a descriptive name for your application.
+       - **Client ID**: This will be auto-generated.
+       - **Client Secret**: This will be auto-generated.
+       - **Redirect URL**: Enter `https://api.nango.dev/oauth/callback`.
+    5. Click **Submit** to create the application.
+  </Step>
+  <Step title="Configure OAuth scopes">
+    1. In the Application Registry, find and open your newly created application.
+    2. In the **Application Scope** tab, click **Add**.
+    3. Search for and select the API scopes your application needs. Common scopes include:
+       - **admin**: Full administrative access
+       - **user_admin**: User administration
+       - **user**: Access to user data
+       - **web_service**: Access to web services
+    4. Click **Save** to apply the selected scopes.
+  </Step>
+  <Step title="Configure OAuth policies">
+    1. In your application record, navigate to the **OAuth Policies** tab.
+    2. Configure the following settings:
+       - **Access Token Lifespan**: Default is 30 minutes (1800 seconds). You can adjust this as needed.
+       - **Refresh Token Lifespan**: Default is 8 hours (28800 seconds). You can adjust this as needed.
+       - **Refresh Token Count**: Set to "Unlimited" to allow continuous refreshing of tokens.
+    3. Click **Update** to save your changes.
+  </Step>
+  <Step title="Obtain your OAuth credentials">
+    1. In the Application Registry, open your application.
+    2. Note the **Client ID** and **Client Secret** values.
+    3. Also note your instance URL, as you'll need this for the authorization and token endpoints.
+  </Step>
+  <Step title="Configure your integration in Nango">
+    When setting up your ServiceNow integration in Nango:
+
+    - Use your **Client ID** and **Client Secret** from the previous step
+    - For the authorization URL, use: `https://[your-instance-name].service-now.com/oauth_auth.do`
+    - For the token URL, use: `https://[your-instance-name].service-now.com/oauth_token.do`
+    - Replace `[your-instance-name]` with your actual ServiceNow instance name
+  </Step>
+  <Step title="Next">
+    Follow the [_Quickstart_](/getting-started/quickstart).
+  </Step>
+</Steps>
+
+For more details on ServiceNow's OAuth implementation, see the [OAuth Applications documentation](https://docs.servicenow.com/bundle/vancouver-platform-security/page/administer/security/concept/c_OAuthApplications.html).
+
+---

--- a/docs/api-integrations/workday.mdx
+++ b/docs/api-integrations/workday.mdx
@@ -1,0 +1,105 @@
+---
+title: 'Workday'
+sidebarTitle: 'Workday'
+description: 'Integrate your application with the Workday API'
+---
+
+## 🚀 Quickstart
+
+Connect to Workday with Nango and see data flow in 2 minutes.
+
+<Steps>
+    <Step title="Create the integration">
+    In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Workday_.
+    </Step>
+    <Step title="Authorize Workday">
+    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then log in to Workday. Later, you'll let your users do the same directly from your app.
+    </Step>
+    <Step title="Call the Workday SOAP API">
+    Let's make your first request to the Workday SOAP API (fetch workers using Human_Resources service). Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+    <Tabs>
+        <Tab title="Node">
+
+        Install Nango's backend SDK and SOAP library with `npm i @nangohq/node soap`. Then run:
+
+        ```typescript
+        import { Nango } from '@nangohq/node';
+        import soap from 'soap';
+
+        const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+        const connectionId = '<CONNECTION-ID>';
+        const providerConfigKey = '<INTEGRATION-ID>';
+
+        const connection = await nango.getConnection(providerConfigKey, connectionId);
+        const { credentials, connection_config } = connection;
+
+        if (
+          credentials.type !== "BASIC" ||
+          !credentials.username ||
+          !credentials.password ||
+          !connection_config["hostname"] ||
+          !connection_config["tenant"]
+        ) {
+          throw new Error(
+            "Invalid credentials: BASIC auth, username, password, hostname, and tenant are all required."
+          );
+        }
+
+        // Example: Get workers using Human_Resources service
+        const serviceType = 'Human_Resources';
+        const version = '40.0';
+        const wsdlUrl = `https://community.workday.com/sites/default/files/file-hosting/productionapi/${serviceType}/v${version}/${serviceType}.wsdl`;
+        const endpointUrl = `https://${connection_config["hostname"]}/ccx/service/${connection_config["tenant"]}/${serviceType}/v${version}`;
+
+
+        const client = await soap.createClientAsync(wsdlUrl, {});
+        client.addHttpHeader("Accept-Encoding", "gzip, deflate"); // Needed or some queries will fail https://github.com/axios/axios/issues/4806
+
+        client.setSecurity(
+          new soap.WSSecurity(credentials.username, credentials.password),
+        );
+        client.setEndpoint(endpointUrl);
+
+        // Make SOAP request to Get_WorkersAsync
+        const [res] = await client["Get_WorkersAsync"]({
+          Response_Filter: {
+            Page: 1,
+            Count: 100,
+          },
+        });
+
+        console.log('Workers Response:', JSON.stringify(res, null, 2));
+        ```
+        </Tab>
+    </Tabs>
+
+    Or fetch credentials dynamically via the [Node SDK](/reference/sdks/node#get-a-connection-with-credentials) or [API](/reference/api/connection/get).
+
+    ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+    </Step>
+
+    <Step title="Implement Nango in your app">
+        Follow our [quickstart](/getting-started/quickstart/embed-in-your-app) to integrate Nango in your app.
+
+        To link your Workday account, follow the connect guide linked below.
+    </Step>
+</Steps>
+
+## 📚 Workday Integration Guides
+
+Nango maintained guides for common use cases.
+
+- [How do I link my Workday account?](/api-integrations/workday/connect)
+Learn how to obtain your Workday credentials and link your account
+
+Official docs: [Workday Web Services (WWS) Directory](https://community.workday.com/sites/default/files/file-hosting/productionapi/index.html)
+
+## 🧩 Pre-built syncs & actions for Workday
+
+Enable them in your dashboard. [Extend and customize](/implementation-guides/building-integrations/extend-reference-implementation) to fit your needs.
+
+import PreBuiltUseCases from "/snippets/generated/workday/PreBuiltUseCases.mdx"
+
+<PreBuiltUseCases />
+
+---

--- a/docs/api-integrations/workday/connect.mdx
+++ b/docs/api-integrations/workday/connect.mdx
@@ -1,0 +1,82 @@
+---
+title: Workday - How do I link my account?
+sidebarTitle: Workday
+---
+
+# Overview
+
+To authenticate with Workday, you need:
+1. **Hostname** - The base URL for the Workday Web Services endpoint.
+2. **Tenant** - The unique identifier for your Workday instance, often included in the URL.
+3. **Username** - The Workday Integration System User (ISU) username.
+4. **Password** – The password for the ISU user, used in combination with the ISU username to authenticate API requests to Workday.
+
+This guide will walk you through finding or generating these credentials within Workday.
+
+### Prerequisites:
+
+- You must have an account with Workday with administrator access.
+
+#### Step 1: Finding your Hostname
+1. Log in to your Workday instance.
+2. In your Workday homepage, go to the search bar and type **View API Clients** then select it.
+3. Look for the **Workday REST API Endpoint** field.
+4. The **Hostname** is everything after `https://` and before `/ccx/api/v1/`.
+- Example: If the endpoint is `https://wd2-impl-services1.workday.com/ccx/api/v1/acme`, the hostname is `wd2-impl-services1.workday.com`.
+<img src="/integrations/all/workday/hostname.png" />
+
+#### Step 2: Finding your Tenant
+1. In the same **Workday REST API Endpoint** field from the **View API Clients** report, the **Tenant** is the final part of the URL after **/v1/**.
+- Example: If the endpoint is `https://wd2-impl-services1.workday.com/ccx/api/v1/acme`, the **Tenant** is `acme`.
+
+
+#### Step 3: Create Integration System User (ISU)
+1. Log into your Workday instance.
+2. In your Workday homepage, go to the search bar and type **Create Integration System User** then select it.
+<img src="/integrations/all/workday/search.png" />
+3. Add in a **Username** and type in a secure **Password** of your choosing. Uncheck the box: **Require New Password at Next Sign In**, then click **Done**.
+<img src="/integrations/all/workday/credentials.png" />
+4. Confirm the ISU account has been created by viewing **All Workday Accounts** and filter on the **Username** you created.
+<img src="/integrations/all/workday/confirm_user.png" />
+5.Go to the search bar and type **Create Security Group** then select it.
+<img src="/integrations/all/workday/search_2.png" />
+<Tip>Creating a security group allows you to assign the necessary permissions to the ISU account</Tip>
+6. When creating the group, the group must be of type **Integration System Security Group (Unconstrained)**. Add in a **Name** for the group and click **OK**.
+<img src="/integrations/all/workday/create_security_group.png" />
+7. Assign the ISU account we created in step 3 above to your new security group and click **OK**.
+<img src="/integrations/all/workday/assign_user.png" />
+8. Go to the search bar and type **View Security Groups for User** then select it.
+<img src="/integrations/all/workday/view_security_group.png" />
+9. In the Person field, search for the ISU username we created above and click **OK**.
+<img src="/integrations/all/workday/view_security_group_for_user.png" />
+10. You should see the security groups associated with the ISU account, including the one you just created (**Integration System Security Group (Unconstrained)**). Scroll down to find this security group, then click on it.
+11. Navigate to **ellipses** > **Security Group** > **Maintain Domain Permissions for Security Group**.
+<img src="/integrations/all/workday/view_isu_group.png" />
+12. Add all of the required domain security policies with the proper view/modify access for the **Integration Permissions**.
+<Tip>In Workday, all security changes remain **pending** until they are activated by a user with the appropriate permissions.</Tip>
+13. Activate your security policy changes by;
+- Go to the search bar and type **Activate Pending Security Policy Changes** then select it.
+<img src="/integrations/all/workday/search_3.png" />
+- Enter a comment and click **OK**.
+<img src="/integrations/all/workday/activate_policy_changes.png" />
+- You will see a list of changes that were made. You must check the **Confirm** box and click **OK**.
+<img src="/integrations/all/workday/verify_policy_change.png" />
+
+#### Step 4: Generating your Username
+- This is the **Username** from the Integration System User (ISU) you created above, followed by `@` and your **Workday tenant** name from above.
+- **Format:** `username@yourtenant`
+- **Example:** `ISU Nango@acme`
+#### Step 5: Finding your Password
+- This is the **Password** you set when creating the Integration System User (ISU) above.
+
+#### Step 6: Enter credentials in the Connect UI
+
+Once you have your **Hostname**, **Tenant**, **Username** and **Password**:
+1. Open the form where you need to authenticate with Workday.
+2. Enter your **Hostname**, **Tenant**, **Username** and **Password** in their designated fields.
+3. Submit the form, and you should be successfully authenticated.
+
+
+<img src="/integrations/all/workday/form.png" style={{maxWidth: "450px" }}/>
+
+You are now connected to Workday.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -314,6 +314,34 @@
     {
       "source": "/integrations/all/zoho-crm",
       "destination": "/api-integrations/zoho-crm"
+    },
+    {
+      "source": "/integrations/all/atlassian",
+      "destination": "/api-integrations/atlassian"
+    },
+    {
+      "source": "/integrations/all/greenhouse",
+      "destination": "/api-integrations/greenhouse"
+    },
+    {
+      "source": "/integrations/all/servicenow",
+      "destination": "/api-integrations/servicenow"
+    },
+    {
+      "source": "/integrations/all/workday",
+      "destination": "/api-integrations/workday"
+    },
+    {
+      "source": "/integrations/all/monday",
+      "destination": "/api-integrations/monday"
+    },
+    {
+      "source": "/integrations/all/docusign",
+      "destination": "/api-integrations/docusign"
+    },
+    {
+      "source": "/integrations/all/lever",
+      "destination": "/api-integrations/lever"
     }
   ],
   "navigation": {
@@ -531,7 +559,7 @@
               "integrations/all/asana-scim",
               "integrations/all/ashby",
               "integrations/all/atlas-so",
-              "integrations/all/atlassian",
+              "api-integrations/atlassian",
               "integrations/all/atlassian-admin",
               "integrations/all/atlassian-government-cloud",
               "api-integrations/attio",
@@ -648,7 +676,7 @@
               "integrations/all/discourse",
               "integrations/all/dixa",
               "integrations/all/document360",
-              "integrations/all/docusign",
+              "api-integrations/docusign",
               "integrations/all/docusign-sandbox",
               "integrations/all/docuware",
               "api-integrations/drata",
@@ -741,7 +769,7 @@
               "integrations/all/grain-api-key",
               "integrations/all/grammarly",
               "integrations/all/grammarly-scim",
-              "integrations/all/greenhouse",
+              "api-integrations/greenhouse",
               "integrations/all/greenhouse-assessment",
               "integrations/all/greenhouse-basic",
               "integrations/all/greenhouse-harvest",
@@ -806,7 +834,7 @@
               "integrations/all/lattice",
               "integrations/all/leadmagic",
               "integrations/all/lessonly",
-              "integrations/all/lever",
+              "api-integrations/lever",
               "integrations/all/lever-basic",
               "integrations/all/lever-basic-sandbox",
               "integrations/all/lever-sandbox",
@@ -847,7 +875,7 @@
               "integrations/all/miro-scim",
               "integrations/all/missive",
               "integrations/all/mixpanel",
-              "integrations/all/monday",
+              "api-integrations/monday",
               "integrations/all/momentum-io",
               "integrations/all/mural",
               "integrations/all/nationbuilder",
@@ -972,7 +1000,7 @@
               "integrations/all/sentry",
               "integrations/all/sentry-oauth",
               "integrations/all/servicem8",
-              "integrations/all/servicenow",
+              "api-integrations/servicenow",
               "integrations/all/setmore",
               "integrations/all/sellsy",
               "integrations/all/sellsy-oauth2-cc",
@@ -1082,7 +1110,7 @@
               "integrations/all/wordpress",
               "integrations/all/workable",
               "integrations/all/workable-oauth",
-              "integrations/all/workday",
+              "api-integrations/workday",
               "integrations/all/workday-oauth",
               "integrations/all/wrike",
               "integrations/all/xai",

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -1162,7 +1162,8 @@ atlassian:
         grant_type: refresh_token
     proxy:
         base_url: https://api.atlassian.com
-    docs: https://nango.dev/docs/integrations/all/atlassian
+    docs: https://nango.dev/docs/api-integrations/atlassian
+    setup_guide_url: https://nango.dev/docs/api-integrations/atlassian/how-to-register-your-own-atlassian-api-oauth-app
 
 atlassian-admin:
     display_name: Atlassian Cloud Admin
@@ -4230,7 +4231,8 @@ docusign:
     proxy:
         base_url: https://www.docusign.net
     post_connection_script: docusignPostConnection
-    docs: https://nango.dev/docs/integrations/all/docusign
+    docs: https://nango.dev/docs/api-integrations/docusign
+    setup_guide_url: https://nango.dev/docs/api-integrations/docusign/how-to-register-your-own-docusign-api-oauth-app
 
 docusign-sandbox:
     display_name: DocuSign (Sandbox)
@@ -6553,8 +6555,9 @@ greenhouse:
             type: link
             limit_name_in_request: per_page
             link_rel_in_response_header: next
-    docs: https://nango.dev/docs/integrations/all/greenhouse
-    docs_connect: https://nango.dev/docs/integrations/all/greenhouse/connect
+    docs: https://nango.dev/docs/api-integrations/greenhouse
+    setup_guide_url: https://nango.dev/docs/api-integrations/greenhouse/how-to-register-your-own-greenhouse-api-oauth-app
+    docs_connect: https://nango.dev/docs/api-integrations/greenhouse/connect
     connection_config:
         resource:
             type: string
@@ -8264,7 +8267,8 @@ lever:
         audience: https://api.lever.co/v1/
     proxy:
         base_url: https://api.lever.co
-    docs: https://nango.dev/docs/integrations/all/lever
+    docs: https://nango.dev/docs/api-integrations/lever
+    setup_guide_url: https://nango.dev/docs/api-integrations/lever/how-to-register-your-own-lever-api-oauth-app
 
 lever-basic:
     display_name: Lever (Basic Auth)
@@ -9295,7 +9299,8 @@ monday:
     token_url: https://auth.monday.com/oauth2/token
     proxy:
         base_url: https://api.monday.com
-    docs: https://nango.dev/docs/integrations/all/monday
+    docs: https://nango.dev/docs/api-integrations/monday
+    setup_guide_url: https://nango.dev/docs/api-integrations/monday/how-to-register-your-own-monday-api-oauth-app
 
 momentum-io:
     display_name: Momentum.io
@@ -12729,7 +12734,8 @@ servicenow:
         grant_type: refresh_token
     proxy:
         base_url: https://${connectionConfig.subdomain}.service-now.com
-    docs: https://nango.dev/docs/integrations/all/servicenow
+    docs: https://nango.dev/docs/api-integrations/servicenow
+    setup_guide_url: https://nango.dev/docs/api-integrations/servicenow/how-to-register-your-own-servicenow-api-oauth-app
     connection_config:
         subdomain:
             type: string
@@ -15231,8 +15237,8 @@ workday:
     auth_mode: BASIC
     proxy:
         base_url: https://${connectionConfig.hostname}/ccx/service/${connectionConfig.tenant}
-    docs: https://nango.dev/docs/integrations/all/workday
-    docs_connect: https://nango.dev/docs/integrations/all/workday/connect
+    docs: https://nango.dev/docs/api-integrations/workday
+    docs_connect: https://nango.dev/docs/api-integrations/workday/connect
     connection_config:
         hostname:
             type: string


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Builds on #5056 and #5037

Migrates over
- atlassian
- greenhouse
- servicenow
- workday
- monday
- docusign
- lever                                                                                                                                         
                                    

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Docs migration for seven integrations with updated navigation & provider metadata**

This PR migrates the Atlassian, Greenhouse, ServiceNow, Workday, Monday, DocuSign, and Lever integration docs into the new IA structure, adding quickstart guides, setup instructions, and SCIM/connect specifics. It also aligns site navigation, redirects, and `providers.yaml` metadata to the new `/api-integrations/...` slug structure so in-product links resolve to the restructured pages.

<details>
<summary><strong>Key Changes</strong></summary>

• Added new `docs/api-integrations/*` guides (quickstart, setup, connect) for Atlassian, Greenhouse, ServiceNow, Workday, Monday, DocuSign, and Lever with updated frontmatter and embedded examples.
• Updated `docs/docs.json` navigation, sidebar entries, and redirects to point legacy `/integrations/all/...` slugs to the new `/api-integrations/...` locations.
• Refreshed `packages/providers/providers.yaml` for the affected providers so `docs`, `setup_guide_url`, and `docs_connect` fields reference the new documentation paths.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Documentation site content under `docs/api-integrations`
• Navigation/redirect configuration in `docs/docs.json`
• Provider metadata in `packages/providers/providers.yaml`

</details>

---
*This summary was automatically generated by @propel-code-bot*