### PR TITLE
fix(webapp): functions tab loading state

### DIFF
--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/Tab.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/Tab.tsx
@@ -8,6 +8,7 @@ import { CopyButton } from '@/components-v2/CopyButton';
 import { Navigation, NavigationContent, NavigationList, NavigationTrigger } from '@/components-v2/Navigation';
 import { Badge } from '@/components-v2/ui/badge';
 import { ButtonLink } from '@/components-v2/ui/button';
+import { Skeleton } from '@/components-v2/ui/skeleton.js';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components-v2/ui/table';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components-v2/ui/tooltip';
 import { useHashNavigation } from '@/hooks/useHashNavigation';
@@ -59,7 +60,7 @@ export const FunctionsTab: React.FC<FunctionsTabProps> = ({ integration }) => {
     );
 
     if (loading) {
-        return <div>Loading...</div>;
+        return <Skeleton className="w-full max-w-2xl h-50" />;
     }
 
     return (


### PR DESCRIPTION
I forgot to replace the stub loading state. A simple skeleton does the trick.

<!-- Summary by @propel-code-bot -->

---

**Replace functions tab loading stub with skeleton UI**

The PR swaps the placeholder loading text in `FunctionsTab` for the shared skeleton component. It imports `Skeleton` from the UI library and renders it when `useGetIntegrationFlows` is still fetching data.

<details>
<summary><strong>Key Changes</strong></summary>

• Import `Skeleton` from `@/components-v2/ui/skeleton.js` in `FunctionsTab`
• Render `<Skeleton className="w-full max-w-2xl h-50" />` when `loading` is true instead of plain text

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/pages/Integrations/providerConfigKey/Functions/Tab.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*