### PR TITLE
feat: do not autoprune records if plan.has_records_autopruning is false

### DIFF
--- a/packages/database/lib/migrations/20260204173100_plan_disable_records_autopruning.cjs
+++ b/packages/database/lib/migrations/20260204173100_plan_disable_records_autopruning.cjs
@@ -1,0 +1,13 @@
+exports.config = { transaction: true };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`
+        ALTER TABLE plans
+        ADD COLUMN IF NOT EXISTS has_records_autopruning boolean NOT NULL DEFAULT true;
+    `);
+};
+
+exports.down = async function () {};

--- a/packages/server/lib/controllers/v1/stripe/postWebhooks.ts
+++ b/packages/server/lib/controllers/v1/stripe/postWebhooks.ts
@@ -1,6 +1,6 @@
 import { billing, getStripe } from '@nangohq/billing';
 import db from '@nangohq/database';
-import { accountService, getPlanBy, handlePlanChanged, updatePlan } from '@nangohq/shared';
+import { accountService, getPlan, handlePlanChanged, updatePlan } from '@nangohq/shared';
 import { Err, Ok, getLogger, report } from '@nangohq/utils';
 
 import { envs } from '../../../env.js';
@@ -70,7 +70,7 @@ async function handleWebhook(event: Stripe.Event, stripe: Stripe): Promise<Resul
                 return Err('missing customer in data');
             }
 
-            const resPlan = await getPlanBy(db.knex, { stripe_customer_id: data.customer });
+            const resPlan = await getPlan(db.knex, { stripeCustomerId: data.customer });
             if (resPlan.isErr()) {
                 return Err(resPlan.error);
             }
@@ -122,7 +122,7 @@ async function handleWebhook(event: Stripe.Event, stripe: Stripe): Promise<Resul
                 return Err('missing customer in data');
             }
 
-            const resPlan = await getPlanBy(db.knex, { stripe_customer_id: customer });
+            const resPlan = await getPlan(db.knex, { stripeCustomerId: customer });
             if (resPlan.isErr()) {
                 return Err(resPlan.error);
             }
@@ -149,7 +149,7 @@ async function handleWebhook(event: Stripe.Event, stripe: Stripe): Promise<Resul
                 return Err('missing customer in data');
             }
 
-            const resPlan = await getPlanBy(db.knex, { stripe_customer_id: customer });
+            const resPlan = await getPlan(db.knex, { stripeCustomerId: customer });
             if (resPlan.isErr()) {
                 return Err(resPlan.error);
             }
@@ -210,7 +210,7 @@ async function handleWebhook(event: Stripe.Event, stripe: Stripe): Promise<Resul
                 return Err('missing customer in data');
             }
 
-            const resPlan = await getPlanBy(db.knex, { stripe_customer_id: customer });
+            const resPlan = await getPlan(db.knex, { stripeCustomerId: customer });
             if (resPlan.isErr()) {
                 return Err(resPlan.error);
             }

--- a/packages/shared/lib/seeders/plan.seeder.ts
+++ b/packages/shared/lib/seeders/plan.seeder.ts
@@ -43,6 +43,7 @@ export function getTestPlan(override?: Partial<DBPlan>): DBPlan {
         action_function_runtime: 'runner',
         webhook_function_runtime: 'runner',
         on_event_function_runtime: 'runner',
+        has_records_autopruning: true,
         ...override
     };
 }

--- a/packages/shared/lib/services/plans/plans.unit.test.ts
+++ b/packages/shared/lib/services/plans/plans.unit.test.ts
@@ -119,6 +119,7 @@ function makePlan({ code, flagOverrides }: { code: DBPlan['name']; flagOverrides
         action_function_runtime: 'runner',
         webhook_function_runtime: 'runner',
         on_event_function_runtime: 'runner',
+        has_records_autopruning: true,
         ...defaultPlanDefinition,
         ...flagOverrides
     };

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -173,4 +173,10 @@ export interface DBPlan extends Timestamps {
      * @default "runner"
      */
     on_event_function_runtime: FunctionRuntime;
+
+    /**
+     * Enable or disable records autopruning
+     * @default true
+     */
+    has_records_autopruning: boolean;
 }


### PR DESCRIPTION
Adding logic to the autopruning daemon to check the plan and skip autopruning if `plan.has_records_autopruning` is false.
Also refactoring getPlan to consolidate it all in one function

<!-- Summary by @propel-code-bot -->

---

The consolidated getPlan helper now handles account, environment, or Stripe customer lookups so shared call sites like the Stripe webhook handlers use the same code path, and the has_records_autopruning flag is persisted in the plan schema, seed data, and tests with sensible defaults.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/persist/lib/daemons/autopruning.daemon.ts`
• `packages/shared/lib/services/plans/plans.ts`
• `packages/server/lib/controllers/v1/stripe/postWebhooks.ts`
• `packages/types/lib/plans/db.ts`
• `packages/shared/lib/seeders/plan.seeder.ts`
• `packages/shared/lib/services/plans/plans.unit.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*