### PR TITLE
feat(connect-ui): mobile friendly

### DIFF
--- a/packages/connect-ui/src/components/Layout.tsx
+++ b/packages/connect-ui/src/components/Layout.tsx
@@ -47,11 +47,11 @@ export const Layout: React.FC = () => {
 
     return (
         <div
-            className={`absolute h-screen w-screen overflow-hidden flex flex-col justify-center items-center p-14 ${isAuthLink ? (isDarkTheme ? 'bg-black' : 'bg-gray-100') : 'bg-subtle/80'}`}
+            className={`absolute h-screen w-screen overflow-hidden flex flex-col justify-center items-center sm:p-14 ${isAuthLink ? (isDarkTheme ? 'bg-black' : 'bg-gray-100') : 'bg-subtle/80'}`}
         >
-            <div ref={ref} className="flex flex-col w-[500px] h-[700px] rounded-md bg-elevated p-px overflow-hidden">
-                <div className="flex-1 w-full bg-surface text-text-primary rounded-md -only:rounded-b-none overflow-y-auto">
-                    <div className="min-h-full p-10 flex flex-col">
+            <div ref={ref} className="flex flex-col w-full h-full sm:w-[500px] sm:h-[700px] sm:rounded-md bg-elevated p-px overflow-hidden">
+                <div className="flex-1 w-full bg-surface text-text-primary sm:rounded-md -only:rounded-b-none overflow-y-auto">
+                    <div className="min-h-full p-5 sm:p-10 flex flex-col">
                         <Outlet />
                     </div>
                 </div>


### PR DESCRIPTION
Essentially, up to sm (640px):
- Removed wrapper padding
- Reduced inner padding
- Removed rounded borders

https://github.com/user-attachments/assets/1d3279c0-994c-48e1-917e-b5fe46e4a2a2

<!-- Summary by @propel-code-bot -->

---

These adjustments also let the connect UI stretch to the full viewport on sub-sm screens, keeping the experience intentionally mobile-friendly.

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/connect-ui/src/components/Layout.tsx

</details>

---
*This summary was automatically generated by @propel-code-bot*