### PR TITLE
fix(npm-publish): add missing repo info

### DIFF
--- a/packages/runner-sdk/package.json
+++ b/packages/runner-sdk/package.json
@@ -4,6 +4,11 @@
     "description": "Nango's Runner SDK",
     "type": "module",
     "main": "dist/index.js",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/NangoHQ/nango.git",
+        "directory": "packages/runner-sdk"
+    },
     "dependencies": {
         "@nangohq/node": "0.69.22",
         "@nangohq/providers": "0.69.22",


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add repository metadata to runner SDK package**

Introduces the missing `repository` block in `packages/runner-sdk/package.json`, pointing to the root git repository and the package directory. This aligns the package metadata with npm expectations for linking back to the source.

<details>
<summary><strong>Key Changes</strong></summary>

• Added a `repository` section (type, URL, directory) to `packages/runner-sdk/package.json`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/runner-sdk/package.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*