### PR TITLE
fix(managed-release): tag commit with image tag

### DIFF
--- a/.github/workflows/managed-release.yaml
+++ b/.github/workflows/managed-release.yaml
@@ -384,6 +384,7 @@ jobs:
                   fi
 
             - name: Retag and push final image
+              id: retag-image
               if: ${{ !env.ACT }}
               run: |
                   echo "Pulling image..."
@@ -391,13 +392,34 @@ jobs:
 
                   if [ "${{ needs.test-deployment.outputs.status }}" = "failure" ]; then
                       echo "Test deployment failed, using bumped major version"
-                      docker tag nangohq/nango:${{ needs.manage-versions.outputs.commit_hash }} nangohq/nango:managed-${{ steps.bump-major.outputs.image_version }}-${{ steps.bump-major.outputs.app_version }}-${{ needs.manage-versions.outputs.commit_hash }}
-                      docker push nangohq/nango:managed-${{ steps.bump-major.outputs.image_version }}-${{ steps.bump-major.outputs.app_version }}-${{ needs.manage-versions.outputs.commit_hash }}
+                      IMAGE_TAG="managed-${{ steps.bump-major.outputs.image_version }}-${{ steps.bump-major.outputs.app_version }}-${{ needs.manage-versions.outputs.commit_hash }}"
                   else
                       echo "Test deployment successful, using original versions"
-                      docker tag nangohq/nango:${{ needs.manage-versions.outputs.commit_hash }} nangohq/nango:managed-${{ needs.manage-versions.outputs.image_version }}-${{ needs.manage-versions.outputs.app_version }}-${{ needs.manage-versions.outputs.commit_hash }}
-                      docker push nangohq/nango:managed-${{ needs.manage-versions.outputs.image_version }}-${{ needs.manage-versions.outputs.app_version }}-${{ needs.manage-versions.outputs.commit_hash }}
+                      IMAGE_TAG="managed-${{ needs.manage-versions.outputs.image_version }}-${{ needs.manage-versions.outputs.app_version }}-${{ needs.manage-versions.outputs.commit_hash }}"
                   fi
+
+                  docker tag nangohq/nango:${{ needs.manage-versions.outputs.commit_hash }} nangohq/nango:${IMAGE_TAG}
+                  docker push nangohq/nango:${IMAGE_TAG}
+
+                  echo "tag_name=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+
+            - name: Tag commit with managed release
+              if: ${{ !env.ACT }}
+              env:
+                  GITHUB_TOKEN: ${{ steps.create_github_app_token.outputs.token }}
+              run: |
+                  # Use the tag name from the Docker image step
+                  TAG_NAME="${{ steps.retag-image.outputs.tag_name }}"
+
+                  # Checkout the specific commit hash
+                  git fetch origin ${{ needs.manage-versions.outputs.commit_hash }}:refs/tags/temp-commit || true
+                  git checkout ${{ needs.manage-versions.outputs.commit_hash }}
+
+                  # Create and push the tag
+                  git config --global user.name "GitHub Actions"
+                  git config --global user.email "actions@github.com"
+                  git tag -a "$TAG_NAME" -m "Managed release ${TAG_NAME}"
+                  git push origin "$TAG_NAME"
 
             - name: Commit and create PR for version changes
               if: ${{ !env.ACT }}

--- a/.github/workflows/managed-release.yaml
+++ b/.github/workflows/managed-release.yaml
@@ -408,6 +408,9 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ steps.create_github_app_token.outputs.token }}
               run: |
+                  # Preserve the updated managed-manifest.json before checking out commit
+                  cp managed-manifest.json managed-manifest.json.backup
+
                   # Use the tag name from the Docker image step
                   TAG_NAME="${{ steps.retag-image.outputs.tag_name }}"
 
@@ -426,6 +429,14 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ steps.create_github_app_token.outputs.token }}
               run: |
+                  # Explicitly checkout master branch to ensure we're on the right branch
+                  git checkout master
+                  git fetch origin master
+                  git reset --hard origin/master
+
+                  # Restore the managed-manifest.json from the backup
+                  mv managed-manifest.json.backup managed-manifest.json
+
                   git config --global user.name "GitHub Actions"
                   git config --global user.email "actions@github.com"
                   git add managed-manifest.json


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Managed release workflow now tags released commit**

Updates `.github/workflows/managed-release.yaml` so the managed release workflow reuses the computed Docker image tag when tagging both the container image and the corresponding Git commit. The workflow now captures the selected image tag via the `Retag and push final image` step, checks out the released commit, creates an annotated Git tag with the same name, and pushes it using the GitHub App credentials. Additional guard steps ensure the local backup of `managed-manifest.json` is restored after tagging.

<details>
<summary><strong>Key Changes</strong></summary>

• Captured the resolved Docker image tag in `Retag and push final image` and exported it via the new `tag_name` output.
• Added a `Tag commit with managed release` step that checks out `needs.manage-versions.outputs.commit_hash`, creates an annotated Git tag named after the managed release image tag, and pushes it.
• Inserted branch reset and manifest restore logic before committing `managed-manifest.json` updates to `master`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• .github/workflows/managed-release.yaml

</details>

---
*This summary was automatically generated by @propel-code-bot*