### PR TITLE
fix: add top level model description to mcp json schema

### DIFF
--- a/packages/server/lib/controllers/mcp/server.ts
+++ b/packages/server/lib/controllers/mcp/server.ts
@@ -82,7 +82,8 @@ function actionToTool(action: DBSyncConfig): Tool | null {
         inputSchema: {
             type: 'object',
             properties: inputSchema?.properties as Record<string, object>,
-            required: inputSchema?.required
+            required: inputSchema?.required,
+            description: inputSchema?.description
         },
         description
     };


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Add input schema description to MCP tool schema**

Propagates the `inputSchema.description` from action models into the MCP tool definition so the generated JSON schema exposes the top-level description text. This keeps the server-generated schema aligned with the action metadata.

<details>
<summary><strong>Key Changes</strong></summary>

• Adds `description: inputSchema?.description` to the tool `inputSchema` block in `packages/server/lib/controllers/mcp/server.ts`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/controllers/mcp/server.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*