### PR TITLE
fix(3cx): prevent assertionOption from appearing in connection creds

### DIFF
--- a/packages/server/lib/controllers/auth/postTwoStep.ts
+++ b/packages/server/lib/controllers/auth/postTwoStep.ts
@@ -163,10 +163,13 @@ export const postPublicTwoStepAuthorization = asyncWrapper<PostPublicTwoStepAuth
 
         const tokenMetadata = getConnectionMetadata(credentials.raw, provider, 'token_response_metadata');
 
+        // Strip assertionOption/assertion_option so they are never stored in connection_config (e.g. 3CX only expects domain)
+        const { assertionOption: _ao, assertion_option: _ao2, ...cleanConnectionConfig } = connectionConfig;
+
         connectionConfig = {
-            ...connectionConfig,
+            ...cleanConnectionConfig,
             ...tokenMetadata
-        };
+        } as Record<string, string>;
 
         const [updatedConnection] = await connectionService.upsertAuthConnection({
             connectionId,

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1249,6 +1249,10 @@ class ConnectionService {
         connectionConfig: Record<string, string>,
         refreshToken?: boolean
     ): Promise<ServiceResponse<TwoStepCredentials>> {
+        // Strip assertionOption/assertion_option so they are never sent to the token endpoint (e.g. 3CX only expects clientId, clientSecret, domain)
+        const { assertionOption: _ao, assertion_option: _ao2, ...cleanConnectionConfig } = connectionConfig;
+        connectionConfig = cleanConnectionConfig as Record<string, string>;
+
         if (provider.signature) {
             const create = jwtClient.createCredentials({
                 config: providerConfig,

--- a/packages/shared/lib/utils/utils.ts
+++ b/packages/shared/lib/utils/utils.ts
@@ -397,8 +397,10 @@ export function interpolateIfNeeded(str: string, replacers: Record<string, any>)
     return str;
 }
 
+const ASSERTION_OPTION_KEYS = ['assertionOption', 'assertion_option'];
+
 export function getConnectionConfig(queryParams: any): Record<string, string> {
-    const arr = Object.entries(queryParams).filter(([, v]) => typeof v === 'string'); // Filter strings
+    const arr = Object.entries(queryParams || {}).filter(([k, v]) => typeof v === 'string' && !ASSERTION_OPTION_KEYS.includes(k)); // Filter to strings only; exclude assertionOption so it never gets stored or sent to token endpoint
     return Object.fromEntries(arr) as Record<string, string>;
 }
 

--- a/packages/shared/lib/utils/utils.unit.test.ts
+++ b/packages/shared/lib/utils/utils.unit.test.ts
@@ -41,6 +41,36 @@ describe('encodeParameters Function Tests', () => {
     });
 });
 
+describe('getConnectionConfig', () => {
+    it('should return only string values and exclude assertionOption/assertion_option', () => {
+        const queryParams = {
+            domain: 'mycompany.3cx.us',
+            clientId: 'client-123',
+            clientSecret: 'secret-456',
+            assertionOption: { foo: 'bar' },
+            assertion_option: '[object Object]'
+        };
+        const result = utils.getConnectionConfig(queryParams);
+        expect(result).toEqual({
+            domain: 'mycompany.3cx.us',
+            clientId: 'client-123',
+            clientSecret: 'secret-456'
+        });
+        expect(result['assertionOption']).toBeUndefined();
+        expect(result['assertion_option']).toBeUndefined();
+    });
+
+    it('should return empty object for null/undefined', () => {
+        expect(utils.getConnectionConfig(null)).toEqual({});
+        expect(utils.getConnectionConfig(undefined)).toEqual({});
+    });
+
+    it('should filter out non-string values', () => {
+        const queryParams = { domain: 'x.com', count: 42, flag: true };
+        expect(utils.getConnectionConfig(queryParams)).toEqual({ domain: 'x.com' });
+    });
+});
+
 describe('interpolateIfNeeded', () => {
     it('should interpolate both parts when "||" is present', () => {
         const input = '${connectionConfig.appDetails} || ${connectionConfig.userEmail}';

--- a/packages/webapp/src/pages/Connection/Authorization.tsx
+++ b/packages/webapp/src/pages/Connection/Authorization.tsx
@@ -223,8 +223,14 @@ export const Authorization: React.FC<AuthorizationProps> = ({ connection, errorL
                         if (key === 'privateKey' && privateKey && typeof privateKey === 'object' && 'id' in privateKey && 'secret' in privateKey) {
                             value = `${privateKey.id}:${privateKey.secret}`;
                             label = 'PRIVATE KEY';
-                        } else if (!['type', 'token', 'expires_at', 'raw'].includes(key)) {
-                            value = (connection.credentials as Record<string, string>)[key];
+                        } else if (!['type', 'token', 'expires_at', 'raw', 'assertionOption', 'assertion_option'].includes(key)) {
+                            const rawValue = (connection.credentials as Record<string, string>)[key];
+                            value =
+                                typeof rawValue === 'string'
+                                    ? rawValue
+                                    : typeof rawValue === 'object' && rawValue !== null
+                                      ? JSON.stringify(rawValue)
+                                      : String(rawValue ?? '');
                             label = key.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
                         } else {
                             return [];


### PR DESCRIPTION
## Describe the problem and your solution

Creating a 3CX (or other two-step) connection showed `Assertionoption: [object Object]` in connection credentials and broke OAuth token requests. 

**Solution:** Treat `assertionOption` / `assertion_option` as internal-only: filter them out in `getConnectionConfig` (input), strip them in `getTwoStepCredentials` and in `postTwoStep` before DB upsert, and hide them (and safely stringify values) on the Authorization page for TWO_STEP credentials.

## Issue ticket number and link

Fixes https://github.com/NangoHQ/nango/issues/5326

## Testing instructions

- **Unit:** `bun run test:unit -- --run packages/shared/lib/utils/utils.unit.test.ts -t "getConnectionConfig"` — checks that these keys are filtered and only string values are kept.
<!-- Summary by @propel-code-bot -->

---

These assertion keys are now stripped before reaching any token endpoints or being persisted back to storage, ensuring they remain internal-only throughout the two-step authorization flow.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/utils/utils.ts`
• `packages/shared/lib/services/connection.service.ts`
• `packages/server/lib/controllers/auth/postTwoStep.ts`
• `packages/webapp/src/pages/Connection/Authorization.tsx`
• `packages/shared/lib/utils/utils.unit.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*

@rguldener can you check this