### PR TITLE
chore: Update react-router versions to address vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11913,10 +11913,11 @@
             "license": "MIT"
         },
         "node_modules/@remix-run/router": {
-            "version": "1.19.1",
-            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.1.tgz",
-            "integrity": "sha512-S45oynt/WH19bHbIXjtli6QmwNYvaz+vtnubvNpNDvUOoA/OWh6j1OikIP3G+v5GHdxyC6EXoChG3HgYGEUfcg==",
+            "version": "1.23.2",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+            "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -24051,6 +24052,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24072,6 +24074,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24093,6 +24096,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24114,6 +24118,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24135,6 +24140,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24156,6 +24162,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24177,6 +24184,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24198,6 +24206,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24219,6 +24228,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24240,6 +24250,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -27306,12 +27317,13 @@
             }
         },
         "node_modules/react-router": {
-            "version": "6.26.1",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.1.tgz",
-            "integrity": "sha512-kIwJveZNwp7teQRI5QmwWo39A5bXRyqpH0COKKmPnyD2vBvDwgFXSqDUYtt1h+FEyfnE8eXr7oe0MxRzVwCcvQ==",
+            "version": "6.30.3",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+            "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@remix-run/router": "1.19.1"
+                "@remix-run/router": "1.23.2"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -27321,13 +27333,14 @@
             }
         },
         "node_modules/react-router-dom": {
-            "version": "6.26.1",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.1.tgz",
-            "integrity": "sha512-veut7m41S1fLql4pLhxeSW3jlqs+4MtjRLj0xvuCEXsxusJCbs6I8yn9BxzzDX2XDgafrccY6hwjmd/bL54tFw==",
+            "version": "6.30.3",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+            "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@remix-run/router": "1.19.1",
-                "react-router": "6.26.1"
+                "@remix-run/router": "1.23.2",
+                "react-router": "6.30.3"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -35597,7 +35610,7 @@
                 "react-dom": "18.3.1",
                 "react-helmet": "6.1.0",
                 "react-hook-form": "7.63.0",
-                "react-router-dom": "6.26.1",
+                "react-router-dom": "6.30.3",
                 "react-toastify": "9.1.1",
                 "react-use": "17.6.0",
                 "recharts": "2.15.4",

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -86,7 +86,7 @@
         "react-dom": "18.3.1",
         "react-helmet": "6.1.0",
         "react-hook-form": "7.63.0",
-        "react-router-dom": "6.26.1",
+        "react-router-dom": "6.30.3",
         "react-toastify": "9.1.1",
         "react-use": "17.6.0",
         "recharts": "2.15.4",


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Address https://github.com/NangoHQ/nango/security/dependabot/267
<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**React Router stack upgraded to patched release**

Bumps the `packages/webapp` dependency on `react-router-dom` from `6.26.1` to `6.30.3` to pick up the upstream vulnerability fix. The regenerated `package-lock.json` now locks `react-router`, `react-router-dom`, and `@remix-run/router` to the corresponding `6.30.3/1.23.2` versions and incorporates npm’s new `peer` metadata for `@esbuild` platform builds.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `packages/webapp/package.json` to require `react-router-dom` `6.30.3`
• Regenerated `package-lock.json` pinning `react-router-dom`, `react-router`, and `@remix-run/router` to the patched versions with refreshed integrity hashes and MIT license entries
• Captured npm `peer` flags for the platform-specific `@esbuild` artifacts within `package-lock.json`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/package.json`
• `package-lock.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*