### PR TITLE
test: add test for `POST /connection` oauth2 with `config_override`

### DIFF
--- a/packages/server/lib/controllers/connection/postConnection.integration.test.ts
+++ b/packages/server/lib/controllers/connection/postConnection.integration.test.ts
@@ -230,6 +230,56 @@ describe(`POST ${endpoint}`, () => {
         });
     });
 
+    it('should import oauth2 connection with config_override', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: env.secret_key,
+            body: {
+                provider_config_key: 'github',
+                credentials: {
+                    type: 'OAUTH2',
+                    access_token: '123',
+                    config_override: { client_id: 'override_client_id', client_secret: 'override_client_secret' }
+                },
+                end_user: { id: '123', display_name: 'John Doe', tags: { projectId: '123' } }
+            }
+        });
+
+        isSuccess(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            connection_config: {},
+            connection_id: expect.any(String),
+            created_at: expect.toBeIsoDate(),
+            credentials: {
+                access_token: '123',
+                config_override: { client_id: 'override_client_id', client_secret: 'override_client_secret' },
+                raw: {
+                    access_token: '123',
+                    config_override: { client_id: 'override_client_id', client_secret: 'override_client_secret' },
+                    type: 'OAUTH2'
+                },
+                type: 'OAUTH2'
+            },
+            end_user: {
+                id: '123',
+                email: null,
+                display_name: 'John Doe',
+                organization: null,
+                tags: { projectId: '123' }
+            },
+            errors: [],
+            id: expect.any(Number),
+            last_fetched_at: expect.toBeIsoDate(),
+            metadata: {},
+            provider: 'github',
+            provider_config_key: 'github',
+            tags: { end_user_id: '123', end_user_display_name: 'John Doe', projectid: '123' },
+            updated_at: expect.toBeIsoDate()
+        });
+    });
+
     describe('tags', () => {
         it('should import connection with valid tags and return tags in response', async () => {
             const { env } = await seeders.seedAccountEnvAndUser();


### PR DESCRIPTION
Adding a test just to cover this.

<!-- Summary by @propel-code-bot -->

---

**Add integration test for oauth2 config override**

Introduces a new integration test in `packages/server/lib/controllers/connection/postConnection.integration.test.ts` that exercises `POST /connections` when OAuth2 credentials include a `config_override`. The test seeds a GitHub config, posts a payload with override values, and asserts the full response structure, including merged tags and raw credential echoing.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `it('should import oauth2 connection with config_override')` to verify `config_override` data is accepted and echoed in the API response
• Asserts the presence of override values within both `credentials` and `credentials.raw`, along with standard connection metadata and tag merging

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/connection/postConnection.integration.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*