### PR TITLE
feat: pipe zod descriptions to json-schema

### DIFF
--- a/packages/cli/lib/services/model.service.ts
+++ b/packages/cli/lib/services/model.service.ts
@@ -106,6 +106,9 @@ export function modelToTypescript({ model }: { model: NangoModel }) {
     if (model.isAnon) {
         output.push(`export type ${model.name} = ${fieldToTypescript({ field: model.fields[0]! })}`);
     } else {
+        if (model.description) {
+            output.push([`/**`, ` * ${model.description}`, ` */`].join('\n'));
+        }
         output.push(`export interface ${model.name} {`);
         output.push(...fieldsToTypescript({ fields: model.fields }));
         output.push(`};`);
@@ -119,6 +122,10 @@ export function fieldsToTypescript({ fields }: { fields: NangoModelField[] }) {
 
     // Insert dynamic key at the beginning
     if (dynamic) {
+        if (dynamic.description) {
+            output.push([`  /**`, `   * ${dynamic.description}`, `   */`].join('\n'));
+        }
+
         output.push(`  [key: string]: ${fieldToTypescript({ field: dynamic })};`);
     }
 
@@ -126,6 +133,10 @@ export function fieldsToTypescript({ fields }: { fields: NangoModelField[] }) {
     for (const field of fields) {
         if (field.dynamic) {
             continue;
+        }
+
+        if (field.description) {
+            output.push([`  /**`, `   * ${field.description}`, `   */`].join('\n'));
         }
 
         output.push(`  ${shouldQuote(field.name) ? `"${field.name}"` : field.name}${field.optional ? '?' : ''}: ${fieldToTypescript({ field: field })};`);

--- a/packages/cli/lib/services/model.service.unit.test.ts
+++ b/packages/cli/lib/services/model.service.unit.test.ts
@@ -89,6 +89,80 @@ describe('buildModelTs', () => {
         }
         expect(removeVersion(acc.join('\n'))).toMatchSnapshot();
     });
+
+    it('should generate JSDoc comments for model and field descriptions', () => {
+        const models: NangoModel[] = [
+            {
+                name: 'User',
+                description: 'Represents a user in the system',
+                fields: [
+                    {
+                        name: '__string',
+                        value: 'string',
+                        tsType: true,
+                        dynamic: true,
+                        description: 'Dynamic string field for additional properties'
+                    },
+                    {
+                        name: 'id',
+                        value: 'number',
+                        tsType: true,
+                        description: 'Unique identifier for the user'
+                    },
+                    {
+                        name: 'name',
+                        value: 'string',
+                        tsType: true,
+                        description: 'Full name of the user',
+                        optional: true
+                    },
+                    {
+                        name: 'email',
+                        value: 'string',
+                        tsType: true,
+                        description: 'Email address of the user'
+                    }
+                ]
+            }
+        ];
+        const res = buildModelsTS({
+            parsed: {
+                yamlVersion: 'v2',
+                models: new Map(Object.entries(models)),
+                integrations: []
+            }
+        });
+
+        // Extract the models section
+        const modelsSection = res.split('// ------ Models')[1]?.split('// ------ /Models')[0]?.trim();
+        expect(modelsSection).toBeDefined();
+
+        const expectedOutput = [
+            '/**',
+            ' * Represents a user in the system',
+            ' */',
+            'export interface User {',
+            '  /**',
+            '   * Dynamic string field for additional properties',
+            '   */',
+            '  [key: string]: string;',
+            '  /**',
+            '   * Unique identifier for the user',
+            '   */',
+            '  id: number;',
+            '  /**',
+            '   * Full name of the user',
+            '   */',
+            '  name?: string | undefined;',
+            '  /**',
+            '   * Email address of the user',
+            '   */',
+            '  email: string;',
+            '};'
+        ].join('\n');
+
+        expect(modelsSection).toBe(expectedOutput);
+    });
 });
 
 describe('fieldsToTypescript', () => {

--- a/packages/cli/lib/zeroYaml/definitions.ts
+++ b/packages/cli/lib/zeroYaml/definitions.ts
@@ -142,9 +142,9 @@ export function buildSync({
     if (metadata) {
         usedModels.add(metadata.name);
         if (!Array.isArray(metadata.value)) {
-            models.set(metadata.name, { name: metadata.name, fields: [{ ...metadata, name: 'metadata' }], isAnon: true });
+            models.set(metadata.name, { name: metadata.name, fields: [{ ...metadata, name: 'metadata' }], isAnon: true, description: metadata.description });
         } else {
-            models.set(metadata.name, { name: metadata.name, fields: metadata.value });
+            models.set(metadata.name, { name: metadata.name, fields: metadata.value, description: metadata.description });
         }
     }
 
@@ -185,7 +185,7 @@ export function buildSync({
         name: basename,
         output: Object.entries(params.models).map(([name, model]) => {
             const to = zodToNangoModelField(name, model);
-            models.set(name, { name, fields: to['value'] as NangoModelField[] });
+            models.set(name, { name, fields: to['value'] as NangoModelField[], description: to.description });
             usedModels.add(name);
             return name;
         }),
@@ -214,16 +214,16 @@ export function buildAction({
     const models = new Map<string, NangoModel>();
     const input = zodToNangoModelField(`ActionInput_${integrationIdClean}_${basenameClean}`, params.input);
     if (!Array.isArray(input.value)) {
-        models.set(input.name, { name: input.name, fields: [{ ...input, name: 'input' }], isAnon: true });
+        models.set(input.name, { name: input.name, fields: [{ ...input, name: 'input' }], isAnon: true, description: input.description });
     } else {
-        models.set(input.name, { name: input.name, fields: input.value });
+        models.set(input.name, { name: input.name, fields: input.value, description: input.description });
     }
 
     const output = zodToNangoModelField(`ActionOutput_${integrationIdClean}_${basenameClean}`, params.output);
     if (!Array.isArray(output.value)) {
-        models.set(output.name, { name: output.name, fields: [{ ...output, name: 'output' }], isAnon: true });
+        models.set(output.name, { name: output.name, fields: [{ ...output, name: 'output' }], isAnon: true, description: output.description });
     } else {
-        models.set(output.name, { name: output.name, fields: output.value });
+        models.set(output.name, { name: output.name, fields: output.value, description: output.description });
     }
 
     const action: ParsedNangoAction = {

--- a/packages/cli/lib/zeroYaml/definitions.unit.test.ts
+++ b/packages/cli/lib/zeroYaml/definitions.unit.test.ts
@@ -50,16 +50,18 @@ describe('buildSync', () => {
         });
         expect(Array.from(def.models.values())).toStrictEqual([
             {
-                fields: [{ name: 'metadata', tsType: true, value: 'void' }],
+                fields: [{ name: 'metadata', tsType: true, value: 'void', description: undefined }],
                 isAnon: true,
-                name: 'SyncMetadata_github_fetchIssues'
+                name: 'SyncMetadata_github_fetchIssues',
+                description: undefined
             },
             {
                 fields: [
-                    { name: 'id', optional: false, tsType: true, value: 'string' },
-                    { name: 'foobar', optional: false, tsType: true, value: 'string' }
+                    { name: 'id', optional: false, tsType: true, value: 'string', description: undefined },
+                    { name: 'foobar', optional: false, tsType: true, value: 'string', description: undefined }
                 ],
-                name: 'Model'
+                name: 'Model',
+                description: undefined
             }
         ]);
     });
@@ -97,14 +99,16 @@ describe('buildSync', () => {
         });
         expect(Array.from(res.models.values())).toStrictEqual([
             {
-                fields: [{ name: 'input', tsType: true, value: 'void' }],
+                fields: [{ name: 'input', tsType: true, value: 'void', description: undefined }],
                 isAnon: true,
-                name: 'ActionInput_github_createIssue'
+                name: 'ActionInput_github_createIssue',
+                description: undefined
             },
             {
-                fields: [{ name: 'output', optional: false, tsType: true, value: 'number' }],
+                fields: [{ name: 'output', optional: false, tsType: true, value: 'number', description: undefined }],
                 isAnon: true,
-                name: 'ActionOutput_github_createIssue'
+                name: 'ActionOutput_github_createIssue',
+                description: undefined
             }
         ]);
     });

--- a/packages/cli/lib/zeroYaml/zodToNango.ts
+++ b/packages/cli/lib/zeroYaml/zodToNango.ts
@@ -1,6 +1,9 @@
 import type { NangoModelField } from '@nangohq/types';
 import type * as z from 'zod';
 
+// When adding support for new Zod types,
+// check if rendering it is well supported in webapp functions input/output rendering and add support accordingly
+
 export function zodToNangoModelField(name: string, schema: z.core.$ZodType): NangoModelField {
     const optional = (schema as z.ZodType).safeParse(undefined).success;
 
@@ -9,66 +12,66 @@ export function zodToNangoModelField(name: string, schema: z.core.$ZodType): Nan
         for (const [key, value] of Object.entries(schema.shape)) {
             values.push(zodToNangoModelField(key, value as z.core.$ZodType));
         }
-        return { name, value: values, optional };
+        return { name, value: values, optional, description: schema.description };
     } else if (isZodString(schema)) {
-        return { name, value: 'string', tsType: true, optional };
+        return { name, value: 'string', tsType: true, optional, description: schema.description };
     } else if (isZodLiteral(schema)) {
         if (schema.def.values.length > 1) {
             const values: NangoModelField['value'] = [];
             for (const [key, value] of Object.entries(schema.def.values)) {
-                values.push({ name: key.toString(), value: value as string });
+                values.push({ name: key.toString(), value: value as string, description: schema.description });
             }
-            return { name, value: values, optional, union: true };
+            return { name, value: values, optional, union: true, description: schema.description };
         }
-        return { name, value: schema.def.values[0] as string, optional };
+        return { name, value: schema.def.values[0] as string, optional, description: schema.description };
     } else if (isZodNumber(schema)) {
-        return { name, value: 'number', tsType: true, optional };
+        return { name, value: 'number', tsType: true, optional, description: schema.description };
     } else if (isZodBoolean(schema)) {
-        return { name, value: 'boolean', tsType: true, optional };
+        return { name, value: 'boolean', tsType: true, optional, description: schema.description };
     } else if (isZodNull(schema)) {
-        return { name, value: null, tsType: true, optional };
+        return { name, value: null, tsType: true, optional, description: schema.description };
     } else if (isZodNullable(schema)) {
-        return { ...zodToNangoModelField(name, schema.def.innerType), optional };
+        return { ...zodToNangoModelField(name, schema.def.innerType), optional, description: schema.description };
     } else if (isZodEnum(schema)) {
         const values: NangoModelField['value'] = [];
         let i = 0;
         for (const value of Object.values(schema.def.entries)) {
-            values.push({ name: i.toString(), value: value as string });
+            values.push({ name: i.toString(), value: value as string, description: schema.description });
             i++;
         }
-        return { name, value: values, optional, union: true };
+        return { name, value: values, optional, union: true, description: schema.description };
     } else if (isZodAny(schema)) {
-        return { name, value: 'any', tsType: true, optional };
+        return { name, value: 'any', tsType: true, optional, description: schema.description };
     } else if (isZodDate(schema)) {
-        return { name, value: 'Date', tsType: true, optional };
+        return { name, value: 'Date', tsType: true, optional, description: schema.description };
     } else if (isZodRecord(schema)) {
-        return { name, value: [{ ...zodToNangoModelField('__string', schema.def.valueType), dynamic: true }], optional };
+        return { name, value: [{ ...zodToNangoModelField('__string', schema.def.valueType), dynamic: true }], optional, description: schema.description };
     } else if (isZodArray(schema)) {
         // console.log('array', schema.def);
         const value = zodToNangoModelField('0', schema.def.element);
         if (isZodObject(schema.def.element)) {
-            return { name, value: [value], array: true, optional };
+            return { name, value: [value], array: true, optional, description: schema.description };
         }
-        return { name, value: value.value, tsType: true, array: true, optional };
+        return { name, value: value.value, tsType: true, array: true, optional, description: schema.description };
     } else if (isZodUnion(schema) || isZodDiscriminatedUnion(schema)) {
         const values: NangoModelField['value'] = [];
 
         for (const [key, value] of Object.entries(schema._zod.def.options)) {
             values.push(zodToNangoModelField(key, value));
         }
-        return { name, value: values, tsType: true, union: true, optional };
+        return { name, value: values, tsType: true, union: true, optional, description: schema.description };
     } else if (isZodNever(schema)) {
-        return { name, value: 'never', tsType: true, optional };
+        return { name, value: 'never', tsType: true, optional, description: schema.description };
     } else if (isZodVoid(schema)) {
-        return { name, value: 'void', tsType: true }; // No optional on purpose because void | undefined is not valid
+        return { name, value: 'void', tsType: true, description: schema.description }; // No optional on purpose because void | undefined is not valid
     } else if (isZodOptional(schema)) {
-        return { ...zodToNangoModelField(name, schema.def.innerType), optional };
+        return { ...zodToNangoModelField(name, schema.def.innerType), optional, description: schema.description };
     } else if (isZodUndefined(schema)) {
         throw new Error('z.undefined() is not supported, please use z.null() or z.optional() instead');
     } else if (isZodUnknown(schema)) {
-        return { name, value: 'unknown', tsType: true, optional };
+        return { name, value: 'unknown', tsType: true, optional, description: schema.description };
     } else if (isZodBigInt(schema)) {
-        return { name, value: 'bigint', tsType: true, optional };
+        return { name, value: 'bigint', tsType: true, optional, description: schema.description };
     } else if (isZodEmail(schema)) {
         // Not supported yet by "ts-json-schema-generator" (2.4.0)
         // return { name, value: 'email', tsType: true, optional };

--- a/packages/cli/lib/zeroYaml/zodToNango.unit.test.ts
+++ b/packages/cli/lib/zeroYaml/zodToNango.unit.test.ts
@@ -52,35 +52,39 @@ describe('zodToNango', () => {
         ).toStrictEqual({
             name: 'test',
             optional: false,
+            description: undefined,
             value: [
-                { name: 'foo', optional: false, value: 'bar' },
+                { name: 'foo', optional: false, value: 'bar', description: undefined },
                 {
                     name: 'literalArray',
                     optional: false,
                     union: true,
                     value: [
-                        { name: '0', value: 'bar' },
-                        { name: '1', value: 'baz' }
-                    ]
+                        { name: '0', value: 'bar', description: undefined },
+                        { name: '1', value: 'baz', description: undefined }
+                    ],
+                    description: undefined
                 },
-                { name: 'num', optional: false, tsType: true, value: 'number' },
-                { name: 'bigint', optional: false, tsType: true, value: 'bigint' },
-                { name: 'bool', optional: false, tsType: true, value: 'boolean' },
-                { name: 'null', optional: false, tsType: true, value: null },
+                { name: 'num', optional: false, tsType: true, value: 'number', description: undefined },
+                { name: 'bigint', optional: false, tsType: true, value: 'bigint', description: undefined },
+                { name: 'bool', optional: false, tsType: true, value: 'boolean', description: undefined },
+                { name: 'null', optional: false, tsType: true, value: null, description: undefined },
                 {
                     name: 'enum',
                     optional: false,
                     union: true,
                     value: [
-                        { name: '0', value: 'tip' },
-                        { name: '1', value: 'top' }
-                    ]
+                        { name: '0', value: 'tip', description: undefined },
+                        { name: '1', value: 'top', description: undefined }
+                    ],
+                    description: undefined
                 },
-                { array: true, name: 'arr', optional: false, tsType: true, value: 'string' },
+                { array: true, name: 'arr', optional: false, tsType: true, value: 'string', description: undefined },
                 {
                     name: 'obj',
                     optional: false,
-                    value: [{ name: 'bar', optional: false, tsType: true, value: 'string' }]
+                    value: [{ name: 'bar', optional: false, tsType: true, value: 'string', description: undefined }],
+                    description: undefined
                 },
                 {
                     name: 'union',
@@ -88,30 +92,33 @@ describe('zodToNango', () => {
                     tsType: true,
                     union: true,
                     value: [
-                        { name: '0', optional: false, tsType: true, value: 'string' },
-                        { name: '1', optional: false, tsType: true, value: 'boolean' }
-                    ]
+                        { name: '0', optional: false, tsType: true, value: 'string', description: undefined },
+                        { name: '1', optional: false, tsType: true, value: 'boolean', description: undefined }
+                    ],
+                    description: undefined
                 },
-                { name: 'any', optional: true, tsType: true, value: 'any' },
+                { name: 'any', optional: true, tsType: true, value: 'any', description: undefined },
                 {
                     name: 'reco',
                     optional: false,
-                    value: [{ dynamic: true, name: '__string', optional: false, tsType: true, value: 'Date' }]
+                    value: [{ dynamic: true, name: '__string', optional: false, tsType: true, value: 'Date', description: undefined }],
+                    description: undefined
                 },
-                { name: 'opt', optional: true, tsType: true, value: 'any' },
-                { name: 'nullable', optional: false, tsType: true, value: 'string' },
-                { name: 'nullableOptional', optional: true, tsType: true, value: 'string' },
-                { name: 'nullish', optional: true, tsType: true, value: 'string' },
+                { name: 'opt', optional: true, tsType: true, value: 'any', description: undefined },
+                { name: 'nullable', optional: false, tsType: true, value: 'string', description: undefined },
+                { name: 'nullableOptional', optional: true, tsType: true, value: 'string', description: undefined },
+                { name: 'nullish', optional: true, tsType: true, value: 'string', description: undefined },
                 {
                     name: 'ref',
                     optional: false,
-                    value: [{ name: 'id', optional: false, tsType: true, value: 'string' }]
+                    value: [{ name: 'id', optional: false, tsType: true, value: 'string', description: undefined }],
+                    description: undefined
                 },
-                { name: 'void', tsType: true, value: 'void' },
-                { name: 'never', optional: false, tsType: true, value: 'never' },
-                { name: 'date', optional: false, tsType: true, value: 'Date' },
-                { name: 'emptyObject', optional: false, value: [] },
-                { name: 'unknown', optional: true, tsType: true, value: 'unknown' },
+                { name: 'void', tsType: true, value: 'void', description: undefined },
+                { name: 'never', optional: false, tsType: true, value: 'never', description: undefined },
+                { name: 'date', optional: false, tsType: true, value: 'Date', description: undefined },
+                { name: 'emptyObject', optional: false, value: [], description: undefined },
+                { name: 'unknown', optional: true, tsType: true, value: 'unknown', description: undefined },
                 {
                     name: 'discriminatedUnion',
                     optional: false,
@@ -122,21 +129,24 @@ describe('zodToNango', () => {
                             name: '0',
                             optional: false,
                             value: [
-                                { name: 'type', optional: false, value: 'a' },
-                                { name: 'foo', optional: false, tsType: true, value: 'string' }
-                            ]
+                                { name: 'type', optional: false, value: 'a', description: undefined },
+                                { name: 'foo', optional: false, tsType: true, value: 'string', description: undefined }
+                            ],
+                            description: undefined
                         },
                         {
                             name: '1',
                             optional: false,
                             value: [
-                                { name: 'type', optional: false, value: 'b' },
-                                { name: 'bar', optional: false, tsType: true, value: 'string' }
-                            ]
+                                { name: 'type', optional: false, value: 'b', description: undefined },
+                                { name: 'bar', optional: false, tsType: true, value: 'string', description: undefined }
+                            ],
+                            description: undefined
                         }
-                    ]
+                    ],
+                    description: undefined
                 },
-                { name: 'coerce', optional: true, tsType: true, value: 'string' }
+                { name: 'coerce', optional: true, tsType: true, value: 'string', description: undefined }
 
                 // {
                 //     name: 'tuple',
@@ -158,14 +168,28 @@ describe('zodToNango', () => {
             name: 'test',
             optional: false,
             value: [
-                { name: 'foo', optional: false, value: [{ name: 'id', optional: false, tsType: true, value: 'string' }] },
+                {
+                    name: 'foo',
+                    optional: false,
+                    value: [{ name: 'id', optional: false, tsType: true, value: 'string', description: undefined }],
+                    description: undefined
+                },
                 {
                     array: true,
                     name: 'arr',
                     optional: false,
-                    value: [{ name: '0', optional: false, value: [{ name: 'id', optional: false, tsType: true, value: 'string' }] }]
+                    value: [
+                        {
+                            name: '0',
+                            optional: false,
+                            value: [{ name: 'id', optional: false, tsType: true, value: 'string', description: undefined }],
+                            description: undefined
+                        }
+                    ],
+                    description: undefined
                 }
-            ]
+            ],
+            description: undefined
         });
     });
 });

--- a/packages/types/lib/nangoYaml/index.ts
+++ b/packages/types/lib/nangoYaml/index.ts
@@ -132,6 +132,7 @@ export type LayoutMode = 'root' | 'nested';
 // TODO: delete when fully replaced by json-schema
 export interface NangoModel {
     name: string;
+    description?: string | undefined;
     fields: NangoModelField[];
     isAnon?: boolean | undefined;
 }
@@ -140,6 +141,7 @@ export interface NangoModel {
 export interface NangoModelField {
     name: string;
     value: string | number | boolean | null | NangoModelField[];
+    description?: string | undefined;
     dynamic?: boolean | undefined;
     tsType?: boolean | undefined;
     model?: boolean | undefined;


### PR DESCRIPTION
We currently ignore descriptions in zod schemas (they don't make it to the json-schema). Descriptions are especially useful for MCP, as they might add context for the LLMs. Our new UI also has support for rendering property descriptions, but because it's ignored by the cli compiler, we don't have cases to show for it.

The path to get to a json-schema is:
- We convert the zod schema to `NangoModel`
- We generate Typescript definitions from the `NangoModel`
- We use `ts-json-schema-generator` to generate json-schemas from the typescript interfaces

Ideally we would eliminate the `NangoModel`. It was my goal in the past but zeroYaml (syncs/action outputs defined in zod as opposed to yaml) was developed in parallel.

As an easier solution: 
`ts-json-schema-generator` grabs descriptions from js-docs on top of properties/interfaces. So if we pipe the descriptions from zod, to the `NangoModel`, to the Typescript definitions we generate, `ts-json-schema-generator` will add them to the json-schema.

Example:
zod schema:
```ts
Model: z.description('My nice model').object({
  id: z.number().description('The id, of course'),
  name: z.string().description('First name only!')
})
```

Becomes Typescript interface:
```ts
/**
 * My nice model
 */
interface Model {
  /**
   * The id, of course
   */
  id: number;
  /**
   * First name only!
   */
  name: string;
}
``` 

And finally the json-schema:
```json
{
  "type": "object",
  "description": "My nice model",
  "properties": {
    "id": {
      "type": "number",
      "description": "The id, of course"
    },
    "name": {
      "type": "string",
      "description": "First name only!"
    }
  }
}
```

And our recent new UI renders descriptions gracefully:
<img width="1058" height="738" alt="image" src="https://github.com/user-attachments/assets/b8740ba7-08d2-4e57-a2d7-bf9ced647e15" />
<!-- Summary by @propel-code-bot -->

---

The work extends the Zero YAML pipeline itself, updating the Zod-to-Nango conversions, sync/action builders, and TypeScript emitters so that model and field descriptions become JSDoc blocks before ts-json-schema-generator produces the CLI’s JSON schema.

<details>
<summary><strong>Key Changes</strong></summary>

• Augmented `NangoModel` and `NangoModelField` in `packages/types/lib/nangoYaml/index.ts` with optional `description` fields.
• Threaded `schema.description` through all branches of `zodToNangoModelField` in `packages/cli/lib/zeroYaml/zodToNango.ts`, ensuring nested and wrapper types retain metadata.
• Updated `buildSync`/`buildAction` in `packages/cli/lib/zeroYaml/definitions.ts` to persist descriptions when constructing `NangoModel` maps.
• Enhanced `modelToTypescript` and `fieldsToTypescript` in `packages/cli/lib/services/model.service.ts` to emit JSDoc blocks for model, dynamic key, and property descriptions.
• Expanded unit tests (e.g., `zodToNango.unit.test.ts`, `model.service.unit.test.ts`, `definitions.unit.test.ts`) to assert presence of the new `description` fields and verify JSDoc generation.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/cli/lib/zeroYaml/zodToNango.ts`
• `packages/cli/lib/zeroYaml/definitions.ts`
• `packages/cli/lib/services/model.service.ts`
• `packages/types/lib/nangoYaml/index.ts`
• Associated unit tests exercising the above modules

</details>

---
*This summary was automatically generated by @propel-code-bot*