### PR TITLE
fix(logs): allow year to be set as well

### DIFF
--- a/packages/webapp/src/components/PeriodSelector.tsx
+++ b/packages/webapp/src/components/PeriodSelector.tsx
@@ -9,7 +9,7 @@ import { Button } from './ui/button/Button';
 
 import type { Period, PeriodPreset } from '../utils/dates';
 
-const dateTimeFormat = 'LLL dd, HH:mm:ss';
+const dateTimeFormat = 'LLL dd, yyyy, HH:mm:ss';
 
 export interface PeriodSelectorProps {
     period: Period | null;

--- a/packages/webapp/src/utils/dates.ts
+++ b/packages/webapp/src/utils/dates.ts
@@ -14,7 +14,7 @@ export interface PeriodPreset {
 
 export function parsePeriod(input: string, dateTimeFormat: string, example: string): { period: Period | null; error: string | null } {
     // Validate input format
-    const dateFormatRegex = /^[A-Z][a-z]{2} \d{1,2}, \d{1,2}:\d{2}:\d{2} - [A-Z][a-z]{2} \d{1,2}, \d{1,2}:\d{2}:\d{2}$/;
+    const dateFormatRegex = /^[A-Z][a-z]{2} \d{1,2}, \d{4}, \d{1,2}:\d{2}:\d{2} - [A-Z][a-z]{2} \d{1,2}, \d{4}, \d{1,2}:\d{2}:\d{2}$/;
     if (!dateFormatRegex.test(input)) {
         return { period: null, error: `Invalid format. Example: ${example}` };
     }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Allow Custom Log Periods to Include Year**

The PR updates the custom period parsing flow so users can specify four-digit years when entering log date ranges. It tightens the validation regex in `parsePeriod` and aligns the UI-supplied format string to include the year component.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `parsePeriod` regex in `packages/webapp/src/utils/dates.ts` to require a four-digit year in both range endpoints
• Adjusted `dateTimeFormat` in `packages/webapp/src/components/PeriodSelector.tsx` to `LLL dd, yyyy, HH:mm:ss` so formatted examples and parsed input include the year

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/webapp/src/utils/dates.ts
• packages/webapp/src/components/PeriodSelector.tsx

</details>

---
*This summary was automatically generated by @propel-code-bot*