### PR TITLE
feat: add checkpoint support to functions-sdk

### DIFF
--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -43,7 +43,17 @@ exports[`buildModelTs > should return empty (with sdk) 1`] = `
 
 import type { Nango } from '@nangohq/node';
 import type { AxiosInstance, AxiosInterceptorManager, AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
-import type { ApiEndUser, DBSyncConfig, DBTeam, GetPublicConnection, GetPublicIntegration, HTTP_METHOD, RunnerFlags, PostPublicTrigger } from '@nangohq/types';
+import type {
+    ApiEndUser,
+    DBSyncConfig,
+    DBTeam,
+    GetPublicConnection,
+    GetPublicIntegration,
+    HTTP_METHOD,
+    RunnerFlags,
+    PostPublicTrigger,
+    Checkpoint
+} from '@nangohq/types';
 import type { ZodSchema, SafeParseSuccess } from 'zod';
 
 export declare const oldLevelToNewLevel: {
@@ -436,7 +446,7 @@ export declare class NangoAction {
     private sendLogToPersist;
     private logAPICall;
 }
-export declare class NangoSync extends NangoAction {
+export declare class NangoSync<TCheckpoint = Checkpoint> extends NangoAction {
     variant: string;
     lastSyncDate?: Date;
     track_deletes: boolean;
@@ -466,6 +476,9 @@ export declare class NangoSync extends NangoAction {
     setMergingStrategy(merging: { strategy: 'ignore_if_modified_after' | 'override' }, model: string): Promise<void>;
     deleteRecordsFromPreviousExecutions(model: string): Promise<{ deletedKeys: string[] }>;
     getRecordsByIds<K = string | number, T = any>(ids: K[], model: string): Promise<Map<K, T>>;
+    getCheckpoint(): Promise<TCheckpoint | null>;
+    saveCheckpoint(checkpoint: TCheckpoint): Promise<void>;
+    clearCheckpoint(): Promise<void>;
 }
 /**
  * @internal

--- a/packages/cli/lib/services/sdk.ts
+++ b/packages/cli/lib/services/sdk.ts
@@ -135,6 +135,22 @@ export class NangoActionCLI extends NangoActionBase {
         // Not applicable to CLI
     }
 
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public override async getCheckpoint(): Promise<null> {
+        // Not applicable to CLI
+        return null;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public override async saveCheckpoint(): Promise<void> {
+        // Not applicable to CLI
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public override async clearCheckpoint(): Promise<void> {
+        // Not applicable to CLI
+    }
+
     protected showLoggerLevelWarning = showLoggerLevelWarning();
 }
 
@@ -172,6 +188,9 @@ export class NangoSyncCLI extends NangoSyncBase {
     tryAcquireLock = NangoActionCLI['prototype']['tryAcquireLock'];
     releaseLock = NangoActionCLI['prototype']['releaseLock'];
     releaseAllLocks = NangoActionCLI['prototype']['releaseAllLocks'];
+    getCheckpoint = NangoActionCLI['prototype']['getCheckpoint'];
+    saveCheckpoint = NangoActionCLI['prototype']['saveCheckpoint'];
+    clearCheckpoint = NangoActionCLI['prototype']['clearCheckpoint'];
 
     protected showLoggerLevelWarning = showLoggerLevelWarning();
 

--- a/packages/cli/lib/services/sdk.ts
+++ b/packages/cli/lib/services/sdk.ts
@@ -136,9 +136,9 @@ export class NangoActionCLI extends NangoActionBase {
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await
-    public override async getCheckpoint(): Promise<null> {
+    public override async getCheckpoint<T = never>(): Promise<T> {
         // Not applicable to CLI
-        return null;
+        return null as T;
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await

--- a/packages/runner-sdk/lib/action.ts
+++ b/packages/runner-sdk/lib/action.ts
@@ -482,7 +482,7 @@ export abstract class NangoActionBase<
      * const checkpoint = await nango.getCheckpoint();
      * ```
      * */
-    public abstract getCheckpoint(): Promise<TCheckpointInferred | null>;
+    public abstract getCheckpoint<T = TCheckpointInferred>(): Promise<T>;
 
     /**
      * Save a checkpoint object that can be used to store progress or state to resume from.
@@ -496,7 +496,7 @@ export abstract class NangoActionBase<
      * });
      * ```
      * */
-    public abstract saveCheckpoint(checkpoint: TCheckpointInferred): Promise<void>;
+    public abstract saveCheckpoint<T = TCheckpointInferred>(checkpoint: T): Promise<void>;
 
     /**
      * Clear the function checkpoint

--- a/packages/runner-sdk/lib/action.ts
+++ b/packages/runner-sdk/lib/action.ts
@@ -482,7 +482,7 @@ export abstract class NangoActionBase<
      * const checkpoint = await nango.getCheckpoint();
      * ```
      * */
-    public abstract getCheckpoint<T = TCheckpointInferred>(): Promise<T>;
+    public abstract getCheckpoint(): Promise<TCheckpointInferred | null>;
 
     /**
      * Save a checkpoint object that can be used to store progress or state to resume from.
@@ -496,7 +496,7 @@ export abstract class NangoActionBase<
      * });
      * ```
      * */
-    public abstract saveCheckpoint<T = TCheckpointInferred>(checkpoint: T): Promise<void>;
+    public abstract saveCheckpoint(checkpoint: TCheckpointInferred): Promise<void>;
 
     /**
      * Clear the function checkpoint

--- a/packages/runner-sdk/lib/action.ts
+++ b/packages/runner-sdk/lib/action.ts
@@ -3,7 +3,7 @@ import { getProvider } from '@nangohq/providers';
 import { AbortedSDKError, ActionError, UnknownProviderSDKError } from './errors.js';
 import paginateService from './paginate.service.js';
 
-import type { ZodMetadata } from './types.js';
+import type { ZodCheckpoint, ZodMetadata } from './types.js';
 import type { Nango } from '@nangohq/node';
 import type {
     ApiKeyCredentials,
@@ -49,7 +49,9 @@ export type ProxyConfiguration = Omit<UserProvidedProxyConfiguration, 'files' | 
 
 export abstract class NangoActionBase<
     TMetadata extends ZodMetadata = never,
-    TMetadataInferred = TMetadata extends never ? never : z.infer<Exclude<TMetadata, undefined>>
+    TCheckpoint extends ZodCheckpoint = never,
+    TMetadataInferred = TMetadata extends never ? never : z.infer<Exclude<TMetadata, undefined>>,
+    TCheckpointInferred = TCheckpoint extends never ? never : z.infer<Exclude<TCheckpoint, undefined>>
 > {
     abstract nango: Nango;
     private attributes = {};
@@ -471,4 +473,33 @@ export abstract class NangoActionBase<
      * Release all locks acquired during the execution of a script.
      */
     public abstract releaseAllLocks(): Promise<void>;
+
+    /**
+     * Retrieve the last saved checkpoint
+     *
+     * @example
+     * ```typescript
+     * const checkpoint = await nango.getCheckpoint();
+     * ```
+     * */
+    public abstract getCheckpoint(): Promise<TCheckpointInferred | null>;
+
+    /**
+     * Save a checkpoint object that can be used to store progress or state to resume from.
+     *
+     * @example
+     * ```typescript
+     * await nango.saveCheckpoint({
+     *     lastProcessedPage: 5,
+     *     lastCursor: "abc123",
+     *     lastRunAt: new Date(),
+     * });
+     * ```
+     * */
+    public abstract saveCheckpoint(checkpoint: TCheckpointInferred): Promise<void>;
+
+    /**
+     * Clear the function checkpoint
+     **/
+    public abstract clearCheckpoint(): Promise<void>;
 }

--- a/packages/runner-sdk/lib/index.ts
+++ b/packages/runner-sdk/lib/index.ts
@@ -1,3 +1,4 @@
+export type { ZodCheckpoint } from './types.js';
 export * from './action.js';
 export * from './dataValidation.js';
 export * from './errors.js';

--- a/packages/runner-sdk/lib/scripts.ts
+++ b/packages/runner-sdk/lib/scripts.ts
@@ -114,7 +114,8 @@ export interface CreateSyncProps<TModels extends Record<string, ZodModel>, TMeta
 
     /**
      * The checkpoint schema for storing sync progress and resume state.
-     * Values must be primitives (string, number, boolean, or Date).
+     * Checkpoint must be an object with string, number, boolean, or Date values.
+     * Nested objects or arrays are not supported.
      *
      * @example
      * ```ts
@@ -275,7 +276,8 @@ export interface CreateActionProps<
 
     /**
      * The checkpoint schema for storing action progress and resume state.
-     * Values must be primitives (string, number, boolean, or Date).
+     * Checkpoint must be an object with string, number, boolean, or Date values.
+     * Nested objects or arrays are not supported.
      *
      * @example
      * ```ts
@@ -385,7 +387,8 @@ export interface CreateOnEventProps<TMetadata extends ZodMetadata = undefined, T
 
     /**
      * The checkpoint schema for storing OnEvent script progress and resume state.
-     * Values must be primitives (string, number, boolean, or Date).
+     * Checkpoint must be an object with string, number, boolean, or Date values.
+     * Nested objects or arrays are not supported.
      *
      * @example
      * ```ts

--- a/packages/runner-sdk/lib/sync.ts
+++ b/packages/runner-sdk/lib/sync.ts
@@ -2,7 +2,7 @@ import { NangoActionBase } from './action.js';
 import { validateData } from './dataValidation.js';
 
 import type { ValidateDataError } from './dataValidation.js';
-import type { RawModel, ZodMetadata, ZodModel } from './types.js';
+import type { RawModel, ZodCheckpoint, ZodMetadata, ZodModel } from './types.js';
 import type { MaybePromise, NangoProps } from '@nangohq/types';
 import type * as z from 'zod';
 
@@ -11,8 +11,9 @@ export const BASE_VARIANT = 'base';
 export abstract class NangoSyncBase<
     TModels extends Record<string, ZodModel> = never,
     TMetadata extends ZodMetadata = never,
+    TCheckpoint extends ZodCheckpoint = never,
     TModelName extends keyof TModels = keyof TModels
-> extends NangoActionBase<TMetadata> {
+> extends NangoActionBase<TMetadata, TCheckpoint> {
     public variant = BASE_VARIANT;
 
     lastSyncDate?: Date;

--- a/packages/runner-sdk/lib/types.ts
+++ b/packages/runner-sdk/lib/types.ts
@@ -2,6 +2,8 @@ import type * as z from 'zod';
 
 export type ZodMetadata = z.ZodObject | z.ZodVoid | undefined;
 
+export type ZodCheckpoint = z.ZodObject<Record<string, z.ZodString | z.ZodNumber | z.ZodBoolean | z.ZodDate>> | z.ZodVoid | undefined;
+
 export type ZodModel = z.ZodObject<{ id: z.ZodString }>;
 export interface RawModel {
     [key: string]: unknown;

--- a/packages/runner-sdk/lib/types.ts
+++ b/packages/runner-sdk/lib/types.ts
@@ -2,7 +2,7 @@ import type * as z from 'zod';
 
 export type ZodMetadata = z.ZodObject | z.ZodVoid | undefined;
 
-export type ZodCheckpoint = z.ZodObject<Record<string, z.ZodString | z.ZodNumber | z.ZodBoolean | z.ZodDate>> | z.ZodVoid | undefined;
+export type ZodCheckpoint = z.ZodObject<Record<string, z.ZodString | z.ZodNumber | z.ZodBoolean | z.ZodDate>> | undefined;
 
 export type ZodModel = z.ZodObject<{ id: z.ZodString }>;
 export interface RawModel {

--- a/packages/runner-sdk/models.d.ts
+++ b/packages/runner-sdk/models.d.ts
@@ -1,6 +1,16 @@
 import type { Nango } from '@nangohq/node';
 import type { AxiosInstance, AxiosInterceptorManager, AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
-import type { ApiEndUser, DBSyncConfig, DBTeam, GetPublicConnection, GetPublicIntegration, HTTP_METHOD, RunnerFlags, PostPublicTrigger } from '@nangohq/types';
+import type {
+    ApiEndUser,
+    DBSyncConfig,
+    DBTeam,
+    GetPublicConnection,
+    GetPublicIntegration,
+    HTTP_METHOD,
+    RunnerFlags,
+    PostPublicTrigger,
+    Checkpoint
+} from '@nangohq/types';
 import type { ZodSchema, SafeParseSuccess } from 'zod';
 
 export declare const oldLevelToNewLevel: {
@@ -393,7 +403,7 @@ export declare class NangoAction {
     private sendLogToPersist;
     private logAPICall;
 }
-export declare class NangoSync extends NangoAction {
+export declare class NangoSync<TCheckpoint = Checkpoint> extends NangoAction {
     variant: string;
     lastSyncDate?: Date;
     track_deletes: boolean;
@@ -423,6 +433,9 @@ export declare class NangoSync extends NangoAction {
     setMergingStrategy(merging: { strategy: 'ignore_if_modified_after' | 'override' }, model: string): Promise<void>;
     deleteRecordsFromPreviousExecutions(model: string): Promise<{ deletedKeys: string[] }>;
     getRecordsByIds<K = string | number, T = any>(ids: K[], model: string): Promise<Map<K, T>>;
+    getCheckpoint(): Promise<TCheckpoint | null>;
+    saveCheckpoint(checkpoint: TCheckpoint): Promise<void>;
+    clearCheckpoint(): Promise<void>;
 }
 /**
  * @internal

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -18,12 +18,12 @@ import { MapLocks } from './sdk/locks.js';
 import { NangoActionRunner, NangoSyncRunner, instrumentSDK } from './sdk/sdk.js';
 
 import type { Locks } from './sdk/locks.js';
-import type { CreateAnyResponse, NangoActionBase, NangoSyncBase } from '@nangohq/runner-sdk';
+import type { CreateAnyResponse } from '@nangohq/runner-sdk';
 import type { NangoProps, Result, RunnerOutput } from '@nangohq/types';
 
 interface ScriptExports {
-    onWebhookPayloadReceived?: (nango: NangoSyncBase, payload?: object) => Promise<unknown>;
-    default: ((nango: NangoActionBase, payload?: object) => Promise<unknown>) | CreateAnyResponse;
+    onWebhookPayloadReceived?: (nango: NangoSyncRunner, payload?: object) => Promise<unknown>;
+    default: ((nango: NangoActionRunner | NangoSyncRunner, payload?: object) => Promise<unknown>) | CreateAnyResponse;
 }
 
 function formatStackTrace(stack: string | undefined, filename: string): string[] {

--- a/packages/runner/lib/sdk/checkpointing.ts
+++ b/packages/runner/lib/sdk/checkpointing.ts
@@ -46,7 +46,7 @@ export class Checkpointing {
 
         if (!this.from) this.from = this.last;
 
-        return this.last.checkpoint;
+        return this.last.deletedAt ? null : this.last.checkpoint;
     }
 
     public async saveCheckpoint(checkpoint: Checkpoint): Promise<void> {

--- a/packages/runner/lib/sdk/checkpointing.ts
+++ b/packages/runner/lib/sdk/checkpointing.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+
+import type { PersistClient } from '../clients/persist.js';
+import type { Checkpoint } from '@nangohq/types';
+
+type CheckpointState = {
+    checkpoint: Checkpoint | null;
+    version: number;
+    deletedAt: string | null;
+} | null;
+
+export class Checkpointing {
+    private persistClient: PersistClient;
+    private environmentId: number;
+    private nangoConnectionId: number;
+    private key: string;
+
+    public from: CheckpointState = null; // checkpoint at first checkpointing call
+    public last: CheckpointState = null; // last saved checkpoint
+
+    constructor(props: { persistClient: PersistClient; environmentId: number; nangoConnectionId: number; key: string }) {
+        this.persistClient = props.persistClient;
+        this.environmentId = props.environmentId;
+        this.nangoConnectionId = props.nangoConnectionId;
+        this.key = props.key;
+    }
+
+    public async getCheckpoint(): Promise<Checkpoint | null> {
+        const res = await this.persistClient.getCheckpoint({
+            environmentId: this.environmentId,
+            nangoConnectionId: this.nangoConnectionId,
+            key: this.key
+        });
+
+        this.last = res.isErr()
+            ? {
+                  version: 1, // If no checkpoint, we initialize the version to 1 for optimistic locking on creation.
+                  checkpoint: null,
+                  deletedAt: null
+              }
+            : {
+                  checkpoint: validateCheckpoint(res.value.checkpoint),
+                  deletedAt: res.value.deletedAt,
+                  version: res.value.version
+              };
+
+        if (!this.from) this.from = this.last;
+
+        return this.last.checkpoint;
+    }
+
+    public async saveCheckpoint(checkpoint: Checkpoint): Promise<void> {
+        const { version } = await this.ensureVersion();
+
+        const res = await this.persistClient.putCheckpoint({
+            environmentId: this.environmentId,
+            nangoConnectionId: this.nangoConnectionId,
+            key: this.key,
+            checkpoint,
+            expectedVersion: version
+        });
+        if (res.isErr()) {
+            throw new Error(`Error saving checkpoint: ${res.error.message}`, { cause: res.error });
+        }
+        this.last = {
+            checkpoint: validateCheckpoint(res.value.checkpoint),
+            version: res.value.version,
+            deletedAt: null
+        };
+    }
+
+    public async clearCheckpoint(): Promise<void> {
+        const { version } = await this.ensureVersion();
+
+        const res = await this.persistClient.deleteCheckpoint({
+            environmentId: this.environmentId,
+            nangoConnectionId: this.nangoConnectionId,
+            key: this.key,
+            expectedVersion: version
+        });
+        if (res.isErr()) {
+            throw new Error(`Error deleting checkpoint: ${res.error.message}`, { cause: res.error });
+        }
+        this.last = null;
+    }
+
+    private async ensureVersion(): Promise<{ version: number }> {
+        // If we haven't loaded the checkpoint yet, load it to get the version for optimistic locking.
+        if (!this.last) {
+            await this.getCheckpoint();
+        }
+
+        if (!this.last?.version) {
+            throw new Error('Missing checkpoint version'); // defensive check - this should never happen
+        }
+
+        return { version: this.last.version };
+    }
+}
+
+/*
+ * The checkpoint can contain date strings.
+ * This function recursively checks the checkpoint object and converts any string that is a valid datetime to a Date object.
+ */
+function validateCheckpoint(checkpoint: Checkpoint): Checkpoint {
+    const validated: Checkpoint = {};
+    for (const [key, value] of Object.entries(checkpoint)) {
+        if (typeof value === 'string') {
+            const parsed = z.string().datetime().safeParse(value);
+            if (parsed.success) {
+                validated[key] = new Date(value);
+                continue;
+            }
+        }
+        validated[key] = value;
+    }
+    return validated;
+}

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -28,7 +28,7 @@ const HTTP_LOG_SAMPLE_PCT = envs.RUNNER_HTTP_LOG_SAMPLE_PCT; // set to empty to 
 /**
  * Action SDK
  */
-export class NangoActionRunner extends NangoActionBase<never, Record<string, string>> {
+export class NangoActionRunner extends NangoActionBase {
     nango: Nango;
     protected persistClient: PersistClient;
     protected locking: Locking;
@@ -268,6 +268,21 @@ export class NangoActionRunner extends NangoActionBase<never, Record<string, str
 
     public override async releaseAllLocks(): Promise<void> {
         return this.locking.releaseAllLocks();
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public override async getCheckpoint(): Promise<null> {
+        throw new Error('Method not implemented.');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public override async saveCheckpoint(): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public override async clearCheckpoint(): Promise<void> {
+        throw new Error('Method not implemented.');
     }
 }
 
@@ -533,6 +548,10 @@ export class NangoSyncRunner extends NangoSyncBase {
     public override async releaseAllLocks(): Promise<void> {
         return this.locking.releaseAllLocks();
     }
+
+    getCheckpoint = NangoActionRunner['prototype']['getCheckpoint'];
+    saveCheckpoint = NangoActionRunner['prototype']['saveCheckpoint'];
+    clearCheckpoint = NangoActionRunner['prototype']['clearCheckpoint'];
 }
 
 class Locking {

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -9,7 +9,7 @@ import { logger } from '../logger.js';
 
 import type { Locks } from './locks.js';
 import type { ProxyConfiguration } from '@nangohq/runner-sdk';
-import type { ApiPublicConnectionFull, MergingStrategy, MessageRowInsert, NangoProps, PostPublicTrigger, UserLogParameters } from '@nangohq/types';
+import type { ApiPublicConnectionFull, Checkpoint, MergingStrategy, MessageRowInsert, NangoProps, PostPublicTrigger, UserLogParameters } from '@nangohq/types';
 import type { AxiosResponse } from 'axios';
 
 export const oldLevelToNewLevel = {
@@ -271,18 +271,18 @@ export class NangoActionRunner extends NangoActionBase {
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await
-    public override async getCheckpoint(): Promise<null> {
-        throw new Error('Method not implemented.');
+    public override async getCheckpoint<T = Checkpoint>(): Promise<T> {
+        throw new Error('Not implemented yet');
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await
-    public override async saveCheckpoint(): Promise<void> {
-        throw new Error('Method not implemented.');
+    public override async saveCheckpoint<T = Checkpoint>(_checkpoint: T): Promise<void> {
+        throw new Error('Not implemented yet');
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await
     public override async clearCheckpoint(): Promise<void> {
-        throw new Error('Method not implemented.');
+        throw new Error('Not implemented yet');
     }
 }
 

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -1,7 +1,17 @@
 import { Nango } from '@nangohq/node';
 import { NangoActionBase, NangoSyncBase } from '@nangohq/runner-sdk';
 import { ProxyRequest, getProxyConfiguration } from '@nangohq/shared';
-import { MAX_LOG_PAYLOAD, isTest, metrics, redactHeaders, redactURL, stringifyAndTruncateValue, stringifyObject, truncateJson } from '@nangohq/utils';
+import {
+    MAX_LOG_PAYLOAD,
+    getCheckpointKey,
+    isTest,
+    metrics,
+    redactHeaders,
+    redactURL,
+    stringifyAndTruncateValue,
+    stringifyObject,
+    truncateJson
+} from '@nangohq/utils';
 
 import { Checkpointing } from './checkpointing.js';
 import { PersistClient } from '../clients/persist.js';
@@ -69,7 +79,7 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
             persistClient: this.persistClient,
             environmentId: this.environmentId,
             nangoConnectionId: this.nangoConnectionId,
-            key: `${this.scriptType}:${this.syncConfig.sync_name}`
+            key: getCheckpointKey({ type: this.scriptType, name: this.syncConfig.sync_name })
         });
     }
 
@@ -339,7 +349,7 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
             persistClient: this.persistClient,
             environmentId: this.environmentId,
             nangoConnectionId: this.nangoConnectionId,
-            key: `${this.scriptType}:${this.syncConfig.sync_name}:${this.variant}`
+            key: getCheckpointKey({ type: this.scriptType, name: this.syncConfig.sync_name, variant: this.variant })
         });
     }
 

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -3,12 +3,13 @@ import { NangoActionBase, NangoSyncBase } from '@nangohq/runner-sdk';
 import { ProxyRequest, getProxyConfiguration } from '@nangohq/shared';
 import { MAX_LOG_PAYLOAD, isTest, metrics, redactHeaders, redactURL, stringifyAndTruncateValue, stringifyObject, truncateJson } from '@nangohq/utils';
 
+import { Checkpointing } from './checkpointing.js';
 import { PersistClient } from '../clients/persist.js';
 import { envs } from '../env.js';
 import { logger } from '../logger.js';
 
 import type { Locks } from './locks.js';
-import type { ProxyConfiguration } from '@nangohq/runner-sdk';
+import type { ProxyConfiguration, ZodCheckpoint } from '@nangohq/runner-sdk';
 import type { ApiPublicConnectionFull, Checkpoint, MergingStrategy, MessageRowInsert, NangoProps, PostPublicTrigger, UserLogParameters } from '@nangohq/types';
 import type { AxiosResponse } from 'axios';
 
@@ -28,16 +29,15 @@ const HTTP_LOG_SAMPLE_PCT = envs.RUNNER_HTTP_LOG_SAMPLE_PCT; // set to empty to 
 /**
  * Action SDK
  */
-export class NangoActionRunner extends NangoActionBase {
+export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
     nango: Nango;
     protected persistClient: PersistClient;
     protected locking: Locking;
+    protected checkpointing: Checkpointing;
     protected httpLogSample: number = 0;
 
     constructor(props: NangoProps, runnerProps: { persistClient?: PersistClient; locks: Locks }) {
         super(props);
-        this.persistClient = runnerProps?.persistClient || new PersistClient({ secretKey: props.secretKey });
-        this.locking = new Locking({ locks: runnerProps.locks, owner: this.activityLogId });
 
         this.nango = new Nango(
             {
@@ -62,6 +62,15 @@ export class NangoActionRunner extends NangoActionBase {
         if (!this.environmentId) throw new Error('Parameter environmentId is required');
         if (!this.nangoConnectionId) throw new Error('Parameter nangoConnectionId is required');
         if (!this.syncConfig) throw new Error('Parameter syncConfig is required');
+
+        this.persistClient = runnerProps?.persistClient || new PersistClient({ secretKey: props.secretKey });
+        this.locking = new Locking({ locks: runnerProps.locks, owner: this.activityLogId });
+        this.checkpointing = new Checkpointing({
+            persistClient: this.persistClient,
+            environmentId: this.environmentId,
+            nangoConnectionId: this.nangoConnectionId,
+            key: `${this.scriptType}:${this.syncConfig.sync_name}`
+        });
     }
 
     public override async proxy<T = any>(config: ProxyConfiguration): Promise<AxiosResponse<T>> {
@@ -270,30 +279,28 @@ export class NangoActionRunner extends NangoActionBase {
         return this.locking.releaseAllLocks();
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    public override async getCheckpoint<T = Checkpoint>(): Promise<T> {
-        throw new Error('Not implemented yet');
+    public override async getCheckpoint(): Promise<Checkpoint | null> {
+        return this.checkpointing.getCheckpoint();
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    public override async saveCheckpoint<T = Checkpoint>(_checkpoint: T): Promise<void> {
-        throw new Error('Not implemented yet');
+    public override async saveCheckpoint(checkpoint: Checkpoint): Promise<void> {
+        return this.checkpointing.saveCheckpoint(checkpoint);
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     public override async clearCheckpoint(): Promise<void> {
-        throw new Error('Not implemented yet');
+        return this.checkpointing.clearCheckpoint();
     }
 }
 
 /**
  * Sync SDK
  */
-export class NangoSyncRunner extends NangoSyncBase {
+export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> {
     nango: Nango;
 
     protected persistClient: PersistClient;
     protected locking: Locking;
+    protected checkpointing: Checkpointing;
     private batchSize = 1000;
     private getRecordsBatchSize = 100;
     private mergingByModel = new Map<string, MergingStrategy>();
@@ -301,9 +308,6 @@ export class NangoSyncRunner extends NangoSyncBase {
 
     constructor(props: NangoProps, runnerProps: { persistClient?: PersistClient; locks: Locks }) {
         super(props);
-
-        this.persistClient = runnerProps?.persistClient || new PersistClient({ secretKey: props.secretKey });
-        this.locking = new Locking({ locks: runnerProps.locks, owner: this.activityLogId });
 
         this.nango = new Nango(
             {
@@ -324,8 +328,19 @@ export class NangoSyncRunner extends NangoSyncBase {
             }
         );
 
+        if (!this.syncConfig) throw new Error('Parameter syncConfig is required');
         if (!this.syncId) throw new Error('Parameter syncId is required');
         if (!this.syncJobId) throw new Error('Parameter syncJobId is required');
+        if (!this.nangoConnectionId) throw new Error('Parameter nangoConnectionId is required');
+
+        this.persistClient = runnerProps?.persistClient || new PersistClient({ secretKey: props.secretKey });
+        this.locking = new Locking({ locks: runnerProps.locks, owner: this.activityLogId });
+        this.checkpointing = new Checkpointing({
+            persistClient: this.persistClient,
+            environmentId: this.environmentId,
+            nangoConnectionId: this.nangoConnectionId,
+            key: `${this.scriptType}:${this.syncConfig.sync_name}:${this.variant}`
+        });
     }
 
     // Can't double extends
@@ -549,9 +564,17 @@ export class NangoSyncRunner extends NangoSyncBase {
         return this.locking.releaseAllLocks();
     }
 
-    getCheckpoint = NangoActionRunner['prototype']['getCheckpoint'];
-    saveCheckpoint = NangoActionRunner['prototype']['saveCheckpoint'];
-    clearCheckpoint = NangoActionRunner['prototype']['clearCheckpoint'];
+    public override async getCheckpoint(): Promise<Checkpoint | null> {
+        return this.checkpointing.getCheckpoint();
+    }
+
+    public override async saveCheckpoint(checkpoint: Checkpoint): Promise<void> {
+        return this.checkpointing.saveCheckpoint(checkpoint);
+    }
+
+    public override async clearCheckpoint(): Promise<void> {
+        return this.checkpointing.clearCheckpoint();
+    }
 }
 
 class Locking {
@@ -603,7 +626,10 @@ const TELEMETRY_ALLOWED_METHODS: (keyof NangoSyncBase)[] = [
     'log',
     'triggerAction',
     'triggerSync',
-    'startSync'
+    'startSync',
+    'getCheckpoint',
+    'saveCheckpoint',
+    'clearCheckpoint'
 ];
 
 /**
@@ -612,7 +638,7 @@ const TELEMETRY_ALLOWED_METHODS: (keyof NangoSyncBase)[] = [
  * This function will enable tracing on the SDK
  * It has been split from the actual code to avoid making the code too dirty and to easily enable/disable tracing if there is an issue with it
  */
-export function instrumentSDK(rawNango: NangoActionBase | NangoSyncBase) {
+export function instrumentSDK(rawNango: NangoActionRunner | NangoSyncRunner) {
     return new Proxy(rawNango, {
         get<T extends typeof rawNango, K extends keyof typeof rawNango>(target: T, propKey: K) {
             // Method name is not matching the allowList we don't do anything else

--- a/packages/runner/lib/sdk/sdk.unit.test.ts
+++ b/packages/runner/lib/sdk/sdk.unit.test.ts
@@ -91,7 +91,7 @@ describe('cache', () => {
 
         it('setMetadata should invalidate connection', async () => {
             await nangoAction.getConnection();
-            await nangoAction.setMetadata({});
+            await nangoAction.setMetadata({} as never);
             await nangoAction.getConnection();
             await nangoAction.getMetadata();
             expect(nango.getConnection).toHaveBeenCalledTimes(2);

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -128,6 +128,7 @@ class SyncController {
             const result = await orchestrator.runSyncCommand({
                 connectionId: connection.id,
                 syncId: sync_id,
+                syncName: sync_name,
                 syncVariant: sync_variant,
                 command,
                 environmentId: environment.id,

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -303,6 +303,7 @@ export class SyncManagerService {
                 await orchestrator.runSyncCommand({
                     connectionId: connection.id,
                     syncId: sync.id,
+                    syncName: sync.name,
                     syncVariant: sync.variant,
                     command,
                     environmentId: environment.id,
@@ -330,6 +331,7 @@ export class SyncManagerService {
                 await orchestrator.runSyncCommand({
                     connectionId: connection.id,
                     syncId: sync.id,
+                    syncName: sync.name,
                     syncVariant: sync.variant,
                     command,
                     environmentId: environment.id,

--- a/packages/utils/lib/checkpoint/checkpoint.ts
+++ b/packages/utils/lib/checkpoint/checkpoint.ts
@@ -1,0 +1,3 @@
+export function getCheckpointKey(opts: { type: 'sync' | 'webhook' | 'action' | 'on-event'; name: string; variant?: string | undefined }) {
+    return `${opts.type}:${opts.name}${opts.variant ? `:${opts.variant}` : ''}`;
+}

--- a/packages/utils/lib/index.ts
+++ b/packages/utils/lib/index.ts
@@ -27,3 +27,4 @@ export * from './date.js';
 export * from './frequency.js';
 export * from './map.js';
 export * from './daemon.js';
+export * from './checkpoint/checkpoint.js';


### PR DESCRIPTION
To be used as follow when writing a function. Similar to the metadata one where the shape of the checkpoint is defined as a zod type which is enforced by the compiler when calling `getCheckpoint/saveCheckpoint`. 
Ex:
```ts
const sync = createSync({
    description: 'My super sync',
    ...
    checkpoint: z.object({
        lastPage: z.number(),
    }),
    exec: async (nango) => {
        const cp = await nango.getCheckpoint();
        for (const entries of nango.paginate({ endpoint: `/entries?page=${cp ? cp.lastPage : 0}` })) {
            const records = ... // process entries
            await nango.batchSave(records, 'MyModel');
            await nango.saveCheckpoint({ lastPage: entries.data.page, });
        }
   ...
}

```

Note: internals are not implemented yet. The objective of this PR is to settle on the interface cc @bastienbeurier 
<!-- Summary by @propel-code-bot -->

---

**Add typed checkpoint support to Functions SDK & runner persistence**

This PR introduces first-class, typed checkpoint support across the Functions SDK, runner, CLI, and orchestration layers. Script factories (`createSync`, `createAction`, `createOnEvent`) now accept a `checkpoint` zod schema whose inferred type flows through `NangoActionBase`/`NangoSyncBase`, exposing strongly-typed `getCheckpoint`, `saveCheckpoint`, and `clearCheckpoint` helpers. On the runner side, a new `Checkpointing` helper coordinates per-connection persistence with optimistic locking, while orchestrator flows clear checkpoints on full re-runs and the CLI stubs the API for dry-run scenarios.

Backend services and utilities were updated to validate checkpoint payloads, support forced deletions, expose checkpoint key helpers, and include telemetry/reporting updates. Type declarations, snapshots, and unit tests were refreshed to reflect the expanded generics and API surface.

<details>
<summary><strong>Key Changes</strong></summary>

• Extended `createSync`/`createAction`/`createOnEvent` props to accept `checkpoint` schemas and thread the generic into `NangoActionBase`/`NangoSyncBase`, adding typed checkpoint methods and docstrings.
• Implemented `packages/runner/lib/sdk/checkpointing.ts` with optimistic locking, checkpoint validation, and state tracking, wiring it into `NangoActionRunner`/`NangoSyncRunner` plus telemetry allowlists.
• Updated persistence services (`deleteCheckpoint`, tests) to allow forced soft-deletes, validate payload shapes, and expose `getCheckpointKey` via `@nangohq/utils` for consistent key generation.
• Orchestrator `runSyncCommand` now clears checkpoints during `RUN_FULL`, and CLI dry-run SDKs stub checkpoint methods to maintain API compatibility.
• Regenerated SDK type declarations and CLI snapshots to include the new generics and methods.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/runner-sdk/lib/scripts.ts`
• `packages/runner-sdk/lib/action.ts`
• `packages/runner-sdk/lib/sync.ts`
• `packages/runner/lib/sdk/checkpointing.ts`
• `packages/runner/lib/sdk/sdk.ts`
• `packages/shared/lib/services/checkpoints/*`
• `packages/utils/lib/checkpoint/checkpoint.ts`
• `packages/shared/lib/clients/orchestrator.ts`
• `packages/cli/lib/services/sdk.ts`
• `packages/runner-sdk/models.d.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*