### PR TITLE
fix(providers): fix token refresh for instagram

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -7219,6 +7219,7 @@ instagram:
     scope_separator: ','
     authorization_url: https://api.instagram.com/oauth/authorize
     token_url: https://api.instagram.com/oauth/access_token
+    refresh_url: https://graph.instagram.com/refresh_access_token
     proxy:
         base_url: https://graph.instagram.com
     docs: https://nango.dev/docs/api-integrations/instagram

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -564,7 +564,7 @@ export async function shouldRefreshCredentials({
 
     // -- At this stage credentials need a refresh whether it's forced or because they are expired
 
-    if (providerConfig.provider === 'facebook' || providerConfig.provider === 'microsoft-admin') {
+    if (providerConfig.provider === 'facebook' || providerConfig.provider === 'microsoft-admin' || providerConfig.provider === 'instagram') {
         return { should: instantRefresh, reason: providerConfig.provider };
     }
 


### PR DESCRIPTION
## Describe the problem and your solution

- Currently, we only generate short-lived access tokens (valid for ~24 hours), which requires users to re-authenticate every 24 hours to keep the connection active. Instagram supports exchanging short-lived tokens for long-lived access tokens (valid for 60 days). This PR updates the flow to perform that exchange, reducing the need for frequent re-authentication.


<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Fix Instagram OAuth token creation and refresh handling**

Adds dedicated Instagram OAuth token handling to `ProviderClient`, covering both the short-lived-to-long-lived exchange and refresh flows. Also updates provider metadata and refresh heuristics so Instagram connections are refreshed immediately when required.

<details>
<summary><strong>Key Changes</strong></summary>

• Added Instagram-specific handling in `packages/shared/lib/clients/provider.client.ts`, including `createInstagramToken` and `refreshInstagramToken`, constants, and switch cases for token creation and refresh
• Extended `shouldRefreshCredentials` logic in `packages/shared/lib/services/connections/credentials/refresh.ts` to treat `instagram` like `facebook` for instant refresh decisions
• Registered `refresh_url` for Instagram in `packages/providers/providers.yaml` so refresh operations have the correct endpoint

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/clients/provider.client.ts`
• `packages/shared/lib/services/connections/credentials/refresh.ts`
• `packages/providers/providers.yaml`

</details>

---
*This summary was automatically generated by @propel-code-bot*