### PR TITLE
feat(webapp): hide breadcrumb when single

### DIFF
--- a/packages/webapp/src/components-v2/Breadcrumbs.tsx
+++ b/packages/webapp/src/components-v2/Breadcrumbs.tsx
@@ -6,6 +6,11 @@ import { useBreadcrumbs } from '@/hooks/useBreadcrumbs';
 export const Breadcrumbs = () => {
     const breadcrumbs = useBreadcrumbs();
 
+    // Single breadcrumbs are redundant
+    if (breadcrumbs.length <= 1) {
+        return <div />;
+    }
+
     return (
         <div className="flex gap-1.5 items-center">
             {breadcrumbs.map((breadcrumb) => (


### PR DESCRIPTION
When in top-level routes, breadcrumbs are redundant.
Feedback from Gabrielle.

<!-- Summary by @propel-code-bot -->

---

**Hide `Breadcrumbs` component when only one item**

Adds an early return in the `Breadcrumbs` component to suppress rendering when only a single breadcrumb is available. Prevents redundant UI on top-level routes by skipping the breadcrumb trail entirely in that scenario.

<details>
<summary><strong>Key Changes</strong></summary>

• Added guard in `Breadcrumbs` to exit early when `breadcrumbs.length <= 1`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/webapp/src/components-v2/Breadcrumbs.tsx

</details>

---
*This summary was automatically generated by @propel-code-bot*