### PR TITLE
fix(audit): ran `npm audit fix`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -354,31 +354,6 @@
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true
         },
-        "node_modules/@asamuzakjp/css-color": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-            "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@csstools/css-calc": "^2.1.3",
-                "@csstools/css-color-parser": "^3.0.9",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
-                "lru-cache": "^10.4.3"
-            }
-        },
-        "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true,
-            "license": "ISC",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/@aws-crypto/crc32": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
@@ -3591,131 +3566,6 @@
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/@csstools/color-helpers": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
-            "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT-0",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@csstools/css-calc": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.3.tgz",
-            "integrity": "sha512-XBG3talrhid44BY1x3MHzUx/aTG8+x/Zi57M4aTKK9RFB4aLlF3TTSzfzn8nWVHWL3FgAXAxmupmDd6VWww+pw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3"
-            }
-        },
-        "node_modules/@csstools/css-color-parser": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.9.tgz",
-            "integrity": "sha512-wILs5Zk7BU86UArYBJTPy/FMPPKVKHMj1ycCEyf3VUptol0JNRLFU/BZsJ4aiIHJEbSLiizzRrw8Pc1uAEDrXw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@csstools/color-helpers": "^5.0.2",
-                "@csstools/css-calc": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3"
-            }
-        },
-        "node_modules/@csstools/css-parser-algorithms": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-            "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@csstools/css-tokenizer": "^3.0.4"
-            }
-        },
-        "node_modules/@csstools/css-tokenizer": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-            "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/@dabh/diagnostics": {
@@ -11916,9 +11766,9 @@
             }
         },
         "node_modules/@redocly/cli/node_modules/undici": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.22.0.tgz",
-            "integrity": "sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw==",
+            "version": "6.23.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+            "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -17122,25 +16972,24 @@
             }
         },
         "node_modules/browserify-sign": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
-            "integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.5.tgz",
+            "integrity": "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "bn.js": "^5.2.1",
-                "browserify-rsa": "^4.1.0",
+                "bn.js": "^5.2.2",
+                "browserify-rsa": "^4.1.1",
                 "create-hash": "^1.2.0",
                 "create-hmac": "^1.1.7",
-                "elliptic": "^6.5.5",
-                "hash-base": "~3.0",
+                "elliptic": "^6.6.1",
                 "inherits": "^2.0.4",
-                "parse-asn1": "^5.1.7",
+                "parse-asn1": "^5.1.9",
                 "readable-stream": "^2.3.8",
                 "safe-buffer": "^5.2.1"
             },
             "engines": {
-                "node": ">= 0.12"
+                "node": ">= 0.10"
             }
         },
         "node_modules/browserify-sign/node_modules/isarray": {
@@ -18716,22 +18565,6 @@
                 "postcss-value-parser": "^4.0.2"
             }
         },
-        "node_modules/cssstyle": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.3.1.tgz",
-            "integrity": "sha512-ZgW+Jgdd7i52AaLYCriF8Mxqft0gD/R9i9wi6RWBhs1pqdPEzPjym7rvRKi397WmQFf3SlyUsszhw+VVCbx79Q==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@asamuzakjp/css-color": "^3.1.2",
-                "rrweb-cssom": "^0.8.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/csstype": {
             "version": "3.1.3",
             "dev": true,
@@ -18852,65 +18685,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
-            }
-        },
-        "node_modules/data-urls": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "whatwg-mimetype": "^4.0.0",
-                "whatwg-url": "^14.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/data-urls/node_modules/tr46": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "punycode": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/data-urls/node_modules/webidl-conversions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/data-urls/node_modules/whatwg-url": {
-            "version": "14.2.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "tr46": "^5.1.0",
-                "webidl-conversions": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/data-view-buffer": {
@@ -19153,15 +18927,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/decimal.js": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-            "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/decimal.js-light": {
             "version": "2.5.1",
             "dev": true,
@@ -19386,9 +19151,9 @@
             "integrity": "sha512-nMNZG0zfMgmdv8S5O0TM5cpwNbGKRGPCxVsr0SmA3NZZy9CYBbuNLL0PD3Acx9e5LIUgwONXtM9kM6RlawPxEQ=="
         },
         "node_modules/devalue": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.3.2.tgz",
-            "integrity": "sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
+            "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
             "dev": true,
             "license": "MIT"
         },
@@ -19402,7 +19167,9 @@
             }
         },
         "node_modules/diff": {
-            "version": "4.0.2",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+            "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
@@ -19823,21 +19590,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/entities": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
-            "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/env-cmd": {
@@ -22679,9 +22431,9 @@
             "license": "MIT"
         },
         "node_modules/hono": {
-            "version": "4.11.3",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.3.tgz",
-            "integrity": "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==",
+            "version": "4.11.5",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.5.tgz",
+            "integrity": "sha512-WemPi9/WfyMwZs+ZUXdiwcCh9Y+m7L+8vki9MzDw3jJ+W9Lc+12HGsd368Qc1vZi1xwW8BWMMsnK5efYKPdt4g==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -22705,21 +22457,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=14"
-            }
-        },
-        "node_modules/html-encoding-sniffer": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "whatwg-encoding": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/html-entities": {
@@ -23406,13 +23143,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-potential-custom-element-name": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/is-promise": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -23961,91 +23691,6 @@
                 }
             }
         },
-        "node_modules/jsdom": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-            "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "cssstyle": "^4.2.1",
-                "data-urls": "^5.0.0",
-                "decimal.js": "^10.5.0",
-                "html-encoding-sniffer": "^4.0.0",
-                "http-proxy-agent": "^7.0.2",
-                "https-proxy-agent": "^7.0.6",
-                "is-potential-custom-element-name": "^1.0.1",
-                "nwsapi": "^2.2.16",
-                "parse5": "^7.2.1",
-                "rrweb-cssom": "^0.8.0",
-                "saxes": "^6.0.0",
-                "symbol-tree": "^3.2.4",
-                "tough-cookie": "^5.1.1",
-                "w3c-xmlserializer": "^5.0.0",
-                "webidl-conversions": "^7.0.0",
-                "whatwg-encoding": "^3.1.1",
-                "whatwg-mimetype": "^4.0.0",
-                "whatwg-url": "^14.1.1",
-                "ws": "^8.18.0",
-                "xml-name-validator": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "canvas": "^3.0.0"
-            },
-            "peerDependenciesMeta": {
-                "canvas": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/jsdom/node_modules/tr46": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "punycode": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/jsdom/node_modules/webidl-conversions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/jsdom/node_modules/whatwg-url": {
-            "version": "14.2.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "tr46": "^5.1.0",
-                "webidl-conversions": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/jsep": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
@@ -24443,7 +24088,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24465,7 +24109,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24487,7 +24130,6 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24509,7 +24151,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24531,7 +24172,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24553,7 +24193,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24575,7 +24214,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24597,7 +24235,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24619,7 +24256,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24641,7 +24277,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -25526,9 +25161,9 @@
             }
         },
         "node_modules/minizlib": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
-            "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -26056,15 +25691,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/nwsapi": {
-            "version": "2.2.20",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
-            "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/oas-kit-common": {
             "version": "1.0.8",
@@ -26676,17 +26302,16 @@
             }
         },
         "node_modules/parse-asn1": {
-            "version": "5.1.7",
-            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
-            "integrity": "sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
+            "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "asn1.js": "^4.10.1",
                 "browserify-aes": "^1.2.0",
                 "evp_bytestokey": "^1.0.3",
-                "hash-base": "~3.0",
-                "pbkdf2": "^3.1.2",
+                "pbkdf2": "^3.1.5",
                 "safe-buffer": "^5.2.1"
             },
             "engines": {
@@ -26715,21 +26340,6 @@
             "license": "MIT",
             "dependencies": {
                 "xtend": "~4.0.1"
-            }
-        },
-        "node_modules/parse5": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "entities": "^6.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "node_modules/parseurl": {
@@ -26870,55 +26480,21 @@
             "version": "0.0.1"
         },
         "node_modules/pbkdf2": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
-            "integrity": "sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
+            "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "create-hash": "~1.1.3",
+                "create-hash": "^1.2.0",
                 "create-hmac": "^1.1.7",
-                "ripemd160": "=2.0.1",
+                "ripemd160": "^2.0.3",
                 "safe-buffer": "^5.2.1",
-                "sha.js": "^2.4.11",
-                "to-buffer": "^1.2.0"
+                "sha.js": "^2.4.12",
+                "to-buffer": "^1.2.1"
             },
             "engines": {
-                "node": ">=0.12"
-            }
-        },
-        "node_modules/pbkdf2/node_modules/create-hash": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-            "integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cipher-base": "^1.0.1",
-                "inherits": "^2.0.1",
-                "ripemd160": "^2.0.0",
-                "sha.js": "^2.4.0"
-            }
-        },
-        "node_modules/pbkdf2/node_modules/hash-base": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-            "integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.1"
-            }
-        },
-        "node_modules/pbkdf2/node_modules/ripemd160": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-            "integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "hash-base": "^2.0.0",
-                "inherits": "^2.0.1"
+                "node": ">= 0.10"
             }
         },
         "node_modules/perfect-scrollbar": {
@@ -28544,15 +28120,81 @@
             }
         },
         "node_modules/ripemd160": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-            "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+            "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1"
+                "hash-base": "^3.1.2",
+                "inherits": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 0.8"
             }
+        },
+        "node_modules/ripemd160/node_modules/hash-base": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+            "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.4",
+                "readable-stream": "^2.3.8",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/ripemd160/node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ripemd160/node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/ripemd160/node_modules/readable-stream/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ripemd160/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/ripemd160/node_modules/string_decoder/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/rollup": {
             "version": "4.53.2",
@@ -28642,15 +28284,6 @@
             "engines": {
                 "node": ">=16"
             }
-        },
-        "node_modules/rrweb-cssom": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-            "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/rsa-pem-from-mod-exp": {
             "version": "0.8.6",
@@ -28816,21 +28449,6 @@
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
             "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
             "license": "BlueOak-1.0.0"
-        },
-        "node_modules/saxes": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
-            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-            "dev": true,
-            "license": "ISC",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "xmlchars": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=v12.22.7"
-            }
         },
         "node_modules/scheduler": {
             "version": "0.23.2",
@@ -30444,13 +30062,6 @@
                 "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/symbol-tree": {
-            "version": "3.2.4",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/synckit": {
             "version": "0.11.8",
             "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
@@ -30529,17 +30140,16 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.4.3",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-            "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+            "version": "7.5.6",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
+            "integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/fs-minipass": "^4.0.0",
                 "chownr": "^3.0.0",
                 "minipass": "^7.1.2",
-                "minizlib": "^3.0.1",
-                "mkdirp": "^3.0.1",
+                "minizlib": "^3.1.0",
                 "yallist": "^5.0.0"
             },
             "engines": {
@@ -30579,22 +30189,6 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/tar/node_modules/mkdirp": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-            "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "mkdirp": "dist/cjs/src/bin.js"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/tar/node_modules/yallist": {
@@ -31009,30 +30603,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/tldts": {
-            "version": "6.1.86",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-            "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "tldts-core": "^6.1.86"
-            },
-            "bin": {
-                "tldts": "bin/cli.js"
-            }
-        },
-        "node_modules/tldts-core": {
-            "version": "6.1.86",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-            "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/tlhunter-sorted-set": {
             "version": "0.1.0",
             "license": "MIT"
@@ -31099,21 +30669,6 @@
             },
             "bin": {
                 "nodetouch": "bin/nodetouch.js"
-            }
-        },
-        "node_modules/tough-cookie": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-            "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "tldts": "^6.1.32"
-            },
-            "engines": {
-                "node": ">=16"
             }
         },
         "node_modules/tr46": {
@@ -32891,21 +32446,6 @@
             "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
             "dev": true
         },
-        "node_modules/w3c-xmlserializer": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
-            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "xml-name-validator": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/watchpack": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
@@ -33077,21 +32617,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
-            }
-        },
-        "node_modules/whatwg-encoding": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "iconv-lite": "0.6.3"
-            },
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/whatwg-mimetype": {
@@ -33449,18 +32974,6 @@
                 "node": ">=16"
             }
         },
-        "node_modules/xml-name-validator": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/xml2js": {
             "version": "0.5.0",
             "license": "MIT",
@@ -33478,15 +32991,6 @@
             "engines": {
                 "node": ">=4.0"
             }
-        },
-        "node_modules/xmlchars": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/xpath": {
             "version": "0.0.33",


### PR DESCRIPTION
I ran `npm audit fix` on the repo root to fix 4 vulnerabilities.

This operation should be safe, as-in it won't force versions that are outside of what our package.json specifies.

However, the diff is suspiciously large. I don't know why that is.

PTAL.

<!-- Summary by @propel-code-bot -->

---

The regenerated package-lock.json refreshes transitive dependencies via the audit fix and drops the jsdom-related optional packages from the dependency graph.

<details>
<summary><strong>Key Changes</strong></summary>

• Upgraded `browserify-sign` to `4.2.5` bringing newer `bn.js`, `browserify-rsa`, `elliptic`, and `parse-asn1` versions.
• Bumped utilities such as `devalue` (`5.6.2`), `diff` (`4.0.4`), `hono` (`4.11.5`), `minizlib` (`3.1.0`), `pbkdf2` (`3.1.5`), `ripemd160` (`2.0.3`), `tar` (`7.5.6`), and `undici` (`6.23.0`).
• Removed the `jsdom` dependency set (including `cssstyle`, `data-urls`, `html-encoding-sniffer`, `parse5`, `rrweb-cssom`, `tough-cookie`, `w3c-xmlserializer`, etc.), along with other optional peer-only packages.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `package-lock.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*