### PR TITLE
fix(action-payloads): remove allow listed variable

### DIFF
--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -11,7 +11,7 @@ import * as unzipper from 'unzipper';
 import * as zod from 'zod';
 
 import { ActionError, ExecutionError, SDKError } from '@nangohq/runner-sdk';
-import { Err, Ok, actionAllowListCustomers, errorToObject, isCloud, isEnterprise, truncateJson } from '@nangohq/utils';
+import { Err, Ok, errorToObject, isEnterprise, truncateJson } from '@nangohq/utils';
 
 import { logger } from './logger.js';
 import { Locks } from './sdk/locks.js';
@@ -19,8 +19,6 @@ import { NangoActionRunner, NangoSyncRunner, instrumentSDK } from './sdk/sdk.js'
 
 import type { CreateAnyResponse, NangoActionBase, NangoSyncBase } from '@nangohq/runner-sdk';
 import type { NangoProps, Result, RunnerOutput } from '@nangohq/types';
-
-const actionPayloadAllowSet = isCloud ? new Set(actionAllowListCustomers) : new Set();
 
 interface ScriptExports {
     onWebhookPayloadReceived?: (nango: NangoSyncBase, payload?: object) => Promise<unknown>;
@@ -179,7 +177,7 @@ export async function exec({
                     const outputSizeInBytes = Buffer.byteLength(stringifiedOutput, 'utf8');
                     const maxSizeInBytes = 2 * 1024 * 1024; // 2MB
 
-                    if (!isEnterprise && nangoProps.team?.id !== undefined && !actionPayloadAllowSet.has(nangoProps.team.id)) {
+                    if (!isEnterprise) {
                         if (outputSizeInBytes > maxSizeInBytes) {
                             throw new Error(
                                 `Output size is too large: ${outputSizeInBytes} bytes. Maximum allowed size is ${maxSizeInBytes} bytes (2MB). See the deprecation announcement: https://nango.dev/docs/changelog/dev-updates#action-payload-output-limit`

--- a/packages/utils/lib/environment/detection.ts
+++ b/packages/utils/lib/environment/detection.ts
@@ -33,5 +33,3 @@ export const flagEnforceCLIVersion = process.env['FLAG_ENFORCE_CLI_VERSION'] ===
 export const flags = {
     hasAdminCapabilities: Boolean(process.env['NANGO_ADMIN_UUID'])
 };
-
-export const actionAllowListCustomers = [0, 662, 1760, 1920, 4530, 5166, 7157, 7359, 7696, 2981, 6254];


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Enforce 2MB action payload limit for all non-enterprise accounts**

Removes the action payload allowlist so that the 2 MB response size limit applies uniformly to all non-enterprise deployments. Also drops the server-side logging path that previously warned allowlisted tenants about large payload usage.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed `actionAllowListCustomers` usage from `postTriggerAction` controller and related logging logic
• Deleted `actionAllowListCustomers` export from `packages/utils/lib/environment/detection.ts`
• Simplified runner payload size enforcement in `packages/runner/lib/exec.ts` to gate solely on `isEnterprise`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/action/postTriggerAction.ts`
• `packages/utils/lib/environment/detection.ts`
• `packages/runner/lib/exec.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*