### PR TITLE
fix(publish): update providers package meta info for trusted publishing

### DIFF
--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -7,6 +7,11 @@
     "typings": "./dist/index.d.ts",
     "private": false,
     "scripts": {},
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/NangoHQ/nango.git",
+        "directory": "packages/providers"
+    },
     "dependencies": {
         "js-yaml": "4.1.1"
     },


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add repository metadata to providers package**

Updates `packages/providers/package.json` to include a `repository` block so the `@nangohq/providers` package exposes the required metadata for trusted publishing flows. No runtime logic or dependency changes are involved.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `repository.type`, `repository.url`, and `repository.directory` entries to `packages/providers/package.json` for the providers package.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/providers/package.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*