### PR TITLE
fix(tokenRefresh): fix token refresh for microsoft admin

### DIFF
--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -395,6 +395,7 @@ export async function refreshCredentialsIfNeeded({
                 refreshGithubAppJwtToken
             });
 
+            console.log('this is the should refresh token here', shouldRefresh);
             return {
                 connection,
                 shouldRefresh,
@@ -564,12 +565,13 @@ export async function shouldRefreshCredentials({
 
     // -- At this stage credentials need a refresh whether it's forced or because they are expired
 
-    if (providerConfig.provider === 'facebook' || providerConfig.provider === 'microsoft-admin' || providerConfig.provider === 'instagram') {
+    if (providerConfig.provider === 'facebook' || providerConfig.provider === 'instagram') {
         return { should: instantRefresh, reason: providerConfig.provider };
     }
 
     if (credentials.type === 'OAUTH2') {
-        if (credentials.refresh_token) {
+        // microsoft-admin doesn't return a refresh_token but we need to refresh it using the client_credentials flow
+        if (credentials.refresh_token || providerConfig.provider === 'microsoft-admin') {
             return { should: true, reason: 'expired_oauth2_with_refresh_token' };
         }
         // We can't refresh since we don't have a refresh token even if we force it

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -395,7 +395,6 @@ export async function refreshCredentialsIfNeeded({
                 refreshGithubAppJwtToken
             });
 
-            console.log('this is the should refresh token here', shouldRefresh);
             return {
                 connection,
                 shouldRefresh,
@@ -570,7 +569,8 @@ export async function shouldRefreshCredentials({
     }
 
     if (credentials.type === 'OAUTH2') {
-        // microsoft-admin doesn't return a refresh_token but we need to refresh it using the client_credentials flow
+        // normally we refresh using a refresh_token for OAUTH2 providers, but microsoft-admin uses the client_credentials flow and doesn't return a refresh_token.
+        // so we allow token refresh either if we have a refresh_token or if the provider is microsoft-admin.
         if (credentials.refresh_token || providerConfig.provider === 'microsoft-admin') {
             return { should: true, reason: 'expired_oauth2_with_refresh_token' };
         }


### PR DESCRIPTION
## Describe the problem and your solution

- Fix token refresh for Microsoft Admin. Microsoft Admin is a special provider in Nango because it uses both the OAuth 2.0 Authorization Code (OAUTH2) and Client Credentials (OAUTH2_CC) flows. We use the OAUTH2 flow to ensure the end user installs the application on their tenant, as it involves redirecting the user to a specific URL. Once this is completed, we obtain tokens using the client credentials flow.

Since the client credentials flow does not return a refresh_token, this change fixes automatic token refresh handling for the Microsoft Admin provider.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Ensure `microsoft-admin` OAuth2 credentials are eligible for scheduled refresh**

The PR adjusts the credential refresh heuristic so that the `microsoft-admin` provider no longer bypasses the regular OAuth2 refresh path when no `refresh_token` is stored. Instead, the refresh logic now explicitly treats `microsoft-admin` as refreshable even without a refresh token, reflecting its client-credentials-based renewal flow.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed `microsoft-admin` from the `instantRefresh`-only provider short-circuit in `shouldRefreshCredentials` so it reaches the general OAuth2 logic
• Updated the OAuth2 branch in `shouldRefreshCredentials` to return `{ should: true }` when the provider is `microsoft-admin` even if `credentials.refresh_token` is absent, with inline documentation explaining the client-credentials flow

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/shared/lib/services/connections/credentials/refresh.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*