### PR TITLE
fix(webhooks): decode email address from resource URI

### DIFF
--- a/packages/server/lib/webhook/google-calendar-webhook-routing.ts
+++ b/packages/server/lib/webhook/google-calendar-webhook-routing.ts
@@ -13,7 +13,7 @@ const route: WebhookHandler = async (nango, headers, body) => {
 
     if (typeof resourceUri === 'string') {
         const match = resourceUri.match(/\/calendars\/([^/]+)\//);
-        if (match) {
+        if (match && match[1]) {
             emailAddress = decodeURIComponent(match[1]);
         }
     }

--- a/packages/server/lib/webhook/google-calendar-webhook-routing.ts
+++ b/packages/server/lib/webhook/google-calendar-webhook-routing.ts
@@ -14,7 +14,7 @@ const route: WebhookHandler = async (nango, headers, body) => {
     if (typeof resourceUri === 'string') {
         const match = resourceUri.match(/\/calendars\/([^/]+)\//);
         if (match) {
-            emailAddress = match[1];
+            emailAddress = decodeURIComponent(match[1]);
         }
     }
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->
Fixes #5349 

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Decode Google Calendar webhook resource emails**

Ensures Google Calendar webhook routing extracts a valid email by guarding the regex capture and decoding percent-encoded identifiers from the `x-goog-resource-uri` header. Downstream webhook scripts now receive human-readable addresses even when Google encodes special characters.

<details>
<summary><strong>Key Changes</strong></summary>

• Gate the regex result with `match && match[1]` before using it to avoid undefined captures
• Apply `decodeURIComponent` to the captured calendar identifier so webhook scripts receive decoded email addresses

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/webhook/google-calendar-webhook-routing.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*