### PR TITLE
feat(webapp): add hash navigation to env settings

### DIFF
--- a/packages/webapp/src/pages/Environment/Settings/Show.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Show.tsx
@@ -15,6 +15,7 @@ import { useStore } from '../../../store';
 import { Navigation, NavigationContent, NavigationList, NavigationTrigger } from '@/components-v2/Navigation';
 import { Badge } from '@/components-v2/ui/badge';
 import { Skeleton } from '@/components-v2/ui/skeleton';
+import { useHashNavigation } from '@/hooks/useHashNavigation';
 
 import type { ReactNode } from 'react';
 
@@ -31,6 +32,7 @@ export const EnvironmentSettings: React.FC = () => {
     const { team } = useTeam(env);
 
     const { environmentAndAccount } = useEnvironment(env);
+    const [activeTab, setActiveTab] = useHashNavigation('general');
 
     if (!environmentAndAccount || !team) {
         return (
@@ -67,7 +69,7 @@ export const EnvironmentSettings: React.FC = () => {
                 </div>
             </div>
             <div className="flex h-fit justify-center" key={env}>
-                <Navigation defaultValue="general" className="max-w-[1153px] mx-auto 4xl:max-w-full">
+                <Navigation value={activeTab} onValueChange={setActiveTab} className="max-w-[1153px] mx-auto 4xl:max-w-full">
                     <NavigationList className="w-[209px] 4xl:w-[236px]">
                         <NavigationTrigger value="general">General</NavigationTrigger>
                         <NavigationTrigger value="backend">Backend</NavigationTrigger>


### PR DESCRIPTION
Allows us to link directly to a specific tab, eg:
http://localhost:3000/dev/environment-settings#backend
http://localhost:3000/dev/environment-settings#connect-ui

I might have broken this when I decoupled hash navigation from the Navigation component.

<!-- Summary by @propel-code-bot -->

---

The EnvironmentSettings navigation now consumes the useHashNavigation-provided active tab state so that tab selections update the URL hash and stay synchronized with direct links.

<details>
<summary><strong>Key Changes</strong></summary>

• Imported `useHashNavigation` into `packages/webapp/src/pages/Environment/Settings/Show.tsx`.
• Initialized `[activeTab, setActiveTab]` with `useHashNavigation('general')` to track tab selection via the URL hash.
• Replaced the `defaultValue` prop on `Navigation` with `value`/`onValueChange` bound to the hash-managed state.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/pages/Environment/Settings/Show.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*