### PR TITLE
feat: Connection and connect session tags

### DIFF
--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -514,7 +514,8 @@ const initDb = async () => {
         providerConfigKey: `provider-test`,
         parsedRawCredentials: {} as AllAuthCredentials,
         connectionConfig: {},
-        environmentId: env.id
+        environmentId: env.id,
+        tags: {}
     });
     const connectionId = connectionRes[0]?.connection.id;
     if (!connectionId) throw new Error('Connection not created');

--- a/packages/server/lib/controllers/auth/postApiKey.ts
+++ b/packages/server/lib/controllers/auth/postApiKey.ts
@@ -168,7 +168,8 @@ export const postPublicApiKeyAuthorization = asyncWrapper<PostPublicApiKeyAuthor
             connectionConfig,
             metadata: {},
             config,
-            environment
+            environment,
+            tags: connectSession?.tags
         });
         if (!updatedConnection) {
             res.status(500).send({ error: { code: 'server_error', message: 'failed to create connection' } });

--- a/packages/server/lib/controllers/auth/postAppStore.ts
+++ b/packages/server/lib/controllers/auth/postAppStore.ts
@@ -173,7 +173,8 @@ export const postPublicAppStoreAuthorization = asyncWrapper<PostPublicAppStoreAu
             providerConfigKey,
             parsedRawCredentials: credentialsRes.value,
             connectionConfig,
-            environmentId: environment.id
+            environmentId: environment.id,
+            tags: connectSession?.tags
         });
         if (!updatedConnection) {
             res.status(500).send({ error: { code: 'server_error', message: 'failed to create connection' } });

--- a/packages/server/lib/controllers/auth/postBasic.ts
+++ b/packages/server/lib/controllers/auth/postBasic.ts
@@ -167,7 +167,8 @@ export const postPublicBasicAuthorization = asyncWrapper<PostPublicBasicAuthoriz
             connectionConfig,
             metadata: {},
             config,
-            environment
+            environment,
+            tags: connectSession?.tags
         });
         if (!updatedConnection) {
             res.status(500).send({ error: { code: 'server_error', message: 'failed to create connection' } });

--- a/packages/server/lib/controllers/auth/postBill.ts
+++ b/packages/server/lib/controllers/auth/postBill.ts
@@ -168,7 +168,8 @@ export const postPublicBillAuthorization = asyncWrapper<PostPublicBillAuthorizat
             connectionConfig,
             metadata: {},
             config,
-            environment
+            environment,
+            tags: connectSession?.tags
         });
         if (!updatedConnection) {
             res.status(500).send({ error: { code: 'server_error', message: 'failed to create connection' } });

--- a/packages/server/lib/controllers/auth/postJwt.ts
+++ b/packages/server/lib/controllers/auth/postJwt.ts
@@ -177,7 +177,8 @@ export const postPublicJwtAuthorization = asyncWrapper<PostPublicJwtAuthorizatio
             connectionConfig,
             metadata: {},
             config,
-            environment
+            environment,
+            tags: connectSession?.tags
         });
         if (!updatedConnection) {
             res.status(500).send({ error: { code: 'server_error', message: 'failed to create connection' } });

--- a/packages/server/lib/controllers/auth/postOauthOutbound.ts
+++ b/packages/server/lib/controllers/auth/postOauthOutbound.ts
@@ -142,7 +142,8 @@ export const postPublicOauthOutboundAuthorization = asyncWrapper<PostPublicOauth
             providerConfigKey,
             parsedRawCredentials: { type: 'OAUTH2' } as any,
             connectionConfig: updatedConnectionConfig,
-            environmentId: environment.id
+            environmentId: environment.id,
+            tags: connectSession?.tags
         });
 
         if (!updatedConnection) {

--- a/packages/server/lib/controllers/auth/postSignature.ts
+++ b/packages/server/lib/controllers/auth/postSignature.ts
@@ -183,7 +183,8 @@ export const postPublicSignatureAuthorization = asyncWrapper<PostPublicSignature
             connectionConfig,
             metadata: {},
             config,
-            environment
+            environment,
+            tags: connectSession?.tags
         });
         if (!updatedConnection) {
             res.status(500).send({ error: { code: 'server_error', message: 'failed to create connection' } });

--- a/packages/server/lib/controllers/auth/postTba.ts
+++ b/packages/server/lib/controllers/auth/postTba.ts
@@ -207,7 +207,8 @@ export const postPublicTbaAuthorization = asyncWrapper<PostPublicTbaAuthorizatio
             },
             metadata: {},
             config,
-            environment
+            environment,
+            tags: connectSession?.tags
         });
         if (!updatedConnection) {
             res.status(500).send({ error: { code: 'server_error', message: 'failed to create connection' } });

--- a/packages/server/lib/controllers/auth/postTwoStep.ts
+++ b/packages/server/lib/controllers/auth/postTwoStep.ts
@@ -175,7 +175,8 @@ export const postPublicTwoStepAuthorization = asyncWrapper<PostPublicTwoStepAuth
             connectionConfig,
             metadata: {},
             config,
-            environment
+            environment,
+            tags: connectSession?.tags
         });
 
         if (!updatedConnection) {

--- a/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
@@ -138,7 +138,7 @@ describe(`GET ${endpoint}`, () => {
         isSuccess(resReconnect.json);
 
         // Check that the connection was updated
-        // Nothing is different except the dates
+        // Nothing is different except the dates and tags (which reflect the updated end_user email)
         const connectionAfter = await connectionService.checkIfConnectionExists(db.knex, {
             connectionId: resConnect.json.connectionId,
             providerConfigKey: resConnect.json.providerConfigKey,
@@ -146,6 +146,7 @@ describe(`GET ${endpoint}`, () => {
         });
         expect(connectionAfter).toMatchObject({
             ...connectionBefore,
+            tags: { end_user_id: '1', end_user_email: 'john.updated@example.com' },
             credentials_expires_at: expect.toBeIsoDate(), // new credentials means new date
             last_refresh_success: expect.toBeIsoDate(),
             updated_at: expect.toBeIsoDate()

--- a/packages/server/lib/controllers/auth/postUnauthenticated.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.ts
@@ -129,7 +129,8 @@ export const postPublicUnauthenticated = asyncWrapper<PostPublicUnauthenticatedA
             connectionId,
             providerConfigKey,
             connectionConfig,
-            environment
+            environment,
+            tags: connectSession?.tags
         });
 
         if (!updatedConnection) {

--- a/packages/server/lib/controllers/connect/postReconnect.integration.test.ts
+++ b/packages/server/lib/controllers/connect/postReconnect.integration.test.ts
@@ -254,4 +254,67 @@ describe(`POST ${endpoint}`, () => {
             });
         });
     });
+
+    describe('tags', () => {
+        let seed: { account: DBTeam; env: DBEnvironment; user: DBUser; plan: DBPlan };
+        let connection: DBConnection;
+
+        beforeEach(async () => {
+            seed = await seeders.seedAccountEnvAndUser();
+            const endUser = await seeders.createEndUser({ environment: seed.env, account: seed.account });
+
+            await seeders.createConfigSeed(seed.env, 'github', 'github');
+            connection = await seeders.createConnectionSeed({ env: seed.env, provider: 'github' });
+            await linkConnection(db.knex, { endUserId: endUser.id, connection });
+        });
+
+        it('should create reconnect session with tags', async () => {
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: seed.env.secret_key,
+                body: {
+                    connection_id: connection.connection_id,
+                    integration_id: 'github',
+                    tags: { projectId: '123', orgId: '456' }
+                }
+            });
+
+            isSuccess(res.json);
+
+            const session = (await getConnectSessionByToken(db.knex, res.json.data.token)).unwrap();
+            // Keys are normalized to lowercase
+            expect(session.connectSession.tags).toStrictEqual({ projectid: '123', orgid: '456' });
+        });
+
+        it('should succeed without tags', async () => {
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: seed.env.secret_key,
+                body: {
+                    connection_id: connection.connection_id,
+                    integration_id: 'github'
+                }
+            });
+
+            isSuccess(res.json);
+        });
+
+        it('should fail with invalid tags', async () => {
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: seed.env.secret_key,
+                body: {
+                    connection_id: connection.connection_id,
+                    integration_id: 'github',
+                    tags: { '123invalid': 'value' }
+                }
+            });
+
+            isError(res.json);
+            expect(res.json).toMatchObject({
+                error: { code: 'invalid_body' }
+            });
+            expect(res.res.status).toBe(400);
+        });
+    });
 });

--- a/packages/server/lib/controllers/connect/postSessions.integration.test.ts
+++ b/packages/server/lib/controllers/connect/postSessions.integration.test.ts
@@ -7,6 +7,7 @@ import { seeders } from '@nangohq/shared';
 
 import { isError, isSuccess, runServer, shouldBeProtected } from '../../utils/tests.js';
 
+import type { DBConnectSession } from '../../services/connectSession.service.js';
 import type { DBEndUser, DBEnvironment, DBPlan, DBTeam, DBUser } from '@nangohq/types';
 
 let api: Awaited<ReturnType<typeof runServer>>;
@@ -284,6 +285,158 @@ describe(`POST ${endpoint}`, () => {
                     token: expect.any(String)
                 }
             });
+        });
+    });
+
+    describe('tags', () => {
+        it('should create session with valid tags', async () => {
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: seed.env.secret_key,
+                body: {
+                    end_user: { id: 'test-user', email: 'test@example.com' },
+                    tags: { projectId: '123', orgId: '456' }
+                }
+            });
+
+            isSuccess(res.json);
+            expect(res.json).toStrictEqual<typeof res.json>({
+                data: {
+                    expires_at: expect.toBeIsoDate(),
+                    connect_link: expect.any(String),
+                    token: expect.any(String)
+                }
+            });
+
+            const session = await db.knex
+                .select('*')
+                .from<DBConnectSession>('connect_sessions')
+                .where({ environment_id: seed.env.id })
+                .orderBy('id', 'desc')
+                .first();
+            // Keys are normalized to lowercase and end_user tags are auto-merged
+            expect(session?.tags).toStrictEqual({ projectid: '123', orgid: '456', end_user_id: 'test-user', end_user_email: 'test@example.com' });
+        });
+
+        it('should create session without tags (optional)', async () => {
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: seed.env.secret_key,
+                body: {
+                    end_user: { id: 'test-user-no-tags', email: 'test@example.com' }
+                }
+            });
+
+            isSuccess(res.json);
+        });
+
+        it('should create session with empty tags object', async () => {
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: seed.env.secret_key,
+                body: {
+                    end_user: { id: 'test-user-empty-tags', email: 'test@example.com' },
+                    tags: {}
+                }
+            });
+
+            isSuccess(res.json);
+
+            const session = await db.knex
+                .select('*')
+                .from<DBConnectSession>('connect_sessions')
+                .where({ environment_id: seed.env.id })
+                .orderBy('id', 'desc')
+                .first();
+            // Even with empty tags, end_user tags are auto-merged
+            expect(session?.tags).toStrictEqual({ end_user_id: 'test-user-empty-tags', end_user_email: 'test@example.com' });
+        });
+
+        it('should fail with invalid tag key format (starts with number)', async () => {
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: seed.env.secret_key,
+                body: {
+                    end_user: { id: 'test-user', email: 'test@example.com' },
+                    tags: { '123invalid': 'value' }
+                }
+            });
+
+            isError(res.json);
+            expect(res.json).toMatchObject({
+                error: { code: 'invalid_body' }
+            });
+            expect(res.res.status).toBe(400);
+        });
+
+        it('should allow tag values with spaces', async () => {
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: seed.env.secret_key,
+                body: {
+                    end_user: { id: 'test-user', email: 'test@example.com' },
+                    tags: { key: 'value with spaces' }
+                }
+            });
+
+            isSuccess(res.json);
+        });
+
+        it('should fail with tag key exceeding max length', async () => {
+            const longKey = 'a'.repeat(65);
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: seed.env.secret_key,
+                body: {
+                    end_user: { id: 'test-user', email: 'test@example.com' },
+                    tags: { [longKey]: 'value' }
+                }
+            });
+
+            isError(res.json);
+            expect(res.json).toMatchObject({
+                error: { code: 'invalid_body' }
+            });
+            expect(res.res.status).toBe(400);
+        });
+
+        it('should fail with tag value exceeding max length', async () => {
+            const longValue = 'a'.repeat(201);
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: seed.env.secret_key,
+                body: {
+                    end_user: { id: 'test-user', email: 'test@example.com' },
+                    tags: { key: longValue }
+                }
+            });
+
+            isError(res.json);
+            expect(res.json).toMatchObject({
+                error: { code: 'invalid_body' }
+            });
+            expect(res.res.status).toBe(400);
+        });
+
+        it('should fail with more than 10 tags', async () => {
+            const tags: Record<string, string> = {};
+            for (let i = 0; i < 11; i++) {
+                tags[`key${i}`] = `value${i}`;
+            }
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: seed.env.secret_key,
+                body: {
+                    end_user: { id: 'test-user', email: 'test@example.com' },
+                    tags
+                }
+            });
+
+            isError(res.json);
+            expect(res.json).toMatchObject({
+                error: { code: 'invalid_body' }
+            });
+            expect(res.res.status).toBe(400);
         });
     });
 });

--- a/packages/server/lib/controllers/connect/postSessions.ts
+++ b/packages/server/lib/controllers/connect/postSessions.ts
@@ -3,10 +3,10 @@ import * as z from 'zod';
 import db from '@nangohq/database';
 import * as keystore from '@nangohq/keystore';
 import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@nangohq/logs';
-import { EndUserMapper, configService } from '@nangohq/shared';
+import { EndUserMapper, buildTagsFromEndUser, configService } from '@nangohq/shared';
 import { connectUrl, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { endUserSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { connectionTagsSchema, endUserSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import * as connectSessionService from '../../services/connectSession.service.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 
@@ -49,7 +49,8 @@ export const bodySchema = z
                     docs_connect: z.string().optional()
                 })
             )
-            .optional()
+            .optional(),
+        tags: connectionTagsSchema.optional()
     })
     .strict();
 
@@ -154,6 +155,8 @@ export async function generateSession(res: Response<any, Required<RequestLocals>
         }
 
         const endUser = body.end_user ? EndUserMapper.apiToEndUser(body.end_user, body.organization) : null;
+        const endUserTags = buildTagsFromEndUser(body.end_user, body.organization);
+        const tags = { ...endUserTags, ...body.tags };
         const logCtx = await logContextGetter.create(
             {
                 operation: { type: 'auth', action: 'create_connection' },
@@ -181,7 +184,8 @@ export async function generateSession(res: Response<any, Required<RequestLocals>
                 : null,
             operationId: logCtx.id,
             overrides: body.overrides || null,
-            endUser
+            endUser,
+            tags
         });
         if (createConnectSession.isErr()) {
             return { status: 500, response: { error: { code: 'server_error', message: 'Failed to create connect session' } } };

--- a/packages/server/lib/controllers/connection/connectionId/getConnection.integration.test.ts
+++ b/packages/server/lib/controllers/connection/connectionId/getConnection.integration.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import db from '@nangohq/database';
 import { connectionService, seeders } from '@nangohq/shared';
 import { MAX_CONSECUTIVE_DAYS_FAILED_REFRESH } from '@nangohq/shared/lib/services/connections/utils.js';
 
@@ -104,6 +105,7 @@ describe(`GET ${endpoint}`, () => {
             metadata: null,
             provider: 'algolia',
             provider_config_key: 'algolia',
+            tags: {},
             updated_at: expect.toBeIsoDateTimezone()
         });
     });
@@ -163,9 +165,54 @@ describe(`GET ${endpoint}`, () => {
             metadata: null,
             provider: 'algolia',
             provider_config_key: 'algolia',
+            tags: {},
             updated_at: expect.toBeIsoDateTimezone()
         });
     });
+
+    it('should return a connection with tags', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'algolia', 'algolia');
+        const conn = await seeders.createConnectionSeed({
+            env,
+            provider: 'algolia',
+            rawCredentials: { type: 'API_KEY', apiKey: 'test_api_key' },
+            connectionConfig: { APP_ID: 'TEST' }
+        });
+
+        await db.knex
+            .update({ tags: { department: 'engineering', priority: 'high' } })
+            .from('_nango_connections')
+            .where('id', conn.id);
+
+        const res = await api.fetch(endpoint, {
+            method: 'GET',
+            token: env.secret_key,
+            params: { connectionId: conn.connection_id },
+            query: { provider_config_key: 'algolia' }
+        });
+
+        isSuccess(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            connection_id: conn.connection_id,
+            created_at: expect.toBeIsoDateTimezone(),
+            credentials: {
+                apiKey: 'test_api_key',
+                type: 'API_KEY'
+            },
+            connection_config: { APP_ID: 'TEST' },
+            end_user: null,
+            errors: [],
+            id: expect.any(Number),
+            last_fetched_at: expect.toBeIsoDateTimezone(),
+            metadata: null,
+            provider: 'algolia',
+            provider_config_key: 'algolia',
+            tags: { department: 'engineering', priority: 'high' },
+            updated_at: expect.toBeIsoDateTimezone()
+        });
+    });
+
     it('should return an error if connection refreshs are exhausted', async () => {
         const provider = 'hubspot';
         const { env, account } = await seeders.seedAccountEnvAndUser();
@@ -218,6 +265,7 @@ describe(`GET ${endpoint}`, () => {
                         metadata: null,
                         provider,
                         provider_config_key: provider,
+                        tags: {},
                         updated_at: expect.toBeIsoDateTimezone()
                     }
                 }
@@ -276,6 +324,7 @@ describe(`GET ${endpoint}`, () => {
                         metadata: null,
                         provider: provider,
                         provider_config_key: provider,
+                        tags: {},
                         updated_at: expect.toBeIsoDateTimezone()
                     }
                 }

--- a/packages/server/lib/controllers/connection/connectionId/patchConnection.integration.test.ts
+++ b/packages/server/lib/controllers/connection/connectionId/patchConnection.integration.test.ts
@@ -1,0 +1,258 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { seeders } from '@nangohq/shared';
+
+import { isError, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
+
+import type { DBConnection } from '@nangohq/types';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+const endpoint = '/connections/:connectionId';
+
+describe(`PATCH ${endpoint}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            params: { connectionId: 'test' },
+            query: { provider_config_key: 'github' },
+            body: {}
+        });
+
+        shouldBeProtected(res);
+    });
+
+    it('should return 400 for unknown provider', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            token: env.secret_key,
+            params: { connectionId: 'test' },
+            query: { provider_config_key: 'unknown' },
+            body: {}
+        });
+
+        isError(res.json);
+        expect(res.json).toMatchObject({
+            error: { code: 'unknown_provider_config' }
+        });
+        expect(res.res.status).toBe(400);
+    });
+
+    it('should return 404 for unknown connection', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            token: env.secret_key,
+            params: { connectionId: 'unknown' },
+            query: { provider_config_key: 'github' },
+            body: {}
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: { code: 'not_found', message: 'Failed to find connection' }
+        });
+        expect(res.res.status).toBe(404);
+    });
+
+    describe('end_user', () => {
+        it('should update end_user only', async () => {
+            const { env } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'github', 'github');
+            const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+            const res = await api.fetch(endpoint, {
+                method: 'PATCH',
+                token: env.secret_key,
+                params: { connectionId: conn.connection_id },
+                query: { provider_config_key: 'github' },
+                body: {
+                    end_user: { id: 'user-123', email: 'test@example.com', display_name: 'Test User' }
+                }
+            });
+
+            isSuccess(res.json);
+            expect(res.json).toStrictEqual({ success: true });
+
+            const updatedConn = await db.knex.select('*').from<DBConnection>('_nango_connections').where({ id: conn.id }).first();
+            expect(updatedConn?.end_user_id).not.toBeNull();
+        });
+    });
+
+    describe('tags', () => {
+        it('should update tags only', async () => {
+            const { env } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'github', 'github');
+            const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+            const res = await api.fetch(endpoint, {
+                method: 'PATCH',
+                token: env.secret_key,
+                params: { connectionId: conn.connection_id },
+                query: { provider_config_key: 'github' },
+                body: { tags: { projectId: '123', orgId: '456' } }
+            });
+
+            isSuccess(res.json);
+            expect(res.json).toStrictEqual({ success: true });
+
+            // Keys are normalized to lowercase by connectionTagsSchema
+            const updatedConn = await db.knex.select('*').from<DBConnection>('_nango_connections').where({ id: conn.id }).first();
+            expect(updatedConn?.tags).toStrictEqual({ projectid: '123', orgid: '456' });
+        });
+
+        it('should update both tags and end_user', async () => {
+            const { env } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'github', 'github');
+            const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+            const res = await api.fetch(endpoint, {
+                method: 'PATCH',
+                token: env.secret_key,
+                params: { connectionId: conn.connection_id },
+                query: { provider_config_key: 'github' },
+                body: {
+                    tags: { env: 'production' },
+                    end_user: { id: 'user-456' }
+                }
+            });
+
+            isSuccess(res.json);
+            expect(res.json).toStrictEqual({ success: true });
+
+            const updatedConn = await db.knex.select('*').from<DBConnection>('_nango_connections').where({ id: conn.id }).first();
+            // Tags are merged: end_user generated tags + explicit tags (explicit tags take priority)
+            expect(updatedConn?.tags).toStrictEqual({ end_user_id: 'user-456', env: 'production' });
+            expect(updatedConn?.end_user_id).not.toBeNull();
+        });
+
+        it('should fail with invalid tag key format', async () => {
+            const { env } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'github', 'github');
+            const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+            const res = await api.fetch(endpoint, {
+                method: 'PATCH',
+                token: env.secret_key,
+                params: { connectionId: conn.connection_id },
+                query: { provider_config_key: 'github' },
+                body: {
+                    tags: { '123invalid': 'value' }
+                }
+            });
+
+            isError(res.json);
+            expect(res.json).toMatchObject({
+                error: { code: 'invalid_body' }
+            });
+            expect(res.res.status).toBe(400);
+        });
+
+        it('should allow tag values with spaces', async () => {
+            const { env } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'github', 'github');
+            const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+            const res = await api.fetch(endpoint, {
+                method: 'PATCH',
+                token: env.secret_key,
+                params: { connectionId: conn.connection_id },
+                query: { provider_config_key: 'github' },
+                body: {
+                    tags: { key: 'value with spaces' }
+                }
+            });
+
+            isSuccess(res.json);
+            expect(res.json).toStrictEqual({ success: true });
+
+            const updatedConn = await db.knex.select('*').from<DBConnection>('_nango_connections').where({ id: conn.id }).first();
+            expect(updatedConn?.tags).toStrictEqual({ key: 'value with spaces' });
+        });
+
+        it('should replace existing tags completely', async () => {
+            const { env } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'github', 'github');
+            const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+            await db
+                .knex('_nango_connections')
+                .where({ id: conn.id })
+                .update({ tags: { old: 'value', keep: 'this' } });
+
+            // Update with new tags (should replace, not merge)
+            const res = await api.fetch(endpoint, {
+                method: 'PATCH',
+                token: env.secret_key,
+                params: { connectionId: conn.connection_id },
+                query: { provider_config_key: 'github' },
+                body: { tags: { new: 'value' } }
+            });
+
+            isSuccess(res.json);
+
+            const updatedConn = await db.knex.select('*').from<DBConnection>('_nango_connections').where({ id: conn.id }).first();
+            expect(updatedConn?.tags).toStrictEqual({ new: 'value' });
+            expect(updatedConn?.tags).not.toHaveProperty('old');
+            expect(updatedConn?.tags).not.toHaveProperty('keep');
+        });
+
+        it('should set tags on connection without existing tags', async () => {
+            const { env } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'github', 'github');
+            const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+            const beforeConn = await db.knex.select('*').from<DBConnection>('_nango_connections').where({ id: conn.id }).first();
+            expect(beforeConn?.tags).toEqual({});
+
+            const res = await api.fetch(endpoint, {
+                method: 'PATCH',
+                token: env.secret_key,
+                params: { connectionId: conn.connection_id },
+                query: { provider_config_key: 'github' },
+                body: { tags: { first: 'tag' } }
+            });
+
+            isSuccess(res.json);
+
+            const updatedConn = await db.knex.select('*').from<DBConnection>('_nango_connections').where({ id: conn.id }).first();
+            expect(updatedConn?.tags).toStrictEqual({ first: 'tag' });
+        });
+
+        it('should allow empty tags object', async () => {
+            const { env } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'github', 'github');
+            const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+            await db
+                .knex('_nango_connections')
+                .where({ id: conn.id })
+                .update({ tags: { existing: 'tag' } });
+
+            const res = await api.fetch(endpoint, {
+                method: 'PATCH',
+                token: env.secret_key,
+                params: { connectionId: conn.connection_id },
+                query: { provider_config_key: 'github' },
+                body: { tags: {} }
+            });
+
+            isSuccess(res.json);
+
+            const updatedConn = await db.knex.select('*').from<DBConnection>('_nango_connections').where({ id: conn.id }).first();
+            expect(updatedConn?.tags).toStrictEqual({});
+        });
+    });
+});

--- a/packages/server/lib/controllers/connection/getConnections.ts
+++ b/packages/server/lib/controllers/connection/getConnections.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod';
 
-import { connectionService } from '@nangohq/shared';
+import { connectionService, connectionTagsSchema } from '@nangohq/shared';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionSimpleToPublicApi } from '../../formatters/connection.js';
@@ -16,6 +16,7 @@ const validationQuery = z
         endUserId: bodySchema.shape.end_user.shape.id.optional(),
         integrationId: z.string().min(1).optional(),
         endUserOrganizationId: bodySchema.shape.end_user.shape.id.optional(),
+        tags: connectionTagsSchema.optional(),
         limit: z.coerce.number().min(1).max(1000).optional(),
         page: z.coerce.number().min(0).optional()
     })
@@ -31,7 +32,7 @@ export const getPublicConnections = asyncWrapper<GetPublicConnections>(async (re
     }
 
     const { environment } = res.locals;
-    const queryParam: GetPublicConnections['Querystring'] = queryParamValues.data;
+    const queryParam = queryParamValues.data;
 
     const connections = await connectionService.listConnections({
         environmentId: environment.id,
@@ -40,6 +41,7 @@ export const getPublicConnections = asyncWrapper<GetPublicConnections>(async (re
         endUserId: queryParam.endUserId,
         integrationIds: queryParam.integrationId ? queryParam.integrationId.split(',').map((id) => id.trim()) : undefined,
         endUserOrganizationId: queryParam.endUserOrganizationId,
+        tags: queryParam.tags,
         page: queryParam.page,
         limit: queryParam.limit || 10_000 // 10_000 to avoid breaking changes. TODO: set to more reasonable default like 1000 in the future
     });

--- a/packages/server/lib/controllers/connection/postConnection.integration.test.ts
+++ b/packages/server/lib/controllers/connection/postConnection.integration.test.ts
@@ -225,7 +225,97 @@ describe(`POST ${endpoint}`, () => {
             metadata: {},
             provider: 'github',
             provider_config_key: 'github',
+            tags: { end_user_id: '123', end_user_display_name: 'John Doe', projectid: '123' },
             updated_at: expect.toBeIsoDate()
+        });
+    });
+
+    describe('tags', () => {
+        it('should import connection with valid tags and return tags in response', async () => {
+            const { env } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'github', 'github');
+            const tags = { projectid: '123', environment: 'production' };
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: env.secret_key,
+                body: {
+                    provider_config_key: 'github',
+                    credentials: { type: 'OAUTH2', access_token: '123' },
+                    tags
+                }
+            });
+
+            isSuccess(res.json);
+            expect(res.json).toMatchObject({
+                provider_config_key: 'github',
+                tags
+            });
+        });
+
+        it('should import connection without tags', async () => {
+            const { env } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'github', 'github');
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: env.secret_key,
+                body: {
+                    provider_config_key: 'github',
+                    credentials: { type: 'OAUTH2', access_token: '123' }
+                }
+            });
+
+            isSuccess(res.json);
+            expect(res.json).toMatchObject({
+                provider_config_key: 'github',
+                tags: {}
+            });
+        });
+
+        it('should fail with invalid tags', async () => {
+            const { env } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'github', 'github');
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: env.secret_key,
+                body: {
+                    provider_config_key: 'github',
+                    credentials: { type: 'OAUTH2', access_token: '123' },
+                    tags: { '123invalid': 'value' }
+                }
+            });
+
+            isError(res.json);
+            expect(res.json).toMatchObject({
+                error: { code: 'invalid_body' }
+            });
+            expect(res.res.status).toBe(400);
+        });
+
+        it('should import connection with both tags and end_user', async () => {
+            const { env } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'github', 'github');
+            const tags = { projectid: '456' };
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: env.secret_key,
+                body: {
+                    provider_config_key: 'github',
+                    credentials: { type: 'OAUTH2', access_token: '123' },
+                    end_user: { id: 'user-123', display_name: 'Test User' },
+                    tags
+                }
+            });
+
+            isSuccess(res.json);
+            expect(res.json).toMatchObject({
+                provider_config_key: 'github',
+                // Merged tags: end_user generated tags + explicit tags (explicit tags take priority)
+                tags: { end_user_id: 'user-123', end_user_display_name: 'Test User', projectid: '456' },
+                end_user: {
+                    id: 'user-123',
+                    display_name: 'Test User'
+                }
+            });
         });
     });
 });

--- a/packages/server/lib/controllers/v1/connect/sessions/postConnectSessions.ts
+++ b/packages/server/lib/controllers/v1/connect/sessions/postConnectSessions.ts
@@ -1,5 +1,6 @@
 import * as z from 'zod';
 
+import { buildTagsFromEndUser } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
@@ -32,14 +33,16 @@ export const postInternalConnectSessions = asyncWrapper<PostInternalConnectSessi
 
     const body: PostInternalConnectSessions['Body'] = valBody.data;
 
-    // req.body is never but we want to fake it on purpose
+    const endUserWithOrigin = { ...body.end_user, tags: { ...body.end_user.tags, origin: 'nango_dashboard' } };
+    const endUserTags = buildTagsFromEndUser(endUserWithOrigin, body.organization);
 
     const emulatedBody = {
         allowed_integrations: body.allowed_integrations,
-        end_user: { ...body.end_user, tags: { origin: 'nango_dashboard' } },
+        end_user: endUserWithOrigin,
         organization: body.organization,
         integrations_config_defaults: body.integrations_config_defaults,
-        overrides: body.overrides
+        overrides: body.overrides,
+        tags: endUserTags
     } satisfies PostConnectSessions['Body'];
 
     await generateSession(res, emulatedBody, res.locals.plan);

--- a/packages/server/lib/formatters/connection.ts
+++ b/packages/server/lib/formatters/connection.ts
@@ -29,6 +29,7 @@ export function connectionSimpleToApi({
         provider,
         errors: activeLog,
         endUser: endUser ? endUserToApi(endUser) : null,
+        tags: data.tags,
         created_at: String(data.created_at),
         updated_at: String(data.updated_at)
     };
@@ -43,6 +44,7 @@ export function connectionFullToApi(connection: DBConnectionDecrypted): ApiConne
         connection_config: connection.connection_config,
         credentials: connection.credentials,
         metadata: connection.metadata,
+        tags: connection.tags,
         last_fetched_at: connection.last_fetched_at ? String(connection.last_fetched_at) : null,
         credentials_expires_at: connection.credentials_expires_at ? String(connection.credentials_expires_at) : null,
         last_refresh_failure: connection.last_refresh_failure ? String(connection.last_refresh_failure) : null,
@@ -72,6 +74,7 @@ export function connectionSimpleToPublicApi({
         provider,
         errors: activeLog,
         end_user: endUser ? endUserToApi(endUser) : null,
+        tags: data.tags,
         metadata: data.metadata || null,
         created: data.created_at instanceof Date ? data.created_at.toISOString() : String(data.created_at)
     };
@@ -95,6 +98,7 @@ export function connectionFullToPublicApi({
         provider,
         errors: activeLog,
         end_user: endUser ? endUserToApi(endUser) : null,
+        tags: data.tags,
         metadata: data.metadata || null,
         connection_config: data.connection_config || {},
         created_at: data.created_at instanceof Date ? data.created_at.toISOString() : String(data.created_at),

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -1,5 +1,9 @@
 import * as z from 'zod';
 
+import { connectionTagsSchema } from '@nangohq/shared';
+
+export { connectionTagsSchema };
+
 export const providerSchema = z
     .string()
     .regex(/^[a-zA-Z0-9_-]+$/)
@@ -148,7 +152,7 @@ export const connectionCredentialsGithubAppSchema = z.strictObject({
     installation_id: z.string().min(1).max(255)
 });
 
-export const connectionTagsSchema = z
+export const connectionEndUserTagsSchema = z
     // Please be careful when changing this:
     // It's a labelling system, if we allow more than string people will store complex data (e.g: nested object) and ask for features around that
     // + It's an object not a an array of string because customers wants to store layers of origin (e.g: projectId, orgId, etc.)
@@ -160,5 +164,5 @@ export const endUserSchema = z.strictObject({
     id: z.string().max(255).min(1),
     email: z.string().email().min(5).optional(),
     display_name: z.string().max(255).optional(),
-    tags: connectionTagsSchema.optional()
+    tags: connectionEndUserTagsSchema.optional()
 });

--- a/packages/server/lib/hooks/connection/credentials-verification-script.ts
+++ b/packages/server/lib/hooks/connection/credentials-verification-script.ts
@@ -60,7 +60,8 @@ async function execute(
         last_refresh_failure: null,
         last_refresh_success: null,
         refresh_attempts: null,
-        refresh_exhausted: false
+        refresh_exhausted: false,
+        tags: {}
     };
 
     const activeSpan = tracer.scope().active();

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -14,9 +14,9 @@ import { Err, Ok, getLogger, isHosted, report } from '@nangohq/utils';
 import { sendAuth as sendAuthWebhook } from '@nangohq/webhooks';
 
 import { pubsub } from '../pubsub.js';
+import { slackService } from '../services/slack.js';
 import { getOrchestrator } from '../utils/utils.js';
 import executeVerificationScript from './connection/credentials-verification-script.js';
-import { slackService } from '../services/slack.js';
 import { postConnectionCreation } from './connection/on/post-connection-creation.js';
 import postConnection from './connection/post-connection.js';
 
@@ -335,7 +335,8 @@ export async function credentialsTest({
         last_refresh_failure: null,
         last_refresh_success: null,
         refresh_attempts: null,
-        refresh_exhausted: false
+        refresh_exhausted: false,
+        tags: {}
     };
 
     void logCtx.info(`Running automatic credentials verification`);

--- a/packages/server/lib/webhook/github-app-oauth-webhook-routing.ts
+++ b/packages/server/lib/webhook/github-app-oauth-webhook-routing.ts
@@ -135,7 +135,8 @@ async function handleCreateWebhook(nango: InternalNango, body: any): Promise<Res
             provider as ProviderGithubApp,
             connectionConfig,
             logCtx,
-            connCreatedHook
+            connCreatedHook,
+            connection.tags
         );
         await logCtx.success();
 

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -32,6 +32,8 @@ export * from './services/sync/config/config.service.js';
 export * from './services/sync/config/endpoint.service.js';
 export * from './services/sync/config/deploy.service.js';
 export * from './services/endUser.service.js';
+export * from './services/tags.service.js';
+export * from './services/tags/schema.js';
 export * as gettingStartedService from './services/getting-started.service.js';
 export * from './services/invitations.js';
 export * from './services/providers.js';

--- a/packages/shared/lib/seeders/connectSession.seeder.ts
+++ b/packages/shared/lib/seeders/connectSession.seeder.ts
@@ -1,0 +1,20 @@
+import type { ConnectSession } from '@nangohq/types';
+
+export function getTestConnectSession(override?: Partial<ConnectSession>): ConnectSession {
+    return {
+        id: 1,
+        accountId: 1,
+        environmentId: 1,
+        endUserId: null,
+        connectionId: null,
+        allowedIntegrations: null,
+        integrationsConfigDefaults: null,
+        operationId: 'op-123',
+        overrides: null,
+        endUser: null,
+        tags: {},
+        createdAt: new Date(),
+        updatedAt: null,
+        ...override
+    };
+}

--- a/packages/shared/lib/seeders/connection.seeder.ts
+++ b/packages/shared/lib/seeders/connection.seeder.ts
@@ -3,7 +3,7 @@ import db from '@nangohq/database';
 import connectionService from '../services/connection.service.js';
 import { linkConnection } from '../services/endUser.service.js';
 
-import type { AllAuthCredentials, ConnectionConfig, DBConnection, DBConnectionDecrypted, DBEnvironment, EndUser } from '@nangohq/types';
+import type { AllAuthCredentials, ConnectionConfig, DBConnection, DBConnectionDecrypted, DBEnvironment, EndUser, Tags } from '@nangohq/types';
 
 export const createConnectionSeeds = async (env: DBEnvironment): Promise<number[]> => {
     const connectionIds = [];
@@ -15,7 +15,8 @@ export const createConnectionSeeds = async (env: DBEnvironment): Promise<number[
             providerConfigKey: `provider-${name}`,
             parsedRawCredentials: {} as AllAuthCredentials,
             connectionConfig: {},
-            environmentId: env.id
+            environmentId: env.id,
+            tags: {}
         });
 
         for (const res of result) {
@@ -36,6 +37,7 @@ export const createConnectionSeed = async ({
     connectionId,
     rawCredentials,
     connectionConfig,
+    tags,
     ...rest
 }: {
     env: DBEnvironment;
@@ -44,8 +46,9 @@ export const createConnectionSeed = async ({
     connectionId?: string;
     rawCredentials?: AllAuthCredentials;
     connectionConfig?: ConnectionConfig;
+    tags?: Tags;
 } & Partial<
-    Omit<DBConnectionDecrypted, 'id' | 'end_user_id' | 'connection_id' | 'provider_config_key' | 'connection_config' | 'environment_id'>
+    Omit<DBConnectionDecrypted, 'id' | 'end_user_id' | 'connection_id' | 'provider_config_key' | 'connection_config' | 'environment_id' | 'tags'>
 >): Promise<DBConnection> => {
     const name = connectionId ? connectionId : Math.random().toString(36).substring(7);
     const result = await connectionService.upsertConnection({
@@ -54,6 +57,7 @@ export const createConnectionSeed = async ({
         parsedRawCredentials: rawCredentials || ({} as AllAuthCredentials),
         connectionConfig: connectionConfig || {},
         environmentId: env.id,
+        tags: tags || {},
         ...rest
     });
 
@@ -94,6 +98,7 @@ export function getTestConnection(override?: Partial<DBConnectionDecrypted>): DB
         last_refresh_success: null,
         refresh_attempts: null,
         refresh_exhausted: false,
+        tags: {},
         ...override
     };
 }

--- a/packages/shared/lib/seeders/index.ts
+++ b/packages/shared/lib/seeders/index.ts
@@ -1,6 +1,7 @@
 export * from './account.seeder.js';
 export * from './config.seeder.js';
 export * from './connection.seeder.js';
+export * from './connectSession.seeder.js';
 export * from './endUser.seeder.js';
 export * from './environment.seeder.js';
 export * from './global.seeder.js';

--- a/packages/shared/lib/services/connection.service.integration.test.ts
+++ b/packages/shared/lib/services/connection.service.integration.test.ts
@@ -188,6 +188,24 @@ describe('Connection service integration tests', () => {
             expect(connectionIds).toEqual([notionError.connection_id]);
         });
 
+        it('should filter connections by tags', async () => {
+            const env = await createEnvironmentSeed();
+
+            await createConfigSeed(env, 'notion', 'notion');
+
+            const tagged = await createConnectionSeed({ env, provider: 'notion', tags: { team: 'backend', region: 'us' } });
+            await createConnectionSeed({ env, provider: 'notion', tags: { team: 'frontend', region: 'eu' } });
+            await createConnectionSeed({ env, provider: 'notion', tags: {} });
+
+            const dbConnections = await connectionService.listConnections({
+                environmentId: env.id,
+                tags: { team: 'backend' }
+            });
+
+            const connectionIds = dbConnections.map((c) => c.connection.connection_id);
+            expect(connectionIds).toEqual([tagged.connection_id]);
+        });
+
         it('should return connections without errors', async () => {
             const env = await createEnvironmentSeed();
 

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -80,6 +80,7 @@ import type {
     ProviderSignature,
     ProviderTwoStep,
     SignatureCredentials,
+    Tags,
     TbaCredentials,
     TwoStepCredentials
 } from '@nangohq/types';
@@ -101,7 +102,8 @@ class ConnectionService {
         parsedRawCredentials,
         connectionConfig,
         environmentId,
-        metadata
+        metadata,
+        tags
     }: {
         connectionId: string;
         providerConfigKey: string;
@@ -109,6 +111,7 @@ class ConnectionService {
         connectionConfig?: ConnectionConfig;
         environmentId: number;
         metadata?: Metadata | null;
+        tags?: Tags | undefined;
     }): Promise<ConnectionUpsertResponse[]> {
         const storedConnection = await this.checkIfConnectionExists(db.knex, { connectionId, providerConfigKey, environmentId });
         const config_id = await configService.getIdByProviderConfigKey(environmentId, providerConfigKey);
@@ -127,7 +130,8 @@ class ConnectionService {
                 last_refresh_success: new Date(),
                 last_refresh_failure: null,
                 refresh_attempts: null,
-                refresh_exhausted: false
+                refresh_exhausted: false,
+                tags: tags ?? storedConnection.tags
             });
 
             const connection = await db.knex
@@ -157,7 +161,8 @@ class ConnectionService {
             refresh_attempts: null,
             refresh_exhausted: false,
             deleted: false,
-            deleted_at: null
+            deleted_at: null,
+            tags: tags ?? {}
         });
         const connection = await db.knex.from<DBConnection>(`_nango_connections`).insert(data).returning('*');
 
@@ -171,7 +176,8 @@ class ConnectionService {
         connectionConfig,
         metadata,
         config,
-        environment
+        environment,
+        tags
     }: {
         connectionId: string;
         providerConfigKey: string;
@@ -180,6 +186,7 @@ class ConnectionService {
         config: ProviderConfig;
         metadata?: Metadata | null;
         environment: DBEnvironment;
+        tags?: Tags | undefined;
     }): Promise<ConnectionUpsertResponse[]> {
         return await db.knex.transaction(async (trx) => {
             const exists = await this.checkIfConnectionExists(trx, { connectionId, providerConfigKey, environmentId: environment.id });
@@ -202,7 +209,8 @@ class ConnectionService {
                 refresh_attempts: null,
                 refresh_exhausted: false,
                 deleted: false,
-                deleted_at: null
+                deleted_at: null,
+                tags: tags ?? exists?.tags ?? {}
             });
 
             const [connection] = await db.knex
@@ -224,7 +232,8 @@ class ConnectionService {
                     last_refresh_failure: encryptedConnection.last_refresh_failure,
                     refresh_attempts: encryptedConnection.refresh_attempts,
                     refresh_exhausted: encryptedConnection.refresh_exhausted,
-                    updated_at: new Date()
+                    updated_at: new Date(),
+                    tags: encryptedConnection.tags
                 })
                 .returning('*');
 
@@ -237,13 +246,15 @@ class ConnectionService {
         providerConfigKey,
         metadata,
         connectionConfig,
-        environment
+        environment,
+        tags
     }: {
         connectionId: string;
         providerConfigKey: string;
         metadata?: Metadata | null;
         connectionConfig?: ConnectionConfig;
         environment: DBEnvironment;
+        tags?: Tags | undefined;
     }): Promise<ConnectionUpsertResponse[]> {
         const storedConnection = await this.checkIfConnectionExists(db.knex, { connectionId, providerConfigKey, environmentId: environment.id });
         const config_id = await configService.getIdByProviderConfigKey(environment.id, providerConfigKey); // TODO remove that
@@ -264,7 +275,8 @@ class ConnectionService {
                     last_refresh_success: new Date(),
                     last_refresh_failure: null,
                     refresh_attempts: null,
-                    refresh_exhausted: false
+                    refresh_exhausted: false,
+                    tags: tags ?? storedConnection.tags
                 })
                 .returning('*');
 
@@ -284,7 +296,8 @@ class ConnectionService {
                 last_refresh_success: new Date(),
                 last_refresh_failure: null,
                 refresh_attempts: null,
-                refresh_exhausted: false
+                refresh_exhausted: false,
+                tags: tags ?? {}
             })
             .returning('*');
 
@@ -298,7 +311,8 @@ class ConnectionService {
         metadata = null,
         connectionConfig = {},
         parsedRawCredentials,
-        connectionCreatedHook
+        connectionCreatedHook,
+        tags
     }: {
         connectionId: string;
         providerConfigKey: string;
@@ -307,6 +321,7 @@ class ConnectionService {
         connectionConfig?: ConnectionConfig;
         parsedRawCredentials: OAuth2Credentials | OAuth1Credentials | OAuth2ClientCredentials;
         connectionCreatedHook: (res: ConnectionUpsertResponse) => MaybePromise<void>;
+        tags?: Tags;
     }) {
         const [importedConnection] = await this.upsertConnection({
             connectionId,
@@ -314,7 +329,8 @@ class ConnectionService {
             parsedRawCredentials,
             connectionConfig,
             environmentId: environment.id,
-            metadata
+            metadata,
+            tags
         });
 
         if (importedConnection) {
@@ -331,7 +347,8 @@ class ConnectionService {
         environment,
         connectionConfig = {},
         credentials,
-        connectionCreatedHook
+        connectionCreatedHook,
+        tags
     }: {
         connectionId: string;
         providerConfigKey: string;
@@ -340,6 +357,7 @@ class ConnectionService {
         connectionConfig?: ConnectionConfig;
         credentials: BasicApiCredentials | ApiKeyCredentials;
         connectionCreatedHook: (res: ConnectionUpsertResponse) => MaybePromise<void>;
+        tags?: Tags;
     }) {
         const config = await configService.getProviderConfig(providerConfigKey, environment.id);
 
@@ -355,7 +373,8 @@ class ConnectionService {
             connectionConfig,
             metadata,
             config,
-            environment
+            environment,
+            tags
         });
 
         if (importedConnection) {
@@ -733,6 +752,7 @@ class ConnectionService {
         search,
         endUserId,
         endUserOrganizationId,
+        tags,
         limit = 1000,
         page = 0
     }: {
@@ -743,6 +763,7 @@ class ConnectionService {
         search?: string | undefined;
         endUserId?: string | undefined;
         endUserOrganizationId?: string | undefined;
+        tags?: Record<string, string> | undefined;
         limit?: number;
         page?: number | undefined;
     }): Promise<{ connection: DBConnectionAsJSONRow; end_user: DBEndUser | null; active_logs: [{ type: string; log_id: string }]; provider: string }[]> {
@@ -763,6 +784,11 @@ class ConnectionService {
                 // Filter by integration IDs
                 if (integrationIds) {
                     subQuery.join('_nango_configs', '_nango_connections.config_id', '_nango_configs.id').whereIn('_nango_configs.unique_key', integrationIds);
+                }
+
+                // Filter by tags (JSONB containment using GIN index)
+                if (tags && Object.keys(tags).length > 0) {
+                    subQuery.whereRaw('_nango_connections.tags @> ?::jsonb', [JSON.stringify(tags)]);
                 }
 
                 // Filter by end user criteria or search
@@ -1015,7 +1041,8 @@ class ConnectionService {
         provider: ProviderGithubApp,
         connectionConfig: ConnectionConfig,
         logCtx: LogContext,
-        connectionCreatedHook: (res: ConnectionUpsertResponse) => MaybePromise<void>
+        connectionCreatedHook: (res: ConnectionUpsertResponse) => MaybePromise<void>,
+        tags?: Tags
     ): Promise<Result<ConnectionUpsertResponse | undefined, AuthCredentialsError>> {
         const create = await githubAppClient.createCredentials({
             integration,
@@ -1034,7 +1061,8 @@ class ConnectionService {
             providerConfigKey: integration.unique_key,
             parsedRawCredentials: create.value,
             connectionConfig,
-            environmentId: integration.environment_id
+            environmentId: integration.environment_id,
+            tags
         });
 
         if (updatedConnection) {

--- a/packages/shared/lib/services/endUser.service.unit.test.ts
+++ b/packages/shared/lib/services/endUser.service.unit.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildTagsFromEndUser } from './endUser.service.js';
+
+describe('endUser.service', () => {
+    describe('buildTagsFromEndUser', () => {
+        it('should return empty object when no inputs provided', () => {
+            expect(buildTagsFromEndUser(null, null)).toEqual({});
+            expect(buildTagsFromEndUser(undefined, undefined)).toEqual({});
+        });
+
+        it('should generate end_user_id from end_user.id', () => {
+            const result = buildTagsFromEndUser({ id: 'user-123' }, null);
+            expect(result).toEqual({ end_user_id: 'user-123' });
+        });
+
+        it('should generate all end_user fields when provided (keys mapped, values preserved)', () => {
+            const result = buildTagsFromEndUser({ id: 'user-123', email: 'test@example.com', display_name: 'Test User' }, null);
+            expect(result).toEqual({
+                end_user_id: 'user-123',
+                end_user_email: 'test@example.com',
+                end_user_display_name: 'Test User'
+            });
+        });
+
+        it('should not include optional end_user fields when not provided', () => {
+            const result = buildTagsFromEndUser({ id: 'user-123' }, null);
+            expect(result).toEqual({ end_user_id: 'user-123' });
+            expect(result).not.toHaveProperty('end_user_email');
+            expect(result).not.toHaveProperty('end_user_display_name');
+        });
+
+        it('should copy end_user.tags', () => {
+            const result = buildTagsFromEndUser({ id: 'user-123', tags: { project_id: 'proj-1', team: 'alpha' } }, null);
+            expect(result).toEqual({
+                end_user_id: 'user-123',
+                project_id: 'proj-1',
+                team: 'alpha'
+            });
+        });
+
+        it('should allow end_user.tags to override auto-generated end_user tags', () => {
+            const result = buildTagsFromEndUser({ id: 'user-123', tags: { end_user_id: 'custom-id' } }, null);
+            expect(result).toEqual({ end_user_id: 'custom-id' });
+        });
+
+        it('should generate organization_id from organization.id', () => {
+            const result = buildTagsFromEndUser(null, { id: 'org-456' });
+            expect(result).toEqual({ organization_id: 'org-456' });
+        });
+
+        it('should generate all organization fields when provided (keys mapped, values preserved)', () => {
+            const result = buildTagsFromEndUser(null, { id: 'org-456', display_name: 'Acme Corp' });
+            expect(result).toEqual({
+                organization_id: 'org-456',
+                organization_display_name: 'Acme Corp'
+            });
+        });
+
+        it('should not include optional organization fields when not provided', () => {
+            const result = buildTagsFromEndUser(null, { id: 'org-456' });
+            expect(result).toEqual({ organization_id: 'org-456' });
+            expect(result).not.toHaveProperty('organization_display_name');
+        });
+
+        it('should handle empty end_user.tags', () => {
+            const result = buildTagsFromEndUser({ id: 'user-123', tags: {} }, null);
+            expect(result).toEqual({ end_user_id: 'user-123' });
+        });
+
+        it('should handle both endUser and organization together (keys mapped, values preserved)', () => {
+            const result = buildTagsFromEndUser({ id: 'user-123', email: 'user@example.com' }, { id: 'org-456', display_name: 'My Org' });
+            expect(result).toEqual({
+                end_user_id: 'user-123',
+                end_user_email: 'user@example.com',
+                organization_id: 'org-456',
+                organization_display_name: 'My Org'
+            });
+        });
+
+        it('should combine end_user fields and end_user.tags with correct priority (keys mapped, values preserved)', () => {
+            const result = buildTagsFromEndUser(
+                {
+                    id: 'user-123',
+                    email: 'test@example.com',
+                    display_name: 'Test',
+                    tags: { custom_key: 'custom_value', end_user_email: 'override@example.com' }
+                },
+                { id: 'org-456', display_name: 'Org' }
+            );
+            expect(result).toEqual({
+                end_user_id: 'user-123',
+                end_user_email: 'override@example.com', // from end_user.tags (overrides auto-gen)
+                end_user_display_name: 'Test',
+                organization_id: 'org-456',
+                organization_display_name: 'Org',
+                custom_key: 'custom_value'
+            });
+        });
+    });
+});

--- a/packages/shared/lib/services/tags.service.ts
+++ b/packages/shared/lib/services/tags.service.ts
@@ -1,0 +1,28 @@
+import { Err, Ok } from '@nangohq/utils';
+
+import { connectionTagsSchema } from './tags/schema.js';
+
+import type { Knex } from '@nangohq/database';
+import type { DBConnection, Result, Tags } from '@nangohq/types';
+
+export { TAG_KEY_MAX_LENGTH, TAG_MAX_COUNT, TAG_VALUE_MAX_LENGTH, connectionTagsSchema } from './tags/schema.js';
+
+type ConnectionWithTags = Pick<DBConnection, 'id' | 'tags'>;
+
+/**
+ * Validates, normalizes, and updates tags for a connection.
+ * Mutates the connection object with the normalized tags and returns it.
+ */
+export async function updateConnectionTags<T extends ConnectionWithTags>(db: Knex, { connection, tags }: { connection: T; tags: Tags }): Promise<Result<T>> {
+    const result = connectionTagsSchema.safeParse(tags);
+    if (!result.success) {
+        return Err(result.error.issues[0]?.message ?? 'Invalid tags');
+    }
+
+    await db<DBConnection>('_nango_connections').where({ id: connection.id }).update({ tags: result.data });
+
+    // Mutate the connection object with the normalized tags
+    connection.tags = result.data;
+
+    return Ok(connection);
+}

--- a/packages/shared/lib/services/tags.service.unit.test.ts
+++ b/packages/shared/lib/services/tags.service.unit.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { updateConnectionTags } from './tags.service.js';
+import { getTestConnection } from '../seeders/connection.seeder.js';
+
+import type { DBConnection } from '@nangohq/types';
+import type { Knex } from 'knex';
+
+describe('tags.service', () => {
+    // getTestConnection returns DBConnectionDecrypted, cast to DBConnection for unit tests
+    const mockConnection = getTestConnection() as unknown as DBConnection;
+
+    describe('updateConnectionTags', () => {
+        it('should call db update with correct parameters and normalize tags', async () => {
+            const mockUpdate = vi.fn().mockResolvedValue(1);
+            const mockWhere = vi.fn().mockReturnValue({ update: mockUpdate });
+            const mockDb = vi.fn().mockReturnValue({ where: mockWhere }) as unknown as Knex;
+
+            const tags = { projectId: '123', orgId: '456' };
+            const result = await updateConnectionTags(mockDb, {
+                connection: mockConnection,
+                tags
+            });
+
+            expect(mockDb).toHaveBeenCalledWith('_nango_connections');
+            expect(mockWhere).toHaveBeenCalledWith({ id: mockConnection.id });
+            expect(mockUpdate).toHaveBeenCalledWith({ tags: { projectid: '123', orgid: '456' } });
+            expect(result.isOk()).toBe(true);
+            expect(result.unwrap()).toBe(mockConnection);
+            expect(mockConnection.tags).toEqual({ projectid: '123', orgid: '456' });
+        });
+
+        it('should normalize uppercase keys to lowercase but preserve values', async () => {
+            const mockUpdate = vi.fn().mockResolvedValue(1);
+            const mockWhere = vi.fn().mockReturnValue({ update: mockUpdate });
+            const mockDb = vi.fn().mockReturnValue({ where: mockWhere }) as unknown as Knex;
+
+            const connectionToUpdate = getTestConnection() as unknown as DBConnection;
+            const tags = { ProjectID: 'ABC123', OrgName: 'TestOrg' };
+            await updateConnectionTags(mockDb, {
+                connection: connectionToUpdate,
+                tags
+            });
+
+            expect(mockUpdate).toHaveBeenCalledWith({ tags: { projectid: 'ABC123', orgname: 'TestOrg' } });
+            expect(connectionToUpdate.tags).toEqual({ projectid: 'ABC123', orgname: 'TestOrg' });
+        });
+
+        it('should return the updated connection', async () => {
+            const mockUpdate = vi.fn().mockResolvedValue(1);
+            const mockWhere = vi.fn().mockReturnValue({ update: mockUpdate });
+            const mockDb = vi.fn().mockReturnValue({ where: mockWhere }) as unknown as Knex;
+
+            const connectionToUpdate = getTestConnection({ tags: {} }) as unknown as DBConnection;
+            const tags = { env: 'prod' };
+
+            const result = await updateConnectionTags(mockDb, {
+                connection: connectionToUpdate,
+                tags
+            });
+
+            expect(result.isOk()).toBe(true);
+            const updatedConnection = result.unwrap();
+            expect(updatedConnection).toBe(connectionToUpdate);
+            expect(updatedConnection.tags).toEqual({ env: 'prod' });
+        });
+    });
+});

--- a/packages/shared/lib/services/tags/schema.ts
+++ b/packages/shared/lib/services/tags/schema.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+
+export const TAG_MAX_COUNT = 10;
+export const TAG_KEY_MAX_LENGTH = 64;
+export const TAG_VALUE_MAX_LENGTH = 200;
+
+const connectionTagsKeySchema = z
+    .string()
+    .regex(/^[a-zA-Z][a-zA-Z0-9_\-./]*$/, {
+        message: 'Tag keys must start with a letter and contain only alphanumerics, underscores, hyphens, periods, or slashes'
+    })
+    .max(TAG_KEY_MAX_LENGTH, { message: `Tag keys must be at most ${TAG_KEY_MAX_LENGTH} characters` });
+
+const connectionTagsValueSchema = z
+    .string()
+    .min(1)
+    .max(TAG_VALUE_MAX_LENGTH, { message: `Tag values must be at most ${TAG_VALUE_MAX_LENGTH} characters` });
+
+/**
+ * Zod schema for connection tags.
+ * Validates tag format and normalizes keys to lowercase.
+ * Values are preserved as-is (they could be case-sensitive IDs).
+ */
+export const connectionTagsSchema = z
+    .record(connectionTagsKeySchema, connectionTagsValueSchema)
+    .superRefine((tags, ctx) => {
+        const entries = Object.entries(tags);
+
+        if (entries.length > TAG_MAX_COUNT) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: `Tags cannot contain more than ${TAG_MAX_COUNT} keys`
+            });
+            return;
+        }
+
+        // Check for duplicate keys after normalization
+        const seen = new Set<string>();
+        for (const [key, value] of entries) {
+            const normalized = key.toLowerCase();
+            if (seen.has(normalized)) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: `Duplicate tag key after case normalization: "${normalized}"`
+                });
+            }
+            seen.add(normalized);
+            if (normalized === 'end_user_email') {
+                const emailResult = z.string().email().min(5).safeParse(value);
+                if (!emailResult.success) {
+                    ctx.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        message: 'Tag "end_user_email" must be a valid email'
+                    });
+                }
+            }
+        }
+    })
+    .transform((tags) => {
+        const normalized: Record<string, string> = {};
+        for (const [key, value] of Object.entries(tags)) {
+            normalized[key.toLowerCase()] = value;
+        }
+        return normalized;
+    });

--- a/packages/shared/lib/services/tags/schema.unit.test.ts
+++ b/packages/shared/lib/services/tags/schema.unit.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest';
+
+import { connectionTagsSchema } from './schema.js';
+
+describe('connectionTagsSchema', () => {
+    describe('normalization', () => {
+        it('should lowercase keys', () => {
+            const result = connectionTagsSchema.safeParse({ ProjectId: 'abc', OrgID: 'def' });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({ projectid: 'abc', orgid: 'def' });
+            }
+        });
+
+        it('should preserve values (not lowercase)', () => {
+            const result = connectionTagsSchema.safeParse({ key: 'MyValue', other: 'TEST' });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({ key: 'MyValue', other: 'TEST' });
+            }
+        });
+
+        it('should lowercase keys but preserve values', () => {
+            const result = connectionTagsSchema.safeParse({ ProjectID: 'ABC123' });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({ projectid: 'ABC123' });
+            }
+        });
+
+        it('should handle empty object', () => {
+            const result = connectionTagsSchema.safeParse({});
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({});
+            }
+        });
+
+        it('should handle already lowercase tags', () => {
+            const result = connectionTagsSchema.safeParse({ key: 'value' });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({ key: 'value' });
+            }
+        });
+
+        it('should lowercase keys but preserve values with special characters', () => {
+            const result = connectionTagsSchema.safeParse({ 'myTag/Key': 'some_Value-Here' });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({ 'mytag/key': 'some_Value-Here' });
+            }
+        });
+
+        it('should reject duplicate keys after normalization', () => {
+            const result = connectionTagsSchema.safeParse({ ProjectId: 'a', projectid: 'b' });
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.error.issues[0]?.message).toBe('Duplicate tag key after case normalization: "projectid"');
+            }
+        });
+
+        it('should reject duplicate keys with different casing', () => {
+            const result = connectionTagsSchema.safeParse({ MyKey: 'a', MYKEY: 'b', mykey: 'c' });
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.error.issues[0]?.message).toContain('Duplicate tag key after case normalization');
+            }
+        });
+    });
+
+    describe('valid cases', () => {
+        it('should accept valid tag with letter-starting key', () => {
+            const result = connectionTagsSchema.safeParse({ project: '123' });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({ project: '123' });
+            }
+        });
+
+        it('should accept keys starting with uppercase letter and normalize to lowercase', () => {
+            const result = connectionTagsSchema.safeParse({ Project: '123' });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({ project: '123' });
+            }
+        });
+
+        it('should accept keys with underscores', () => {
+            const result = connectionTagsSchema.safeParse({ my_tag: 'value' });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({ my_tag: 'value' });
+            }
+        });
+
+        it('should accept keys with hyphens', () => {
+            const result = connectionTagsSchema.safeParse({ 'my-tag': 'value' });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({ 'my-tag': 'value' });
+            }
+        });
+
+        it('should accept keys with periods', () => {
+            const result = connectionTagsSchema.safeParse({ 'my.tag': 'value' });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({ 'my.tag': 'value' });
+            }
+        });
+
+        it('should accept keys with slashes', () => {
+            const result = connectionTagsSchema.safeParse({ 'my/tag': 'value' });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({ 'my/tag': 'value' });
+            }
+        });
+
+        it('should accept keys with numbers after first letter', () => {
+            const result = connectionTagsSchema.safeParse({ tag123: 'value' });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({ tag123: 'value' });
+            }
+        });
+
+        it('should reject empty string values', () => {
+            const result = connectionTagsSchema.safeParse({ key: '' });
+            expect(result.success).toBe(false);
+        });
+
+        it('should accept arbitrary text values', () => {
+            const result = connectionTagsSchema.safeParse({ key: 'Value with spaces, symbols @#!, and punctuation.' });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({ key: 'Value with spaces, symbols @#!, and punctuation.' });
+            }
+        });
+
+        it('should accept end_user_email tag with valid email', () => {
+            const result = connectionTagsSchema.safeParse({ end_user_email: 'user@example.com' });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({ end_user_email: 'user@example.com' });
+            }
+        });
+
+        it('should accept multiple valid tags and normalize keys only', () => {
+            const result = connectionTagsSchema.safeParse({
+                projectId: '123',
+                orgId: '456',
+                envType: 'Production'
+            });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({
+                    projectid: '123',
+                    orgid: '456',
+                    envtype: 'Production'
+                });
+            }
+        });
+
+        it('should accept exactly 10 keys', () => {
+            const tags: Record<string, string> = {};
+            for (let i = 0; i < 10; i++) {
+                tags[`key${i}`] = `value${i}`;
+            }
+            const result = connectionTagsSchema.safeParse(tags);
+            expect(result.success).toBe(true);
+        });
+
+        it('should accept key at max length (64 chars)', () => {
+            const key = 'a'.repeat(64);
+            const result = connectionTagsSchema.safeParse({ [key]: 'value' });
+            expect(result.success).toBe(true);
+        });
+
+        it('should accept value at max length (200 chars)', () => {
+            const value = 'a'.repeat(200);
+            const result = connectionTagsSchema.safeParse({ key: value });
+            expect(result.success).toBe(true);
+        });
+    });
+
+    describe('invalid cases', () => {
+        it('should reject keys starting with number', () => {
+            const result = connectionTagsSchema.safeParse({ '123project': 'value' });
+            expect(result.success).toBe(false);
+        });
+
+        it('should reject keys starting with underscore', () => {
+            const result = connectionTagsSchema.safeParse({ _project: 'value' });
+            expect(result.success).toBe(false);
+        });
+
+        it('should reject keys starting with hyphen', () => {
+            const result = connectionTagsSchema.safeParse({ '-project': 'value' });
+            expect(result.success).toBe(false);
+        });
+
+        it('should reject keys with spaces', () => {
+            const result = connectionTagsSchema.safeParse({ 'my tag': 'value' });
+            expect(result.success).toBe(false);
+        });
+
+        it('should reject keys longer than 64 chars', () => {
+            const key = 'a'.repeat(65);
+            const result = connectionTagsSchema.safeParse({ [key]: 'value' });
+            expect(result.success).toBe(false);
+        });
+
+        it('should reject values longer than 200 chars', () => {
+            const value = 'a'.repeat(201);
+            const result = connectionTagsSchema.safeParse({ key: value });
+            expect(result.success).toBe(false);
+        });
+
+        it('should reject more than 10 keys', () => {
+            const tags: Record<string, string> = {};
+            for (let i = 0; i < 11; i++) {
+                tags[`key${i}`] = `value${i}`;
+            }
+            const result = connectionTagsSchema.safeParse(tags);
+            expect(result.success).toBe(false);
+        });
+
+        it('should reject keys with invalid special characters', () => {
+            const result = connectionTagsSchema.safeParse({ 'key@invalid': 'value' });
+            expect(result.success).toBe(false);
+        });
+
+        it('should reject end_user_email tag with invalid email', () => {
+            const result = connectionTagsSchema.safeParse({ end_user_email: 'not-an-email' });
+            expect(result.success).toBe(false);
+        });
+
+        it('should reject keys with colons', () => {
+            const result = connectionTagsSchema.safeParse({ 'my:tag': 'value' });
+            expect(result.success).toBe(false);
+        });
+    });
+});

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -40,6 +40,7 @@ import type {
     GetConnectionsCount,
     GetPublicConnection,
     GetPublicConnections,
+    PatchPublicConnection,
     PostConnectionRefresh,
     PostPublicConnection
 } from './connection/api/get.js';
@@ -120,6 +121,7 @@ export type PublicApiEndpoints =
     | GetAsyncActionResult
     | PostPublicOauthOutboundAuthorization
     | PostPublicConnection
+    | PatchPublicConnection
     | PostPublicSyncStart
     | PostPublicSyncPause
     | GetPublicSyncStatus

--- a/packages/types/lib/connect/api.ts
+++ b/packages/types/lib/connect/api.ts
@@ -26,6 +26,7 @@ export interface ConnectSessionInput {
               display_name?: string | undefined;
           }
         | undefined;
+    tags?: Record<string, string> | undefined;
     overrides?: Record<string, { docs_connect?: string | undefined }> | undefined;
 }
 
@@ -65,6 +66,7 @@ export type PostPublicConnectSessionsReconnect = Endpoint<{
         end_user?: ConnectSessionInput['end_user'] | undefined;
         organization?: ConnectSessionInput['organization'];
         overrides?: ConnectSessionInput['overrides'];
+        tags?: ConnectSessionInput['tags'];
     };
     Success: {
         data: {

--- a/packages/types/lib/connect/session.ts
+++ b/packages/types/lib/connect/session.ts
@@ -1,3 +1,4 @@
+import type { Tags } from '../db.js';
 import type { InternalEndUser } from '../endUser/index.js';
 
 export interface ConnectSession {
@@ -11,6 +12,7 @@ export interface ConnectSession {
     readonly integrationsConfigDefaults: Record<string, ConnectSessionIntegrationConfigDefaults> | null;
     readonly overrides: Record<string, ConnectSessionOverrides> | null;
     readonly endUser: InternalEndUser | null;
+    readonly tags: Tags;
     readonly createdAt: Date;
     readonly updatedAt: Date | null;
 }

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -9,6 +9,7 @@ import type {
     TbaCredentials
 } from '../../auth/api.js';
 import type { EndUserInput } from '../../connect/api.js';
+import type { Tags } from '../../db.js';
 import type { ApiEndUser } from '../../endUser/index.js';
 import type { ActiveLog } from '../../notification/active-logs/db.js';
 import type { ReplaceInObject } from '../../utils.js';
@@ -19,6 +20,7 @@ export type ApiConnectionSimple = Pick<Merge<DBConnection, ApiTimestamps>, 'id' 
     provider: string;
     errors: { type: string; log_id: string }[];
     endUser: ApiEndUser | null;
+    tags: Tags;
 };
 export type GetConnections = Endpoint<{
     Method: 'GET';
@@ -53,6 +55,7 @@ export type ApiPublicConnection = Pick<DBConnection, 'id' | 'connection_id'> & {
     provider: string;
     errors: { type: string; log_id: string }[];
     end_user: ApiEndUser | null;
+    tags: Tags;
 };
 export type GetPublicConnections = Endpoint<{
     Method: 'GET';
@@ -62,6 +65,7 @@ export type GetPublicConnections = Endpoint<{
         endUserId?: string | undefined;
         integrationId?: string | undefined;
         endUserOrganizationId?: string | undefined;
+        tags?: Tags | undefined;
         limit?: number | undefined;
         page?: number | undefined;
     };
@@ -90,6 +94,7 @@ export type PostPublicConnection = Endpoint<{
             | { type: 'CUSTOM'; app_id: string; installation_id: string }
             | { type: 'NONE' };
         end_user?: EndUserInput | undefined;
+        tags?: Tags | undefined;
     };
     Success: ApiPublicConnectionFull;
 }>;
@@ -128,6 +133,7 @@ export type ApiPublicConnectionFull = Pick<DBConnection, 'id' | 'connection_id' 
     provider: string;
     errors: { type: string; log_id: string }[];
     end_user: ApiEndUser | null;
+    tags: Tags;
     credentials: AllAuthCredentials;
 };
 export type GetPublicConnection = Endpoint<{
@@ -157,6 +163,7 @@ export type PatchPublicConnection = Endpoint<{
     };
     Body: {
         end_user?: EndUserInput | undefined;
+        tags?: Tags | undefined;
     };
     Success: { success: boolean };
     Error: ApiError<'unknown_provider_config'>;

--- a/packages/types/lib/connection/db.ts
+++ b/packages/types/lib/connection/db.ts
@@ -1,5 +1,5 @@
 import type { AllAuthCredentials, AuthModeType, AuthOperationType } from '../auth/api.js';
-import type { TimestampsAndDeletedCorrect } from '../db.js';
+import type { Tags, TimestampsAndDeletedCorrect } from '../db.js';
 import type { InternalEndUser } from '../endUser/index.js';
 import type { DBEnvironment } from '../environment/db.js';
 import type { DBTeam } from '../team/db.js';
@@ -19,6 +19,7 @@ export interface DBConnection extends TimestampsAndDeletedCorrect {
     id: number;
     config_id: number;
     end_user_id: number | null;
+    tags: Tags;
     /**
      * @deprecated
      */

--- a/packages/types/lib/db.ts
+++ b/packages/types/lib/db.ts
@@ -14,3 +14,5 @@ export interface DeletedCorrect {
 
 export interface TimestampsAndDeleted extends Timestamps, Deleted {}
 export interface TimestampsAndDeletedCorrect extends Timestamps, DeletedCorrect {}
+
+export type Tags = Record<string, string>;

--- a/packages/types/lib/webhooks/api.ts
+++ b/packages/types/lib/webhooks/api.ts
@@ -53,6 +53,7 @@ export interface NangoAuthWebhookBodyBase extends NangoWebhookBase {
     provider: string;
     environment: string;
     operation: AuthOperationType;
+    tags?: Record<string, string> | undefined;
     /**
      * Only presents if the connection happened with a session token
      */

--- a/packages/webhooks/lib/auth.ts
+++ b/packages/webhooks/lib/auth.ts
@@ -71,6 +71,7 @@ export async function sendAuth({
         provider: providerConfig?.provider || 'unknown',
         environment: environment.name,
         operation,
+        tags: 'tags' in connection ? (connection.tags ?? undefined) : undefined,
         endUser: endUser
             ? {
                   endUserId: endUser.endUserId,


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
⚠️ The PR seems big but most of the new lines are actually just tests. ⚠️ 

Add tags to connect sessions and connections. There are multiple ways these tags get set
- Existing endUser/organization data on connect sessions/connections is translated into tags
- Can be set as a separate field when creating connect sessions / reconnecting. These will get passed on to a new connection that gets created during the connect session
- Can be updated via the API (e.g. PATCH /connections/:connectionId)

They are then visible in
- The connect session / connection APIs, although they are undocumented
- Various auth webhooks e.g. connection-created (if they are set). This is also undocumented

This is a 3rd attempt at building an attribution mechanism between connect sessions and connections and we want to give it to customers who weren't able to use the previous 2 to first give us some feedback before we document it fully.

I left a few comments with questions:
- should we normalize tags to lower case?
- is 64 tags per connection too many?

Further reading: https://linear.app/nango/project/connection-tags-9bf95766e842/overview

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

The implementation also normalizes tag keys to lowercase with validation safeguards and extends the connection listing endpoints so tags can be queried and filtered alongside their inclusion in auth webhooks.

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/controllers/connection/*
• packages/server/lib/controllers/connect/*
• packages/server/lib/controllers/auth/*
• packages/shared/lib/services/connection.service.ts
• packages/shared/lib/services/connectSession.service.ts
• packages/shared/lib/services/tags/*
• packages/types/lib/*
• packages/webhooks/lib/*

</details>

---
*This summary was automatically generated by @propel-code-bot*