### PR TITLE
fix: page param for listConnections

### DIFF
--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -272,6 +272,11 @@ paths:
                   schema:
                       type: integer
                   description: Limit the number of connections returned
+                - name: page
+                  in: query
+                  schema:
+                      type: integer
+                  description: Page number for paginated results
             responses:
                 '200':
                     description: Successfully returned a list of connections
@@ -728,6 +733,11 @@ paths:
                   schema:
                       type: integer
                   description: Limit the number of connections returned
+                - name: page
+                  in: query
+                  schema:
+                      type: integer
+                  description: Page number for paginated results
             responses:
                 '200':
                     description: Successfully returned a list of connections

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -271,7 +271,7 @@ paths:
                   in: query
                   schema:
                       type: integer
-                      description: Limit the number of connections returned
+                  description: Limit the number of connections returned
             responses:
                 '200':
                     description: Successfully returned a list of connections
@@ -727,7 +727,7 @@ paths:
                   in: query
                   schema:
                       type: integer
-                      description: Limit the number of connections returned
+                  description: Limit the number of connections returned
             responses:
                 '200':
                     description: Successfully returned a list of connections

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -270,6 +270,7 @@ export class Nango {
                   integrationId?: string | string[];
                   tags?: Record<'displayName' | 'email', string>;
                   limit?: number;
+                  page?: number;
               },
         search?: string,
         queries?: Omit<GetPublicConnections['Querystring'], 'connectionId' | 'search'>
@@ -279,7 +280,7 @@ export class Nango {
         // Handle both call signatures
         if (typeof connectionIdOrParams === 'object') {
             // New object parameter syntax
-            const { connectionId, userId, integrationId, tags, limit } = connectionIdOrParams;
+            const { connectionId, userId, integrationId, tags, limit, page } = connectionIdOrParams;
 
             if (connectionId) {
                 url.searchParams.append('connectionId', connectionId);
@@ -301,6 +302,9 @@ export class Nango {
             if (limit) {
                 url.searchParams.append('limit', limit.toString());
             }
+            if (page) {
+                url.searchParams.append('page', page.toString());
+            }
         } else {
             // Legacy parameter syntax
             if (connectionIdOrParams) {
@@ -317,6 +321,9 @@ export class Nango {
             }
             if (queries?.limit) {
                 url.searchParams.append('limit', queries.limit.toString());
+            }
+            if (queries?.page) {
+                url.searchParams.append('page', queries.page.toString());
             }
         }
 

--- a/packages/server/lib/controllers/connection/getConnections.integration.test.ts
+++ b/packages/server/lib/controllers/connection/getConnections.integration.test.ts
@@ -180,14 +180,14 @@ describe(`GET ${endpoint}`, () => {
         });
     });
 
-    it('should limit the number of connections', async () => {
+    it('should be paginable', async () => {
         const { env } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         for (let i = 0; i < 5; i++) {
             await seeders.createConnectionSeed({ env, provider: 'github' });
         }
 
-        const res = await api.fetch(endpoint, {
+        const page0 = await api.fetch(endpoint, {
             method: 'GET',
             token: env.secret_key,
             query: {
@@ -195,7 +195,31 @@ describe(`GET ${endpoint}`, () => {
             }
         });
 
-        isSuccess(res.json);
-        expect(res.json.connections).toHaveLength(3);
+        isSuccess(page0.json);
+        expect(page0.json.connections).toHaveLength(3);
+
+        const page1 = await api.fetch(endpoint, {
+            method: 'GET',
+            token: env.secret_key,
+            query: {
+                limit: 3,
+                page: 1
+            }
+        });
+
+        isSuccess(page1.json);
+        expect(page1.json.connections).toHaveLength(2);
+
+        const page2 = await api.fetch(endpoint, {
+            method: 'GET',
+            token: env.secret_key,
+            query: {
+                limit: 3,
+                page: 2
+            }
+        });
+
+        isSuccess(page2.json);
+        expect(page2.json.connections).toHaveLength(0);
     });
 });

--- a/packages/server/lib/controllers/connection/getConnections.ts
+++ b/packages/server/lib/controllers/connection/getConnections.ts
@@ -16,7 +16,8 @@ const validationQuery = z
         endUserId: bodySchema.shape.end_user.shape.id.optional(),
         integrationId: z.string().min(1).optional(),
         endUserOrganizationId: bodySchema.shape.end_user.shape.id.optional(),
-        limit: z.coerce.number().min(1).max(1000).optional()
+        limit: z.coerce.number().min(1).max(1000).optional(),
+        page: z.coerce.number().min(0).optional()
     })
     .strict();
 
@@ -39,6 +40,7 @@ export const getPublicConnections = asyncWrapper<GetPublicConnections>(async (re
         endUserId: queryParam.endUserId,
         integrationIds: queryParam.integrationId ? queryParam.integrationId.split(',').map((id) => id.trim()) : undefined,
         endUserOrganizationId: queryParam.endUserOrganizationId,
+        page: queryParam.page,
         limit: queryParam.limit || 10_000 // 10_000 to avoid breaking changes. TODO: set to more reasonable default like 1000 in the future
     });
 

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -63,6 +63,7 @@ export type GetPublicConnections = Endpoint<{
         integrationId?: string | undefined;
         endUserOrganizationId?: string | undefined;
         limit?: number | undefined;
+        page?: number | undefined;
     };
     Path: '/connection';
     Success: {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Support page query parameter for public connections listing**

Extends the public connections listing to accept a `page` query parameter across the server handler, TypeScript types, Node SDK, and OpenAPI spec. The integration test suite now exercises multi-page pagination to confirm correct page slicing behavior.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `packages/server/lib/controllers/connection/getConnections.ts` validation schema to accept `page` and forward it to `connectionService.listConnections`
• Enhanced `packages/server/lib/controllers/connection/getConnections.integration.test.ts` with pagination assertions across three pages
• Extended `packages/node-client/lib/index.ts` `listConnections` helper to accept and propagate `page` in both modern and legacy call signatures
• Aligned `packages/types/lib/connection/api/get.ts` and `docs/spec.yaml` to document the new `page` query parameter

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/connection/getConnections.ts`
• `packages/server/lib/controllers/connection/getConnections.integration.test.ts`
• `packages/node-client/lib/index.ts`
• `packages/types/lib/connection/api/get.ts`
• `docs/spec.yaml`

</details>

---
*This summary was automatically generated by @propel-code-bot*