### PR TITLE
feat(webapp): add breadcrumbs

### DIFF
--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -48,7 +48,6 @@ const theme = createTheme({
     fontFamily: 'Inter'
 });
 
-// Wrapper component for conditional getting started route
 const GettingStartedRoute = () => {
     const showGettingStarted = useStore((state) => state.showGettingStarted);
 
@@ -65,7 +64,6 @@ const ActivityRedirect = () => {
     return <Navigate to={`/${env}/logs`} replace={true} />;
 };
 
-// Build routes - most routes are static, only auth routes depend on feature flag
 const buildRoutes = () => {
     const authRoutes = globalEnv.features.auth
         ? [
@@ -107,54 +105,84 @@ const buildRoutes = () => {
     return [
         {
             path: '/',
-            element: <Root />
+            element: <Root />,
+            handle: { breadcrumb: 'Home' }
         },
         {
             element: <PrivateRoute />,
             children: [
                 {
                     path: '/:env',
-                    element: <Homepage />
+                    element: <Homepage />,
+                    handle: {
+                        breadcrumb: 'Metrics'
+                    }
                 },
                 {
                     path: '/dev/getting-started',
-                    element: <GettingStartedRoute />
+                    element: <GettingStartedRoute />,
+                    handle: { breadcrumb: 'Getting Started' }
                 },
                 {
                     path: '/:env/integrations',
-                    element: <IntegrationsList />
-                },
-                {
-                    path: '/:env/integrations/create',
-                    element: <CreateIntegration />
-                },
-                {
-                    path: '/:env/integration/:providerConfigKey',
-                    element: <Navigate to={'/integrations'} />
-                },
-                {
-                    path: '/:env/integrations/:providerConfigKey/functions/:functionName',
-                    element: <FunctionsOne />
-                },
-                {
-                    path: '/:env/integrations/:providerConfigKey/*',
-                    element: <ShowIntegration />
+                    handle: { breadcrumb: 'Integrations' },
+                    children: [
+                        {
+                            index: true,
+                            element: <IntegrationsList />
+                        },
+                        {
+                            path: 'create',
+                            element: <CreateIntegration />,
+                            handle: { breadcrumb: 'Create Integration' }
+                        },
+                        {
+                            path: ':providerConfigKey',
+                            handle: {
+                                breadcrumb: (params: Record<string, string | undefined>) => params.providerConfigKey || 'Integration'
+                            },
+                            children: [
+                                {
+                                    index: true,
+                                    element: <ShowIntegration />
+                                },
+                                {
+                                    path: 'functions/:functionName',
+                                    element: <FunctionsOne />,
+                                    handle: { breadcrumb: (params: Record<string, string | undefined>) => params.functionName || 'Function' }
+                                },
+                                {
+                                    path: '*',
+                                    element: <ShowIntegration />
+                                }
+                            ]
+                        }
+                    ]
                 },
                 {
                     path: '/:env/connections',
-                    element: <ConnectionList />
-                },
-                {
-                    path: '/:env/connections/create',
-                    element: <ConnectionCreate />
-                },
-                {
-                    path: '/:env/connections/create-legacy',
-                    element: <ConnectionCreateLegacy />
-                },
-                {
-                    path: '/:env/connections/:providerConfigKey/:connectionId',
-                    element: <ConnectionShow />
+                    handle: { breadcrumb: 'Connections' },
+                    children: [
+                        {
+                            index: true,
+                            element: <ConnectionList />
+                        },
+                        {
+                            path: 'create',
+                            element: <ConnectionCreate />,
+                            handle: { breadcrumb: 'Create Connection' }
+                        },
+                        {
+                            path: 'create-legacy',
+                            element: <ConnectionCreateLegacy />,
+                            handle: { breadcrumb: 'Create Connection (Legacy)' }
+                        },
+                        {
+                            path: ':providerConfigKey/:connectionId',
+                            element: <ConnectionShow />,
+                            handle: { breadcrumb: (params: Record<string, string | undefined>) => params.connectionId || 'Connection' }
+                        }
+                    ]
                 },
                 {
                     path: '/:env/activity',
@@ -162,11 +190,13 @@ const buildRoutes = () => {
                 },
                 {
                     path: '/:env/logs',
-                    element: <LogsShow />
+                    element: <LogsShow />,
+                    handle: { breadcrumb: 'Logs' }
                 },
                 {
                     path: '/:env/environment-settings',
-                    element: <EnvironmentSettings />
+                    element: <EnvironmentSettings />,
+                    handle: { breadcrumb: 'Environment Settings' }
                 },
                 {
                     path: '/:env/project-settings',
@@ -178,15 +208,18 @@ const buildRoutes = () => {
                 },
                 {
                     path: '/:env/team-settings',
-                    element: <TeamSettings />
+                    element: <TeamSettings />,
+                    handle: { breadcrumb: 'Team Settings' }
                 },
                 {
                     path: '/:env/team/billing',
-                    element: <TeamBilling />
+                    element: <TeamBilling />,
+                    handle: { breadcrumb: 'Billing' }
                 },
                 {
                     path: '/:env/user-settings',
-                    element: <UserSettings />
+                    element: <UserSettings />,
+                    handle: { breadcrumb: 'User Settings' }
                 }
             ]
         },

--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -1,7 +1,7 @@
 import { MantineProvider, createTheme } from '@mantine/core';
 import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { useEffect, useRef } from 'react';
-import { Navigate, RouterProvider } from 'react-router-dom';
+import { Navigate, RouterProvider, useParams } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
 import { useLocalStorage } from 'react-use';
 import { SWRConfig } from 'swr';
@@ -58,6 +58,17 @@ const GettingStartedRoute = () => {
     }
 
     return globalEnv.isCloud ? <GettingStarted /> : <ClassicGettingStarted />;
+};
+
+const RedirectWithEnv = ({ path }: { path: string }) => {
+    const env = useStore((state) => state.env);
+    const params = useParams<Record<string, string>>();
+
+    const pathWithParams = Object.entries(params)
+        .filter(([_, value]) => value !== undefined)
+        .reduce((acc, [key, value]) => acc.replace(`:${key}`, value!), path);
+
+    return <Navigate to={`/${env}/${pathWithParams}`} replace />;
 };
 
 const router = sentryCreateBrowserRouter([
@@ -119,6 +130,10 @@ const router = sentryCreateBrowserRouter([
                 ]
             },
             {
+                path: '/:env/integration/:providerConfigKey',
+                element: <RedirectWithEnv path="integrations/:providerConfigKey" />
+            },
+            {
                 path: '/:env/connections',
                 handle: { breadcrumb: 'Connections' } as BreadcrumbHandle,
                 children: [
@@ -147,6 +162,10 @@ const router = sentryCreateBrowserRouter([
                 path: '/:env/logs',
                 element: <LogsShow />,
                 handle: { breadcrumb: 'Logs' } as BreadcrumbHandle
+            },
+            {
+                path: '/:env/activity',
+                element: <RedirectWithEnv path="logs" />
             },
             {
                 path: '/:env/environment-settings',

--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -42,6 +42,8 @@ import { LocalStorageKeys } from './utils/local-storage';
 import { sentryCreateBrowserRouter } from './utils/sentry';
 import { useSignout } from './utils/user';
 
+import type { BreadcrumbHandle } from './hooks/useBreadcrumbs';
+
 import 'react-toastify/dist/ReactToastify.css';
 
 const theme = createTheme({
@@ -105,8 +107,7 @@ const buildRoutes = () => {
     return [
         {
             path: '/',
-            element: <Root />,
-            handle: { breadcrumb: 'Home' }
+            element: <Root />
         },
         {
             element: <PrivateRoute />,
@@ -121,11 +122,11 @@ const buildRoutes = () => {
                 {
                     path: '/dev/getting-started',
                     element: <GettingStartedRoute />,
-                    handle: { breadcrumb: 'Getting Started' }
+                    handle: { breadcrumb: 'Getting started' } as BreadcrumbHandle
                 },
                 {
                     path: '/:env/integrations',
-                    handle: { breadcrumb: 'Integrations' },
+                    handle: { breadcrumb: 'Integrations' } as BreadcrumbHandle,
                     children: [
                         {
                             index: true,
@@ -134,13 +135,13 @@ const buildRoutes = () => {
                         {
                             path: 'create',
                             element: <CreateIntegration />,
-                            handle: { breadcrumb: 'Create Integration' }
+                            handle: { breadcrumb: 'Create Integration' } as BreadcrumbHandle
                         },
                         {
                             path: ':providerConfigKey',
                             handle: {
-                                breadcrumb: (params: Record<string, string | undefined>) => params.providerConfigKey || 'Integration'
-                            },
+                                breadcrumb: (params) => params.providerConfigKey || 'Integration'
+                            } as BreadcrumbHandle,
                             children: [
                                 {
                                     index: true,
@@ -149,7 +150,9 @@ const buildRoutes = () => {
                                 {
                                     path: 'functions/:functionName',
                                     element: <FunctionsOne />,
-                                    handle: { breadcrumb: (params: Record<string, string | undefined>) => params.functionName || 'Function' }
+                                    handle: {
+                                        breadcrumb: (params) => params.functionName || 'Function'
+                                    } as BreadcrumbHandle
                                 },
                                 {
                                     path: '*',
@@ -161,7 +164,7 @@ const buildRoutes = () => {
                 },
                 {
                     path: '/:env/connections',
-                    handle: { breadcrumb: 'Connections' },
+                    handle: { breadcrumb: 'Connections' } as BreadcrumbHandle,
                     children: [
                         {
                             index: true,
@@ -170,17 +173,17 @@ const buildRoutes = () => {
                         {
                             path: 'create',
                             element: <ConnectionCreate />,
-                            handle: { breadcrumb: 'Create Connection' }
+                            handle: { breadcrumb: 'Create Connection' } as BreadcrumbHandle
                         },
                         {
                             path: 'create-legacy',
                             element: <ConnectionCreateLegacy />,
-                            handle: { breadcrumb: 'Create Connection (Legacy)' }
+                            handle: { breadcrumb: 'Create Connection (Legacy)' } as BreadcrumbHandle
                         },
                         {
                             path: ':providerConfigKey/:connectionId',
                             element: <ConnectionShow />,
-                            handle: { breadcrumb: (params: Record<string, string | undefined>) => params.connectionId || 'Connection' }
+                            handle: { breadcrumb: (params) => params.connectionId || 'Connection' } as BreadcrumbHandle
                         }
                     ]
                 },
@@ -191,12 +194,12 @@ const buildRoutes = () => {
                 {
                     path: '/:env/logs',
                     element: <LogsShow />,
-                    handle: { breadcrumb: 'Logs' }
+                    handle: { breadcrumb: 'Logs' } as BreadcrumbHandle
                 },
                 {
                     path: '/:env/environment-settings',
                     element: <EnvironmentSettings />,
-                    handle: { breadcrumb: 'Environment Settings' }
+                    handle: { breadcrumb: 'Environment settings' } as BreadcrumbHandle
                 },
                 {
                     path: '/:env/project-settings',
@@ -209,17 +212,17 @@ const buildRoutes = () => {
                 {
                     path: '/:env/team-settings',
                     element: <TeamSettings />,
-                    handle: { breadcrumb: 'Team Settings' }
+                    handle: { breadcrumb: 'Team settings' } as BreadcrumbHandle
                 },
                 {
                     path: '/:env/team/billing',
                     element: <TeamBilling />,
-                    handle: { breadcrumb: 'Billing' }
+                    handle: { breadcrumb: 'Billing' } as BreadcrumbHandle
                 },
                 {
                     path: '/:env/user-settings',
                     element: <UserSettings />,
-                    handle: { breadcrumb: 'User Settings' }
+                    handle: { breadcrumb: 'User settings' } as BreadcrumbHandle
                 }
             ]
         },

--- a/packages/webapp/src/components-v2/AppHeader.tsx
+++ b/packages/webapp/src/components-v2/AppHeader.tsx
@@ -1,19 +1,23 @@
 import { BookOpen } from 'lucide-react';
 
+import { Breadcrumbs } from './Breadcrumbs';
 import { ButtonLink } from './ui/button';
 import { SlackIcon } from '@/assets/SlackIcon';
 
 export const AppHeader: React.FC = () => {
     return (
-        <header className="h-16 px-10 py-2.5 items-center flex justify-end shrink-0 gap-1.5">
-            <ButtonLink to="https://nango.dev/docs" target="_blank" variant="secondary" size="sm">
-                <BookOpen />
-                Docs
-            </ButtonLink>
-            <ButtonLink to="https://nango.dev/slack" target="_blank" variant="secondary" size="sm">
-                <SlackIcon />
-                Help
-            </ButtonLink>
+        <header className="h-16 px-10 py-2.5 items-center flex justify-between shrink-0 gap-1.5">
+            <Breadcrumbs />
+            <div className="flex gap-1.5 justify-end">
+                <ButtonLink to="https://nango.dev/docs" target="_blank" variant="secondary" size="sm">
+                    <BookOpen />
+                    Docs
+                </ButtonLink>
+                <ButtonLink to="https://nango.dev/slack" target="_blank" variant="secondary" size="sm">
+                    <SlackIcon />
+                    Help
+                </ButtonLink>
+            </div>
         </header>
     );
 };

--- a/packages/webapp/src/components-v2/AppHeader.tsx
+++ b/packages/webapp/src/components-v2/AppHeader.tsx
@@ -6,7 +6,7 @@ import { SlackIcon } from '@/assets/SlackIcon';
 
 export const AppHeader: React.FC = () => {
     return (
-        <header className="h-16 px-10 py-2.5 items-center flex justify-between shrink-0 gap-1.5">
+        <header className="h-16 px-10 pl-2 py-2.5 items-center flex justify-between shrink-0 gap-1.5">
             <Breadcrumbs />
             <div className="flex gap-1.5 justify-end">
                 <ButtonLink to="https://nango.dev/docs" target="_blank" variant="secondary" size="sm">

--- a/packages/webapp/src/components-v2/Breadcrumbs.tsx
+++ b/packages/webapp/src/components-v2/Breadcrumbs.tsx
@@ -1,0 +1,23 @@
+import { ChevronRight } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import { useBreadcrumbs } from '@/hooks/useBreadcrumbs';
+
+export const Breadcrumbs = () => {
+    const breadcrumbs = useBreadcrumbs();
+
+    return (
+        <div className="flex gap-1.5 items-center">
+            {breadcrumbs.map((breadcrumb) => (
+                <div className="group flex items-center gap-1.5" key={breadcrumb.path}>
+                    <Link to={breadcrumb.path} key={breadcrumb.path}>
+                        <span className="text-breadcrumb-default group-[&:last-child]:text-breadcrumb-press hover:text-breadcrumb-press transition-colors text-body-medium-medium">
+                            {breadcrumb.label}
+                        </span>
+                    </Link>
+                    <ChevronRight className="size-4 text-breadcrumb-default group-[&:last-child]:hidden" />
+                </div>
+            ))}
+        </div>
+    );
+};

--- a/packages/webapp/src/components-v2/Breadcrumbs.tsx
+++ b/packages/webapp/src/components-v2/Breadcrumbs.tsx
@@ -10,7 +10,7 @@ export const Breadcrumbs = () => {
         <div className="flex gap-1.5 items-center">
             {breadcrumbs.map((breadcrumb) => (
                 <div className="group flex items-center gap-1.5" key={breadcrumb.path}>
-                    <Link to={breadcrumb.path} key={breadcrumb.path}>
+                    <Link to={breadcrumb.path}>
                         <span className="text-breadcrumb-default group-[&:last-child]:text-breadcrumb-press hover:text-breadcrumb-press transition-colors text-body-medium-medium">
                             {breadcrumb.label}
                         </span>

--- a/packages/webapp/src/hooks/useBreadcrumbs.tsx
+++ b/packages/webapp/src/hooks/useBreadcrumbs.tsx
@@ -1,8 +1,5 @@
 import { useMatches } from 'react-router-dom';
 
-// Type for breadcrumb handle (for use in useBreadcrumbs hook)
-// - string: static breadcrumb label
-// - function: dynamic breadcrumb based on route params
 export interface BreadcrumbHandle {
     breadcrumb?: string | ((params: Record<string, string | undefined>) => string);
 }
@@ -12,18 +9,6 @@ export interface BreadcrumbItem {
     path: string;
 }
 
-/**
- * Hook to extract breadcrumbs from the current route matches.
- * Uses the `handle.breadcrumb` property from each matched route.
- *
- * @returns Array of breadcrumb items with label and path
- *
- * @example
- * ```tsx
- * const breadcrumbs = useBreadcrumbs();
- * // Returns: [{ label: 'Dashboard', path: '/dev' }, { label: 'Integrations', path: '/dev/integrations' }]
- * ```
- */
 export function useBreadcrumbs(): BreadcrumbItem[] {
     const matches = useMatches();
 
@@ -37,14 +22,12 @@ export function useBreadcrumbs(): BreadcrumbItem[] {
 
         let breadcrumb: string | undefined;
 
-        // Handle different breadcrumb types
         if (typeof handle.breadcrumb === 'string') {
             breadcrumb = handle.breadcrumb;
         } else if (typeof handle.breadcrumb === 'function') {
             breadcrumb = handle.breadcrumb(match.params as Record<string, string | undefined>);
         }
 
-        // Skip empty breadcrumbs
         if (!breadcrumb) {
             return;
         }

--- a/packages/webapp/src/hooks/useBreadcrumbs.tsx
+++ b/packages/webapp/src/hooks/useBreadcrumbs.tsx
@@ -1,0 +1,62 @@
+import { useMatches } from 'react-router-dom';
+
+// Type for breadcrumb handle (for use in useBreadcrumbs hook)
+// - string: static breadcrumb label
+// - function: dynamic breadcrumb based on route params
+export interface BreadcrumbHandle {
+    breadcrumb?: string | ((params: Record<string, string | undefined>) => string);
+}
+
+export interface BreadcrumbItem {
+    label: string;
+    path: string;
+}
+
+/**
+ * Hook to extract breadcrumbs from the current route matches.
+ * Uses the `handle.breadcrumb` property from each matched route.
+ *
+ * @returns Array of breadcrumb items with label and path
+ *
+ * @example
+ * ```tsx
+ * const breadcrumbs = useBreadcrumbs();
+ * // Returns: [{ label: 'Dashboard', path: '/dev' }, { label: 'Integrations', path: '/dev/integrations' }]
+ * ```
+ */
+export function useBreadcrumbs(): BreadcrumbItem[] {
+    const matches = useMatches();
+
+    const breadcrumbs: BreadcrumbItem[] = [];
+
+    matches.forEach((match) => {
+        const handle = match.handle as BreadcrumbHandle | undefined;
+        if (!handle?.breadcrumb) {
+            return;
+        }
+
+        let breadcrumb: string | undefined;
+
+        // Handle different breadcrumb types
+        if (typeof handle.breadcrumb === 'string') {
+            breadcrumb = handle.breadcrumb;
+        } else if (typeof handle.breadcrumb === 'function') {
+            breadcrumb = handle.breadcrumb(match.params as Record<string, string | undefined>);
+        }
+
+        // Skip empty breadcrumbs
+        if (!breadcrumb) {
+            return;
+        }
+
+        // Use the pathname from the match (it's already the full path)
+        const path = match.pathname || '/';
+
+        breadcrumbs.push({
+            label: breadcrumb,
+            path
+        });
+    });
+
+    return breadcrumbs;
+}

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -417,6 +417,11 @@ layer(base);
     --color-link-hover: var(--color-brand-500);
     --color-link-press: var(--color-brand-700);
     --color-link-disabled: var(--color-gray-700);
+
+    /* Breadcrumb */
+    --color-breadcrumb-default: var(--color-gray-700);
+    --color-breadcrumb-hover: var(--color-gray-900);
+    --color-breadcrumb-press: var(--color-gray-1000);
 }
 
 @layer theme {
@@ -515,6 +520,11 @@ layer(base);
             --color-link-hover: var(--color-brand-300);
             --color-link-press: var(--color-brand-500);
             --color-link-disabled: var(--color-gray-500);
+
+            /* Breadcrumb */
+            --color-breadcrumb-default: var(--color-gray-300);
+            --color-breadcrumb-hover: var(--color-gray-100);
+            --color-breadcrumb-press: var(--color-gray-50);
         }
     }
 }

--- a/packages/webapp/src/index.tsx
+++ b/packages/webapp/src/index.tsx
@@ -4,7 +4,6 @@ import posthog from 'posthog-js';
 import { PostHogProvider } from 'posthog-js/react';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
 
 import App from './App';
 import { ErrorBoundary } from './components/ErrorBoundary';
@@ -30,13 +29,11 @@ root.render(
     <React.StrictMode>
         <SentryErrorBoundary fallback={<ErrorBoundary />}>
             <PostHogProvider client={posthog}>
-                <BrowserRouter>
-                    <NuqsAdapter>
-                        <QueryClientProvider client={queryClient}>
-                            <App />
-                        </QueryClientProvider>
-                    </NuqsAdapter>
-                </BrowserRouter>
+                <NuqsAdapter>
+                    <QueryClientProvider client={queryClient}>
+                        <App />
+                    </QueryClientProvider>
+                </NuqsAdapter>
             </PostHogProvider>
         </SentryErrorBoundary>
     </React.StrictMode>

--- a/packages/webapp/src/utils/sentry.tsx
+++ b/packages/webapp/src/utils/sentry.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/react';
 import { useEffect } from 'react';
-import { Routes, createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-router-dom';
+import { createBrowserRouter, createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-router-dom';
 
 import { globalEnv } from './env';
 
@@ -23,6 +23,6 @@ Sentry.init({
     maxBreadcrumbs: 50
 });
 
-export const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
+export const sentryCreateBrowserRouter = Sentry.wrapCreateBrowserRouterV6(createBrowserRouter);
 
 export const SentryErrorBoundary = Sentry.ErrorBoundary;


### PR DESCRIPTION
This PR adds a breadcrumb system, displayed on the AppHeader.
To achieve so, I've refactored our routes to use the "Data mode" of react-router, replacing our current "Declarative mode" (jsx definitions), which allows us to leverage route handles.

This approach works for what we currently need, but I'm open to alternative suggestions.

<img width="1510" height="799" alt="image" src="https://github.com/user-attachments/assets/6c5753f4-3171-48ed-b086-e76f6951ce23" />
<img width="1510" height="799" alt="image" src="https://github.com/user-attachments/assets/9b13305f-dfaf-4589-b428-7daa815b3039" />
<img width="1510" height="803" alt="image" src="https://github.com/user-attachments/assets/7d9fdcd4-747d-455a-8562-1d3ce4b611c8" />
<!-- Summary by @propel-code-bot -->

---

The router is now instantiated through `sentryCreateBrowserRouter`, which drives a new `useBreadcrumbs` hook and `Breadcrumbs` component that derive labels from `useMatches`, with dedicated breadcrumb color tokens in `index.css` rounding out the visual styling.

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/webapp/src/App.tsx
• packages/webapp/src/index.tsx
• packages/webapp/src/components-v2/AppHeader.tsx
• packages/webapp/src/components-v2/Breadcrumbs.tsx
• packages/webapp/src/hooks/useBreadcrumbs.tsx
• packages/webapp/src/utils/sentry.tsx
• packages/webapp/src/index.css

</details>

---
*This summary was automatically generated by @propel-code-bot*