### PR TITLE
refactor(api-secrets): stop using env.secret_key in tests, use secret instead

### DIFF
--- a/packages/server/lib/controllers/action/getAsyncActionResult.integration.test.ts
+++ b/packages/server/lib/controllers/action/getAsyncActionResult.integration.test.ts
@@ -26,10 +26,10 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should validate request', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             params: { id: 'not-uuid' }
         });
 

--- a/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
@@ -18,12 +18,12 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should create one connection with sessionToken', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
 
         const resSession = await api.fetch('/connect/sessions', {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: { end_user: { id: '1', email: 'john@example.com' } }
         });
         isSuccess(resSession.json);
@@ -42,13 +42,13 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should not be allowed to connect to an integration if disallowed by sessionToken', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
         await seeders.createConfigSeed(env, 'not_this_one', 'unauthenticated');
 
         const resSession = await api.fetch('/connect/sessions', {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: { end_user: { id: '1', email: 'john@example.com' }, allowed_integrations: ['not_this_one'] }
         });
         isSuccess(resSession.json);
@@ -66,12 +66,12 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should not be allowed to pass a connection_id with session token', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
 
         const resSession = await api.fetch('/connect/sessions', {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: { end_user: { id: '1', email: 'john@example.com' }, allowed_integrations: ['unauthenticated'] }
         });
         isSuccess(resSession.json);
@@ -92,13 +92,13 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should be allowed to reconnect', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
 
         // Initial session token
         const resSession = await api.fetch('/connect/sessions', {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: { end_user: { id: '1', email: 'john@example.com' }, allowed_integrations: ['unauthenticated'] }
         });
         isSuccess(resSession.json);
@@ -120,7 +120,7 @@ describe(`GET ${endpoint}`, () => {
         // Reconnect session token
         const resSessionReconnect = await api.fetch('/connect/sessions/reconnect', {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 connection_id: resConnect.json.connectionId,
                 integration_id: resConnect.json.providerConfigKey,

--- a/packages/server/lib/controllers/connect/getSession.integration.test.ts
+++ b/packages/server/lib/controllers/connect/getSession.integration.test.ts
@@ -28,10 +28,10 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should fail if using secret key', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key
+            token: secret.secret
         });
 
         isError(res.json);
@@ -63,14 +63,14 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should get a session', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
 
         // Create session
         const endUserId = 'knownId';
         const resCreate = await api.fetch('/connect/sessions', {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: { end_user: { id: endUserId, email: 'a@b.com' }, allowed_integrations: ['github'] }
         });
         isSuccess(resCreate.json);
@@ -93,7 +93,7 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should get a session with custom connect UI settings when both customization flags are enabled', async () => {
-        const { env, plan } = await seeders.seedAccountEnvAndUser();
+        const { env, secret, plan } = await seeders.seedAccountEnvAndUser();
         // Enable both features so custom settings can be preserved
         await updatePlan(db.knex, { id: plan.id, can_customize_connect_ui_theme: true, can_disable_connect_ui_watermark: true });
         await seeders.createConfigSeed(env, 'github', 'github');
@@ -117,7 +117,7 @@ describe(`GET ${endpoint}`, () => {
         const endUserId = 'knownId';
         const resCreate = await api.fetch('/connect/sessions', {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: { end_user: { id: endUserId, email: 'a@b.com' }, allowed_integrations: ['github'] }
         });
         isSuccess(resCreate.json);
@@ -140,7 +140,7 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should get a session with default connect UI settings when both customization flags are disabled', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
 
         // Create custom connect UI settings
@@ -162,7 +162,7 @@ describe(`GET ${endpoint}`, () => {
         const endUserId = 'knownId';
         const resCreate = await api.fetch('/connect/sessions', {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: { end_user: { id: endUserId, email: 'a@b.com' }, allowed_integrations: ['github'] }
         });
         isSuccess(resCreate.json);

--- a/packages/server/lib/controllers/connect/postReconnect.integration.test.ts
+++ b/packages/server/lib/controllers/connect/postReconnect.integration.test.ts
@@ -6,7 +6,7 @@ import { linkConnection, seeders } from '@nangohq/shared';
 import { getConnectSessionByToken } from '../../services/connectSession.service.js';
 import { isError, isSuccess, runServer, shouldBeProtected } from '../../utils/tests.js';
 
-import type { DBConnection, DBEnvironment, DBPlan, DBTeam, DBUser } from '@nangohq/types';
+import type { DBAPISecret, DBConnection, DBEnvironment, DBPlan, DBTeam, DBUser } from '@nangohq/types';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 
@@ -31,10 +31,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should fail if no connection_id or integration_id', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: {}
         });
@@ -53,7 +53,7 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should get a session token', async () => {
-        const { account, env } = await seeders.seedAccountEnvAndUser();
+        const { account, env, secret } = await seeders.seedAccountEnvAndUser();
 
         const endUser = await seeders.createEndUser({ environment: env, account });
 
@@ -64,7 +64,7 @@ describe(`POST ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 connection_id: connection.connection_id,
                 integration_id: 'github'
@@ -85,7 +85,7 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should fail if the connection was not created with a session token', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
 
         // Create an initial connection
         await seeders.createConfigSeed(env, 'github', 'github');
@@ -93,7 +93,7 @@ describe(`POST ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 connection_id: connection.connection_id,
                 integration_id: 'github'
@@ -109,7 +109,7 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should fail if integration_id does not exist in allowed_integrations', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
 
         // Create an initial connection
         await seeders.createConfigSeed(env, 'github', 'github');
@@ -117,7 +117,7 @@ describe(`POST ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: { connection_id: connection.connection_id, integration_id: 'random' }
         });
         isError(res.json);
@@ -130,7 +130,7 @@ describe(`POST ${endpoint}`, () => {
     });
 
     describe('docs connect url override validation', () => {
-        let seed: { account: DBTeam; env: DBEnvironment; user: DBUser; plan: DBPlan };
+        let seed: { account: DBTeam; env: DBEnvironment; user: DBUser; plan: DBPlan; secret: DBAPISecret };
         let connection: DBConnection;
         beforeEach(async () => {
             seed = await seeders.seedAccountEnvAndUser();
@@ -148,7 +148,7 @@ describe(`POST ${endpoint}`, () => {
 
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     connection_id: connection.connection_id,
                     integration_id: 'github',
@@ -176,7 +176,7 @@ describe(`POST ${endpoint}`, () => {
 
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     connection_id: connection.connection_id,
                     integration_id: 'github',
@@ -204,7 +204,7 @@ describe(`POST ${endpoint}`, () => {
 
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     connection_id: connection.connection_id,
                     integration_id: 'github',
@@ -232,7 +232,7 @@ describe(`POST ${endpoint}`, () => {
 
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     connection_id: connection.connection_id,
                     integration_id: 'github',
@@ -256,7 +256,7 @@ describe(`POST ${endpoint}`, () => {
     });
 
     describe('tags', () => {
-        let seed: { account: DBTeam; env: DBEnvironment; user: DBUser; plan: DBPlan };
+        let seed: { account: DBTeam; env: DBEnvironment; user: DBUser; plan: DBPlan; secret: DBAPISecret };
         let connection: DBConnection;
 
         beforeEach(async () => {
@@ -271,7 +271,7 @@ describe(`POST ${endpoint}`, () => {
         it('should create reconnect session with tags', async () => {
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     connection_id: connection.connection_id,
                     integration_id: 'github',
@@ -289,7 +289,7 @@ describe(`POST ${endpoint}`, () => {
         it('should succeed without tags', async () => {
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     connection_id: connection.connection_id,
                     integration_id: 'github'
@@ -302,7 +302,7 @@ describe(`POST ${endpoint}`, () => {
         it('should fail with invalid tags', async () => {
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     connection_id: connection.connection_id,
                     integration_id: 'github',

--- a/packages/server/lib/controllers/connect/postSessions.integration.test.ts
+++ b/packages/server/lib/controllers/connect/postSessions.integration.test.ts
@@ -8,14 +8,14 @@ import { seeders } from '@nangohq/shared';
 import { isError, isSuccess, runServer, shouldBeProtected } from '../../utils/tests.js';
 
 import type { DBConnectSession } from '../../services/connectSession.service.js';
-import type { DBEndUser, DBEnvironment, DBPlan, DBTeam, DBUser } from '@nangohq/types';
+import type { DBAPISecret, DBEndUser, DBEnvironment, DBPlan, DBTeam, DBUser } from '@nangohq/types';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 
 const endpoint = '/connect/sessions';
 
 describe(`POST ${endpoint}`, () => {
-    let seed: { account: DBTeam; env: DBEnvironment; user: DBUser; plan: DBPlan };
+    let seed: { account: DBTeam; env: DBEnvironment; user: DBUser; plan: DBPlan; secret: DBAPISecret };
 
     beforeAll(async () => {
         api = await runServer();
@@ -40,7 +40,7 @@ describe(`POST ${endpoint}`, () => {
     it('should fail if no endUser', async () => {
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: seed.env.secret_key,
+            token: seed.secret.secret,
             // @ts-expect-error on purpose
             body: {}
         });
@@ -58,7 +58,7 @@ describe(`POST ${endpoint}`, () => {
     it('should fail if no endUserId', async () => {
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: seed.env.secret_key,
+            token: seed.secret.secret,
             body: {
                 // @ts-expect-error on purpose
                 end_user: {}
@@ -83,7 +83,7 @@ describe(`POST ${endpoint}`, () => {
         const orgDisplayName = 'OrgName';
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: seed.env.secret_key,
+            token: seed.secret.secret,
             body: {
                 end_user: { id: endUserId, email, display_name: displayName },
                 organization: { id: orgId, display_name: orgDisplayName }
@@ -100,7 +100,7 @@ describe(`POST ${endpoint}`, () => {
         const endUserId = 'knownId';
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: seed.env.secret_key,
+            token: seed.secret.secret,
             body: { end_user: { id: endUserId, email: 'a@b.com' }, allowed_integrations: ['random'] }
         });
         isError(res.json);
@@ -116,7 +116,7 @@ describe(`POST ${endpoint}`, () => {
         const endUserId = 'knownId';
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: seed.env.secret_key,
+            token: seed.secret.secret,
             body: { end_user: { id: endUserId, email: 'a@b.com' }, integrations_config_defaults: { random: { connection_config: {} } } }
         });
         isError(res.json);
@@ -132,7 +132,7 @@ describe(`POST ${endpoint}`, () => {
         const endUserId = 'knownId';
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: seed.env.secret_key,
+            token: seed.secret.secret,
             body: { end_user: { id: endUserId, email: 'a@b.com' }, overrides: { random: { docs_connect: 'https://nango.dev/docs' } } }
         });
         isError(res.json);
@@ -148,7 +148,7 @@ describe(`POST ${endpoint}`, () => {
         const endUserId = 'knownId';
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: seed.env.secret_key,
+            token: seed.secret.secret,
             body: { end_user: { id: endUserId, email: 'a@b.com' }, allowed_integrations: ['github'] }
         });
         isSuccess(res.json);
@@ -165,7 +165,7 @@ describe(`POST ${endpoint}`, () => {
         const endUserId = 'knownId';
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: seed.env.secret_key,
+            token: seed.secret.secret,
             body: { end_user: { id: endUserId, email: 'a@b.com' }, integrations_config_defaults: { github: { connection_config: {} } } }
         });
         isSuccess(res.json);
@@ -185,7 +185,7 @@ describe(`POST ${endpoint}`, () => {
 
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     end_user: { id: 'test-user', email: 'test@example.com' },
                     overrides: {
@@ -212,7 +212,7 @@ describe(`POST ${endpoint}`, () => {
 
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     end_user: { id: 'test-user', email: 'test@example.com' },
                     overrides: {
@@ -239,7 +239,7 @@ describe(`POST ${endpoint}`, () => {
 
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     end_user: { id: 'test-user', email: 'test@example.com' },
                     overrides: {
@@ -266,7 +266,7 @@ describe(`POST ${endpoint}`, () => {
 
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     end_user: { id: 'test-user', email: 'test@example.com' },
                     overrides: {
@@ -292,7 +292,7 @@ describe(`POST ${endpoint}`, () => {
         it('should create session with valid tags', async () => {
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     end_user: { id: 'test-user', email: 'test@example.com' },
                     tags: { projectId: '123', orgId: '456' }
@@ -321,7 +321,7 @@ describe(`POST ${endpoint}`, () => {
         it('should create session without tags (optional)', async () => {
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     end_user: { id: 'test-user-no-tags', email: 'test@example.com' }
                 }
@@ -333,7 +333,7 @@ describe(`POST ${endpoint}`, () => {
         it('should create session with empty tags object', async () => {
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     end_user: { id: 'test-user-empty-tags', email: 'test@example.com' },
                     tags: {}
@@ -355,7 +355,7 @@ describe(`POST ${endpoint}`, () => {
         it('should fail with invalid tag key format (starts with number)', async () => {
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     end_user: { id: 'test-user', email: 'test@example.com' },
                     tags: { '123invalid': 'value' }
@@ -372,7 +372,7 @@ describe(`POST ${endpoint}`, () => {
         it('should allow tag values with spaces', async () => {
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     end_user: { id: 'test-user', email: 'test@example.com' },
                     tags: { key: 'value with spaces' }
@@ -386,7 +386,7 @@ describe(`POST ${endpoint}`, () => {
             const longKey = 'a'.repeat(65);
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     end_user: { id: 'test-user', email: 'test@example.com' },
                     tags: { [longKey]: 'value' }
@@ -404,7 +404,7 @@ describe(`POST ${endpoint}`, () => {
             const longValue = 'a'.repeat(256);
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     end_user: { id: 'test-user', email: 'test@example.com' },
                     tags: { key: longValue }
@@ -425,7 +425,7 @@ describe(`POST ${endpoint}`, () => {
             }
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: seed.env.secret_key,
+                token: seed.secret.secret,
                 body: {
                     end_user: { id: 'test-user', email: 'test@example.com' },
                     tags

--- a/packages/server/lib/controllers/connection/connectionId/getConnection.integration.test.ts
+++ b/packages/server/lib/controllers/connection/connectionId/getConnection.integration.test.ts
@@ -29,11 +29,11 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should 404 on unknown provider', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             params: { connectionId: 'test' },
             query: { provider_config_key: 'github' }
         });
@@ -45,12 +45,12 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should 404 on unknown connectionId', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             params: { connectionId: 'test' },
             query: { provider_config_key: 'github' }
         });
@@ -62,7 +62,7 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should get a connection', async () => {
-        const { env, account } = await seeders.seedAccountEnvAndUser();
+        const { env, secret, account } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'algolia', 'algolia');
         const endUser = await seeders.createEndUser({ environment: env, account });
         const conn = await seeders.createConnectionSeed({
@@ -75,7 +75,7 @@ describe(`GET ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             params: { connectionId: conn.connection_id },
             query: { provider_config_key: 'algolia' }
         });
@@ -111,7 +111,7 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should get a connection despite another connection with same name on a different provider', async () => {
-        const { env, account } = await seeders.seedAccountEnvAndUser();
+        const { env, secret, account } = await seeders.seedAccountEnvAndUser();
 
         await seeders.createConfigSeed(env, 'algolia', 'algolia');
         const endUser = await seeders.createEndUser({ environment: env, account });
@@ -135,7 +135,7 @@ describe(`GET ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             params: { connectionId: conn.connection_id },
             query: { provider_config_key: 'algolia' }
         });
@@ -171,7 +171,7 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should return a connection with tags', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'algolia', 'algolia');
         const conn = await seeders.createConnectionSeed({
             env,
@@ -187,7 +187,7 @@ describe(`GET ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             params: { connectionId: conn.connection_id },
             query: { provider_config_key: 'algolia' }
         });
@@ -215,7 +215,7 @@ describe(`GET ${endpoint}`, () => {
 
     it('should return an error if connection refreshs are exhausted', async () => {
         const provider = 'hubspot';
-        const { env, account } = await seeders.seedAccountEnvAndUser();
+        const { env, secret, account } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, provider, provider);
         const endUser = await seeders.createEndUser({ environment: env, account });
         const conn = await seeders.createConnectionSeed({
@@ -232,7 +232,7 @@ describe(`GET ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             params: { connectionId: conn.connection_id },
             query: { provider_config_key: provider }
         });
@@ -274,7 +274,7 @@ describe(`GET ${endpoint}`, () => {
     });
     it('should return an error if connection fails to refresh', async () => {
         const provider = 'hubspot';
-        const { env, account } = await seeders.seedAccountEnvAndUser();
+        const { env, secret, account } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, provider, provider);
         const endUser = await seeders.createEndUser({ environment: env, account });
         const conn = await seeders.createConnectionSeed({
@@ -286,7 +286,7 @@ describe(`GET ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             params: { connectionId: conn.connection_id },
             query: { provider_config_key: provider, force_refresh: true }
         });

--- a/packages/server/lib/controllers/connection/connectionId/metadata/patchMetadata.integration.test.ts
+++ b/packages/server/lib/controllers/connection/connectionId/metadata/patchMetadata.integration.test.ts
@@ -30,10 +30,10 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should validate body with an empty connection id', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 connection_id: '',
                 provider_config_key: 'test',
@@ -57,11 +57,11 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should validate body with an empty provider config key', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 connection_id: 'abc',
                 provider_config_key: '',
@@ -85,14 +85,14 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should provide an unknown connection response if a bad connection is provided', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const connection_id = 'abc';
         const provider_config_key = 'test';
 
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 connection_id,
                 provider_config_key,
@@ -110,14 +110,14 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should provide an unknown connection response if bad connections are provided', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const connection_id = ['abc', 'def'];
         const provider_config_key = 'test';
 
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 connection_id,
                 provider_config_key,
@@ -135,7 +135,7 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('Should update metadata and not overwrite', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const unique_key = 'test-update';
         await seeders.createConfigSeed(env, unique_key, 'google');
         const connections = await seeders.createConnectionSeed({ env, provider: unique_key });
@@ -149,7 +149,7 @@ describe(`PATCH ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 connection_id,
                 provider_config_key,
@@ -174,7 +174,7 @@ describe(`PATCH ${endpoint}`, () => {
 
         const resTwo = await api.fetch(endpoint, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 connection_id,
                 provider_config_key,

--- a/packages/server/lib/controllers/connection/connectionId/metadata/postMetadata.integration.test.ts
+++ b/packages/server/lib/controllers/connection/connectionId/metadata/postMetadata.integration.test.ts
@@ -30,11 +30,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate body with an empty connection_id', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 connection_id: '',
                 provider_config_key: 'test',
@@ -58,11 +58,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate body with an empty provider config key', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 connection_id: 'abc',
                 provider_config_key: '',
@@ -86,14 +86,14 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should provide an unknown connection response if a bad connection is provided', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const connection_id = 'abc';
         const provider_config_key = 'test';
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 connection_id,
                 provider_config_key,
@@ -111,14 +111,14 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should provide an unknown connection response if bad connections are provided', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const connection_id = ['abc', 'def'];
         const provider_config_key = 'test';
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 connection_id,
                 provider_config_key,
@@ -136,7 +136,7 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('Should replace existing metadata, overwriting anything existing', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'test-replace', 'google');
         const connections = await seeders.createConnectionSeed({ env, provider: 'test-replace' });
 
@@ -149,7 +149,7 @@ describe(`POST ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 connection_id,
                 provider_config_key,
@@ -174,7 +174,7 @@ describe(`POST ${endpoint}`, () => {
 
         const resTwo = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 connection_id,
                 provider_config_key,

--- a/packages/server/lib/controllers/connection/connectionId/patchConnection.integration.test.ts
+++ b/packages/server/lib/controllers/connection/connectionId/patchConnection.integration.test.ts
@@ -31,11 +31,11 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should return 400 for unknown provider', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             params: { connectionId: 'test' },
             query: { provider_config_key: 'unknown' },
             body: {}
@@ -49,12 +49,12 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should return 404 for unknown connection', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
 
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             params: { connectionId: 'unknown' },
             query: { provider_config_key: 'github' },
             body: {}
@@ -69,13 +69,13 @@ describe(`PATCH ${endpoint}`, () => {
 
     describe('end_user', () => {
         it('should update end_user only', async () => {
-            const { env } = await seeders.seedAccountEnvAndUser();
+            const { env, secret } = await seeders.seedAccountEnvAndUser();
             await seeders.createConfigSeed(env, 'github', 'github');
             const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
 
             const res = await api.fetch(endpoint, {
                 method: 'PATCH',
-                token: env.secret_key,
+                token: secret.secret,
                 params: { connectionId: conn.connection_id },
                 query: { provider_config_key: 'github' },
                 body: {
@@ -93,13 +93,13 @@ describe(`PATCH ${endpoint}`, () => {
 
     describe('tags', () => {
         it('should update tags only', async () => {
-            const { env } = await seeders.seedAccountEnvAndUser();
+            const { env, secret } = await seeders.seedAccountEnvAndUser();
             await seeders.createConfigSeed(env, 'github', 'github');
             const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
 
             const res = await api.fetch(endpoint, {
                 method: 'PATCH',
-                token: env.secret_key,
+                token: secret.secret,
                 params: { connectionId: conn.connection_id },
                 query: { provider_config_key: 'github' },
                 body: { tags: { projectId: '123', orgId: '456' } }
@@ -114,13 +114,13 @@ describe(`PATCH ${endpoint}`, () => {
         });
 
         it('should update both tags and end_user', async () => {
-            const { env } = await seeders.seedAccountEnvAndUser();
+            const { env, secret } = await seeders.seedAccountEnvAndUser();
             await seeders.createConfigSeed(env, 'github', 'github');
             const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
 
             const res = await api.fetch(endpoint, {
                 method: 'PATCH',
-                token: env.secret_key,
+                token: secret.secret,
                 params: { connectionId: conn.connection_id },
                 query: { provider_config_key: 'github' },
                 body: {
@@ -139,13 +139,13 @@ describe(`PATCH ${endpoint}`, () => {
         });
 
         it('should fail with invalid tag key format', async () => {
-            const { env } = await seeders.seedAccountEnvAndUser();
+            const { env, secret } = await seeders.seedAccountEnvAndUser();
             await seeders.createConfigSeed(env, 'github', 'github');
             const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
 
             const res = await api.fetch(endpoint, {
                 method: 'PATCH',
-                token: env.secret_key,
+                token: secret.secret,
                 params: { connectionId: conn.connection_id },
                 query: { provider_config_key: 'github' },
                 body: {
@@ -161,13 +161,13 @@ describe(`PATCH ${endpoint}`, () => {
         });
 
         it('should allow tag values with spaces', async () => {
-            const { env } = await seeders.seedAccountEnvAndUser();
+            const { env, secret } = await seeders.seedAccountEnvAndUser();
             await seeders.createConfigSeed(env, 'github', 'github');
             const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
 
             const res = await api.fetch(endpoint, {
                 method: 'PATCH',
-                token: env.secret_key,
+                token: secret.secret,
                 params: { connectionId: conn.connection_id },
                 query: { provider_config_key: 'github' },
                 body: {
@@ -183,7 +183,7 @@ describe(`PATCH ${endpoint}`, () => {
         });
 
         it('should replace existing tags completely', async () => {
-            const { env } = await seeders.seedAccountEnvAndUser();
+            const { env, secret } = await seeders.seedAccountEnvAndUser();
             await seeders.createConfigSeed(env, 'github', 'github');
             const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
 
@@ -195,7 +195,7 @@ describe(`PATCH ${endpoint}`, () => {
             // Update with new tags (should replace, not merge)
             const res = await api.fetch(endpoint, {
                 method: 'PATCH',
-                token: env.secret_key,
+                token: secret.secret,
                 params: { connectionId: conn.connection_id },
                 query: { provider_config_key: 'github' },
                 body: { tags: { new: 'value' } }
@@ -210,7 +210,7 @@ describe(`PATCH ${endpoint}`, () => {
         });
 
         it('should set tags on connection without existing tags', async () => {
-            const { env } = await seeders.seedAccountEnvAndUser();
+            const { env, secret } = await seeders.seedAccountEnvAndUser();
             await seeders.createConfigSeed(env, 'github', 'github');
             const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
 
@@ -219,7 +219,7 @@ describe(`PATCH ${endpoint}`, () => {
 
             const res = await api.fetch(endpoint, {
                 method: 'PATCH',
-                token: env.secret_key,
+                token: secret.secret,
                 params: { connectionId: conn.connection_id },
                 query: { provider_config_key: 'github' },
                 body: { tags: { first: 'tag' } }
@@ -232,7 +232,7 @@ describe(`PATCH ${endpoint}`, () => {
         });
 
         it('should allow empty tags object', async () => {
-            const { env } = await seeders.seedAccountEnvAndUser();
+            const { env, secret } = await seeders.seedAccountEnvAndUser();
             await seeders.createConfigSeed(env, 'github', 'github');
             const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
 
@@ -243,7 +243,7 @@ describe(`PATCH ${endpoint}`, () => {
 
             const res = await api.fetch(endpoint, {
                 method: 'PATCH',
-                token: env.secret_key,
+                token: secret.secret,
                 params: { connectionId: conn.connection_id },
                 query: { provider_config_key: 'github' },
                 body: { tags: {} }

--- a/packages/server/lib/controllers/connection/getConnections.integration.test.ts
+++ b/packages/server/lib/controllers/connection/getConnections.integration.test.ts
@@ -26,11 +26,11 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should list empty connections', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {}
         });
 
@@ -41,13 +41,13 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should list one connection', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {}
         });
 
@@ -70,13 +70,13 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should list connection with tags', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const conn = await seeders.createConnectionSeed({ env, provider: 'github', tags: { department: 'sales', tier: 'enterprise' } });
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {}
         });
 
@@ -99,7 +99,7 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should filter connections by single tag', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const conn1 = await seeders.createConnectionSeed({
             env,
@@ -110,7 +110,7 @@ describe(`GET ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {
                 tags: { department: 'engineering,backend' }
             }
@@ -122,7 +122,7 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should filter connections with manually built URL', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const conn1 = await seeders.createConnectionSeed({
             env,
@@ -137,7 +137,7 @@ describe(`GET ${endpoint}`, () => {
         const url = `${api.url}${endpoint}?${params.toString()}`;
         const res = await fetch(url, {
             method: 'GET',
-            headers: { Authorization: `Bearer ${env.secret_key}` }
+            headers: { Authorization: `Bearer ${secret.secret}` }
         });
         const json = await res.json();
 
@@ -147,7 +147,7 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should filter connections by multiple tags (AND logic)', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const conn1 = await seeders.createConnectionSeed({ env, provider: 'github', tags: { department: 'engineering', env: 'production' } });
         await seeders.createConnectionSeed({ env, provider: 'github', tags: { department: 'engineering', env: 'staging' } });
@@ -155,7 +155,7 @@ describe(`GET ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {
                 tags: { department: 'engineering', env: 'production' }
             }
@@ -167,13 +167,13 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should return empty when no connections match tags', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         await seeders.createConnectionSeed({ env, provider: 'github', tags: { department: 'engineering' } });
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {
                 tags: { department: 'sales' }
             }
@@ -184,13 +184,13 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should not match when tag key exists but value differs', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         await seeders.createConnectionSeed({ env, provider: 'github', tags: { department: 'engineering' } });
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {
                 tags: { department: 'sales' }
             }
@@ -201,11 +201,11 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should return 400 when tag keys are invalid', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {
                 tags: { '123invalid': 'value' }
             }
@@ -227,7 +227,7 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should filter by tag values containing colons (e.g. IPv6)', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         // Tag values can contain colons (e.g., IPv6 addresses)
         const conn1 = await seeders.createConnectionSeed({ env, provider: 'github', tags: { ip: '2001:db8::1' } });
@@ -236,7 +236,7 @@ describe(`GET ${endpoint}`, () => {
         // First colon separates key from value: ip:2001:db8::1 -> { ip: "2001:db8::1" }
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {
                 tags: { ip: '2001:db8::1' }
             }
@@ -248,14 +248,14 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should search connections', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         await seeders.createConnectionSeed({ env, provider: 'github' });
         const conn2 = await seeders.createConnectionSeed({ env, provider: 'github' });
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {
                 search: conn2.connection_id
             }
@@ -269,14 +269,14 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should return end user', async () => {
-        const { env, account } = await seeders.seedAccountEnvAndUser();
+        const { env, account, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const endUser = await seeders.createEndUser({ environment: env, account });
         const conn = await seeders.createConnectionSeed({ env, provider: 'github', endUser });
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {}
         });
 
@@ -300,14 +300,14 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should filter one connection by non-existing endUserId', async () => {
-        const { env, account } = await seeders.seedAccountEnvAndUser();
+        const { env, account, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const endUser = await seeders.createEndUser({ environment: env, account });
         await seeders.createConnectionSeed({ env, provider: 'github', endUser });
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {
                 endUserId: 'non-existing'
             }
@@ -320,14 +320,14 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should filter one connection by endUserId', async () => {
-        const { env, account } = await seeders.seedAccountEnvAndUser();
+        const { env, account, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const endUser = await seeders.createEndUser({ environment: env, account });
         const conn = await seeders.createConnectionSeed({ env, provider: 'github', endUser });
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {
                 endUserId: endUser.endUserId
             }
@@ -340,14 +340,14 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should filter one connection by endUserOrganizationId', async () => {
-        const { env, account } = await seeders.seedAccountEnvAndUser();
+        const { env, account, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const endUser = await seeders.createEndUser({ environment: env, account });
         const conn = await seeders.createConnectionSeed({ env, provider: 'github', endUser });
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {
                 endUserOrganizationId: endUser.organization?.organizationId
             }
@@ -360,7 +360,7 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should be paginable', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         for (let i = 0; i < 5; i++) {
             await seeders.createConnectionSeed({ env, provider: 'github' });
@@ -368,7 +368,7 @@ describe(`GET ${endpoint}`, () => {
 
         const page0 = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {
                 limit: 3
             }
@@ -379,7 +379,7 @@ describe(`GET ${endpoint}`, () => {
 
         const page1 = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {
                 limit: 3,
                 page: 1
@@ -391,7 +391,7 @@ describe(`GET ${endpoint}`, () => {
 
         const page2 = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {
                 limit: 3,
                 page: 2

--- a/packages/server/lib/controllers/connection/postConnection.integration.test.ts
+++ b/packages/server/lib/controllers/connection/postConnection.integration.test.ts
@@ -27,10 +27,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate oauth2 credentials', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { provider_config_key: 'github', credentials: { type: 'OAUTH2' } }
         });
@@ -45,10 +45,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate oauth2_cc credentials', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { provider_config_key: 'github', credentials: { type: 'OAUTH2_CC' } }
         });
@@ -67,10 +67,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate oauth1 credentials', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { provider_config_key: 'github', credentials: { type: 'OAUTH1' } }
         });
@@ -88,10 +88,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate api_key credentials', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { provider_config_key: 'github', credentials: { type: 'API_KEY' } }
         });
@@ -106,10 +106,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate basic credentials', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { provider_config_key: 'github', credentials: { type: 'BASIC' } }
         });
@@ -127,10 +127,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate none credentials', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { provider_config_key: 'unauthenticated', credentials: { type: 'NONE', foo: 'bar' } }
         });
@@ -145,10 +145,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate TBA credentials', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { provider_config_key: 'github', credentials: { type: 'TBA' } }
         });
@@ -166,10 +166,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate APP credentials', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { provider_config_key: 'github', credentials: { type: 'APP' } }
         });
@@ -187,11 +187,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should import oauth2 connection', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 provider_config_key: 'github',
                 credentials: { type: 'OAUTH2', access_token: '123' },
@@ -232,12 +232,12 @@ describe(`POST ${endpoint}`, () => {
 
     describe('tags', () => {
         it('should import connection with valid tags and return tags in response', async () => {
-            const { env } = await seeders.seedAccountEnvAndUser();
+            const { env, secret } = await seeders.seedAccountEnvAndUser();
             await seeders.createConfigSeed(env, 'github', 'github');
             const tags = { projectid: '123', environment: 'production' };
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: env.secret_key,
+                token: secret.secret,
                 body: {
                     provider_config_key: 'github',
                     credentials: { type: 'OAUTH2', access_token: '123' },
@@ -253,11 +253,11 @@ describe(`POST ${endpoint}`, () => {
         });
 
         it('should import connection without tags', async () => {
-            const { env } = await seeders.seedAccountEnvAndUser();
+            const { env, secret } = await seeders.seedAccountEnvAndUser();
             await seeders.createConfigSeed(env, 'github', 'github');
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: env.secret_key,
+                token: secret.secret,
                 body: {
                     provider_config_key: 'github',
                     credentials: { type: 'OAUTH2', access_token: '123' }
@@ -272,11 +272,11 @@ describe(`POST ${endpoint}`, () => {
         });
 
         it('should fail with invalid tags', async () => {
-            const { env } = await seeders.seedAccountEnvAndUser();
+            const { env, secret } = await seeders.seedAccountEnvAndUser();
             await seeders.createConfigSeed(env, 'github', 'github');
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: env.secret_key,
+                token: secret.secret,
                 body: {
                     provider_config_key: 'github',
                     credentials: { type: 'OAUTH2', access_token: '123' },
@@ -292,12 +292,12 @@ describe(`POST ${endpoint}`, () => {
         });
 
         it('should import connection with both tags and end_user', async () => {
-            const { env } = await seeders.seedAccountEnvAndUser();
+            const { env, secret } = await seeders.seedAccountEnvAndUser();
             await seeders.createConfigSeed(env, 'github', 'github');
             const tags = { projectid: '456' };
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: env.secret_key,
+                token: secret.secret,
                 body: {
                     provider_config_key: 'github',
                     credentials: { type: 'OAUTH2', access_token: '123' },

--- a/packages/server/lib/controllers/integrations/getListIntegrations.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/getListIntegrations.integration.test.ts
@@ -22,26 +22,26 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should be accessible with private key', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
-        const res = await api.fetch(endpoint, { method: 'GET', token: env.secret_key });
+        const { secret } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(endpoint, { method: 'GET', token: secret.secret });
         isSuccess(res.json);
         expect(res.res.status).toBe(200);
     });
 
     it('should be accessible with connect session token', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
-        const token = await getConnectSessionToken(api, env);
+        const { secret } = await seeders.seedAccountEnvAndUser();
+        const token = await getConnectSessionToken(api, secret.secret);
         const res = await api.fetch(endpoint, { method: 'GET', token });
         isSuccess(res.json);
         expect(res.res.status).toBe(200);
     });
 
     it('should enforce no query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             query: { foo: 'bar' }
         });
@@ -56,9 +56,9 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should list empty', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
-        const res = await api.fetch(endpoint, { method: 'GET', token: env.secret_key });
+        const res = await api.fetch(endpoint, { method: 'GET', token: secret.secret });
 
         isSuccess(res.json);
         expect(res.res.status).toBe(200);
@@ -68,10 +68,10 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should list one', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
 
-        const res = await api.fetch(endpoint, { method: 'GET', token: env.secret_key });
+        const res = await api.fetch(endpoint, { method: 'GET', token: secret.secret });
 
         isSuccess(res.json);
         expect(res.res.status).toBe(200);
@@ -91,11 +91,11 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should not list other env', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const { env: env2 } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env2, 'github', 'github');
 
-        const res = await api.fetch(endpoint, { method: 'GET', token: env.secret_key });
+        const res = await api.fetch(endpoint, { method: 'GET', token: secret.secret });
 
         isSuccess(res.json);
         expect(res.res.status).toBe(200);

--- a/packages/server/lib/controllers/integrations/postIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/postIntegration.integration.test.ts
@@ -28,10 +28,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate the body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { provider: 'invalid', unique_key: '1832_@$ùé&', display_name: false, credentials: { authType: 'INVALID' } }
         });
@@ -50,10 +50,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate the provider', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: { provider: 'invalid', unique_key: 'foobar' }
         });
 
@@ -64,10 +64,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should create an integration', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: { provider: 'algolia', unique_key: 'foobar' }
         });
 
@@ -86,10 +86,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should add webhookSecret when creds.webhook_secret is present', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 provider: 'github',
                 unique_key: 'github',
@@ -118,7 +118,7 @@ describe(`POST ${endpoint}`, () => {
 
         const resGet = await api.fetch(getEndpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             params: { uniqueKey: 'github' },
             query: { include: ['credentials'] }
         });
@@ -129,10 +129,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should not add webhookSecret when creds.webhook_secret is not present', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 provider: 'github',
                 unique_key: 'github',
@@ -160,7 +160,7 @@ describe(`POST ${endpoint}`, () => {
 
         const resGet = await api.fetch(getEndpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             params: { uniqueKey: 'github' },
             query: { include: ['credentials'] }
         });

--- a/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.integration.test.ts
@@ -24,10 +24,10 @@ describe(`DELETE ${endpoint}`, () => {
     });
 
     it('should delete one', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github', { oauth_client_id: 'foo', oauth_client_secret: 'bar', oauth_scopes: 'hello, world' });
 
-        const res = await api.fetch(endpoint, { method: 'DELETE', token: env.secret_key, params: { uniqueKey: 'github' } });
+        const res = await api.fetch(endpoint, { method: 'DELETE', token: secret.secret, params: { uniqueKey: 'github' } });
 
         isSuccess(res.json);
         expect(res.res.status).toBe(200);
@@ -37,7 +37,7 @@ describe(`DELETE ${endpoint}`, () => {
     });
 
     it('should delete getting started meta', async () => {
-        const { env, account } = await seeders.seedAccountEnvAndUser();
+        const { env, account, secret } = await seeders.seedAccountEnvAndUser();
 
         // Getting started meta expects a preprovisioned provider config
         await seeders.createPreprovisionedProviderConfigSeed(env, 'github-getting-started', 'github', 'github-getting-started', {
@@ -49,7 +49,7 @@ describe(`DELETE ${endpoint}`, () => {
         const metaResult = await gettingStartedService.getOrCreateMeta(db.knex, account.id, env.id);
         expect(metaResult.isOk()).toBe(true);
 
-        const res = await api.fetch(endpoint, { method: 'DELETE', token: env.secret_key, params: { uniqueKey: 'github-getting-started' } });
+        const res = await api.fetch(endpoint, { method: 'DELETE', token: secret.secret, params: { uniqueKey: 'github-getting-started' } });
         isSuccess(res.json);
 
         const metaAfter = await gettingStartedService.getMetaByAccountId(db.knex, account.id);

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.integration.test.ts
@@ -23,19 +23,19 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should not be accessible with connect session token', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
-        const token = await getConnectSessionToken(api, env);
+        const { secret } = await seeders.seedAccountEnvAndUser();
+        const token = await getConnectSessionToken(api, secret.secret);
         const res = await api.fetch(endpoint, { method: 'GET', token, params: { uniqueKey: 'github' }, query: {} });
         isError(res.json);
         expect(res.res.status).toBe(401);
     });
 
     it('should enforce no query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             query: { foo: 'bar' }
         });
@@ -50,9 +50,9 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should list empty', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
-        const res = await api.fetch(endpoint, { method: 'GET', token: env.secret_key, params: { uniqueKey: 'github' }, query: {} });
+        const res = await api.fetch(endpoint, { method: 'GET', token: secret.secret, params: { uniqueKey: 'github' }, query: {} });
 
         isError(res.json);
         expect(res.res.status).toBe(404);
@@ -62,10 +62,10 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should list one', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
 
-        const res = await api.fetch(endpoint, { method: 'GET', token: env.secret_key, params: { uniqueKey: 'github' }, query: {} });
+        const res = await api.fetch(endpoint, { method: 'GET', token: secret.secret, params: { uniqueKey: 'github' }, query: {} });
 
         isSuccess(res.json);
         expect(res.res.status).toBe(200);
@@ -83,10 +83,10 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should get webhook', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
 
-        const res = await api.fetch(endpoint, { method: 'GET', token: env.secret_key, params: { uniqueKey: 'github' }, query: { include: ['webhook'] } });
+        const res = await api.fetch(endpoint, { method: 'GET', token: secret.secret, params: { uniqueKey: 'github' }, query: { include: ['webhook'] } });
 
         isSuccess(res.json);
         expect(res.res.status).toBe(200);
@@ -94,21 +94,21 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should not list other env', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const { env: env2 } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env2, 'github', 'github');
 
-        const res = await api.fetch(endpoint, { method: 'GET', token: env.secret_key, params: { uniqueKey: 'github' }, query: {} });
+        const res = await api.fetch(endpoint, { method: 'GET', token: secret.secret, params: { uniqueKey: 'github' }, query: {} });
 
         isError(res.json);
         expect(res.res.status).toBe(404);
     });
 
     it('should get credentials', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github', { oauth_client_id: 'foo', oauth_client_secret: 'bar', oauth_scopes: 'hello, world' });
 
-        const res = await api.fetch(endpoint, { method: 'GET', token: env.secret_key, params: { uniqueKey: 'github' }, query: { include: ['credentials'] } });
+        const res = await api.fetch(endpoint, { method: 'GET', token: secret.secret, params: { uniqueKey: 'github' }, query: { include: ['credentials'] } });
 
         isSuccess(res.json);
         expect(res.res.status).toBe(200);

--- a/packages/server/lib/controllers/integrations/uniqueKey/patchIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/patchIntegration.integration.test.ts
@@ -27,11 +27,11 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should validate the body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             params: { uniqueKey: 'github' },
             // @ts-expect-error on purpose
             body: { unique_key: '1832_@$ùé&', display_name: false, credentials: { type: 'INVALID' } }
@@ -51,11 +51,11 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should update an integration', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             params: { uniqueKey: 'github' },
             body: { display_name: 'DISPLAY' }
         });
@@ -75,11 +75,11 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should be able to rename integration', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             params: { uniqueKey: 'github' },
             body: { unique_key: 'renamed' }
         });
@@ -90,7 +90,7 @@ describe(`PATCH ${endpoint}`, () => {
         // Get renamed integration
         const resGet = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {},
             params: { uniqueKey: 'renamed' }
         });
@@ -102,7 +102,7 @@ describe(`PATCH ${endpoint}`, () => {
         // Old name should not exists
         const resOld = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {},
             params: { uniqueKey: 'github' }
         });
@@ -114,12 +114,12 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should not be able to rename integration with active connection', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         await seeders.createConnectionSeed({ env, provider: 'github' });
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             params: { uniqueKey: 'github' },
             body: { unique_key: 'renamed' }
         });
@@ -131,12 +131,12 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should update webhook_secret for OAUTH2 integration', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
 
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             params: { uniqueKey: 'github' },
             body: { credentials: { type: 'OAUTH2', client_id: 'client_id', client_secret: 'client_secret', webhook_secret: 'new_secret' } }
         });
@@ -156,7 +156,7 @@ describe(`PATCH ${endpoint}`, () => {
 
         const resGet = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             params: { uniqueKey: 'github' },
             query: { include: ['credentials'] }
         });

--- a/packages/server/lib/controllers/providers/getProvider.integration.test.ts
+++ b/packages/server/lib/controllers/providers/getProvider.integration.test.ts
@@ -21,9 +21,9 @@ describe(`GET ${route}`, () => {
     });
 
     it('should get one', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
-            token: env.secret_key,
+            token: secret.secret,
             params: { provider: 'hubspot' }
         });
 
@@ -40,9 +40,9 @@ describe(`GET ${route}`, () => {
     });
 
     it('should return 404', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
-            token: env.secret_key,
+            token: secret.secret,
             params: { provider: 'foobar' }
         });
 

--- a/packages/server/lib/controllers/providers/getProviders.integration.test.ts
+++ b/packages/server/lib/controllers/providers/getProviders.integration.test.ts
@@ -21,24 +21,24 @@ describe(`GET ${route}`, () => {
     });
 
     it('should be authorized by private key', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
-        const res = await api.fetch(route, { method: 'GET', token: env.secret_key, query: {} });
+        const { secret } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(route, { method: 'GET', token: secret.secret, query: {} });
         isSuccess(res.json);
         expect(res.res.status).toBe(200);
     });
 
     it('should be authorized by connect session token', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
-        const token = await getConnectSessionToken(api, env);
+        const { secret } = await seeders.seedAccountEnvAndUser();
+        const token = await getConnectSessionToken(api, secret.secret);
         const res = await api.fetch(route, { method: 'GET', token, query: {} });
         isSuccess(res.json);
         expect(res.res.status).toBe(200);
     });
 
     it('should list all', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
-            token: env.secret_key,
+            token: secret.secret,
             query: {}
         });
 
@@ -50,9 +50,9 @@ describe(`GET ${route}`, () => {
     });
 
     it('should allow search', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
-            token: env.secret_key,
+            token: secret.secret,
             query: { search: 'hubspot' }
         });
 
@@ -71,9 +71,9 @@ describe(`GET ${route}`, () => {
     });
 
     it('should return empty array when search has no results', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
-            token: env.secret_key,
+            token: secret.secret,
             query: { search: 'foobar' }
         });
 

--- a/packages/server/lib/controllers/proxy/allProxy.integration.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.integration.test.ts
@@ -25,10 +25,10 @@ describe(`GET ${route}`, () => {
     });
 
     it('should require headers', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             headers: {}
         });
@@ -51,12 +51,12 @@ describe(`GET ${route}`, () => {
     });
 
     it('should call the proxy', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const integration = await seeders.createConfigSeed(env, 'github', 'github');
         const connection = await seeders.createConnectionSeed({ env, config_id: integration.id!, provider: 'github' });
         const res = await api.fetch(route, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             params: { anyPath: 'users/octocat' },
             headers: { 'connection-id': connection.connection_id, 'provider-config-key': integration.unique_key }
         });
@@ -79,12 +79,12 @@ describe(`GET ${route}`, () => {
     });
 
     it('should use all the headers', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const integration = await seeders.createConfigSeed(env, 'github', 'github');
         const connection = await seeders.createConnectionSeed({ env, config_id: integration.id!, provider: 'github' });
         const res = await api.fetch(route, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             params: { anyPath: 'users/octocat' },
             headers: {
                 'connection-id': connection.connection_id,

--- a/packages/server/lib/controllers/records/getRecords.integration.test.ts
+++ b/packages/server/lib/controllers/records/getRecords.integration.test.ts
@@ -27,11 +27,11 @@ describe(`GET ${route}`, () => {
     });
 
     it('should require model', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         // @ts-expect-error on purpose
         const res = await api.fetch(route, {
             method: 'GET',
-            token: env.secret_key
+            token: secret.secret
         });
         isError(res.json);
         expect(res.res.status).toBe(400);
@@ -44,11 +44,11 @@ describe(`GET ${route}`, () => {
     });
 
     it('should require headers', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         // @ts-expect-error on purpose
         const res = await api.fetch(route, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: { model: 'Ticket' }
         });
         isError(res.json);
@@ -65,10 +65,10 @@ describe(`GET ${route}`, () => {
     });
 
     it('should complain about unknown connection', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: { model: 'Ticket' },
             headers: { 'connection-id': 't', 'provider-config-key': 'a' }
         });
@@ -80,11 +80,11 @@ describe(`GET ${route}`, () => {
     });
 
     it('should get empty records', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
         const res = await api.fetch(route, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: { model: 'Ticket' },
             headers: { 'connection-id': conn.connection_id, 'provider-config-key': 'github' }
         });
@@ -97,7 +97,7 @@ describe(`GET ${route}`, () => {
     });
 
     it('should get multiple page of records', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
 
         await records.upsert({
@@ -122,7 +122,7 @@ describe(`GET ${route}`, () => {
         // Fetch first page
         const resPage1 = await api.fetch(route, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: { model: 'Ticket', limit: 2 },
             headers: { 'connection-id': conn.connection_id, 'provider-config-key': 'github' }
         });
@@ -161,7 +161,7 @@ describe(`GET ${route}`, () => {
         // Fetch second page
         const resPage2 = await api.fetch(route, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: { model: 'Ticket', limit: 2, cursor: resPage1.json.next_cursor! },
             headers: { 'connection-id': conn.connection_id, 'provider-config-key': 'github' }
         });
@@ -186,7 +186,7 @@ describe(`GET ${route}`, () => {
     });
 
     it('should filter', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
 
         await records.upsert({
@@ -211,7 +211,7 @@ describe(`GET ${route}`, () => {
         // Added
         const resAdded = await api.fetch(route, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: { model: 'Ticket', filter: 'added' },
             headers: { 'connection-id': conn.connection_id, 'provider-config-key': 'github' }
         });
@@ -236,7 +236,7 @@ describe(`GET ${route}`, () => {
         // Updated
         const resUpdated = await api.fetch(route, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: { model: 'Ticket', filter: 'UPDATED' },
             headers: { 'connection-id': conn.connection_id, 'provider-config-key': 'github' }
         });
@@ -246,7 +246,7 @@ describe(`GET ${route}`, () => {
         // Deleted
         const resDeleted = await api.fetch(route, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: { model: 'Ticket', filter: 'deleted' },
             headers: { 'connection-id': conn.connection_id, 'provider-config-key': 'github' }
         });
@@ -256,7 +256,7 @@ describe(`GET ${route}`, () => {
         // Multiple filters
         const resMultiple = await api.fetch(route, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: { model: 'Ticket', filter: 'added,UPDATED' },
             headers: { 'connection-id': conn.connection_id, 'provider-config-key': 'github' }
         });
@@ -266,7 +266,7 @@ describe(`GET ${route}`, () => {
     });
 
     it('should query by id', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
 
         await records.upsert({
@@ -291,7 +291,7 @@ describe(`GET ${route}`, () => {
         // One ID
         const res = await api.fetch(route, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: { model: 'Ticket', ids: ['record2'] },
             headers: { 'connection-id': conn.connection_id, 'provider-config-key': 'github' }
         });
@@ -302,7 +302,7 @@ describe(`GET ${route}`, () => {
         // Multiple ID
         const resMulti = await api.fetch(route, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: { model: 'Ticket', ids: ['record2', 'record3'] },
             headers: { 'connection-id': conn.connection_id, 'provider-config-key': 'github' }
         });

--- a/packages/server/lib/controllers/records/patchPruneRecords.integration.test.ts
+++ b/packages/server/lib/controllers/records/patchPruneRecords.integration.test.ts
@@ -27,11 +27,11 @@ describe(`PATCH ${route}`, () => {
     });
 
     it('should require all mandatory parameters', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         // @ts-expect-error on purpose
         const res = await api.fetch(route, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             body: {} as { model: string; until_cursor: string }
         });
         isError(res.json);
@@ -48,11 +48,11 @@ describe(`PATCH ${route}`, () => {
     });
 
     it('should require headers', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         // @ts-expect-error on purpose
         const res = await api.fetch(route, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             body: { model: 'Ticket', until_cursor: 'abc' }
         });
         isError(res.json);
@@ -69,10 +69,10 @@ describe(`PATCH ${route}`, () => {
     });
 
     it('should complain about unknown connection', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             body: { model: 'Ticket', until_cursor: 'abc' },
             headers: { 'connection-id': 't', 'provider-config-key': 'a' }
         });
@@ -84,7 +84,7 @@ describe(`PATCH ${route}`, () => {
     });
 
     it('should prune page of records', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
 
         await records.upsert({
@@ -119,7 +119,7 @@ describe(`PATCH ${route}`, () => {
         // prune one record (limit 1)
         const res1 = await api.fetch(route, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 model: 'Ticket',
                 until_cursor: cursor!,
@@ -137,7 +137,7 @@ describe(`PATCH ${route}`, () => {
         // Prune until the cursor (2nd record - inclusive)
         const res2 = await api.fetch(route, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 model: 'Ticket',
                 until_cursor: cursor!
@@ -154,7 +154,7 @@ describe(`PATCH ${route}`, () => {
         // Prune the last record
         const res3 = await api.fetch(route, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 model: 'Ticket',
                 until_cursor: cursorLast!
@@ -172,7 +172,7 @@ describe(`PATCH ${route}`, () => {
         // Try to prune more records (none left)
         const res4 = await api.fetch(route, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 model: 'Ticket',
                 until_cursor: cursorLast!
@@ -189,7 +189,7 @@ describe(`PATCH ${route}`, () => {
     });
 
     it('should handle updated records', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
 
         await records.upsert({
@@ -242,7 +242,7 @@ describe(`PATCH ${route}`, () => {
 
         const res1 = await api.fetch(route, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 model: 'Ticket',
                 until_cursor: cursorLast!,
@@ -260,7 +260,7 @@ describe(`PATCH ${route}`, () => {
         // Try to prune more records (none left)
         const res2 = await api.fetch(route, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 model: 'Ticket',
                 until_cursor: cursorLast!

--- a/packages/server/lib/controllers/sync/deploy/postConfirmation.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postConfirmation.integration.test.ts
@@ -26,10 +26,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 // @ts-expect-error on purpose
                 debug: 'er'
@@ -51,10 +51,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should accept empty body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 debug: false,
                 flowConfigs: [],
@@ -83,13 +83,13 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should show correct on-events scripts diff', async () => {
-        const { account, env: environment } = await seeders.seedAccountEnvAndUser();
+        const { account, env: environment, secret } = await seeders.seedAccountEnvAndUser();
         const { unique_key: providerConfigKey } = await seeders.createConfigSeed(environment, 'notion-123', 'notion');
         const existingOnEvent = await seeders.createOnEventScript({ account, environment, providerConfigKey, sdkVersion: '0.0.0-yaml' });
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: environment.secret_key,
+            token: secret.secret,
             body: {
                 debug: false,
                 flowConfigs: [],

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
@@ -5,7 +5,7 @@ import { getSyncConfigsAsStandardConfig, seeders } from '@nangohq/shared';
 
 import { isError, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
 
-import type { DBEnvironment } from '@nangohq/types';
+import type { DBAPISecret, DBEnvironment } from '@nangohq/types';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 
@@ -31,10 +31,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 // @ts-expect-error on purpose
                 debug: 'er'
@@ -58,10 +58,10 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should accept empty body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 debug: false,
                 flowConfigs: [],
@@ -81,15 +81,17 @@ describe(`POST ${endpoint}`, () => {
 
     describe('deploy', () => {
         let env: DBEnvironment;
+        let secret: DBAPISecret;
         // This describe must be executed in order
 
         it('should deploy', async () => {
             const seed = await seeders.seedAccountEnvAndUser();
             env = seed.env;
+            secret = seed.secret;
             await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: env.secret_key,
+                token: secret.secret,
                 body: {
                     debug: false,
                     jsonSchema: {
@@ -203,7 +205,7 @@ describe(`POST ${endpoint}`, () => {
         it('should have removed syncs from DB', async () => {
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: env.secret_key,
+                token: secret.secret,
                 body: {
                     debug: false,
                     jsonSchema: {

--- a/packages/server/lib/controllers/sync/getSyncStatus.integration.test.ts
+++ b/packages/server/lib/controllers/sync/getSyncStatus.integration.test.ts
@@ -40,11 +40,11 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should return 400 for for invalid body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             query: {},
             headers: {}
@@ -67,7 +67,7 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should handle syncs as comma-separated string', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const integration = await seeders.createConfigSeed(env, 'github', 'github');
         const connection = await seeders.createConnectionSeed({ env, provider: integration.provider, config_id: integration.id! });
         await seeders.createSyncSeeds({ connectionId: connection.id, environment_id: env.id, sync_name: 'sync1', nango_config_id: integration.id! });
@@ -75,7 +75,7 @@ describe(`GET ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {
                 syncs: 'sync1,sync2',
                 provider_config_key: 'github'
@@ -100,7 +100,7 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should handle wildcard syncs parameter', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const integration = await seeders.createConfigSeed(env, 'github', 'github');
         const connection = await seeders.createConnectionSeed({ env, provider: integration.provider, config_id: integration.id! });
         await seeders.createSyncSeeds({ connectionId: connection.id, environment_id: env.id, sync_name: 'sync1', nango_config_id: integration.id! });
@@ -108,7 +108,7 @@ describe(`GET ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {
                 syncs: '*',
                 provider_config_key: integration.unique_key
@@ -133,7 +133,7 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should handle syncs with variants', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const integration = await seeders.createConfigSeed(env, 'github', 'github');
         const connection = await seeders.createConnectionSeed({ env, provider: integration.provider, config_id: integration.id! });
         await seeders.createSyncSeeds({ connectionId: connection.id, environment_id: env.id, sync_name: 'sync3', nango_config_id: integration.id! });
@@ -141,7 +141,7 @@ describe(`GET ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'GET',
-            token: env.secret_key,
+            token: secret.secret,
             query: {
                 syncs: 'sync3::v1,sync4::v2',
                 provider_config_key: 'github'

--- a/packages/server/lib/controllers/sync/postSyncPause.integration.test.ts
+++ b/packages/server/lib/controllers/sync/postSyncPause.integration.test.ts
@@ -35,11 +35,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should return 400 for for invalid body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 // @ts-expect-error on purpose
                 syncs: [{ invalid: 'object' }, 'valid-sync', null]
@@ -61,11 +61,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should handle syncs as strings', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 syncs: ['sync1', 'sync2'],
                 provider_config_key: 'test-key',
@@ -87,11 +87,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should handle syncs as object', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 syncs: [
                     { name: 'sync1', variant: 'v1' },

--- a/packages/server/lib/controllers/sync/postSyncStart.integration.test.ts
+++ b/packages/server/lib/controllers/sync/postSyncStart.integration.test.ts
@@ -35,11 +35,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should return 400 for for invalid body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 // @ts-expect-error on purpose
                 syncs: [{ invalid: 'object' }, 'valid-sync', null]
@@ -61,11 +61,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should handle syncs as strings', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 syncs: ['sync1', 'sync2'],
                 provider_config_key: 'test-key',
@@ -87,11 +87,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should handle syncs as object', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 syncs: [
                     { name: 'sync1', variant: 'v1' },

--- a/packages/server/lib/controllers/sync/postTrigger.integration.test.ts
+++ b/packages/server/lib/controllers/sync/postTrigger.integration.test.ts
@@ -36,11 +36,11 @@ describe(`POST ${endpoint}`, () => {
 
     describe('validation', () => {
         it('should return 400 for for invalid body', async () => {
-            const { env } = await seeders.seedAccountEnvAndUser();
+            const { secret } = await seeders.seedAccountEnvAndUser();
 
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: env.secret_key,
+                token: secret.secret,
                 body: {
                     // @ts-expect-error on purpose
                     syncs: [{ invalid: 'object' }, 'valid-sync', null],
@@ -83,11 +83,11 @@ describe(`POST ${endpoint}`, () => {
         });
 
         it('should return 400 if provider_config_key is missing from body and headers', async () => {
-            const { env } = await seeders.seedAccountEnvAndUser();
+            const { secret } = await seeders.seedAccountEnvAndUser();
 
             const res = await api.fetch(endpoint, {
                 method: 'POST',
-                token: env.secret_key,
+                token: secret.secret,
                 body: {
                     syncs: ['sync1'],
                     sync_mode: 'full_refresh',
@@ -107,11 +107,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should take provider_config_key and connection_id from headers', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 syncs: ['sync1'],
                 connection_id: '123'
@@ -126,11 +126,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should handle syncs as strings', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 syncs: ['sync1', 'sync2'],
                 provider_config_key: 'test-key',
@@ -152,11 +152,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should handle syncs as object', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 syncs: [
                     { name: 'sync1', variant: 'v1' },
@@ -184,11 +184,11 @@ describe(`POST ${endpoint}`, () => {
         [true, 'RUN_FULL'],
         [false, 'RUN']
     ])('should handle valid full_resync parameter (%s -> %s)', async (full_resync, expectedCommand) => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 syncs: ['sync1'],
                 full_resync,
@@ -211,11 +211,11 @@ describe(`POST ${endpoint}`, () => {
         ['full_refresh_and_clear_cache', 'RUN_FULL', true],
         ['incremental', 'RUN', false]
     ])('should handle sync_mode parameter (%s -> %s)', async (sync_mode, expectedCommand, expectedShouldDeleteRecords) => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 syncs: ['sync1'],
                 // @ts-expect-error on purpose (sync_mode as a string)

--- a/packages/server/lib/controllers/sync/putSyncConnectionFrequency.integration.test.ts
+++ b/packages/server/lib/controllers/sync/putSyncConnectionFrequency.integration.test.ts
@@ -30,11 +30,11 @@ describe(`POST ${endpoint}`, () => {
 
     describe('validation', () => {
         it('should return 400 for for invalid body', async () => {
-            const { env } = await seeders.seedAccountEnvAndUser();
+            const { secret } = await seeders.seedAccountEnvAndUser();
 
             const res = await api.fetch(endpoint, {
                 method: 'PUT',
-                token: env.secret_key,
+                token: secret.secret,
                 body: {
                     connection_id: 'a1-£$',
                     frequency: 'foobar',

--- a/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.integration.test.ts
+++ b/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.integration.test.ts
@@ -32,12 +32,12 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should block if admin capabilities are not enabled', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: 'test' },
-            token: env.secret_key,
+            token: secret.secret,
             body: { accountUUID: 'test', loginReason: 'test' }
         });
 
@@ -54,12 +54,12 @@ describe(`POST ${endpoint}`, () => {
         flags.hasAdminCapabilities = true;
         envs.NANGO_ADMIN_UUID = 'e1e8fee9-a459-46fe-9e82-15c93dae2406';
 
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: 'test' },
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { accountUUID: 'test' }
         });
@@ -80,12 +80,12 @@ describe(`POST ${endpoint}`, () => {
         flags.hasAdminCapabilities = true;
         envs.NANGO_ADMIN_UUID = 'e1e8fee9-a459-46fe-9e82-15c93dae2406'; // will not match current account
 
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: 'test' },
-            token: env.secret_key,
+            token: secret.secret,
             body: { accountUUID: 'f8ca4c4e-8c5a-4502-93f9-cd89d7551362', loginReason: 'test' }
         });
 

--- a/packages/server/lib/controllers/v1/connectUISettings/getConnectUISettings.integration.test.ts
+++ b/packages/server/lib/controllers/v1/connectUISettings/getConnectUISettings.integration.test.ts
@@ -41,15 +41,15 @@ describe(`GET ${route}`, () => {
     });
 
     it('should enforce env query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         // @ts-expect-error missing env query param
-        const res = await api.fetch(route, { token: env.secret_key });
+        const res = await api.fetch(route, { token: secret.secret });
 
         shouldRequireQueryEnv(res);
     });
 
     it('should return default settings when no custom settings exist', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
 
         // Ensure no custom settings exist for this environment
         await db.knex('connect_ui_settings').where('environment_id', env.id).del();
@@ -57,7 +57,7 @@ describe(`GET ${route}`, () => {
         const res = await api.fetch(route, {
             method: 'GET',
             query: { env: 'dev' },
-            token: env.secret_key
+            token: secret.secret
         });
 
         expect(res.res.status).toBe(200);
@@ -68,7 +68,7 @@ describe(`GET ${route}`, () => {
     });
 
     it('should return custom settings when they exist and both plan features are enabled', async () => {
-        const { env, plan } = await seeders.seedAccountEnvAndUser();
+        const { env, plan, secret } = await seeders.seedAccountEnvAndUser();
 
         await updatePlan(db.knex, { id: plan.id, can_customize_connect_ui_theme: true, can_disable_connect_ui_watermark: true });
 
@@ -81,7 +81,7 @@ describe(`GET ${route}`, () => {
         const res = await api.fetch(route, {
             method: 'GET',
             query: { env: 'dev' },
-            token: env.secret_key
+            token: secret.secret
         });
 
         expect(res.res.status).toBe(200);
@@ -92,7 +92,7 @@ describe(`GET ${route}`, () => {
     });
 
     it('should return default theme when plan does not have can_customize_connect_ui_theme flag', async () => {
-        const { env, plan } = await seeders.seedAccountEnvAndUser();
+        const { env, plan, secret } = await seeders.seedAccountEnvAndUser();
 
         const testSettings = {
             ...getCustomSettings(),
@@ -108,7 +108,7 @@ describe(`GET ${route}`, () => {
         const res = await api.fetch(route, {
             method: 'GET',
             query: { env: 'dev' },
-            token: env.secret_key
+            token: secret.secret
         });
 
         expect(res.res.status).toBe(200);
@@ -120,7 +120,7 @@ describe(`GET ${route}`, () => {
     });
 
     it('should return default showWatermark when plan does not have can_disable_connect_ui_watermark flag', async () => {
-        const { env, plan } = await seeders.seedAccountEnvAndUser();
+        const { env, plan, secret } = await seeders.seedAccountEnvAndUser();
 
         // Create custom settings with non-default watermark setting
         const testSettings = {
@@ -137,7 +137,7 @@ describe(`GET ${route}`, () => {
         const res = await api.fetch(route, {
             method: 'GET',
             query: { env: 'dev' },
-            token: env.secret_key
+            token: secret.secret
         });
 
         expect(res.res.status).toBe(200);
@@ -149,7 +149,7 @@ describe(`GET ${route}`, () => {
     });
 
     it('should return default values for both features when plan has neither flag', async () => {
-        const { env, plan } = await seeders.seedAccountEnvAndUser();
+        const { env, plan, secret } = await seeders.seedAccountEnvAndUser();
 
         // Create custom settings with non-default values
         const testSettings = getCustomSettings();
@@ -163,7 +163,7 @@ describe(`GET ${route}`, () => {
         const res = await api.fetch(route, {
             method: 'GET',
             query: { env: 'dev' },
-            token: env.secret_key
+            token: secret.secret
         });
 
         expect(res.res.status).toBe(200);
@@ -174,7 +174,7 @@ describe(`GET ${route}`, () => {
     });
 
     it('should return default settings when no custom settings exist and plan has no feature flags', async () => {
-        const { env, plan } = await seeders.seedAccountEnvAndUser();
+        const { env, plan, secret } = await seeders.seedAccountEnvAndUser();
 
         // Ensure no custom settings exist for this environment
         await db.knex('connect_ui_settings').where('environment_id', env.id).del();
@@ -185,7 +185,7 @@ describe(`GET ${route}`, () => {
         const res = await api.fetch(route, {
             method: 'GET',
             query: { env: 'dev' },
-            token: env.secret_key
+            token: secret.secret
         });
 
         expect(res.res.status).toBe(200);

--- a/packages/server/lib/controllers/v1/connectUISettings/putConnectUISettings.integration.test.ts
+++ b/packages/server/lib/controllers/v1/connectUISettings/putConnectUISettings.integration.test.ts
@@ -45,11 +45,11 @@ describe(`PUT ${route}`, () => {
     });
 
     it('should enforce env query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         // @ts-expect-error missing env query param
         const res = await api.fetch(route, {
             method: 'PUT',
-            token: env.secret_key,
+            token: secret.secret,
             body: getCustomSettings()
         });
 
@@ -57,7 +57,7 @@ describe(`PUT ${route}`, () => {
     });
 
     it('should create new settings when they do not exist initially and both plan features are enabled', async () => {
-        const { env, plan } = await seeders.seedAccountEnvAndUser();
+        const { env, plan, secret } = await seeders.seedAccountEnvAndUser();
 
         // Enable both plan features so custom settings can be preserved
         await updatePlan(db.knex, { id: plan.id, can_customize_connect_ui_theme: true, can_disable_connect_ui_watermark: true });
@@ -72,7 +72,7 @@ describe(`PUT ${route}`, () => {
         const res = await api.fetch(route, {
             method: 'PUT',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: newSettings
         });
 
@@ -89,7 +89,7 @@ describe(`PUT ${route}`, () => {
     });
 
     it('should update existing settings when they already exist and both plan features are enabled', async () => {
-        const { env, plan } = await seeders.seedAccountEnvAndUser();
+        const { env, plan, secret } = await seeders.seedAccountEnvAndUser();
 
         // Enable both plan features so custom settings can be preserved
         await updatePlan(db.knex, { id: plan.id, can_customize_connect_ui_theme: true, can_disable_connect_ui_watermark: true });
@@ -116,7 +116,7 @@ describe(`PUT ${route}`, () => {
         const res = await api.fetch(route, {
             method: 'PUT',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: updatedSettings
         });
 
@@ -133,7 +133,7 @@ describe(`PUT ${route}`, () => {
     });
 
     it('should reject invalid body with missing required fields', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const invalidBody = {
             showWatermark: true,
@@ -144,7 +144,7 @@ describe(`PUT ${route}`, () => {
         const res = await api.fetch(route, {
             method: 'PUT',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: invalidBody
         });
 
@@ -170,7 +170,7 @@ describe(`PUT ${route}`, () => {
     });
 
     it('should reject invalid body with missing properties', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const invalidBody = {
             // Missing showWatermark
@@ -187,7 +187,7 @@ describe(`PUT ${route}`, () => {
         const res = await api.fetch(route, {
             method: 'PUT',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: invalidBody
         });
 
@@ -223,7 +223,7 @@ describe(`PUT ${route}`, () => {
     });
 
     it('should override theme to defaults when plan does not have can_customize_connect_ui_theme flag', async () => {
-        const { env, plan } = await seeders.seedAccountEnvAndUser();
+        const { env, plan, secret } = await seeders.seedAccountEnvAndUser();
 
         // Disable the theme customization feature for this plan, but enable watermark customization
         await updatePlan(db.knex, { id: plan.id, can_customize_connect_ui_theme: false, can_disable_connect_ui_watermark: true });
@@ -236,7 +236,7 @@ describe(`PUT ${route}`, () => {
         const res = await api.fetch(route, {
             method: 'PUT',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: testSettings
         });
 
@@ -255,7 +255,7 @@ describe(`PUT ${route}`, () => {
     });
 
     it('should override showWatermark to defaults when plan does not have can_disable_connect_ui_watermark flag', async () => {
-        const { env, plan } = await seeders.seedAccountEnvAndUser();
+        const { env, plan, secret } = await seeders.seedAccountEnvAndUser();
 
         // Disable the watermark customization feature for this plan, but enable theme customization
         await updatePlan(db.knex, { id: plan.id, can_customize_connect_ui_theme: true, can_disable_connect_ui_watermark: false });
@@ -268,7 +268,7 @@ describe(`PUT ${route}`, () => {
         const res = await api.fetch(route, {
             method: 'PUT',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: testSettings
         });
 
@@ -287,7 +287,7 @@ describe(`PUT ${route}`, () => {
     });
 
     it('should override both features to defaults when plan has neither flag', async () => {
-        const { env, plan } = await seeders.seedAccountEnvAndUser();
+        const { env, plan, secret } = await seeders.seedAccountEnvAndUser();
 
         // Disable both features for this plan
         await updatePlan(db.knex, { id: plan.id, can_customize_connect_ui_theme: false, can_disable_connect_ui_watermark: false });
@@ -297,7 +297,7 @@ describe(`PUT ${route}`, () => {
         const res = await api.fetch(route, {
             method: 'PUT',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: testSettings
         });
 

--- a/packages/server/lib/controllers/v1/environment/deleteEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/deleteEnvironment.integration.test.ts
@@ -4,6 +4,7 @@ import db from '@nangohq/database';
 import { PROD_ENVIRONMENT_NAME, environmentService, getProvider, seeders } from '@nangohq/shared';
 import { createConfigSeed } from '@nangohq/shared/lib/seeders/config.seeder.js';
 import { createSyncSeeds } from '@nangohq/shared/lib/seeders/index.js';
+import secretService from '@nangohq/shared/lib/services/secret.service.js';
 
 import { isError, runServer, shouldBeProtected } from '../../../utils/tests.js';
 
@@ -38,11 +39,13 @@ describe(`DELETE ${endpoint}`, () => {
             throw new Error('Failed to create prod environment');
         }
 
+        const prodSecret = (await secretService.getDefaultSecretForEnv(db.knex, prodEnv.id)).unwrap();
+
         const res = await api.fetch(endpoint, {
             method: 'DELETE',
             // @ts-expect-error query params are required
             query: { env: PROD_ENVIRONMENT_NAME },
-            token: prodEnv.secret_key
+            token: prodSecret.secret
         });
 
         expect(res.res.status).toBe(400);
@@ -62,11 +65,13 @@ describe(`DELETE ${endpoint}`, () => {
             throw new Error('Failed to create test environment');
         }
 
+        const testSecret = (await secretService.getDefaultSecretForEnv(db.knex, testEnv.id)).unwrap();
+
         const res = await api.fetch(endpoint, {
             method: 'DELETE',
             // @ts-expect-error query params are required
             query: { env: testEnv.name },
-            token: testEnv.secret_key
+            token: testSecret.secret
         });
 
         expect(res.res.status).toBe(204);
@@ -83,6 +88,8 @@ describe(`DELETE ${endpoint}`, () => {
         if (!testEnv) {
             throw new Error('Failed to create test environment');
         }
+
+        const testSecret = (await secretService.getDefaultSecretForEnv(db.knex, testEnv.id)).unwrap();
 
         // Create a provider config for this environment
         const providerName = 'github';
@@ -127,7 +134,7 @@ describe(`DELETE ${endpoint}`, () => {
             method: 'DELETE',
             // @ts-expect-error query params are required
             query: { env: testEnv.name },
-            token: testEnv.secret_key
+            token: testSecret.secret
         });
 
         expect(res.res.status).toBe(204);

--- a/packages/server/lib/controllers/v1/environment/getEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.ts
@@ -1,3 +1,4 @@
+import db from '@nangohq/database';
 import {
     accountService,
     connectionService,
@@ -7,6 +8,7 @@ import {
     getGlobalWebhookReceiveUrl,
     getWebsocketsPath
 } from '@nangohq/shared';
+import secretService from '@nangohq/shared/lib/services/secret.service.js';
 import { isCloud, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { envs } from '../../../env.js';
@@ -26,16 +28,32 @@ export const getEnvironment = asyncWrapper<GetEnvironment>(async (req, res) => {
 
     const { environment, account, user, plan } = res.locals;
 
+    let defaultSecret: string = '';
+    let pendingSecret: string | null = null;
+
     if (!isCloud) {
         environment.websockets_path = getWebsocketsPath();
         if (process.env[`NANGO_SECRET_KEY_${environment.name.toUpperCase()}`]) {
-            environment.secret_key = process.env[`NANGO_SECRET_KEY_${environment.name.toUpperCase()}`] as string;
+            defaultSecret = process.env[`NANGO_SECRET_KEY_${environment.name.toUpperCase()}`] as string;
             environment.secret_key_rotatable = false;
         }
 
         if (process.env[`NANGO_PUBLIC_KEY_${environment.name.toUpperCase()}`]) {
             environment.public_key = process.env[`NANGO_PUBLIC_KEY_${environment.name.toUpperCase()}`] as string;
             environment.public_key_rotatable = false;
+        }
+    } else {
+        const secrets = await secretService.getAllSecretsForEnv(db.knex, environment.id);
+        if (secrets.isErr()) {
+            res.status(500).send({ error: { code: 'server_error' } });
+            return;
+        }
+        for (const secret of secrets.value) {
+            if (secret.is_default) {
+                defaultSecret = secret.secret;
+            } else {
+                pendingSecret = secret.secret;
+            }
         }
     }
 
@@ -91,7 +109,9 @@ export const getEnvironment = asyncWrapper<GetEnvironment>(async (req, res) => {
             uuid: account.uuid,
             name: account.name,
             email: user.email,
-            slack_notifications_channel
+            slack_notifications_channel,
+            secret: defaultSecret,
+            pending_secret: pendingSecret
         }
     });
 });

--- a/packages/server/lib/controllers/v1/environment/patchEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/patchEnvironment.integration.test.ts
@@ -29,7 +29,7 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should successfully rename an environment', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const newName = 'renamed-env';
 
         const res = await api.fetch(endpoint, {
@@ -37,7 +37,7 @@ describe(`PATCH ${endpoint}`, () => {
             // @ts-expect-error query params are required
             query: { env: env.name },
             body: { name: newName },
-            token: env.secret_key
+            token: secret.secret
         });
 
         expect(res.res.status).toBe(200);
@@ -54,7 +54,7 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should not allow renaming to an existing environment name', async () => {
-        const { env, account } = await seeders.seedAccountEnvAndUser();
+        const { env, account, secret } = await seeders.seedAccountEnvAndUser();
         await environmentService.createEnvironment(db.knex, { accountId: account.id, name: 'existing' });
 
         const res = await api.fetch(endpoint, {
@@ -62,7 +62,7 @@ describe(`PATCH ${endpoint}`, () => {
             // @ts-expect-error query params are required
             query: { env: env.name },
             body: { name: 'existing' },
-            token: env.secret_key
+            token: secret.secret
         });
 
         expect(res.res.status).toBe(409);

--- a/packages/server/lib/controllers/v1/environment/postEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/postEnvironment.integration.test.ts
@@ -27,14 +27,14 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should not allow environment name to be the same as an existing environment', async () => {
-        const { env, plan } = await seeders.seedAccountEnvAndUser();
+        const { env, plan, secret } = await seeders.seedAccountEnvAndUser();
         await updatePlan(db.knex, { id: plan.id, environments_max: 10 });
         await environmentService.createEnvironment(db.knex, { accountId: env.account_id, name: 'existing' });
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
             body: { name: 'existing' },
-            token: env.secret_key
+            token: secret.secret
         });
 
         isError(res.json);
@@ -47,13 +47,13 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should limit the number of environments based on environments_max flag', async () => {
-        const { env, plan } = await seeders.seedAccountEnvAndUser();
+        const { plan, secret } = await seeders.seedAccountEnvAndUser();
         await updatePlan(db.knex, { id: plan.id, environments_max: 1 });
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
             body: { name: 'dev' },
-            token: env.secret_key
+            token: secret.secret
         });
 
         isError(res.json);

--- a/packages/server/lib/controllers/v1/environment/variables/postVariables.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/variables/postVariables.integration.test.ts
@@ -27,11 +27,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should enforce env query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error - intentionally missing env query param
             query: {},
             body: { variables: [] }
@@ -41,11 +41,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             query: { env: env.name },
             // @ts-expect-error - intentionally invalid body
             body: { invalid: 'body' }
@@ -57,7 +57,7 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should store and retrieve environment variables', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
 
         const variables = [
             { name: 'TEST_VAR', value: 'test_value' },
@@ -66,7 +66,7 @@ describe(`POST ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             query: { env: env.name },
             body: { variables }
         });
@@ -81,14 +81,14 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should store environment variable with value up to 4000 characters', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
 
         const largeValue = 'x'.repeat(4000);
         const variables = [{ name: 'LARGE_VALUE_VAR', value: largeValue }];
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             query: { env: env.name },
             body: { variables }
         });
@@ -103,14 +103,14 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should store environment variable with name up to 256 characters', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
 
         const largeName = 'X'.repeat(256);
         const variables = [{ name: largeName, value: 'test_value' }];
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             query: { env: env.name },
             body: { variables }
         });
@@ -125,14 +125,14 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should reject environment variable name exceeding 256 characters', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
 
         const tooLongName = 'X'.repeat(257);
         const variables = [{ name: tooLongName, value: 'test_value' }];
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             query: { env: env.name },
             body: { variables }
         });
@@ -143,14 +143,14 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should reject environment variable value exceeding 4000 characters', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
 
         const tooLongValue = 'x'.repeat(4001);
         const variables = [{ name: 'TEST_VAR', value: tooLongValue }];
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             query: { env: env.name },
             body: { variables }
         });
@@ -161,7 +161,7 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should reject more than 100 environment variables', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
 
         const variables = Array.from({ length: 101 }, (_, i) => ({
             name: `VAR_${i}`,
@@ -170,7 +170,7 @@ describe(`POST ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             query: { env: env.name },
             body: { variables }
         });

--- a/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts
@@ -27,12 +27,12 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should fail if no template exists for this provider and script name', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: { provider: 'github', providerConfigKey: 'github', scriptName: 'test', type: 'sync' }
         });
 
@@ -44,12 +44,12 @@ describe(`POST ${endpoint}`, () => {
 
     it('should deploy a template', async () => {
         vi.spyOn(remoteFileService, 'copy').mockResolvedValue('_LOCAL_FILE_');
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const integration = await seeders.createConfigSeed(env, 'airtable', 'airtable');
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: { provider: 'airtable', providerConfigKey: 'airtable', scriptName: 'tables', type: 'sync' }
         });
 

--- a/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/patchGettingStarted.integration.test.ts
@@ -23,10 +23,10 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should validate body schema', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             query: { env: env.name },
             // @ts-expect-error on purpose
             body: { step: 'invalid' }
@@ -43,10 +43,10 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should validate step is non-negative integer', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             query: { env: 'dev' },
             body: { step: -1 }
         });

--- a/packages/server/lib/controllers/v1/integrations/postIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/postIntegration.integration.test.ts
@@ -27,11 +27,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate the body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: env.name },
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { provider: 'github', useSharedCredentials: 'invalid' }
         });
@@ -41,11 +41,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate the provider', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: env.name },
-            token: env.secret_key,
+            token: secret.secret,
             body: { provider: 'invalid-provider', useSharedCredentials: false }
         });
 
@@ -56,12 +56,12 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate integrationId uniqueness', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github-unique', 'github');
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: env.name },
-            token: env.secret_key,
+            token: secret.secret,
             body: { provider: 'github', useSharedCredentials: false, integrationId: 'github-unique' }
         });
 
@@ -72,11 +72,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should validate authType compatibility', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: env.name },
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 provider: 'github',
                 useSharedCredentials: false,
@@ -96,11 +96,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should create an empty integration', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: env.name },
-            token: env.secret_key,
+            token: secret.secret,
             body: { provider: 'github', useSharedCredentials: false }
         });
 
@@ -115,11 +115,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should create an integration with custom integrationId', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: env.name },
-            token: env.secret_key,
+            token: secret.secret,
             body: { provider: 'github', useSharedCredentials: false, integrationId: 'custom-github' }
         });
 
@@ -134,11 +134,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should create an integration with displayName', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: env.name },
-            token: env.secret_key,
+            token: secret.secret,
             body: { provider: 'github', useSharedCredentials: false, displayName: 'My GitHub Integration' }
         });
 
@@ -153,11 +153,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should create an integration with forward_webhooks set to false', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: env.name },
-            token: env.secret_key,
+            token: secret.secret,
             body: { provider: 'github', useSharedCredentials: false, forward_webhooks: false }
         });
 
@@ -171,11 +171,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should create an integration with OAUTH2 credentials', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: env.name },
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 provider: 'github',
                 useSharedCredentials: false,
@@ -200,7 +200,7 @@ describe(`POST ${endpoint}`, () => {
         const resGet = await api.fetch('/api/v1/integrations/:providerConfigKey', {
             method: 'GET',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             params: { providerConfigKey: 'github' }
         });
 
@@ -209,11 +209,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should create an integration with all fields', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: env.name },
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 provider: 'github',
                 useSharedCredentials: false,
@@ -243,7 +243,7 @@ describe(`POST ${endpoint}`, () => {
         const resGet = await api.fetch('/api/v1/integrations/:providerConfigKey', {
             method: 'GET',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             params: { providerConfigKey: 'full-integration' }
         });
 
@@ -255,12 +255,12 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should create integration with shared credentials', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createSharedCredentialsSeed('github');
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: { provider: 'github', useSharedCredentials: true }
         });
 
@@ -274,12 +274,12 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should create integration with shared credentials and custom integrationId', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createSharedCredentialsSeed('github');
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 provider: 'github',
                 useSharedCredentials: true,
@@ -298,12 +298,12 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should generate unique key when provider name already exists', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: env.name },
-            token: env.secret_key,
+            token: secret.secret,
             body: { provider: 'github', useSharedCredentials: false }
         });
 
@@ -312,11 +312,11 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should allow scopes with spaces', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: env.name },
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 provider: 'github',
                 useSharedCredentials: false,

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/flows/getFlows.integration.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/flows/getFlows.integration.test.ts
@@ -21,24 +21,24 @@ describe(`GET ${route}`, () => {
     });
 
     it('should enforce env query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(
             route,
             // @ts-expect-error missing query on purpose
-            { method: 'GET', token: env.secret_key, params: { providerConfigKey: 'test' } }
+            { method: 'GET', token: secret.secret, params: { providerConfigKey: 'test' } }
         );
 
         shouldRequireQueryEnv(res);
     });
 
     it('should get 404', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(route, {
             method: 'GET',
             query: { env: 'dev' },
             params: { providerConfigKey: 'test' },
-            token: env.secret_key
+            token: secret.secret
         });
 
         isError(res.json);
@@ -49,14 +49,14 @@ describe(`GET ${route}`, () => {
     });
 
     it('should get github templates', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
 
         const res = await api.fetch(route, {
             method: 'GET',
             query: { env: 'dev' },
             params: { providerConfigKey: 'github' },
-            token: env.secret_key
+            token: secret.secret
         });
 
         expect(res.res.status).toBe(200);
@@ -83,7 +83,7 @@ describe(`GET ${route}`, () => {
     });
 
     it('should create same template and deduplicate correctly', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         const config = await seeders.createConfigSeed(env, 'github', 'github');
         const connection = await seeders.createConnectionSeed({ env, provider: 'github' });
 
@@ -101,7 +101,7 @@ describe(`GET ${route}`, () => {
             method: 'GET',
             query: { env: 'dev' },
             params: { providerConfigKey: 'github' },
-            token: env.secret_key
+            token: secret.secret
         });
 
         expect(res.res.status).toBe(200);

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.integration.test.ts
@@ -28,12 +28,12 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should be able to rename integration', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             params: { providerConfigKey: 'github' },
             body: { integrationId: 'renamed' }
         });
@@ -47,7 +47,7 @@ describe(`PATCH ${endpoint}`, () => {
         const resGet = await api.fetch(endpoint, {
             method: 'GET',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             params: { providerConfigKey: 'renamed' }
         });
         isSuccess(resGet.json);
@@ -59,7 +59,7 @@ describe(`PATCH ${endpoint}`, () => {
         const resOld = await api.fetch(endpoint, {
             method: 'GET',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             params: { providerConfigKey: 'github' }
         });
 
@@ -70,13 +70,13 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should not be able to rename integration with active connection', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         await seeders.createConnectionSeed({ env, provider: 'github' });
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             params: { providerConfigKey: 'github' },
             body: { integrationId: 'renamed' }
         });
@@ -88,12 +88,12 @@ describe(`PATCH ${endpoint}`, () => {
     });
 
     it('should allow scopes with spaces', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const res = await api.fetch(endpoint, {
             method: 'PATCH',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             params: { providerConfigKey: 'github' },
             body: { authType: 'OAUTH2', clientId: 'test-client', clientSecret: 'test-secret', scopes: 'read write,admin access' }
         });

--- a/packages/server/lib/controllers/v1/invite/deleteInvite.integration.test.ts
+++ b/packages/server/lib/controllers/v1/invite/deleteInvite.integration.test.ts
@@ -22,10 +22,10 @@ describe(`DELETE ${route}`, () => {
     });
 
     it('should enforce env query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
             method: 'DELETE',
-            token: env.secret_key,
+            token: secret.secret,
             body: { email: '' },
             // @ts-expect-error missing query on purpose
             query: {}
@@ -35,11 +35,11 @@ describe(`DELETE ${route}`, () => {
     });
 
     it('should validate body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
             method: 'DELETE',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { email: 1 }
         });
@@ -54,19 +54,19 @@ describe(`DELETE ${route}`, () => {
     });
 
     it('should revoke an invite', async () => {
-        const { env, account, user } = await seeders.seedAccountEnvAndUser();
+        const { account, user, secret } = await seeders.seedAccountEnvAndUser();
 
         const email = 'foo@example.com';
         await inviteEmail({ email, name: email, accountId: account.id, invitedByUserId: user.id, trx: db.knex });
 
-        const listBefore = await api.fetch('/api/v1/team', { method: 'GET', query: { env: 'dev' }, token: env.secret_key });
+        const listBefore = await api.fetch('/api/v1/team', { method: 'GET', query: { env: 'dev' }, token: secret.secret });
         isSuccess(listBefore.json);
         expect(listBefore.json.data.invitedUsers).toHaveLength(1);
 
         const res = await api.fetch(route, {
             method: 'DELETE',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: { email: email }
         });
 
@@ -76,7 +76,7 @@ describe(`DELETE ${route}`, () => {
             data: { success: true }
         });
 
-        const listAfter = await api.fetch('/api/v1/team', { method: 'GET', query: { env: 'dev' }, token: env.secret_key });
+        const listAfter = await api.fetch('/api/v1/team', { method: 'GET', query: { env: 'dev' }, token: secret.secret });
         isSuccess(listAfter.json);
         expect(listAfter.json.data.invitedUsers).toHaveLength(0);
     });

--- a/packages/server/lib/controllers/v1/invite/postInvite.integration.test.ts
+++ b/packages/server/lib/controllers/v1/invite/postInvite.integration.test.ts
@@ -21,10 +21,10 @@ describe(`POST ${route}`, () => {
     });
 
     it('should enforce env query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             body: { emails: [] },
             // @ts-expect-error missing query on purpose
             query: {}
@@ -34,11 +34,11 @@ describe(`POST ${route}`, () => {
     });
 
     it('should validate body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { emails: 1 }
         });

--- a/packages/server/lib/controllers/v1/logs/getOperation.integration.test.ts
+++ b/packages/server/lib/controllers/v1/logs/getOperation.integration.test.ts
@@ -21,25 +21,25 @@ describe('GET /logs/operations/:operationId', () => {
     });
 
     it('should enforce env query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(
             '/api/v1/logs/operations/:operationId',
             // @ts-expect-error missing query on purpose
-            { token: env.secret_key, params: { operationId: '1' } }
+            { token: secret.secret, params: { operationId: '1' } }
         );
 
         shouldRequireQueryEnv(res);
     });
 
     it('should validate query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch('/api/v1/logs/operations/:operationId', {
             query: {
                 env: 'dev',
                 // @ts-expect-error on purpose
                 foo: 'bar'
             },
-            token: env.secret_key,
+            token: secret.secret,
             params: { operationId: '1' }
         });
 
@@ -59,10 +59,10 @@ describe('GET /logs/operations/:operationId', () => {
     });
 
     it('should get empty result', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch('/api/v1/logs/operations/:operationId', {
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             params: { operationId: '1741878251660_XQMgbkGG' }
         });
 
@@ -73,7 +73,7 @@ describe('GET /logs/operations/:operationId', () => {
     });
 
     it('should get one result', async () => {
-        const { env, account } = await seeders.seedAccountEnvAndUser();
+        const { env, account, secret } = await seeders.seedAccountEnvAndUser();
 
         const logCtx = await logContextGetter.create({ operation: { type: 'proxy', action: 'call' } }, { account, environment: env });
         await logCtx.info('test info');
@@ -81,7 +81,7 @@ describe('GET /logs/operations/:operationId', () => {
 
         const res = await api.fetch(`/api/v1/logs/operations/:operationId`, {
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             params: { operationId: logCtx.id }
         });
 
@@ -121,7 +121,7 @@ describe('GET /logs/operations/:operationId', () => {
 
         const res = await api.fetch(`/api/v1/logs/operations/:operationId`, {
             query: { env: 'dev' },
-            token: env2.env.secret_key,
+            token: env2.secret.secret,
             params: { operationId: logCtx.id }
         });
 

--- a/packages/server/lib/controllers/v1/logs/postInsights.integration.test.ts
+++ b/packages/server/lib/controllers/v1/logs/postInsights.integration.test.ts
@@ -20,13 +20,13 @@ describe('POST /logs/insights', () => {
     });
 
     it('should enforce env query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(
             '/api/v1/logs/insights',
             // @ts-expect-error missing query on purpose
             {
                 method: 'POST',
-                token: env.secret_key,
+                token: secret.secret,
                 body: { type: 'action' }
             }
         );
@@ -35,7 +35,7 @@ describe('POST /logs/insights', () => {
     });
 
     it('should validate body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch('/api/v1/logs/insights', {
             method: 'POST',
             query: {
@@ -43,7 +43,7 @@ describe('POST /logs/insights', () => {
                 // @ts-expect-error on purpose
                 foo: 'bar'
             },
-            token: env.secret_key,
+            token: secret.secret,
             body: {
                 // @ts-expect-error on purpose
                 type: 'foobar'
@@ -66,11 +66,11 @@ describe('POST /logs/insights', () => {
     });
 
     it('should get empty result', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch('/api/v1/logs/insights', {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: { type: 'sync:run' }
         });
 

--- a/packages/server/lib/controllers/v1/logs/searchFilters.integration.test.ts
+++ b/packages/server/lib/controllers/v1/logs/searchFilters.integration.test.ts
@@ -21,19 +21,19 @@ describe('POST /logs/filters', () => {
     });
 
     it('should enforce env query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         // @ts-expect-error missing query on purpose
-        const res = await api.fetch('/api/v1/logs/filters', { method: 'POST', token: env.secret_key, body: { category: 'config' } });
+        const res = await api.fetch('/api/v1/logs/filters', { method: 'POST', token: secret.secret, body: { category: 'config' } });
 
         shouldRequireQueryEnv(res);
     });
 
     it('should validate body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch('/api/v1/logs/filters', {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { category: 'a', foo: 'bar' }
         });
@@ -59,11 +59,11 @@ describe('POST /logs/filters', () => {
     });
 
     it('should search filters and get empty results', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch('/api/v1/logs/filters', {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: { category: 'integration', search: '' }
         });
 
@@ -75,7 +75,7 @@ describe('POST /logs/filters', () => {
     });
 
     it('should search filters and get one result', async () => {
-        const { env, account } = await seeders.seedAccountEnvAndUser();
+        const { env, account, secret } = await seeders.seedAccountEnvAndUser();
 
         const logCtx = await logContextGetter.create(
             { operation: { type: 'proxy', action: 'call' } },
@@ -87,7 +87,7 @@ describe('POST /logs/filters', () => {
         const res = await api.fetch('/api/v1/logs/filters', {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: { category: 'integration', search: '' }
         });
 
@@ -99,7 +99,7 @@ describe('POST /logs/filters', () => {
     });
 
     it('should search filters with a query and get one result', async () => {
-        const { env, account } = await seeders.seedAccountEnvAndUser();
+        const { env, account, secret } = await seeders.seedAccountEnvAndUser();
 
         const logCtx = await logContextGetter.create(
             { operation: { type: 'proxy', action: 'call' } },
@@ -111,7 +111,7 @@ describe('POST /logs/filters', () => {
         const res = await api.fetch('/api/v1/logs/filters', {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: { category: 'integration', search: 'hel' }
         });
 
@@ -136,7 +136,7 @@ describe('POST /logs/filters', () => {
         const res = await api.fetch('/api/v1/logs/filters', {
             method: 'POST',
             query: { env: 'dev' },
-            token: env2.env.secret_key,
+            token: env2.secret.secret,
             body: { category: 'integration', search: '' }
         });
 

--- a/packages/server/lib/controllers/v1/logs/searchMessages.integration.test.ts
+++ b/packages/server/lib/controllers/v1/logs/searchMessages.integration.test.ts
@@ -21,19 +21,19 @@ describe('POST /logs/messages', () => {
     });
 
     it('should enforce env query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         // @ts-expect-error missing query on purpose
-        const res = await api.fetch('/api/v1/logs/messages', { method: 'POST', token: env.secret_key, body: { operationId: '1' } });
+        const res = await api.fetch('/api/v1/logs/messages', { method: 'POST', token: secret.secret, body: { operationId: '1' } });
 
         shouldRequireQueryEnv(res);
     });
 
     it('should validate body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch('/api/v1/logs/messages', {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { limit: 'a', foo: 'bar' }
         });
@@ -64,7 +64,7 @@ describe('POST /logs/messages', () => {
     });
 
     it('should search messages and get empty results', async () => {
-        const { account, env } = await seeders.seedAccountEnvAndUser();
+        const { account, env, secret } = await seeders.seedAccountEnvAndUser();
 
         const logCtx = await logContextGetter.create({ operation: { type: 'proxy', action: 'call' } }, { account, environment: env });
         await logCtx.success();
@@ -72,7 +72,7 @@ describe('POST /logs/messages', () => {
         const res = await api.fetch('/api/v1/logs/messages', {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: { operationId: logCtx.id, limit: 10 }
         });
 
@@ -85,7 +85,7 @@ describe('POST /logs/messages', () => {
     });
 
     it('should search messages and get one result', async () => {
-        const { env, account } = await seeders.seedAccountEnvAndUser();
+        const { env, account, secret } = await seeders.seedAccountEnvAndUser();
 
         const logCtx = await logContextGetter.create({ operation: { type: 'proxy', action: 'call' } }, { account, environment: env });
         await logCtx.info('test info');
@@ -94,7 +94,7 @@ describe('POST /logs/messages', () => {
         const res = await api.fetch('/api/v1/logs/messages', {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: { operationId: logCtx.id, limit: 10 }
         });
 
@@ -128,7 +128,7 @@ describe('POST /logs/messages', () => {
         const res = await api.fetch('/api/v1/logs/messages', {
             method: 'POST',
             query: { env: 'dev' },
-            token: env2.env.secret_key,
+            token: env2.secret.secret,
             body: { operationId: logCtx.id, limit: 10 }
         });
 

--- a/packages/server/lib/controllers/v1/logs/searchOperations.integration.test.ts
+++ b/packages/server/lib/controllers/v1/logs/searchOperations.integration.test.ts
@@ -22,19 +22,19 @@ describe('POST /logs/operations', () => {
     });
 
     it('should enforce env query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         // @ts-expect-error missing query on purpose
-        const res = await api.fetch('/api/v1/logs/operations', { method: 'POST', token: env.secret_key });
+        const res = await api.fetch('/api/v1/logs/operations', { method: 'POST', token: secret.secret });
 
         shouldRequireQueryEnv(res);
     });
 
     it('should validate body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch('/api/v1/logs/operations', {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { limit: 'a', foo: 'bar' }
         });
@@ -60,11 +60,11 @@ describe('POST /logs/operations', () => {
     });
 
     it('should search logs and get empty results', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch('/api/v1/logs/operations', {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: { limit: 10 }
         });
 
@@ -77,7 +77,7 @@ describe('POST /logs/operations', () => {
     });
 
     it('should search logs and get one result', async () => {
-        const { env, account } = await seeders.seedAccountEnvAndUser();
+        const { env, account, secret } = await seeders.seedAccountEnvAndUser();
 
         const logCtx = await logContextGetter.create({ operation: { type: 'auth', action: 'create_connection' } }, { account, environment: env });
         await logCtx.info('test info');
@@ -86,7 +86,7 @@ describe('POST /logs/operations', () => {
         const res = await api.fetch('/api/v1/logs/operations', {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: { limit: 10 }
         });
 
@@ -131,7 +131,7 @@ describe('POST /logs/operations', () => {
         const res = await api.fetch('/api/v1/logs/operations', {
             method: 'POST',
             query: { env: 'dev' },
-            token: env2.env.secret_key,
+            token: env2.secret.secret,
             body: { limit: 10 }
         });
 

--- a/packages/server/lib/controllers/v1/plans/trial/postPlanExtendTrial.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/trial/postPlanExtendTrial.integration.test.ts
@@ -22,10 +22,10 @@ describe(`POST ${route}`, () => {
     });
 
     it('should enforce env query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
             method: 'POST',
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error missing query on purpose
             query: {}
         });
@@ -34,11 +34,11 @@ describe(`POST ${route}`, () => {
     });
 
     it('should validate body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { test: 1 }
         });
@@ -53,7 +53,7 @@ describe(`POST ${route}`, () => {
     });
 
     it('should extend trial', async () => {
-        const { env, plan } = await seeders.seedAccountEnvAndUser();
+        const { plan, secret } = await seeders.seedAccountEnvAndUser();
 
         // start trial
         const endDate = new Date(Date.now() + TRIAL_DURATION);
@@ -62,7 +62,7 @@ describe(`POST ${route}`, () => {
         const res = await api.fetch(route, {
             method: 'POST',
             query: { env: 'dev' },
-            token: env.secret_key
+            token: secret.secret
         });
 
         isSuccess(res.json);

--- a/packages/server/lib/controllers/v1/team/getTeam.integration.test.ts
+++ b/packages/server/lib/controllers/v1/team/getTeam.integration.test.ts
@@ -21,23 +21,23 @@ describe(`GET ${route}`, () => {
     });
 
     it('should enforce env query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(
             route,
             // @ts-expect-error missing query on purpose
-            { token: env.secret_key, params: { operationId: '1' } }
+            { token: secret.secret, params: { operationId: '1' } }
         );
 
         shouldRequireQueryEnv(res);
     });
 
     it('should get team', async () => {
-        const { env, user, account } = await seeders.seedAccountEnvAndUser();
+        const { user, account, secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(route, {
             method: 'GET',
             query: { env: 'dev' },
-            token: env.secret_key
+            token: secret.secret
         });
 
         expect(res.res.status).toBe(200);

--- a/packages/server/lib/controllers/v1/team/putTeam.integration.test.ts
+++ b/packages/server/lib/controllers/v1/team/putTeam.integration.test.ts
@@ -21,22 +21,22 @@ describe(`PUT ${route}`, () => {
     });
 
     it('should enforce env query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(
             route,
             // @ts-expect-error missing query on purpose
-            { token: env.secret_key, params: { operationId: '1' } }
+            { token: secret.secret, params: { operationId: '1' } }
         );
 
         shouldRequireQueryEnv(res);
     });
 
     it('should validate body', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
             method: 'PUT',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             body: { name: 1 }
         });
@@ -51,12 +51,12 @@ describe(`PUT ${route}`, () => {
     });
 
     it('should put team name', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
 
         const res = await api.fetch(route, {
             method: 'PUT',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             body: { name: 'hello' }
         });
 

--- a/packages/server/lib/controllers/v1/team/users/deleteTeamUser.integration.test.ts
+++ b/packages/server/lib/controllers/v1/team/users/deleteTeamUser.integration.test.ts
@@ -21,10 +21,10 @@ describe(`DELETE ${route}`, () => {
     });
 
     it('should enforce env query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
             method: 'DELETE',
-            token: env.secret_key,
+            token: secret.secret,
             params: { id: 1 },
             // @ts-expect-error missing query on purpose
             query: {}
@@ -34,11 +34,11 @@ describe(`DELETE ${route}`, () => {
     });
 
     it('should validate params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
             method: 'DELETE',
             query: { env: 'dev' },
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             params: { id: 'a' }
         });

--- a/packages/server/lib/controllers/v1/user/getUser.integration.test.ts
+++ b/packages/server/lib/controllers/v1/user/getUser.integration.test.ts
@@ -21,9 +21,9 @@ describe(`GET ${route}`, () => {
     });
 
     it('should enforce no query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             query: { env: 'dev' }
         });

--- a/packages/server/lib/controllers/v1/user/patchUser.integration.test.ts
+++ b/packages/server/lib/controllers/v1/user/patchUser.integration.test.ts
@@ -21,10 +21,10 @@ describe(`PATCH ${route}`, () => {
     });
 
     it('should enforce no query params', async () => {
-        const { env } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
             method: 'PATCH',
-            token: env.secret_key,
+            token: secret.secret,
             // @ts-expect-error on purpose
             query: { env: 'dev' },
             body: { name: 'name' }

--- a/packages/server/lib/utils/tests.ts
+++ b/packages/server/lib/utils/tests.ts
@@ -173,7 +173,7 @@ export async function runServer(): Promise<{ server: Server; url: string; fetch:
 /**
  * Get connect session token
  * @param api
- * @param env
+ * @param secret
  * @returns connect session token
  * @throws Error if no connect session token
  * @example const token = await getConnectSessionToken(api, env);

--- a/packages/server/lib/utils/tests.ts
+++ b/packages/server/lib/utils/tests.ts
@@ -178,12 +178,12 @@ export async function runServer(): Promise<{ server: Server; url: string; fetch:
  * @throws Error if no connect session token
  * @example const token = await getConnectSessionToken(api, env);
  */
-export async function getConnectSessionToken(api: Awaited<ReturnType<typeof runServer>>, env: { secret_key: string }) {
+export async function getConnectSessionToken(api: Awaited<ReturnType<typeof runServer>>, secret: string) {
     const endUserId = Math.random().toString(36).substring(7);
     const getSession = await fetch(`${api.url}/connect/sessions`, {
         method: 'POST',
         body: JSON.stringify({ end_user: { id: endUserId, email: `${endUserId}@domain.com` } }),
-        headers: { Authorization: `Bearer ${env.secret_key}`, 'content-type': 'application/json' }
+        headers: { Authorization: `Bearer ${secret}`, 'content-type': 'application/json' }
     });
     const {
         data: { token }


### PR DESCRIPTION
I split this out from a larger change set.

This PR rewires all integration tests in `package/server/lib/controllers` to stop using `env.secret_key` and use their default secret instead.

This is a voluminous but repetitive PR: It's the same edit applied over and over.

This is in preparation for the next PR that will remove the fields `secret_key` and `pending_secret_key` (and siblings) entirely from the environment object.

Notes:
 - The first commit is the bulk of the work.
 - I accidentally committed a file that I didn't want to, so I reverted it in the second commit.
 - Contrapositively, I missed one file, so I added it in the third commit.

<!-- Summary by @propel-code-bot -->

---

Seeder helpers and shared utilities now return or fetch the seeded secret directly—using secretService when only an environment reference exists—and the common getConnectSessionToken helper was updated to accept a raw secret string so every test follows the same secret-handling path.

---
*This summary was automatically generated by @propel-code-bot*