### PR TITLE
feat(cli): disable dep check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22863,7 +22863,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -22885,7 +22884,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -22907,7 +22905,6 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -22929,7 +22926,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -22951,7 +22947,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -22973,7 +22968,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -22995,7 +22989,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -23017,7 +23010,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -23039,7 +23031,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -23061,7 +23052,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },

--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -367,9 +367,9 @@ program
     .command('dev')
     .description('Watch tsc files while developing. Set --no-compile-interfaces to disable watching the config file')
     .option('--no-compile-interfaces', `Watch the ${nangoConfigFile} and recompile the interfaces on change`, true)
-    .option('--disable-dep-check', 'Disable dependency check', false)
+    .option('--no-dep-check', 'Disable dependency check', false)
     .action(async function (this: Command) {
-        const { compileInterfaces, debug, disableDepCheck } = this.opts();
+        const { compileInterfaces, debug, depCheck } = this.opts();
         const fullPath = process.cwd();
 
         const precheck = await verificationService.preCheck({ fullPath, debug });
@@ -380,7 +380,7 @@ program
         }
 
         if (precheck.isZeroYaml) {
-            if (!disableDepCheck) {
+            if (!depCheck) {
                 const resCheck = await checkAndSyncPackageJson({ fullPath, debug });
                 if (resCheck.isErr()) {
                     console.log(chalk.red('Failed to check and sync package.json. Exiting'));

--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -367,8 +367,9 @@ program
     .command('dev')
     .description('Watch tsc files while developing. Set --no-compile-interfaces to disable watching the config file')
     .option('--no-compile-interfaces', `Watch the ${nangoConfigFile} and recompile the interfaces on change`, true)
+    .option('--disable-dep-check', 'Disable dependency check', false)
     .action(async function (this: Command) {
-        const { compileInterfaces, debug } = this.opts();
+        const { compileInterfaces, debug, disableDepCheck } = this.opts();
         const fullPath = process.cwd();
 
         const precheck = await verificationService.preCheck({ fullPath, debug });
@@ -379,11 +380,13 @@ program
         }
 
         if (precheck.isZeroYaml) {
-            const resCheck = await checkAndSyncPackageJson({ fullPath, debug });
-            if (resCheck.isErr()) {
-                console.log(chalk.red('Failed to check and sync package.json. Exiting'));
-                process.exitCode = 1;
-                return;
+            if (!disableDepCheck) {
+                const resCheck = await checkAndSyncPackageJson({ fullPath, debug });
+                if (resCheck.isErr()) {
+                    console.log(chalk.red('Failed to check and sync package.json. Exiting'));
+                    process.exitCode = 1;
+                    return;
+                }
             }
 
             await dev({ fullPath, debug });


### PR DESCRIPTION
Continously asks to upgrade packages while in dev mode:

```
> ./integrations
> nango dev --auto-confirm

A new version of nango is available: 0.69.22
Would you like to upgrade? (yes/no)
```

This option disables the check only in devmode

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add opt-out flag for dependency check in `nango dev`**

Introduces a `--no-dep-check` option to the `nango dev` CLI command and wires the resulting `depCheck` flag into the Zero YAML flow before invoking `dev()`. Also updates `package-lock.json` by dropping several `peer` markers from platform-specific `@esbuild` packages.

<details>
<summary><strong>Key Changes</strong></summary>

• Added the `--no-dep-check` option to the `dev` command in `packages/cli/lib/index.ts` and gated the `checkAndSyncPackageJson` call on the `depCheck` flag
• Removed multiple `"peer": true` entries for platform-specific `@esbuild` binaries in `package-lock.json`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/cli/lib/index.ts`
• `package-lock.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*