### PR TITLE
fix: only create index if not exists

### DIFF
--- a/packages/database/lib/migrations/20260113104700_add_connections_created_at_index.cjs
+++ b/packages/database/lib/migrations/20260113104700_add_connections_created_at_index.cjs
@@ -2,7 +2,7 @@ exports.config = { transaction: false };
 
 exports.up = async function (knex) {
     await knex.schema.raw(
-        'CREATE INDEX CONCURRENTLY idx_connections_env_createdat_not_deleted ON _nango_connections (environment_id, created_at DESC) WHERE NOT deleted;'
+        'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_connections_env_createdat_not_deleted ON _nango_connections (environment_id, created_at DESC) WHERE NOT deleted;'
     );
 };
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Make connections index creation idempotent**

Updates the migration that creates `idx_connections_env_createdat_not_deleted` so it only attempts to create the index when it does not already exist. This avoids migration failures caused by re-running the migration against databases where the index is present.

<details>
<summary><strong>Key Changes</strong></summary>

• Adds `IF NOT EXISTS` to the `CREATE INDEX CONCURRENTLY` statement in `packages/database/lib/migrations/20260113104700_add_connections_created_at_index.cjs`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/database/lib/migrations/20260113104700_add_connections_created_at_index.cjs`

</details>

---
*This summary was automatically generated by @propel-code-bot*