### PR TITLE
fix(env-service): Remove duplicate pending_secret_key update.

### DIFF
--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -238,9 +238,6 @@ class EnvironmentService {
         }
 
         const pending_secret_key = uuid.v4();
-
-        await db.knex.from<DBEnvironment>(TABLE).where({ id }).update({ pending_secret_key });
-
         environment.pending_secret_key = pending_secret_key;
 
         const encryptedEnvironment = await encryptionManager.encryptEnvironment(environment);


### PR DESCRIPTION
The pending_secret_key is updated twice in a row, once unencrypted, once encrypted. This was an oversight and there's no need to do it twice. Only the encrypted update matters.

<!-- Summary by @propel-code-bot -->

---

This adjustment is made within EnvironmentService.rotateSecretKey so the pending secret key is now persisted a single time through the encrypted payload, aligning the flow with the intended behavior.

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/shared/lib/services/environment.service.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*