### PR TITLE
feat(integrations): add refresh_token override for workday

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -16131,6 +16131,13 @@ workday-oauth:
             example: yourtenant
             order: 2
             doc_section: '#step-3-finding-your-tenant'
+        oauth_refresh_token_override:
+            type: string
+            title: Refresh Token
+            example: Your Refresh Token
+            description: The Refresh Token for your Client
+            optional: true
+
 wrike:
     display_name: Wrike
     categories:


### PR DESCRIPTION
## Describe the problem and your solution

- add `refresh_token` override for workday in `providers.yaml`.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This introduces an optional `oauth_refresh_token_override` value in the Workday connection configuration, letting teams supply a refresh token directly in the config while leaving other providers untouched.

---
*This summary was automatically generated by @propel-code-bot*