### PR TITLE
perf(listConnextion): optimize query early filtering/limiting + index

### DIFF
--- a/packages/database/lib/migrations/20260113104700_add_connections_created_at_index.cjs
+++ b/packages/database/lib/migrations/20260113104700_add_connections_created_at_index.cjs
@@ -1,0 +1,9 @@
+exports.config = { transaction: false };
+
+exports.up = async function (knex) {
+    await knex.schema.raw(
+        'CREATE INDEX CONCURRENTLY idx_connections_env_createdat_not_deleted ON _nango_connections (environment_id, created_at DESC) WHERE NOT deleted;'
+    );
+};
+
+exports.down = async function () {};


### PR DESCRIPTION
- Filter to target connections before joins and aggregations
- Add composite index on (environment_id, created_at DESC) WHERE NOT deleted

Example execution time for a connections-heavy customer: 68s → 0.57ms (119,000x faster)
    - Eliminated disk spills: 47MB temp writes → 0
    - I/O wait time: 30s → 0ms
    - Buffer hits: 78,404 → 189 (99.7% reduction)
    - Rows processed: 10,429 → 20 (early filtering)
    - Removed expensive GROUP BY before LIMIT
    - Sort method: external merge (disk) → index scan (no sort needed)

BEFORE 
```
Limit  (cost=53283.55..53283.60 rows=20 width=130) (actual time=67954.163..68002.128 rows=20 loops=1)
  Output: (row_to_json(_nango_connections.*)), (row_to_json(end_users.*)), (COALESCE(json_agg(json_build_object('type', _nango_active_logs.type, 'log_id', _nango_active_logs.log_id)) FILTER (WHERE (_nango_active_logs.id IS NOT NULL)))), (count(_nango_active_logs.id)), _nango_configs.provider, _nango_connections.created_at, _nango_connections.id, end_users.id
  Buffers: shared hit=78404, temp read=19027 written=19291
  I/O Timings: temp read=31.371 write=30404.030
  ->  Sort  (cost=53283.55..53313.70 rows=12061 width=130) (actual time=67954.163..68002.125 rows=20 loops=1)
        Output: (row_to_json(_nango_connections.*)), (row_to_json(end_users.*)), (COALESCE(json_agg(json_build_object('type', _nango_active_logs.type, 'log_id', _nango_active_logs.log_id)) FILTER (WHERE (_nango_active_logs.id IS NOT NULL)))), (count(_nango_active_logs.id)), _nango_configs.provider, _nango_connections.created_at, _nango_connections.id, end_users.id
        Sort Key: _nango_connections.created_at DESC
        Sort Method: top-N heapsort  Memory: 189kB
        Buffers: shared hit=78404, temp read=19027 written=19291
        I/O Timings: temp read=31.371 write=30404.030
        ->  GroupAggregate  (cost=51196.03..52962.61 rows=12061 width=130) (actual time=67363.682..67993.334 rows=10429 loops=1)
              Output: row_to_json(_nango_connections.*), row_to_json(end_users.*), COALESCE(json_agg(json_build_object('type', _nango_active_logs.type, 'log_id', _nango_active_logs.log_id)) FILTER (WHERE (_nango_active_logs.id IS NOT NULL))), count(_nango_active_logs.id), _nango_configs.provider, _nango_connections.created_at, _nango_connections.id, end_users.id
              Group Key: _nango_connections.id, end_users.id, _nango_configs.provider
              Buffers: shared hit=78404, temp read=19027 written=19291
              I/O Timings: temp read=31.371 write=30404.030
              ->  Gather Merge  (cost=51196.03..52570.63 rows=12061 width=1142) (actual time=67363.652..67426.895 rows=10653 loops=1)
                    Output: _nango_configs.provider, _nango_connections.id, end_users.id, _nango_connections.*, end_users.*, _nango_active_logs.type, _nango_active_logs.log_id, _nango_active_logs.id, _nango_connections.created_at
                    Workers Planned: 1
                    Workers Launched: 1
                    Buffers: shared hit=78404, temp read=19027 written=19291
                    I/O Timings: temp read=31.371 write=30404.030
                    ->  Sort  (cost=50196.02..50213.76 rows=7095 width=1142) (actual time=67325.488..67333.868 rows=5326 loops=2)
                          Output: _nango_configs.provider, _nango_connections.id, end_users.id, _nango_connections.*, end_users.*, _nango_active_logs.type, _nango_active_logs.log_id, _nango_active_logs.id, _nango_connections.created_at
                          Sort Key: _nango_connections.id, end_users.id, _nango_configs.provider
                          Sort Method: external merge  Disk: 23448kB
                          Buffers: shared hit=78404, temp read=19027 written=19291
                          I/O Timings: temp read=31.371 write=30404.030
                          Worker 0:  actual time=67287.710..67295.896 rows=5347 loops=1
                            Sort Method: external merge  Disk: 23728kB
                            Buffers: shared hit=39668, temp read=9729 written=13127
                            I/O Timings: temp read=16.288
                          ->  Parallel Hash Right Join  (cost=43370.82..46200.20 rows=7095 width=1142) (actual time=50270.162..50283.311 rows=5326 loops=2)
                                Output: _nango_configs.provider, _nango_connections.id, end_users.id, _nango_connections.*, end_users.*, _nango_active_logs.type, _nango_active_logs.log_id, _nango_active_logs.id, _nango_connections.created_at
                                Hash Cond: (_nango_active_logs.connection_id = _nango_connections.id)
                                Buffers: shared hit=78389, temp read=13130 written=13384
                                I/O Timings: temp read=21.362 write=13335.187
                                Worker 0:  actual time=50268.848..50282.225 rows=5347 loops=1
                                  Buffers: shared hit=39653, temp read=6763 written=10156
                                  I/O Timings: temp read=11.411
                                ->  Parallel Seq Scan on nango._nango_active_logs  (cost=0.00..2561.06 rows=70335 width=35) (actual time=0.009..9.534 rows=59799 loops=2)
                                      Output: _nango_active_logs.type, _nango_active_logs.log_id, _nango_active_logs.id, _nango_active_logs.connection_id
                                      Filter: _nango_active_logs.active
                                      Rows Removed by Filter: 45
                                      Buffers: shared hit=1857
                                      Worker 0:  actual time=0.010..9.178 rows=55274 loops=1
                                        Buffers: shared hit=825
                                ->  Parallel Hash  (cost=43308.00..43308.00 rows=5025 width=1111) (actual time=47598.450..47598.458 rows=5214 loops=2)
                                      Output: _nango_connections.*, _nango_connections.created_at, _nango_connections.id, _nango_configs.provider, end_users.*, end_users.id
                                      Buckets: 2048 (originally 16384)  Batches: 8 (originally 1)  Memory Usage: 6448kB
                                      Buffers: shared hit=76532, temp read=6844 written=12552
                                      I/O Timings: temp read=11.950 write=10684.619
                                      Worker 0:  actual time=47596.277..47596.284 rows=10389 loops=1
                                        Buffers: shared hit=38828, temp read=3217 written=9772
                                        I/O Timings: temp read=6.198
                                      ->  Parallel Hash Right Join  (cost=38857.75..43308.00 rows=5025 width=1111) (actual time=8669.995..8682.648 rows=5214 loops=2)
                                            Output: _nango_connections.*, _nango_connections.created_at, _nango_connections.id, _nango_configs.provider, end_users.*, end_users.id
                                            Hash Cond: (end_users.id = _nango_connections.end_user_id)
                                            Buffers: shared hit=76532, temp read=3750 written=3980
                                            I/O Timings: temp read=5.976 write=7697.422
                                            Worker 0:  actual time=8668.943..8674.677 rows=10389 loops=1
                                              Buffers: shared hit=38828, temp read=123 written=2076
                                              I/O Timings: temp read=0.224
                                            ->  Parallel Seq Scan on nango.end_users  (cost=0.00..3992.62 rows=72762 width=206) (actual time=0.015..28.976 rows=87588 loops=2)
                                                  Output: end_users.*, end_users.id
                                                  Buffers: shared hit=3265
                                                  Worker 0:  actual time=0.017..31.007 rows=92545 loops=1
                                                    Buffers: shared hit=1721
                                            ->  Parallel Hash  (cost=38794.94..38794.94 rows=5025 width=909) (actual time=399.074..399.077 rows=5214 loops=2)
                                                  Output: _nango_connections.*, _nango_connections.created_at, _nango_connections.id, _nango_connections.end_user_id, _nango_configs.provider
                                                  Buckets: 2048 (originally 16384)  Batches: 32 (originally 1)  Memory Usage: 49776kB
                                                  Buffers: shared hit=73267, temp read=10 written=168
                                                  I/O Timings: temp read=0.046 write=311.852
                                                  Worker 0:  actual time=397.030..397.033 rows=5320 loops=1
                                                    Buffers: shared hit=37107, temp read=5 written=68
                                                    I/O Timings: temp read=0.023
                                                  ->  Nested Loop  (cost=866.20..38794.94 rows=5025 width=909) (actual time=3.599..61.723 rows=5214 loops=2)
                                                        Output: _nango_connections.*, _nango_connections.created_at, _nango_connections.id, _nango_connections.end_user_id, _nango_configs.provider
                                                        Inner Unique: true
                                                        Buffers: shared hit=73267
                                                        Worker 0:  actual time=1.609..59.690 rows=5320 loops=1
                                                          Buffers: shared hit=37107
                                                        ->  Parallel Bitmap Heap Scan on nango._nango_connections  (cost=865.90..37393.51 rows=5025 width=903) (actual time=3.569..58.827 rows=5214 loops=2)
                                                              Output: _nango_connections.*, _nango_connections.created_at, _nango_connections.id, _nango_connections.config_id, _nango_connections.end_user_id
                                                              Recheck Cond: ((_nango_connections.environment_id = ?) AND (NOT _nango_connections.deleted))
                                                              Heap Blocks: exact=9401
                                                              Buffers: shared hit=73236
                                                              Worker 0:  actual time=1.568..56.715 rows=5320 loops=1
                                                                Buffers: shared hit=37091
                                                              ->  Bitmap Index Scan on idx_connections_envid_connectionid_provider_where_deleted  (cost=0.00..862.88 rows=12061 width=0) (actual time=3.208..3.209 rows=22034 loops=1)
                                                                    Index Cond: (_nango_connections.environment_id = ?)
                                                                    Buffers: shared hit=282
                                                        ->  Memoize  (cost=0.30..0.69 rows=1 width=14) (actual time=0.000..0.000 rows=1 loops=10429)
                                                              Output: _nango_configs.provider, _nango_configs.id
                                                              Cache Key: _nango_connections.config_id
                                                              Cache Mode: logical
                                                              Hits: 5104  Misses: 5  Evictions: 0  Overflows: 0  Memory Usage: 1kB
                                                              Buffers: shared hit=31
                                                              Worker 0:  actual time=0.000..0.000 rows=1 loops=5320
                                                                Hits: 5315  Misses: 5  Evictions: 0  Overflows: 0  Memory Usage: 1kB
                                                                Buffers: shared hit=16
                                                              ->  Index Scan using _nango_configs_pkey on nango._nango_configs  (cost=0.29..0.68 rows=1 width=14) (actual time=0.005..0.005 rows=1 loops=10)
                                                                    Output: _nango_configs.provider, _nango_configs.id
                                                                    Index Cond: (_nango_configs.id = _nango_connections.config_id)
                                                                    Buffers: shared hit=31
                                                                    Worker 0:  actual time=0.004..0.004 rows=1 loops=5
                                                                      Buffers: shared hit=16
Query Identifier: 289066794011705444
Planning:
  Buffers: shared hit=584
Planning Time: 1.108 ms
Execution Time: 68006.630 ms
```

AFTER
```
Hash Left Join  (cost=150.85..334.53 rows=20 width=106) (actual time=0.182..0.510 rows=20 loops=1)
  Output: row_to_json(_nango_connections.*), row_to_json(end_users.*), COALESCE(active_logs_agg.active_logs, '[]'::json), _nango_configs.provider
  Inner Unique: true
  Hash Cond: (_nango_connections.id = active_logs_agg.connection_id)
  Buffers: shared hit=189
  CTE filtered_connections
    ->  Limit  (cost=0.42..66.13 rows=20 width=12) (actual time=0.017..0.055 rows=20 loops=1)
          Output: _nango_connections_1.id, _nango_connections_1.created_at
          Buffers: shared hit=28
          ->  Index Scan using idx_connections_env_createdat_not_deleted on nango._nango_connections _nango_connections_1  (cost=0.42..39156.20 rows=11919 width=12) (actual time=0.017..0.053 rows=20 loops=1)
                Output: _nango_connections_1.id, _nango_connections_1.created_at
                Index Cond: (_nango_connections_1.environment_id = ?)
                Buffers: shared hit=28
  ->  Nested Loop Left Join  (cost=1.14..184.66 rows=20 width=1094) (actual time=0.038..0.180 rows=20 loops=1)
        Output: _nango_connections.*, _nango_connections.id, _nango_configs.provider, end_users.*
        Inner Unique: true
        Buffers: shared hit=155
        ->  Nested Loop  (cost=0.71..175.52 rows=20 width=896) (actual time=0.034..0.162 rows=20 loops=1)
              Output: _nango_connections.*, _nango_connections.id, _nango_connections.end_user_id, _nango_configs.provider
              Inner Unique: true
              Buffers: shared hit=155
              ->  Nested Loop  (cost=0.42..169.25 rows=20 width=890) (actual time=0.028..0.121 rows=20 loops=1)
                    Output: _nango_connections.*, _nango_connections.id, _nango_connections.config_id, _nango_connections.end_user_id
                    Inner Unique: true
                    Buffers: shared hit=95
                    ->  CTE Scan on filtered_connections  (cost=0.00..0.40 rows=20 width=4) (actual time=0.019..0.022 rows=20 loops=1)
                          Output: filtered_connections.id
                          Buffers: shared hit=5
                    ->  Index Scan using _nango_connections_pkey on nango._nango_connections  (cost=0.42..8.44 rows=1 width=890) (actual time=0.004..0.004 rows=1 loops=20)
                          Output: _nango_connections.*, _nango_connections.id, _nango_connections.config_id, _nango_connections.end_user_id
                          Index Cond: (_nango_connections.id = filtered_connections.id)
                          Buffers: shared hit=90
              ->  Index Scan using _nango_configs_pkey on nango._nango_configs  (cost=0.29..0.31 rows=1 width=14) (actual time=0.001..0.001 rows=1 loops=20)
                    Output: _nango_configs.id, _nango_configs.created_at, _nango_configs.updated_at, _nango_configs.unique_key, _nango_configs.provider, _nango_configs.oauth_client_id, _nango_configs.oauth_client_secret, _nango_configs.oauth_scopes, _nango_configs.oauth_client_secret_iv, _nango_configs.oauth_client_secret_tag, _nango_configs.environment_id, _nango_configs.deleted, _nango_configs.deleted_at, _nango_configs.app_link, _nango_configs.custom, _nango_configs.missing_fields, _nango_configs.display_name, _nango_configs.forward_webhooks, _nango_configs.shared_credentials_id
                    Index Cond: (_nango_configs.id = _nango_connections.config_id)
                    Buffers: shared hit=60
        ->  Index Scan using end_users_pkey on nango.end_users  (cost=0.42..0.46 rows=1 width=206) (actual time=0.000..0.000 rows=0 loops=20)
              Output: end_users.*, end_users.id
              Index Cond: (end_users.id = _nango_connections.end_user_id)
  ->  Hash  (cost=83.45..83.45 rows=11 width=36) (actual time=0.126..0.127 rows=5 loops=1)
        Output: active_logs_agg.active_logs, active_logs_agg.connection_id
        Buckets: 1024  Batches: 1  Memory Usage: 9kB
        Buffers: shared hit=34
        ->  Subquery Scan on active_logs_agg  (cost=0.82..83.45 rows=11 width=36) (actual time=0.074..0.124 rows=5 loops=1)
              Output: active_logs_agg.active_logs, active_logs_agg.connection_id
              Buffers: shared hit=34
              ->  GroupAggregate  (cost=0.82..83.34 rows=11 width=36) (actual time=0.073..0.123 rows=5 loops=1)
                    Output: _nango_active_logs.connection_id, json_agg(json_build_object('type', _nango_active_logs.type, 'log_id', _nango_active_logs.log_id))
                    Group Key: _nango_active_logs.connection_id
                    Buffers: shared hit=34
                    InitPlan 2
                      ->  CTE Scan on filtered_connections filtered_connections_1  (cost=0.00..0.40 rows=20 width=4) (actual time=0.000..0.043 rows=20 loops=1)
                            Output: filtered_connections_1.id
                            Buffers: shared hit=23
                    ->  Index Scan using idx_activelogs_connectionid_where_active on nango._nango_active_logs  (cost=0.42..82.72 rows=11 width=31) (actual time=0.064..0.105 rows=8 loops=1)
                          Output: _nango_active_logs.id, _nango_active_logs.type, _nango_active_logs.action, _nango_active_logs.connection_id, _nango_active_logs.log_id, _nango_active_logs.active, _nango_active_logs.sync_id, _nango_active_logs.created_at, _nango_active_logs.updated_at
                          Index Cond: (_nango_active_logs.connection_id = ANY ((InitPlan 2).col1))
                          Buffers: shared hit=34
Query Identifier: 8822331568651939424
Planning:
  Buffers: shared hit=321
Planning Time: 0.778 ms
Execution Time: 0.572 ms
```

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

The refactor now revolves around `filtered_connections` and `active_logs_agg` CTEs so pagination, filtering, and active log aggregation all occur before touching the heavier tables, with error states expressed through NULL checks rather than HAVING clauses, and the supporting index delivered via a concurrent migration that intentionally leaves `exports.down` empty.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/services/connection.service.ts` (function `listConnections`)
• `packages/database/lib/migrations/20260113104700_add_connections_created_at_index.cjs`

</details>

---
*This summary was automatically generated by @propel-code-bot*