### PR TITLE
feat(ui): Use tags for email and display_name in AvatarOrganization

### DIFF
--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -22,7 +22,7 @@ import { useConnections, useConnectionsCount } from '../../hooks/useConnections'
 import { useListIntegration } from '../../hooks/useIntegration';
 import DashboardLayout from '../../layout/DashboardLayout';
 import { useStore } from '../../store';
-import { getConnectionDisplayName } from '../../utils/endUser';
+import { getConnectionDisplayName, getEndUserEmail } from '../../utils/endUser';
 import { formatDateToInternationalFormat } from '../../utils/utils';
 
 import type { ApiConnectionSimple } from '@nangohq/types';
@@ -58,8 +58,8 @@ const columns: ColumnDef<ApiConnectionSimple>[] = [
             return (
                 <div className="flex gap-3 items-center">
                     <AvatarOrganization
-                        email={data.endUser?.email ? data.endUser.email : null}
-                        displayName={getConnectionDisplayName({ endUser: data.endUser, connectionId: data.connection_id })}
+                        email={getEndUserEmail(data.endUser, data.tags)}
+                        displayName={getConnectionDisplayName({ endUser: data.endUser, connectionId: data.connection_id, connectionTags: data.tags })}
                     />
 
                     {data.endUser ? (

--- a/packages/webapp/src/pages/Connection/Show.tsx
+++ b/packages/webapp/src/pages/Connection/Show.tsx
@@ -25,7 +25,7 @@ import { useSyncs } from '../../hooks/useSyncs';
 import { useToast } from '../../hooks/useToast';
 import DashboardLayout from '../../layout/DashboardLayout';
 import { useStore } from '../../store';
-import { getConnectionDisplayName } from '../../utils/endUser';
+import { getConnectionDisplayName, getEndUserEmail } from '../../utils/endUser';
 import { globalEnv } from '../../utils/env';
 import { connectSlack } from '../../utils/slack-connection';
 
@@ -175,8 +175,12 @@ export const ConnectionShow: React.FC = () => {
                             <div className="absolute -bottom-3 -right-3">
                                 <AvatarOrganization
                                     size={'sm'}
-                                    email={connection.endUser?.email ? connection.endUser.email : null}
-                                    displayName={getConnectionDisplayName({ endUser: connection.endUser, connectionId: connection.connection.connection_id })}
+                                    email={getEndUserEmail(connection.endUser, connection.connection.tags)}
+                                    displayName={getConnectionDisplayName({
+                                        endUser: connection.endUser,
+                                        connectionId: connection.connection.connection_id,
+                                        connectionTags: connection.connection.tags
+                                    })}
                                 />
                             </div>
                         </div>

--- a/packages/webapp/src/utils/endUser.ts
+++ b/packages/webapp/src/utils/endUser.ts
@@ -1,5 +1,17 @@
-import type { ApiEndUser } from '@nangohq/types';
+import type { ApiEndUser, Tags } from '@nangohq/types';
 
-export function getConnectionDisplayName({ endUser, connectionId }: { endUser?: ApiEndUser | null; connectionId: string }): string {
-    return endUser?.display_name || endUser?.email || connectionId;
+export function getConnectionDisplayName({
+    endUser,
+    connectionId,
+    connectionTags
+}: {
+    endUser?: ApiEndUser | null;
+    connectionId: string;
+    connectionTags?: Tags;
+}): string {
+    return connectionTags?.end_user_display_name || endUser?.display_name || endUser?.email || connectionId;
+}
+
+export function getEndUserEmail(endUser: ApiEndUser | null | undefined, connectionTags?: Tags): string | null {
+    return connectionTags?.end_user_email || endUser?.email || null;
 }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Use tag metadata for end-user avatar fallbacks**

Extends the connection UI helpers so that `AvatarOrganization` can display tag-provided `end_user_display_name` and `end_user_email` values when the `ApiEndUser` payload lacks these fields. Both the connection list and single connection view now consume the updated helpers to pass tag data into the avatar component, ensuring consistent fallback logic across views.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `getConnectionDisplayName` in `packages/webapp/src/utils/endUser.ts` to accept optional `connectionTags` and prioritize `end_user_display_name` from tags over end-user data and connection IDs.
• Added new helper `getEndUserEmail` to centralize email fallback logic with tag support.
• Propagated the new helpers (and tag data) to `packages/webapp/src/pages/Connection/Show.tsx` and `packages/webapp/src/pages/Connection/List.tsx` so `AvatarOrganization` receives the enriched display name and email.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/webapp/src/utils/endUser.ts
• packages/webapp/src/pages/Connection/Show.tsx
• packages/webapp/src/pages/Connection/List.tsx

</details>

---
*This summary was automatically generated by @propel-code-bot*