### PR TITLE
feat(share-link): create shareable Connect UI links

### DIFF
--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -311,7 +311,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
                                         loading={isShareLinkLoading}
                                         disabled={usageCapReached || integrationHasMissingFields || !isFormValid}
                                     >
-                                        <Link2 className="size-4.5" />
+                                        <Link2 />
                                         Share connect link
                                     </Button>
                                 </span>


### PR DESCRIPTION
<!-- Describe the problem and your solution -->
- Add shareable Connect UI link creation that copies a session-based URL and shows expiry.

<!-- Issue ticket number and link (if applicable) -->
[NAN-2630](https://linear.app/nango/issue/NAN-2630/connect-link-in-nango-ui)

<!-- Testing instructions (skip if just adding/editing providers) -->
- Manually tested:
<img width="853" height="318" alt="Screenshot 2026-02-03 at 10 00 04 AM" src="https://github.com/user-attachments/assets/3055c84d-ddd1-4aed-b28b-3eb88e420263" />

<!-- Summary by @propel-code-bot -->

---

**Add shareable Connect UI link option**

This PR extends `CreateConnectionSelector` with a second CTA that can mint and copy a shareable Connect UI session link alongside the existing in-app authorization flow. The session creation logic has been consolidated into a reusable `createConnectSession` helper, while the UI now exposes loading feedback, analytics tracking, tooltip messaging, and an expiry notification when the link is copied.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced `createConnectSession` (memoized via `useCallback`) so both `onClickConnectUI` and the new `onClickShareConnectionLink` share identical payload construction when calling `apiConnectSessions`.
• Added `onClickShareConnectionLink`, which tracks analytics, creates a session, injects `globalEnv.apiUrl` into the returned `connect_link`, copies it via `navigator.clipboard.writeText`, and surfaces success/error toasts including the formatted expiry via `formatDateToPreciseUSFormat`.
• Updated the CTA section to a horizontal layout with a secondary `Button` (variant `secondary`, `loading` support, `Link2` icon) plus an `InfoTooltip` explaining the 30-minute expiry.
• Removed redundant 10 ms delays, using `setTimeout(..., 0)` for iframe initialization and eliminating the timeout entirely for the share-link workflow.
• Hooked up a local `isShareLinkLoading` state to disable/animate the new button while the session is being generated.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*