### PR TITLE
fix(webhooks): decode email address from resource URI

### DIFF
--- a/packages/server/lib/webhook/google-calendar-webhook-routing.ts
+++ b/packages/server/lib/webhook/google-calendar-webhook-routing.ts
@@ -13,7 +13,7 @@ const route: WebhookHandler = async (nango, headers, body) => {
 
     if (typeof resourceUri === 'string') {
         const match = resourceUri.match(/\/calendars\/([^/]+)\//);
-        if (match) {
+        if (match && match[1]) {
             emailAddress = decodeURIComponent(match[1]);
         }
     }

--- a/packages/server/lib/webhook/google-calendar-webhook-routing.ts
+++ b/packages/server/lib/webhook/google-calendar-webhook-routing.ts
@@ -14,7 +14,7 @@ const route: WebhookHandler = async (nango, headers, body) => {
     if (typeof resourceUri === 'string') {
         const match = resourceUri.match(/\/calendars\/([^/]+)\//);
         if (match) {
-            emailAddress = match[1];
+            emailAddress = decodeURIComponent(match[1]);
         }
     }
 


### PR DESCRIPTION
Clone of https://github.com/NangoHQ/nango/pull/5351

Authored fully by https://github.com/DavideViolante

Fixes #5349

We needed to clone the PR because our current CI pipeline doesn't allow for external PRs.

<!-- Summary by @propel-code-bot -->

---

**Properly decode Google Calendar webhook email identifiers**

Updates `packages/server/lib/webhook/google-calendar-webhook-routing.ts` so that the email parsed from the `x-goog-resource-uri` header is URL-decoded before being forwarded to downstream handlers. Also adds a guard to ensure `match[1]` exists before passing it to `decodeURIComponent`, addressing the TypeScript type error noted in the original PR.

<details>
<summary><strong>Key Changes</strong></summary>

• Decode the captured calendar identifier with `decodeURIComponent` before assigning it to `emailAddress`.
• Add an explicit `match && match[1]` check to prevent undefined from being passed to `decodeURIComponent`.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/webhook/google-calendar-webhook-routing.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*