### PR TITLE
fix(webapp): Fix missing Save button in Connect UI

### DIFF
--- a/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
@@ -198,22 +198,20 @@ export const ConnectUISettings = () => {
                         {canCustomizeTheme && <ThemeColorPickers disabled={false} form={form} />}
                         {canDisableWatermark && <WatermarkToggle disabled={false} form={form} />}
 
-                        {(canCustomizeTheme || canDisableWatermark) && (
-                            <form.Subscribe selector={(state) => [state.canSubmit, state.isDirty, state.isSubmitting]}>
-                                {([canSubmit, isDirty]) => (
-                                    <Button
-                                        type="submit"
-                                        variant="primary"
-                                        size="sm"
-                                        className="self-start"
-                                        disabled={!canSubmit || !isDirty}
-                                        loading={isUpdatingConnectUISettings}
-                                    >
-                                        Save
-                                    </Button>
-                                )}
-                            </form.Subscribe>
-                        )}
+                        <form.Subscribe selector={(state) => [state.canSubmit, state.isDirty, state.isSubmitting]}>
+                            {([canSubmit, isDirty]) => (
+                                <Button
+                                    type="submit"
+                                    variant="primary"
+                                    size="sm"
+                                    className="self-start"
+                                    disabled={!canSubmit || !isDirty}
+                                    loading={isUpdatingConnectUISettings}
+                                >
+                                    Save
+                                </Button>
+                            )}
+                        </form.Subscribe>
 
                         {(!canCustomizeTheme || !canDisableWatermark) && (
                             <div className="bg-bg-elevated p-6 flex flex-col gap-6">


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
The Save button was gated only for customers who are on a plan that allows customizing the Connect UI. However, even the most basic plans have the ability to change the Default theme, so they need to be able to save the selection
<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

The Save button still adheres to the existing form state safeguards, including submission eligibility, dirty state checks, and loading behavior.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*