### PR TITLE
fix(undisclosed): security advisory

### DIFF
--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -566,7 +566,9 @@ export class DryRunService {
                     URLSearchParams
                 };
 
-                const context = vm.createContext(sandbox);
+                const context = vm.createContext(sandbox, {
+                    codeGeneration: { strings: false, wasm: false }
+                });
                 const scriptExports: { default?: ((nango: NangoActionBase, payload?: object) => Promise<unknown>) | nangoScript.CreateAnyResponse } =
                     scriptObj.runInContext(context);
 

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -114,7 +114,9 @@ export async function exec({
                 URLSearchParams
             };
 
-            const context = vm.createContext(sandbox);
+            const context = vm.createContext(sandbox, {
+                codeGeneration: { strings: false, wasm: false }
+            });
             const scriptExports = script.runInContext(context) as ScriptExports;
 
             const def = scriptExports.default;


### PR DESCRIPTION
Mitigation for yet undisclosed security advisory.

<!-- Summary by @propel-code-bot -->

---

**Disable dynamic code generation in VM sandboxes**

Updates both runner and CLI dry-run sandboxes to instantiate Node.js VM contexts with `codeGeneration` for `strings` and `wasm` disabled. This mitigation prevents user-supplied scripts executed through `packages/runner/lib/exec.ts` and `packages/cli/lib/services/dryrun.service.ts` from invoking `eval`-style dynamic code paths, addressing the undisclosed security advisory.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `vm.createContext` invocation in `packages/runner/lib/exec.ts` to pass `{ codeGeneration: { strings: false, wasm: false } }` when building the runner sandbox.
• Applied the same `codeGeneration` restriction to the CLI dry-run sandbox in `packages/cli/lib/services/dryrun.service.ts`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/runner/lib/exec.ts`
• `packages/cli/lib/services/dryrun.service.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*