### PR TITLE
fix(server): filter connections with errors before paginating

### DIFF
--- a/packages/shared/lib/services/connection.service.integration.test.ts
+++ b/packages/shared/lib/services/connection.service.integration.test.ts
@@ -229,6 +229,52 @@ describe('Connection service integration tests', () => {
             const connectionIds = dbConnections.map((c) => c.connection.connection_id);
             expect(connectionIds).toEqual([notionOK.connection_id]);
         });
+
+        it('should filter errored connections before pagination', async () => {
+            const env = await createEnvironmentSeed();
+
+            await createConfigSeed(env, 'notion', 'notion');
+
+            // Create 10 connections, every other one with errors (5 with errors, 5 without)
+            const erroredConnections = [];
+            for (let i = 0; i < 10; i++) {
+                const conn = await createConnectionSeed({ env, provider: 'notion' });
+
+                if (i % 2 === 0) {
+                    await errorNotificationService.auth.create({
+                        type: 'auth',
+                        action: 'connection_test',
+                        connection_id: conn.id,
+                        log_id: Math.random().toString(36).substring(7),
+                        active: true
+                    });
+                    erroredConnections.push(conn);
+                }
+            }
+
+            // Get a single page with limit 5 and withError=true
+            // This should return all 5 errored connections, not just the first 5 connections
+            const page = await connectionService.listConnections({
+                environmentId: env.id,
+                withError: true,
+                limit: 5,
+                page: 0
+            });
+
+            // Verify we got all 5 errored connections on the first page
+            expect(page.length).toBe(5);
+
+            const returnedConnectionIds = page.map((c) => c.connection.connection_id).sort();
+            const expectedErroredConnectionIds = erroredConnections.map((c) => c.connection_id).sort();
+            expect(returnedConnectionIds).toEqual(expectedErroredConnectionIds);
+
+            // Verify all returned connections have errors
+            for (const conn of page) {
+                expect(conn.active_logs).toBeDefined();
+                expect(Array.isArray(conn.active_logs)).toBe(true);
+                expect(conn.active_logs.length).toBeGreaterThan(0);
+            }
+        });
     });
 
     describe('count', () => {

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -815,7 +815,7 @@ class ConnectionService {
                 if (withError === false) {
                     // Only connections without active logs
                     subQuery.whereNotExists(function () {
-                        this.select('*')
+                        this.select('1')
                             .from(ACTIVE_LOG_TABLE)
                             .whereRaw(`${ACTIVE_LOG_TABLE}.connection_id = _nango_connections.id`)
                             .where(`${ACTIVE_LOG_TABLE}.active`, true);
@@ -823,7 +823,7 @@ class ConnectionService {
                 } else if (withError === true) {
                     // Only connections with active logs
                     subQuery.whereExists(function () {
-                        this.select('*')
+                        this.select('1')
                             .from(ACTIVE_LOG_TABLE)
                             .whereRaw(`${ACTIVE_LOG_TABLE}.connection_id = _nango_connections.id`)
                             .where(`${ACTIVE_LOG_TABLE}.active`, true);

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -815,7 +815,7 @@ class ConnectionService {
                 if (withError === false) {
                     // Only connections without active logs
                     subQuery.whereNotExists(function () {
-                        this.select('1')
+                        this.select(db.knex.raw('1'))
                             .from(ACTIVE_LOG_TABLE)
                             .whereRaw(`${ACTIVE_LOG_TABLE}.connection_id = _nango_connections.id`)
                             .where(`${ACTIVE_LOG_TABLE}.active`, true);
@@ -823,7 +823,7 @@ class ConnectionService {
                 } else if (withError === true) {
                     // Only connections with active logs
                     subQuery.whereExists(function () {
-                        this.select('1')
+                        this.select(db.knex.raw('1'))
                             .from(ACTIVE_LOG_TABLE)
                             .whereRaw(`${ACTIVE_LOG_TABLE}.connection_id = _nango_connections.id`)
                             .where(`${ACTIVE_LOG_TABLE}.active`, true);


### PR DESCRIPTION
Error filtering was happening after pagination

<!-- Summary by @propel-code-bot -->

---

**Filter errored connections before pagination**

The `withError` filtering in `connectionService.listConnections` now happens inside the `filtered_connections` CTE so pagination operates on prefiltered IDs. The change also removes redundant post-join filtering and adds an integration test that reproduces the original issue by mixing errored and non-errored connections.

<details>
<summary><strong>Key Changes</strong></summary>

• Applied `whereExists`/`whereNotExists` against `ACTIVE_LOG_TABLE` inside `filtered_connections` when `withError` is `true` or `false`, ensuring the ID set is filtered before `orderBy`, `limit`, and `offset` are applied.
• Removed the downstream `whereNull`/`whereNotNull` checks on `active_logs_agg.connection_id` because error filtering now occurs upstream.
• Added integration test `should filter errored connections before pagination` to verify a `withError: true` request returns the first five errored connections even when underlying rows alternate between errored and non-errored.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/services/connection.service.ts`
• `packages/shared/lib/services/connection.service.integration.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*