### PR TITLE
fix: don't allow empty value edits in integration settings

### DIFF
--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/getIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/getIntegration.ts
@@ -55,8 +55,8 @@ export const getIntegration = asyncWrapper<GetIntegration>(async (req, res) => {
         webhookSecret = crypto.createHash('sha256').update(hash).digest('hex');
     }
 
-    if (provider.auth_mode === 'CUSTOM' && integration.custom) {
-        integration.custom['private_key'] = Buffer.from(integration.custom['private_key'] as string, 'base64').toString('ascii');
+    if (provider.auth_mode === 'CUSTOM' && integration.custom?.['private_key'] && integration.custom?.['app_id']) {
+        integration.custom['private_key'] = Buffer.from(integration.custom['private_key'], 'base64').toString('ascii');
         const hash = `${integration.custom['app_id']}${integration.custom['private_key']}${integration.app_link}`;
         webhookSecret = crypto.createHash('sha256').update(hash).digest('hex');
     }

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/AppAuthSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/AppAuthSettings.tsx
@@ -6,7 +6,7 @@ import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components-v2/ui
 import { Label } from '@/components-v2/ui/label';
 import { apiPatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
-import { validateUrl } from '@/pages/Integrations/utils';
+import { validateNotEmpty, validateUrl } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
 import { defaultCallback } from '@/utils/utils';
 
@@ -60,7 +60,7 @@ export const AppAuthSettings: React.FC<{ data: GetIntegration['Success']['data']
                     <Label htmlFor="app_id">App ID</Label>
                     <InfoTooltip>Obtain the app id from the app page.</InfoTooltip>
                 </div>
-                <EditableInput initialValue={integration.oauth_client_id || ''} onSave={(value) => onSave({ appId: value })} />
+                <EditableInput initialValue={integration.oauth_client_id || ''} onSave={(value) => onSave({ appId: value })} validate={validateNotEmpty} />
             </div>
 
             {/* App Public Link */}

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/AppPrivateKeyInput.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/AppPrivateKeyInput.tsx
@@ -22,9 +22,6 @@ export const AppPrivateKeyInput: React.FC<AppPrivateKeyInputProps> = ({ initialV
                 initialValue={initialValue}
                 hintText='Private key must start with "-----BEGIN RSA PRIVATE KEY----" and end with "-----END RSA PRIVATE KEY-----"'
                 validate={(value) => {
-                    if (!value.trim()) {
-                        return 'Private key is required';
-                    }
                     if (!value.trim().startsWith('-----BEGIN RSA PRIVATE KEY----') || !value.trim().endsWith('-----END RSA PRIVATE KEY-----')) {
                         return 'Private key must start with "-----BEGIN RSA PRIVATE KEY----" and end with "-----END RSA PRIVATE KEY-----"';
                     }

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/CustomAuthSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/CustomAuthSettings.tsx
@@ -11,7 +11,7 @@ import { Label } from '@/components-v2/ui/label';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { apiPatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
-import { validateUrl } from '@/pages/Integrations/utils';
+import { validateNotEmpty, validateUrl } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
 import { defaultCallback } from '@/utils/utils';
 
@@ -91,7 +91,7 @@ export const CustomAuthSettings: React.FC<{ data: GetIntegration['Success']['dat
                     <Label htmlFor="app_id">App ID</Label>
                     <InfoTooltip>Obtain the app id from the app page.</InfoTooltip>
                 </div>
-                <EditableInput initialValue={integration.custom?.app_id || ''} onSave={(value) => onSave({ appId: value })} />
+                <EditableInput initialValue={integration.custom?.app_id || ''} onSave={(value) => onSave({ appId: value })} validate={validateNotEmpty} />
             </div>
 
             {/* App Public Link */}
@@ -107,7 +107,12 @@ export const CustomAuthSettings: React.FC<{ data: GetIntegration['Success']['dat
             <div className="flex flex-col gap-2">
                 <Label htmlFor="client_id">Client ID</Label>
                 <>
-                    <EditableInput initialValue={integration.oauth_client_id || ''} onSave={handleClientIdSave} onEditingChange={setIsEditingClientId} />
+                    <EditableInput
+                        initialValue={integration.oauth_client_id || ''}
+                        onSave={handleClientIdSave}
+                        onEditingChange={setIsEditingClientId}
+                        validate={validateNotEmpty}
+                    />
                     {isEditingClientId && hasExistingClientId && (
                         <Alert variant="warning">
                             <AlertTriangle />
@@ -122,7 +127,12 @@ export const CustomAuthSettings: React.FC<{ data: GetIntegration['Success']['dat
             {/* Client Secret */}
             <div className="flex flex-col gap-2">
                 <Label htmlFor="client_secret">Client Secret</Label>
-                <EditableInput secret initialValue={integration.oauth_client_secret || ''} onSave={(value) => onSave({ clientSecret: value })} />
+                <EditableInput
+                    secret
+                    initialValue={integration.oauth_client_secret || ''}
+                    onSave={(value) => onSave({ clientSecret: value })}
+                    validate={validateNotEmpty}
+                />
             </div>
 
             {/* App Private Key */}

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/GeneralSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/GeneralSettings.tsx
@@ -12,6 +12,7 @@ import { Switch } from '@/components-v2/ui/switch';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { apiPatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
+import { validateNotEmpty } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
 
 import type { ApiEnvironment, GetIntegration, PatchIntegration } from '@nangohq/types';
@@ -72,7 +73,11 @@ export const GeneralSettings: React.FC<{ data: GetIntegration['Success']['data']
             {/* Display name */}
             <div className="flex flex-col gap-2">
                 <Label htmlFor="display_name">Display name</Label>
-                <EditableInput initialValue={integration.display_name || template.display_name} onSave={(value) => onSave({ displayName: value })} />
+                <EditableInput
+                    initialValue={integration.display_name || template.display_name}
+                    onSave={(value) => onSave({ displayName: value })}
+                    validate={validateNotEmpty}
+                />
             </div>
 
             {/* Integration ID */}

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/InstallPluginSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/InstallPluginSettings.tsx
@@ -2,7 +2,7 @@ import { EditableInput } from '@/components-v2/EditableInput';
 import { Label } from '@/components-v2/ui/label';
 import { apiPatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
-import { validateUrl } from '@/pages/Integrations/utils';
+import { validateNotEmpty, validateUrl } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
 
 import type { ApiEnvironment, GetIntegration, PatchIntegration, ProviderInstallPlugin } from '@nangohq/types';
@@ -42,13 +42,23 @@ export const InstallPluginSettings: React.FC<{ data: GetIntegration['Success']['
                     {/* Username */}
                     <div className="flex flex-col gap-2">
                         <Label htmlFor="username">Username</Label>
-                        <EditableInput secret initialValue={integration.custom?.['username'] || ''} onSave={(value) => onSave({ username: value } as any)} />
+                        <EditableInput
+                            secret
+                            initialValue={integration.custom?.['username'] || ''}
+                            onSave={(value) => onSave({ username: value } as any)}
+                            validate={validateNotEmpty}
+                        />
                     </div>
 
                     {/* Password */}
                     <div className="flex flex-col gap-2">
                         <Label htmlFor="password">Password</Label>
-                        <EditableInput secret initialValue={integration.custom?.['password'] || ''} onSave={(value) => onSave({ password: value } as any)} />
+                        <EditableInput
+                            secret
+                            initialValue={integration.custom?.['password'] || ''}
+                            onSave={(value) => onSave({ password: value } as any)}
+                            validate={validateNotEmpty}
+                        />
                     </div>
                 </>
             )}

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/McpGenericSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/McpGenericSettings.tsx
@@ -4,7 +4,7 @@ import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components-v2/ui
 import { Label } from '@/components-v2/ui/label';
 import { apiPatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
-import { validateUrl } from '@/pages/Integrations/utils';
+import { validateNotEmpty, validateUrl } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
 import { defaultCallback } from '@/utils/utils';
 
@@ -49,13 +49,21 @@ export const McpGenericSettings: React.FC<{ data: GetIntegration['Success']['dat
             {/* OAuth Client Name */}
             <div className="flex flex-col gap-2">
                 <Label htmlFor="client_name">OAuth Client Name</Label>
-                <EditableInput initialValue={integration.custom?.oauth_client_name || ''} onSave={(value) => onSave({ clientName: value })} />
+                <EditableInput
+                    initialValue={integration.custom?.oauth_client_name || ''}
+                    onSave={(value) => onSave({ clientName: value })}
+                    validate={validateNotEmpty}
+                />
             </div>
 
             {/* OAuth Client URI */}
             <div className="flex flex-col gap-2">
                 <Label htmlFor="client_uri">OAuth Client URI</Label>
-                <EditableInput initialValue={integration.custom?.oauth_client_uri || ''} onSave={(value) => onSave({ clientUri: value })} />
+                <EditableInput
+                    initialValue={integration.custom?.oauth_client_uri || ''}
+                    onSave={(value) => onSave({ clientUri: value })}
+                    validate={validateNotEmpty}
+                />
             </div>
 
             {/* OAuth Client Logo URI */}

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuthSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuthSettings.tsx
@@ -11,6 +11,7 @@ import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { apiPatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
 import { NangoProvidedInput } from '@/pages/Integrations/components/NangoProvidedInput';
+import { validateNotEmpty } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
 import { defaultCallback } from '@/utils/utils';
 
@@ -108,7 +109,12 @@ export const OAuthSettings: React.FC<{ data: GetIntegration['Success']['data']; 
                     <NangoProvidedInput fakeValueSize={24} />
                 ) : (
                     <>
-                        <EditableInput initialValue={integration.oauth_client_id || ''} onSave={handleClientIdSave} onEditingChange={setIsEditingClientId} />
+                        <EditableInput
+                            initialValue={integration.oauth_client_id || ''}
+                            onSave={handleClientIdSave}
+                            onEditingChange={setIsEditingClientId}
+                            validate={validateNotEmpty}
+                        />
                         {isEditingClientId && hasExistingClientId && (
                             <Alert variant="warning">
                                 <AlertTriangle />
@@ -127,7 +133,12 @@ export const OAuthSettings: React.FC<{ data: GetIntegration['Success']['data']; 
                 {isSharedCredentials ? (
                     <NangoProvidedInput fakeValueSize={48} />
                 ) : (
-                    <EditableInput secret initialValue={integration.oauth_client_secret || ''} onSave={(value) => onSave({ clientSecret: value })} />
+                    <EditableInput
+                        secret
+                        initialValue={integration.oauth_client_secret || ''}
+                        onSave={(value) => onSave({ clientSecret: value })}
+                        validate={validateNotEmpty}
+                    />
                 )}
             </div>
 

--- a/packages/webapp/src/pages/Integrations/utils.ts
+++ b/packages/webapp/src/pages/Integrations/utils.ts
@@ -42,3 +42,10 @@ export function validateUrl(value: string): string | null {
         return message;
     }
 }
+
+export function validateNotEmpty(value: string): string | null {
+    if (value.trim() === '') {
+        return 'Must not be empty';
+    }
+    return null;
+}


### PR DESCRIPTION
In integration settings, when trying to clear a field that had a value, saving would fail in the backend. That's because our validation schemas, despite being optional (can be omitted), isn't nullable (values can't be cleared), and requires a string with minimum length of 1. Example:
```ts
export const integrationAuthTypeOAuthSchema = z
    .object({
        authType: z.enum(['OAUTH1', 'OAUTH2', 'TBA']),
        clientId: z.string().min(1).max(255).optional(),
        clientSecret: z.string().min(1).optional(),
        scopes: scopesSchema
    })
    .strict();
```

Ideally, I wanted to allow the users to clear fields by:
- Making the backend validation schemas `.nullable()`.
- Sending any empty strings as `null` from the frontend.

However, making these types nullable has all sorts of effects throughout the code-base (lots of things break).
To avoid unforeseen side-effects, I'm left with 2 options:
1. Removing the `.min()` validation and allowing empty strings to be saved.
   > Saving empty strings could still have unforeseen side-effects.
2. Simply don't allow empty strings to be saved. One can create an integration with empty values initially (those are saved as `null` by `POST /integrations`), but he can't edit a field to be empty later (because `PATCH /integrations` doesn't allow it).
   > This is the same behavior as the one we had before redesigning. It's safer and the user abilities are unchanged from before the redesign.
   
So this PR is solution 2.

<!-- Summary by @propel-code-bot -->

---

The update formalizes this behavior by adding a shared validateNotEmpty helper that is applied across the integration credential inputs and by tightening the server controller to skip decoding custom private keys unless the required fields are present.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `validateNotEmpty` utility and applied it to credential inputs in `InstallPluginSettings.tsx`, `McpGenericSettings.tsx`, `CustomAuthSettings.tsx`, `OAuthSettings.tsx`, `AppAuthSettings.tsx`, and `GeneralSettings.tsx`
• Adjusted `AppPrivateKeyInput.tsx` validation to rely on format checking while still failing empty input via the existing prefix/suffix check
• Updated `packages/server/lib/controllers/v1/integrations/providerConfigKey/getIntegration.ts` to decode custom `private_key` only when both `private_key` and `app_id` exist

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components
• packages/webapp/src/pages/Integrations/utils.ts
• packages/server/lib/controllers/v1/integrations/providerConfigKey/getIntegration.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*