### PR TITLE
fix: replace TRPCClientError with more user-friendly msg

### DIFF
--- a/packages/jobs/lib/runtime/runner.adapter.ts
+++ b/packages/jobs/lib/runtime/runner.adapter.ts
@@ -29,13 +29,17 @@ export class RunnerRuntimeAdapter implements RuntimeAdapter {
             return Err(runner.error);
         }
 
-        const res = await runner.value.client.start.mutate({
-            taskId: params.taskId,
-            nangoProps: params.nangoProps,
-            code: params.code,
-            codeParams: params.codeParams
-        });
+        try {
+            const res = await runner.value.client.start.mutate({
+                taskId: params.taskId,
+                nangoProps: params.nangoProps,
+                code: params.code,
+                codeParams: params.codeParams
+            });
 
-        return Ok(res);
+            return Ok(res);
+        } catch (err) {
+            return Err(new Error(`Nango runner was unable to execute the function`, { cause: err }));
+        }
     }
 }


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Improve runtime adapter error messaging for job execution**

Wraps Lambda and runner runtime invocations in try/catch blocks so low-level `TRPCClientError` instances are converted into clearer `Error` messages before propagating through the job pipeline. The `startScript` operation now throws immediately on missing scripts, missing teams, adapter resolution failures, or adapter invoke errors, ensuring downstream callers receive explicit exceptions rather than opaque `Err` strings.

<details>
<summary><strong>Key Changes</strong></summary>

• Made `LambdaRuntimeAdapter.getFunction` private and wrapped `invoke` in a try/catch that returns `Err(new Error('Lambda was unable to execute the function', { cause: err }))` when AWS invocation fails
• Added try/catch around `RunnerRuntimeAdapter.invoke` to convert runner client failures into `Err(new Error('Nango runner was unable to execute the function', { cause: err }))`
• Updated `startScript` to throw on missing script/team data, throw adapter errors directly, rethrow failed runtime invocations, and log a consistent `Error starting function ...` message before returning `Err(errMessage)`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/jobs/lib/runtime/lambda.adapter.ts
• packages/jobs/lib/runtime/runner.adapter.ts
• packages/jobs/lib/execution/operations/start.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*