### PR TITLE
feat(webapp): add searchbar to integrations list

### DIFF
--- a/packages/webapp/src/pages/Integrations/Create.tsx
+++ b/packages/webapp/src/pages/Integrations/Create.tsx
@@ -110,6 +110,12 @@ export const CreateIntegration = () => {
 
     const debouncedFilterProviders = useMemo(() => debounce(filterProviders, 300), [filterProviders]);
 
+    useEffect(() => {
+        return () => {
+            debouncedFilterProviders.cancel();
+        };
+    }, [debouncedFilterProviders]);
+
     const handleInputChange = useCallback(
         (event: React.ChangeEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>) => {
             debouncedFilterProviders(event.currentTarget.value);

--- a/packages/webapp/src/pages/Integrations/Create.tsx
+++ b/packages/webapp/src/pages/Integrations/Create.tsx
@@ -161,7 +161,7 @@ export const CreateIntegration = () => {
             </header>
 
             <InputGroup className="bg-bg-subtle">
-                <InputGroupInput type="text" placeholder="Github, accounting, oauth..." onChange={handleInputChange} onKeyUp={handleInputChange} autoFocus />
+                <InputGroupInput type="text" placeholder="Github, accounting, oauth..." onChange={handleInputChange} autoFocus />
                 <InputGroupAddon>
                     <Search />
                 </InputGroupAddon>

--- a/packages/webapp/src/pages/Integrations/Create.tsx
+++ b/packages/webapp/src/pages/Integrations/Create.tsx
@@ -96,22 +96,13 @@ export const CreateIntegration = () => {
 
     const filterProviders = useCallback(
         (value: string) => {
-            if (!value.trim()) {
+            if (!value.trim() || !fuse) {
                 setProviders(initialProviders);
                 return;
             }
 
-            if (!fuse) {
-                setProviders(initialProviders);
-                return;
-            }
-
-            // Perform fuzzy search
             const results = fuse.search(value);
-
-            // Extract providers from results, sorted by relevance (lower score = better match)
             const filtered = results.map((result) => result.item);
-
             setProviders(filtered);
         },
         [initialProviders, fuse]
@@ -164,7 +155,7 @@ export const CreateIntegration = () => {
             </header>
 
             <InputGroup className="bg-bg-subtle">
-                <InputGroupInput type="text" placeholder="Github, accounting, oauth..." onChange={handleInputChange} onKeyUp={handleInputChange} />
+                <InputGroupInput type="text" placeholder="Github, accounting, oauth..." onChange={handleInputChange} onKeyUp={handleInputChange} autoFocus />
                 <InputGroupAddon>
                     <Search />
                 </InputGroupAddon>

--- a/packages/webapp/src/pages/Integrations/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/Show.tsx
@@ -73,6 +73,12 @@ export const IntegrationsList = () => {
 
     const debouncedFilterIntegrations = useMemo(() => debounce(filterIntegrations, 300), [filterIntegrations]);
 
+    useEffect(() => {
+        return () => {
+            debouncedFilterIntegrations.cancel();
+        };
+    }, [debouncedFilterIntegrations]);
+
     const handleInputChange = useCallback(
         (event: React.ChangeEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>) => {
             debouncedFilterIntegrations(event.currentTarget.value);

--- a/packages/webapp/src/pages/Integrations/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/Show.tsx
@@ -103,7 +103,7 @@ export const IntegrationsList = () => {
             </header>
 
             <InputGroup className="bg-bg-subtle">
-                <InputGroupInput type="text" placeholder="Search integration" onChange={handleInputChange} onKeyUp={handleInputChange} autoFocus />
+                <InputGroupInput type="text" placeholder="Search integration" onChange={handleInputChange} autoFocus />
                 <InputGroupAddon>
                     <Search />
                 </InputGroupAddon>

--- a/packages/webapp/src/pages/Integrations/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/Show.tsx
@@ -1,3 +1,7 @@
+import Fuse from 'fuse.js';
+import debounce from 'lodash/debounce';
+import { Search } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { useNavigate } from 'react-router-dom';
 
@@ -7,17 +11,74 @@ import { ErrorPageComponent } from '@/components/ErrorComponent';
 import { CopyButton } from '@/components-v2/CopyButton';
 import { IntegrationLogo } from '@/components-v2/IntegrationLogo';
 import { ButtonLink } from '@/components-v2/ui/button';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components-v2/ui/input-group';
 import { Skeleton } from '@/components-v2/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components-v2/ui/table';
 import { useListIntegration } from '@/hooks/useIntegration';
 import DashboardLayout from '@/layout/DashboardLayout';
 import { useStore } from '@/store';
 
+import type { ApiIntegrationList } from '@nangohq/types';
+
 export const IntegrationsList = () => {
     const navigate = useNavigate();
 
     const env = useStore((state) => state.env);
     const { list, loading, error } = useListIntegration(env);
+    const [integrations, setIntegrations] = useState<ApiIntegrationList[] | null>(null);
+
+    const initialIntegrations = useMemo(() => {
+        return list ?? null;
+    }, [list]);
+
+    useEffect(() => {
+        if (initialIntegrations) {
+            setIntegrations(initialIntegrations);
+        }
+    }, [initialIntegrations]);
+
+    const fuse = useMemo(() => {
+        if (!initialIntegrations || initialIntegrations.length === 0) {
+            return null;
+        }
+
+        return new Fuse(initialIntegrations, {
+            keys: [
+                { name: 'meta.displayName', weight: 0.3 },
+                { name: 'provider', weight: 0.3 },
+                { name: 'unique_key', weight: 0.2 },
+                { name: 'meta.authMode', weight: 0.2 }
+            ],
+            threshold: 0.4, // 0.0 = exact match, 1.0 = match anything. 0.4 is a good balance
+            includeScore: true,
+            minMatchCharLength: 1,
+            ignoreLocation: true, // Search anywhere in the string
+            findAllMatches: true // Find all matches, not just the first
+        });
+    }, [initialIntegrations]);
+
+    const filterIntegrations = useCallback(
+        (value: string) => {
+            if (!value.trim() || !fuse) {
+                setIntegrations(initialIntegrations);
+                return;
+            }
+
+            const results = fuse.search(value);
+            const filtered = results.map((result) => result.item);
+            setIntegrations(filtered);
+        },
+        [initialIntegrations, fuse]
+    );
+
+    const debouncedFilterIntegrations = useMemo(() => debounce(filterIntegrations, 300), [filterIntegrations]);
+
+    const handleInputChange = useCallback(
+        (event: React.ChangeEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>) => {
+            debouncedFilterIntegrations(event.currentTarget.value);
+        },
+        [debouncedFilterIntegrations]
+    );
 
     if (error) {
         return <ErrorPageComponent title="Integrations" error={error.json} />;
@@ -34,6 +95,13 @@ export const IntegrationsList = () => {
                     Set up new integration
                 </ButtonLink>
             </header>
+
+            <InputGroup className="bg-bg-subtle">
+                <InputGroupInput type="text" placeholder="Search integration" onChange={handleInputChange} onKeyUp={handleInputChange} autoFocus />
+                <InputGroupAddon>
+                    <Search />
+                </InputGroupAddon>
+            </InputGroup>
 
             <AutoIdlingBanner />
 
@@ -56,7 +124,17 @@ export const IntegrationsList = () => {
                 </div>
             )}
 
-            {list && list.length > 0 && (
+            {list && list.length > 0 && integrations && integrations.length === 0 && (
+                <div className="flex flex-col gap-5 p-20 items-center justify-center bg-bg-elevated rounded">
+                    <h3 className="text-title-body text-text-primary">No integrations found</h3>
+                    <p className="text-text-secondary text-body-medium-regular">Could not find any integrations matching your search.</p>
+                    <ButtonLink to={`/${env}/integrations/create`} size="lg">
+                        Set up new integration
+                    </ButtonLink>
+                </div>
+            )}
+
+            {integrations && integrations.length > 0 && (
                 <Table>
                     <TableHeader className="h-11">
                         <TableRow>
@@ -67,7 +145,7 @@ export const IntegrationsList = () => {
                         </TableRow>
                     </TableHeader>
                     <TableBody>
-                        {list.map((integration) => (
+                        {integrations.map((integration) => (
                             <TableRow
                                 key={integration.unique_key}
                                 className="h-14 cursor-pointer"


### PR DESCRIPTION
Adds search bar to integrations page.

<img width="1280" height="459" alt="image" src="https://github.com/user-attachments/assets/0e40ca71-d4b7-4345-a145-80070c14bd77" />
<img width="1285" height="625" alt="image" src="https://github.com/user-attachments/assets/2e4f4b4f-2d2f-4db7-b0af-3da66aacff09" />
<!-- Summary by @propel-code-bot -->

---

**Add fuzzy search UI to integrations list**

Introduces a debounced `Fuse`-powered search flow on the integrations list page and aligns the create-integration catalog search with the same behavior. The list view now maintains a derived `integrations` state, renders a search input with icon, and shows dedicated empty states for no data versus no search matches.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `Fuse` fuzzy search with 300 ms debounce and state cleanup to `packages/webapp/src/pages/Integrations/Show.tsx`
• Rendered searchable UI via `InputGroup` with new search-empty state messaging in `IntegrationsList`
• Simplified provider filtering guard, cancelled debounced callbacks on unmount, and enabled `autoFocus` on the create page search input in `packages/webapp/src/pages/Integrations/Create.tsx`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/pages/Integrations/Show.tsx`
• `packages/webapp/src/pages/Integrations/Create.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*