### PR TITLE
feat(jobs): Broadcast task cancellation to all active runners

### DIFF
--- a/packages/jobs/lib/execution/operations/abort.ts
+++ b/packages/jobs/lib/execution/operations/abort.ts
@@ -5,7 +5,7 @@ import { Err, Ok } from '@nangohq/utils';
 import { orchestratorClient } from '../../clients.js';
 import { envs } from '../../env.js';
 import { logger } from '../../logger.js';
-import { getRunner } from '../../runner/runner.js';
+import { getRunners } from '../../runner/runner.js';
 
 import type { TaskAbort } from '@nangohq/nango-orchestrator';
 import type { Result } from '@nangohq/utils';
@@ -38,12 +38,15 @@ export async function abortTask(task: TaskAbort): Promise<Result<void>> {
 export async function abortTaskWithId({ taskId, teamId }: { taskId: string; teamId: number }): Promise<Result<void>> {
     try {
         await setAbortFlag(taskId);
-        const runner = await getRunner(teamId);
-        if (runner.isErr()) {
-            return Err(runner.error);
+        const runners = await getRunners(teamId);
+        if (runners.isErr()) {
+            return Err(runners.error);
         }
-        const isAborted = await runner.value.client.abort.mutate({ taskId });
-        if (!isAborted) {
+
+        const results = await Promise.allSettled(runners.value.map((runner) => runner.client.abort.mutate({ taskId })));
+        const didAbort = results.some((result) => result.status === 'fulfilled' && result.value);
+
+        if (!didAbort) {
             return Err(`Error aborting script for task: ${taskId}`);
         }
         return Ok(undefined);

--- a/packages/jobs/lib/execution/operations/abort.unit.test.ts
+++ b/packages/jobs/lib/execution/operations/abort.unit.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@nangohq/kvstore', () => ({
+    getKVStore: vi.fn(() => Promise.resolve({ set: vi.fn() })),
+    getFeatureFlagsClient: vi.fn(() => Promise.resolve({}))
+}));
+
+vi.mock('../../runner/runner.js', () => ({
+    getRunners: vi.fn()
+}));
+
+vi.mock('../../env.js', () => ({
+    envs: {
+        RUNNER_ABORT_CHECK_INTERVAL_MS: 1000
+    }
+}));
+
+vi.mock('../../logger.js', () => ({
+    logger: {
+        error: vi.fn()
+    }
+}));
+
+import { Ok } from '@nangohq/utils';
+
+import { abortTaskWithId } from './abort.js';
+import { getRunners } from '../../runner/runner.js';
+
+describe('abortTaskWithId', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('broadcasts abort and succeeds when any runner confirms', async () => {
+        const abortA = vi.fn().mockResolvedValue(false);
+        const abortB = vi.fn().mockResolvedValue(true);
+
+        (getRunners as unknown as { mockResolvedValue: (value: any) => void }).mockResolvedValue(
+            Ok([{ client: { abort: { mutate: abortA } } }, { client: { abort: { mutate: abortB } } }] as any[])
+        );
+
+        const result = await abortTaskWithId({ taskId: 'task-1', teamId: 42 });
+
+        expect(result.isOk()).toBe(true);
+        expect(abortA).toHaveBeenCalledWith({ taskId: 'task-1' });
+        expect(abortB).toHaveBeenCalledWith({ taskId: 'task-1' });
+    });
+
+    it('succeeds with a single runner that confirms abort', async () => {
+        const abortA = vi.fn().mockResolvedValue(true);
+
+        (getRunners as unknown as { mockResolvedValue: (value: any) => void }).mockResolvedValue(Ok([{ client: { abort: { mutate: abortA } } }] as any[]));
+
+        const result = await abortTaskWithId({ taskId: 'task-2', teamId: 7 });
+
+        expect(result.isOk()).toBe(true);
+        expect(abortA).toHaveBeenCalledWith({ taskId: 'task-2' });
+    });
+
+    it('returns error when all runners fail to abort', async () => {
+        const abortA = vi.fn().mockResolvedValue(false);
+        const abortB = vi.fn().mockResolvedValue(false);
+
+        (getRunners as unknown as { mockResolvedValue: (value: any) => void }).mockResolvedValue(
+            Ok([{ client: { abort: { mutate: abortA } } }, { client: { abort: { mutate: abortB } } }] as any[])
+        );
+
+        const result = await abortTaskWithId({ taskId: 'task-3', teamId: 9 });
+
+        expect(result.isErr()).toBe(true);
+        expect(abortA).toHaveBeenCalledWith({ taskId: 'task-3' });
+        expect(abortB).toHaveBeenCalledWith({ taskId: 'task-3' });
+    });
+});

--- a/packages/jobs/lib/runner/runner.unit.test.ts
+++ b/packages/jobs/lib/runner/runner.unit.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@nangohq/nango-runner', () => ({
+    getRunnerClient: vi.fn(() => ({
+        abort: { mutate: vi.fn() },
+        start: { mutate: vi.fn() }
+    }))
+}));
+
+vi.mock('../env.js', () => ({
+    envs: {
+        RUNNER_TYPE: 'KUBERNETES',
+        RUNNER_CLIENT_HEADERS_TIMEOUT_MS: 1000,
+        RUNNER_CLIENT_CONNECT_TIMEOUT_MS: 1000,
+        RUNNER_CLIENT_RESPONSE_TIMEOUT_MS: 1000
+    }
+}));
+
+vi.mock('../runtime/runtimes.js', () => ({
+    getDefaultFleet: vi.fn()
+}));
+
+vi.mock('@nangohq/utils', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...(actual as object),
+        env: 'test',
+        isProd: true
+    };
+});
+
+import { Ok } from '@nangohq/utils';
+
+import { getRunners } from './runner.js';
+import { getDefaultFleet } from '../runtime/runtimes.js';
+
+describe('getRunners', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns all runners from fleet nodes for team routing id', async () => {
+        const nodes = [
+            { id: 1, url: 'http://runner-a' },
+            { id: 2, url: 'http://runner-b' }
+        ] as any[];
+
+        (getDefaultFleet as unknown as { mockReturnValue: (value: any) => void }).mockReturnValue({
+            getNodesByRoutingId: vi.fn().mockResolvedValue(Ok(nodes)),
+            getRunningNode: vi.fn()
+        });
+
+        const result = await getRunners(123);
+
+        expect(result.isOk()).toBe(true);
+        expect(result.value).toHaveLength(2);
+        expect(result.value.map((runner) => runner.url)).toEqual(['http://runner-a', 'http://runner-b']);
+    });
+
+    it('falls back to a single runner when no nodes are found', async () => {
+        const node = { id: 3, url: 'http://runner-fallback' } as any;
+
+        (getDefaultFleet as unknown as { mockReturnValue: (value: any) => void }).mockReturnValue({
+            getNodesByRoutingId: vi.fn().mockResolvedValue(Ok([])),
+            getRunningNode: vi.fn().mockResolvedValue(Ok(node))
+        });
+
+        const result = await getRunners(123);
+
+        expect(result.isOk()).toBe(true);
+        expect(result.value).toHaveLength(1);
+        expect(result.value[0]?.url).toBe('http://runner-fallback');
+    });
+});


### PR DESCRIPTION
<!-- Describe the problem and your solution -->
Cancellation only targeted a single runner, which failed when a task was still running on a different active runner (e.g., after key rotation).
Fan out abort requests to all active runners for the team’s routingId and succeed if any runner confirms the abort.
<!-- Issue ticket number and link (if applicable) -->
[NAN-4519](https://linear.app/nango/issue/NAN-4519/task-cancellation-must-broadcast-to-all-active-runners)
<!-- Testing instructions (skip if just adding/editing providers) -->
- Added test cases for new functionality
- Want to attempt to test it on an actual run

<!-- Summary by @propel-code-bot -->

---

The update also introduces runner discovery so abort messages can reach every active node for a routing ID, and its tests specifically exercise multi-runner discovery and broadcast confirmation paths.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced `getRunners` in `packages/jobs/lib/runner/runner.ts` to resolve all fleet nodes (or fall back to a single runner) for a team routing ID
• Updated `abortTaskWithId` and `RunnerRuntimeAdapter.cancel` to call `getRunners` and broadcast abort mutations via `Promise.allSettled`, succeeding when any runner returns truthy
• Extended `packages/fleet/lib/fleet.ts` with `getNodesByRoutingId` plus default state filtering to retrieve multiple active nodes
• Added unit tests covering runner discovery fallbacks and abort broadcasting success/failure scenarios

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/jobs/lib/runner/runner.ts`
• `packages/jobs/lib/execution/operations/abort.ts` and `.unit.test.ts`
• `packages/jobs/lib/runtime/runner.adapter.ts`
• `packages/fleet/lib/fleet.ts`
• `packages/jobs/lib/runner/runner.unit.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*