### PR TITLE
feat(pre-provisioned): pick the latest credential for shared providers with multiple entries

### DIFF
--- a/packages/shared/lib/services/shared-credentials.service.ts
+++ b/packages/shared/lib/services/shared-credentials.service.ts
@@ -36,6 +36,7 @@ class SharedCredentialsService {
                     .select('*')
                     .from<DBSharedCredentials>('providers_shared_credentials')
                     .where('name', shared_credentials_name ?? providerName)
+                    .orderBy('created_at', 'desc')
                     .first();
 
                 if (!sharedCredentials) {


### PR DESCRIPTION
## Describe the problem and your solution

- pick the latest credentials for shared providers with multiple entries, based on this [migration](https://github.com/NangoHQ/nango/pull/5387).

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

It explicitly orders shared provider credential lookups by creation time so pre-provisioned setups always pull the most recent record, keeping the service behavior consistent with the migration that now allows duplicate names.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `packages/shared/lib/services/shared-credentials.service.ts` to append `.orderBy('created_at', 'desc')` before `.first()` when reading from `providers_shared_credentials`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `shared-credentials.service.ts` pre-provisioned provider creation path

</details>

---
*This summary was automatically generated by @propel-code-bot*