### PR TITLE
fix(server): Fix constraints around large environment variables

### DIFF
--- a/packages/database/lib/migrations/20260116165950_increase_environment_variables_column_sizes.cjs
+++ b/packages/database/lib/migrations/20260116165950_increase_environment_variables_column_sizes.cjs
@@ -1,0 +1,30 @@
+const TABLE_NAME = '_nango_environment_variables';
+
+/**
+ * Increase the size of name and value columns for environment variables.
+ *
+ * The API validation allows:
+ * - name: up to 256 characters
+ * - value: up to 4000 characters
+ *
+ * But the database was using varchar(255) for both columns,
+ * causing "value too long for type character varying(255)" errors.
+ *
+ * This migration changes:
+ * - name: varchar(255) -> varchar(256) to match API validation
+ * - value: varchar(255) -> text to accommodate large values up to 4000 chars
+ */
+
+exports.up = async function (knex) {
+    return knex.schema.alterTable(TABLE_NAME, function (table) {
+        table.string('name', 256).notNullable().alter({ alterType: true });
+        table.text('value').notNullable().alter({ alterType: true });
+    });
+};
+
+exports.down = async function (knex) {
+    return knex.schema.alterTable(TABLE_NAME, function (table) {
+        table.string('name', 255).notNullable().alter({ alterType: true });
+        table.string('value', 255).notNullable().alter({ alterType: true });
+    });
+};

--- a/packages/server/lib/controllers/v1/environment/variables/postVariables.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/variables/postVariables.integration.test.ts
@@ -1,0 +1,182 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { environmentService, seeders } from '@nangohq/shared';
+
+import { isError, isSuccess, runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../../utils/tests.js';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+const endpoint = '/api/v1/environments/variables';
+
+describe(`POST ${endpoint}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            query: { env: 'dev' },
+            body: { variables: [] }
+        });
+
+        shouldBeProtected(res);
+    });
+
+    it('should enforce env query params', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: env.secret_key,
+            // @ts-expect-error - intentionally missing env query param
+            query: {},
+            body: { variables: [] }
+        });
+
+        shouldRequireQueryEnv(res);
+    });
+
+    it('should validate body', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: env.secret_key,
+            query: { env: env.name },
+            // @ts-expect-error - intentionally invalid body
+            body: { invalid: 'body' }
+        });
+
+        expect(res.res.status).toBe(400);
+        isError(res.json);
+        expect(res.json.error.code).toBe('invalid_body');
+    });
+
+    it('should store and retrieve environment variables', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+
+        const variables = [
+            { name: 'TEST_VAR', value: 'test_value' },
+            { name: 'ANOTHER_VAR', value: 'another_value' }
+        ];
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: env.secret_key,
+            query: { env: env.name },
+            body: { variables }
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json).toStrictEqual({ success: true });
+
+        const retrieved = await environmentService.getEnvironmentVariables(env.id);
+        expect(retrieved).toHaveLength(2);
+        expect(retrieved.map((v) => ({ name: v.name, value: v.value }))).toEqual(expect.arrayContaining(variables));
+    });
+
+    it('should store environment variable with value up to 4000 characters', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+
+        const largeValue = 'x'.repeat(4000);
+        const variables = [{ name: 'LARGE_VALUE_VAR', value: largeValue }];
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: env.secret_key,
+            query: { env: env.name },
+            body: { variables }
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+
+        const retrieved = await environmentService.getEnvironmentVariables(env.id);
+        expect(retrieved).toHaveLength(1);
+        expect(retrieved[0]!.value).toBe(largeValue);
+        expect(retrieved[0]!.value).toHaveLength(4000);
+    });
+
+    it('should store environment variable with name up to 256 characters', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+
+        const largeName = 'X'.repeat(256);
+        const variables = [{ name: largeName, value: 'test_value' }];
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: env.secret_key,
+            query: { env: env.name },
+            body: { variables }
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+
+        const retrieved = await environmentService.getEnvironmentVariables(env.id);
+        expect(retrieved).toHaveLength(1);
+        expect(retrieved[0]!.name).toBe(largeName);
+        expect(retrieved[0]!.name).toHaveLength(256);
+    });
+
+    it('should reject environment variable name exceeding 256 characters', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+
+        const tooLongName = 'X'.repeat(257);
+        const variables = [{ name: tooLongName, value: 'test_value' }];
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: env.secret_key,
+            query: { env: env.name },
+            body: { variables }
+        });
+
+        expect(res.res.status).toBe(400);
+        isError(res.json);
+        expect(res.json.error.code).toBe('invalid_body');
+    });
+
+    it('should reject environment variable value exceeding 4000 characters', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+
+        const tooLongValue = 'x'.repeat(4001);
+        const variables = [{ name: 'TEST_VAR', value: tooLongValue }];
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: env.secret_key,
+            query: { env: env.name },
+            body: { variables }
+        });
+
+        expect(res.res.status).toBe(400);
+        isError(res.json);
+        expect(res.json.error.code).toBe('invalid_body');
+    });
+
+    it('should reject more than 100 environment variables', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+
+        const variables = Array.from({ length: 101 }, (_, i) => ({
+            name: `VAR_${i}`,
+            value: `value_${i}`
+        }));
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: env.secret_key,
+            query: { env: env.name },
+            body: { variables }
+        });
+
+        expect(res.res.status).toBe(400);
+        isError(res.json);
+        expect(res.json.error.code).toBe('invalid_body');
+    });
+});

--- a/packages/shared/lib/services/environment.service.integration.test.ts
+++ b/packages/shared/lib/services/environment.service.integration.test.ts
@@ -5,6 +5,7 @@ import db, { multipleMigrations } from '@nangohq/database';
 
 import environmentService, { hashSecretKey } from './environment.service.js';
 import { createAccount } from '../seeders/account.seeder.js';
+import { createEnvironmentSeed } from '../seeders/environment.seeder.js';
 
 describe('Environment service', () => {
     beforeAll(async () => {
@@ -73,5 +74,23 @@ describe('Environment service', () => {
         expect(env3.pending_secret_key).toBeNull();
         expect(env3.secret_key).toEqual(env2.pending_secret_key);
         expect(env3.secret_key_hashed).toEqual(await hashSecretKey(env3.secret_key));
+    });
+
+    describe('environment variables', () => {
+        it('should store and retrieve environment variables', async () => {
+            const account = await createAccount();
+            const env = await createEnvironmentSeed(account.id, uuid());
+
+            const variables = [
+                { name: 'TEST_VAR', value: 'test_value' },
+                { name: 'ANOTHER_VAR', value: 'another_value' }
+            ];
+
+            await environmentService.editEnvironmentVariable(env.id, variables);
+
+            const retrieved = await environmentService.getEnvironmentVariables(env.id);
+            expect(retrieved).toHaveLength(2);
+            expect(retrieved.map((v) => ({ name: v.name, value: v.value }))).toEqual(expect.arrayContaining(variables));
+        });
     });
 });

--- a/packages/types/lib/environment/variable/api.ts
+++ b/packages/types/lib/environment/variable/api.ts
@@ -5,6 +5,7 @@ export type ApiEnvironmentVariable = Pick<DBEnvironmentVariable, 'name' | 'value
 export type PostEnvironmentVariables = Endpoint<{
     Method: 'POST';
     Path: '/api/v1/environments/variables';
+    Querystring: { env: string };
     Body: { variables: { name: string; value: string }[] };
     Success: {
         success: boolean;


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Our API allowed for environment variables with keys up-to 256 characters, and values up-to 4000 characters. However, our DB only allowed 255 characters each. This introduces a migration and adds test to match what the API declared constraints.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

It adds integration coverage at the controller and service layers to confirm that boundary-length payloads are accepted while invalid submissions are rejected, and updates the API type definition so the env query parameter is required.

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/database/lib/migrations/20260116165950_increase_environment_variables_column_sizes.cjs
• packages/server/lib/controllers/v1/environment/variables/postVariables.integration.test.ts
• packages/shared/lib/services/environment.service.integration.test.ts
• packages/types/lib/environment/variable/api.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*