### PR TITLE
fix(cli): disable ora spinner in non-interactive environments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17637,12 +17637,12 @@
             }
         },
         "node_modules/cli-spinners": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-            "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+            "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
             "license": "MIT",
             "engines": {
-                "node": ">=6"
+                "node": ">=18.20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -24169,6 +24169,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24190,6 +24191,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24211,6 +24213,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24232,6 +24235,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24253,6 +24257,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24274,6 +24279,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24295,6 +24301,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24316,6 +24323,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24337,6 +24345,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24358,6 +24367,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24761,28 +24771,16 @@
             "license": "MIT"
         },
         "node_modules/log-symbols": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
-            "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+            "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
             "license": "MIT",
             "dependencies": {
-                "chalk": "^5.3.0",
-                "is-unicode-supported": "^1.3.0"
+                "is-unicode-supported": "^2.0.0",
+                "yoctocolors": "^2.1.1"
             },
             "engines": {
                 "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/log-symbols/node_modules/is-unicode-supported": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-            "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -26177,32 +26175,31 @@
             }
         },
         "node_modules/ora": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
-            "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-9.2.0.tgz",
+            "integrity": "sha512-4sGT6oNDbqIuciDfD2aCkoPgHLmOe+g+xpFK2WDO0aQuD/bNHNwfdFosWP+DXmcxRyXeF8vnki6kXnOOHTuRSA==",
             "license": "MIT",
             "dependencies": {
-                "chalk": "^5.3.0",
+                "chalk": "^5.6.2",
                 "cli-cursor": "^5.0.0",
-                "cli-spinners": "^2.9.2",
+                "cli-spinners": "^3.2.0",
                 "is-interactive": "^2.0.0",
-                "is-unicode-supported": "^2.0.0",
-                "log-symbols": "^6.0.0",
-                "stdin-discarder": "^0.2.2",
-                "string-width": "^7.2.0",
-                "strip-ansi": "^7.1.0"
+                "is-unicode-supported": "^2.1.0",
+                "log-symbols": "^7.0.1",
+                "stdin-discarder": "^0.3.1",
+                "string-width": "^8.1.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ora/node_modules/ansi-regex": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -26211,33 +26208,38 @@
                 "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
-        "node_modules/ora/node_modules/emoji-regex": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-            "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
-            "license": "MIT"
+        "node_modules/ora/node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
         },
         "node_modules/ora/node_modules/string-width": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.1.tgz",
+            "integrity": "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==",
             "license": "MIT",
             "dependencies": {
-                "emoji-regex": "^10.3.0",
-                "get-east-asian-width": "^1.0.0",
+                "get-east-asian-width": "^1.3.0",
                 "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ora/node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^6.0.1"
@@ -29512,9 +29514,9 @@
             "dev": true
         },
         "node_modules/stdin-discarder": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-            "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.1.tgz",
+            "integrity": "sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -33123,6 +33125,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/yoctocolors": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+            "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/zip-stream": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
@@ -33302,7 +33316,7 @@
                 "js-yaml": "4.1.1",
                 "jscodeshift": "17.3.0",
                 "npm-package-arg": "10.1.0",
-                "ora": "8.2.0",
+                "ora": "9.2.0",
                 "parse-link-header": "2.0.0",
                 "promptly": "3.2.0",
                 "semver": "7.5.4",

--- a/packages/cli/lib/cli.ts
+++ b/packages/cli/lib/cli.ts
@@ -27,7 +27,6 @@ export const getVersionOutput = (): string => {
     const version = NANGO_VERSION;
     return `${chalk.green('Nango CLI version:')} ${version}`;
 };
-
 export function generate({ fullPath, debug = false }: { fullPath: string; debug?: boolean }) {
     const syncTemplateContents = fs.readFileSync(path.resolve(__dirname, './templates/sync.ejs'), 'utf8');
     const actionTemplateContents = fs.readFileSync(path.resolve(__dirname, './templates/action.ejs'), 'utf8');

--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -224,7 +224,7 @@ program
         'Compile the integration files to JavaScript and update the .nango directory. This is useful for one off changes instead of watching for changes continuously.'
     )
     .action(async function (this: Command) {
-        const { debug } = this.opts<GlobalOptions>();
+        const { debug, interactive } = this.opts<GlobalOptions>();
         const fullPath = process.cwd();
         const precheck = await verificationService.preCheck({ fullPath, debug });
         if (!precheck.isNango) {
@@ -241,7 +241,7 @@ program
                 return;
             }
 
-            const res = await compileAll({ fullPath, debug });
+            const res = await compileAll({ fullPath, debug, interactive });
             if (res.isErr()) {
                 process.exitCode = 1;
             }
@@ -344,7 +344,7 @@ program
                 return;
             }
 
-            const res = await compileAll({ fullPath, debug });
+            const res = await compileAll({ fullPath, debug, interactive });
             if (res.isErr()) {
                 process.exitCode = 1;
                 return;
@@ -440,7 +440,7 @@ program
                 return;
             }
 
-            const resCompile = await compileAll({ fullPath, debug });
+            const resCompile = await compileAll({ fullPath, debug, interactive });
             if (resCompile.isErr()) {
                 process.exitCode = 1;
                 return;

--- a/packages/cli/lib/services/test.service.ts
+++ b/packages/cli/lib/services/test.service.ts
@@ -8,8 +8,8 @@ import readline from 'readline';
 import axios from 'axios';
 import chalk from 'chalk';
 import ejs from 'ejs';
-import ora from 'ora';
 
+import { Spinner } from '../utils/spinner.js';
 import { printDebug } from '../utils.js';
 import { compileAll } from '../zeroYaml/compile.js';
 import { buildDefinitions } from '../zeroYaml/definitions.js';
@@ -419,7 +419,8 @@ export async function generateTests({
     syncName,
     actionName,
     debug = false,
-    autoConfirm = false
+    autoConfirm = false,
+    interactive = true
 }: {
     absolutePath: string;
     integrationId?: string;
@@ -427,13 +428,15 @@ export async function generateTests({
     actionName?: string;
     debug?: boolean;
     autoConfirm?: boolean;
+    interactive?: boolean;
 }): Promise<{ success: boolean; generatedFiles: string[] }> {
     try {
         if (debug) {
             printDebug(`Generating test files in ${absolutePath}`);
         }
 
-        const spinner = ora({ text: 'Setting up test dependencies' }).start();
+        const spinnerFactory = new Spinner({ interactive });
+        const spinner = spinnerFactory.start('Setting up test dependencies');
         try {
             await injectTestDependencies({ debug });
             spinner.succeed();
@@ -472,7 +475,7 @@ export async function generateTests({
         }
 
         // compile then use js definitions
-        const compileResult = await compileAll({ fullPath: absolutePath, debug });
+        const compileResult = await compileAll({ fullPath: absolutePath, debug, interactive });
         if (compileResult.isErr()) {
             console.error(chalk.red(`Failed to compile TypeScript: ${compileResult.error}`));
             return { success: false, generatedFiles: [] };

--- a/packages/cli/lib/utils/spinner.ts
+++ b/packages/cli/lib/utils/spinner.ts
@@ -1,0 +1,171 @@
+import ora from 'ora';
+
+import type { Ora } from 'ora';
+
+/**
+ * A wrapper around ora that provides a consistent spinner experience
+ * across interactive and non-interactive environments.
+ *
+ * In non-interactive environments (CI, pre-commit hooks, piped output),
+ * it prints text-based progress instead of animated spinners to avoid
+ * hangs caused by ora's stdin-discarder dependency.
+ *
+ * Non-interactive output format:
+ *   ✓ Typechecking
+ *   ✓ Building 3 file(s)
+ *   ✗ Exporting definitions
+ */
+export class Spinner {
+    private readonly canUseSpinner: boolean;
+
+    constructor({ interactive = true }: { interactive?: boolean } = {}) {
+        this.canUseSpinner = interactive && Boolean(process.stdout.isTTY) && Boolean(process.stdin?.isTTY);
+    }
+
+    /**
+     * Creates and starts a new spinner with the given text.
+     * In non-interactive mode, nothing is printed until completion (succeed/fail/warn/info).
+     */
+    start(text: string): Ora {
+        if (this.canUseSpinner) {
+            return ora({ text }).start();
+        }
+
+        // Non-interactive mode: don't print anything yet, wait for completion
+        return this.createNoOpSpinner(text);
+    }
+
+    private createNoOpSpinner(initialText: string): Ora {
+        const state = {
+            text: initialText,
+            isSpinning: true,
+            completed: false,
+            indent: 0,
+            color: 'cyan' as const,
+            prefixText: '',
+            suffixText: ''
+        };
+
+        // Use a Proxy to safely handle any Ora method/property access
+        // This prevents runtime crashes if code uses methods we haven't explicitly handled
+        const handler: ProxyHandler<object> = {
+            get(_target, prop: string | symbol) {
+                // Handle known properties
+                if (prop === 'text') return state.text;
+                if (prop === 'isSpinning') return state.isSpinning;
+                if (prop === 'indent') return state.indent;
+                if (prop === 'color') return state.color;
+                if (prop === 'prefixText') return state.prefixText;
+                if (prop === 'suffixText') return state.suffixText;
+
+                // Handle completion methods that print output
+                if (prop === 'succeed') {
+                    return (text?: string) => {
+                        if (state.completed) {
+                            // Already completed - if new text provided, print as new line
+                            if (text && text !== state.text) {
+                                console.log(`✓ ${text}`);
+                            }
+                            return proxy;
+                        }
+                        state.completed = true;
+                        state.isSpinning = false;
+                        console.log(`✓ ${text ?? state.text}`);
+                        return proxy;
+                    };
+                }
+                if (prop === 'fail') {
+                    return (text?: string) => {
+                        if (state.completed) {
+                            if (text && text !== state.text) {
+                                console.log(`✗ ${text}`);
+                            }
+                            return proxy;
+                        }
+                        state.completed = true;
+                        state.isSpinning = false;
+                        console.log(`✗ ${text ?? state.text}`);
+                        return proxy;
+                    };
+                }
+                if (prop === 'warn') {
+                    return (text?: string) => {
+                        if (state.completed) {
+                            if (text && text !== state.text) {
+                                console.log(`⚠ ${text}`);
+                            }
+                            return proxy;
+                        }
+                        state.completed = true;
+                        state.isSpinning = false;
+                        console.log(`⚠ ${text ?? state.text}`);
+                        return proxy;
+                    };
+                }
+                if (prop === 'info') {
+                    return (text?: string) => {
+                        if (state.completed) {
+                            if (text && text !== state.text) {
+                                console.log(`ℹ ${text}`);
+                            }
+                            return proxy;
+                        }
+                        state.completed = true;
+                        state.isSpinning = false;
+                        console.log(`ℹ ${text ?? state.text}`);
+                        return proxy;
+                    };
+                }
+                if (prop === 'stopAndPersist') {
+                    return (options?: { text?: string; symbol?: string }) => {
+                        if (state.completed) return proxy;
+                        state.completed = true;
+                        state.isSpinning = false;
+                        const symbol = options?.symbol ?? '✓';
+                        console.log(`${symbol} ${options?.text ?? state.text}`);
+                        return proxy;
+                    };
+                }
+
+                // Handle methods that return string
+                if (prop === 'frame') {
+                    return () => '';
+                }
+
+                // Handle all other methods as no-ops that return the proxy (for chaining)
+                // This includes: start, stop, clear, render, etc.
+                return (..._args: unknown[]) => proxy;
+            },
+            set(_target, prop: string | symbol, value: unknown) {
+                if (prop === 'text' && typeof value === 'string') {
+                    // Print new text on a new line to show progress (like ora updates in-place)
+                    if (value !== state.text && state.isSpinning) {
+                        console.log(`  ${value}`);
+                    }
+                    state.text = value;
+                    return true;
+                }
+                if (prop === 'indent' && typeof value === 'number') {
+                    state.indent = value;
+                    return true;
+                }
+                if (prop === 'color' && typeof value === 'string') {
+                    state.color = value as typeof state.color;
+                    return true;
+                }
+                if (prop === 'prefixText' && typeof value === 'string') {
+                    state.prefixText = value;
+                    return true;
+                }
+                if (prop === 'suffixText' && typeof value === 'string') {
+                    state.suffixText = value;
+                    return true;
+                }
+                return true;
+            }
+        };
+
+        const proxy = new Proxy({}, handler) as Ora;
+        return proxy;
+    }
+}

--- a/packages/cli/lib/zeroYaml/init.ts
+++ b/packages/cli/lib/zeroYaml/init.ts
@@ -4,8 +4,8 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 
 import chalk from 'chalk';
-import ora from 'ora';
 
+import { Spinner } from '../utils/spinner.js';
 import { detectPackageManager, printDebug } from '../utils.js';
 import { NANGO_VERSION } from '../version.js';
 import { compileAll } from './compile.js';
@@ -21,13 +21,16 @@ const execAsync = promisify(exec);
 export async function initZero({
     absolutePath,
     debug = false,
-    onlyCopy = false
+    onlyCopy = false,
+    interactive = true
 }: {
     absolutePath: string;
     debug?: boolean;
     onlyCopy?: boolean;
+    interactive?: boolean;
 }): Promise<boolean> {
     printDebug(`Creating the nango integrations directory in ${absolutePath}`, debug);
+    const spinnerFactory = new Spinner({ interactive });
 
     const stat = fs.statSync(absolutePath, { throwIfNoEntry: false });
 
@@ -43,7 +46,7 @@ export async function initZero({
 
     // Copy example folder
     {
-        const spinner = ora({ text: 'Copy example' }).start();
+        const spinner = spinnerFactory.start('Copy example');
         try {
             printDebug(`Copy example folder`, debug);
 
@@ -81,7 +84,7 @@ export async function initZero({
 
     // Install dependencies
     {
-        const spinner = ora({ text: 'Install dependencies' }).start();
+        const spinner = spinnerFactory.start('Install dependencies');
         try {
             printDebug(`Running package manager install`, debug);
 
@@ -96,7 +99,7 @@ export async function initZero({
     }
 
     {
-        const res = await compileAll({ fullPath: absolutePath, debug });
+        const res = await compileAll({ fullPath: absolutePath, debug, interactive });
         if (res.isErr()) {
             return false;
         }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,7 +65,7 @@
         "js-yaml": "4.1.1",
         "jscodeshift": "17.3.0",
         "npm-package-arg": "10.1.0",
-        "ora": "8.2.0",
+        "ora": "9.2.0",
         "parse-link-header": "2.0.0",
         "promptly": "3.2.0",
         "semver": "7.5.4",


### PR DESCRIPTION
## Issue
`nango compile` hangs indefinitely when run via pre-commit hooks due to an upstream bug in ora's `stdin-discarder` dependency (#5207). This is blocking a customer's CI/CD workflow.

## Root cause
The bug was fixed in `stdin-discarder@0.3.1`, but `ora@9.1.0` (latest) still depends on `stdin-discarder@^0.2.2` and hasn't released a patched version yet.

## Fix
Added a `createSpinner()` wrapper that returns a no-op spinner when running in non-interactive environments (CI, pre-commit hooks, piped output, or when `--no-interactive` flag is passed). The real ora spinner is only used when both `interactive=true` AND `process.stdout.isTTY` is true.

This workaround should be removed once `ora` releases a patched version

I have opened a PR to actually bump the `stdin-discarder` version on the `ora` repo (https://github.com/sindresorhus/ora/pull/251) 

Closes #5207

<!-- Summary by @propel-code-bot -->

---

**Add resilient spinner wrapper and propagate non-interactive handling across CLI**

Introduces a centralized `Spinner` utility that wraps `ora`, falls back to text-based logging when either stdin/stdout is non-TTY, and is wired through compile, dev, deploy, migrations, init, clone, and test generation flows. Global CLI options now auto-disable interactivity in CI environments (`isCI` or `--no-interactive`), ensuring commands invoked from hooks or piped executions no longer hang, while also updating `ora` to `9.2.0` and related dependencies (e.g., `stdin-discarder@0.3.1`).

<details>
<summary><strong>Key Changes</strong></summary>

• Created `packages/cli/lib/utils/spinner.ts` implementing a Proxy-based `Spinner` class that mirrors the `Ora` interface and prints textual status when `process.stdin` or `stdout` is non-TTY.
• Replaced direct `ora` usage across CLI commands (`compile`, `dev`, `deploy`, zero-yaml migrations, init, clone, tests, etc.) with the new `Spinner`, adding `interactive` parameters where needed.
• Updated `packages/cli/lib/index.ts` global option handling to default to interactive mode, automatically disable it under CI, and pass the flag through to all commands.
• Bumped `ora` to `9.2.0` in `packages/cli/package.json` and lockfile, pulling in the fixed `stdin-discarder@0.3.1` plus new transitive dependencies.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/cli/lib/utils/spinner.ts
• packages/cli/lib/zeroYaml/* (compile, dev, deploy, migrations, init, check)
• packages/cli/lib/services/{clone,test}.service.ts
• packages/cli/lib/index.ts
• packages/cli/package.json & package-lock.json

</details>

---
*This summary was automatically generated by @propel-code-bot*