### PR TITLE
fix(jobs): pass NANGO_CONNECT_UI_PORT to Kubernetes runner pods

### DIFF
--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -424,7 +424,8 @@ class Kubernetes {
             { name: 'DD_TRACE_ENABLED', value: String(node.isTracingEnabled || node.isProfilingEnabled) },
             { name: 'JOBS_SERVICE_URL', value: getJobsUrl() },
             { name: 'PROVIDERS_URL', value: getProvidersUrl() },
-            { name: 'PROVIDERS_RELOAD_INTERVAL', value: envs.PROVIDERS_RELOAD_INTERVAL.toString() }
+            { name: 'PROVIDERS_RELOAD_INTERVAL', value: envs.PROVIDERS_RELOAD_INTERVAL.toString() },
+            { name: 'NANGO_CONNECT_UI_PORT', value: envs.NANGO_CONNECT_UI_PORT.toString() }
         ];
     }
 


### PR DESCRIPTION
Kubernetes runner pods crash on startup:
```
ubuntu@prod1:~$ kubectl logs -n nango production-runner-account-default-k8s-12-9bc98666-9xv2s
file:///app/nango/packages/utils/dist/environment/parse.js:403
        throw new Error(`Missing or invalid env vars: ${zodErrorToString(res.error.issues)}`);
              ^

Error: Missing or invalid env vars: NANGO_CONNECT_UI_PORT (invalid_type Invalid input: expected number, received NaN)
    at parseEnvs (file:///app/nango/packages/utils/dist/environment/parse.js:403:15)
    at file:///app/nango/packages/logs/dist/env.js:4:21
    at ModuleJob.run (node:internal/modules/esm/module_job:343:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:665:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
```

seems like `getEnvironmentVariables` in `packages/jobs/lib/runner/kubernetes.ts` doesn't pass `NANGO_CONNECT_UI_PORT` to dynamically created runner pods, which causes `parseEnvs` to fail.

