### PR TITLE
chore: replace deprecated zod methods

### DIFF
--- a/docs/implementation-guides/platform/functions/testing.mdx
+++ b/docs/implementation-guides/platform/functions/testing.mdx
@@ -88,7 +88,7 @@ const TicketSchema = z.object({
   id: z.string(),
   title: z.string(),
   status: z.enum(['open', 'closed']),
-  createdAt: z.string().datetime(),
+  createdAt: z.iso.datetime(),
 });
 
 export default createSync({

--- a/docs/implementation-guides/use-cases/unified-apis.mdx
+++ b/docs/implementation-guides/use-cases/unified-apis.mdx
@@ -69,7 +69,7 @@ Start by defining your unified model with a zod model in a file, e.g., `models.t
 export const UserUnified = z.object({
   id: z.string(),
   name: z.string(),
-  email: z.string().email(),
+  email: z.email(),
 });
 ```
 

--- a/packages/jobs/lib/routes/tasks/putTask.ts
+++ b/packages/jobs/lib/routes/tasks/putTask.ts
@@ -32,7 +32,7 @@ const bodySchema = z.object({
         .nullable()
         .default(null)
 });
-const paramsSchema = z.object({ taskId: z.string().uuid() }).strict();
+const paramsSchema = z.object({ taskId: z.uuid() }).strict();
 
 const validate = validateRequest<PutTask>({
     parseBody: (data) => bodySchema.parse(data),

--- a/packages/jobs/lib/routes/tasks/taskId/postHeartbeat.ts
+++ b/packages/jobs/lib/routes/tasks/taskId/postHeartbeat.ts
@@ -7,7 +7,7 @@ import { orchestratorClient } from '../../../clients.js';
 import type { PostHeartbeat } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, RouteHandler } from '@nangohq/utils';
 
-const paramsSchema = z.object({ taskId: z.string().uuid() }).strict();
+const paramsSchema = z.object({ taskId: z.uuid() }).strict();
 
 const validate = validateRequest<PostHeartbeat>({
     parseParams: (data) => paramsSchema.parse(data)

--- a/packages/jobs/lib/schemas/nango-props.ts
+++ b/packages/jobs/lib/schemas/nango-props.ts
@@ -45,7 +45,7 @@ export const nangoPropsSchema = z.looseObject({
         // deleted: z.boolean().optional(),
         // deleted_at: z.coerce.date().optional().nullable(),
     }),
-    syncId: z.string().uuid().optional(),
+    syncId: z.uuid().optional(),
     syncJobId: z.number().optional(),
     activityLogId: operationIdRegex,
     secretKey: z.string().min(1),

--- a/packages/lambda-runner/lib/schemas.ts
+++ b/packages/lambda-runner/lib/schemas.ts
@@ -21,7 +21,7 @@ export const nangoPropsSchema = z.object({
     providerConfigKey: z.string().min(1),
     provider: z.string().min(1),
     lastSyncDate: z.coerce.date().optional(),
-    syncId: z.string().uuid().optional(),
+    syncId: z.uuid().optional(),
     syncVariant: z.string().optional(),
     nangoConnectionId: z.number(),
     syncJobId: z.number().optional(),

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -22,7 +22,7 @@ export const commonSchemaArgsFields = {
 export const abortArgsSchema = z.object({
     type: z.literal('abort'),
     abortedTask: z.object({
-        id: z.string().uuid(),
+        id: z.uuid(),
         state: z.enum(taskStates)
     }),
     reason: z.string().min(1),
@@ -74,7 +74,7 @@ export const onEventArgsSchema = z.object({
 });
 
 const commonSchemaFields = {
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: z.string().min(1),
     groupKey: z.string().min(1),
     groupMaxConcurrency: z.number().int().min(0).default(0),
@@ -250,7 +250,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
 export function validateSchedule(schedule: Schedule): Result<OrchestratorSchedule> {
     const scheduleSchema = z
         .object({
-            id: z.string().uuid(),
+            id: z.uuid(),
             name: z.string().min(1),
             state: z.enum(['STARTED', 'PAUSED', 'DELETED']),
             startsAt: z.coerce.date(),
@@ -264,7 +264,7 @@ export function validateSchedule(schedule: Schedule): Result<OrchestratorSchedul
             createdAt: z.coerce.date(),
             updatedAt: z.coerce.date(),
             deletedAt: z.coerce.date().nullable(),
-            lastScheduledTaskId: z.string().uuid().nullable(),
+            lastScheduledTaskId: z.uuid().nullable(),
             lastScheduledTaskState: z.enum(taskStates).nullable(),
             nextExecutionAt: z.coerce.date().nullable()
         })

--- a/packages/orchestrator/lib/routes/v1/retries/retryKey/getOutput.ts
+++ b/packages/orchestrator/lib/routes/v1/retries/retryKey/getOutput.ts
@@ -23,7 +23,7 @@ const path = '/v1/retries/:retryKey/output';
 const method = 'GET';
 
 const querySchema = z.object({ ownerKey: z.string().min(1) }).strict();
-const paramsSchema = z.object({ retryKey: z.string().uuid() }).strict();
+const paramsSchema = z.object({ retryKey: z.uuid() }).strict();
 
 const validate = validateRequest<GetRetryOutput>({
     parseQuery: (data) => querySchema.parse(data),

--- a/packages/orchestrator/lib/routes/v1/tasks/postSearch.ts
+++ b/packages/orchestrator/lib/routes/v1/tasks/postSearch.ts
@@ -25,7 +25,7 @@ const bodySchema = z
     .object({
         groupKey: z.string().min(1).optional(),
         limit: z.coerce.number().positive().optional(),
-        ids: z.array(z.string().uuid()).optional()
+        ids: z.array(z.uuid()).optional()
     })
     .strict();
 

--- a/packages/orchestrator/lib/routes/v1/tasks/putTaskId.ts
+++ b/packages/orchestrator/lib/routes/v1/tasks/putTaskId.ts
@@ -34,7 +34,7 @@ const bodySchema = z
         nextExecutionInMs: z.number().int().nonnegative().optional()
     })
     .strict();
-const paramsSchema = z.object({ taskId: z.string().uuid() }).strict();
+const paramsSchema = z.object({ taskId: z.uuid() }).strict();
 
 const validate = validateRequest<PutTask>({
     parseBody: (data) => bodySchema.parse(data),

--- a/packages/orchestrator/lib/routes/v1/tasks/taskId/getOutput.ts
+++ b/packages/orchestrator/lib/routes/v1/tasks/taskId/getOutput.ts
@@ -29,7 +29,7 @@ const method = 'GET';
 const querySchema = z.object({
     longPolling: z.coerce.number().optional()
 });
-const paramsSchema = z.object({ taskId: z.string().uuid() }).strict();
+const paramsSchema = z.object({ taskId: z.uuid() }).strict();
 
 const validate = validateRequest<GetOutput>({
     parseQuery: (data) => querySchema.parse(data),

--- a/packages/orchestrator/lib/routes/v1/tasks/taskId/postHeartbeat.ts
+++ b/packages/orchestrator/lib/routes/v1/tasks/taskId/postHeartbeat.ts
@@ -19,7 +19,7 @@ type PostHeartbeat = Endpoint<{
     Success: never;
 }>;
 
-const paramsSchema = z.object({ taskId: z.string().uuid() }).strict();
+const paramsSchema = z.object({ taskId: z.uuid() }).strict();
 
 const validate = validateRequest<PostHeartbeat>({
     parseParams: (data) => paramsSchema.parse(data)

--- a/packages/server/lib/controllers/action/getAsyncActionResult.ts
+++ b/packages/server/lib/controllers/action/getAsyncActionResult.ts
@@ -12,7 +12,7 @@ const orchestrator = getOrchestrator();
 
 const paramValidation = z
     .object({
-        id: z.string().uuid()
+        id: z.uuid()
     })
     .strict();
 

--- a/packages/server/lib/controllers/records/getRecords.ts
+++ b/packages/server/lib/controllers/records/getRecords.ts
@@ -13,8 +13,8 @@ export const validationQuery = z
     .object({
         model: modelSchema,
         variant: variantSchema.optional(),
-        delta: z.string().datetime().optional(),
-        modified_after: z.string().datetime().optional(),
+        delta: z.iso.datetime().optional(),
+        modified_after: z.iso.datetime().optional(),
         limit: z.coerce.number().min(1).max(10000).default(100).optional(),
         filter: z
             .string()

--- a/packages/server/lib/controllers/v1/account/getEmailByExpiredToken.ts
+++ b/packages/server/lib/controllers/v1/account/getEmailByExpiredToken.ts
@@ -12,7 +12,7 @@ const logger = getLogger('Server.GetEmailByExpiredToken');
 
 const validation = z
     .object({
-        token: z.string().uuid()
+        token: z.uuid()
     })
     .strict();
 

--- a/packages/server/lib/controllers/v1/account/getEmailByUuid.ts
+++ b/packages/server/lib/controllers/v1/account/getEmailByUuid.ts
@@ -9,7 +9,7 @@ import type { GetEmailByUuid } from '@nangohq/types';
 
 const validation = z
     .object({
-        uuid: z.string().uuid()
+        uuid: z.uuid()
     })
     .strict();
 

--- a/packages/server/lib/controllers/v1/account/managed/postSignup.ts
+++ b/packages/server/lib/controllers/v1/account/managed/postSignup.ts
@@ -14,7 +14,7 @@ export interface InviteAccountState {
 const validation = z
     .object({
         provider: z.enum(['GoogleOAuth']),
-        token: z.string().uuid().optional()
+        token: z.uuid().optional()
     })
     .strict();
 

--- a/packages/server/lib/controllers/v1/account/postForgotPassword.ts
+++ b/packages/server/lib/controllers/v1/account/postForgotPassword.ts
@@ -10,7 +10,7 @@ import { resetPasswordSecret } from '../../../utils/utils.js';
 
 import type { PostForgotPassword } from '@nangohq/types';
 
-const validation = z.object({ email: z.string().email() }).strict();
+const validation = z.object({ email: z.email() }).strict();
 
 export const postForgotPassword = asyncWrapper<PostForgotPassword>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);

--- a/packages/server/lib/controllers/v1/account/resendVerificationEmailByEmail.ts
+++ b/packages/server/lib/controllers/v1/account/resendVerificationEmailByEmail.ts
@@ -10,7 +10,7 @@ import type { ResendVerificationEmailByEmail } from '@nangohq/types';
 
 const validation = z
     .object({
-        email: z.string().email()
+        email: z.email()
     })
     .strict();
 

--- a/packages/server/lib/controllers/v1/account/resendVerificationEmailByUuid.ts
+++ b/packages/server/lib/controllers/v1/account/resendVerificationEmailByUuid.ts
@@ -10,7 +10,7 @@ import type { ResendVerificationEmailByUuid } from '@nangohq/types';
 
 const validation = z
     .object({
-        uuid: z.string().uuid()
+        uuid: z.uuid()
     })
     .strict();
 

--- a/packages/server/lib/controllers/v1/account/signin.ts
+++ b/packages/server/lib/controllers/v1/account/signin.ts
@@ -10,7 +10,7 @@ import type { PostSignin } from '@nangohq/types';
 
 const validation = z
     .object({
-        email: z.string().email(),
+        email: z.email(),
         password: z.string().min(8).max(64)
     })
     .strict();

--- a/packages/server/lib/controllers/v1/account/signup.ts
+++ b/packages/server/lib/controllers/v1/account/signup.ts
@@ -23,7 +23,7 @@ export const passwordSchema = z
 
 const validation = z
     .object({
-        email: z.string().email(),
+        email: z.email(),
         password: passwordSchema,
         name: z.string(),
         token: z.string().uuid().optional(),

--- a/packages/server/lib/controllers/v1/account/signup.ts
+++ b/packages/server/lib/controllers/v1/account/signup.ts
@@ -26,7 +26,7 @@ const validation = z
         email: z.email(),
         password: passwordSchema,
         name: z.string(),
-        token: z.string().uuid().optional(),
+        token: z.uuid().optional(),
         foundUs: z.string().optional()
     })
     .strict();

--- a/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.ts
+++ b/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.ts
@@ -12,7 +12,7 @@ import type { PostImpersonate } from '@nangohq/types';
 
 const schemaBody = z
     .object({
-        accountUUID: z.string().uuid(),
+        accountUUID: z.uuid(),
         loginReason: z.string().min(1).max(1024)
     })
     .strict();

--- a/packages/server/lib/controllers/v1/environment/patchEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/patchEnvironment.ts
@@ -12,11 +12,11 @@ import type { DBEnvironment, PatchEnvironment } from '@nangohq/types';
 const validationBody = z
     .object({
         name: envSchema.optional(),
-        callback_url: z.string().url().optional(),
+        callback_url: z.url().optional(),
         hmac_key: z.string().min(0).max(1000).optional(),
         hmac_enabled: z.boolean().optional(),
         slack_notifications: z.boolean().optional(),
-        otlp_endpoint: z.string().url().or(z.literal('')).optional(),
+        otlp_endpoint: z.url().or(z.literal('')).optional(),
         otlp_headers: z
             .array(z.object({ name: z.string().min(1).max(256), value: z.string().min(1).max(4000) }))
             .max(100)

--- a/packages/server/lib/controllers/v1/invite/acceptInvite.ts
+++ b/packages/server/lib/controllers/v1/invite/acceptInvite.ts
@@ -9,7 +9,7 @@ import type { AcceptInvite } from '@nangohq/types';
 
 const validation = z
     .object({
-        id: z.string().uuid()
+        id: z.uuid()
     })
     .strict();
 

--- a/packages/server/lib/controllers/v1/invite/declineInvite.ts
+++ b/packages/server/lib/controllers/v1/invite/declineInvite.ts
@@ -9,7 +9,7 @@ import type { DeclineInvite } from '@nangohq/types';
 
 const validation = z
     .object({
-        id: z.string().uuid()
+        id: z.uuid()
     })
     .strict();
 

--- a/packages/server/lib/controllers/v1/invite/getInvite.ts
+++ b/packages/server/lib/controllers/v1/invite/getInvite.ts
@@ -13,7 +13,7 @@ import type { GetInvite } from '@nangohq/types';
 
 const validation = z
     .object({
-        id: z.string().uuid()
+        id: z.uuid()
     })
     .strict();
 

--- a/packages/server/lib/controllers/v1/logs/searchMessages.ts
+++ b/packages/server/lib/controllers/v1/logs/searchMessages.ts
@@ -19,7 +19,7 @@ const validation = z
             .default(['all']),
         cursorBefore: z.string().or(z.null()).optional(),
         cursorAfter: z.string().or(z.null()).optional(),
-        period: z.object({ from: z.string().datetime(), to: z.string().datetime() }).optional()
+        period: z.object({ from: z.iso.datetime(), to: z.iso.datetime() }).optional()
     })
     .strict();
 

--- a/packages/server/lib/controllers/v1/logs/searchOperations.ts
+++ b/packages/server/lib/controllers/v1/logs/searchOperations.ts
@@ -50,7 +50,7 @@ const validation = z
         integrations: z.array(z.string()).max(20).optional().default(['all']),
         connections: z.array(z.string()).max(20).optional().default(['all']),
         syncs: z.array(z.string()).max(20).optional().default(['all']),
-        period: z.object({ from: z.string().datetime(), to: z.string().datetime() }).optional(),
+        period: z.object({ from: z.iso.datetime(), to: z.iso.datetime() }).optional(),
         cursor: z.string().or(z.null()).optional()
     })
     .strict();

--- a/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
+++ b/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
@@ -15,7 +15,7 @@ import type { DBPlan, PostPublicWebhook } from '@nangohq/types';
 
 const paramValidation = z
     .object({
-        environmentUuid: z.string().uuid(),
+        environmentUuid: z.uuid(),
         providerConfigKey: providerConfigKeySchema
     })
     .strict();

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -166,7 +166,7 @@ export const connectionEndUserTagsSchema = z
 
 export const endUserSchema = z.strictObject({
     id: z.string().max(255).min(1),
-    email: z.string().email().min(5).optional(),
+    email: z.email().min(5).optional(),
     display_name: z.string().max(255).optional(),
     tags: connectionEndUserTagsSchema.optional()
 });

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -52,7 +52,7 @@ export const frequencySchema = z
     );
 
 export const connectionCredential = z.union([
-    z.object({ public_key: z.string().uuid(), hmac: z.string().optional() }),
+    z.object({ public_key: z.uuid(), hmac: z.string().optional() }),
     z.object({ connect_session_token: connectSessionTokenSchema })
 ]);
 

--- a/packages/shared/lib/services/tags/schema.ts
+++ b/packages/shared/lib/services/tags/schema.ts
@@ -33,7 +33,7 @@ export const validateCaseInsensitiveTagKeys = (tags: Record<string, string>): st
         }
         seen.add(normalized);
         if (normalized === 'end_user_email') {
-            const emailResult = z.string().email().min(5).safeParse(value);
+            const emailResult = z.email().min(5).safeParse(value);
             if (!emailResult.success) {
                 issues.push('Tag "end_user_email" must be a valid email');
             }

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -360,7 +360,7 @@ export const ENVS = z.object({
 
     // Slack
     NANGO_SLACK_INTEGRATION_KEY: z.string().optional().default('slack'),
-    NANGO_ADMIN_UUID: z.string().uuid().optional(),
+    NANGO_ADMIN_UUID: z.uuid().optional(),
 
     // Stripe
     PUBLIC_STRIPE_KEY: z.string().optional(),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Just replaced zod deprecated methods:
- email
- url
- datetime
- uuid

Ref: https://zod.dev/v4/changelog?id=deprecates-email-etc

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Replace deprecated Zod helper methods with v4 equivalents**

This PR updates Zod schema usage across the codebase to replace deprecated chained helpers with new top-level helpers, such as `z.email()`, `z.url()`, `z.uuid()`, and `z.iso.datetime()`. Changes are applied consistently across server controllers, orchestrator routes, jobs/lambda schemas, shared validators, environment parsing, and documentation snippets.

---
*This summary was automatically generated by @propel-code-bot*