### PR TITLE
fix(deps): Undepend from vulnerable `qs` lib version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16129,7 +16129,6 @@
             "version": "4.10.1",
             "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
             "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bn.js": "^4.0.0",
@@ -16141,7 +16140,6 @@
             "version": "4.12.2",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
             "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/assertion-error": {
@@ -16190,7 +16188,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
             "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-            "dev": true,
             "dependencies": {
                 "possible-typed-array-names": "^1.0.0"
             },
@@ -16490,7 +16487,6 @@
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
             "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/body-parser": {
@@ -16913,14 +16909,12 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
             "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/browserify-aes": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "buffer-xor": "^1.0.3",
@@ -16935,7 +16929,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
             "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "browserify-aes": "^1.0.4",
@@ -16947,7 +16940,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
             "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cipher-base": "^1.0.1",
@@ -16960,7 +16952,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
             "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bn.js": "^5.2.1",
@@ -16975,7 +16966,6 @@
             "version": "4.2.5",
             "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.5.tgz",
             "integrity": "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "bn.js": "^5.2.2",
@@ -16996,14 +16986,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/browserify-sign/node_modules/readable-stream": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -17019,14 +17007,12 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/browserify-sign/node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
@@ -17036,7 +17022,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/browserslist": {
@@ -17115,7 +17100,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
             "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/buildcheck": {
@@ -17211,7 +17195,6 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
             "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-            "dev": true,
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.0",
                 "es-define-property": "^1.0.0",
@@ -17457,7 +17440,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
             "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.4",
@@ -18435,7 +18417,6 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
             "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bn.js": "^4.1.0",
@@ -18446,14 +18427,12 @@
             "version": "4.12.2",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
             "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/create-hash": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cipher-base": "^1.0.1",
@@ -18467,7 +18446,6 @@
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cipher-base": "^1.0.3",
@@ -18507,7 +18485,6 @@
             "version": "3.12.1",
             "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
             "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "browserify-cipher": "^1.0.1",
@@ -19009,7 +18986,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
             "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-            "dev": true,
             "dependencies": {
                 "es-define-property": "^1.0.0",
                 "es-errors": "^1.3.0",
@@ -19189,7 +19165,6 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bn.js": "^4.1.0",
@@ -19201,7 +19176,6 @@
             "version": "4.12.2",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
             "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/docker-compose": {
@@ -19536,7 +19510,6 @@
             "version": "6.6.1",
             "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
             "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bn.js": "^4.11.9",
@@ -19552,7 +19525,6 @@
             "version": "4.12.2",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
             "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/emoji-regex": {
@@ -20854,7 +20826,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "md5.js": "^1.3.4",
@@ -21494,7 +21465,6 @@
         },
         "node_modules/for-each": {
             "version": "0.3.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-callable": "^1.1.3"
@@ -22306,7 +22276,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
             "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-            "dev": true,
             "dependencies": {
                 "es-define-property": "^1.0.0"
             },
@@ -22357,7 +22326,6 @@
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
             "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.4",
@@ -22371,7 +22339,6 @@
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
             "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.3",
@@ -22409,7 +22376,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
             "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "hash.js": "^1.0.3",
@@ -22909,7 +22875,6 @@
         },
         "node_modules/is-callable": {
             "version": "1.2.7",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -23269,7 +23234,6 @@
             "version": "1.1.15",
             "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
             "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-            "dev": true,
             "dependencies": {
                 "which-typed-array": "^1.1.16"
             },
@@ -23605,10 +23569,9 @@
             }
         },
         "node_modules/js-base64": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
-            "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==",
-            "dev": true,
+            "version": "3.7.7",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+            "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/js-cookie": {
@@ -25001,7 +24964,6 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
             "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "hash-base": "^3.0.0",
@@ -25055,7 +25017,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
             "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bn.js": "^4.0.0",
@@ -25069,7 +25030,6 @@
             "version": "4.12.2",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
             "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/mime-db": {
@@ -25133,7 +25093,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
             "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/minimatch": {
@@ -26305,7 +26264,6 @@
             "version": "5.1.9",
             "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
             "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "asn1.js": "^4.10.1",
@@ -26485,7 +26443,6 @@
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
             "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "create-hash": "^1.2.0",
@@ -26717,7 +26674,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
             "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -27061,7 +27017,6 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
             "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bn.js": "^4.1.0",
@@ -27076,7 +27031,6 @@
             "version": "4.12.2",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
             "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/pump": {
@@ -27145,7 +27099,6 @@
         },
         "node_modules/randombytes": {
             "version": "2.1.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "^5.1.0"
@@ -27155,7 +27108,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
             "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "randombytes": "^2.0.5",
@@ -28125,7 +28077,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
             "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "hash-base": "^3.1.2",
@@ -28139,7 +28090,6 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
             "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.4",
@@ -28155,14 +28105,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/ripemd160/node_modules/readable-stream": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -28178,14 +28126,12 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/ripemd160/node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
@@ -28195,7 +28141,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/rollup": {
@@ -28801,7 +28746,6 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
             "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-            "dev": true,
             "dependencies": {
                 "define-data-property": "^1.1.4",
                 "es-errors": "^1.3.0",
@@ -28859,7 +28803,6 @@
             "version": "2.4.12",
             "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
             "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
-            "dev": true,
             "license": "(MIT AND BSD-3-Clause)",
             "dependencies": {
                 "inherits": "^2.0.4",
@@ -30622,7 +30565,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
             "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "isarray": "^2.0.5",
@@ -30637,7 +30579,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
             "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/to-regex-range": {
@@ -31174,7 +31115,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
             "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-            "dev": true,
             "dependencies": {
                 "call-bound": "^1.0.3",
                 "es-errors": "^1.3.0",
@@ -32484,17 +32424,16 @@
             "license": "Apache-2.0"
         },
         "node_modules/webflow-api": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/webflow-api/-/webflow-api-3.1.3.tgz",
-            "integrity": "sha512-BF0AdAAQwoDuug7oyeqERXo2eBn1HuMieU/3//OxHxLkIyD7W0QEsH1NnaY0sSmStb5R3HPKBup7B+KktrSuiA==",
-            "dev": true,
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/webflow-api/-/webflow-api-3.2.1.tgz",
+            "integrity": "sha512-NvBH15JPvVIdKHEDpzKzrJWnJytwqaBuUDVxlhW91fgK5hSr9kXrD3t67ZqIS1zzi3AnnGSVJl/sauJS0TqBDg==",
             "dependencies": {
-                "crypto-browserify": "^3.12.0",
+                "crypto-browserify": "^3.12.1",
                 "form-data": "^4.0.0",
                 "formdata-node": "^6.0.3",
-                "js-base64": "3.7.2",
-                "node-fetch": "2.7.0",
-                "qs": "6.11.2",
+                "js-base64": "3.7.7",
+                "node-fetch": "^2.7.0",
+                "qs": "^6.13.1",
                 "readable-stream": "^4.5.2",
                 "url-join": "4.0.1"
             }
@@ -32503,33 +32442,15 @@
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-6.0.3.tgz",
             "integrity": "sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 18"
-            }
-        },
-        "node_modules/webflow-api/node_modules/qs": {
-            "version": "6.11.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
-            "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "side-channel": "^1.0.4"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/webflow-api/node_modules/readable-stream": {
             "version": "4.5.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
             "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "abort-controller": "^3.0.0",
@@ -32734,7 +32655,6 @@
             "version": "1.1.18",
             "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
             "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
-            "dev": true,
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
                 "call-bind": "^1.0.8",
@@ -35394,6 +35314,7 @@
                 "simple-oauth2": "5.1.0",
                 "undici": "6.21.2",
                 "uuid": "9.0.0",
+                "webflow-api": "^3.2.1",
                 "xml-crypto": "6.1.2",
                 "zod": "4.0.5"
             },
@@ -36191,7 +36112,7 @@
                 "git-cliff": "2.10.0",
                 "js-yaml": "4.1.1",
                 "semver": "^7.7.2",
-                "webflow-api": "3.1.3",
+                "webflow-api": "^3.2.1",
                 "zx": "8.8.5"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -35314,7 +35314,7 @@
                 "simple-oauth2": "5.1.0",
                 "undici": "6.21.2",
                 "uuid": "9.0.0",
-                "webflow-api": "^3.2.1",
+                "webflow-api": "3.2.1",
                 "xml-crypto": "6.1.2",
                 "zod": "4.0.5"
             },
@@ -36112,7 +36112,7 @@
                 "git-cliff": "2.10.0",
                 "js-yaml": "4.1.1",
                 "semver": "^7.7.2",
-                "webflow-api": "^3.2.1",
+                "webflow-api": "3.2.1",
                 "zx": "8.8.5"
             }
         },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -49,7 +49,7 @@
         "simple-oauth2": "5.1.0",
         "undici": "6.21.2",
         "uuid": "9.0.0",
-        "webflow-api": "^3.2.1",
+        "webflow-api": "3.2.1",
         "xml-crypto": "6.1.2",
         "zod": "4.0.5"
     },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -26,6 +26,7 @@
         "@nangohq/nango-yaml": "file:../nango-yaml",
         "@nangohq/providers": "file:../providers",
         "@nangohq/utils": "file:../utils",
+        "@xmldom/xmldom": "0.8.11",
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
         "archiver": "7.0.1",
@@ -48,8 +49,8 @@
         "simple-oauth2": "5.1.0",
         "undici": "6.21.2",
         "uuid": "9.0.0",
+        "webflow-api": "^3.2.1",
         "xml-crypto": "6.1.2",
-        "@xmldom/xmldom": "0.8.11",
         "zod": "4.0.5"
     },
     "devDependencies": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -10,7 +10,7 @@
         "git-cliff": "2.10.0",
         "js-yaml": "4.1.1",
         "semver": "^7.7.2",
-        "webflow-api": "^3.2.1",
+        "webflow-api": "3.2.1",
         "zx": "8.8.5"
     }
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -10,7 +10,7 @@
         "git-cliff": "2.10.0",
         "js-yaml": "4.1.1",
         "semver": "^7.7.2",
-        "webflow-api": "3.1.3",
+        "webflow-api": "^3.2.1",
         "zx": "8.8.5"
     }
 }


### PR DESCRIPTION
We depend on a 'high' vulnerability in `qs` via `webflow-api`.

I updated webflow-api to its latest version in `shared` and `scripts`.

This fixes the 'high' severity vulnerability and leaves us with:

> 15 vulnerabilities (5 low, 7 moderate, 3 high)

This was done via `npm i webflow-api@latest` in `shared/` and in `scripts/`.

No files were manually edited.

Unit and integration tests ran.
<!-- Summary by @propel-code-bot -->

---

The dependency bump pins `webflow-api` at version 3.2.1 and includes a refreshed root lockfile so the patched `qs` range and its related transitive updates—such as `crypto-browserify`, `js-base64`, and `node-fetch`—are captured.

---
*This summary was automatically generated by @propel-code-bot*