### PR TITLE
fix(trace): Fix wrongly copy-pasted trace span name.

### DIFF
--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -377,7 +377,7 @@ export class AccessMiddleware {
 
     async connectSessionOrPublicKeyAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
         const active = tracer.scope().active();
-        const span = tracer.startSpan('connectSessionOrSecretKeyAuth', {
+        const span = tracer.startSpan('connectSessionOrPublicKeyAuth', {
             childOf: active!
         });
 


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Correct trace span name for connect session/public key auth middleware**

Updates the `tracer.startSpan` invocation in `connectSessionOrPublicKeyAuth` so the span label matches the handler name. This fixes copy-pasted telemetry that previously reported under the secret-key auth span.

<details>
<summary><strong>Key Changes</strong></summary>

• Renamed the `tracer.startSpan` identifier to `connectSessionOrPublicKeyAuth` in `packages/server/lib/middleware/access.middleware.ts` to align tracing with the actual handler.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/middleware/access.middleware.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*