### PR TITLE
feat(checkpoint): add checkpoint data model

### DIFF
--- a/packages/database/lib/migrations/20260127120000_create_checkpoints_table.cjs
+++ b/packages/database/lib/migrations/20260127120000_create_checkpoints_table.cjs
@@ -1,0 +1,37 @@
+const CHECKPOINTS_TABLE = 'checkpoints';
+
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`
+        CREATE TABLE IF NOT EXISTS ${CHECKPOINTS_TABLE} (
+            id SERIAL PRIMARY KEY,
+            environment_id INTEGER NOT NULL REFERENCES _nango_environments(id) ON DELETE CASCADE,
+            key VARCHAR(255) NOT NULL,
+            checkpoint JSONB NOT NULL DEFAULT '{}',
+            version INTEGER NOT NULL DEFAULT 1,
+            created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            deleted_at TIMESTAMP WITH TIME ZONE DEFAULT NULL,
+            UNIQUE(environment_id, key)
+        )
+    `);
+
+    // Index to optimize prefix searches on the 'key' column
+    // Note: The UNIQUE(environment_id, key) constraint already creates an index for exact lookups
+    // This is useful for queries that look for keys starting with a certain prefix
+    // e.g., WHERE key LIKE 'prefix%'
+    await knex.raw(`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_checkpoints_key_prefix
+            ON ${CHECKPOINTS_TABLE}
+            USING BTREE (environment_id, key varchar_pattern_ops)
+    `);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -39,6 +39,7 @@ export * from './services/proxy/utils.js';
 export * from './services/proxy/request.js';
 export * from './services/plans/plans.js';
 export * from './services/plans/definitions.js';
+export * from './services/checkpoints/checkpoints.js';
 export * from './services/shared-credentials.service.js';
 export * as connectUISettingsService from './services/connect-ui-settings.service.js';
 export { deployTemplate, upgradeTemplate } from './services/deploy/template.js';

--- a/packages/shared/lib/services/checkpoints/checkpoints.integration.test.ts
+++ b/packages/shared/lib/services/checkpoints/checkpoints.integration.test.ts
@@ -1,0 +1,263 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import db, { multipleMigrations } from '@nangohq/database';
+
+import { deleteCheckpoint, getCheckpoint, hardDeleteCheckpointsByPrefix, upsertCheckpoint } from './checkpoints.js';
+import { createAccount } from '../../seeders/account.seeder.js';
+import { createEnvironmentSeed } from '../../seeders/environment.seeder.js';
+
+describe('Checkpoint service', () => {
+    let environmentId: number;
+
+    beforeAll(async () => {
+        await multipleMigrations();
+        const account = await createAccount();
+        const environment = await createEnvironmentSeed(account.id);
+        environmentId = environment.id;
+    });
+
+    describe('upsertCheckpoint', () => {
+        it('should create a new checkpoint with version 1', async () => {
+            const key = 'connection:1:function:1';
+            const checkpoint = { cursor: 'abc123', page: 1, hasMore: true };
+
+            const res = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint })).unwrap();
+
+            expect(res.environment_id).toBe(environmentId);
+            expect(res.key).toBe(key);
+            expect(res.checkpoint).toEqual(checkpoint);
+            expect(res.version).toBe(1);
+            expect(res.deleted_at).toBeNull();
+            expect(res.created_at).toBeDefined();
+            expect(res.updated_at).toBeDefined();
+        });
+
+        it('should fail to update existing checkpoint without expectedVersion', async () => {
+            const key = 'connection:2:function:2';
+            const initialCheckpoint = { page: 1 };
+            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: initialCheckpoint })).unwrap();
+            expect(created.version).toBe(1);
+
+            const updatedCheckpoint = { page: 2, cursor: 'new-cursor' };
+            const result = await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: updatedCheckpoint });
+
+            expect(result.isErr()).toBe(true);
+            if (result.isErr()) {
+                expect(result.error.message).toBe('checkpoint_conflict');
+            }
+        });
+
+        it('should update existing checkpoint with correct expectedVersion', async () => {
+            const key = 'connection:3:function:3';
+            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { page: 1 } })).unwrap();
+            expect(created.version).toBe(1);
+
+            const updatedCheckpoint = { page: 2 };
+            const res = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: updatedCheckpoint, expectedVersion: 1 })).unwrap();
+
+            expect(res.checkpoint).toEqual(updatedCheckpoint);
+            expect(res.version).toBe(2);
+        });
+
+        it('should fail to update with wrong expectedVersion', async () => {
+            const key = 'connection:4:function:4';
+            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { page: 1 } })).unwrap();
+            expect(created.version).toBe(1);
+
+            const result = await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { page: 2 }, expectedVersion: 99 });
+
+            expect(result.isErr()).toBe(true);
+            if (result.isErr()) {
+                expect(result.error.message).toBe('checkpoint_conflict');
+            }
+        });
+
+        it('should fail to resurrect deleted checkpoint with wrong expectedVersion', async () => {
+            const key = 'connection:5:function:5';
+            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { page: 1 } })).unwrap();
+            await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: created.version });
+
+            // After delete, version is 2. Trying with wrong version should fail.
+            const result = await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { page: 2 }, expectedVersion: 1 });
+
+            expect(result.isErr()).toBe(true);
+            if (result.isErr()) {
+                expect(result.error.message).toBe('checkpoint_conflict');
+            }
+        });
+
+        it('should resurrect deleted checkpoint with correct expectedVersion', async () => {
+            const key = 'connection:6:function:6';
+            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { page: 1 } })).unwrap();
+            await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: created.version });
+
+            // After delete, version is 2. Providing correct version should resurrect.
+            const res = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { page: 99 }, expectedVersion: 2 })).unwrap();
+
+            expect(res.checkpoint).toEqual({ page: 99 });
+            expect(res.deleted_at).toBeNull();
+            expect(res.version).toBe(3);
+        });
+
+        it('should fail to upsert deleted checkpoint without expectedVersion', async () => {
+            const key = 'connection:7:function:7';
+            const initialCheckpoint = { page: 1 };
+            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: initialCheckpoint })).unwrap();
+            await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: created.version });
+
+            // Without expectedVersion, should fail even for deleted checkpoints
+            const result = await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { page: 99 } });
+
+            expect(result.isErr()).toBe(true);
+            if (result.isErr()) {
+                expect(result.error.message).toBe('checkpoint_conflict');
+            }
+        });
+
+        it('should reject overly long keys', async () => {
+            const key = 'k'.repeat(300);
+            const checkpoint = { test: true };
+
+            const result = await upsertCheckpoint(db.knex, { environmentId, key, checkpoint });
+            expect(result.isErr()).toBe(true);
+            if (result.isErr()) {
+                expect(result.error.message).toBe('checkpoint_key_too_long');
+            }
+        });
+
+        it('should reject invalid checkpoint format', async () => {
+            const key = 'connection:7:function:7';
+            const invalidCheckpoint = { nested: { key: 'value' } } as any;
+
+            const result = await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: invalidCheckpoint });
+            expect(result.isErr()).toBe(true);
+        });
+    });
+
+    describe('getCheckpoint', () => {
+        it('should return checkpoint if exists', async () => {
+            const key = 'connection:10:function:10';
+            const checkpoint = { status: 'active', count: 42 };
+
+            await upsertCheckpoint(db.knex, { environmentId, key, checkpoint });
+            const res = (await getCheckpoint(db.knex, { environmentId, key })).unwrap();
+
+            expect(res?.checkpoint).toEqual(checkpoint);
+            expect(res?.version).toBe(1);
+        });
+
+        it('should return null if checkpoint does not exist', async () => {
+            const res = (await getCheckpoint(db.knex, { environmentId, key: 'connection:999:function:999' })).unwrap();
+            expect(res).toBeNull();
+        });
+
+        it('should return null for deleted checkpoint', async () => {
+            const key = 'connection:11:function:11';
+            const checkpoint = { test: true };
+
+            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint })).unwrap();
+            await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: created.version });
+
+            const res = (await getCheckpoint(db.knex, { environmentId, key })).unwrap();
+            expect(res).toBeNull();
+        });
+    });
+
+    describe('deleteCheckpoint', () => {
+        it('should soft delete existing checkpoint with correct version', async () => {
+            const key = 'connection:20:function:20';
+            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { test: true } })).unwrap();
+
+            await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: created.version });
+
+            const res = (await getCheckpoint(db.knex, { environmentId, key })).unwrap();
+            expect(res).toBeNull();
+        });
+
+        it('should fail to delete with wrong version', async () => {
+            const key = 'connection:21:function:21';
+            await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { test: true } });
+
+            const result = await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: 99 });
+
+            expect(result.isErr()).toBe(true);
+            if (result.isErr()) {
+                expect(result.error.message).toBe('checkpoint_conflict');
+            }
+        });
+
+        it('should fail to delete non-existent checkpoint', async () => {
+            const key = 'connection:888:function:888';
+
+            const result = await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: 1 });
+
+            expect(result.isErr()).toBe(true);
+            if (result.isErr()) {
+                expect(result.error.message).toBe('checkpoint_conflict');
+            }
+        });
+
+        it('should fail to delete already deleted checkpoint', async () => {
+            const key = 'connection:22:function:22';
+            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { test: true } })).unwrap();
+            await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: created.version });
+
+            // Try to delete again with the new version (2)
+            const result = await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: 2 });
+
+            expect(result.isErr()).toBe(true);
+            if (result.isErr()) {
+                expect(result.error.message).toBe('checkpoint_conflict');
+            }
+        });
+    });
+
+    describe('hardDeleteCheckpointsByPrefix', () => {
+        it('should hard delete all checkpoints matching prefix', async () => {
+            const key1 = 'connection:30:function:1';
+            const key2 = 'connection:30:function:2';
+            const key3 = 'connection:30:function:3';
+            const otherKey = 'connection:99:function:1';
+
+            await upsertCheckpoint(db.knex, { environmentId, key: key1, checkpoint: { a: 1 } });
+            await upsertCheckpoint(db.knex, { environmentId, key: key2, checkpoint: { b: 2 } });
+            await upsertCheckpoint(db.knex, { environmentId, key: key3, checkpoint: { c: 3 } });
+            await upsertCheckpoint(db.knex, { environmentId, key: otherKey, checkpoint: { other: true } });
+
+            const count = (await hardDeleteCheckpointsByPrefix(db.knex, { environmentId, keyPrefix: 'connection:30:' })).unwrap();
+
+            expect(count).toBe(3);
+            expect((await getCheckpoint(db.knex, { environmentId, key: key1 })).unwrap()).toBeNull();
+            expect((await getCheckpoint(db.knex, { environmentId, key: key2 })).unwrap()).toBeNull();
+            expect((await getCheckpoint(db.knex, { environmentId, key: key3 })).unwrap()).toBeNull();
+            expect((await getCheckpoint(db.knex, { environmentId, key: otherKey })).unwrap()).not.toBeNull();
+        });
+
+        it('should return 0 if no checkpoints match prefix', async () => {
+            const count = (await hardDeleteCheckpointsByPrefix(db.knex, { environmentId, keyPrefix: 'nonexistent:' })).unwrap();
+            expect(count).toBe(0);
+        });
+
+        it('should handle special character in prefix', async () => {
+            const key1 = 'connection:40_%:function:1';
+            const key2 = 'connection:40AB:function:2';
+            await upsertCheckpoint(db.knex, { environmentId, key: key1, checkpoint: { special: true } });
+            await upsertCheckpoint(db.knex, { environmentId, key: key2, checkpoint: { special: true } });
+
+            const count = (await hardDeleteCheckpointsByPrefix(db.knex, { environmentId, keyPrefix: 'connection:40_%:' })).unwrap();
+
+            expect(count).toBe(1);
+            expect((await getCheckpoint(db.knex, { environmentId, key: key1 })).unwrap()).toBeNull();
+        });
+
+        it('should also delete soft-deleted checkpoints', async () => {
+            const key = 'connection:50:function:1';
+            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { a: 1 } })).unwrap();
+            await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: created.version });
+
+            const count = (await hardDeleteCheckpointsByPrefix(db.knex, { environmentId, keyPrefix: 'connection:50:' })).unwrap();
+
+            expect(count).toBe(1);
+        });
+    });
+});

--- a/packages/shared/lib/services/checkpoints/checkpoints.integration.test.ts
+++ b/packages/shared/lib/services/checkpoints/checkpoints.integration.test.ts
@@ -151,7 +151,7 @@ describe('Checkpoint service', () => {
             expect(res).toBeNull();
         });
 
-        it('should return null for deleted checkpoint', async () => {
+        it('should return soft-deleted checkpoint with deleted_at set', async () => {
             const key = 'connection:11:function:11';
             const checkpoint = { test: true };
 
@@ -159,19 +159,26 @@ describe('Checkpoint service', () => {
             await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: created.version });
 
             const res = (await getCheckpoint(db.knex, { environmentId, key })).unwrap();
-            expect(res).toBeNull();
+            expect(res).not.toBeNull();
+            expect(res?.checkpoint).toEqual(checkpoint);
+            expect(res?.deleted_at).not.toBeNull();
+            expect(res?.version).toBe(2);
         });
     });
 
     describe('deleteCheckpoint', () => {
         it('should soft delete existing checkpoint with correct version', async () => {
             const key = 'connection:20:function:20';
-            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { test: true } })).unwrap();
+            const checkpoint = { test: true };
+            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint })).unwrap();
 
             await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: created.version });
 
             const res = (await getCheckpoint(db.knex, { environmentId, key })).unwrap();
-            expect(res).toBeNull();
+            expect(res).not.toBeNull();
+            expect(res?.checkpoint).toEqual(checkpoint);
+            expect(res?.deleted_at).not.toBeNull();
+            expect(res?.version).toBe(2);
         });
 
         it('should fail to delete with wrong version', async () => {

--- a/packages/shared/lib/services/checkpoints/checkpoints.integration.test.ts
+++ b/packages/shared/lib/services/checkpoints/checkpoints.integration.test.ts
@@ -2,28 +2,35 @@ import { beforeAll, describe, expect, it } from 'vitest';
 
 import db, { multipleMigrations } from '@nangohq/database';
 
-import { deleteCheckpoint, getCheckpoint, hardDeleteCheckpointsByPrefix, upsertCheckpoint } from './checkpoints.js';
+import { deleteCheckpoint, getCheckpoint, hardDeleteCheckpoints, upsertCheckpoint } from './checkpoints.js';
 import { createAccount } from '../../seeders/account.seeder.js';
+import { createConfigSeed } from '../../seeders/config.seeder.js';
+import { createConnectionSeed } from '../../seeders/connection.seeder.js';
 import { createEnvironmentSeed } from '../../seeders/environment.seeder.js';
 
 describe('Checkpoint service', () => {
     let environmentId: number;
+    let connectionId: number;
 
     beforeAll(async () => {
         await multipleMigrations();
         const account = await createAccount();
         const environment = await createEnvironmentSeed(account.id);
         environmentId = environment.id;
+        await createConfigSeed(environment, 'github', 'github');
+        const connection = await createConnectionSeed({ env: environment, provider: 'github' });
+        connectionId = connection.id;
     });
 
     describe('upsertCheckpoint', () => {
         it('should create a new checkpoint with version 1', async () => {
-            const key = 'connection:1:function:1';
+            const key = 'function:1';
             const checkpoint = { cursor: 'abc123', page: 1, hasMore: true };
 
-            const res = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint })).unwrap();
+            const res = (await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint })).unwrap();
 
             expect(res.environment_id).toBe(environmentId);
+            expect(res.connection_id).toBe(connectionId);
             expect(res.key).toBe(key);
             expect(res.checkpoint).toEqual(checkpoint);
             expect(res.version).toBe(1);
@@ -33,13 +40,13 @@ describe('Checkpoint service', () => {
         });
 
         it('should fail to update existing checkpoint without expectedVersion', async () => {
-            const key = 'connection:2:function:2';
+            const key = 'function:2';
             const initialCheckpoint = { page: 1 };
-            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: initialCheckpoint })).unwrap();
+            const created = (await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint: initialCheckpoint })).unwrap();
             expect(created.version).toBe(1);
 
             const updatedCheckpoint = { page: 2, cursor: 'new-cursor' };
-            const result = await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: updatedCheckpoint });
+            const result = await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint: updatedCheckpoint });
 
             expect(result.isErr()).toBe(true);
             if (result.isErr()) {
@@ -48,23 +55,23 @@ describe('Checkpoint service', () => {
         });
 
         it('should update existing checkpoint with correct expectedVersion', async () => {
-            const key = 'connection:3:function:3';
-            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { page: 1 } })).unwrap();
+            const key = 'function:3';
+            const created = (await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint: { page: 1 } })).unwrap();
             expect(created.version).toBe(1);
 
             const updatedCheckpoint = { page: 2 };
-            const res = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: updatedCheckpoint, expectedVersion: 1 })).unwrap();
+            const res = (await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint: updatedCheckpoint, expectedVersion: 1 })).unwrap();
 
             expect(res.checkpoint).toEqual(updatedCheckpoint);
             expect(res.version).toBe(2);
         });
 
         it('should fail to update with wrong expectedVersion', async () => {
-            const key = 'connection:4:function:4';
-            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { page: 1 } })).unwrap();
+            const key = 'function:4';
+            const created = (await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint: { page: 1 } })).unwrap();
             expect(created.version).toBe(1);
 
-            const result = await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { page: 2 }, expectedVersion: 99 });
+            const result = await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint: { page: 2 }, expectedVersion: 99 });
 
             expect(result.isErr()).toBe(true);
             if (result.isErr()) {
@@ -73,12 +80,12 @@ describe('Checkpoint service', () => {
         });
 
         it('should fail to resurrect deleted checkpoint with wrong expectedVersion', async () => {
-            const key = 'connection:5:function:5';
-            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { page: 1 } })).unwrap();
-            await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: created.version });
+            const key = 'function:5';
+            const created = (await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint: { page: 1 } })).unwrap();
+            await deleteCheckpoint(db.knex, { environmentId, connectionId, key, expectedVersion: created.version });
 
             // After delete, version is 2. Trying with wrong version should fail.
-            const result = await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { page: 2 }, expectedVersion: 1 });
+            const result = await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint: { page: 2 }, expectedVersion: 1 });
 
             expect(result.isErr()).toBe(true);
             if (result.isErr()) {
@@ -87,12 +94,12 @@ describe('Checkpoint service', () => {
         });
 
         it('should resurrect deleted checkpoint with correct expectedVersion', async () => {
-            const key = 'connection:6:function:6';
-            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { page: 1 } })).unwrap();
-            await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: created.version });
+            const key = 'function:6';
+            const created = (await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint: { page: 1 } })).unwrap();
+            await deleteCheckpoint(db.knex, { environmentId, connectionId, key, expectedVersion: created.version });
 
             // After delete, version is 2. Providing correct version should resurrect.
-            const res = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { page: 99 }, expectedVersion: 2 })).unwrap();
+            const res = (await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint: { page: 99 }, expectedVersion: 2 })).unwrap();
 
             expect(res.checkpoint).toEqual({ page: 99 });
             expect(res.deleted_at).toBeNull();
@@ -100,13 +107,13 @@ describe('Checkpoint service', () => {
         });
 
         it('should fail to upsert deleted checkpoint without expectedVersion', async () => {
-            const key = 'connection:7:function:7';
+            const key = 'function:7';
             const initialCheckpoint = { page: 1 };
-            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: initialCheckpoint })).unwrap();
-            await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: created.version });
+            const created = (await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint: initialCheckpoint })).unwrap();
+            await deleteCheckpoint(db.knex, { environmentId, connectionId, key, expectedVersion: created.version });
 
             // Without expectedVersion, should fail even for deleted checkpoints
-            const result = await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { page: 99 } });
+            const result = await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint: { page: 99 } });
 
             expect(result.isErr()).toBe(true);
             if (result.isErr()) {
@@ -118,7 +125,7 @@ describe('Checkpoint service', () => {
             const key = 'k'.repeat(300);
             const checkpoint = { test: true };
 
-            const result = await upsertCheckpoint(db.knex, { environmentId, key, checkpoint });
+            const result = await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint });
             expect(result.isErr()).toBe(true);
             if (result.isErr()) {
                 expect(result.error.message).toBe('checkpoint_key_too_long');
@@ -126,39 +133,39 @@ describe('Checkpoint service', () => {
         });
 
         it('should reject invalid checkpoint format', async () => {
-            const key = 'connection:7:function:7';
+            const key = 'function:8';
             const invalidCheckpoint = { nested: { key: 'value' } } as any;
 
-            const result = await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: invalidCheckpoint });
+            const result = await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint: invalidCheckpoint });
             expect(result.isErr()).toBe(true);
         });
     });
 
     describe('getCheckpoint', () => {
         it('should return checkpoint if exists', async () => {
-            const key = 'connection:10:function:10';
+            const key = 'function:10';
             const checkpoint = { status: 'active', count: 42 };
 
-            await upsertCheckpoint(db.knex, { environmentId, key, checkpoint });
-            const res = (await getCheckpoint(db.knex, { environmentId, key })).unwrap();
+            await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint });
+            const res = (await getCheckpoint(db.knex, { environmentId, connectionId, key })).unwrap();
 
             expect(res?.checkpoint).toEqual(checkpoint);
             expect(res?.version).toBe(1);
         });
 
         it('should return null if checkpoint does not exist', async () => {
-            const res = (await getCheckpoint(db.knex, { environmentId, key: 'connection:999:function:999' })).unwrap();
+            const res = (await getCheckpoint(db.knex, { environmentId, connectionId, key: 'function:999' })).unwrap();
             expect(res).toBeNull();
         });
 
         it('should return soft-deleted checkpoint with deleted_at set', async () => {
-            const key = 'connection:11:function:11';
+            const key = 'function:11';
             const checkpoint = { test: true };
 
-            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint })).unwrap();
-            await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: created.version });
+            const created = (await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint })).unwrap();
+            await deleteCheckpoint(db.knex, { environmentId, connectionId, key, expectedVersion: created.version });
 
-            const res = (await getCheckpoint(db.knex, { environmentId, key })).unwrap();
+            const res = (await getCheckpoint(db.knex, { environmentId, connectionId, key })).unwrap();
             expect(res).not.toBeNull();
             expect(res?.checkpoint).toEqual(checkpoint);
             expect(res?.deleted_at).not.toBeNull();
@@ -168,13 +175,13 @@ describe('Checkpoint service', () => {
 
     describe('deleteCheckpoint', () => {
         it('should soft delete existing checkpoint with correct version', async () => {
-            const key = 'connection:20:function:20';
+            const key = 'function:20';
             const checkpoint = { test: true };
-            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint })).unwrap();
+            const created = (await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint })).unwrap();
 
-            await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: created.version });
+            await deleteCheckpoint(db.knex, { environmentId, connectionId, key, expectedVersion: created.version });
 
-            const res = (await getCheckpoint(db.knex, { environmentId, key })).unwrap();
+            const res = (await getCheckpoint(db.knex, { environmentId, connectionId, key })).unwrap();
             expect(res).not.toBeNull();
             expect(res?.checkpoint).toEqual(checkpoint);
             expect(res?.deleted_at).not.toBeNull();
@@ -182,10 +189,10 @@ describe('Checkpoint service', () => {
         });
 
         it('should fail to delete with wrong version', async () => {
-            const key = 'connection:21:function:21';
-            await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { test: true } });
+            const key = 'function:21';
+            await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint: { test: true } });
 
-            const result = await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: 99 });
+            const result = await deleteCheckpoint(db.knex, { environmentId, connectionId, key, expectedVersion: 99 });
 
             expect(result.isErr()).toBe(true);
             if (result.isErr()) {
@@ -194,9 +201,9 @@ describe('Checkpoint service', () => {
         });
 
         it('should fail to delete non-existent checkpoint', async () => {
-            const key = 'connection:888:function:888';
+            const key = 'function:888';
 
-            const result = await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: 1 });
+            const result = await deleteCheckpoint(db.knex, { environmentId, connectionId, key, expectedVersion: 1 });
 
             expect(result.isErr()).toBe(true);
             if (result.isErr()) {
@@ -205,12 +212,12 @@ describe('Checkpoint service', () => {
         });
 
         it('should fail to delete already deleted checkpoint', async () => {
-            const key = 'connection:22:function:22';
-            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { test: true } })).unwrap();
-            await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: created.version });
+            const key = 'function:22';
+            const created = (await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint: { test: true } })).unwrap();
+            await deleteCheckpoint(db.knex, { environmentId, connectionId, key, expectedVersion: created.version });
 
             // Try to delete again with the new version (2)
-            const result = await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: 2 });
+            const result = await deleteCheckpoint(db.knex, { environmentId, connectionId, key, expectedVersion: 2 });
 
             expect(result.isErr()).toBe(true);
             if (result.isErr()) {
@@ -219,52 +226,76 @@ describe('Checkpoint service', () => {
         });
     });
 
-    describe('hardDeleteCheckpointsByPrefix', () => {
+    describe('hardDeleteCheckpoints', () => {
         it('should hard delete all checkpoints matching prefix', async () => {
-            const key1 = 'connection:30:function:1';
-            const key2 = 'connection:30:function:2';
-            const key3 = 'connection:30:function:3';
-            const otherKey = 'connection:99:function:1';
+            const key1 = 'function:301';
+            const key2 = 'function:302';
+            const key3 = 'function:303';
+            const otherKey = 'function:99';
 
-            await upsertCheckpoint(db.knex, { environmentId, key: key1, checkpoint: { a: 1 } });
-            await upsertCheckpoint(db.knex, { environmentId, key: key2, checkpoint: { b: 2 } });
-            await upsertCheckpoint(db.knex, { environmentId, key: key3, checkpoint: { c: 3 } });
-            await upsertCheckpoint(db.knex, { environmentId, key: otherKey, checkpoint: { other: true } });
+            await upsertCheckpoint(db.knex, { environmentId, connectionId, key: key1, checkpoint: { a: 1 } });
+            await upsertCheckpoint(db.knex, { environmentId, connectionId, key: key2, checkpoint: { b: 2 } });
+            await upsertCheckpoint(db.knex, { environmentId, connectionId, key: key3, checkpoint: { c: 3 } });
+            await upsertCheckpoint(db.knex, { environmentId, connectionId, key: otherKey, checkpoint: { other: true } });
 
-            const count = (await hardDeleteCheckpointsByPrefix(db.knex, { environmentId, keyPrefix: 'connection:30:' })).unwrap();
+            const count = (await hardDeleteCheckpoints(db.knex, { environmentId, connectionId, keyPrefix: 'function:30' })).unwrap();
 
             expect(count).toBe(3);
-            expect((await getCheckpoint(db.knex, { environmentId, key: key1 })).unwrap()).toBeNull();
-            expect((await getCheckpoint(db.knex, { environmentId, key: key2 })).unwrap()).toBeNull();
-            expect((await getCheckpoint(db.knex, { environmentId, key: key3 })).unwrap()).toBeNull();
-            expect((await getCheckpoint(db.knex, { environmentId, key: otherKey })).unwrap()).not.toBeNull();
+            expect((await getCheckpoint(db.knex, { environmentId, connectionId, key: key1 })).unwrap()).toBeNull();
+            expect((await getCheckpoint(db.knex, { environmentId, connectionId, key: key2 })).unwrap()).toBeNull();
+            expect((await getCheckpoint(db.knex, { environmentId, connectionId, key: key3 })).unwrap()).toBeNull();
+            expect((await getCheckpoint(db.knex, { environmentId, connectionId, key: otherKey })).unwrap()).not.toBeNull();
         });
 
         it('should return 0 if no checkpoints match prefix', async () => {
-            const count = (await hardDeleteCheckpointsByPrefix(db.knex, { environmentId, keyPrefix: 'nonexistent:' })).unwrap();
+            const count = (await hardDeleteCheckpoints(db.knex, { environmentId, connectionId, keyPrefix: 'nonexistent:' })).unwrap();
             expect(count).toBe(0);
         });
 
         it('should handle special character in prefix', async () => {
-            const key1 = 'connection:40_%:function:1';
-            const key2 = 'connection:40AB:function:2';
-            await upsertCheckpoint(db.knex, { environmentId, key: key1, checkpoint: { special: true } });
-            await upsertCheckpoint(db.knex, { environmentId, key: key2, checkpoint: { special: true } });
+            const key1 = 'function:40_%';
+            const key2 = 'function:40AB';
+            await upsertCheckpoint(db.knex, { environmentId, connectionId, key: key1, checkpoint: { special: true } });
+            await upsertCheckpoint(db.knex, { environmentId, connectionId, key: key2, checkpoint: { special: true } });
 
-            const count = (await hardDeleteCheckpointsByPrefix(db.knex, { environmentId, keyPrefix: 'connection:40_%:' })).unwrap();
+            const count = (await hardDeleteCheckpoints(db.knex, { environmentId, connectionId, keyPrefix: 'function:40_%' })).unwrap();
 
             expect(count).toBe(1);
-            expect((await getCheckpoint(db.knex, { environmentId, key: key1 })).unwrap()).toBeNull();
+            expect((await getCheckpoint(db.knex, { environmentId, connectionId, key: key1 })).unwrap()).toBeNull();
         });
 
         it('should also delete soft-deleted checkpoints', async () => {
-            const key = 'connection:50:function:1';
-            const created = (await upsertCheckpoint(db.knex, { environmentId, key, checkpoint: { a: 1 } })).unwrap();
-            await deleteCheckpoint(db.knex, { environmentId, key, expectedVersion: created.version });
+            const key = 'function:50';
+            const created = (await upsertCheckpoint(db.knex, { environmentId, connectionId, key, checkpoint: { a: 1 } })).unwrap();
+            await deleteCheckpoint(db.knex, { environmentId, connectionId, key, expectedVersion: created.version });
 
-            const count = (await hardDeleteCheckpointsByPrefix(db.knex, { environmentId, keyPrefix: 'connection:50:' })).unwrap();
+            const count = (await hardDeleteCheckpoints(db.knex, { environmentId, connectionId, keyPrefix: 'function:50' })).unwrap();
 
             expect(count).toBe(1);
+        });
+
+        it('should delete all checkpoints for connection when no prefix provided', async () => {
+            // Setup new environment and connection to avoid interfering with other tests
+            const account = await createAccount();
+            const environment = await createEnvironmentSeed(account.id);
+            const connection = await createConnectionSeed({ env: environment, provider: 'hubspot' });
+            const connectionId = connection.id;
+            const environmentId = environment.id;
+
+            const key1 = 'function:601';
+            const key2 = 'function:602';
+            const key3 = 'other:603';
+
+            await upsertCheckpoint(db.knex, { environmentId, connectionId, key: key1, checkpoint: { a: 1 } });
+            await upsertCheckpoint(db.knex, { environmentId, connectionId, key: key2, checkpoint: { b: 2 } });
+            await upsertCheckpoint(db.knex, { environmentId, connectionId, key: key3, checkpoint: { c: 3 } });
+
+            const count = (await hardDeleteCheckpoints(db.knex, { environmentId, connectionId })).unwrap();
+
+            expect(count).toBe(3);
+            expect((await getCheckpoint(db.knex, { environmentId, connectionId, key: key1 })).unwrap()).toBeNull();
+            expect((await getCheckpoint(db.knex, { environmentId, connectionId, key: key2 })).unwrap()).toBeNull();
+            expect((await getCheckpoint(db.knex, { environmentId, connectionId, key: key3 })).unwrap()).toBeNull();
         });
     });
 });

--- a/packages/shared/lib/services/checkpoints/checkpoints.ts
+++ b/packages/shared/lib/services/checkpoints/checkpoints.ts
@@ -39,14 +39,13 @@ export function validateCheckpoint(data: unknown): Result<Checkpoint> {
 
 /**
  * Get a checkpoint by environment ID and key.
- * Only returns non-deleted checkpoints.
  * @param environmentId - The environment ID the checkpoint belongs to.
  * @param key - The key of the checkpoint.
  * @returns The checkpoint if found, or null if not found.
  */
 export async function getCheckpoint(db: Knex, { environmentId, key }: { environmentId: number; key: string }): Promise<Result<DBCheckpoint | null>> {
     try {
-        const result = await db.from<DBCheckpoint>(TABLE).where({ environment_id: environmentId, key }).whereNull('deleted_at').first();
+        const result = await db.from<DBCheckpoint>(TABLE).where({ environment_id: environmentId, key }).first();
         return Ok(result ?? null);
     } catch (err) {
         return Err(new Error('failed_to_get_checkpoint', { cause: err }));

--- a/packages/shared/lib/services/checkpoints/checkpoints.ts
+++ b/packages/shared/lib/services/checkpoints/checkpoints.ts
@@ -1,0 +1,167 @@
+import { z } from 'zod';
+
+import { Err, Ok } from '@nangohq/utils';
+
+import type { Checkpoint, DBCheckpoint } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+import type { Knex } from 'knex';
+
+const TABLE = 'checkpoints';
+
+const MAX_KEY_LENGTH = 255;
+const MAX_STRING_VALUE_LENGTH = 255;
+const MAX_FIELDS = 16;
+
+/**
+ * Zod schema for checkpoint validation.
+ * - Keys: max 255 characters
+ * - String values: max 255 characters
+ * - Date values: converted to ISO string
+ * - Max 16 fields
+ */
+const checkpointValueSchema = z.union([z.string().max(MAX_STRING_VALUE_LENGTH), z.number(), z.boolean(), z.date().transform((d) => d.toISOString())]);
+
+const checkpointSchema = z.record(z.string().max(MAX_KEY_LENGTH), checkpointValueSchema).refine((data) => Object.keys(data).length <= MAX_FIELDS, {
+    message: `Checkpoint cannot have more than ${MAX_FIELDS} fields`
+});
+
+/**
+ * Validates that a checkpoint object only contains flat key-value pairs
+ * with string, number, or boolean values.
+ */
+export function validateCheckpoint(data: unknown): Result<Checkpoint> {
+    const result = checkpointSchema.safeParse(data);
+    if (result.success) {
+        return Ok(result.data);
+    }
+    return Err(new Error('invalid_checkpoint_format'));
+}
+
+/**
+ * Get a checkpoint by environment ID and key.
+ * Only returns non-deleted checkpoints.
+ * @param environmentId - The environment ID the checkpoint belongs to.
+ * @param key - The key of the checkpoint.
+ * @returns The checkpoint if found, or null if not found.
+ */
+export async function getCheckpoint(db: Knex, { environmentId, key }: { environmentId: number; key: string }): Promise<Result<DBCheckpoint | null>> {
+    try {
+        const result = await db.from<DBCheckpoint>(TABLE).where({ environment_id: environmentId, key }).whereNull('deleted_at').first();
+        return Ok(result ?? null);
+    } catch (err) {
+        return Err(new Error('failed_to_get_checkpoint', { cause: err }));
+    }
+}
+
+/**
+ * Upsert a checkpoint with optimistic locking.
+ *
+ * @param environmentId - The environment ID the checkpoint belongs to.
+ * @param key - The key of the checkpoint.
+ * @param checkpoint - The checkpoint data to save.
+ * @param expectedVersion - Required for updates. Must match the current version.
+ *                          Without expectedVersion, only new checkpoints can be created.
+ *                          With correct expectedVersion, can update or resurrect deleted checkpoints.
+ * @returns The checkpoint, or an error if there's a conflict.
+ */
+export async function upsertCheckpoint(
+    db: Knex,
+    { environmentId, key, checkpoint, expectedVersion }: { environmentId: number; key: string; checkpoint: Checkpoint; expectedVersion?: number }
+): Promise<Result<DBCheckpoint>> {
+    if (key.length > MAX_KEY_LENGTH) {
+        return Err(new Error('checkpoint_key_too_long'));
+    }
+
+    const validation = validateCheckpoint(checkpoint);
+    if (validation.isErr()) {
+        return Err(validation.error);
+    }
+
+    const validatedCheckpoint = validation.unwrap();
+
+    try {
+        const result = await db.raw<{ rows: DBCheckpoint[] }>(
+            `
+            INSERT INTO ${TABLE} (environment_id, key, checkpoint, version, created_at, updated_at)
+            VALUES (?, ?, ?::jsonb, 1, NOW(), NOW())
+            ON CONFLICT (environment_id, key)
+            DO UPDATE SET
+                checkpoint = EXCLUDED.checkpoint,
+                version = ${TABLE}.version + 1,
+                deleted_at = NULL,
+                updated_at = NOW()
+            WHERE
+                ${TABLE}.version = ?
+            RETURNING *
+            `,
+            [environmentId, key, JSON.stringify(validatedCheckpoint), expectedVersion ?? null]
+        );
+
+        const row = result.rows[0];
+        if (!row) {
+            return Err(new Error('checkpoint_conflict'));
+        }
+        return Ok(row);
+    } catch (err) {
+        return Err(new Error('failed_to_save_checkpoint', { cause: err }));
+    }
+}
+
+/**
+ * Soft delete checkpoint with optimistic locking
+ *
+ * @param environmentId - The environment ID the checkpoint belongs to.
+ * @param key - The key of the checkpoint to delete.
+ * @param expectedVersion - The expected version of the checkpoint. Delete will fail if version doesn't match.
+ */
+export async function deleteCheckpoint(
+    db: Knex,
+    { environmentId, key, expectedVersion }: { environmentId: number; key: string; expectedVersion: number }
+): Promise<Result<void>> {
+    try {
+        const count = await db
+            .from<DBCheckpoint>(TABLE)
+            .where({ environment_id: environmentId, key, version: expectedVersion })
+            .whereNull('deleted_at')
+            .update({
+                deleted_at: db.fn.now(),
+                version: db.raw('version + 1')
+            });
+
+        if (count === 0) {
+            return Err(new Error('checkpoint_conflict'));
+        }
+        return Ok(undefined);
+    } catch (err) {
+        return Err(new Error('failed_to_delete_checkpoint', { cause: err }));
+    }
+}
+
+/**
+ * Hard delete all checkpoints matching a key prefix (e.g., all checkpoints for a connection).
+ * This does not use optimistic locking as it's typically used for cleanup operations.
+ *
+ * @param environmentId - The environment ID the checkpoints belong to.
+ * @param keyPrefix - The prefix of the keys to delete.
+ * @example
+ * deleteCheckpointsByPrefix(db, { environmentId: 1, keyPrefix: "connection:123:" })
+ */
+export async function hardDeleteCheckpointsByPrefix(
+    db: Knex,
+    { environmentId, keyPrefix }: { environmentId: number; keyPrefix: string }
+): Promise<Result<number>> {
+    try {
+        // Escape special characters for SQL LIKE query
+        // % and _ are wildcards, \ is the escape character
+        const escapedPrefix = keyPrefix.replace(/[%_\\]/g, '\\$&');
+
+        const count = await db
+            .from<DBCheckpoint>(TABLE)
+            .where('environment_id', environmentId)
+            .whereRaw("key LIKE ? ESCAPE '\\'", [`${escapedPrefix}%`])
+            .delete();
+        return Ok(count);
+    } catch (err) {
+        return Err(new Error('failed_to_delete_checkpoints_by_prefix', { cause: err }));
+    }
+}

--- a/packages/shared/lib/services/checkpoints/checkpoints.unit.test.ts
+++ b/packages/shared/lib/services/checkpoints/checkpoints.unit.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateCheckpoint } from './checkpoints.js';
+
+describe('validateCheckpoint', () => {
+    describe('valid checkpoints', () => {
+        it('should validate checkpoint with string values', () => {
+            const cp = { cursor: 'abc123', status: 'active' };
+            const result = validateCheckpoint(cp);
+            expect(result.unwrap()).toEqual(cp);
+        });
+
+        it('should validate checkpoint with number values', () => {
+            const cp = { page: 5, total: 100 };
+            const result = validateCheckpoint(cp);
+            expect(result.unwrap()).toEqual(cp);
+        });
+
+        it('should validate checkpoint with boolean values', () => {
+            const cp = { isComplete: true, hasMore: false };
+            const result = validateCheckpoint(cp);
+            expect(result.unwrap()).toEqual(cp);
+        });
+
+        it('should validate checkpoint with mixed primitive values', () => {
+            const cp = { cursor: 'abc123', page: 5, hasMore: true };
+            const result = validateCheckpoint(cp);
+            expect(result.unwrap()).toEqual(cp);
+        });
+
+        it('should validate empty object', () => {
+            const result = validateCheckpoint({});
+            expect(result.unwrap()).toEqual({});
+        });
+    });
+
+    describe('invalid checkpoints', () => {
+        it('should fail for null', () => {
+            expect(validateCheckpoint(null).isErr()).toBe(true);
+        });
+
+        it('should fail for undefined', () => {
+            expect(validateCheckpoint(undefined).isErr()).toBe(true);
+        });
+
+        it('should fail for array', () => {
+            expect(validateCheckpoint(['a', 'b']).isErr()).toBe(true);
+        });
+
+        it('should fail for primitive values', () => {
+            expect(validateCheckpoint('string').isErr()).toBe(true);
+            expect(validateCheckpoint(123).isErr()).toBe(true);
+            expect(validateCheckpoint(true).isErr()).toBe(true);
+        });
+
+        it('should fail for nested objects', () => {
+            expect(validateCheckpoint({ nested: { key: 'value' } }).isErr()).toBe(true);
+        });
+
+        it('should fail for arrays as values', () => {
+            expect(validateCheckpoint({ items: [1, 2, 3] }).isErr()).toBe(true);
+        });
+
+        it('should fail for null values', () => {
+            expect(validateCheckpoint({ key: null }).isErr()).toBe(true);
+        });
+
+        it('should fail for undefined values', () => {
+            expect(validateCheckpoint({ key: undefined }).isErr()).toBe(true);
+        });
+
+        it('should fail for function values', () => {
+            expect(validateCheckpoint({ fn: () => {} }).isErr()).toBe(true);
+        });
+    });
+
+    describe('date values', () => {
+        it('should validate Date values and convert to ISO string', () => {
+            const date = new Date('2024-01-15T10:30:00.000Z');
+            const result = validateCheckpoint({ lastRun: date });
+            expect(result.isOk()).toBe(true);
+            expect(result.unwrap()).toEqual({ lastRun: '2024-01-15T10:30:00.000Z' });
+        });
+    });
+
+    describe('size limits', () => {
+        it('should fail for key exceeding 255 characters', () => {
+            const longKey = 'a'.repeat(256);
+            const result = validateCheckpoint({ [longKey]: 'value' });
+            expect(result.isErr()).toBe(true);
+        });
+
+        it('should fail for string value exceeding 255 characters', () => {
+            const longValue = 'a'.repeat(256);
+            const result = validateCheckpoint({ key: longValue });
+            expect(result.isErr()).toBe(true);
+        });
+
+        it('should fail for more than 16 fields', () => {
+            const tooManyFields: Record<string, number> = {};
+            for (let i = 0; i < 17; i++) {
+                tooManyFields[`field${i}`] = i;
+            }
+            const result = validateCheckpoint(tooManyFields);
+            expect(result.isErr()).toBe(true);
+        });
+    });
+});

--- a/packages/types/lib/checkpoint/db.ts
+++ b/packages/types/lib/checkpoint/db.ts
@@ -33,6 +33,7 @@ export type Checkpoint = Record<string, CheckpointValue>;
 export interface DBCheckpoint extends Timestamps {
     id: number;
     environment_id: number;
+    connection_id: number;
     key: string;
     checkpoint: Checkpoint;
     version: number;

--- a/packages/types/lib/checkpoint/db.ts
+++ b/packages/types/lib/checkpoint/db.ts
@@ -1,0 +1,40 @@
+import type { Timestamps } from '../db.js';
+
+/**
+ * Allowed types for checkpoint values.
+ * Only flat key-value structures are supported (no nested objects or arrays).
+ * Date values are automatically converted to ISO strings when stored.
+ */
+export type CheckpointValue = string | number | boolean | Date;
+
+/**
+ * A checkpoint is a flat key-value object that can be used to store
+ * progress or state during function execution.
+ * Date values are automatically converted to ISO strings when stored.
+ *
+ * @example
+ * ```typescript
+ * const checkpoint: Checkpoint = {
+ *     lastProcessedPage: 5,
+ *     lastCursor: "abc123",
+ *     lastRunAt: new Date(), // stored as ISO string
+ * };
+ * ```
+ */
+export type Checkpoint = Record<string, CheckpointValue>;
+
+/**
+ * Checkpoints are identified by a flexible key format that allows
+ * attaching checkpoints to various entities:
+ *
+ * @example Key formats:
+ * - `connection:123:config:456` - checkpoint for a specific sync/action per connection
+ */
+export interface DBCheckpoint extends Timestamps {
+    id: number;
+    environment_id: number;
+    key: string;
+    checkpoint: Checkpoint;
+    version: number;
+    deleted_at: Date | null;
+}

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -92,4 +92,6 @@ export type * from './fleet/index.js';
 export type * from './persist/api.js';
 export type * from './jobs/api.js';
 
+export type * from './checkpoint/db.js';
+
 export type * from './mcp/api.js';


### PR DESCRIPTION
It will be possible for customers to get/save checkpoint explicitely in function to allow customers to implement "incremental" syncs, track progress, etc...

See inlined comments to discuss design decision.

Note: code isn't wired anywhere yet. The goal of this PR is to validate the checkpoints data model

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Checkpoint persistence model and service layer**

Adds a dedicated `checkpoints` persistence layer (migration, types, service helpers) so future function executions can save and resume progress per environment/connection/key with optimistic locking semantics. Includes comprehensive validation plus unit and integration coverage, but the tables/services are not yet wired into runtime flows.

<details>
<summary><strong>Key Changes</strong></summary>

• Created migration `packages/database/lib/migrations/20260127120000_create_checkpoints_table.cjs` for the `checkpoints` table with `(environment_id, connection_id, key)` uniqueness, soft-delete support, version counter, and a concurrent `varchar_pattern_ops` index to accelerate prefix cleanup queries.
• Defined checkpoint type contracts in `packages/types/lib/checkpoint/db.ts` and re-exported them so other packages can consume `Checkpoint`, `CheckpointValue`, and `DBCheckpoint`.
• Implemented `validateCheckpoint`, `getCheckpoint`, `upsertCheckpoint`, `deleteCheckpoint`, and `hardDeleteCheckpoints` in `packages/shared/lib/services/checkpoints/checkpoints.ts`, enforcing flat payloads, size limits, and optimistic locking/versioning.
• Added extensive unit tests for validation rules plus integration tests covering upsert/update/resurrection, soft delete, hard delete (with prefix + escaping), and database interactions.
• Re-exported the checkpoint service via `packages/shared/lib/index.ts` to make the helpers available to other modules.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `checkpoints` database table and migration
• `packages/shared/lib/services/checkpoints` service + tests
• `packages/types` exports
• `@nangohq/shared` public surface area

</details>

---
*This summary was automatically generated by @propel-code-bot*