### PR TITLE
feat: Add new tags columns to connect and connect sessions

### DIFF
--- a/packages/database/lib/migrations/20260120193001_connect_sessions_add_tags.cjs
+++ b/packages/database/lib/migrations/20260120193001_connect_sessions_add_tags.cjs
@@ -1,0 +1,31 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.schema.alterTable('connect_sessions', (table) => {
+        table.jsonb('tags').notNullable().defaultTo('{}');
+    });
+    await knex.schema.alterTable('_nango_connections', (table) => {
+        table.jsonb('tags').notNullable().defaultTo('{}');
+    });
+
+    await knex.raw(`CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_connect_sessions_tags" ON "connect_sessions" USING GIN ("tags")`);
+    await knex.raw(`CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_nango_connections_tags" ON "_nango_connections" USING GIN ("tags")`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS "idx_connect_sessions_tags"`);
+    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS "idx_nango_connections_tags"`);
+
+    await knex.schema.alterTable('connect_sessions', (table) => {
+        table.dropColumn('tags');
+    });
+    await knex.schema.alterTable('_nango_connections', (table) => {
+        table.dropColumn('tags');
+    });
+};


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add `tags` JSONB columns with GIN indexes to connections tables**

Adds a migration that introduces non-null `jsonb` `tags` columns to both `connect_sessions` and `_nango_connections`. The migration also creates GIN indexes on the new columns and drops them on rollback.

<details>
<summary><strong>Key Changes</strong></summary>

• Adds `jsonb` `tags` column with default `'{}'` to `connect_sessions`
• Adds `jsonb` `tags` column with default `'{}'` to `_nango_connections`
• Creates concurrent GIN indexes on the new `tags` columns and drops them in `exports.down`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/database/lib/migrations/20260120193001_connect_sessions_add_tags.cjs`

</details>

---
*This summary was automatically generated by @propel-code-bot*