### PR TITLE
fix: bump modelcontextprotocol to 1.25.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3088,6 +3088,18 @@
                 "react": ">= 16 || ^19.0.0-rc"
             }
         },
+        "node_modules/@hono/node-server": {
+            "version": "1.19.8",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.8.tgz",
+            "integrity": "sha512-0/g2lIOPzX8f3vzW1ggQgvG5mjtFBDBHFAzI5SFAi2DzSqS9luJwqg9T6O/gKYLi+inS7eNxBeIFkkghIPvrMA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.14.1"
+            },
+            "peerDependencies": {
+                "hono": "^4"
+            }
+        },
         "node_modules/@hookform/resolvers": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
@@ -3527,11 +3539,12 @@
             }
         },
         "node_modules/@modelcontextprotocol/sdk": {
-            "version": "1.24.3",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.3.tgz",
-            "integrity": "sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==",
+            "version": "1.25.2",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.2.tgz",
+            "integrity": "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==",
             "license": "MIT",
             "dependencies": {
+                "@hono/node-server": "^1.19.7",
                 "ajv": "^8.17.1",
                 "ajv-formats": "^3.0.1",
                 "content-type": "^1.0.5",
@@ -3542,6 +3555,7 @@
                 "express": "^5.0.1",
                 "express-rate-limit": "^7.5.0",
                 "jose": "^6.1.1",
+                "json-schema-typed": "^8.0.2",
                 "pkce-challenge": "^5.0.0",
                 "raw-body": "^3.0.0",
                 "zod": "^3.25 || ^4.0",
@@ -20650,6 +20664,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/hono": {
+            "version": "4.11.3",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.3.tgz",
+            "integrity": "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=16.9.0"
+            }
+        },
         "node_modules/hosted-git-info": {
             "version": "6.1.1",
             "license": "ISC",
@@ -22039,7 +22063,9 @@
             "license": "MIT"
         },
         "node_modules/json-schema-typed": {
-            "version": "8.0.1",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+            "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
             "license": "BSD-2-Clause"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
@@ -32773,7 +32799,7 @@
             "version": "1.0.0",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@modelcontextprotocol/sdk": "1.24.3",
+                "@modelcontextprotocol/sdk": "1.25.2",
                 "@nangohq/account-usage": "file:../account-usage",
                 "@nangohq/billing": "file:../billing",
                 "@nangohq/database": "file:../database",
@@ -32901,7 +32927,7 @@
             "dependencies": {
                 "@aws-sdk/client-s3": "3.796.0",
                 "@hapi/boom": "10.0.1",
-                "@modelcontextprotocol/sdk": "1.24.3",
+                "@modelcontextprotocol/sdk": "1.25.2",
                 "@nangohq/database": "file:../database",
                 "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/nango-yaml": "file:../nango-yaml",

--- a/packages/server/lib/controllers/mcp/mcp.ts
+++ b/packages/server/lib/controllers/mcp/mcp.ts
@@ -47,9 +47,7 @@ export const postMcp = asyncWrapper<PostMcp>(async (req, res) => {
     }
 
     const server = result.value;
-    const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: undefined
-    });
+    const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport();
 
     res.on('close', () => {
         void transport.close();

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,7 +19,7 @@
     },
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
-        "@modelcontextprotocol/sdk": "1.24.3",
+        "@modelcontextprotocol/sdk": "1.25.2",
         "@nangohq/account-usage": "file:../account-usage",
         "@nangohq/billing": "file:../billing",
         "@nangohq/database": "file:../database",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,7 +20,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "3.796.0",
         "@hapi/boom": "10.0.1",
-        "@modelcontextprotocol/sdk": "1.24.3",
+        "@modelcontextprotocol/sdk": "1.25.2",
         "@nangohq/database": "file:../database",
         "@nangohq/kvstore": "file:../kvstore",
         "@nangohq/nango-yaml": "file:../nango-yaml",


### PR DESCRIPTION
https://github.com/NangoHQ/nango/security/dependabot/264

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Update MCP SDK to 1.25.2 and align server transport usage**

Updates `@modelcontextprotocol/sdk` to `1.25.2` across the server and shared packages with lockfile refresh, introducing new transitive dependencies `@hono/node-server`, `hono`, and `json-schema-typed@8.0.2`. Adjusts `packages/server/lib/controllers/mcp/mcp.ts` to instantiate `StreamableHTTPServerTransport` without the options object required by the previous SDK signature.

<details>
<summary><strong>Key Changes</strong></summary>

• Bumped `@modelcontextprotocol/sdk` from `1.24.3` to `1.25.2` in `packages/shared/package.json` and `packages/server/package.json`
• Regenerated `package-lock.json` to include new transitive dependencies `@hono/node-server@1.19.8`, `hono@4.11.3`, and `json-schema-typed@8.0.2`
• Updated `packages/server/lib/controllers/mcp/mcp.ts` to construct `StreamableHTTPServerTransport` without options to align with the new SDK API

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/mcp/mcp.ts`
• `packages/shared/package.json`
• `packages/server/package.json`
• `package-lock.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*