### PR TITLE
feat(webapp): move env-agnostic routes

### DIFF
--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -189,27 +189,27 @@ const router = sentryCreateBrowserRouter([
                     {
                         path: 'project-settings',
                         element: <Navigate to="/environment-settings" />
-                    },
-                    {
-                        path: 'account-settings',
-                        element: <Navigate to="/team-settings" />
-                    },
-                    {
-                        path: 'team-settings',
-                        element: <TeamSettings />,
-                        handle: { breadcrumb: 'Team settings' } as BreadcrumbHandle
-                    },
-                    {
-                        path: 'team/billing',
-                        element: <TeamBilling />,
-                        handle: { breadcrumb: 'Billing' } as BreadcrumbHandle
-                    },
-                    {
-                        path: 'user-settings',
-                        element: <UserSettings />,
-                        handle: { breadcrumb: 'User settings' } as BreadcrumbHandle
                     }
                 ]
+            },
+            {
+                path: 'account-settings',
+                element: <Navigate to="/team-settings" />
+            },
+            {
+                path: 'team-settings',
+                element: <TeamSettings />,
+                handle: { breadcrumb: 'Team settings' } as BreadcrumbHandle
+            },
+            {
+                path: 'team/billing',
+                element: <TeamBilling />,
+                handle: { breadcrumb: 'Billing' } as BreadcrumbHandle
+            },
+            {
+                path: 'user-settings',
+                element: <UserSettings />,
+                handle: { breadcrumb: 'User settings' } as BreadcrumbHandle
             }
         ]
     },

--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -81,130 +81,135 @@ const router = sentryCreateBrowserRouter([
         element: <PrivateRoute />,
         children: [
             {
-                path: '/:env',
-                element: <Homepage />,
-                handle: {
-                    breadcrumb: 'Metrics'
-                }
-            },
-            {
-                path: '/dev/getting-started',
+                path: 'dev/getting-started',
                 element: <GettingStartedRoute />,
                 handle: { breadcrumb: 'Getting started' } as BreadcrumbHandle
             },
             {
-                path: '/:env/integrations',
-                handle: { breadcrumb: 'Integrations' } as BreadcrumbHandle,
+                path: '/:env',
                 children: [
                     {
                         index: true,
-                        element: <IntegrationsList />
+                        element: <Homepage />,
+                        handle: {
+                            breadcrumb: 'Metrics'
+                        }
                     },
                     {
-                        path: 'create',
-                        handle: { breadcrumb: 'Create Integration' } as BreadcrumbHandle,
+                        path: 'integrations',
+                        handle: { breadcrumb: 'Integrations' } as BreadcrumbHandle,
                         children: [
                             {
                                 index: true,
-                                element: <CreateIntegrationList />
+                                element: <IntegrationsList />
+                            },
+                            {
+                                path: 'create',
+                                handle: { breadcrumb: 'Create Integration' } as BreadcrumbHandle,
+                                children: [
+                                    {
+                                        index: true,
+                                        element: <CreateIntegrationList />
+                                    },
+                                    {
+                                        path: ':providerConfigKey',
+                                        element: <CreateIntegration />,
+                                        handle: { breadcrumb: (params) => params.providerConfigKey || 'Integration' } as BreadcrumbHandle
+                                    }
+                                ]
                             },
                             {
                                 path: ':providerConfigKey',
-                                element: <CreateIntegration />,
-                                handle: { breadcrumb: (params) => params.providerConfigKey || 'Integration' } as BreadcrumbHandle
+                                handle: {
+                                    breadcrumb: (params) => params.providerConfigKey || 'Integration'
+                                } as BreadcrumbHandle,
+                                children: [
+                                    {
+                                        index: true,
+                                        element: <ShowIntegration />
+                                    },
+                                    {
+                                        path: 'functions/:functionName',
+                                        element: <FunctionsOne />,
+                                        handle: {
+                                            breadcrumb: (params) => params.functionName || 'Function'
+                                        } as BreadcrumbHandle
+                                    },
+                                    {
+                                        path: '*',
+                                        element: <ShowIntegration />
+                                    }
+                                ]
                             }
                         ]
                     },
                     {
-                        path: ':providerConfigKey',
-                        handle: {
-                            breadcrumb: (params) => params.providerConfigKey || 'Integration'
-                        } as BreadcrumbHandle,
+                        path: 'integration/:providerConfigKey',
+                        element: <RedirectWithEnv path="integrations/:providerConfigKey" />
+                    },
+                    {
+                        path: 'connections',
+                        handle: { breadcrumb: 'Connections' } as BreadcrumbHandle,
                         children: [
                             {
                                 index: true,
-                                element: <ShowIntegration />
+                                element: <ConnectionList />
                             },
                             {
-                                path: 'functions/:functionName',
-                                element: <FunctionsOne />,
-                                handle: {
-                                    breadcrumb: (params) => params.functionName || 'Function'
-                                } as BreadcrumbHandle
+                                path: 'create',
+                                element: <ConnectionCreate />,
+                                handle: { breadcrumb: 'Create Connection' } as BreadcrumbHandle
                             },
                             {
-                                path: '*',
-                                element: <ShowIntegration />
+                                path: 'create-legacy',
+                                element: <ConnectionCreateLegacy />,
+                                handle: { breadcrumb: 'Create Connection (Legacy)' } as BreadcrumbHandle
+                            },
+                            {
+                                path: ':providerConfigKey/:connectionId',
+                                element: <ConnectionShow />,
+                                handle: { breadcrumb: (params) => params.connectionId || 'Connection' } as BreadcrumbHandle
                             }
                         ]
+                    },
+                    {
+                        path: 'logs',
+                        element: <LogsShow />,
+                        handle: { breadcrumb: 'Logs' } as BreadcrumbHandle
+                    },
+                    {
+                        path: 'activity',
+                        element: <RedirectWithEnv path="logs" />
+                    },
+                    {
+                        path: 'environment-settings',
+                        element: <EnvironmentSettings />,
+                        handle: { breadcrumb: 'Environment settings' } as BreadcrumbHandle
+                    },
+                    {
+                        path: 'project-settings',
+                        element: <Navigate to="/environment-settings" />
+                    },
+                    {
+                        path: 'account-settings',
+                        element: <Navigate to="/team-settings" />
+                    },
+                    {
+                        path: 'team-settings',
+                        element: <TeamSettings />,
+                        handle: { breadcrumb: 'Team settings' } as BreadcrumbHandle
+                    },
+                    {
+                        path: 'team/billing',
+                        element: <TeamBilling />,
+                        handle: { breadcrumb: 'Billing' } as BreadcrumbHandle
+                    },
+                    {
+                        path: 'user-settings',
+                        element: <UserSettings />,
+                        handle: { breadcrumb: 'User settings' } as BreadcrumbHandle
                     }
                 ]
-            },
-            {
-                path: '/:env/integration/:providerConfigKey',
-                element: <RedirectWithEnv path="integrations/:providerConfigKey" />
-            },
-            {
-                path: '/:env/connections',
-                handle: { breadcrumb: 'Connections' } as BreadcrumbHandle,
-                children: [
-                    {
-                        index: true,
-                        element: <ConnectionList />
-                    },
-                    {
-                        path: 'create',
-                        element: <ConnectionCreate />,
-                        handle: { breadcrumb: 'Create Connection' } as BreadcrumbHandle
-                    },
-                    {
-                        path: 'create-legacy',
-                        element: <ConnectionCreateLegacy />,
-                        handle: { breadcrumb: 'Create Connection (Legacy)' } as BreadcrumbHandle
-                    },
-                    {
-                        path: ':providerConfigKey/:connectionId',
-                        element: <ConnectionShow />,
-                        handle: { breadcrumb: (params) => params.connectionId || 'Connection' } as BreadcrumbHandle
-                    }
-                ]
-            },
-            {
-                path: '/:env/logs',
-                element: <LogsShow />,
-                handle: { breadcrumb: 'Logs' } as BreadcrumbHandle
-            },
-            {
-                path: '/:env/activity',
-                element: <RedirectWithEnv path="logs" />
-            },
-            {
-                path: '/:env/environment-settings',
-                element: <EnvironmentSettings />,
-                handle: { breadcrumb: 'Environment settings' } as BreadcrumbHandle
-            },
-            {
-                path: '/:env/project-settings',
-                element: <Navigate to="/environment-settings" />
-            },
-            {
-                path: '/:env/account-settings',
-                element: <Navigate to="/team-settings" />
-            },
-            {
-                path: '/:env/team-settings',
-                element: <TeamSettings />,
-                handle: { breadcrumb: 'Team settings' } as BreadcrumbHandle
-            },
-            {
-                path: '/:env/team/billing',
-                element: <TeamBilling />,
-                handle: { breadcrumb: 'Billing' } as BreadcrumbHandle
-            },
-            {
-                path: '/:env/user-settings',
-                element: <UserSettings />,
-                handle: { breadcrumb: 'User settings' } as BreadcrumbHandle
             }
         ]
     },

--- a/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
@@ -12,7 +12,6 @@ import { globalEnv } from '@/utils/env';
 import { useSignout } from '@/utils/user';
 
 export const ProfileDropdown: React.FC = () => {
-    const env = useStore((state) => state.env);
     const { meta } = useMeta();
     const navigate = useNavigate();
     const signout = useSignout();
@@ -24,12 +23,12 @@ export const ProfileDropdown: React.FC = () => {
             {
                 label: 'Team',
                 icon: Users,
-                href: `/${env}/team-settings`
+                href: `/team-settings`
             },
             {
                 label: 'Profile',
                 icon: UserRoundCog,
-                href: `/${env}/user-settings`
+                href: `/user-settings`
             }
         ];
 
@@ -37,7 +36,7 @@ export const ProfileDropdown: React.FC = () => {
             list.push({
                 label: 'Getting Started',
                 icon: Sparkle,
-                href: `/${env}/getting-started`
+                href: `/dev/getting-started`
             });
         }
 
@@ -45,12 +44,12 @@ export const ProfileDropdown: React.FC = () => {
             list.push({
                 label: 'Billing & usage',
                 icon: CreditCard,
-                href: `/${env}/team/billing`
+                href: `/team/billing`
             });
         }
 
         return list;
-    }, [env, meta, showGettingStarted]);
+    }, [meta, showGettingStarted]);
 
     const initials = user?.name ? toAcronym(user.name) : '';
 

--- a/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
@@ -52,7 +52,7 @@ export default function UsageCard() {
 
     return (
         <Link
-            to={`/${env}/team/billing#usage`}
+            to={`/team/billing#usage`}
             className="flex flex-col gap-4.5 px-3 py-3.5 text-xs rounded-sm bg-bg-surface border-[0.5px] border-border-muted cursor-pointer transition-colors hover:bg-bg-elevated hover:border-transparent"
         >
             {isLoading ? (

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -203,7 +203,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
             return (
                 <p>
                     Connection limit reached.{' '}
-                    <Link to={`/${env}/team/billing`} className="underline">
+                    <Link to={`/team/billing`} className="underline">
                         Upgrade your plan
                     </Link>{' '}
                     to get rid of connection limits.

--- a/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
@@ -231,7 +231,7 @@ export const ConnectUISettings = () => {
                                 {!canCustomizeTheme && <ThemeColorPickers disabled={true} form={form} />}
                                 {!canDisableWatermark && <WatermarkToggle disabled={true} form={form} />}
 
-                                <ButtonLink to={`/${env}/team/billing#plans`} variant="secondary" target="_blank">
+                                <ButtonLink to={`/team/billing#plans`} variant="secondary" target="_blank">
                                     Upgrade to &apos;Growth&apos; plan
                                 </ButtonLink>
                             </div>

--- a/packages/webapp/src/pages/Integrations/components/AutoIdlingBanner.tsx
+++ b/packages/webapp/src/pages/Integrations/components/AutoIdlingBanner.tsx
@@ -46,7 +46,7 @@ export const AutoIdlingBanner: React.FC = () => {
                         {trialLoading && <Loader2 className="size-4 animate-spin" />}
                         Restart
                     </AlertButton>
-                    <AlertButtonLink variant={'warning'} to={`/${env}/team/billing`}>
+                    <AlertButtonLink variant={'warning'} to={`/team/billing`}>
                         Upgrade
                     </AlertButtonLink>
                 </AlertActions>
@@ -64,7 +64,7 @@ export const AutoIdlingBanner: React.FC = () => {
                     {trialLoading && <Loader2 className="size-4 animate-spin" />}
                     Extend
                 </AlertButton>
-                <AlertButtonLink variant={'info'} to={`/${env}/team/billing`}>
+                <AlertButtonLink variant={'info'} to={`/team/billing`}>
                     Upgrade
                 </AlertButtonLink>
             </AlertActions>


### PR DESCRIPTION
Pages like Billing, Team settings and Profile are env-agnostic (they don't change based on the selected env), yet their routes were still under an env (eg. `/dev/team-settings`). This is annoying when trying to link one of those to a customer, since we might not know their environments.

<!-- Summary by @propel-code-bot -->

---

The router now keeps environment-scoped pages under the `/:env` branch while exposing absolute paths such as `/team-settings`, `/team/billing`, `/user-settings`, and `/account-settings`, and all navigation entry points route directly to these env-free destinations so they remain independent of the currently selected environment.

<details>
<summary><strong>Key Changes</strong></summary>

• Rearranged `packages/webapp/src/App.tsx` to group env-specific screens under the `/:env` branch while adding top-level routes for team, billing, and user settings plus the account-settings redirect.
• Updated `ProfileDropdown`, `UsageCard`, `AutoIdlingBanner`, `CreateConnectionSelector`, and `ConnectUISettings` to use the new env-agnostic URLs when linking to billing or settings pages.
• Removed unnecessary `env` dependencies from UI components whose targets are now global, simplifying memoized link lists.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/App.tsx`
• `packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx`
• `packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx`
• `packages/webapp/src/pages/Integrations/components/AutoIdlingBanner.tsx`
• `packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx`
• `packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*