### PR TITLE
chore: replace xmldom with @xmldom/xmldom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15665,9 +15665,10 @@
             }
         },
         "node_modules/@xmldom/xmldom": {
-            "version": "0.8.10",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-            "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+            "version": "0.8.11",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+            "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -33487,15 +33488,6 @@
             "optional": true,
             "peer": true
         },
-        "node_modules/xmldom": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-            "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/xpath": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.33.tgz",
@@ -35872,6 +35864,7 @@
                 "@nangohq/nango-yaml": "file:../nango-yaml",
                 "@nangohq/providers": "file:../providers",
                 "@nangohq/utils": "file:../utils",
+                "@xmldom/xmldom": "0.8.11",
                 "ajv": "8.17.1",
                 "ajv-formats": "3.0.1",
                 "archiver": "7.0.1",
@@ -35895,7 +35888,6 @@
                 "undici": "6.21.2",
                 "uuid": "9.0.0",
                 "xml-crypto": "6.1.2",
-                "xmldom": "0.6.0",
                 "zod": "4.0.5"
             },
             "devDependencies": {

--- a/packages/shared/lib/auth/samlAssertion.ts
+++ b/packages/shared/lib/auth/samlAssertion.ts
@@ -1,8 +1,8 @@
 import { createPrivateKey } from 'crypto';
 
+import { DOMImplementation, XMLSerializer } from '@xmldom/xmldom';
 import { v4 as uuidv4 } from 'uuid';
 import { SignedXml } from 'xml-crypto';
-import { DOMImplementation, XMLSerializer } from 'xmldom';
 
 import { Err, Ok } from '@nangohq/utils';
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -49,7 +49,7 @@
         "undici": "6.21.2",
         "uuid": "9.0.0",
         "xml-crypto": "6.1.2",
-        "xmldom": "0.6.0",
+        "@xmldom/xmldom": "0.8.11",
         "zod": "4.0.5"
     },
     "devDependencies": {


### PR DESCRIPTION
## Describe the problem and your solution

- replace `xmldom` with `@xmldom/xmldom`

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

It also ensures the SAML assertion helper now imports DOM utilities from the maintained scoped package and refreshes the lockfile to drop the old dependency tree while pinning @xmldom/xmldom at version 0.8.11.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/package.json`
• `packages/shared/lib/auth/samlAssertion.ts`
• `package-lock.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*