### PR TITLE
fix(providers): fix ironclad authorization url

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -7850,7 +7850,7 @@ ironclad:
     categories:
         - legal
     auth_mode: OAUTH2
-    authorization_url: https://${connectionConfig.subdomain}.ironcladapp.com/oauth/authorize
+    authorization_url: https://ironcladapp.com/oauth/authorize
     token_url: https://${connectionConfig.subdomain}.ironcladapp.com/oauth/token
     disable_pkce: true
     authorization_params:


### PR DESCRIPTION
## Describe the problem and your solution

- This pr attempts to address an issue encountered by Ironclad users using SSO login, where they are not redirected back to nango’s callback URL during the authorization code exchange step. I haven’t been able to test this change locally, as our Ironclad sandbox account does not support SSO logins, and the customer is also unable to provide an environment for testing. The proposed fix is based on feedback and guidance received from the Ironclad team:

```
After some further investigation and discussion with my team, we were able to find an ongoing issue regarding requests made to https://na1.ironcladapp.com/ and https://ironcladapp.com/. We found that the inclusion of the na1 subdomain leads to issues with resolving the authorization request with the Identity Provider, as the subdomain may not be included in the callback URL, depending on how old the config is, as the subdomain is a change we've made in mid 2025. 
 
Can you please update your request URL to drop the na1 subdomain and run the test once more with your customer's IdP? The key here is ensuring the base URLs used in your API requests and the IdP match.
```

```
Yes, the subdomain omission will also work for non-SSO users as well. They will not require a reroute to the connected Identity Provider and will authenticate directly with Ironclad to create the API connection. 
Your team can be confident that dropping the subdomain will work for any login method a user has. 
```


Once this is deployed and confirmed to be working, I’ll make further improvements to this provider.


<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

The ironclad provider configuration now explicitly points its authorization_url at https://ironcladapp.com/oauth/authorize and leaves all other provider settings unchanged.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/providers/providers.yaml` (`ironclad` provider definition)

</details>

---
*This summary was automatically generated by @propel-code-bot*