### PR TITLE
chore: Fix secretService imports

### DIFF
--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -11,9 +11,9 @@ import {
     externalWebhookService,
     getApiUrl,
     getEndUserByConnectionId,
-    getSyncConfigRaw
+    getSyncConfigRaw,
+    secretService
 } from '@nangohq/shared';
-import secretService from '@nangohq/shared/lib/services/secret.service.js';
 import { Err, Ok, tagTraceUser } from '@nangohq/utils';
 import { sendAsyncActionWebhook } from '@nangohq/webhooks';
 

--- a/packages/jobs/lib/execution/onEvent.ts
+++ b/packages/jobs/lib/execution/onEvent.ts
@@ -1,7 +1,6 @@
 import db from '@nangohq/database';
 import { logContextGetter } from '@nangohq/logs';
-import { NangoError, accountService, configService, environmentService, getApiUrl, getEndUserByConnectionId } from '@nangohq/shared';
-import secretService from '@nangohq/shared/lib/services/secret.service.js';
+import { NangoError, accountService, configService, environmentService, getApiUrl, getEndUserByConnectionId, secretService } from '@nangohq/shared';
 import { Err, Ok, tagTraceUser } from '@nangohq/utils';
 
 import { bigQueryClient } from '../clients.js';

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -22,11 +22,11 @@ import {
     getLastSyncDate,
     getSyncConfigRaw,
     getSyncJobByRunId,
+    secretService,
     setLastSyncDate,
     updateSyncJobResult,
     updateSyncJobStatus
 } from '@nangohq/shared';
-import secretService from '@nangohq/shared/lib/services/secret.service.js';
 import { Err, Ok, getFrequencyMs, tagTraceUser } from '@nangohq/utils';
 import { sendSync as sendSyncWebhook } from '@nangohq/webhooks';
 

--- a/packages/jobs/lib/execution/webhook.ts
+++ b/packages/jobs/lib/execution/webhook.ts
@@ -15,9 +15,9 @@ import {
     getEndUserByConnectionId,
     getSync,
     getSyncConfigRaw,
+    secretService,
     updateSyncJobStatus
 } from '@nangohq/shared';
-import secretService from '@nangohq/shared/lib/services/secret.service.js';
 import { Err, Ok, tagTraceUser } from '@nangohq/utils';
 import { sendSync as sendSyncWebhook } from '@nangohq/webhooks';
 

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -15,9 +15,9 @@ import {
     createSync,
     createSyncJob,
     environmentService,
-    getProvider
+    getProvider,
+    secretService
 } from '@nangohq/shared';
-import secretService from '@nangohq/shared/lib/services/secret.service.js';
 
 import { server } from './server.js';
 

--- a/packages/server/lib/controllers/v1/environment/deleteEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/deleteEnvironment.integration.test.ts
@@ -1,10 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import db from '@nangohq/database';
-import { PROD_ENVIRONMENT_NAME, environmentService, getProvider, seeders } from '@nangohq/shared';
+import { PROD_ENVIRONMENT_NAME, environmentService, getProvider, secretService, seeders } from '@nangohq/shared';
 import { createConfigSeed } from '@nangohq/shared/lib/seeders/config.seeder.js';
 import { createSyncSeeds } from '@nangohq/shared/lib/seeders/index.js';
-import secretService from '@nangohq/shared/lib/services/secret.service.js';
 
 import { isError, runServer, shouldBeProtected } from '../../../utils/tests.js';
 

--- a/packages/server/lib/controllers/v1/environment/getEnvironments.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironments.integration.test.ts
@@ -1,8 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import db from '@nangohq/database';
-import { seeders } from '@nangohq/shared';
-import secretService from '@nangohq/shared/lib/services/secret.service.js';
+import { secretService, seeders } from '@nangohq/shared';
 
 import { isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
 

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -9,9 +9,9 @@ import {
     externalWebhookService,
     getProxyConfiguration,
     productTracking,
+    secretService,
     syncManager
 } from '@nangohq/shared';
-import secretService from '@nangohq/shared/lib/services/secret.service.js';
 import { Err, Ok, getLogger, isHosted, report } from '@nangohq/utils';
 import { sendAuth as sendAuthWebhook } from '@nangohq/webhooks';
 

--- a/packages/server/lib/webhook/webhook.manager.ts
+++ b/packages/server/lib/webhook/webhook.manager.ts
@@ -1,8 +1,7 @@
 import tracer from 'dd-trace';
 
 import db from '@nangohq/database';
-import { NangoError, externalWebhookService, getProvider } from '@nangohq/shared';
-import secretService from '@nangohq/shared/lib/services/secret.service.js';
+import { NangoError, externalWebhookService, getProvider, secretService } from '@nangohq/shared';
 import { Err, getLogger } from '@nangohq/utils';
 import { forwardWebhook } from '@nangohq/webhooks';
 

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -12,6 +12,7 @@ import flowService from './services/flow.service.js';
 import hmacService from './services/hmac.service.js';
 import { errorNotificationService } from './services/notification/error.service.js';
 import { SlackService, generateSlackConnectionId } from './services/notification/slack.service.js';
+import secretService from './services/secret.service.js';
 import sharedCredentialsService from './services/shared-credentials.service.js';
 import syncManager, { syncCommandToOperation } from './services/sync/manager.service.js';
 import userService from './services/user.service.js';
@@ -78,6 +79,7 @@ export {
     pbkdf2,
     providerClientManager,
     remoteFileService,
+    secretService,
     seeders,
     sharedCredentialsService,
     syncCommandToOperation,


### PR DESCRIPTION
Export secretService on `shared` and fix imports

<!-- Summary by @propel-code-bot -->

---

It routes all server, jobs, and persistence consumers through the shared entry point so the service stays centralized and avoids scattered deep imports.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/shared/lib/index.ts`
• `packages/jobs/lib/execution/*` modules (action/onEvent/sync/webhook)`
• `packages/server/lib/controllers/v1/environment/*` tests
• `packages/server/lib/hooks/hooks.ts`
• `packages/persist/lib/server.integration.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*