### PR TITLE
fix(webapp): integrations screens feedback

### DIFF
--- a/packages/webapp/src/components-v2/ui/alert.tsx
+++ b/packages/webapp/src/components-v2/ui/alert.tsx
@@ -41,7 +41,7 @@ function AlertActions({ className, ...props }: React.ComponentProps<'div'>) {
     return (
         <div
             data-slot="alert-actions"
-            className={cn('col-start-3 row-start-1 row-span-2 inline-flex gap-1 text-body-medium-regular self-center', className)}
+            className={cn('col-start-3 row-start-1 row-span-2 inline-flex gap-3 text-body-medium-regular self-center', className)}
             {...props}
         />
     );

--- a/packages/webapp/src/pages/Integrations/components/jsonSchema/JsonSchema.tsx
+++ b/packages/webapp/src/pages/Integrations/components/jsonSchema/JsonSchema.tsx
@@ -11,7 +11,12 @@ import type { JSONSchema7, JSONSchema7Type } from 'json-schema';
 
 export const JsonSchemaTopLevelObject: React.FC<{ schema: JSONSchema7 }> = ({ schema }) => {
     if (!isObjectSchema(schema)) {
-        throw new Error('Expected object schema.');
+        return (
+            <div className="flex flex-col gap-1.5">
+                <CatalogBadge variant="light">{schema.type}</CatalogBadge>
+                {schema.description && <p className="text-text-tertiary text-body-small-medium">{schema.description}</p>}
+            </div>
+        );
     }
 
     return (

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -169,26 +169,36 @@ export const FunctionsOne: React.FC = () => {
                             )}
                         </div>
                         <TabsContent value="input" className="flex flex-col gap-4">
-                            <InfoCallout type={func.type as 'action' | 'sync'} variant="input" />
-                            {inputSchema ? <JsonSchemaTopLevelObject schema={inputSchema} /> : <EmptyCard content={`No inputs.`} />}
+                            {inputSchema ? (
+                                <>
+                                    <InfoCallout type={func.type as 'action' | 'sync'} variant="input" />
+                                    <JsonSchemaTopLevelObject schema={inputSchema} />
+                                </>
+                            ) : (
+                                <EmptyCard content={`No inputs.`} />
+                            )}
                         </TabsContent>
                         <TabsContent value="output" className="flex flex-col gap-4">
-                            <InfoCallout type={func.type as 'action' | 'sync'} variant="output" />
                             {outputSchemas && outputSchemas.length > 0 ? (
-                                <Navigation defaultValue={outputSchemas[0].name} orientation="horizontal">
-                                    <NavigationList>
+                                <>
+                                    <InfoCallout type={func.type as 'action' | 'sync'} variant="output" />
+                                    <Navigation defaultValue={outputSchemas[0].name} orientation="horizontal">
+                                        {outputSchemas.length > 1 && (
+                                            <NavigationList>
+                                                {outputSchemas.map((outputSchema) => (
+                                                    <NavigationTrigger key={outputSchema.name} value={outputSchema.name}>
+                                                        {outputSchema.name}
+                                                    </NavigationTrigger>
+                                                ))}
+                                            </NavigationList>
+                                        )}
                                         {outputSchemas.map((outputSchema) => (
-                                            <NavigationTrigger key={outputSchema.name} value={outputSchema.name}>
-                                                {outputSchema.name}
-                                            </NavigationTrigger>
+                                            <NavigationContent key={outputSchema.name} value={outputSchema.name}>
+                                                <JsonSchemaTopLevelObject schema={outputSchema.schema} />
+                                            </NavigationContent>
                                         ))}
-                                    </NavigationList>
-                                    {outputSchemas.map((outputSchema) => (
-                                        <NavigationContent key={outputSchema.name} value={outputSchema.name}>
-                                            <JsonSchemaTopLevelObject schema={outputSchema.schema} />
-                                        </NavigationContent>
-                                    ))}
-                                </Navigation>
+                                    </Navigation>
+                                </>
                             ) : (
                                 <EmptyCard content="No outputs." />
                             )}

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/components/IntegrationSideInfo.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/components/IntegrationSideInfo.tsx
@@ -1,5 +1,7 @@
+import { ExternalLink } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
 import { CopyButton } from '@/components-v2/CopyButton';
-import { StyledLink } from '@/components-v2/StyledLink';
 import { useApiStatus } from '@/hooks/useApiStatus';
 import { StatusWidget } from '@/pages/Integrations/components/StatusWidget';
 import { getDisplayName } from '@/pages/Integrations/utils';
@@ -30,9 +32,9 @@ export const IntegrationSideInfo: React.FC<{ integration: ApiIntegration; provid
             </InfoRow>
             <InfoRow label="API documentation">
                 <span className="text-text-primary text-body-medium-regular inline-flex flex-wrap items-baseline gap-1">
-                    <StyledLink to={provider.docs} icon type="external">
-                        {provider.display_name}
-                    </StyledLink>
+                    <Link to={provider.docs} target="_blank" className="group w-fit inline-flex items-center gap-1">
+                        {provider.display_name} <ExternalLink className="size-3.5 text-link-disabled group-hover:text-link-default" />
+                    </Link>
                 </span>
             </InfoRow>
             {apiStatus?.status && apiStatus?.status !== 'unknown' && (


### PR DESCRIPTION
Implementing some feedback received on the integration and function screens.

<!-- Summary by @propel-code-bot -->

---

**UI polish for integration function detail views**

Adjusts the integrations function detail screens to conditionally show callouts and schema navigation elements only when data is present, and updates documentation links to match design feedback. Also updates `JsonSchemaTopLevelObject` to gracefully handle top-level primitive schemas and tweaks alert action spacing.

<details>
<summary><strong>Key Changes</strong></summary>

• Wraps `InfoCallout` and `JsonSchemaTopLevelObject` in `Functions/One.tsx` so input/output tabs render callouts only when schemas exist, and hides the output navigation list when there is a single schema.
• Replaces `StyledLink` with a `Link` plus `ExternalLink` icon for API documentation in `IntegrationSideInfo.tsx`.
• Allows `JsonSchemaTopLevelObject` to render primitive schemas by showing a badge and optional description instead of throwing an error.
• Increases spacing between alert actions in `ui/alert.tsx` via the `AlertActions` component.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx`
• `packages/webapp/src/pages/Integrations/providerConfigKey/components/IntegrationSideInfo.tsx`
• `packages/webapp/src/pages/Integrations/components/jsonSchema/JsonSchema.tsx`
• `packages/webapp/src/components-v2/ui/alert.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*