### PR TITLE
feat: add has_records_autopruning to plans table

### DIFF
--- a/packages/database/lib/migrations/20260204173100_plan_disable_records_autopruning.cjs
+++ b/packages/database/lib/migrations/20260204173100_plan_disable_records_autopruning.cjs
@@ -1,0 +1,13 @@
+exports.config = { transaction: true };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`
+        ALTER TABLE plans
+        ADD COLUMN IF NOT EXISTS has_records_autopruning boolean NOT NULL DEFAULT true;
+    `);
+};
+
+exports.down = async function () {};


### PR DESCRIPTION
We need to be able to disable records autopruning for specific customers.
This commit is adding a `has_records_autopruning` column (default true) to the plans table. It won't be exposed to customers. It is for us to be able to control it and disable autopruning for very specific reasons.

I thought about having a autopruning threshold duration column so we can set different duration for different customers but it would make the background processing much less efficient. It is currently looking at the records table directly, fetching candidates for pruning based on the records updated_at. Having a dynamic value to evaluate records staleness would make the entire process slower and more complicated. So for now the setting is a on/off switch since we don't need more than that.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

The migration executes within a transaction but currently provides no rollback implementation, so reverting this schema change would require a separate follow-up.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/database/lib/migrations/20260204173100_plan_disable_records_autopruning.cjs`

</details>

---
*This summary was automatically generated by @propel-code-bot*