### PR TITLE
feat(server): Increase the max value length of tags

### DIFF
--- a/packages/server/lib/controllers/connect/postSessions.integration.test.ts
+++ b/packages/server/lib/controllers/connect/postSessions.integration.test.ts
@@ -401,7 +401,7 @@ describe(`POST ${endpoint}`, () => {
         });
 
         it('should fail with tag value exceeding max length', async () => {
-            const longValue = 'a'.repeat(201);
+            const longValue = 'a'.repeat(256);
             const res = await api.fetch(endpoint, {
                 method: 'POST',
                 token: seed.env.secret_key,

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -157,7 +157,7 @@ export const connectionEndUserTagsSchema = z
     // It's a labelling system, if we allow more than string people will store complex data (e.g: nested object) and ask for features around that
     // + It's an object not a an array of string because customers wants to store layers of origin (e.g: projectId, orgId, etc.)
     // But they complained a lot about concatenation of string, so an object solves that cleanly
-    .record(z.string(), z.string())
+    .record(z.string(), z.string().max(255))
     .refine((v) => Object.keys(v).length < 64, { message: 'Tags can not contain more than 64 keys' });
 
 export const endUserSchema = z.strictObject({

--- a/packages/shared/lib/services/tags/schema.ts
+++ b/packages/shared/lib/services/tags/schema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const TAG_MAX_COUNT = 10;
 export const TAG_KEY_MAX_LENGTH = 64;
-export const TAG_VALUE_MAX_LENGTH = 200;
+export const TAG_VALUE_MAX_LENGTH = 255;
 
 const connectionTagsKeySchema = z
     .string()

--- a/packages/shared/lib/services/tags/schema.unit.test.ts
+++ b/packages/shared/lib/services/tags/schema.unit.test.ts
@@ -178,8 +178,8 @@ describe('connectionTagsSchema', () => {
             expect(result.success).toBe(true);
         });
 
-        it('should accept value at max length (200 chars)', () => {
-            const value = 'a'.repeat(200);
+        it('should accept value at max length (255 chars)', () => {
+            const value = 'a'.repeat(255);
             const result = connectionTagsSchema.safeParse({ key: value });
             expect(result.success).toBe(true);
         });
@@ -212,8 +212,8 @@ describe('connectionTagsSchema', () => {
             expect(result.success).toBe(false);
         });
 
-        it('should reject values longer than 200 chars', () => {
-            const value = 'a'.repeat(201);
+        it('should reject values longer than 255 chars', () => {
+            const value = 'a'.repeat(256);
             const result = connectionTagsSchema.safeParse({ key: value });
             expect(result.success).toBe(false);
         });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
This is to match the limits of old end_user fields. The end user tags had no limit before but I did some queries in the prod DB and there are some tags with values ~228 so this should be fine too. As a precaution, I added a limit of 255 on the end_user tags as well for as long as people are still able to use that.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Raise tag value limits to 255 characters**

Increases the allowable length of tag values from 200 to 255 characters to match historical end-user tag behavior while now enforcing the same 255-character cap on legacy end-user tags. Unit and integration tests were updated to reflect the new boundary conditions so both schemas and runtime validation stay aligned.

<details>
<summary><strong>Key Changes</strong></summary>

• Raised `TAG_VALUE_MAX_LENGTH` in `packages/shared/lib/services/tags/schema.ts` from 200 to 255 so `connectionTagsSchema` accepts longer values
• Updated `packages/server/lib/helpers/validation.ts` to cap `connectionEndUserTagsSchema` values at 255 characters instead of being unbounded
• Adjusted unit (`schema.unit.test.ts`) and integration (`postSessions.integration.test.ts`) tests to cover the 255/256 character acceptance and rejection cases

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/services/tags/schema.ts`
• `packages/shared/lib/services/tags/schema.unit.test.ts`
• `packages/server/lib/helpers/validation.ts`
• `packages/server/lib/controllers/connect/postSessions.integration.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*