### PR TITLE
fix(release): release action breaks package-lock.json

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,8 +36,8 @@ jobs:
                   node-version-file: '.nvmrc'
                   registry-url: 'https://registry.npmjs.org'
 
-            - name: Update npm to latest
-              run: npm install -g npm@11.5.1
+            - name: Update npm to pinned version
+              run: npm install -g npm@10.9.2
 
             - name: Install dependencies
               run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -24157,6 +24157,226 @@
                 "lightningcss-win32-x64-msvc": "1.30.1"
             }
         },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
+            "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
+            "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
+            "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
+            "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
+            "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
+            "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+            "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
+            "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
+            "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
+            "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/limiter": {
             "version": "1.1.5"
         },
@@ -33133,9 +33353,9 @@
             }
         },
         "packages/cli/node_modules/@nangohq/node/node_modules/@nangohq/types": {
-            "version": "0.69.28",
-            "resolved": "https://registry.npmjs.org/@nangohq/types/-/types-0.69.28.tgz",
-            "integrity": "sha512-9SKy58wUUjOMX49PET2oiV8ZNZtGOwqKDDFFSFNsmqG8o9nsOyO8KzvRx7yVxWa2BM1wN4PeMqMvUSEwt2d8XQ==",
+            "version": "0.69.27",
+            "resolved": "https://registry.npmjs.org/@nangohq/types/-/types-0.69.27.tgz",
+            "integrity": "sha512-beis3NK+joc1T1ExzL5ZAwdjaIqq5798bFIubxahRiKpGGnQD5s/Q8oV3RJnD7G5Ai32iX5N7pb46mZcISSemg==",
             "extraneous": true,
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
@@ -33145,13 +33365,13 @@
             }
         },
         "packages/cli/node_modules/@nangohq/runner-sdk/node_modules/@nangohq/node": {
-            "version": "0.69.28",
-            "resolved": "https://registry.npmjs.org/@nangohq/node/-/node-0.69.28.tgz",
-            "integrity": "sha512-LtaW/Dk91zY/g50VI6Ns3Jclj8D4LgVyBYMCdYAJHIacFrpAshpWOZ5jJdTcYfSiCdMn+3ouz2b5cyjlrx7PiA==",
+            "version": "0.69.27",
+            "resolved": "https://registry.npmjs.org/@nangohq/node/-/node-0.69.27.tgz",
+            "integrity": "sha512-DgIyFl7puf+Y3zuBOx4EAkHvgU4kaoGeg3WFQpA6AHJIdtDlv9HOTyStSUJlub2g55KEEEKHDpQnuKH6AWAZBg==",
             "extraneous": true,
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@nangohq/types": "0.69.28",
+                "@nangohq/types": "0.69.27",
                 "axios": "1.12.0"
             },
             "engines": {
@@ -33159,18 +33379,18 @@
             }
         },
         "packages/cli/node_modules/@nangohq/runner-sdk/node_modules/@nangohq/providers": {
-            "version": "0.69.28",
-            "resolved": "https://registry.npmjs.org/@nangohq/providers/-/providers-0.69.28.tgz",
-            "integrity": "sha512-gEkk4eHYLr27oxUg0ET/YJ/5Nb52utD1+ivxDnp7P6EhxqAmDg3lO3r3WFVd2h1Tf8v1Zer907NuJxCnR5bb5g==",
+            "version": "0.69.27",
+            "resolved": "https://registry.npmjs.org/@nangohq/providers/-/providers-0.69.27.tgz",
+            "integrity": "sha512-X/L4LAxxsg3ziS+qUI9VtZOA/r9IsfGYiMzsQwSp1LeX7BVhEFrPCPyxc4m0Fr4ur/33TBaCm6vMmq/dr3x4Tg==",
             "extraneous": true,
             "dependencies": {
                 "js-yaml": "4.1.1"
             }
         },
         "packages/cli/node_modules/@nangohq/runner-sdk/node_modules/@nangohq/types": {
-            "version": "0.69.28",
-            "resolved": "https://registry.npmjs.org/@nangohq/types/-/types-0.69.28.tgz",
-            "integrity": "sha512-9SKy58wUUjOMX49PET2oiV8ZNZtGOwqKDDFFSFNsmqG8o9nsOyO8KzvRx7yVxWa2BM1wN4PeMqMvUSEwt2d8XQ==",
+            "version": "0.69.27",
+            "resolved": "https://registry.npmjs.org/@nangohq/types/-/types-0.69.27.tgz",
+            "integrity": "sha512-beis3NK+joc1T1ExzL5ZAwdjaIqq5798bFIubxahRiKpGGnQD5s/Q8oV3RJnD7G5Ai32iX5N7pb46mZcISSemg==",
             "extraneous": true,
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
@@ -35620,9 +35840,9 @@
             }
         },
         "packages/webapp/node_modules/@nangohq/frontend/node_modules/@nangohq/types": {
-            "version": "0.69.28",
-            "resolved": "https://registry.npmjs.org/@nangohq/types/-/types-0.69.28.tgz",
-            "integrity": "sha512-9SKy58wUUjOMX49PET2oiV8ZNZtGOwqKDDFFSFNsmqG8o9nsOyO8KzvRx7yVxWa2BM1wN4PeMqMvUSEwt2d8XQ==",
+            "version": "0.69.27",
+            "resolved": "https://registry.npmjs.org/@nangohq/types/-/types-0.69.27.tgz",
+            "integrity": "sha512-beis3NK+joc1T1ExzL5ZAwdjaIqq5798bFIubxahRiKpGGnQD5s/Q8oV3RJnD7G5Ai32iX5N7pb46mZcISSemg==",
             "extraneous": true,
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -63,7 +63,12 @@ if (!skipCli) {
 
 await $`npm version "${nextVersion}" --no-git-tag-version --allow-same-version`;
 
+// Clean regenerate lockfile to preserve cross-platform optional dependencies
+// See: https://github.com/npm/cli/issues/4828
 echo``;
+echo`Regenerating package-lock.json with all platform dependencies...`;
+await $`rm -rf node_modules`;
+await $`rm -f package-lock.json`;
 await npmInstall();
 echo(chalk.green(`${figures.tick} npm install`));
 echo(chalk.grey('done'));


### PR DESCRIPTION
## Summary
- Fix lockfile corruption during releases by regenerating it cleanly
- Restore missing platform-specific optional dependencies in package-lock.json

## Problem
The release workflow was corrupting `package-lock.json`, removing cross-platform optional dependencies (like `lightningcss-darwin-*`, `lightningcss-linux-*`). This caused subsequent installs to fail with:

```
npm error Missing: lightningcss-darwin-arm64@1.30.1 from lock file
npm error Missing: lightningcss-darwin-x64@1.30.1 from lock file
...
```

## Root Cause
This is a [known npm bug (npm/cli#4828)](https://github.com/npm/cli/issues/4828) since April 2022, still unresolved:

1. `publish.mjs` runs `npm i` multiple times during the release process
2. When `node_modules` exists and you run `npm install`, npm only includes platform-specific deps for the **current machine**
3. It **prunes** other platforms' optional dependencies from the lockfile
4. `gitrelease.mjs` commits this corrupted lockfile
5. Future installs on fail because entries are missing

## Fix
- **`scripts/publish.mjs`**: At the end, delete `node_modules` and `package-lock.json` before running final `npm i` - this forces npm to regenerate a complete lockfile with all platform variants
- **`.github/workflows/publish.yaml`**: Pin npm to 10.9.2 for consistency with repo settings
- **`package-lock.json`**: Restore complete lockfile with all platform-specific entries

## Test plan
- [x] Verify `npm ci` works on macOS
- [x] Verify `npm ci` works on Linux (CI)
- [ ] Next release should preserve all platform entries in lockfile

## Sources
- [npm/cli#4828 - Platform-specific optional dependencies not being included](https://github.com/npm/cli/issues/4828)
- [npm/cli#7961 - Optional dependencies for OS/CPU package variants being pruned](https://github.com/npm/cli/issues/7961)
<!-- Summary by @propel-code-bot -->

---

This work stabilizes the release lockfile regeneration by forcing each publish run to rebuild from a clean dependency tree and by re-aligning nested workspace packages—such as the @nangohq modules—back to version 0.69.27 alongside the restored platform-specific entries.

---
*This summary was automatically generated by @propel-code-bot*