### PR TITLE
fix(webapp): change nango cli docs link near clone snippet

### DIFF
--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -157,7 +157,7 @@ export const FunctionsOne: React.FC = () => {
                             <div className="flex flex-col gap-1">
                                 <span className="text-text-primary text-body-medium-semi">Customize this template</span>
                                 <Link
-                                    to="https://nango.dev/docs/reference/cli"
+                                    to="https://nango.dev/docs/implementation-guides/platform/functions/functions-setup"
                                     target="_blank"
                                     className="text-text-tertiary text-body-medium-medium inline-flex items-center gap-1.5"
                                 >


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Update CLI link for template customization banner**

The `FunctionsOne` page now points the "Get started with the Nango CLI" link inside the template customization card to the dedicated functions setup guide rather than the generic CLI reference. This ensures users opening the helper link from the clone snippet land directly on the relevant instructions for configuring platform functions.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated the `Link` component in `packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx` to target `https://nango.dev/docs/implementation-guides/platform/functions/functions-setup`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Webapp functions detail page (`packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx`)

</details>

---
*This summary was automatically generated by @propel-code-bot*