### PR TITLE
fix(webflow): webflow not in draft

### DIFF
--- a/scripts/webflow-api-sync.ts
+++ b/scripts/webflow-api-sync.ts
@@ -168,7 +168,7 @@ for (const [slug, provider] of Object.entries(neededProviders)) {
 
             try {
                 if (!dryRun) {
-                    await webflow.collections.items.updateItem(apiCollectionId, item.id, update);
+                    await webflow.collections.items.updateItem(apiCollectionId, item.id, { isDraft: false, ...update });
                 }
 
                 console.log(`Updated ${slug} ${dryRun ? '(dry run)' : ''}`);
@@ -184,6 +184,7 @@ for (const [slug, provider] of Object.entries(neededProviders)) {
 
             if (!dryRun) {
                 await webflow.collections.items.createItem(apiCollectionId, {
+                    isDraft: false,
                     fieldData: {
                         name: provider.display_name,
                         slug: slug,
@@ -221,7 +222,7 @@ for (const [slug, provider] of Object.entries(neededProviders)) {
                     };
 
                     if (!dryRun) {
-                        await webflow.collections.items.updateItem(apiCollectionId, foundInOriginal.id, update);
+                        await webflow.collections.items.updateItem(apiCollectionId, foundInOriginal.id, { isDraft: false, ...update });
                     }
                     console.log(`Updated ${slug} ${dryRun ? '(dry run)' : ''}`);
                     await setTimeout(rateLimitSleep);


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Ensure Webflow sync publishes items instead of leaving drafts**

Updates the Webflow sync script so that both item creation and item updates explicitly set `isDraft` to `false`. This ensures all synced Webflow CMS items are published when the script runs outside of dry-run mode.

<details>
<summary><strong>Key Changes</strong></summary>

• Set `isDraft` to `false` when updating existing items in `scripts/webflow-api-sync.ts`
• Set `isDraft` to `false` when creating new items in `scripts/webflow-api-sync.ts`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• scripts/webflow-api-sync.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*