### PR TITLE
fix(listConnections): don't return connection metadata unless requested

### DIFF
--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -306,11 +306,6 @@ paths:
                                                 created:
                                                     type: string
                                                     description: Connection creation date.
-                                                metadata:
-                                                    anyOf:
-                                                        - type: object
-                                                        - type: 'null'
-                                                    description: Custom metadata attached to the connection
                                                 errors:
                                                     type: array
                                                     items:
@@ -757,11 +752,6 @@ paths:
                                                 created:
                                                     type: string
                                                     description: Connection creation date.
-                                                metadata:
-                                                    anyOf:
-                                                        - type: object
-                                                        - type: 'null'
-                                                    description: Custom metadata attached to the connection
                                                 errors:
                                                     type: array
                                                     items:

--- a/packages/server/lib/controllers/connection/connectionId/getConnection.integration.test.ts
+++ b/packages/server/lib/controllers/connection/connectionId/getConnection.integration.test.ts
@@ -69,7 +69,8 @@ describe(`GET ${endpoint}`, () => {
             provider: 'algolia',
             endUser,
             rawCredentials: { type: 'API_KEY', apiKey: 'test_api_key' },
-            connectionConfig: { APP_ID: 'TEST' }
+            connectionConfig: { APP_ID: 'TEST' },
+            metadata: { some: 'data' }
         });
 
         const res = await api.fetch(endpoint, {
@@ -101,7 +102,7 @@ describe(`GET ${endpoint}`, () => {
             errors: [],
             id: expect.any(Number),
             last_fetched_at: expect.toBeIsoDateTimezone(),
-            metadata: null,
+            metadata: { some: 'data' },
             provider: 'algolia',
             provider_config_key: 'algolia',
             updated_at: expect.toBeIsoDateTimezone()

--- a/packages/server/lib/controllers/connection/connectionId/getConnection.ts
+++ b/packages/server/lib/controllers/connection/connectionId/getConnection.ts
@@ -72,7 +72,12 @@ export const getPublicConnection = asyncWrapper<GetPublicConnection>(async (req,
 
     const getApiPublicConnection = async (credentials: AllAuthCredentials = {}): Promise<Result<ApiPublicConnectionFull>> => {
         // We are using listConnections because it has everything we need, but this is a bit wrong
-        const finalConnections = await connectionService.listConnections({ environmentId: environment.id, connectionId, integrationIds: [providerConfigKey] });
+        const finalConnections = await connectionService.listConnections({
+            environmentId: environment.id,
+            connectionId,
+            integrationIds: [providerConfigKey],
+            opts: { includesMetadata: true }
+        });
         if (finalConnections.length !== 1 || !finalConnections[0]) {
             return Err('Failed to get connection');
         }

--- a/packages/shared/lib/services/connection.service.integration.test.ts
+++ b/packages/shared/lib/services/connection.service.integration.test.ts
@@ -92,6 +92,26 @@ describe('Connection service integration tests', () => {
             expect(connectionIds).toEqual([notion.connection_id, google.connection_id]);
         });
 
+        it('should return metadata on demand', async () => {
+            const env = await createEnvironmentSeed();
+
+            await createConfigSeed(env, 'google', 'google');
+            await createConnectionSeed({ env, provider: 'google', metadata: { test: 'value' } });
+
+            // By default metadata is not returned
+            const dbConnections = await connectionService.listConnections({
+                environmentId: env.id
+            });
+            expect(dbConnections[0]?.connection.metadata).toBeUndefined();
+
+            // When requested, metadata is returned
+            const withMetadataConnections = await connectionService.listConnections({
+                environmentId: env.id,
+                opts: { includesMetadata: true }
+            });
+            expect(withMetadataConnections[0]?.connection.metadata).toEqual({ test: 'value' });
+        });
+
         it('should paginate', async () => {
             const env = await createEnvironmentSeed();
 

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -733,7 +733,10 @@ class ConnectionService {
         endUserId,
         endUserOrganizationId,
         limit = 1000,
-        page = 0
+        page = 0,
+        opts = {
+            includesMetadata: false
+        }
     }: {
         environmentId: number;
         connectionId?: string | undefined;
@@ -744,11 +747,16 @@ class ConnectionService {
         endUserOrganizationId?: string | undefined;
         limit?: number;
         page?: number | undefined;
+        opts?: {
+            includesMetadata?: boolean;
+        };
     }): Promise<{ connection: DBConnectionAsJSONRow; end_user: DBEndUser | null; active_logs: [{ type: string; log_id: string }]; provider: string }[]> {
         const query = db.readOnly
             .from<DBConnection>(`_nango_connections`)
             .select<{ connection: DBConnectionAsJSONRow; end_user: DBEndUser | null; active_logs: [{ type: string; log_id: string }]; provider: string }[]>(
-                db.knex.raw('row_to_json(_nango_connections.*) as connection'),
+                opts.includesMetadata
+                    ? db.knex.raw('row_to_json(_nango_connections.*) as connection')
+                    : db.knex.raw("row_to_json(_nango_connections.*)::jsonb - 'metadata' as connection"),
                 db.knex.raw('row_to_json(end_users.*) as end_user'),
                 db.knex.raw(`
                     COALESCE(


### PR DESCRIPTION
connection metadata are set by customers and can end up very big. Loading big json from disk can be slowing down the main database. 
This PR excludes loading/returning the connection metadata when calling listConnections unless requested explicitly

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

The single-connection endpoint now explicitly opts in to metadata so its response remains unchanged, with integration coverage and API documentation updated to reflect the new default exclusion behaviour.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/services/connection.service.ts`
• `packages/server/lib/controllers/connection/connectionId/getConnection.ts`
• `packages/shared/lib/services/connection.service.integration.test.ts`
• `packages/server/lib/controllers/connection/connectionId/getConnection.integration.test.ts`
• `docs/spec.yaml`

</details>

---
*This summary was automatically generated by @propel-code-bot*