### PR TITLE
feat: add limit optional parameter to list connection endpoint/function

### DIFF
--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -267,6 +267,11 @@ paths:
                   schema:
                       type: string
                   description: Filter the list of connections based on the given end user's organization id.
+                - name: limit
+                  in: query
+                  schema:
+                      type: integer
+                      description: Limit the number of connections returned
             responses:
                 '200':
                     description: Successfully returned a list of connections
@@ -718,6 +723,11 @@ paths:
                   schema:
                       type: string
                   description: Filter the list of connections based on the given end user's organization id.
+                - name: limit
+                  in: query
+                  schema:
+                      type: integer
+                      description: Limit the number of connections returned
             responses:
                 '200':
                     description: Successfully returned a list of connections

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -258,6 +258,7 @@ export class Nango {
         userId?: string;
         integrationId?: string | string[];
         tags?: Record<'displayName' | 'email', string>;
+        limit?: number;
     }): Promise<GetPublicConnections['Success']>;
 
     public async listConnections(
@@ -268,6 +269,7 @@ export class Nango {
                   userId?: string;
                   integrationId?: string | string[];
                   tags?: Record<'displayName' | 'email', string>;
+                  limit?: number;
               },
         search?: string,
         queries?: Omit<GetPublicConnections['Querystring'], 'connectionId' | 'search'>
@@ -277,7 +279,7 @@ export class Nango {
         // Handle both call signatures
         if (typeof connectionIdOrParams === 'object') {
             // New object parameter syntax
-            const { connectionId, userId, integrationId, tags } = connectionIdOrParams;
+            const { connectionId, userId, integrationId, tags, limit } = connectionIdOrParams;
 
             if (connectionId) {
                 url.searchParams.append('connectionId', connectionId);
@@ -296,6 +298,9 @@ export class Nango {
                     url.searchParams.append('email', tags['email']);
                 }
             }
+            if (limit) {
+                url.searchParams.append('limit', limit.toString());
+            }
         } else {
             // Legacy parameter syntax
             if (connectionIdOrParams) {
@@ -309,6 +314,9 @@ export class Nango {
             }
             if (queries?.endUserOrganizationId) {
                 url.searchParams.append('endUserOrganizationId', queries.endUserOrganizationId);
+            }
+            if (queries?.limit) {
+                url.searchParams.append('limit', queries.limit.toString());
             }
         }
 

--- a/packages/server/lib/controllers/connection/getConnections.integration.test.ts
+++ b/packages/server/lib/controllers/connection/getConnections.integration.test.ts
@@ -179,4 +179,23 @@ describe(`GET ${endpoint}`, () => {
             connections: [{ connection_id: conn.connection_id, end_user: { id: endUser.endUserId } }]
         });
     });
+
+    it('should limit the number of connections', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+        for (let i = 0; i < 5; i++) {
+            await seeders.createConnectionSeed({ env, provider: 'github' });
+        }
+
+        const res = await api.fetch(endpoint, {
+            method: 'GET',
+            token: env.secret_key,
+            query: {
+                limit: 3
+            }
+        });
+
+        isSuccess(res.json);
+        expect(res.json.connections).toHaveLength(3);
+    });
 });

--- a/packages/server/lib/controllers/connection/getConnections.ts
+++ b/packages/server/lib/controllers/connection/getConnections.ts
@@ -15,7 +15,8 @@ const validationQuery = z
         search: z.string().min(1).max(255).optional(),
         endUserId: bodySchema.shape.end_user.shape.id.optional(),
         integrationId: z.string().min(1).optional(),
-        endUserOrganizationId: bodySchema.shape.end_user.shape.id.optional()
+        endUserOrganizationId: bodySchema.shape.end_user.shape.id.optional(),
+        limit: z.coerce.number().min(1).max(1000).optional()
     })
     .strict();
 
@@ -38,7 +39,7 @@ export const getPublicConnections = asyncWrapper<GetPublicConnections>(async (re
         endUserId: queryParam.endUserId,
         integrationIds: queryParam.integrationId ? queryParam.integrationId.split(',').map((id) => id.trim()) : undefined,
         endUserOrganizationId: queryParam.endUserOrganizationId,
-        limit: 10000
+        limit: queryParam.limit || 10_000 // 10_000 to avoid breaking changes. TODO: set to more reasonable default like 1000 in the future
     });
 
     res.status(200).send({

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -62,6 +62,7 @@ export type GetPublicConnections = Endpoint<{
         endUserId?: string | undefined;
         integrationId?: string | undefined;
         endUserOrganizationId?: string | undefined;
+        limit?: number | undefined;
     };
     Path: '/connection';
     Success: {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add optional `limit` query support for listing connections**

Introduces a new optional `limit` query parameter for the public connections listing endpoint and the corresponding Node client helper. The server controller now validates `limit` as a coerced number between 1 and 1000, forwards the provided value to `connectionService.listConnections`, and falls back to the previous behavior of requesting 10_000 records when no limit is supplied. Types, OpenAPI documentation, and integration coverage were updated to reflect the new argument.

<details>
<summary><strong>Key Changes</strong></summary>

• Validated an optional `limit` field in `packages/server/lib/controllers/connection/getConnections.ts` and wired it into `connectionService.listConnections` with a 10_000 default when absent.
• Extended the Node client `listConnections` method in `packages/node-client/lib/index.ts` to accept and forward a `limit` parameter in both legacy and object call signatures.
• Updated `GetPublicConnections` typings in `packages/types/lib/connection/api/get.ts`, integration tests, and the OpenAPI spec to document and exercise the new query parameter.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/connection/getConnections.ts`
• `packages/node-client/lib/index.ts`
• `packages/types/lib/connection/api/get.ts`
• `packages/server/lib/controllers/connection/getConnections.integration.test.ts`
• `docs/spec.yaml`

</details>

---
*This summary was automatically generated by @propel-code-bot*