### PR TITLE
feat(tags): Match the validation of end_user tags to new tags

### DIFF
--- a/packages/shared/lib/services/tags.service.ts
+++ b/packages/shared/lib/services/tags.service.ts
@@ -5,7 +5,7 @@ import { connectionTagsSchema } from './tags/schema.js';
 import type { Knex } from '@nangohq/database';
 import type { DBConnection, Result, Tags } from '@nangohq/types';
 
-export { TAG_KEY_MAX_LENGTH, TAG_MAX_COUNT, TAG_VALUE_MAX_LENGTH, connectionTagsSchema } from './tags/schema.js';
+export { TAG_KEY_MAX_LENGTH, TAG_MAX_COUNT, TAG_VALUE_MAX_LENGTH, connectionTagsKeySchema, connectionTagsSchema } from './tags/schema.js';
 
 type ConnectionWithTags = Pick<DBConnection, 'id' | 'tags'>;
 

--- a/packages/shared/lib/services/tags/schema.ts
+++ b/packages/shared/lib/services/tags/schema.ts
@@ -4,7 +4,7 @@ export const TAG_MAX_COUNT = 10;
 export const TAG_KEY_MAX_LENGTH = 64;
 export const TAG_VALUE_MAX_LENGTH = 255;
 
-const connectionTagsKeySchema = z
+export const connectionTagsKeySchema = z
     .string()
     .regex(/^[a-zA-Z][a-zA-Z0-9_\-./]*$/, {
         message: 'Tag keys must start with a letter and contain only alphanumerics, underscores, hyphens, periods, or slashes'
@@ -16,6 +16,33 @@ const connectionTagsValueSchema = z
     .min(1)
     .max(TAG_VALUE_MAX_LENGTH, { message: `Tag values must be at most ${TAG_VALUE_MAX_LENGTH} characters` });
 
+export const validateCaseInsensitiveTagKeys = (tags: Record<string, string>): string[] => {
+    const entries = Object.entries(tags);
+
+    if (entries.length > TAG_MAX_COUNT) {
+        return [`Tags cannot contain more than ${TAG_MAX_COUNT} keys`];
+    }
+
+    // Check for duplicate keys after normalization
+    const issues: string[] = [];
+    const seen = new Set<string>();
+    for (const [key, value] of entries) {
+        const normalized = key.toLowerCase();
+        if (seen.has(normalized)) {
+            issues.push(`Duplicate tag key after case normalization: "${normalized}"`);
+        }
+        seen.add(normalized);
+        if (normalized === 'end_user_email') {
+            const emailResult = z.string().email().min(5).safeParse(value);
+            if (!emailResult.success) {
+                issues.push('Tag "end_user_email" must be a valid email');
+            }
+        }
+    }
+
+    return issues;
+};
+
 /**
  * Zod schema for connection tags.
  * Validates tag format and normalizes keys to lowercase.
@@ -23,37 +50,9 @@ const connectionTagsValueSchema = z
  */
 export const connectionTagsSchema = z
     .record(connectionTagsKeySchema, connectionTagsValueSchema)
-    .superRefine((tags, ctx) => {
-        const entries = Object.entries(tags);
-
-        if (entries.length > TAG_MAX_COUNT) {
-            ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: `Tags cannot contain more than ${TAG_MAX_COUNT} keys`
-            });
-            return;
-        }
-
-        // Check for duplicate keys after normalization
-        const seen = new Set<string>();
-        for (const [key, value] of entries) {
-            const normalized = key.toLowerCase();
-            if (seen.has(normalized)) {
-                ctx.addIssue({
-                    code: z.ZodIssueCode.custom,
-                    message: `Duplicate tag key after case normalization: "${normalized}"`
-                });
-            }
-            seen.add(normalized);
-            if (normalized === 'end_user_email') {
-                const emailResult = z.string().email().min(5).safeParse(value);
-                if (!emailResult.success) {
-                    ctx.addIssue({
-                        code: z.ZodIssueCode.custom,
-                        message: 'Tag "end_user_email" must be a valid email'
-                    });
-                }
-            }
+    .check((payload) => {
+        for (const message of validateCaseInsensitiveTagKeys(payload.value)) {
+            payload.issues.push({ code: 'custom', message, input: payload.value });
         }
     })
     .transform((tags) => {


### PR DESCRIPTION
Make sure end_user.tags have the same validation on almost all levels as the new tags so that we don't have issues during the mapping for customers who haven't transitioned to the new tags yet and might populate invalid data in the future.

The only difference really is that we won't lowercase the end user tags to keep existing behavior intact.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Align `end_user.tags` validation with connection tag rules**

This PR centralizes tag validation logic so that legacy `end_user.tags` accept only the same key/ value patterns as the newer connection tags. A reusable helper now enforces key count limits, case-insensitive duplicate detection, and `end_user_email` formatting, and the server-side end-user schema reuses the shared key schema while deliberately omitting tag lowercasing to maintain historical behavior.

<details>
<summary><strong>Key Changes</strong></summary>

• Exported `connectionTagsKeySchema` and introduced `validateCaseInsensitiveTagKeys` in `packages/shared/lib/services/tags/schema.ts`, replacing the deprecated `.superRefine` block with a `.check` that consumes the helper.
• Re-exported the new schema elements from `packages/shared/lib/services/tags.service.ts` for downstream consumers.
• Updated `packages/server/lib/helpers/validation.ts` so `connectionEndUserTagsSchema` uses `connectionTagsKeySchema` plus the shared validation helper, ensuring API-level checks mirror the connection tag rules without altering key casing.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/services/tags/schema.ts`
• `packages/shared/lib/services/tags.service.ts`
• `packages/server/lib/helpers/validation.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*