### PR TITLE
feat(tags): Add backfill script/migration for end user tags -> connection tags

### DIFF
--- a/packages/database/lib/backfillConnectionTags.integration.test.ts
+++ b/packages/database/lib/backfillConnectionTags.integration.test.ts
@@ -1,0 +1,220 @@
+import { randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
+
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import db, { multipleMigrations } from './index.js';
+
+const require = createRequire(import.meta.url);
+const { buildConnectionTagsBackfillUpdateSql } = require('./migration-helpers/backfillConnectionTagsSql.cjs');
+
+// Inline seeds to avoid circular dependency with @nangohq/shared
+
+interface TestAccount {
+    id: number;
+    name: string;
+    uuid: string;
+}
+
+interface TestEnvironment {
+    id: number;
+    account_id: number;
+    name: string;
+}
+
+interface TestConfig {
+    id: number;
+    environment_id: number;
+    unique_key: string;
+    provider: string;
+}
+
+interface TestEndUser {
+    id: number;
+    end_user_id: string;
+    account_id: number;
+    environment_id: number;
+    email: string;
+    display_name: string | null;
+    organization_id: string | null;
+    organization_display_name: string | null;
+    tags: Record<string, string> | null;
+}
+
+interface TestConnection {
+    id: number;
+    environment_id: number;
+    provider_config_key: string;
+    connection_id: string;
+    end_user_id: number | null;
+    tags: Record<string, string>;
+}
+
+async function createTestAccount(): Promise<TestAccount> {
+    const name = `test-account-${randomUUID()}`;
+    const [account] = await db.knex.insert({ name }).into('_nango_accounts').returning('*');
+    return account;
+}
+
+async function createTestEnvironment(accountId: number): Promise<TestEnvironment> {
+    const [env] = await db.knex.insert({ account_id: accountId, name: 'dev' }).into('_nango_environments').returning('*');
+    return env;
+}
+
+async function createTestConfig(environmentId: number, uniqueKey: string, provider: string): Promise<TestConfig> {
+    const [config] = await db.knex
+        .insert({
+            environment_id: environmentId,
+            unique_key: uniqueKey,
+            provider: provider
+        })
+        .into('_nango_configs')
+        .returning('*');
+    return config;
+}
+
+async function createTestEndUser({
+    accountId,
+    environmentId,
+    endUserId,
+    email,
+    displayName,
+    organization,
+    tags
+}: {
+    accountId: number;
+    environmentId: number;
+    endUserId: string;
+    email: string;
+    displayName?: string | null;
+    organization?: { organizationId: string; displayName?: string | null } | null;
+    tags?: Record<string, string>;
+}): Promise<TestEndUser> {
+    const [endUser] = await db.knex
+        .insert({
+            end_user_id: endUserId,
+            account_id: accountId,
+            environment_id: environmentId,
+            email: email,
+            display_name: displayName ?? null,
+            organization_id: organization?.organizationId ?? null,
+            organization_display_name: organization?.displayName ?? null,
+            tags: tags ?? null
+        })
+        .into('end_users')
+        .returning('*');
+    return endUser;
+}
+
+async function createTestConnection({
+    environmentId,
+    configId,
+    providerConfigKey,
+    endUser,
+    tags
+}: {
+    environmentId: number;
+    configId: number;
+    providerConfigKey: string;
+    endUser?: TestEndUser;
+    tags?: Record<string, string>;
+}): Promise<TestConnection> {
+    const connectionId = `conn-${randomUUID()}`;
+    const [connection] = await db.knex
+        .insert({
+            environment_id: environmentId,
+            config_id: configId,
+            provider_config_key: providerConfigKey,
+            connection_id: connectionId,
+            credentials: {},
+            connection_config: {},
+            end_user_id: endUser?.id ?? null,
+            tags: tags ?? {}
+        })
+        .into('_nango_connections')
+        .returning('*');
+    return connection;
+}
+
+async function getConnectionTags(connectionId: number) {
+    const record = await db.knex.select('tags').from('_nango_connections').where({ id: connectionId }).first();
+    return record?.tags ?? null;
+}
+
+describe('Connection tags backfill', () => {
+    beforeAll(async () => {
+        await multipleMigrations();
+    });
+
+    it('backfills tags with edge cases', async () => {
+        const account = await createTestAccount();
+        const env = await createTestEnvironment(account.id);
+        const config = await createTestConfig(env.id, 'github', 'github');
+
+        // Test case 1: Special characters in all fields
+        const specialEndUser = await createTestEndUser({
+            accountId: account.id,
+            environmentId: env.id,
+            endUserId: 'user id/1?=+&',
+            email: 'user+test@example.com',
+            displayName: 'Jane Doe (R&D)',
+            organization: { organizationId: 'org:alpha/1', displayName: 'Org & Co' },
+            tags: {
+                project: 'R&D / alpha',
+                team: 'core team',
+                ip: '2001:db8::1'
+            }
+        });
+        const specialConn = await createTestConnection({
+            environmentId: env.id,
+            configId: config.id,
+            providerConfigKey: 'github',
+            endUser: specialEndUser,
+            tags: {}
+        });
+        const expectedSpecialTags = {
+            end_user_id: 'user id/1?=+&',
+            end_user_email: 'user+test@example.com',
+            end_user_display_name: 'Jane Doe (R&D)',
+            organization_id: 'org:alpha/1',
+            organization_display_name: 'Org & Co',
+            project: 'R&D / alpha',
+            team: 'core team',
+            ip: '2001:db8::1'
+        };
+
+        // Test case 2: Existing tags should take precedence over generated tags
+        const overrideEndUser = await createTestEndUser({
+            accountId: account.id,
+            environmentId: env.id,
+            endUserId: 'user-override',
+            email: 'original@example.com'
+        });
+        const overrideConn = await createTestConnection({
+            environmentId: env.id,
+            configId: config.id,
+            providerConfigKey: 'github',
+            endUser: overrideEndUser,
+            tags: { end_user_email: 'override@example.com', custom: 'keep' }
+        });
+        const expectedOverrideTags = {
+            end_user_id: 'user-override',
+            end_user_email: 'override@example.com',
+            custom: 'keep'
+        };
+
+        // Test case 3: Connection without end_user should not be affected
+        const noEndUserConn = await createTestConnection({
+            environmentId: env.id,
+            configId: config.id,
+            providerConfigKey: 'github',
+            tags: { existing: 'yes' }
+        });
+
+        await db.knex.raw(buildConnectionTagsBackfillUpdateSql());
+
+        await expect(getConnectionTags(specialConn.id)).resolves.toEqual(expectedSpecialTags);
+        await expect(getConnectionTags(overrideConn.id)).resolves.toEqual(expectedOverrideTags);
+        await expect(getConnectionTags(noEndUserConn.id)).resolves.toEqual({ existing: 'yes' });
+    });
+});

--- a/packages/database/lib/migration-helpers/backfillConnectionTagsSql.cjs
+++ b/packages/database/lib/migration-helpers/backfillConnectionTagsSql.cjs
@@ -14,56 +14,137 @@ WITH source AS (
     INNER JOIN end_users AS eu
         ON eu.id = c.end_user_id
 ),
-generated AS (
+base AS (
     SELECT
         id,
         existing_tags,
-        (
-            jsonb_strip_nulls(
-                jsonb_build_object(
-                    'end_user_id', end_user_id,
-                    'end_user_email', email,
-                    'end_user_display_name', display_name,
-                    'organization_id', organization_id,
-                    'organization_display_name', organization_display_name
-                )
+        jsonb_strip_nulls(
+            jsonb_build_object(
+                'end_user_id', NULLIF(left(end_user_id::text, 255), ''),
+                'end_user_email', NULLIF(left(email::text, 255), ''),
+                'end_user_display_name', NULLIF(left(display_name::text, 255), ''),
+                'organization_id', NULLIF(left(organization_id::text, 255), ''),
+                'organization_display_name', NULLIF(left(organization_display_name::text, 255), '')
             )
-            || COALESCE(
-                (
-                    SELECT jsonb_object_agg(key, value)
-                    FROM jsonb_each_text(COALESCE(end_user_tags::jsonb, '{}'::jsonb))
-                ),
-                '{}'::jsonb
-            )
-        ) AS raw_tags
+        ) AS base_tags,
+        COALESCE(end_user_tags::jsonb, '{}'::jsonb) AS end_user_tags_object
     FROM source
-),
-lowercased AS (
+ ),
+end_user_tag_entries AS (
     SELECT
-        id,
-        existing_tags,
+        b.id,
+        kv.key AS raw_key,
+        kv.value AS raw_value,
+        left(lower(kv.key), 64) AS normalized_key,
+        NULLIF(left(kv.value, 255), '') AS normalized_value,
+        (length(kv.key) > 64) AS key_too_long,
+        (length(kv.value) > 255) AS value_too_long,
+        (left(lower(kv.key), 64) ~ '^[a-z][a-z0-9_./-]*$') AS key_valid,
+        (NULLIF(left(kv.value, 255), '') IS NOT NULL) AS value_valid
+    FROM base AS b
+    CROSS JOIN LATERAL jsonb_each_text(b.end_user_tags_object) AS kv(key, value)
+ ),
+sanitized_end_user_tags AS (
+    SELECT
+        b.id,
+        b.existing_tags,
+        b.base_tags,
         COALESCE(
-            (
-                SELECT jsonb_object_agg(lower(key), value)
-                FROM jsonb_each_text(raw_tags)
-            ),
+            jsonb_object_agg(e.normalized_key, e.normalized_value) FILTER (WHERE e.key_valid AND e.value_valid),
             '{}'::jsonb
-        ) AS generated_tags
-    FROM generated
-),
+        ) AS end_user_tags_sanitized
+    FROM base
+        AS b
+    LEFT JOIN end_user_tag_entries AS e
+        ON e.id = b.id
+    GROUP BY
+        b.id,
+        b.existing_tags,
+        b.base_tags
+ ),
+bounded AS (
+    SELECT
+        s.id,
+        s.existing_tags,
+        s.base_tags,
+        s.end_user_tags_sanitized,
+        s.candidate_key_count,
+        CASE
+            WHEN s.candidate_key_count > 10 THEN true
+            ELSE false
+        END AS dropped_end_user_tags_due_to_max_count,
+        CASE
+            WHEN s.candidate_key_count > 10 THEN s.base_tags
+            ELSE (s.base_tags || s.end_user_tags_sanitized)
+        END AS generated_tags
+    FROM (
+        SELECT
+            id,
+            existing_tags,
+            base_tags,
+            end_user_tags_sanitized,
+            (SELECT COUNT(*) FROM jsonb_object_keys(base_tags || end_user_tags_sanitized)) AS candidate_key_count
+        FROM sanitized_end_user_tags
+    ) AS s
+ ),
 merged AS (
     SELECT
         id,
-        existing_tags,
-        generated_tags,
+        dropped_end_user_tags_due_to_max_count,
         (generated_tags || existing_tags) AS merged_tags
-    FROM lowercased
-)
-UPDATE _nango_connections AS c
-SET tags = merged.merged_tags
-FROM merged
-WHERE c.id = merged.id
-  AND merged.merged_tags IS DISTINCT FROM c.tags;`;
+    FROM bounded
+ ),
+updated AS (
+    UPDATE _nango_connections AS c
+    SET tags = merged.merged_tags
+    FROM merged
+    WHERE c.id = merged.id
+      AND merged.merged_tags IS DISTINCT FROM c.tags
+    RETURNING c.id
+ )
+ SELECT
+     200 AS offending_keys_cap,
+     (SELECT COUNT(*) FROM updated) AS updated_rows,
+     (SELECT COUNT(*) FROM source) AS scanned_rows,
+     (SELECT COUNT(*) FROM merged WHERE dropped_end_user_tags_due_to_max_count) AS dropped_end_user_tags_due_to_max_count_connections,
+
+     (SELECT COUNT(*) FROM end_user_tag_entries WHERE key_too_long) AS truncated_key_entries,
+     (SELECT COALESCE(jsonb_agg(key), '[]'::jsonb) FROM (
+         SELECT DISTINCT raw_key AS key
+         FROM end_user_tag_entries
+         WHERE key_too_long
+         ORDER BY raw_key
+         LIMIT 200
+     ) AS t) AS truncated_key_keys,
+
+     (SELECT COUNT(*) FROM end_user_tag_entries WHERE value_too_long) AS truncated_value_entries,
+     (SELECT COALESCE(jsonb_agg(key), '[]'::jsonb) FROM (
+         SELECT DISTINCT raw_key AS key
+         FROM end_user_tag_entries
+         WHERE value_too_long
+         ORDER BY raw_key
+         LIMIT 200
+     ) AS t) AS truncated_value_keys,
+
+     (SELECT COUNT(*) FROM end_user_tag_entries WHERE NOT key_valid) AS invalid_key_format_entries,
+     (SELECT COALESCE(jsonb_agg(key), '[]'::jsonb) FROM (
+         SELECT DISTINCT raw_key AS key
+         FROM end_user_tag_entries
+         WHERE NOT key_valid
+         ORDER BY raw_key
+         LIMIT 200
+     ) AS t) AS invalid_key_format_keys,
+
+     (SELECT COALESCE(jsonb_agg(key), '[]'::jsonb) FROM (
+         SELECT DISTINCT e.raw_key AS key
+         FROM end_user_tag_entries AS e
+         INNER JOIN merged AS m
+             ON m.id = e.id
+         WHERE m.dropped_end_user_tags_due_to_max_count
+         ORDER BY e.raw_key
+         LIMIT 200
+     ) AS t) AS dropped_end_user_tags_due_to_max_count_keys
+ ;`;
 }
 
 module.exports = {

--- a/packages/database/lib/migration-helpers/backfillConnectionTagsSql.cjs
+++ b/packages/database/lib/migration-helpers/backfillConnectionTagsSql.cjs
@@ -1,0 +1,71 @@
+function buildConnectionTagsBackfillUpdateSql() {
+    return `
+WITH source AS (
+    SELECT
+        c.id,
+        COALESCE(c.tags, '{}'::jsonb) AS existing_tags,
+        eu.end_user_id,
+        eu.email,
+        eu.display_name,
+        eu.organization_id,
+        eu.organization_display_name,
+        eu.tags AS end_user_tags
+    FROM _nango_connections AS c
+    INNER JOIN end_users AS eu
+        ON eu.id = c.end_user_id
+),
+generated AS (
+    SELECT
+        id,
+        existing_tags,
+        (
+            jsonb_strip_nulls(
+                jsonb_build_object(
+                    'end_user_id', end_user_id,
+                    'end_user_email', email,
+                    'end_user_display_name', display_name,
+                    'organization_id', organization_id,
+                    'organization_display_name', organization_display_name
+                )
+            )
+            || COALESCE(
+                (
+                    SELECT jsonb_object_agg(key, value)
+                    FROM jsonb_each_text(COALESCE(end_user_tags::jsonb, '{}'::jsonb))
+                ),
+                '{}'::jsonb
+            )
+        ) AS raw_tags
+    FROM source
+),
+lowercased AS (
+    SELECT
+        id,
+        existing_tags,
+        COALESCE(
+            (
+                SELECT jsonb_object_agg(lower(key), value)
+                FROM jsonb_each_text(raw_tags)
+            ),
+            '{}'::jsonb
+        ) AS generated_tags
+    FROM generated
+),
+merged AS (
+    SELECT
+        id,
+        existing_tags,
+        generated_tags,
+        (generated_tags || existing_tags) AS merged_tags
+    FROM lowercased
+)
+UPDATE _nango_connections AS c
+SET tags = merged.merged_tags
+FROM merged
+WHERE c.id = merged.id
+  AND merged.merged_tags IS DISTINCT FROM c.tags;`;
+}
+
+module.exports = {
+    buildConnectionTagsBackfillUpdateSql
+};

--- a/packages/database/lib/migrations/20260128120000_backfill_connection_tags.cjs
+++ b/packages/database/lib/migrations/20260128120000_backfill_connection_tags.cjs
@@ -1,0 +1,9 @@
+exports.config = { transaction: false };
+
+const { buildConnectionTagsBackfillUpdateSql } = require('../migration-helpers/backfillConnectionTagsSql.cjs');
+
+exports.up = async function (knex) {
+    await knex.raw(buildConnectionTagsBackfillUpdateSql());
+};
+
+exports.down = async function () {};

--- a/packages/database/lib/migrations/20260128120000_backfill_connection_tags.cjs
+++ b/packages/database/lib/migrations/20260128120000_backfill_connection_tags.cjs
@@ -3,7 +3,11 @@ exports.config = { transaction: false };
 const { buildConnectionTagsBackfillUpdateSql } = require('../migration-helpers/backfillConnectionTagsSql.cjs');
 
 exports.up = async function (knex) {
-    await knex.raw(buildConnectionTagsBackfillUpdateSql());
+    const result = await knex.raw(buildConnectionTagsBackfillUpdateSql());
+    const summary = result?.rows?.[0];
+    if (summary) {
+        console.log('[connection tags backfill] summary', summary);
+    }
 };
 
 exports.down = async function () {};

--- a/packages/shared/lib/services/endUser.service.ts
+++ b/packages/shared/lib/services/endUser.service.ts
@@ -3,7 +3,7 @@ import { Err, Ok, getLogger } from '@nangohq/utils';
 
 const logger = getLogger('endUser.service');
 
-import { connectionTagsSchema } from './tags/schema.js';
+import { TAG_KEY_MAX_LENGTH, TAG_MAX_COUNT, TAG_VALUE_MAX_LENGTH, connectionTagsKeySchema, connectionTagsSchema } from './tags/schema.js';
 
 import type { Knex } from '@nangohq/database';
 import type {
@@ -319,30 +319,106 @@ export function buildTagsFromEndUser(
     endUser: ConnectSessionInput['end_user'] | null | undefined,
     organization: ConnectSessionInput['organization'] | null | undefined
 ): Tags {
-    const generatedTags: Tags = {};
+    const MAX_LOG_KEYS = 200;
+
+    const pushCapped = <T>(list: T[], item: T) => {
+        if (list.length >= MAX_LOG_KEYS) {
+            return;
+        }
+        list.push(item);
+    };
+
+    const issues: {
+        truncated_key: { key: string; truncated_key: string; original_length: number }[];
+        truncated_value: { key: string; original_length: number }[];
+        invalid_key_format: { key: string; normalized_key: string; message: string }[];
+        dropped_end_user_tags_due_to_max_count: string[];
+        truncated_base_value: { key: string; original_length: number }[];
+    } = {
+        truncated_key: [],
+        truncated_value: [],
+        invalid_key_format: [],
+        dropped_end_user_tags_due_to_max_count: [],
+        truncated_base_value: []
+    };
+
+    const truncate = (value: string, maxLength: number): string => {
+        return value.length > maxLength ? value.slice(0, maxLength) : value;
+    };
+
+    const setIfValidValue = (tags: Tags, key: string, value: unknown) => {
+        if (typeof value !== 'string') {
+            return;
+        }
+
+        if (value.length > TAG_VALUE_MAX_LENGTH) {
+            pushCapped(issues.truncated_base_value, { key, original_length: value.length });
+        }
+
+        const truncated = truncate(value, TAG_VALUE_MAX_LENGTH);
+        if (truncated.length === 0) {
+            return;
+        }
+
+        tags[key] = truncated;
+    };
+
+    const baseTags: Tags = {};
 
     if (endUser) {
-        generatedTags['end_user_id'] = endUser.id;
-
-        if (endUser.email) {
-            generatedTags['end_user_email'] = endUser.email;
-        }
-        if (endUser.display_name) {
-            generatedTags['end_user_display_name'] = endUser.display_name;
-        }
-
-        if (endUser.tags) {
-            for (const [key, value] of Object.entries(endUser.tags)) {
-                generatedTags[key] = value;
-            }
-        }
+        setIfValidValue(baseTags, 'end_user_id', endUser.id);
+        setIfValidValue(baseTags, 'end_user_email', endUser.email);
+        setIfValidValue(baseTags, 'end_user_display_name', endUser.display_name);
     }
 
     if (organization) {
-        generatedTags['organization_id'] = organization.id;
+        setIfValidValue(baseTags, 'organization_id', organization.id);
+        setIfValidValue(baseTags, 'organization_display_name', organization.display_name);
+    }
 
-        if (organization.display_name) {
-            generatedTags['organization_display_name'] = organization.display_name;
+    const endUserTags: Tags = {};
+    const rawEndUserTagKeys: string[] = [];
+    if (endUser?.tags) {
+        for (const [rawKey, rawValue] of Object.entries(endUser.tags)) {
+            pushCapped(rawEndUserTagKeys, rawKey);
+
+            if (typeof rawValue !== 'string') {
+                continue;
+            }
+
+            const lowerKey = rawKey.toLowerCase();
+            const truncatedKey = truncate(lowerKey, TAG_KEY_MAX_LENGTH);
+            if (lowerKey.length > TAG_KEY_MAX_LENGTH) {
+                pushCapped(issues.truncated_key, { key: rawKey, truncated_key: truncatedKey, original_length: lowerKey.length });
+            }
+
+            const parseKeyResult = connectionTagsKeySchema.safeParse(truncatedKey);
+            if (!parseKeyResult.success) {
+                const message = parseKeyResult.error.issues[0]?.message ?? 'Invalid tag key';
+                pushCapped(issues.invalid_key_format, { key: rawKey, normalized_key: truncatedKey, message });
+                continue;
+            }
+
+            if (rawValue.length > TAG_VALUE_MAX_LENGTH) {
+                pushCapped(issues.truncated_value, { key: rawKey, original_length: rawValue.length });
+            }
+
+            const truncatedValue = truncate(rawValue, TAG_VALUE_MAX_LENGTH);
+
+            endUserTags[truncatedKey] = truncatedValue;
+        }
+    }
+
+    let generatedTags: Tags = baseTags;
+    const hasEndUserTags = Object.keys(endUserTags).length > 0;
+    if (hasEndUserTags) {
+        generatedTags = { ...baseTags, ...endUserTags };
+        // If base + end_user.tags exceeds the max key count, drop end_user.tags entirely.
+        if (Object.keys(generatedTags).length > TAG_MAX_COUNT) {
+            for (const key of rawEndUserTagKeys) {
+                pushCapped(issues.dropped_end_user_tags_due_to_max_count, key);
+            }
+            generatedTags = baseTags;
         }
     }
 
@@ -350,10 +426,38 @@ export function buildTagsFromEndUser(
         return {};
     }
 
+    const hasIssues =
+        issues.truncated_key.length > 0 ||
+        issues.truncated_value.length > 0 ||
+        issues.invalid_key_format.length > 0 ||
+        issues.dropped_end_user_tags_due_to_max_count.length > 0 ||
+        issues.truncated_base_value.length > 0;
+
+    if (hasIssues) {
+        logger.warning('Adjusted tags to meet constraints, found issues', {
+            end_user_id: endUser?.id,
+            organization_id: organization?.id,
+            issues_cap: MAX_LOG_KEYS,
+            issues
+        });
+    };
+
     const result = connectionTagsSchema.safeParse(generatedTags);
-    if (!result.success) {
-        logger.warn(`Failed to normalize tags from endUser/organization: ${result.error.issues[0]?.message}`);
-        return {};
+    if (result.success) {
+        return result.data;
     }
-    return result.data;
+
+    const validationError = result.error.issues[0]?.message;
+
+    // Best effort fallback: keep base tags if end_user.tags is somehow invalid.
+    if (hasEndUserTags) {
+        const baseResult = connectionTagsSchema.safeParse(baseTags);
+        if (baseResult.success) {
+            logger.warning(`Failed to normalize tags from end_user.tags, using base tags only: ${validationError}`);
+            return baseResult.data;
+        }
+    }
+
+    logger.warning(`Failed to normalize tags from endUser/organization: ${validationError}`);
+    return {};
 }

--- a/scripts/one-off/connection-tags-migration/README.md
+++ b/scripts/one-off/connection-tags-migration/README.md
@@ -1,0 +1,32 @@
+# Connection Tags Migration Runbook
+
+Uses .env to figure out the DB connection
+
+## Run
+
+Dry run (runs the query in a transaction and then rolls back):
+
+```bash
+npx tsx scripts/one-off/connection-tags-migration/migrate.ts --dry-run
+```
+
+Execute the update:
+
+```bash
+npx tsx scripts/one-off/connection-tags-migration/migrate.ts
+```
+
+Execute the update and mark the migration as applied (cloud manual workflow):
+
+```bash
+npx tsx scripts/one-off/connection-tags-migration/migrate.ts --mark-migration
+```
+
+## Options
+
+- `--dry-run` shows count of rows to update without making changes.
+- `--mark-migration` records the migration in `_nango_auth_migrations` after a successful update.
+
+## Output
+
+- `Updated rows` shows actual count after execution (unless dry run).

--- a/scripts/one-off/connection-tags-migration/README.md
+++ b/scripts/one-off/connection-tags-migration/README.md
@@ -4,12 +4,6 @@ Uses .env to figure out the DB connection
 
 ## Run
 
-Dry run (runs the query in a transaction and then rolls back):
-
-```bash
-npx tsx scripts/one-off/connection-tags-migration/migrate.ts --dry-run
-```
-
 Execute the update:
 
 ```bash
@@ -24,9 +18,8 @@ npx tsx scripts/one-off/connection-tags-migration/migrate.ts --mark-migration
 
 ## Options
 
-- `--dry-run` shows count of rows to update without making changes.
 - `--mark-migration` records the migration in `_nango_auth_migrations` after a successful update.
 
 ## Output
 
-- `Updated rows` shows actual count after execution (unless dry run).
+- `Updated rows` shows actual count after execution.

--- a/scripts/one-off/connection-tags-migration/migrate.ts
+++ b/scripts/one-off/connection-tags-migration/migrate.ts
@@ -1,0 +1,97 @@
+import { createRequire } from 'node:module';
+
+import { KnexDatabase } from '../../../packages/database/lib/index.js';
+
+const require = createRequire(import.meta.url);
+const { buildConnectionTagsBackfillUpdateSql } = require('../../../packages/database/lib/migration-helpers/backfillConnectionTagsSql.cjs');
+
+interface ScriptOptions {
+    dryRun: boolean;
+    markMigration: boolean;
+}
+
+function parseArgs(argv: string[]): ScriptOptions {
+    const opts: ScriptOptions = {
+        dryRun: false,
+        markMigration: false
+    };
+
+    for (const arg of argv) {
+        if (arg === '--dry-run') {
+            opts.dryRun = true;
+            continue;
+        }
+
+        if (arg === '--mark-migration') {
+            opts.markMigration = true;
+            continue;
+        }
+    }
+
+    return opts;
+}
+
+async function markMigrationApplied(knex: KnexDatabase['knex'], schemaName: string) {
+    const migrationName = '20260128120000_backfill_connection_tags.cjs';
+    const migrationTable = '_nango_auth_migrations';
+
+    const existing = await knex.withSchema(schemaName).select('name').from(migrationTable).where({ name: migrationName }).first();
+    if (existing) {
+        console.log(`Migration already marked: ${migrationName}`);
+        return;
+    }
+
+    const batchResult = await knex.withSchema(schemaName).from(migrationTable).max('batch as max').first();
+    const maxBatch = Number(batchResult?.max ?? 0);
+    const nextBatch = Number.isNaN(maxBatch) ? 1 : maxBatch + 1;
+
+    await knex.withSchema(schemaName).from(migrationTable).insert({
+        name: migrationName,
+        batch: nextBatch,
+        migration_time: new Date()
+    });
+
+    console.log(`Migration marked as applied: ${migrationName}`);
+}
+
+async function run() {
+    const options = parseArgs(process.argv.slice(2));
+
+    const database = new KnexDatabase({ timeoutMs: 60000 });
+    const knex = database.knex;
+    const updateSql = buildConnectionTagsBackfillUpdateSql();
+    const schemaName = database.schema();
+
+    console.log('Starting connection tags migration');
+    console.log(`Dry run: ${options.dryRun ? 'true' : 'false'}`);
+    console.log(`Mark migration: ${options.markMigration ? 'true' : 'false'}`);
+
+    try {
+        if (options.dryRun) {
+            const trx = await knex.transaction();
+            try {
+                const updateResult = await trx.raw(updateSql);
+                const updatedCount = updateResult.rowCount ?? 0;
+                console.log(`Dry run updated rows (rolled back): ${updatedCount}`);
+            } finally {
+                await trx.rollback();
+            }
+            return;
+        }
+
+        const updateResult = await knex.raw(updateSql);
+        const updatedCount = updateResult.rowCount ?? 0;
+        console.log(`Updated rows: ${updatedCount}`);
+
+        if (options.markMigration) {
+            await markMigrationApplied(knex, schemaName);
+        }
+    } finally {
+        await database.destroy();
+    }
+}
+
+run().catch((err: unknown) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/scripts/one-off/connection-tags-migration/seed-local.ts
+++ b/scripts/one-off/connection-tags-migration/seed-local.ts
@@ -1,0 +1,132 @@
+import db from '../../../packages/database/lib/index.js';
+import { createEndUser, seeders } from '../../../packages/shared/lib/index.js';
+
+import type { EndUser } from '@nangohq/types';
+
+async function createCustomEndUser({
+    accountId,
+    environmentId,
+    endUserId,
+    email,
+    displayName,
+    organization,
+    tags
+}: {
+    accountId: number;
+    environmentId: number;
+    endUserId: string;
+    email: string;
+    displayName?: string | null;
+    organization?: { organizationId: string; displayName?: string | null } | null;
+    tags?: EndUser['tags'];
+}): Promise<EndUser> {
+    const result = await createEndUser(db.knex, {
+        accountId,
+        environmentId,
+        endUserId,
+        email,
+        displayName: displayName ?? null,
+        organization: organization ?? null,
+        tags: tags || {}
+    });
+
+    if (result.isErr()) {
+        throw result.error;
+    }
+
+    return result.value;
+}
+
+async function seed() {
+    const { account, env } = await seeders.seedAccountEnvAndUser();
+    const providerKey = `backfill-tags-${Date.now()}`;
+    await seeders.createConfigSeed(env, providerKey, 'github');
+
+    const specialEndUser = await createCustomEndUser({
+        accountId: account.id,
+        environmentId: env.id,
+        endUserId: 'user id/1?=+&',
+        email: 'user+test@example.com',
+        displayName: 'Jane Doe (R&D)',
+        organization: { organizationId: 'org:alpha/1', displayName: 'Org & Co' },
+        tags: {
+            project: 'R&D / alpha',
+            team: 'core team',
+            ip: '2001:db8::1'
+        }
+    });
+    const specialConn = await seeders.createConnectionSeed({
+        env,
+        provider: providerKey,
+        endUser: specialEndUser,
+        tags: {}
+    });
+
+    const overrideEndUser = await createCustomEndUser({
+        accountId: account.id,
+        environmentId: env.id,
+        endUserId: 'user-override',
+        email: 'original@example.com'
+    });
+    const overrideConn = await seeders.createConnectionSeed({
+        env,
+        provider: providerKey,
+        endUser: overrideEndUser,
+        tags: { end_user_email: 'override@example.com', custom: 'keep' }
+    });
+
+    const tooManyTags = Object.fromEntries(Array.from({ length: 9 }, (_, index) => [`tag${index + 1}`, `value${index + 1}`]));
+    const tooManyTagsEndUser = await createCustomEndUser({
+        accountId: account.id,
+        environmentId: env.id,
+        endUserId: 'user-too-many',
+        email: 'too-many@example.com',
+        tags: tooManyTags as unknown as EndUser['tags']
+    });
+    const tooManyTagsConn = await seeders.createConnectionSeed({
+        env,
+        provider: providerKey,
+        endUser: tooManyTagsEndUser,
+        tags: { existing: 'yes' }
+    });
+
+    const tooLongValue = 'a'.repeat(201);
+    const tooLongValueEndUser = await createCustomEndUser({
+        accountId: account.id,
+        environmentId: env.id,
+        endUserId: 'user-long',
+        email: 'long@example.com',
+        tags: { long: tooLongValue } as unknown as EndUser['tags']
+    });
+    const tooLongValueConn = await seeders.createConnectionSeed({
+        env,
+        provider: providerKey,
+        endUser: tooLongValueEndUser,
+        tags: { existing: 'yes' }
+    });
+
+    const noEndUserConn = await seeders.createConnectionSeed({
+        env,
+        provider: providerKey,
+        tags: { existing: 'yes' }
+    });
+
+    console.log('Seeded connection tags test data');
+    console.log(`Account ID: ${account.id}`);
+    console.log(`Environment ID: ${env.id}`);
+    console.log(`Provider key: ${providerKey}`);
+    console.log(`Special connection ID: ${specialConn.id}`);
+    console.log(`Override connection ID: ${overrideConn.id}`);
+    console.log(`Too-many-tags connection ID: ${tooManyTagsConn.id}`);
+    console.log(`Too-long-value connection ID: ${tooLongValueConn.id}`);
+    console.log(`No-end-user connection ID: ${noEndUserConn.id}`);
+}
+
+seed()
+    .catch((err: unknown) => {
+        console.error(err);
+        process.exit(1);
+    })
+    .finally(async () => {
+        await db.destroy();
+    });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
This query will update `114 282` rows in production. I will run it asynchronously using the migrate script in our cloud, and let knex automatically migrate connections for on-prem/self-hosted deployments.

There are a few assumptions in this query to make it simpler, but I did run the queries in prod DB to verify we don't have to care about them
- It doesn't truncate keys longer than 64 characters or values longer than 250 characters (which would be invalid new tags) because there are no existing keys or values that long
- It doesn't validate that it won't create more than 10 tags because there are no end users with that many (max is 4)
- It doesn't validate invalid key format because all existing end user tags are valid

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Backfill connection tags and harden tag sanitization**

Introduces a reusable SQL CTE pipeline and operational tooling to backfill `_nango_connections.tags` from existing end-user metadata while aligning runtime tag generation with the same constraints. Adds a non-transactional Knex migration, an operational `migrate.ts` runner with optional migration marking, a local seeding helper, and an end-to-end integration test that exercises truncation, invalid keys, tag precedence, and connections lacking end users. Updates `buildTagsFromEndUser` to normalize keys/values, enforce length/count limits, emit structured telemetry about dropped or truncated tags, and fall back to base tags when custom data is invalid so online ingestion matches the migration behavior.

<details>
<summary><strong>Key Changes</strong></summary>

• Added SQL helper `packages/database/lib/migration-helpers/backfillConnectionTagsSql.cjs` that normalizes base tags, sanitizes end-user tag entries, enforces 10-key limits, merges with existing connection tags, and returns summary metrics for operational visibility.
• Registered non-transactional migration `packages/database/lib/migrations/20260128120000_backfill_connection_tags.cjs` plus `scripts/one-off/connection-tags-migration/migrate.ts` (with `--mark-migration`) and companion README/seed tooling for cloud and self-hosted deployments.
• Created integration test `packages/database/lib/backfillConnectionTags.integration.test.ts` with inline seed helpers covering special characters, precedence, truncation, invalid formats, over-limit keys, and connections lacking end users.
• Expanded `packages/shared/lib/services/endUser.service.ts` to truncate/validate tags, log structured telemetry, drop custom tags when exceeding limits, and fall back gracefully if custom tags fail schema validation, updating unit tests accordingly.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/database/lib/migration-helpers/backfillConnectionTagsSql.cjs`
• `packages/database/lib/migrations/20260128120000_backfill_connection_tags.cjs`
• `scripts/one-off/connection-tags-migration/*`
• `packages/database/lib/backfillConnectionTags.integration.test.ts`
• `packages/shared/lib/services/endUser.service.ts` and unit tests

</details>

---
*This summary was automatically generated by @propel-code-bot*