### PR TITLE
style: Fix env settings responsiveness

### DIFF
--- a/packages/webapp/src/pages/Environment/Settings/Show.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Show.tsx
@@ -46,7 +46,7 @@ export const EnvironmentSettings: React.FC = () => {
                     </div>
                 </div>
                 <div className="flex gap-6 h-[280px]">
-                    <Skeleton className="w-[209px] 4xl:w-[236px]" />
+                    <Skeleton className="w-[209px]" />
                     <Skeleton className="h-full w-full" />
                 </div>
             </DashboardLayout>
@@ -55,13 +55,13 @@ export const EnvironmentSettings: React.FC = () => {
     const canSeeDeprecatedAuthorization = new Date(team.created_at) <= new Date('2025-08-25');
 
     return (
-        <DashboardLayout fullWidth className="flex-col justify-center 4xl:px-51">
+        <DashboardLayout fullWidth className="flex-col justify-center">
             <Helmet>
                 <title>Environment Settings - Nango</title>
             </Helmet>
 
             <div className="flex mb-8 justify-center">
-                <div className="flex text-left text-3xl tracking-tight text-white w-[1153px] 4xl:w-full gap-2.5">
+                <div className="flex text-left text-3xl tracking-tight text-white w-[1153px] gap-2.5">
                     <h2 className="font-semibold">Environment Settings</h2>
                     <Badge size="custom" className="px-3.5 text-title-group">
                         {env}
@@ -69,8 +69,8 @@ export const EnvironmentSettings: React.FC = () => {
                 </div>
             </div>
             <div className="flex h-fit justify-center" key={env}>
-                <Navigation value={activeTab} onValueChange={setActiveTab} className="max-w-[1153px] mx-auto 4xl:max-w-full">
-                    <NavigationList className="w-[209px] 4xl:w-[236px]">
+                <Navigation value={activeTab} onValueChange={setActiveTab} className="max-w-[1153px] mx-auto">
+                    <NavigationList className="w-[209px]">
                         <NavigationTrigger value="general">General</NavigationTrigger>
                         <NavigationTrigger value="backend">Backend</NavigationTrigger>
                         <NavigationTrigger value="connect-ui">Connect UI</NavigationTrigger>


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
The responsive system we implemented for the environment settings doesn't work on ultrawide screens (e.g. 2560x1440). I reduced the responsiveness past a certain screen size, there is just not enough content on the page to go full-width at those sizes.

Before:
<img width="2335" height="1243" alt="image" src="https://github.com/user-attachments/assets/3c61e3d8-fe1d-41c7-bc98-065df59cfed6" />

After:
<img width="1170" height="379" alt="image" src="https://github.com/user-attachments/assets/66e1ca45-30cd-4df7-a927-bc0499786074" />

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

Removing the 4xl utility overrides keeps the Environment Settings layout, header, navigation, and skeletons clamped to their intended widths—roughly a 1153px content area with a fixed 209px sidebar—so the page no longer stretches beyond the layout’s intended bounds on ultra-wide displays.

<details>
<summary><strong>Key Changes</strong></summary>

• Dropped `4xl:px-51`, `4xl:w-full`, and `4xl:max-w-full` classes from `DashboardLayout`, header container, and `Navigation` to maintain the 1153px clamp
• Removed `4xl:w-[236px]` overrides from `NavigationList` and loading `Skeleton`, keeping the sidebar at `w-[209px]` across breakpoints

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/webapp/src/pages/Environment/Settings/Show.tsx`

</details>

---
*This summary was automatically generated by @propel-code-bot*