### PR TITLE
fix: GET /connections: metadata is back, connectionConfig/credentials are optional

### DIFF
--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -306,6 +306,11 @@ paths:
                                                 created:
                                                     type: string
                                                     description: Connection creation date.
+                                                metadata:
+                                                    anyOf:
+                                                        - type: object
+                                                        - type: 'null'
+                                                    description: Custom metadata attached to the connection
                                                 errors:
                                                     type: array
                                                     items:
@@ -752,6 +757,11 @@ paths:
                                                 created:
                                                     type: string
                                                     description: Connection creation date.
+                                                metadata:
+                                                    anyOf:
+                                                        - type: object
+                                                        - type: 'null'
+                                                    description: Custom metadata attached to the connection
                                                 errors:
                                                     type: array
                                                     items:

--- a/packages/server/lib/controllers/connection/connectionId/getConnection.ts
+++ b/packages/server/lib/controllers/connection/connectionId/getConnection.ts
@@ -76,7 +76,7 @@ export const getPublicConnection = asyncWrapper<GetPublicConnection>(async (req,
             environmentId: environment.id,
             connectionId,
             integrationIds: [providerConfigKey],
-            opts: { includesMetadata: true }
+            opts: { includesConnectionConfig: true, includesCredentials: true }
         });
         if (finalConnections.length !== 1 || !finalConnections[0]) {
             return Err('Failed to get connection');


### PR DESCRIPTION


temporary quickfix to speed up listConnections query. connectionConfig and credentials are not being returned by the endpoint so let's not query them.
Next: rewrite the query for listing connections that strictly load the required data, avoid grouping and use proper db indexes.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

The service now makes those heavier fields optional, only loading them when explicitly requested, and the public GET controller, documentation, and integration tests have been updated to reflect the new selective retrieval behavior.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/services/connection.service.ts`
• `packages/server/lib/controllers/connection/connectionId/getConnection.ts`
• `packages/shared/lib/services/connection.service.integration.test.ts`
• `docs/spec.yaml`

</details>

---
*This summary was automatically generated by @propel-code-bot*