### PR TITLE
fix(persist): trace tag

### DIFF
--- a/packages/persist/lib/daemons/autodeleting.daemon.ts
+++ b/packages/persist/lib/daemons/autodeleting.daemon.ts
@@ -28,54 +28,55 @@ export function autoDeletingDaemon(): Awaited<ReturnType<typeof cancellableDaemo
                         logger.error(`[Auto-deleting] error getting candidate: ${candidate.error.message}`);
                         return;
                     }
-                    if (candidate.value) {
-                        span?.addTags({ candidate: candidate.value });
-
-                        const isStale = await isSyncStale({
-                            connectionId: candidate.value.connectionId,
-                            model: candidate.value.model,
-                            staleAfterMs: envs.PERSIST_AUTO_DELETING_STALE_AFTER_MS
-                        });
-                        if (isStale.isErr()) {
-                            span?.addTags({ error: isStale.error.message });
-                            logger.error(`[Auto-deleting] error checking if sync is stale: ${isStale.error.message}`);
-                            return;
-                        }
-
-                        if (!isStale.value) {
-                            span?.addTags({ skipped: 'candidate_not_stale' });
-                            return;
-                        }
-
-                        const res = await records.deleteRecords({
-                            environmentId: candidate.value.environmentId,
-                            connectionId: candidate.value.connectionId,
-                            model: candidate.value.model,
-                            mode: 'hard',
-                            limit: envs.PERSIST_AUTO_DELETING_LIMIT,
-                            dryRun
-                        });
-                        if (res.isErr()) {
-                            span?.addTags({ error: res.error.message });
-                            logger.error(`[Auto-deleting] error deleting records: ${res.error.message}`);
-                            return;
-                        }
-                        // lag: how far behind are we from the desired deleting point
-                        // high lag means we are not keeping up with deleting
-                        let lagMs: number | null = null;
-                        if (res.value.lastCursor) {
-                            const cursorSort = Cursor.from(res.value.lastCursor)?.sort;
-                            if (cursorSort) {
-                                const cursorDate = new Date(cursorSort);
-                                lagMs = Date.now() - cursorDate.getTime() - envs.PERSIST_AUTO_DELETING_STALE_AFTER_MS;
-                            }
-                        }
-                        span?.addTags({
-                            deleted: res.value.count,
-                            ...(lagMs ? { lagMs } : {})
-                        });
+                    if (!candidate.value) {
+                        span?.addTags({ deleted: 0, candidate: 'none_found' });
+                        return;
                     }
-                    span?.addTags({ deleted: 0, candidate: 'none_found' });
+                    span?.addTags({ candidate: candidate.value });
+
+                    const isStale = await isSyncStale({
+                        connectionId: candidate.value.connectionId,
+                        model: candidate.value.model,
+                        staleAfterMs: envs.PERSIST_AUTO_DELETING_STALE_AFTER_MS
+                    });
+                    if (isStale.isErr()) {
+                        span?.addTags({ error: isStale.error.message });
+                        logger.error(`[Auto-deleting] error checking if sync is stale: ${isStale.error.message}`);
+                        return;
+                    }
+
+                    if (!isStale.value) {
+                        span?.addTags({ skipped: 'candidate_not_stale' });
+                        return;
+                    }
+
+                    const res = await records.deleteRecords({
+                        environmentId: candidate.value.environmentId,
+                        connectionId: candidate.value.connectionId,
+                        model: candidate.value.model,
+                        mode: 'hard',
+                        limit: envs.PERSIST_AUTO_DELETING_LIMIT,
+                        dryRun
+                    });
+                    if (res.isErr()) {
+                        span?.addTags({ error: res.error.message });
+                        logger.error(`[Auto-deleting] error deleting records: ${res.error.message}`);
+                        return;
+                    }
+                    // lag: how far behind are we from the desired deleting point
+                    // high lag means we are not keeping up with deleting
+                    let lagMs: number | null = null;
+                    if (res.value.lastCursor) {
+                        const cursorSort = Cursor.from(res.value.lastCursor)?.sort;
+                        if (cursorSort) {
+                            const cursorDate = new Date(cursorSort);
+                            lagMs = Date.now() - cursorDate.getTime() - envs.PERSIST_AUTO_DELETING_STALE_AFTER_MS;
+                        }
+                    }
+                    span?.addTags({
+                        deleted: res.value.count,
+                        ...(lagMs ? { lagMs } : {})
+                    });
                 } catch (err) {
                     span?.addTags({ error: (err as Error).message });
                     logger.error(`[Auto-deleting] unexpected error: ${(err as Error).message}`);

--- a/packages/persist/lib/daemons/autopruning.daemon.ts
+++ b/packages/persist/lib/daemons/autopruning.daemon.ts
@@ -28,45 +28,46 @@ export function autoPruningDaemon(): Awaited<ReturnType<typeof cancellableDaemon
                         logger.error(`[Auto-pruning] error getting candidate: ${candidate.error.message}`);
                         return;
                     }
-                    if (candidate.value) {
-                        const connection = await connectionService.getConnectionById(candidate.value.connectionId);
-                        if (!connection) {
-                            span?.addTags({ error: `Connection ${candidate.value.connectionId} not found` });
-                            logger.error(`[Auto-pruning] connection ${candidate.value.connectionId} not found`);
-                            return;
-                        }
-                        span?.addTags({ environmentId: connection.environment_id, candidate: candidate.value });
-
-                        const res = await records.deleteRecords({
-                            environmentId: connection.environment_id,
-                            connectionId: candidate.value.connectionId,
-                            model: candidate.value.model,
-                            mode: 'prune',
-                            toCursorIncluded: candidate.value.cursor,
-                            limit: envs.PERSIST_AUTO_PRUNING_LIMIT,
-                            dryRun
-                        });
-                        if (res.isErr()) {
-                            span?.addTags({ error: res.error.message });
-                            logger.error(`[Auto-pruning] error pruning records: ${res.error.message}`);
-                            return;
-                        }
-                        // lag: how far behind are we from the desired pruning point
-                        // high lag means we are not keeping up with pruning
-                        let lagMs: number | null = null;
-                        if (res.value.lastCursor) {
-                            const cursorSort = Cursor.from(res.value.lastCursor)?.sort;
-                            if (cursorSort) {
-                                const cursorDate = new Date(cursorSort);
-                                lagMs = Date.now() - cursorDate.getTime() - envs.PERSIST_AUTO_PRUNING_STALE_AFTER_MS;
-                            }
-                        }
-                        span?.addTags({
-                            pruned: res.value.count,
-                            ...(lagMs ? { lagMs } : {})
-                        });
+                    if (!candidate.value) {
+                        span?.addTags({ pruned: 0, candidate: 'none_found' });
+                        return;
                     }
-                    span?.addTags({ pruned: 0, candidate: 'none_found' });
+                    const connection = await connectionService.getConnectionById(candidate.value.connectionId);
+                    if (!connection) {
+                        span?.addTags({ error: `Connection ${candidate.value.connectionId} not found` });
+                        logger.error(`[Auto-pruning] connection ${candidate.value.connectionId} not found`);
+                        return;
+                    }
+                    span?.addTags({ environmentId: connection.environment_id, candidate: candidate.value });
+
+                    const res = await records.deleteRecords({
+                        environmentId: connection.environment_id,
+                        connectionId: candidate.value.connectionId,
+                        model: candidate.value.model,
+                        mode: 'prune',
+                        toCursorIncluded: candidate.value.cursor,
+                        limit: envs.PERSIST_AUTO_PRUNING_LIMIT,
+                        dryRun
+                    });
+                    if (res.isErr()) {
+                        span?.addTags({ error: res.error.message });
+                        logger.error(`[Auto-pruning] error pruning records: ${res.error.message}`);
+                        return;
+                    }
+                    // lag: how far behind are we from the desired pruning point
+                    // high lag means we are not keeping up with pruning
+                    let lagMs: number | null = null;
+                    if (res.value.lastCursor) {
+                        const cursorSort = Cursor.from(res.value.lastCursor)?.sort;
+                        if (cursorSort) {
+                            const cursorDate = new Date(cursorSort);
+                            lagMs = Date.now() - cursorDate.getTime() - envs.PERSIST_AUTO_PRUNING_STALE_AFTER_MS;
+                        }
+                    }
+                    span?.addTags({
+                        pruned: res.value.count,
+                        ...(lagMs ? { lagMs } : {})
+                    });
                 } catch (err) {
                     logger.error(`[Auto-pruning] unexpected error: ${(err as Error).message}`);
                     span?.addTags({ error: (err as Error).message });


### PR DESCRIPTION
persist cleaning daemons: correctly set `candidate not found` tag (only when candidate isn't found) :)
<!-- Summary by @propel-code-bot -->

---

When a candidate is available, the daemons continue to attach that candidate’s details to the span before running the staleness review and cleanup work.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/persist/lib/daemons/autodeleting.daemon.ts`
• `packages/persist/lib/daemons/autopruning.daemon.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*