### PR TITLE
feat(persist): adds checkpoint endpoints to the persist

### DIFF
--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/checkpoint/deleteCheckpoint.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/checkpoint/deleteCheckpoint.ts
@@ -1,0 +1,58 @@
+import db from '@nangohq/database';
+import { deleteCheckpoint } from '@nangohq/shared';
+import { validateRequest } from '@nangohq/utils';
+
+import { deleteCheckpointRequestParser } from './validate.js';
+
+import type { AuthLocals } from '../../../../../../middleware/auth.middleware.js';
+import type { ApiError, Endpoint } from '@nangohq/types';
+import type { EndpointRequest, EndpointResponse, Route, RouteHandler } from '@nangohq/utils';
+
+type DeleteCheckpoint = Endpoint<{
+    Method: typeof method;
+    Path: typeof path;
+    Params: {
+        environmentId: number;
+        nangoConnectionId: number;
+    };
+    Body: {
+        key: string;
+        expectedVersion: number;
+    };
+    Error: ApiError<'delete_checkpoint_failed' | 'checkpoint_conflict'>;
+    Success: never;
+}>;
+
+const path = '/environment/:environmentId/connection/:nangoConnectionId/checkpoint';
+const method = 'DELETE';
+
+const validate = validateRequest<DeleteCheckpoint>(deleteCheckpointRequestParser);
+
+const handler = async (_req: EndpointRequest, res: EndpointResponse<DeleteCheckpoint, AuthLocals>) => {
+    const {
+        parsedParams: { nangoConnectionId, environmentId },
+        parsedBody: { key, expectedVersion }
+    } = res.locals;
+
+    const result = await deleteCheckpoint(db.knex, { environmentId, connectionId: nangoConnectionId, key, expectedVersion });
+
+    if (result.isErr()) {
+        if (result.error.message === 'checkpoint_conflict') {
+            res.status(409).json({ error: { code: 'checkpoint_conflict', message: 'Checkpoint has been updated since last read' } });
+            return;
+        }
+        res.status(500).json({ error: { code: 'delete_checkpoint_failed', message: `Failed to delete checkpoint: ${result.error.message}` } });
+        return;
+    }
+
+    res.status(204).send();
+};
+
+export const route: Route<DeleteCheckpoint> = { path, method };
+
+export const routeHandler: RouteHandler<DeleteCheckpoint, AuthLocals> = {
+    method,
+    path,
+    validate,
+    handler
+};

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/checkpoint/getCheckpoint.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/checkpoint/getCheckpoint.ts
@@ -1,0 +1,63 @@
+import db from '@nangohq/database';
+import { getCheckpoint } from '@nangohq/shared';
+import { validateRequest } from '@nangohq/utils';
+
+import { getCheckpointRequestParser } from './validate.js';
+
+import type { AuthLocals } from '../../../../../../middleware/auth.middleware.js';
+import type { ApiError, Endpoint, GetCheckpointSuccess } from '@nangohq/types';
+import type { EndpointRequest, EndpointResponse, Route, RouteHandler } from '@nangohq/utils';
+
+type GetCheckpoint = Endpoint<{
+    Method: typeof method;
+    Path: typeof path;
+    Params: {
+        environmentId: number;
+        nangoConnectionId: number;
+    };
+    Querystring: {
+        key: string;
+    };
+    Error: ApiError<'get_checkpoint_failed' | 'checkpoint_not_found'>;
+    Success: GetCheckpointSuccess;
+}>;
+
+const path = '/environment/:environmentId/connection/:nangoConnectionId/checkpoint';
+const method = 'GET';
+
+const validate = validateRequest<GetCheckpoint>(getCheckpointRequestParser);
+
+const handler = async (_req: EndpointRequest, res: EndpointResponse<GetCheckpoint, AuthLocals>) => {
+    const {
+        parsedParams: { nangoConnectionId, environmentId },
+        parsedQuery: { key }
+    } = res.locals;
+
+    const result = await getCheckpoint(db.knex, { environmentId, connectionId: nangoConnectionId, key });
+
+    if (result.isErr()) {
+        res.status(500).json({ error: { code: 'get_checkpoint_failed', message: `Failed to get checkpoint: ${result.error.message}` } });
+        return;
+    }
+
+    const checkpoint = result.value;
+    if (!checkpoint) {
+        res.status(404).json({ error: { code: 'checkpoint_not_found', message: `Checkpoint not found` } });
+        return;
+    }
+
+    res.json({
+        checkpoint: checkpoint.checkpoint,
+        version: checkpoint.version,
+        deletedAt: checkpoint.deleted_at?.toISOString() || null
+    });
+};
+
+export const route: Route<GetCheckpoint> = { path, method };
+
+export const routeHandler: RouteHandler<GetCheckpoint, AuthLocals> = {
+    method,
+    path,
+    validate,
+    handler
+};

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/checkpoint/putCheckpoint.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/checkpoint/putCheckpoint.ts
@@ -1,0 +1,65 @@
+import db from '@nangohq/database';
+import { upsertCheckpoint } from '@nangohq/shared';
+import { validateRequest } from '@nangohq/utils';
+
+import { putCheckpointRequestParser } from './validate.js';
+
+import type { AuthLocals } from '../../../../../../middleware/auth.middleware.js';
+import type { ApiError, Checkpoint, Endpoint, PutCheckpointSuccess } from '@nangohq/types';
+import type { EndpointRequest, EndpointResponse, Route, RouteHandler } from '@nangohq/utils';
+
+type PutCheckpoint = Endpoint<{
+    Method: typeof method;
+    Path: typeof path;
+    Params: {
+        environmentId: number;
+        nangoConnectionId: number;
+    };
+    Body: {
+        key: string;
+        checkpoint: Checkpoint;
+        expectedVersion: number;
+    };
+    Error: ApiError<'put_checkpoint_failed' | 'checkpoint_conflict'>;
+    Success: PutCheckpointSuccess;
+}>;
+
+const path = '/environment/:environmentId/connection/:nangoConnectionId/checkpoint';
+const method = 'PUT';
+
+const validate = validateRequest<PutCheckpoint>(putCheckpointRequestParser);
+
+const handler = async (_req: EndpointRequest, res: EndpointResponse<PutCheckpoint, AuthLocals>) => {
+    const {
+        parsedParams: { nangoConnectionId, environmentId },
+        parsedBody: { key, checkpoint, expectedVersion }
+    } = res.locals;
+
+    const result = await upsertCheckpoint(db.knex, {
+        environmentId,
+        connectionId: nangoConnectionId,
+        key,
+        checkpoint,
+        expectedVersion
+    });
+
+    if (result.isErr()) {
+        if (result.error.message === 'checkpoint_conflict') {
+            res.status(409).json({ error: { code: 'checkpoint_conflict', message: 'Checkpoint has been updated since last read' } });
+            return;
+        }
+        res.status(500).json({ error: { code: 'put_checkpoint_failed', message: `Failed to save checkpoint: ${result.error.message}` } });
+        return;
+    }
+
+    res.json({ checkpoint: result.value.checkpoint, version: result.value.version });
+};
+
+export const route: Route<PutCheckpoint> = { path, method };
+
+export const routeHandler: RouteHandler<PutCheckpoint, AuthLocals> = {
+    method,
+    path,
+    validate,
+    handler
+};

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/checkpoint/validate.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/checkpoint/validate.ts
@@ -1,0 +1,49 @@
+import * as z from 'zod';
+
+import { CHECKPOINT_KEY_MAX_LENGTH, checkpointSchema } from '@nangohq/shared';
+
+const checkpointParamsSchema = z
+    .object({
+        environmentId: z.coerce.number().int().positive(),
+        nangoConnectionId: z.coerce.number().int().positive()
+    })
+    .strict();
+
+// GET checkpoint?key=KEY
+const getCheckpointQuerySchema = z
+    .object({
+        key: z.string().min(1).max(CHECKPOINT_KEY_MAX_LENGTH)
+    })
+    .strict();
+
+export const getCheckpointRequestParser = {
+    parseParams: (data: unknown) => checkpointParamsSchema.parse(data),
+    parseQuery: (data: unknown) => getCheckpointQuerySchema.parse(data)
+};
+
+// PUT checkpoint
+const putCheckpointBodySchema = z
+    .object({
+        key: z.string().min(1).max(CHECKPOINT_KEY_MAX_LENGTH),
+        checkpoint: checkpointSchema,
+        expectedVersion: z.number().int().positive()
+    })
+    .strict();
+
+export const putCheckpointRequestParser = {
+    parseParams: (data: unknown) => checkpointParamsSchema.parse(data),
+    parseBody: (data: unknown) => putCheckpointBodySchema.parse(data)
+};
+
+// DELETE checkpoint
+const deleteCheckpointBodySchema = z
+    .object({
+        key: z.string().min(1).max(CHECKPOINT_KEY_MAX_LENGTH),
+        expectedVersion: z.number().int().positive()
+    })
+    .strict();
+
+export const deleteCheckpointRequestParser = {
+    parseParams: (data: unknown) => checkpointParamsSchema.parse(data),
+    parseBody: (data: unknown) => deleteCheckpointBodySchema.parse(data)
+};

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -452,6 +452,157 @@ describe('Persist API', () => {
             });
         });
     });
+
+    describe('checkpoint', () => {
+        it('should return 404 if checkpoint not found', async () => {
+            const response = await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/checkpoint?key=non-existent`, {
+                method: 'GET',
+                headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+            expect(response.status).toEqual(404);
+            expect(await response.json()).toMatchObject({ error: { code: 'checkpoint_not_found' } });
+        });
+
+        it('should create/get a new checkpoint', async () => {
+            const key = 'test-checkpoint-create';
+            const checkpoint = { status: 'running', count: 10 };
+
+            const createResponse = await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/checkpoint`, {
+                method: 'PUT',
+                body: JSON.stringify({ key, checkpoint, expectedVersion: 1 }),
+                headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+            expect(createResponse.status).toEqual(200);
+            expect(await createResponse.json()).toStrictEqual({ checkpoint, version: 1 });
+
+            const response = await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/checkpoint?key=${key}`, {
+                method: 'GET',
+                headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+            expect(response.status).toEqual(200);
+            expect(await response.json()).toStrictEqual({ checkpoint, version: 1, deletedAt: null });
+        });
+
+        it('should update checkpoint', async () => {
+            const key = 'test-checkpoint-update';
+            const checkpoint1 = { step: 1 };
+            const checkpoint2 = { step: 2 };
+
+            await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/checkpoint`, {
+                method: 'PUT',
+                body: JSON.stringify({ key, checkpoint: checkpoint1, expectedVersion: 1 }),
+                headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            const response = await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/checkpoint`, {
+                method: 'PUT',
+                body: JSON.stringify({ key, checkpoint: checkpoint2, expectedVersion: 1 }),
+                headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+            expect(response.status).toEqual(200);
+            expect(await response.json()).toStrictEqual({ checkpoint: checkpoint2, version: 2 });
+        });
+
+        it('should return 409 on version conflict for PUT', async () => {
+            const key = 'test-checkpoint-update-conflict';
+            const checkpoint = { data: 'initial' };
+
+            await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/checkpoint`, {
+                method: 'PUT',
+                body: JSON.stringify({ key, checkpoint, expectedVersion: 1 }),
+                headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            const response = await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/checkpoint`, {
+                method: 'PUT',
+                body: JSON.stringify({ key, checkpoint: { data: 'updated' }, expectedVersion: 99 }),
+                headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+            expect(response.status).toEqual(409);
+            expect(await response.json()).toMatchObject({ error: { code: 'checkpoint_conflict' } });
+        });
+
+        it('should delete checkpoint', async () => {
+            const key = 'test-checkpoint-delete';
+            const checkpoint = { toDelete: true };
+
+            await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/checkpoint`, {
+                method: 'PUT',
+                body: JSON.stringify({ key, checkpoint, expectedVersion: 1 }),
+                headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            const deleteResponse = await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/checkpoint`, {
+                method: 'DELETE',
+                body: JSON.stringify({ key, expectedVersion: 1 }),
+                headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+            expect(deleteResponse.status).toEqual(204);
+
+            const getResponse = await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/checkpoint?key=${key}`, {
+                method: 'GET',
+                headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+            expect(getResponse.status).toEqual(200);
+            const body = (await getResponse.json()) as { checkpoint: object; version: number; deletedAt: string | null };
+            expect(body).toMatchObject({ checkpoint, version: 2, deletedAt: expect.toBeIsoDate() });
+        });
+
+        it('should return 409 on version conflict for DELETE', async () => {
+            const key = 'test-checkpoint-delete-conflict';
+            const checkpoint = { data: 'to-delete' };
+
+            await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/checkpoint`, {
+                method: 'PUT',
+                body: JSON.stringify({ key, checkpoint, expectedVersion: 1 }),
+                headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            const response = await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/checkpoint`, {
+                method: 'DELETE',
+                body: JSON.stringify({ key, expectedVersion: 99 }),
+                headers: {
+                    Authorization: `Bearer ${mockSecretKey}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+            expect(response.status).toEqual(409);
+            expect(await response.json()).toMatchObject({ error: { code: 'checkpoint_conflict' } });
+        });
+    });
 });
 
 const initDb = async () => {

--- a/packages/persist/lib/server.ts
+++ b/packages/persist/lib/server.ts
@@ -4,6 +4,12 @@ import { createRoute } from '@nangohq/utils';
 
 import { authMiddleware } from './middleware/auth.middleware.js';
 import { recordsPath } from './records.js';
+import { routeHandler as deleteCheckpointHandler } from './routes/environment/environmentId/connection/connectionId/checkpoint/deleteCheckpoint.js';
+import {
+    route as getCheckpointRoute,
+    routeHandler as getCheckpointHandler
+} from './routes/environment/environmentId/connection/connectionId/checkpoint/getCheckpoint.js';
+import { routeHandler as putCheckpointHandler } from './routes/environment/environmentId/connection/connectionId/checkpoint/putCheckpoint.js';
 import { route as getCursorRoute, routeHandler as getCursorHandler } from './routes/environment/environmentId/connection/connectionId/getCursor.js';
 import { route as getRecordsRoute, routeHandler as getRecordsHandler } from './routes/environment/environmentId/connection/connectionId/getRecords.js';
 import {
@@ -32,6 +38,7 @@ server.use(recordsPath, express.json({ limit: maxSizeJsonRecords }));
 server.use(getCursorRoute.path, express.json());
 server.use(getRecordsRoute.path, express.json());
 server.use(deleteOutdatedRecordsRoute.path, express.json());
+server.use(getCheckpointRoute.path, express.json());
 
 createRoute(server, getHealthHandler);
 createRoute(server, postLogHandler);
@@ -41,6 +48,9 @@ createRoute(server, deleteOutdatedRecordsHandler);
 createRoute(server, putRecordsHandler);
 createRoute(server, getCursorHandler);
 createRoute(server, getRecordsHandler);
+createRoute(server, getCheckpointHandler);
+createRoute(server, putCheckpointHandler);
+createRoute(server, deleteCheckpointHandler);
 
 server.use((_req: Request, res: Response, next: NextFunction) => {
     res.status(404);

--- a/packages/persist/tsconfig.json
+++ b/packages/persist/tsconfig.json
@@ -33,5 +33,5 @@
             "path": "../pubsub"
         }
     ],
-    "include": ["lib/**/*"]
+    "include": ["lib/**/*", "../utils/lib/vitest.d.ts"]
 }

--- a/packages/shared/lib/services/checkpoints/checkpoints.ts
+++ b/packages/shared/lib/services/checkpoints/checkpoints.ts
@@ -8,9 +8,9 @@ import type { Knex } from 'knex';
 
 const TABLE = 'checkpoints';
 
-const MAX_KEY_LENGTH = 255;
-const MAX_STRING_VALUE_LENGTH = 255;
-const MAX_FIELDS = 16;
+export const CHECKPOINT_KEY_MAX_LENGTH = 255;
+export const CHECKPOINT_STRING_VALUE_MAX_LENGTH = 255;
+export const CHECKPOINT_MAX_FIELDS = 16;
 
 /**
  * Zod schema for checkpoint validation.
@@ -19,16 +19,19 @@ const MAX_FIELDS = 16;
  * - Date values: converted to ISO string
  * - Max 16 fields
  */
-const checkpointValueSchema = z.union([z.string().max(MAX_STRING_VALUE_LENGTH), z.number(), z.boolean(), z.date().transform((d) => d.toISOString())]);
+const checkpointValueSchema = z.union([
+    z.string().max(CHECKPOINT_STRING_VALUE_MAX_LENGTH),
+    z.number(),
+    z.boolean(),
+    z.date().transform((d) => d.toISOString())
+]);
 
-const checkpointSchema = z.record(z.string().max(MAX_KEY_LENGTH), checkpointValueSchema).refine((data) => Object.keys(data).length <= MAX_FIELDS, {
-    message: `Checkpoint cannot have more than ${MAX_FIELDS} fields`
-});
+export const checkpointSchema = z
+    .record(z.string().max(CHECKPOINT_KEY_MAX_LENGTH), checkpointValueSchema)
+    .refine((data) => Object.keys(data).length <= CHECKPOINT_MAX_FIELDS, {
+        message: `Checkpoint cannot have more than ${CHECKPOINT_MAX_FIELDS} fields`
+    });
 
-/**
- * Validates that a checkpoint object only contains flat key-value pairs
- * with string, number, or boolean values.
- */
 export function validateCheckpoint(data: unknown): Result<Checkpoint> {
     const result = checkpointSchema.safeParse(data);
     if (result.success) {
@@ -78,7 +81,7 @@ export async function upsertCheckpoint(
         expectedVersion
     }: { environmentId: number; connectionId: number; key: string; checkpoint: Checkpoint; expectedVersion?: number }
 ): Promise<Result<DBCheckpoint>> {
-    if (key.length > MAX_KEY_LENGTH) {
+    if (key.length > CHECKPOINT_KEY_MAX_LENGTH) {
         return Err(new Error('checkpoint_key_too_long'));
     }
 

--- a/packages/types/lib/checkpoint/db.ts
+++ b/packages/types/lib/checkpoint/db.ts
@@ -1,27 +1,5 @@
 import type { Timestamps } from '../db.js';
-
-/**
- * Allowed types for checkpoint values.
- * Only flat key-value structures are supported (no nested objects or arrays).
- * Date values are automatically converted to ISO strings when stored.
- */
-export type CheckpointValue = string | number | boolean | Date;
-
-/**
- * A checkpoint is a flat key-value object that can be used to store
- * progress or state during function execution.
- * Date values are automatically converted to ISO strings when stored.
- *
- * @example
- * ```typescript
- * const checkpoint: Checkpoint = {
- *     lastProcessedPage: 5,
- *     lastCursor: "abc123",
- *     lastRunAt: new Date(), // stored as ISO string
- * };
- * ```
- */
-export type Checkpoint = Record<string, CheckpointValue>;
+import type { Checkpoint } from './types.js';
 
 /**
  * Checkpoints are identified by a flexible key format that allows

--- a/packages/types/lib/checkpoint/types.ts
+++ b/packages/types/lib/checkpoint/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Allowed types for checkpoint values.
+ * Only flat key-value structures are supported (no nested objects or arrays).
+ * Date values are automatically converted to ISO strings when stored.
+ */
+export type CheckpointValue = string | number | boolean | Date;
+
+/**
+ * A checkpoint is a flat key-value object that can be used to store
+ * progress or state during function execution.
+ * Date values are automatically converted to ISO strings when stored.
+ *
+ * @example
+ * ```typescript
+ * const checkpoint: Checkpoint = {
+ *     lastProcessedPage: 5,
+ *     lastCursor: "abc123",
+ *     lastRunAt: new Date(), // stored as ISO string
+ * };
+ * ```
+ */
+export type Checkpoint = Record<string, CheckpointValue>;

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -92,6 +92,7 @@ export type * from './fleet/index.js';
 export type * from './persist/api.js';
 export type * from './jobs/api.js';
 
+export type * from './checkpoint/types.js';
 export type * from './checkpoint/db.js';
 
 export type * from './mcp/api.js';

--- a/packages/types/lib/persist/api.ts
+++ b/packages/types/lib/persist/api.ts
@@ -1,4 +1,5 @@
 import type { ApiError, Endpoint } from '../api.js';
+import type { Checkpoint } from '../checkpoint/types.js';
 import type { MessageRowInsert } from '../logs/messages.js';
 import type { MergingStrategy, NangoRecord } from '../record/api.js';
 
@@ -41,4 +42,15 @@ export interface GetCursorSuccess {
 export interface GetRecordsSuccess {
     records: NangoRecord[];
     nextCursor?: string;
+}
+
+export interface GetCheckpointSuccess {
+    checkpoint: Checkpoint;
+    version: number;
+    deletedAt: string | null;
+}
+
+export interface PutCheckpointSuccess {
+    checkpoint: Checkpoint;
+    version: number;
 }


### PR DESCRIPTION
New Endpoints
- GET /environment/:environmentId/connection/:nangoConnectionId/checkpoint?key=... - Retrieve checkpoint
- PUT /environment/:environmentId/connection/:nangoConnectionId/checkpoint - Create/update checkpoint
- DELETE /environment/:environmentId/connection/:nangoConnectionId/checkpoint - Soft delete checkpoint

Those endpoints will be called by the runner-sdk to manipulate checkpoints.
<!-- Summary by @propel-code-bot -->

---

The routes are wired into the persist server with Zod validation and optimistic-locking safeguards, while shared checkpoint schemas and types are re-exported for reuse across packages, and related integration tests plus tsconfig/type adjustments ensure the new behavior is fully covered and properly typed.

<details>
<summary><strong>Affected Areas</strong></summary>

• Checkpoint service (`packages/shared/lib/services/checkpoints/checkpoints.ts`)
• Persist API routes (`packages/persist/lib/routes/environment/.../checkpoint/*`)
• Persist server wiring (`packages/persist/lib/server.ts`)
• Types package (`packages/types/lib/checkpoint/*`, `packages/types/lib/persist/api.ts`, `packages/types/lib/index.ts`)
• Integration tests (`packages/persist/lib/server.integration.test.ts`)
• Persist tsconfig (`packages/persist/tsconfig.json`)

</details>

---
*This summary was automatically generated by @propel-code-bot*