### PR TITLE
fix: attempt at fixing privatekeys flacky test

### DIFF
--- a/packages/keystore/lib/models/privatekeys.integration.test.ts
+++ b/packages/keystore/lib/models/privatekeys.integration.test.ts
@@ -89,7 +89,7 @@ describe('PrivateKey', async () => {
 
     it('should be retrieved before it expires', async () => {
         const entityType = 'connect_session';
-        const ttlInMs = 100;
+        const ttlInMs = 10_000;
         const createKey = await createPrivateKey(db, {
             displayName: 'this is my key',
             entityType,


### PR DESCRIPTION
I have seen this privatekey integration test fail randomly.
I though a ttl of 100ms would be more than enough but it looks like under some circumstance that I am not fully understanding the key expires before the test check. 
Increasing the ttl so it doesn't affect the result of the check.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

It explicitly raises the TTL to 10,000 ms so the retrieval-before-expiry check remains stable during assertions.

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/keystore/lib/models/privatekeys.integration.test.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*