### PR TITLE
feat(runner): add checkpoints function to persist client

### DIFF
--- a/packages/runner/lib/clients/persist.ts
+++ b/packages/runner/lib/clients/persist.ts
@@ -6,13 +6,16 @@ import { httpFetch } from './http.js';
 import { logger } from '../logger.js';
 
 import type {
+    Checkpoint,
     CursorOffset,
     DeleteOutdatedRecordsSuccess,
     DeleteRecordsSuccess,
+    GetCheckpointSuccess,
     GetCursorSuccess,
     GetRecordsSuccess,
     MergingStrategy,
     PostRecordsSuccess,
+    PutCheckpointSuccess,
     PutRecordsSuccess
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
@@ -298,6 +301,72 @@ export class PersistClient {
         });
         if (res.isErr()) {
             return Err(new Error(`Failed to get records: ${res.error.message}`));
+        }
+        return res;
+    }
+
+    public async getCheckpoint({
+        environmentId,
+        nangoConnectionId,
+        key
+    }: {
+        environmentId: number;
+        nangoConnectionId: number;
+        key: string;
+    }): Promise<Result<GetCheckpointSuccess>> {
+        const res = await this.fetch<GetCheckpointSuccess>({
+            method: 'GET',
+            path: `/environment/${environmentId}/connection/${nangoConnectionId}/checkpoint`,
+            params: { key }
+        });
+        if (res.isErr()) {
+            return Err(new Error(`Failed to get checkpoint: ${res.error.message}`));
+        }
+        return res;
+    }
+
+    public async putCheckpoint({
+        environmentId,
+        nangoConnectionId,
+        key,
+        checkpoint,
+        expectedVersion
+    }: {
+        environmentId: number;
+        nangoConnectionId: number;
+        key: string;
+        checkpoint: Checkpoint;
+        expectedVersion: number;
+    }): Promise<Result<PutCheckpointSuccess>> {
+        const res = await this.fetch<PutCheckpointSuccess>({
+            method: 'PUT',
+            path: `/environment/${environmentId}/connection/${nangoConnectionId}/checkpoint`,
+            data: { key, checkpoint, expectedVersion }
+        });
+        if (res.isErr()) {
+            return Err(new Error(`Failed to save checkpoint: ${res.error.message}`));
+        }
+        return res;
+    }
+
+    public async deleteCheckpoint({
+        environmentId,
+        nangoConnectionId,
+        key,
+        expectedVersion
+    }: {
+        environmentId: number;
+        nangoConnectionId: number;
+        key: string;
+        expectedVersion: number;
+    }): Promise<Result<void>> {
+        const res = await this.fetch<void>({
+            method: 'DELETE',
+            path: `/environment/${environmentId}/connection/${nangoConnectionId}/checkpoint`,
+            data: { key, expectedVersion }
+        });
+        if (res.isErr()) {
+            return Err(new Error(`Failed to delete checkpoint: ${res.error.message}`));
         }
         return res;
     }


### PR DESCRIPTION
Note: those functions are not used yet.

<!-- Summary by @propel-code-bot -->

---

**Runner persist client gains checkpoint helpers**

Extends `packages/runner/lib/clients/persist.ts` with checkpoint CRUD helpers on `PersistClient`, allowing the runner to interact with `/checkpoint` endpoints for a given environment/connection. New imports from `@nangohq/types` provide strong typing for checkpoint payloads and responses, matching the existing style of record and cursor helpers.

<details>
<summary><strong>Key Changes</strong></summary>

• Imported `Checkpoint`, `GetCheckpointSuccess`, and `PutCheckpointSuccess` DTOs into `PersistClient`
• Added `getCheckpoint`, `putCheckpoint`, and `deleteCheckpoint` methods that call the persist API using `this.fetch` with consistent error wrapping
• Required `expectedVersion` to be supplied for `putCheckpoint` to enforce optimistic locking semantics

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/runner/lib/clients/persist.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*