### PR TITLE
feat(persist):  automatic deletion of records when sync hasn't run recently

### DIFF
--- a/packages/persist/lib/daemons/autodeleting.daemon.ts
+++ b/packages/persist/lib/daemons/autodeleting.daemon.ts
@@ -1,0 +1,84 @@
+import tracer from 'dd-trace';
+
+import { Cursor, records } from '@nangohq/records';
+import { isSyncStale } from '@nangohq/shared';
+import { cancellableDaemon } from '@nangohq/utils';
+
+import { envs } from '../env.js';
+import { logger } from '../logger.js';
+
+/*
+ * Auto-deleting daemon
+ * This daemon runs in a loop and hard-delete records for syncs that haven't run in a defined stale period
+ * Each tick, a candidate connection/model is selected for deletion
+ * The candidate's associated sync is then checked to ensure it is stale
+ * Only a limited number of records are deleted per tick to avoid overwhelming the database
+ * We rely on the daemon to run periodically on each persist instance to continue deleting records
+ */
+export function autoDeletingDaemon(): Awaited<ReturnType<typeof cancellableDaemon>> {
+    return cancellableDaemon({
+        tickIntervalMs: envs.PERSIST_AUTO_DELETING_INTERVAL_MS,
+        tick: async (): Promise<void> => {
+            const dryRun = true; // TODO: removed after grace period given to customer (March 8th 2026)
+            const active = tracer.scope().active();
+            const span = tracer.startSpan('nango.persist.daemon.autodeleting', {
+                childOf: active as tracer.Span,
+                tags: { dryRun }
+            });
+            const candidate = await records.autoDeletingCandidate({ staleAfterMs: envs.PERSIST_AUTO_DELETING_STALE_AFTER_MS });
+            if (candidate.isErr()) {
+                span.addTags({ error: candidate.error.message }).finish();
+                logger.error(`[Auto-deleting] error getting candidate: ${candidate.error.message}`);
+                return;
+            }
+            if (candidate.value) {
+                span.addTags({ candidate: candidate.value });
+
+                const isStale = await isSyncStale({
+                    connectionId: candidate.value.connectionId,
+                    model: candidate.value.model,
+                    staleAfterMs: envs.PERSIST_AUTO_DELETING_STALE_AFTER_MS
+                });
+                if (isStale.isErr()) {
+                    span.addTags({ error: isStale.error.message }).finish();
+                    logger.error(`[Auto-deleting] error checking if sync is stale: ${isStale.error.message}`);
+                    return;
+                }
+
+                if (!isStale.value) {
+                    span.addTags({ skipped: 'candidate_not_stale' }).finish();
+                    return;
+                }
+
+                const res = await records.deleteRecords({
+                    environmentId: candidate.value.environmentId,
+                    connectionId: candidate.value.connectionId,
+                    model: candidate.value.model,
+                    mode: 'hard',
+                    limit: envs.PERSIST_AUTO_DELETING_LIMIT,
+                    dryRun
+                });
+                if (res.isErr()) {
+                    span.addTags({ error: res.error.message }).finish();
+                    logger.error(`[Auto-deleting] error deleting records: ${res.error.message}`);
+                    return;
+                }
+                // lag: how far behind are we from the desired deleting point
+                // high lag means we are not keeping up with deleting
+                let lagMs: number | null = null;
+                if (res.value.lastCursor) {
+                    const cursorSort = Cursor.from(res.value.lastCursor)?.sort;
+                    if (cursorSort) {
+                        const cursorDate = new Date(cursorSort);
+                        lagMs = Date.now() - cursorDate.getTime() - envs.PERSIST_AUTO_DELETING_STALE_AFTER_MS;
+                    }
+                }
+                span.addTags({
+                    deleted: res.value.count,
+                    ...(lagMs ? { lagMs } : {})
+                }).finish();
+            }
+            span.addTags({ deleted: 0, candidate: 'none_found' }).finish();
+        }
+    });
+}

--- a/packages/persist/lib/daemons/autodeleting.daemon.ts
+++ b/packages/persist/lib/daemons/autodeleting.daemon.ts
@@ -20,65 +20,69 @@ export function autoDeletingDaemon(): Awaited<ReturnType<typeof cancellableDaemo
         tickIntervalMs: envs.PERSIST_AUTO_DELETING_INTERVAL_MS,
         tick: async (): Promise<void> => {
             const dryRun = true; // TODO: removed after grace period given to customer (March 8th 2026)
-            const active = tracer.scope().active();
-            const span = tracer.startSpan('nango.persist.daemon.autodeleting', {
-                childOf: active as tracer.Span,
-                tags: { dryRun }
-            });
-            const candidate = await records.autoDeletingCandidate({ staleAfterMs: envs.PERSIST_AUTO_DELETING_STALE_AFTER_MS });
-            if (candidate.isErr()) {
-                span.addTags({ error: candidate.error.message }).finish();
-                logger.error(`[Auto-deleting] error getting candidate: ${candidate.error.message}`);
-                return;
-            }
-            if (candidate.value) {
-                span.addTags({ candidate: candidate.value });
-
-                const isStale = await isSyncStale({
-                    connectionId: candidate.value.connectionId,
-                    model: candidate.value.model,
-                    staleAfterMs: envs.PERSIST_AUTO_DELETING_STALE_AFTER_MS
-                });
-                if (isStale.isErr()) {
-                    span.addTags({ error: isStale.error.message }).finish();
-                    logger.error(`[Auto-deleting] error checking if sync is stale: ${isStale.error.message}`);
-                    return;
-                }
-
-                if (!isStale.value) {
-                    span.addTags({ skipped: 'candidate_not_stale' }).finish();
-                    return;
-                }
-
-                const res = await records.deleteRecords({
-                    environmentId: candidate.value.environmentId,
-                    connectionId: candidate.value.connectionId,
-                    model: candidate.value.model,
-                    mode: 'hard',
-                    limit: envs.PERSIST_AUTO_DELETING_LIMIT,
-                    dryRun
-                });
-                if (res.isErr()) {
-                    span.addTags({ error: res.error.message }).finish();
-                    logger.error(`[Auto-deleting] error deleting records: ${res.error.message}`);
-                    return;
-                }
-                // lag: how far behind are we from the desired deleting point
-                // high lag means we are not keeping up with deleting
-                let lagMs: number | null = null;
-                if (res.value.lastCursor) {
-                    const cursorSort = Cursor.from(res.value.lastCursor)?.sort;
-                    if (cursorSort) {
-                        const cursorDate = new Date(cursorSort);
-                        lagMs = Date.now() - cursorDate.getTime() - envs.PERSIST_AUTO_DELETING_STALE_AFTER_MS;
+            return tracer.trace('nango.persist.daemon.autodeleting', { tags: { dryRun } }, async (span) => {
+                try {
+                    const candidate = await records.autoDeletingCandidate({ staleAfterMs: envs.PERSIST_AUTO_DELETING_STALE_AFTER_MS });
+                    if (candidate.isErr()) {
+                        span?.addTags({ error: candidate.error.message });
+                        logger.error(`[Auto-deleting] error getting candidate: ${candidate.error.message}`);
+                        return;
                     }
+                    if (candidate.value) {
+                        span?.addTags({ candidate: candidate.value });
+
+                        const isStale = await isSyncStale({
+                            connectionId: candidate.value.connectionId,
+                            model: candidate.value.model,
+                            staleAfterMs: envs.PERSIST_AUTO_DELETING_STALE_AFTER_MS
+                        });
+                        if (isStale.isErr()) {
+                            span?.addTags({ error: isStale.error.message });
+                            logger.error(`[Auto-deleting] error checking if sync is stale: ${isStale.error.message}`);
+                            return;
+                        }
+
+                        if (!isStale.value) {
+                            span?.addTags({ skipped: 'candidate_not_stale' });
+                            return;
+                        }
+
+                        const res = await records.deleteRecords({
+                            environmentId: candidate.value.environmentId,
+                            connectionId: candidate.value.connectionId,
+                            model: candidate.value.model,
+                            mode: 'hard',
+                            limit: envs.PERSIST_AUTO_DELETING_LIMIT,
+                            dryRun
+                        });
+                        if (res.isErr()) {
+                            span?.addTags({ error: res.error.message });
+                            logger.error(`[Auto-deleting] error deleting records: ${res.error.message}`);
+                            return;
+                        }
+                        // lag: how far behind are we from the desired deleting point
+                        // high lag means we are not keeping up with deleting
+                        let lagMs: number | null = null;
+                        if (res.value.lastCursor) {
+                            const cursorSort = Cursor.from(res.value.lastCursor)?.sort;
+                            if (cursorSort) {
+                                const cursorDate = new Date(cursorSort);
+                                lagMs = Date.now() - cursorDate.getTime() - envs.PERSIST_AUTO_DELETING_STALE_AFTER_MS;
+                            }
+                        }
+                        span?.addTags({
+                            deleted: res.value.count,
+                            ...(lagMs ? { lagMs } : {})
+                        });
+                    }
+                    span?.addTags({ deleted: 0, candidate: 'none_found' });
+                } catch (err) {
+                    span?.addTags({ error: (err as Error).message });
+                    logger.error(`[Auto-deleting] unexpected error: ${(err as Error).message}`);
+                } finally {
+                    span?.finish();
                 }
-                span.addTags({
-                    deleted: res.value.count,
-                    ...(lagMs ? { lagMs } : {})
-                }).finish();
-            }
-            span.addTags({ deleted: 0, candidate: 'none_found' }).finish();
+            });
         }
     });
 }

--- a/packages/persist/lib/daemons/autopruning.daemon.ts
+++ b/packages/persist/lib/daemons/autopruning.daemon.ts
@@ -20,56 +20,61 @@ export function autoPruningDaemon(): Awaited<ReturnType<typeof cancellableDaemon
         tickIntervalMs: envs.PERSIST_AUTO_PRUNING_INTERVAL_MS,
         tick: async (): Promise<void> => {
             const dryRun = true; // TODO: removed after grace period given to customer (Feb 8th 2026)
-            const active = tracer.scope().active();
-            const span = tracer.startSpan('nango.persist.daemon.autopruning', {
-                childOf: active as tracer.Span,
-                tags: { dryRun }
-            });
-            const candidate = await records.autoPruningCandidate({ staleAfterMs: envs.PERSIST_AUTO_PRUNING_STALE_AFTER_MS });
-            if (candidate.isErr()) {
-                span.addTags({ error: candidate.error.message }).finish();
-                logger.error(`[Auto-pruning] error getting candidate: ${candidate.error.message}`);
-                return;
-            }
-            if (candidate.value) {
-                const connection = await connectionService.getConnectionById(candidate.value.connectionId);
-                if (!connection) {
-                    span.addTags({ error: `Connection ${candidate.value.connectionId} not found` }).finish();
-                    logger.error(`[Auto-pruning] connection ${candidate.value.connectionId} not found`);
-                    return;
-                }
-                span.addTags({ environmentId: connection.environment_id, candidate: candidate.value });
-
-                const res = await records.deleteRecords({
-                    environmentId: connection.environment_id,
-                    connectionId: candidate.value.connectionId,
-                    model: candidate.value.model,
-                    mode: 'prune',
-                    toCursorIncluded: candidate.value.cursor,
-                    limit: envs.PERSIST_AUTO_PRUNING_LIMIT,
-                    dryRun
-                });
-                if (res.isErr()) {
-                    span.addTags({ error: res.error.message }).finish();
-                    logger.error(`[Auto-pruning] error pruning records: ${res.error.message}`);
-                    return;
-                }
-                // lag: how far behind are we from the desired pruning point
-                // high lag means we are not keeping up with pruning
-                let lagMs: number | null = null;
-                if (res.value.lastCursor) {
-                    const cursorSort = Cursor.from(res.value.lastCursor)?.sort;
-                    if (cursorSort) {
-                        const cursorDate = new Date(cursorSort);
-                        lagMs = Date.now() - cursorDate.getTime() - envs.PERSIST_AUTO_PRUNING_STALE_AFTER_MS;
+            return tracer.trace('nango.persist.daemon.autopruning', { tags: { dryRun } }, async (span) => {
+                try {
+                    const candidate = await records.autoPruningCandidate({ staleAfterMs: envs.PERSIST_AUTO_PRUNING_STALE_AFTER_MS });
+                    if (candidate.isErr()) {
+                        span?.addTags({ error: candidate.error.message });
+                        logger.error(`[Auto-pruning] error getting candidate: ${candidate.error.message}`);
+                        return;
                     }
+                    if (candidate.value) {
+                        const connection = await connectionService.getConnectionById(candidate.value.connectionId);
+                        if (!connection) {
+                            span?.addTags({ error: `Connection ${candidate.value.connectionId} not found` });
+                            logger.error(`[Auto-pruning] connection ${candidate.value.connectionId} not found`);
+                            return;
+                        }
+                        span?.addTags({ environmentId: connection.environment_id, candidate: candidate.value });
+
+                        const res = await records.deleteRecords({
+                            environmentId: connection.environment_id,
+                            connectionId: candidate.value.connectionId,
+                            model: candidate.value.model,
+                            mode: 'prune',
+                            toCursorIncluded: candidate.value.cursor,
+                            limit: envs.PERSIST_AUTO_PRUNING_LIMIT,
+                            dryRun
+                        });
+                        if (res.isErr()) {
+                            span?.addTags({ error: res.error.message });
+                            logger.error(`[Auto-pruning] error pruning records: ${res.error.message}`);
+                            return;
+                        }
+                        // lag: how far behind are we from the desired pruning point
+                        // high lag means we are not keeping up with pruning
+                        let lagMs: number | null = null;
+                        if (res.value.lastCursor) {
+                            const cursorSort = Cursor.from(res.value.lastCursor)?.sort;
+                            if (cursorSort) {
+                                const cursorDate = new Date(cursorSort);
+                                lagMs = Date.now() - cursorDate.getTime() - envs.PERSIST_AUTO_PRUNING_STALE_AFTER_MS;
+                            }
+                        }
+                        span?.addTags({
+                            pruned: res.value.count,
+                            ...(lagMs ? { lagMs } : {})
+                        });
+                    }
+                    span?.addTags({ pruned: 0, candidate: 'none_found' });
+                } catch (err) {
+                    logger.error(`[Auto-pruning] unexpected error: ${(err as Error).message}`);
+                    span?.addTags({ error: (err as Error).message });
+                    return;
+                } finally {
+                    span?.finish();
                 }
-                span.addTags({
-                    pruned: res.value.count,
-                    ...(lagMs ? { lagMs } : {})
-                }).finish();
-            }
-            span.addTags({ pruned: 0, candidate: 'none_found' }).finish();
+            });
         }
     });
 }

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -60,6 +60,12 @@ export const ENVS = z.object({
         .number()
         .optional()
         .default(30 * 24 * 3600 * 1000), // 30 days
+    PERSIST_AUTO_DELETING_INTERVAL_MS: z.coerce.number().optional().default(5_000), // set to 0 to disable
+    PERSIST_AUTO_DELETING_LIMIT: z.coerce.number().optional().default(1_000),
+    PERSIST_AUTO_DELETING_STALE_AFTER_MS: z.coerce
+        .number()
+        .optional()
+        .default(60 * 24 * 3600 * 1000), // 60 days
     NANGO_PERSIST_PORT: z.coerce.number().optional().default(3007),
 
     // Orchestrator

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -96,9 +96,7 @@ export enum Types {
 
     USAGE_IS_CAPPED = 'nango.capping.isCapped',
 
-    PUBSUB_PUBLISH = 'nango.pubsub.publish',
-
-    PERSIST_RECORDS_AUTO_PRUNING = 'nango.persist.daemon.autopruning'
+    PUBSUB_PUBLISH = 'nango.pubsub.publish'
 }
 
 type Dimensions = Record<string, string | number> | undefined;

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -96,7 +96,9 @@ export enum Types {
 
     USAGE_IS_CAPPED = 'nango.capping.isCapped',
 
-    PUBSUB_PUBLISH = 'nango.pubsub.publish'
+    PUBSUB_PUBLISH = 'nango.pubsub.publish',
+
+    PERSIST_RECORDS_AUTO_PRUNING = 'nango.persist.daemon.autopruning'
 }
 
 type Dimensions = Record<string, string | number> | undefined;


### PR DESCRIPTION
similar to auto-pruning where a background daemon in persist attempts at deleting records for syncs that have not run in a while.
A candidate connection/model is first selected if its count hasn't been updated recently. The associated sync is then checked to see if it hasn't run recently
No records are being deleted yet. The daemon is running in dryrun mode until the grace period we communicated to customers elapsed (2 months from now)

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

Persist now boots both the existing auto-pruning and the new auto-deleting daemons with improved tracing and cleanup, while new environment variables govern the cadence, candidate limits, and staleness thresholds. The records module now exposes the candidate selection and dry-run deletion paths without mutating counts, and integration coverage was expanded to exercise the selection behaviour.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/persist/lib/daemons/autodeleting.daemon.ts`
• `packages/persist/lib/daemons/autopruning.daemon.ts`
• `packages/persist/lib/app.ts`
• `packages/records/lib/models/records.ts`
• `packages/records/lib/models/records.integration.test.ts`
• `packages/shared/lib/services/sync/sync.service.ts`
• `packages/utils/lib/environment/parse.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*