### PR TITLE
feat(server): increase `listConnections` limit

### DIFF
--- a/packages/server/lib/controllers/connection/getConnections.ts
+++ b/packages/server/lib/controllers/connection/getConnections.ts
@@ -17,7 +17,7 @@ const validationQuery = z
         integrationId: z.string().min(1).optional(),
         endUserOrganizationId: bodySchema.shape.end_user.shape.id.optional(),
         tags: connectionTagsSchema.optional(),
-        limit: z.coerce.number().min(1).max(1000).optional(),
+        limit: z.coerce.number().min(1).max(2000).optional(),
         page: z.coerce.number().min(0).optional()
     })
     .strict();


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Increase `listConnections` limit ceiling**

Raised the `limit` validator in `getConnections.ts` so clients can request up to 2000 connections per call instead of the previous 1000 cap. No other logic or defaults were modified.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated the `zod` schema for `limit` in `packages/server/lib/controllers/connection/getConnections.ts` from `max(1000)` to `max(2000)`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/connection/getConnections.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*