### PR TITLE
fix(auth): correct token refresh for providers using providerClient

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1415,7 +1415,7 @@ class ConnectionService {
     > {
         if (providerClient.shouldUseProviderClient(providerConfig.provider)) {
             const credentials = connection.credentials as OAuth2Credentials;
-            if (credentials.config_override && credentials.config_override.client_id && credentials.config_override.client_secret) {
+            if (credentials.config_override?.client_id && credentials.config_override?.client_secret) {
                 providerConfig = {
                     ...providerConfig,
                     oauth_client_id: credentials.config_override.client_id,
@@ -1425,7 +1425,7 @@ class ConnectionService {
             const rawCreds = await providerClient.refreshToken(provider as ProviderOAuth2, providerConfig, connection);
             const parsedCreds = this.parseRawCredentials(rawCreds, 'OAUTH2', provider as ProviderOAuth2) as OAuth2Credentials;
 
-            if (credentials.config_override && credentials.config_override.client_id && credentials.config_override.client_secret) {
+            if (credentials.config_override?.client_id && credentials.config_override?.client_secret) {
                 parsedCreds.config_override = {
                     client_id: credentials.config_override.client_id,
                     client_secret: credentials.config_override.client_secret

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1414,8 +1414,23 @@ class ConnectionService {
         >
     > {
         if (providerClient.shouldUseProviderClient(providerConfig.provider)) {
+            const credentials = connection.credentials as OAuth2Credentials;
+            if (credentials.config_override && credentials.config_override.client_id && credentials.config_override.client_secret) {
+                providerConfig = {
+                    ...providerConfig,
+                    oauth_client_id: credentials.config_override.client_id,
+                    oauth_client_secret: credentials.config_override.client_secret
+                };
+            }
             const rawCreds = await providerClient.refreshToken(provider as ProviderOAuth2, providerConfig, connection);
             const parsedCreds = this.parseRawCredentials(rawCreds, 'OAUTH2', provider as ProviderOAuth2) as OAuth2Credentials;
+
+            if (credentials.config_override && credentials.config_override.client_id && credentials.config_override.client_secret) {
+                parsedCreds.config_override = {
+                    client_id: credentials.config_override.client_id,
+                    client_secret: credentials.config_override.client_secret
+                };
+            }
 
             return { success: true, error: null, response: parsedCreds };
         } else if (provider.auth_mode === 'OAUTH2_CC') {


### PR DESCRIPTION
## Describe the problem and your solution
- Fix token refresh for providers using `providerClient` with `config_overrides`.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

The refresh flow now temporarily applies the override client credentials before invoking the provider client and reapplies those overrides to the returned OAuth2 credentials so downstream consumers continue receiving the correct metadata.

<details>
<summary><strong>Key Changes</strong></summary>

• Injects override `client_id` and `client_secret` into `providerConfig` prior to invoking `providerClient.refreshToken`.
• Reattaches the override `client_id` and `client_secret` onto the refreshed `OAuth2Credentials.config_override` payload.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/shared/lib/services/connection.service.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*