### PR TITLE
chore: update package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -323,6 +323,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -2858,6 +2859,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
             "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
@@ -3749,7 +3751,6 @@
             "version": "11.11.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.16.7",
                 "@babel/runtime": "^7.18.3",
@@ -3768,7 +3769,6 @@
             "version": "0.5.7",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3777,7 +3777,6 @@
             "version": "11.11.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@emotion/memoize": "^0.8.1",
                 "@emotion/sheet": "^1.2.2",
@@ -3789,8 +3788,7 @@
         "node_modules/@emotion/hash": {
             "version": "0.9.1",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@emotion/is-prop-valid": {
             "version": "1.2.2",
@@ -3835,7 +3833,6 @@
             "version": "1.1.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@emotion/hash": "^0.9.1",
                 "@emotion/memoize": "^0.8.1",
@@ -3847,8 +3844,7 @@
         "node_modules/@emotion/sheet": {
             "version": "1.2.2",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@emotion/unitless": {
             "version": "0.8.1",
@@ -3859,7 +3855,6 @@
             "version": "1.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "react": ">=16.8.0"
             }
@@ -3867,14 +3862,12 @@
         "node_modules/@emotion/utils": {
             "version": "1.2.1",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@emotion/weak-memoize": {
             "version": "0.3.1",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@esbuild/darwin-arm64": {
             "version": "0.25.5",
@@ -4112,7 +4105,6 @@
             "version": "0.19.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@floating-ui/react-dom": "^1.3.0",
                 "aria-hidden": "^1.1.3",
@@ -4127,7 +4119,6 @@
             "version": "1.3.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@floating-ui/dom": "^1.2.1"
             },
@@ -4147,6 +4138,7 @@
             "version": "2.3.8",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.16.7"
             },
@@ -5066,7 +5058,6 @@
             "version": "0.3.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.0",
                 "@jridgewell/trace-mapping": "^0.3.9"
@@ -5196,7 +5187,6 @@
             "version": "5.10.5",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "clsx": "1.1.1",
                 "csstype": "3.0.9"
@@ -5213,7 +5203,6 @@
             "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5221,8 +5210,7 @@
         "node_modules/@mantine/styles/node_modules/csstype": {
             "version": "3.0.9",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@mantine/utils": {
             "version": "5.10.5",
@@ -5504,6 +5492,7 @@
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
             "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -5523,6 +5512,7 @@
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
             "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             },
@@ -5534,6 +5524,7 @@
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
             "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "1.28.0"
             },
@@ -5637,6 +5628,7 @@
             "version": "0.57.2",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
             "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/api-logs": "0.57.2",
                 "@types/shimmer": "^1.2.0",
@@ -6550,7 +6542,6 @@
             "version": "1.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10"
             }
@@ -6559,7 +6550,6 @@
             "version": "1.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10"
             }
@@ -7330,7 +7320,6 @@
             "version": "1.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10"
             },
@@ -7629,7 +7618,6 @@
             "version": "1.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10"
             },
@@ -9406,7 +9394,6 @@
             "version": "1.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10",
                 "@radix-ui/react-compose-refs": "1.0.0",
@@ -9421,7 +9408,6 @@
             "version": "1.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10",
                 "@radix-ui/react-slot": "1.0.1"
@@ -9763,7 +9749,6 @@
             "version": "1.0.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10",
                 "@radix-ui/number": "1.0.0",
@@ -11346,7 +11331,6 @@
             "version": "1.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10"
             },
@@ -11463,7 +11447,6 @@
             "version": "1.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10"
             },
@@ -11638,6 +11621,7 @@
         "node_modules/@redis/client": {
             "version": "1.5.14",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cluster-key-slot": "1.1.2",
                 "generic-pool": "3.9.0",
@@ -12510,6 +12494,7 @@
             "version": "1.30.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.30.0.tgz",
             "integrity": "sha512-4VlGgo32k2EQ2wcCY3vEU28A0O13aOtHz3Xt2/2U5FAh9EfhD6t6DqL5Z6yAnRCntbTFDU4YfbpyzSlHNWycPw==",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             }
@@ -13345,6 +13330,7 @@
             "integrity": "sha512-pTzb864TQWDRQBPLgSPFRoyjSDUqpCkbEgTzpsjiTjGz1Z5SxZNXJek28w1s6Dyry4CyW4/Izj5jHE/J9hCJYQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12.16"
             }
@@ -13355,6 +13341,7 @@
             "integrity": "sha512-YWqn+0IKXDhqVLKoac4v2tV6hJqB/wOh8/Br8zjqeqBkKa77Qb0Kw2i7LOFzjFNZbZaPH6AlMGlBwNrxaauaAg==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@swc/counter": "^0.1.3",
                 "@swc/types": "^0.1.23"
@@ -13557,6 +13544,7 @@
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
             "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.8.0"
             }
@@ -14213,7 +14201,8 @@
             "funding": [
                 "https://trpc.io/sponsor"
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.9",
@@ -14483,7 +14472,6 @@
             "version": "8.37.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -14495,7 +14483,6 @@
             "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/eslint": "*",
                 "@types/estree": "*"
@@ -14512,6 +14499,7 @@
             "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.2.tgz",
             "integrity": "sha512-BtjL3ZwbCQriyb0DGw+Rt12qAXPiBTPs815lsUvtt1Grk0vLRMZNMUZ741d5rjk+UQOxfDiBZ3dxpX00vSkK3g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^5.0.0",
@@ -14660,6 +14648,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
             "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -14712,8 +14701,7 @@
         "node_modules/@types/parse-json": {
             "version": "4.0.2",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/parse-link-header": {
             "version": "2.0.3",
@@ -14808,6 +14796,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.4.tgz",
             "integrity": "sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -15074,6 +15063,7 @@
             "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.38.0",
                 "@typescript-eslint/types": "8.38.0",
@@ -15447,7 +15437,6 @@
             "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/helper-numbers": "1.13.2",
                 "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -15458,24 +15447,21 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
             "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
             "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-buffer": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
             "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.13.2",
@@ -15483,7 +15469,6 @@
             "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/floating-point-hex-parser": "1.13.2",
                 "@webassemblyjs/helper-api-error": "1.13.2",
@@ -15495,8 +15480,7 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
             "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
             "version": "1.14.1",
@@ -15504,7 +15488,6 @@
             "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -15518,7 +15501,6 @@
             "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
@@ -15529,7 +15511,6 @@
             "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
@@ -15539,8 +15520,7 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
             "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/wasm-edit": {
             "version": "1.14.1",
@@ -15548,7 +15528,6 @@
             "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -15566,7 +15545,6 @@
             "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -15581,7 +15559,6 @@
             "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -15595,7 +15572,6 @@
             "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-api-error": "1.13.2",
@@ -15611,7 +15587,6 @@
             "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@xtuc/long": "4.2.2"
@@ -15651,16 +15626,14 @@
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
             "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true,
-            "license": "Apache-2.0",
-            "peer": true
+            "license": "Apache-2.0"
         },
         "node_modules/@zeit/schemas": {
             "version": "2.36.0",
@@ -15689,6 +15662,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -15749,6 +15723,7 @@
             "version": "6.12.6",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -15797,7 +15772,6 @@
             "version": "3.5.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "ajv": "^6.9.1"
             }
@@ -16374,7 +16348,6 @@
             "version": "3.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.12.5",
                 "cosmiconfig": "^7.0.0",
@@ -17161,6 +17134,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001726",
                 "electron-to-chromium": "^1.5.173",
@@ -17533,7 +17507,6 @@
             "version": "1.0.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.0"
             }
@@ -18313,8 +18286,7 @@
         "node_modules/convert-source-map": {
             "version": "1.9.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/cookie": {
             "version": "0.7.2",
@@ -18418,6 +18390,7 @@
             "integrity": "sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==",
             "dev": true,
             "hasInstallScript": true,
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
@@ -18456,7 +18429,6 @@
             "version": "7.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/parse-json": "^4.0.0",
                 "import-fresh": "^3.2.1",
@@ -18472,7 +18444,6 @@
             "version": "1.10.2",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -19930,6 +19901,7 @@
             "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -20361,6 +20333,7 @@
             "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -20421,6 +20394,7 @@
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
             "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -20686,7 +20660,6 @@
             "version": "5.1.1",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
@@ -20867,7 +20840,6 @@
             "version": "4.3.0",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -20988,6 +20960,7 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
             "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.0",
@@ -21485,8 +21458,7 @@
         "node_modules/find-root": {
             "version": "1.1.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/find-up": {
             "version": "5.0.0",
@@ -22246,8 +22218,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/globals": {
             "version": "15.14.0",
@@ -23622,7 +23593,6 @@
             "version": "27.5.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -23636,7 +23606,6 @@
             "version": "8.1.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -23651,6 +23620,7 @@
             "version": "1.21.0",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -23777,6 +23747,7 @@
             "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
             "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 10.16.0"
             }
@@ -24156,6 +24127,216 @@
                 "lightningcss-win32-x64-msvc": "1.30.1"
             }
         },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
+            "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
+            "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
+            "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
+            "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
+            "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
+            "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+            "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
+            "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
+            "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
+            "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/limiter": {
             "version": "1.1.5"
         },
@@ -24478,7 +24659,6 @@
             "version": "4.3.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.11.5"
             }
@@ -25079,6 +25259,7 @@
             "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/mobx"
@@ -25954,6 +26135,7 @@
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -26374,6 +26556,7 @@
         "node_modules/pg": {
             "version": "8.11.3",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "buffer-writer": "2.0.0",
                 "packet-reader": "1.0.0",
@@ -26605,6 +26788,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.8",
                 "picocolors": "^1.1.1",
@@ -26729,6 +26913,7 @@
             "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -27075,6 +27260,7 @@
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -27101,6 +27287,7 @@
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -27146,6 +27333,7 @@
             "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18.0.0"
             },
@@ -27219,6 +27407,7 @@
             "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@remix-run/router": "1.23.2"
             },
@@ -27235,6 +27424,7 @@
             "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@remix-run/router": "1.23.2",
                 "react-router": "6.30.3"
@@ -27312,7 +27502,6 @@
             "version": "8.3.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.10.2",
                 "use-composed-ref": "^1.3.0",
@@ -28337,6 +28526,7 @@
             "version": "8.12.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -28497,7 +28687,6 @@
             "version": "6.0.2",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
             }
@@ -29654,6 +29843,7 @@
             "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@emotion/is-prop-valid": "1.2.2",
                 "@emotion/unitless": "0.8.1",
@@ -29742,8 +29932,7 @@
         "node_modules/stylis": {
             "version": "4.2.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/sucrase": {
             "version": "3.35.0",
@@ -29975,7 +30164,8 @@
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
             "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/tailwindcss-animate": {
             "version": "1.0.7",
@@ -30139,7 +30329,6 @@
             "version": "5.27.0",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
                 "acorn": "^8.8.2",
@@ -30157,7 +30346,6 @@
             "version": "5.3.10",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.20",
                 "jest-worker": "^27.4.5",
@@ -30191,7 +30379,6 @@
             "version": "0.3.22",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -30201,7 +30388,6 @@
             "version": "3.3.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
@@ -30218,8 +30404,7 @@
         "node_modules/terser/node_modules/commander": {
             "version": "2.20.3",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/testcontainers": {
             "version": "10.24.2",
@@ -30421,6 +30606,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -30746,7 +30932,8 @@
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "peer": true
         },
         "node_modules/tsup": {
             "version": "8.5.0",
@@ -30941,6 +31128,7 @@
             "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "~0.25.0",
                 "get-tsconfig": "^4.7.5"
@@ -31104,6 +31292,7 @@
             "version": "5.8.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -31565,6 +31754,7 @@
             "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.5.0",
@@ -32012,6 +32202,7 @@
             "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
             "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.21.3",
                 "@svgr/babel-preset": "8.1.0",
@@ -32147,6 +32338,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -32303,7 +32495,6 @@
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
             "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
@@ -32429,7 +32620,6 @@
             "version": "3.2.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.13.0"
             }
@@ -32438,7 +32628,6 @@
             "version": "3.3.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
@@ -32776,6 +32965,7 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
             "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -32855,6 +33045,7 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
             "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
             "devOptional": true,
+            "peer": true,
             "bin": {
                 "yaml": "bin.mjs"
             },
@@ -32948,6 +33139,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -33182,6 +33374,7 @@
             "version": "8.17.1",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -33460,6 +33653,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
             "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -33485,6 +33679,7 @@
             "integrity": "sha512-SBrYOvMbDB7cV8ZfNpaiLcgjH/a1c7aK0lK+aNigpf4xWLO8q+o4tcvVurv3c4EOyzn/3dCsYt4GKD42VvJ/+A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18.0.0"
             },


### PR DESCRIPTION
## Describe the problem and your solution

- Update package-lock.json; this appears to have broken again with the latest npm [release](https://github.com/NangoHQ/nango/commit/abe43363098d809eaa79cf9573378e71cbe44fbd).

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This single-file update refreshes package-lock.json metadata to capture current peer, license, and optional platform build details while leaving package.json and all application code untouched, so the impact remains confined to dependency resolution data.

<details>
<summary><strong>Key Changes</strong></summary>

• Marked many dependencies as `peer` (and in some cases restored missing `license` fields) throughout `package-lock.json`
• Added architecture/OS-specific `lightningcss` optional packages that were previously absent from the lockfile
• Regenerated integrity/metadata entries (e.g., `peerDependencies`, `engines`, binary info) for various tooling packages such as `typescript`, `tslib`, `prettier`, `@types/*`, `esbuild`, and `tailwindcss`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• Dependency lockfile metadata (`package-lock.json`)

</details>

---
*This summary was automatically generated by @propel-code-bot*