### PR TITLE
fix(oauth): fix OAuth callback error page closing before error is visible

### DIFF
--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -1082,7 +1082,7 @@ class OAuthController {
             const err = new Error('No state found in callback');
 
             errorManager.report(err, { source: ErrorSourceEnum.PLATFORM, operation: LogActionEnum.AUTH });
-            authHtml({ res, error: err.message });
+            authHtml({ res, error: err.message, queryParams: req.query });
             return;
         }
 
@@ -1091,7 +1091,7 @@ class OAuthController {
             session = await oAuthSessionService.findById(state as string);
         } catch (err) {
             errorManager.report(err, { source: ErrorSourceEnum.PLATFORM, operation: LogActionEnum.AUTH });
-            authHtml({ res, error: 'invalid_oauth_state' });
+            authHtml({ res, error: 'invalid_oauth_state', queryParams: req.query });
             return;
         }
 
@@ -1099,7 +1099,7 @@ class OAuthController {
             const err = new Error(`No session found for state: ${JSON.stringify(state)}`);
 
             errorManager.report(err, { source: ErrorSourceEnum.PLATFORM, operation: LogActionEnum.AUTH });
-            authHtml({ res, error: err.message });
+            authHtml({ res, error: err.message, queryParams: req.query });
             return;
         } else {
             await oAuthSessionService.delete(state as string);


### PR DESCRIPTION
## Describe the problem and your solution

- previously, if an error happened during authorization, the callback page stayed hidden or disappeared too quickly, so users couldn’t see the error message. This change fixes that and also displays the query parameters, since error details can be returned here, making it easier to debug issues.

https://github.com/user-attachments/assets/8dc87884-a242-4820-a2c6-ec877161b4e0

This is the flow that displays the error after the changes.


https://github.com/user-attachments/assets/fc9b686f-cc6a-4075-807d-cedafbdc25a5


<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

It also ensures both the error message and serialized query parameters are HTML-escaped before rendering so the callback page shows them safely without introducing injection risks.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/utils/html.ts`
• `packages/server/lib/controllers/oauth.controller.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*