### PR TITLE
feat(webapp): add `nango clone` snippet to template funcitons

### DIFF
--- a/packages/webapp/src/components-v2/LineSnippet.tsx
+++ b/packages/webapp/src/components-v2/LineSnippet.tsx
@@ -1,0 +1,10 @@
+import { CopyButton } from './CopyButton';
+
+export const LineSnippet: React.FC<{ snippet: string }> = ({ snippet }) => {
+    return (
+        <div className="inline-flex items-center justify-between gap-2 min-w-100 h-10 p-4 rounded-sm bg-bg-elevated border border-border-disabled ">
+            <span className="text-text-secondary text-body-medium-regular">{snippet}</span>
+            <CopyButton text={snippet} />
+        </div>
+    );
+};

--- a/packages/webapp/src/constants.ts
+++ b/packages/webapp/src/constants.ts
@@ -1,1 +1,2 @@
 export const PROD_ENVIRONMENT_NAME = 'prod';
+export const INTEGRATION_TEMPLATES_GITHUB_URL = 'https://github.com/NangoHQ/integration-templates';

--- a/packages/webapp/src/pages/Integrations/components/CardLayout.tsx
+++ b/packages/webapp/src/pages/Integrations/components/CardLayout.tsx
@@ -6,6 +6,10 @@ export const CardHeader: React.FC<{ children: React.ReactNode }> = ({ children }
     return <header className="flex flex-col gap-6 px-11 py-8 bg-bg-elevated border border-b-0 border-border-muted rounded-t-md">{children}</header>;
 };
 
+export const CardSubheader: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    return <div className="p-11 bg-bg-subtle border-x border-border-muted">{children}</div>;
+};
+
 export const CardContent: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     return <div className="px-11 py-8 border border-t-0 border-border-muted rounded-b-md">{children}</div>;
 };

--- a/packages/webapp/src/pages/Integrations/components/FunctionSwitch.tsx
+++ b/packages/webapp/src/pages/Integrations/components/FunctionSwitch.tsx
@@ -135,18 +135,16 @@ export const FunctionSwitch: React.FC<{
                 e.stopPropagation();
             }}
         >
-            <div>
-                <Switch
-                    name="script"
-                    checked={flow.enabled === true}
-                    className="cursor-pointer"
-                    disabled={loading}
-                    onClick={(e) => {
-                        e.preventDefault();
-                        toggleSync();
-                    }}
-                />
-            </div>
+            <Switch
+                name="script"
+                checked={flow.enabled === true}
+                className="cursor-pointer"
+                disabled={loading}
+                onClick={(e) => {
+                    e.preventDefault();
+                    toggleSync();
+                }}
+            />
             {flow.type === 'action' && loading && <Loader2 className="animate-spin size-4" />}
             {DialogComponent}
         </div>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -1,9 +1,9 @@
 import { ExternalLink, Info } from 'lucide-react';
 import { useMemo } from 'react';
 import { Helmet } from 'react-helmet';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 
-import { CardContent, CardHeader, CardLayout } from '../../components/CardLayout';
+import { CardContent, CardHeader, CardLayout, CardSubheader } from '../../components/CardLayout';
 import { EmptyCard } from '../../components/EmptyCard';
 import { FunctionSwitch } from '../../components/FunctionSwitch';
 import { IntegrationsBadge } from '../../components/IntegrationsBadge';
@@ -11,6 +11,7 @@ import { JsonSchemaTopLevelObject } from '../../components/jsonSchema/JsonSchema
 import { isNullSchema, isObjectWithNoProperties } from '../../components/jsonSchema/utils';
 import { CopyButton } from '@/components-v2/CopyButton';
 import { IntegrationLogo } from '@/components-v2/IntegrationLogo';
+import { LineSnippet } from '@/components-v2/LineSnippet';
 import { Navigation, NavigationContent, NavigationList, NavigationTrigger } from '@/components-v2/Navigation';
 import { StyledLink } from '@/components-v2/StyledLink';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components-v2/Tabs';
@@ -32,9 +33,10 @@ export const FunctionsOne: React.FC = () => {
     const { data: integrationData, loading: integrationLoading } = useGetIntegration(env, providerConfigKey!);
     const { data, loading: flowsLoading } = useGetIntegrationFlows(env, providerConfigKey!);
 
-    const func = useMemo(() => {
-        return data?.flows.find((flow) => flow.name === functionName);
-    }, [data, functionName]);
+    const func = data?.flows.find((flow) => flow.name === functionName);
+
+    const gitDir = func ? `${integrationData?.integration.provider}/${func.type === 'action' ? 'actions' : 'syncs'}/${func.name}` : '';
+    const gitUrl = `https://github.com/NangoHQ/integration-templates/tree/main/integrations/${gitDir}.ts`;
 
     const inputSchema: JSONSchema7 | null = useMemo(() => {
         if (!func || !func.input || !func.json_schema) {
@@ -149,6 +151,29 @@ export const FunctionsOne: React.FC = () => {
                         {func.scopes && func.scopes.length > 0 && <IntegrationsBadge label="Required scopes">{func.scopes?.join(', ')}</IntegrationsBadge>}
                     </div>
                 </CardHeader>
+
+                {func.pre_built && (
+                    <CardSubheader>
+                        <div className="flex items-center justify-between gap-2">
+                            <div className="flex flex-col gap-1">
+                                <span className="text-text-primary text-body-medium-semi">Customize this template</span>
+                                <Link
+                                    to="https://nango.dev/docs/reference/cli"
+                                    type="external"
+                                    className="text-text-tertiary text-body-medium-medium inline-flex items-center gap-1.5"
+                                >
+                                    Get started with the Nango CLI <ExternalLink className="size-3.5" />
+                                </Link>
+                            </div>
+                            <div className="inline-flex gap-3">
+                                <LineSnippet snippet={`nango clone ${gitDir}`} />
+                                <ButtonLink to={gitUrl} target="_blank" variant="secondary" size="lg">
+                                    View code <ExternalLink />
+                                </ButtonLink>
+                            </div>
+                        </div>
+                    </CardSubheader>
+                )}
 
                 <CardContent>
                     <Tabs value={activeTab} onValueChange={setActiveTab} className="gap-4">

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -18,6 +18,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components-v2/Tabs';
 import { Alert, AlertDescription } from '@/components-v2/ui/alert';
 import { ButtonLink } from '@/components-v2/ui/button';
 import { Skeleton } from '@/components-v2/ui/skeleton';
+import { INTEGRATION_TEMPLATES_GITHUB_URL } from '@/constants';
 import { useHashNavigation } from '@/hooks/useHashNavigation';
 import { useGetIntegration, useGetIntegrationFlows } from '@/hooks/useIntegration';
 import DashboardLayout from '@/layout/DashboardLayout';
@@ -34,9 +35,6 @@ export const FunctionsOne: React.FC = () => {
     const { data, loading: flowsLoading } = useGetIntegrationFlows(env, providerConfigKey!);
 
     const func = data?.flows.find((flow) => flow.name === functionName);
-
-    const gitDir = func ? `${integrationData?.integration.provider}/${func.type === 'action' ? 'actions' : 'syncs'}/${func.name}` : '';
-    const gitUrl = `https://github.com/NangoHQ/integration-templates/tree/main/integrations/${gitDir}.ts`;
 
     const inputSchema: JSONSchema7 | null = useMemo(() => {
         if (!func || !func.input || !func.json_schema) {
@@ -83,17 +81,15 @@ export const FunctionsOne: React.FC = () => {
                 <CardLayout>
                     <CardHeader>
                         <div className="flex items-center justify-between gap-2">
-                            <div className="inline-flex gap-2">
+                            <div className="inline-flex items-center gap-2.5">
                                 <Skeleton className="bg-bg-subtle size-10.5" />
-                                <div className="flex flex-col gap-1">
-                                    <Skeleton className="bg-bg-subtle w-36 h-5" />
-                                    <Skeleton className="bg-bg-subtle w-24 h-4" />
-                                </div>
+                                <Skeleton className="bg-bg-subtle w-36 h-5" />
+                                <Skeleton className="bg-bg-subtle w-24 h-4" />
                             </div>
                             <Skeleton className="bg-bg-subtle w-8 h-5" />
                         </div>
-                        <Skeleton className="bg-bg-subtle w-full h-6" />
                         <Skeleton className="bg-bg-subtle w-1/2 h-6" />
+                        <Skeleton className="bg-bg-subtle w-full h-6" />
                     </CardHeader>
                     <CardContent>
                         <Skeleton className="bg-bg-subtle w-full h-50" />
@@ -106,6 +102,9 @@ export const FunctionsOne: React.FC = () => {
     if (!func || !integrationData) {
         return <PageNotFound />;
     }
+
+    const gitDir = `${integrationData?.integration.provider}/${func.type === 'action' ? 'actions' : 'syncs'}/${func.name}`;
+    const gitUrl = `${INTEGRATION_TEMPLATES_GITHUB_URL}/tree/main/integrations/${gitDir}.ts`;
 
     return (
         <DashboardLayout>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -114,20 +114,20 @@ export const FunctionsOne: React.FC = () => {
             <CardLayout>
                 <CardHeader>
                     <div className="flex items-center justify-between gap-2">
-                        <div className="inline-flex gap-2">
+                        <div className="inline-flex items-center gap-2.5">
                             <IntegrationLogo provider={integrationData?.integration.provider} className="size-10.5" />
-                            <div className="flex flex-col gap-0.5">
-                                <span className="text-text-primary text-body-medium-semi">
-                                    {integrationData.integration.display_name ?? integrationData.template.display_name}
-                                </span>
-                                <div className="inline-flex gap-1">
-                                    <span className="text-text-secondary text-body-medium-regular font-mono">{func.name}</span>
-                                    <CopyButton text={func.name} />
-                                </div>
+                            <span className="text-text-primary text-body-large-semi">
+                                {integrationData.integration.display_name ?? integrationData.template.display_name}
+                            </span>
+                            <div className="inline-flex gap-1">
+                                <span className="text-text-secondary text-body-medium-regular font-mono">{func.name}</span>
+                                <CopyButton text={func.name} />
                             </div>
                         </div>
                         <FunctionSwitch flow={func} integration={integrationData.integration} />
                     </div>
+
+                    <span className="text-text-secondary text-body-medium-medium">{func.description}</span>
 
                     <div className="flex flex-wrap gap-4 gap-y-2">
                         <IntegrationsBadge label="Type">
@@ -148,7 +148,6 @@ export const FunctionsOne: React.FC = () => {
                         {func.version && <IntegrationsBadge label="Version">v{func.version}</IntegrationsBadge>}
                         {func.scopes && func.scopes.length > 0 && <IntegrationsBadge label="Required scopes">{func.scopes?.join(', ')}</IntegrationsBadge>}
                     </div>
-                    <span className="text-text-tertiary text-body-medium-medium">{func.description}</span>
                 </CardHeader>
 
                 <CardContent>
@@ -159,11 +158,11 @@ export const FunctionsOne: React.FC = () => {
                                 <TabsTrigger value="output">Output</TabsTrigger>
                             </TabsList>
                             {func.type === 'action' ? (
-                                <ButtonLink variant="primary" to="https://nango.dev/docs/guides/use-cases/actions" target="_blank">
+                                <ButtonLink variant="tertiary" to="https://nango.dev/docs/guides/use-cases/actions" target="_blank">
                                     How to use Actions <ExternalLink />
                                 </ButtonLink>
                             ) : (
-                                <ButtonLink variant="primary" to="https://nango.dev/docs/guides/use-cases/syncs" target="_blank">
+                                <ButtonLink variant="tertiary" to="https://nango.dev/docs/guides/use-cases/syncs" target="_blank">
                                     How to use Syncs <ExternalLink />
                                 </ButtonLink>
                             )}

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -158,7 +158,7 @@ export const FunctionsOne: React.FC = () => {
                                 <span className="text-text-primary text-body-medium-semi">Customize this template</span>
                                 <Link
                                     to="https://nango.dev/docs/reference/cli"
-                                    type="external"
+                                    target="_blank"
                                     className="text-text-tertiary text-body-medium-medium inline-flex items-center gap-1.5"
                                 >
                                     Get started with the Nango CLI <ExternalLink className="size-3.5" />


### PR DESCRIPTION
Adds `nango clone` snippet and link to view code in repo for template functions.

Also, did a few updated in the header as requested by Gabrielle.

<img width="1099" height="658" alt="Screenshot 2026-01-26 at 15 53 28" src="https://github.com/user-attachments/assets/f24d0cf0-45d2-4359-9429-c2de764ab54c" />
<!-- Summary by @propel-code-bot -->

---

It also introduces a reusable LineSnippet component and restructures the function detail card layout with an optional subheader to present guidance content more cleanly.

<details>
<summary><strong>Key Changes</strong></summary>

• Added new `LineSnippet` component with inline copy support for displaying command snippets
• Exposed `INTEGRATION_TEMPLATES_GITHUB_URL` in `packages/webapp/src/constants.ts` for constructing repository links
• Refactored `packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx` to render the CLI snippet, external doc links, and adjusted typography/layout for pre-built templates
• Introduced `CardSubheader` in `packages/webapp/src/pages/Integrations/components/CardLayout.tsx` to separate supplementary guidance from primary headers
• Simplified `packages/webapp/src/pages/Integrations/components/FunctionSwitch.tsx` switch markup while preserving existing behavior

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx`
• `packages/webapp/src/pages/Integrations/components/CardLayout.tsx`
• `packages/webapp/src/components-v2/LineSnippet.tsx`
• `packages/webapp/src/pages/Integrations/components/FunctionSwitch.tsx`
• `packages/webapp/src/constants.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*