### PR TITLE
fix(cli): NAN-4700: Pipe the getConnection parameters on the CLI SDK

### DIFF
--- a/packages/cli/lib/services/sdk.service.unit.test.ts
+++ b/packages/cli/lib/services/sdk.service.unit.test.ts
@@ -1,8 +1,72 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { NangoActionBase } from '@nangohq/runner-sdk';
+
 import { NangoSyncCLI } from './sdk.js';
 
 import type { DryRunService } from './dryrun.service.js';
+
+describe('NangoSyncCLI - getConnection', () => {
+    let instance: NangoSyncCLI;
+
+    beforeEach(() => {
+        const mockDryRunService: DryRunService = {
+            run: vi.fn(),
+            fullPath: '',
+            isZeroYaml: false,
+            validation: true,
+            runScript: vi.fn()
+        };
+
+        instance = new NangoSyncCLI(
+            {
+                secretKey: 'test-secret-key',
+                syncConfig: {
+                    models_json_schema: { definitions: {} }
+                }
+            } as any,
+            { dryRunService: mockDryRunService }
+        );
+    });
+
+    it('should pass options parameter to parent getConnection', async () => {
+        const mockConnection = {
+            id: 1,
+            connection_id: 'test-connection',
+            provider_config_key: 'test-provider',
+            provider: 'test',
+            credentials: { type: 'OAUTH2', access_token: 'token', refresh_token: 'refresh' }
+        };
+
+        const parentGetConnectionSpy = vi.spyOn(NangoActionBase.prototype, 'getConnection').mockResolvedValue(mockConnection as any);
+
+        const options = { refreshToken: true, forceRefresh: false };
+        await instance.getConnection('provider-key', 'connection-id', options);
+
+        expect(parentGetConnectionSpy).toHaveBeenCalledWith('provider-key', 'connection-id', options);
+
+        parentGetConnectionSpy.mockRestore();
+    });
+
+    it('should pass options with refreshGithubAppJwtToken to parent getConnection', async () => {
+        const mockConnection = {
+            id: 1,
+            connection_id: 'test-connection',
+            provider_config_key: 'test-provider',
+            provider: 'test',
+            credentials: { type: 'OAUTH2', access_token: 'token' }
+        };
+
+        const parentGetConnectionSpy = vi.spyOn(NangoActionBase.prototype, 'getConnection').mockResolvedValue(mockConnection as any);
+
+        const options = { refreshGithubAppJwtToken: true };
+        await instance.getConnection(undefined, undefined, options);
+
+        expect(parentGetConnectionSpy).toHaveBeenCalledWith(undefined, undefined, options);
+
+        parentGetConnectionSpy.mockRestore();
+    });
+});
 
 describe('NangoSyncCLI - batchSave', () => {
     let instance: NangoSyncCLI;

--- a/packages/cli/lib/services/sdk.ts
+++ b/packages/cli/lib/services/sdk.ts
@@ -279,8 +279,12 @@ export class NangoSyncCLI extends NangoSyncBase {
         return super.getMetadata<TMetadata>();
     }
 
-    public override async getConnection(providerConfigKeyOverride?: string, connectionIdOverride?: string): Promise<GetPublicConnection['Success']> {
-        const fetchedConnection = await super.getConnection(providerConfigKeyOverride, connectionIdOverride);
+    public override async getConnection(
+        providerConfigKeyOverride?: string,
+        connectionIdOverride?: string,
+        options?: { refreshToken?: boolean; refreshGithubAppJwtToken?: boolean; forceRefresh?: boolean }
+    ): Promise<GetPublicConnection['Success']> {
+        const fetchedConnection = await super.getConnection(providerConfigKeyOverride, connectionIdOverride, options);
         if (this.stubbedMetadata) {
             return { ...fetchedConnection, metadata: this.stubbedMetadata };
         }


### PR DESCRIPTION
When using `nango.getConnection()` with the `refreshToken: true` option during dryrun, the refresh token was not being returned in the credentials. This worked correctly in actual cloud runs but not in dryrun mode.

```typescript
const connection = await nango.getConnection(undefined, undefined, {
  refreshToken: true,
});
```

The `NangoSyncCLI.getConnection()` override in the CLI package was missing the `options` parameter in its signature. This caused the `refreshToken`, `forceRefresh`, and `refreshGithubAppJwtToken` options to be silently ignored when passed by user code.

Fixed by adding the `options` parameter to the override and passing it through to the parent class.

<!-- Summary by @propel-code-bot -->

---

The update also expands the CLI unit tests by spying on the base implementation to ensure option objects—including cases with explicit provider/connection overrides and default parameters—are forwarded during dry runs, preventing regressions in future executions.

---
*This summary was automatically generated by @propel-code-bot*