### PR TITLE
fix(records): Flaky integration test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "dwh": "npm run dev:watch:headless",
         "test": "concurrently --kill-others \"npm run test:unit\" \"npm run test:integration\" \"npm run test:cli\"",
         "test:unit": "vitest",
-        "test:integration": "vitest --config ./vite.integration.config.ts",
+        "test:integration": "vitest --config ./vite.integration.config.ts ${npm_config_dir:-.}",
         "test:cli": "vitest --config ./vite.cli.config.ts",
         "test:cli:update-snapshots": "vitest --config ./vite.cli.config.ts --update",
         "test:openapi": "npx @apidevtools/swagger-cli validate docs/spec.yaml && npx @redocly/cli lint docs/spec.yaml",


### PR DESCRIPTION
Function `paginateCounts` had some issues and was causing flaky tests.

In order to make debugging such tests easier, I added `${npm_config_dir:-.}` to our `test:integration` script.
This allows us to pass an optional `--dir` flag to `npm run test:integration`, specifying which subdirectory to test.
The flag defaults to the npm root dir, so it has no effects for extant users.

<!-- Summary by @propel-code-bot -->

---

The pagination helper itself was reinforced by validating `batchSize`, rebuilding the typed query so the optional `whereIn('environment_id', environmentIds)` filter only applies when needed, and halting iteration cleanly whenever a partial batch is read or an error must propagate through the iterator contract.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/records/lib/models/records.ts`
• `package.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*