### PR TITLE
fix(providers): use correct key names for sap successFactors

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -12810,12 +12810,12 @@ sap-success-factors:
         assertion: ${credentials.assertion}
         new_token: true
     assertion:
-        key: ${assertionOption.cert}
+        key: ${assertionOption.privateKey}
         issuer: www.successfactors.com
-        lifetimeInSeconds: 315360000
+        lifetimeInSeconds: '315360000'
         audiences: www.successfactors.com
         attributes:
-            api_key: ${credentials.privateKey}
+            api_key: ${credentials.apiKey}
             use_username: true
             use_email: false
             external_user: false


### PR DESCRIPTION
## Describe the problem and your solution

- use correct key names for sap successFactors in the `connect-ui` form

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Correct SAP SuccessFactors credential keys in provider config**

Aligns the SAP SuccessFactors provider definition so the SAML assertion consumes the same credential keys exposed in the Connect UI. The assertion now references `assertionOption.privateKey` and `credentials.apiKey`, and the token lifetime is expressed as a quoted value to satisfy the schema.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `packages/providers/providers.yaml` to reference `assertionOption.privateKey` instead of `assertionOption.cert` within the SAP SuccessFactors assertion block.
• Switched the assertion attribute `api_key` to pull from `credentials.apiKey` and quoted `lifetimeInSeconds` to match expected schema typing.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/providers/providers.yaml

</details>

---
*This summary was automatically generated by @propel-code-bot*