### PR TITLE
feat(connection tags): Make end_user optional when tags are present

### DIFF
--- a/packages/server/lib/controllers/connect/getSession.integration.test.ts
+++ b/packages/server/lib/controllers/connect/getSession.integration.test.ts
@@ -92,6 +92,64 @@ describe(`GET ${endpoint}`, () => {
         expect(res.res.status).toBe(200);
     });
 
+    it('should get a session without endUser when created with tags', async () => {
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+
+        // Create session
+        const resCreate = await api.fetch('/connect/sessions', {
+            method: 'POST',
+            token: secret.secret,
+            body: { tags: { projectId: '123' }, allowed_integrations: ['github'] }
+        });
+        isSuccess(resCreate.json);
+
+        // Get session
+        const res = await api.fetch(endpoint, {
+            method: 'GET',
+            token: resCreate.json.data.token
+        });
+
+        isSuccess(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            data: {
+                endUser: null,
+                allowed_integrations: ['github'],
+                connectUISettings: connectUISettingsService.getDefaultConnectUISettings()
+            }
+        });
+        expect(res.res.status).toBe(200);
+    });
+
+    it('should get a session without endUser when created with empty tags object', async () => {
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+
+        // Create session
+        const resCreate = await api.fetch('/connect/sessions', {
+            method: 'POST',
+            token: secret.secret,
+            body: { tags: {}, allowed_integrations: ['github'] }
+        });
+        isSuccess(resCreate.json);
+
+        // Get session
+        const res = await api.fetch(endpoint, {
+            method: 'GET',
+            token: resCreate.json.data.token
+        });
+
+        isSuccess(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            data: {
+                endUser: null,
+                allowed_integrations: ['github'],
+                connectUISettings: connectUISettingsService.getDefaultConnectUISettings()
+            }
+        });
+        expect(res.res.status).toBe(200);
+    });
+
     it('should get a session with custom connect UI settings when both customization flags are enabled', async () => {
         const { env, secret, plan } = await seeders.seedAccountEnvAndUser();
         // Enable both features so custom settings can be preserved

--- a/packages/server/lib/controllers/connect/postSessions.integration.test.ts
+++ b/packages/server/lib/controllers/connect/postSessions.integration.test.ts
@@ -289,6 +289,50 @@ describe(`POST ${endpoint}`, () => {
     });
 
     describe('tags', () => {
+        it('should create session with tags but without end_user', async () => {
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: seed.secret.secret,
+                body: {
+                    tags: { projectId: '123' }
+                }
+            });
+
+            isSuccess(res.json);
+
+            const session = await db.knex
+                .select('*')
+                .from<DBConnectSession>('connect_sessions')
+                .where({ environment_id: seed.env.id })
+                .orderBy('id', 'desc')
+                .first();
+
+            expect(session?.end_user).toBeNull();
+            expect(session?.tags).toStrictEqual({ projectid: '123' });
+        });
+
+        it('should create session with empty tags object but without end_user', async () => {
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: seed.secret.secret,
+                body: {
+                    tags: {}
+                }
+            });
+
+            isSuccess(res.json);
+
+            const session = await db.knex
+                .select('*')
+                .from<DBConnectSession>('connect_sessions')
+                .where({ environment_id: seed.env.id })
+                .orderBy('id', 'desc')
+                .first();
+
+            expect(session?.end_user).toBeNull();
+            expect(session?.tags).toStrictEqual({});
+        });
+
         it('should create session with valid tags', async () => {
             const res = await api.fetch(endpoint, {
                 method: 'POST',

--- a/packages/types/lib/connect/api.ts
+++ b/packages/types/lib/connect/api.ts
@@ -38,15 +38,25 @@ export interface EndUserInput {
 }
 
 export type ConnectSessionOutput = Omit<ConnectSessionInput, 'end_user' | 'organization'> & {
-    endUser: ApiEndUser;
+    endUser: ApiEndUser | null;
     isReconnecting?: boolean;
     connectUISettings: ConnectUISettings;
 };
 
+export type PostConnectSessionsBody =
+    | ConnectSessionInput
+    | (Omit<ConnectSessionInput, 'end_user' | 'tags'> & {
+          /**
+           * When top-level tags is provided, end_user becomes optional.
+           */
+          tags: NonNullable<ConnectSessionInput['tags']>;
+          end_user?: ConnectSessionInput['end_user'] | undefined;
+      });
+
 export type PostConnectSessions = Endpoint<{
     Method: 'POST';
     Path: '/connect/sessions';
-    Body: ConnectSessionInput;
+    Body: PostConnectSessionsBody;
     Success: {
         data: {
             token: string;


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Allow tag-only connect sessions (creation, fetch, reconnect)**

Extends connect session handling so that new sessions (and reconnect sessions) can be created without supplying `end_user` data as long as top-level `tags` are present. The GET endpoint now returns nullable `endUser`, enforces a defensive guard that either an `endUser` or `tags` exist on the session, and type definitions plus integration coverage were updated to reflect the new payload union and nullable response.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced `bodySchemaWithTagsNoEndUser` in `packages/server/lib/controllers/connect/postSessions.ts` and routing logic that validates tag-only payloads before calling `generateSession`.
• Updated `packages/server/lib/controllers/connect/getSession.ts` to treat `endUser` as nullable, add a guard that rejects sessions lacking both `endUser` and `tags`, and return `endUser: null` when appropriate.
• Relaxed `packages/server/lib/controllers/connect/postReconnect.ts` so reconnect sessions no longer require `connection.end_user_id`, persisting `endUserId: null` when tags-only flows are used.
• Extended shared types in `packages/types/lib/connect/api.ts` with `PostConnectSessionsBody` union and nullable `ConnectSessionOutput['endUser']`.
• Added integration tests covering tag-only create, fetch, and reconnect scenarios (including empty tag objects) to ensure the new flows work end-to-end.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/server/lib/controllers/connect/postSessions.ts
• packages/server/lib/controllers/connect/getSession.ts
• packages/server/lib/controllers/connect/postReconnect.ts
• packages/types/lib/connect/api.ts
• connect session integration tests

</details>

---
*This summary was automatically generated by @propel-code-bot*