### PR TITLE
fix: unknown bearer token should return a 401

### DIFF
--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -45,7 +45,7 @@ export class AccessMiddleware {
         }
         const accountContext = await accountService.getAccountContextBySecretKey(secret);
         if (!accountContext) {
-            return Err('unknown_user_account');
+            return Err('unknown_account');
         }
 
         if (flagHasPlan && !accountContext.plan) {
@@ -113,7 +113,7 @@ export class AccessMiddleware {
 
         const accountContext = await accountService.getAccountContextByPublicKey(publicKey);
         if (!accountContext) {
-            return Err('unknown_user_account');
+            return Err('unknown_account');
         }
 
         if (flagHasPlan && !accountContext.plan) {

--- a/packages/server/lib/routes.integration.test.ts
+++ b/packages/server/lib/routes.integration.test.ts
@@ -58,4 +58,22 @@ describe('route', () => {
             });
         });
     });
+
+    describe('Authenticated endpoints', () => {
+        it('should return 401 if unknown bearer token', async () => {
+            const res = await fetch(`${api.url}/providers`, {
+                method: 'GET',
+                headers: { Authorization: `Bearer 00000000-0000-4000-8000-000000000000` }
+            });
+
+            expect(res.status).toBe(401);
+            expect(await res.json()).toStrictEqual({
+                error: {
+                    message: 'Authentication failed. The provided authorization header does not match any account.',
+                    code: 'unknown_account',
+                    payload: {}
+                }
+            });
+        });
+    });
 });

--- a/packages/server/lib/routes.integration.test.ts
+++ b/packages/server/lib/routes.integration.test.ts
@@ -69,7 +69,7 @@ describe('route', () => {
             expect(res.status).toBe(401);
             expect(await res.json()).toStrictEqual({
                 error: {
-                    message: 'Authentication failed. The provided authorization header does not match any account.',
+                    message: expect.any(String),
                     code: 'unknown_account',
                     payload: {}
                 }


### PR DESCRIPTION
unknown_user_account is not a known error code https://github.com/NangoHQ/nango/blob/85976c3ce6451660f17ef5f6847b3e833fccf5ad/packages/shared/lib/utils/error.ts#L51
hence the API returning a 500 status code instead of 401


<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

Secret and public key authentication failures now reuse the existing unknown_account error so the error manager responds with a 401, and an integration test against the /providers endpoint confirms the status code and payload for unknown bearer tokens.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced `unknown_user_account` with `unknown_account` in `packages/server/lib/middleware/access.middleware.ts` for secret and public key validation failures.
• Added an integration test in `packages/server/lib/routes.integration.test.ts` asserting a `401` with code `unknown_account` when an unrecognized bearer token is used.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/middleware/access.middleware.ts`
• `packages/server/lib/routes.integration.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*