### PR TITLE
docs: Update demo link

### DIFF
--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -140,5 +140,5 @@ A limited [free self-hosting](/guides/platform/free-self-hosting/configuration) 
 </Info>
 
 <Tip>
-If you are interested in the Enterprise self-hosting version, please get in touch with us in the [community](https://nango.dev/slack) or [book a demo](https://nango.dev/chat).
+If you are interested in the Enterprise self-hosting version, please get in touch with us in the [community](https://nango.dev/slack) or [book a demo](https://nango.dev/demo).
 </Tip>


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Update Enterprise self-hosting demo link**

Replaces the outdated Enterprise demo booking URL in `docs/guides/platform/self-hosting.mdx` with the current link. Ensures the self-hosting guide directs readers to the correct demo scheduling page.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `docs/guides/platform/self-hosting.mdx` enterprise CTA to point the "book a demo" reference to https://nango.dev/demo

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs/guides/platform/self-hosting.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*