### PR TITLE
docs: update docs to note that `NANGO_ENCRYPTION_KEY`  is required for connect ui

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@
 #
 # - To enable database credentials encryption, uncomment with a base64-encoded 256-bit key (warning: you cannot change this key once set).
 # - To generate a key: `openssl rand -base64 32`
+# - This key is also required for Connect UI functionality, as it is needed to generate Connect UI sessions.
 #
 # NANGO_ENCRYPTION_KEY=<ADD-BASE64-256BIT-KEY>
 #

--- a/docs/guides/platform/security.mdx
+++ b/docs/guides/platform/security.mdx
@@ -53,7 +53,7 @@ The following data types are encrypted at rest:
 ### Key management
 
 - **Nango Cloud**: Encryption keys are securely managed by Nango. All credentials are encrypted at rest.
-- **Self-hosted**: You must provide your own encryption key via the `NANGO_ENCRYPTION_KEY` environment variable to enable encryption at rest. Without this key, credentials are stored unencrypted. **This key is also crucial for the Connect UI**—it's required to generate sessions for the [Connect UI](/reference/sdks/frontend#connect-using-nango-connect-ui). Without it, the Connect UI will not work.
+- **Self-hosted**: You must provide your own encryption key via the `NANGO_ENCRYPTION_KEY` environment variable to enable encryption at rest. Without this key, credentials are stored unencrypted. **This key is also crucial for the Connect UI**. It's required to generate sessions for the [Connect UI](/reference/sdks/frontend#connect-using-nango-connect-ui). Without it, the Connect UI will not work.
 
 <Note>
 The encryption key must be a base64-encoded 256-bit (32-byte) key. Key rotation is not supported—changing the key after initial setup will cause decryption failures. Plan your key management accordingly.

--- a/docs/guides/platform/security.mdx
+++ b/docs/guides/platform/security.mdx
@@ -53,7 +53,7 @@ The following data types are encrypted at rest:
 ### Key management
 
 - **Nango Cloud**: Encryption keys are securely managed by Nango. All credentials are encrypted at rest.
-- **Self-hosted**: You must provide your own encryption key via the `NANGO_ENCRYPTION_KEY` environment variable to enable encryption at rest. Without this key, credentials are stored unencrypted.
+- **Self-hosted**: You must provide your own encryption key via the `NANGO_ENCRYPTION_KEY` environment variable to enable encryption at rest. Without this key, credentials are stored unencrypted. **This key is also crucial for the Connect UI**—it's required to generate sessions for the [Connect UI](/reference/sdks/frontend#connect-using-nango-connect-ui). Without it, the Connect UI will not work.
 
 <Note>
 The encryption key must be a base64-encoded 256-bit (32-byte) key. Key rotation is not supported—changing the key after initial setup will cause decryption failures. Plan your key management accordingly.

--- a/docs/guides/self-hosting/free-self-hosting/configuration.mdx
+++ b/docs/guides/self-hosting/free-self-hosting/configuration.mdx
@@ -124,6 +124,10 @@ Once you restart the Nango server, the encryption of the database will happen
 automatically. Please note that, at the current time, you cannot modify this
 encryption key once you have set it.
 
+<Warning>
+The `NANGO_ENCRYPTION_KEY` is also required for Connect UI to function—it's used to generate sessions for [Connect UI](/reference/sdks/frontend#connect-using-nango-connect-ui). Without this key, the Connect UI will not work.
+</Warning>
+
 ### Custom websockets path[](#custom-websockets-path 'Direct link to Custom websockets path')
 
 The Nango server serves websockets from the `/` path by default for use by `@nangohq/frontend` during the login flow.

--- a/docs/guides/self-hosting/free-self-hosting/configuration.mdx
+++ b/docs/guides/self-hosting/free-self-hosting/configuration.mdx
@@ -125,7 +125,7 @@ automatically. Please note that, at the current time, you cannot modify this
 encryption key once you have set it.
 
 <Warning>
-The `NANGO_ENCRYPTION_KEY` is also required for Connect UI to function—it's used to generate sessions for [Connect UI](/reference/sdks/frontend#connect-using-nango-connect-ui). Without this key, the Connect UI will not work.
+The `NANGO_ENCRYPTION_KEY` is also required for Connect UI to function. It's used to generate sessions for [Connect UI](/reference/sdks/frontend#connect-using-nango-connect-ui). Without this key, the Connect UI will not work.
 </Warning>
 
 ### Custom websockets path[](#custom-websockets-path 'Direct link to Custom websockets path')


### PR DESCRIPTION
## Describe the problem and your solution

- update docs to note that `NANGO_ENCRYPTION_KEY`  is [required](https://github.com/NangoHQ/nango/blob/0d3ab348e3825f20cf0d1853e195564401952d1d/packages/server/lib/controllers/connect/postSessions.ts#L191) for connect ui to generate connect ui [sessions](https://github.com/NangoHQ/nango/blob/0d3ab348e3825f20cf0d1853e195564401952d1d/packages/keystore/lib/models/privatekeys.ts#L87) tokens.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

It also refreshes the self-hosting and security guides—alongside the `.env.example` comments—to reinforce the encryption-at-rest guidance tied to this Connect UI requirement.

<details>
<summary><strong>Affected Areas</strong></summary>

• docs/guides/self-hosting/free-self-hosting/configuration.mdx
• docs/guides/platform/security.mdx
• .env.example

</details>

---
*This summary was automatically generated by @propel-code-bot*