### PR TITLE
fix(webapp): filtering connections by integrations

### DIFF
--- a/packages/webapp/src/hooks/useConnections.tsx
+++ b/packages/webapp/src/hooks/useConnections.tsx
@@ -19,9 +19,7 @@ export function useConnections(queries: Omit<GetConnections['Querystring'], 'pag
                 usp.set('search', queries.search);
             }
             if (queries.integrationIds && queries.integrationIds.length > 0) {
-                queries.integrationIds.forEach((id) => {
-                    usp.append('integrationIds', id);
-                });
+                usp.append('integrationIds', queries.integrationIds.join(','));
             }
             if (queries.withError !== undefined) {
                 usp.set('withError', String(queries.withError));

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -210,7 +210,7 @@ export const ConnectionList = () => {
     }
 
     return (
-        <DashboardLayout>
+        <DashboardLayout fullWidth>
             <Helmet>
                 <title>Connections - Nango</title>
             </Helmet>


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Fix integration filter serialization and layout width**

Updates the connections query builder to serialize multiple `integrationIds` as a single comma-delimited value, matching the backend contract. Also renders the connections list inside `DashboardLayout` with the `fullWidth` prop to expand the page layout.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced per-ID `URLSearchParams.append` loop with `usp.append('integrationIds', queries.integrationIds.join(','))` in `packages/webapp/src/hooks/useConnections.tsx`
• Enabled `DashboardLayout` full-width rendering for the connections list page in `packages/webapp/src/pages/Connection/List.tsx`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/hooks/useConnections.tsx`
• `packages/webapp/src/pages/Connection/List.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*