### PR TITLE
feat(jobs): Broadcast task cancellation to all active runners

### DIFF
--- a/packages/jobs/lib/execution/operations/abort.ts
+++ b/packages/jobs/lib/execution/operations/abort.ts
@@ -38,7 +38,7 @@ export async function abortTask(task: TaskAbort): Promise<Result<void>> {
 export async function abortTaskWithId({ taskId, teamId }: { taskId: string; teamId: number }): Promise<Result<void>> {
     try {
         await setAbortFlag(taskId);
-        // Broadcast abort to all runners as a task might still be running on a different active runner during/after rollouts (e.g., after key rotation).
+        // Broadcast abort to all runners as a task might still be running on a different active runner during/after rollouts (e.g. deploying a new runner version).
         const runners = await getRunners(teamId);
         if (runners.isErr()) {
             return Err(runners.error);

--- a/packages/jobs/lib/execution/operations/abort.unit.test.ts
+++ b/packages/jobs/lib/execution/operations/abort.unit.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@nangohq/kvstore', () => ({
+    getKVStore: vi.fn(() => Promise.resolve({ set: vi.fn() })),
+    getFeatureFlagsClient: vi.fn(() => Promise.resolve({}))
+}));
+
+vi.mock('../../runner/runner.js', () => ({
+    getRunners: vi.fn()
+}));
+
+vi.mock('../../env.js', () => ({
+    envs: {
+        RUNNER_ABORT_CHECK_INTERVAL_MS: 1000
+    }
+}));
+
+vi.mock('../../logger.js', () => ({
+    logger: {
+        error: vi.fn()
+    }
+}));
+
+import { Ok } from '@nangohq/utils';
+
+import { abortTaskWithId } from './abort.js';
+import { getRunners } from '../../runner/runner.js';
+
+describe('abortTaskWithId', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('broadcasts abort and succeeds when any runner confirms', async () => {
+        const abortA = vi.fn().mockResolvedValue(false);
+        const abortB = vi.fn().mockResolvedValue(true);
+
+        (getRunners as unknown as { mockResolvedValue: (value: any) => void }).mockResolvedValue(
+            Ok([{ client: { abort: { mutate: abortA } } }, { client: { abort: { mutate: abortB } } }] as any[])
+        );
+
+        const result = await abortTaskWithId({ taskId: 'task-1', teamId: 42 });
+
+        expect(result.isOk()).toBe(true);
+        expect(abortA).toHaveBeenCalledWith({ taskId: 'task-1' });
+        expect(abortB).toHaveBeenCalledWith({ taskId: 'task-1' });
+    });
+
+    it('succeeds with a single runner that confirms abort', async () => {
+        const abortA = vi.fn().mockResolvedValue(true);
+
+        (getRunners as unknown as { mockResolvedValue: (value: any) => void }).mockResolvedValue(Ok([{ client: { abort: { mutate: abortA } } }] as any[]));
+
+        const result = await abortTaskWithId({ taskId: 'task-2', teamId: 7 });
+
+        expect(result.isOk()).toBe(true);
+        expect(abortA).toHaveBeenCalledWith({ taskId: 'task-2' });
+    });
+
+    it('returns error when all runners fail to abort', async () => {
+        const abortA = vi.fn().mockResolvedValue(false);
+        const abortB = vi.fn().mockResolvedValue(false);
+
+        (getRunners as unknown as { mockResolvedValue: (value: any) => void }).mockResolvedValue(
+            Ok([{ client: { abort: { mutate: abortA } } }, { client: { abort: { mutate: abortB } } }] as any[])
+        );
+
+        const result = await abortTaskWithId({ taskId: 'task-3', teamId: 9 });
+
+        expect(result.isErr()).toBe(true);
+        expect(abortA).toHaveBeenCalledWith({ taskId: 'task-3' });
+        expect(abortB).toHaveBeenCalledWith({ taskId: 'task-3' });
+    });
+});

--- a/packages/jobs/lib/runner/runner.unit.test.ts
+++ b/packages/jobs/lib/runner/runner.unit.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@nangohq/nango-runner', () => ({
+    getRunnerClient: vi.fn(() => ({
+        abort: { mutate: vi.fn() },
+        start: { mutate: vi.fn() }
+    }))
+}));
+
+vi.mock('../env.js', () => ({
+    envs: {
+        RUNNER_TYPE: 'KUBERNETES',
+        RUNNER_CLIENT_HEADERS_TIMEOUT_MS: 1000,
+        RUNNER_CLIENT_CONNECT_TIMEOUT_MS: 1000,
+        RUNNER_CLIENT_RESPONSE_TIMEOUT_MS: 1000
+    }
+}));
+
+vi.mock('../runtime/runtimes.js', () => ({
+    getDefaultFleet: vi.fn()
+}));
+
+vi.mock('@nangohq/utils', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...(actual as object),
+        env: 'test',
+        isProd: true
+    };
+});
+
+import { Ok } from '@nangohq/utils';
+
+import { getRunners } from './runner.js';
+import { getDefaultFleet } from '../runtime/runtimes.js';
+
+describe('getRunners', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns all runners from fleet nodes for team routing id', async () => {
+        const nodes = [
+            { id: 1, url: 'http://runner-a' },
+            { id: 2, url: 'http://runner-b' }
+        ] as any[];
+
+        (getDefaultFleet as unknown as { mockReturnValue: (value: any) => void }).mockReturnValue({
+            getNodesByRoutingId: vi.fn().mockResolvedValue(Ok(nodes)),
+            getRunningNode: vi.fn()
+        });
+
+        const result = await getRunners(123);
+
+        expect(result.isOk()).toBe(true);
+        if (result.isErr()) {
+            throw result.error;
+        }
+        expect(result.value).toHaveLength(2);
+        expect(result.value.map((runner) => runner.url)).toEqual(['http://runner-a', 'http://runner-b']);
+    });
+
+    it('falls back to a single runner when no nodes are found', async () => {
+        const node = { id: 3, url: 'http://runner-fallback' } as any;
+
+        (getDefaultFleet as unknown as { mockReturnValue: (value: any) => void }).mockReturnValue({
+            getNodesByRoutingId: vi.fn().mockResolvedValue(Ok([])),
+            getRunningNode: vi.fn().mockResolvedValue(Ok(node))
+        });
+
+        const result = await getRunners(123);
+
+        expect(result.isOk()).toBe(true);
+        if (result.isErr()) {
+            throw result.error;
+        }
+        expect(result.value).toHaveLength(1);
+        expect(result.value[0]?.url).toBe('http://runner-fallback');
+    });
+});


### PR DESCRIPTION
<!-- Describe the problem and your solution -->
Cancellation only targeted a single runner, which failed when a task was still running on a different active runner (e.g., after key rotation).
Fan out abort requests to all active runners for the team’s routingId and succeed if any runner confirms the abort.
<!-- Issue ticket number and link (if applicable) -->
[NAN-4519](https://linear.app/nango/issue/NAN-4519/task-cancellation-must-broadcast-to-all-active-runners)
<!-- Testing instructions (skip if just adding/editing providers) -->
- Added test cases for new functionality
- Want to attempt to test it on an actual run

<!-- Summary by @propel-code-bot -->

---

**Broadcast abort requests to every active runner**

This PR changes task cancellation so that abort requests are fanned out to every active runner registered under a team’s routing ID, ensuring cancellation succeeds even if execution has shifted to another node during rollouts. It introduces a shared `getRunners` helper that consults fleet state (or falls back to the legacy single-runner lookup) plus a fleet-level `getNodesByRoutingId` API to enumerate applicable nodes, and updates the runtime adapter and abort operation to treat success as soon as any runner confirms the abort.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `getRunnerIdForTeam` and new `getRunners` helper in `packages/jobs/lib/runner/runner.ts` that queries the fleet for `RUNNING`/`OUTDATED` nodes (with remote/default fallbacks) and returns multiple `FleetRunner` clients.
• Extended `packages/fleet/lib/fleet.ts` with a `getNodesByRoutingId` method (including `NodeState` typing) to retrieve nodes matching a routing ID and optional state filter.
• Updated `packages/jobs/lib/execution/operations/abort.ts` and `packages/jobs/lib/runtime/runner.adapter.ts` to broadcast aborts via `Promise.allSettled`, treating the operation as successful if any runner fulfills with `true`, and added explanatory comments.
• Introduced targeted unit tests in `packages/jobs/lib/runner/runner.unit.test.ts` and `packages/jobs/lib/execution/operations/abort.unit.test.ts` covering multi-runner selection, fallbacks, and success/error cases.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/jobs/lib/runner/runner.ts
• packages/jobs/lib/execution/operations/abort.ts
• packages/jobs/lib/runtime/runner.adapter.ts
• packages/fleet/lib/fleet.ts
• packages/jobs/lib/runner/runner.unit.test.ts
• packages/jobs/lib/execution/operations/abort.unit.test.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*