### PR TITLE
feat(cli): fetch environments dynamically from server

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -305,7 +305,7 @@ program
 
         try {
             const ensure = new Ensure(interactive);
-            environment = await ensure.environment(environment);
+            environment = await ensure.environment(environment, debug);
 
             const definitions = await buildDefinitions({ fullPath, debug });
             if (definitions.isOk()) {
@@ -410,7 +410,7 @@ program
 
         try {
             const ensure = new Ensure(interactive);
-            environment = await ensure.environment(environment);
+            environment = await ensure.environment(environment, debug);
         } catch (err: any) {
             console.error(chalk.red(err.message));
             if (err instanceof MissingArgumentError) {

--- a/packages/cli/lib/services/ensure.service.ts
+++ b/packages/cli/lib/services/ensure.service.ts
@@ -57,8 +57,8 @@ export class Ensure {
         return this.ensure(current, () => promptForFunctionName(functionType), 'Function name is required');
     }
 
-    public async environment(current: string | undefined): Promise<string> {
-        return this.ensure(current, () => promptForEnvironment(), 'Environment is required');
+    public async environment(current: string | undefined, debug = false): Promise<string> {
+        return this.ensure(current, () => promptForEnvironment(debug), 'Environment is required');
     }
 
     public async function(current: string | undefined, availableFunctions: { name: string; type: string }[]): Promise<string> {

--- a/packages/cli/lib/services/interactive.service.ts
+++ b/packages/cli/lib/services/interactive.service.ts
@@ -1,9 +1,10 @@
+import chalk from 'chalk';
 import inquirer from 'inquirer';
 
 import { Nango } from '@nangohq/node';
 
 import { FUNCTION_TYPES } from '../types.js';
-import { parseSecretKey } from '../utils.js';
+import { getEnvironments, parseSecretKey } from '../utils.js';
 
 import type { FunctionType } from '../types.js';
 import type { GetPublicConnections } from '@nangohq/types';
@@ -68,13 +69,26 @@ export async function promptForFunctionName(type: FunctionType): Promise<string>
     return name;
 }
 
-export async function promptForEnvironment(): Promise<string> {
+export async function promptForEnvironment(debug = false): Promise<string> {
+    let choices = ['dev', 'prod', new inquirer.Separator(), OTHER_CHOICE];
+
+    const environments = await getEnvironments(debug);
+    if (environments) {
+        if (environments.data.length > 0) {
+            choices = environments.data.map((e) => e.name);
+        } else {
+            console.log(chalk.yellow('Warning: No environments found. Using default options.'));
+        }
+    } else {
+        console.log(chalk.yellow('Warning: Could not fetch environments. Using default options.'));
+    }
+
     const { env } = await inquirer.prompt([
         {
             type: 'rawlist',
             name: 'env',
             message: 'Which environment do you want to use?',
-            choices: ['dev', 'prod', new inquirer.Separator(), OTHER_CHOICE]
+            choices
         }
     ]);
 

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -17,7 +17,7 @@ import { cloudHost } from './constants.js';
 import { state } from './state.js';
 import { NANGO_VERSION } from './version.js';
 
-import type { GetPublicConnection, GetPublicIntegration } from '@nangohq/types';
+import type { GetEnvironments, GetPublicConnection, GetPublicIntegration } from '@nangohq/types';
 import type { PackageJson } from 'type-fest';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -210,6 +210,22 @@ export async function getConfig(providerConfigKey: string, debug = false): Promi
     try {
         const res = await http.get(url, { headers });
         return res.data as GetPublicIntegration['Success'];
+    } catch (err) {
+        console.log(`❌ ${err instanceof AxiosError ? err.response?.data.error : JSON.stringify(err, ['message'])}`);
+        return;
+    }
+}
+
+export async function getEnvironments(debug = false): Promise<GetEnvironments['Success'] | undefined> {
+    const url = process.env['NANGO_HOSTPORT'] + `/api/v1/environments`;
+    const headers = enrichHeaders();
+    if (debug) {
+        printDebug(`getEnvironments endpoint to the URL: ${url} with headers: ${JSON.stringify(headers, null, 2)}`);
+    }
+
+    try {
+        const res = await http.get(url, { headers });
+        return res.data as GetEnvironments['Success'];
     } catch (err) {
         console.log(`❌ ${err instanceof AxiosError ? err.response?.data.error : JSON.stringify(err, ['message'])}`);
         return;

--- a/packages/server/lib/controllers/v1/environment/getEnvironments.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironments.integration.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { seeders } from '@nangohq/shared';
+
+import { isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
+
+const route = '/api/v1/environments';
+let api: Awaited<ReturnType<typeof runServer>>;
+
+describe(`GET ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(route, { method: 'GET' });
+
+        shouldBeProtected(res);
+    });
+
+    it('should return user environments', async () => {
+        const { account } = await seeders.seedAccountEnvAndUser();
+        const env = await seeders.createEnvironmentSeed(account.id, 'test');
+        await seeders.createEnvironmentSeed(account.id, 'prod');
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            token: env.secret_key
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            data: [
+                {
+                    name: 'dev'
+                },
+                {
+                    name: 'prod'
+                },
+                {
+                    name: 'test'
+                }
+            ]
+        });
+    });
+
+    it('should not return result from an other account', async () => {
+        const { account: account, env } = await seeders.seedAccountEnvAndUser();
+        const { account: account2 } = await seeders.seedAccountEnvAndUser();
+
+        await seeders.createEnvironmentSeed(account.id, 'test');
+        await seeders.createEnvironmentSeed(account2.id, 'test1');
+        await seeders.createEnvironmentSeed(account2.id, 'test2');
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            token: env.secret_key
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            data: [
+                {
+                    name: 'dev'
+                },
+                {
+                    name: 'test'
+                }
+            ]
+        });
+    });
+});

--- a/packages/server/lib/controllers/v1/environment/getEnvironments.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironments.ts
@@ -1,0 +1,23 @@
+import { environmentService } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+
+import type { GetEnvironments } from '@nangohq/types';
+
+export const getEnvironments = asyncWrapper<GetEnvironments>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const accountId = res.locals.account.id;
+    const environments = await environmentService.getEnvironmentsByAccountId(accountId);
+
+    res.status(200).send({
+        data: environments.map((env) => {
+            return { name: env.name };
+        })
+    });
+});

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -36,6 +36,7 @@ import { getConnections } from './controllers/v1/connections/getConnections.js';
 import { getConnectionsCount } from './controllers/v1/connections/getConnectionsCount.js';
 import { deleteEnvironment } from './controllers/v1/environment/deleteEnvironment.js';
 import { getEnvironment } from './controllers/v1/environment/getEnvironment.js';
+import { getEnvironments } from './controllers/v1/environment/getEnvironments.js';
 import { patchEnvironment } from './controllers/v1/environment/patchEnvironment.js';
 import { postEnvironment } from './controllers/v1/environment/postEnvironment.js';
 import { postEnvironmentVariables } from './controllers/v1/environment/variables/postVariables.js';
@@ -167,6 +168,7 @@ web.route('/plans/usage').get(webAuth, getUsage);
 web.route('/plans/billing-usage').get(webAuth, getBillingUsage);
 web.route('/plans/change').post(webAuth, postPlanChange);
 
+web.route('/environments').get(webAuth, getEnvironments);
 web.route('/environments').post(webAuth, postEnvironment);
 web.route('/environments/').patch(webAuth, patchEnvironment);
 web.route('/environments/').delete(webAuth, deleteEnvironment);

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -45,7 +45,7 @@ import type {
 } from './connection/api/get.js';
 import type { SetMetadata, UpdateMetadata } from './connection/api/metadata.js';
 import type { PostDeploy, PostDeployConfirmation, PostDeployInternal } from './deploy/api.js';
-import type { DeleteEnvironment, PatchEnvironment, PostEnvironment } from './environment/api/index.js';
+import type { DeleteEnvironment, GetEnvironments, PatchEnvironment, PostEnvironment } from './environment/api/index.js';
 import type { PatchWebhook } from './environment/api/webhook.js';
 import type { PostEnvironmentVariables } from './environment/variable/api.js';
 import type { PatchFlowDisable, PatchFlowEnable, PatchFlowFrequency, PostPreBuiltDeploy, PutUpgradePreBuiltFlow } from './flow/http.api.js';
@@ -170,6 +170,7 @@ export type PrivateApiEndpoints =
     | PostEnvironment
     | PatchEnvironment
     | DeleteEnvironment
+    | GetEnvironments
     | PatchWebhook
     | PostEnvironmentVariables
     | PostImpersonate

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -10,6 +10,14 @@ export type ApiEnvironment = Omit<
 >;
 export type ApiWebhooks = Omit<DBExternalWebhook, 'id' | 'environment_id' | 'created_at' | 'updated_at'>;
 
+export type GetEnvironments = Endpoint<{
+    Method: 'GET';
+    Path: '/api/v1/environments';
+    Success: {
+        data: Pick<DBEnvironment, 'name'>[];
+    };
+}>;
+
 export type PostEnvironment = Endpoint<{
     Method: 'POST';
     Path: '/api/v1/environments';


### PR DESCRIPTION
Description: This PR updates the CLI to dynamically fetch available environments from the server when prompting the user, instead of relying solely on hardcoded defaults.
Changes:
- Added GET /api/v1/environments endpoint to the server to list environments for the current account.
- Updated CLI utils.ts to include getEnvironments function.
- Updated interactive.service.ts to use getEnvironments to populate the environment selection prompt.
- Updated ensure.service.ts to integrate with the updated prompt logic.

Another alternative would have been to use the GetMeta endpoint to get the environments, but decided to add an endpoint specifically to get them instead.

[NAN-4556](https://linear.app/nango/issue/NAN-4556/get-envs-from-api-when-doing-a-deploy-from-cli)

<!-- Summary by @propel-code-bot -->

---

The CLI now logs warnings and falls back to the default environment list when the API request fails or returns no environments, and a debug flag surfaces the request diagnostics during the interactive prompts.

---
*This summary was automatically generated by @propel-code-bot*