### PR TITLE
docs: fix `getConnection` parameters

### DIFF
--- a/docs/reference/functions.mdx
+++ b/docs/reference/functions.mdx
@@ -712,12 +712,25 @@ await nango.getConnection();
 **Parameters**
 
 <Expandable>
-  <ResponseField name="forceRefresh" type="boolean">
-    Defaults to `false`. If `false`, the token will only be refreshed if it expires within 15 minutes. If `true`, a token refresh attempt will happen on each request. This is only useful for testing and should not be done at high traffic.
-  </ResponseField>
-  <ResponseField name="refreshToken" type="boolean">
-    Defaults to `false`. If `false`, the refresh token is not included in the response, otherwise it is. In production, it is not advised to return the refresh token, for security reasons, since only the access token is needed to sign requests.
-  </ResponseField>
+    <ResponseField name="providerConfigKeyOverride" type="string">
+        An optional integration ID to override the one from the function context.
+    </ResponseField>
+    <ResponseField name="connectionIdOverride" type="string">
+        An optional connection ID to override the one from the function context.
+    </ResponseField>
+    <ResponseField name="options" type="object">
+        <Expandable>
+            <ResponseField name="forceRefresh" type="boolean">
+                Defaults to `false`. If `false`, the token will only be refreshed if it expires within 15 minutes. If `true`, a token refresh attempt will happen on each request. This is only useful for testing and should not be done at high traffic.
+            </ResponseField>
+            <ResponseField name="refreshToken" type="boolean">
+                Defaults to `false`. If `false`, the refresh token is not included in the response, otherwise it is. In production, it is not advised to return the refresh token, for security reasons, since only the access token is needed to sign requests.
+            </ResponseField>
+            <ResponseField name="refreshGithubAppJwtToken" type="boolean">
+                Defaults to `false`. If true, this will refresh the JWT token for GitHub App / Github App OAuth connections
+            </ResponseField>
+        </Expandable>
+    </ResponseField>
 </Expandable>
 
 **Example Response**


### PR DESCRIPTION
The correct signature for functions is this:
https://github.com/NangoHQ/nango/blob/e52a648f5b54f099037b3ad9ceb0f2cd825dbf21/packages/runner-sdk/lib/action.ts#L243-L248

<!-- Summary by @propel-code-bot -->

---

**Update `getConnection` documentation to match SDK signature**

The PR revises `docs/reference/functions.mdx` so the documented `getConnection` signature matches the current runner SDK. It adds the optional override arguments and documents the `options` object with its nested token-refresh flags, including the new `refreshGithubAppJwtToken` option.

<details>
<summary><strong>Key Changes</strong></summary>

• Documented optional `providerConfigKeyOverride` and `connectionIdOverride` parameters for `getConnection`
• Reorganized token-refresh flags under an `options` object within the parameter list
• Added documentation for the `refreshGithubAppJwtToken` boolean option

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `docs/reference/functions.mdx`

</details>

---
*This summary was automatically generated by @propel-code-bot*