### PR TITLE
fix: fix create shared credentials

### DIFF
--- a/packages/shared/lib/seeders/config.seeder.ts
+++ b/packages/shared/lib/seeders/config.seeder.ts
@@ -124,10 +124,6 @@ export async function createSharedCredentialsSeed(providerName: string): Promise
             credentials
         })
         .into('providers_shared_credentials')
-        .onConflict('name')
-        .merge({
-            credentials
-        })
         .returning('*');
 
     const sharedCredentials = sharedCredentialsResult[0];

--- a/packages/shared/lib/services/shared-credentials.service.ts
+++ b/packages/shared/lib/services/shared-credentials.service.ts
@@ -148,8 +148,6 @@ class SharedCredentialsService {
                     credentials: configToInsert
                 })
                 .into<DBSharedCredentials>('providers_shared_credentials')
-                .onConflict('name')
-                .ignore()
                 .returning('*');
         } catch (err) {
             return Err(new Error('failed_to_create_shared_credentials', { cause: err }));


### PR DESCRIPTION
## Describe the problem and your solution

- Since the unique constraint was removed from the table, this pr updates the related queries to handle that change correctly.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Align shared credential inserts with removed uniqueness constraint**

The PR removes use of `onConflict` when inserting into `providers_shared_credentials` in both the config seeder and shared credentials service so that inserts succeed now that the `name` column no longer has a uniqueness constraint. Inserts now simply return the created rows without attempting to merge or ignore conflicts.

<details>
<summary><strong>Key Changes</strong></summary>

• Stopped calling `onConflict('name').merge()` in `packages/shared/lib/seeders/config.seeder.ts` when seeding shared credentials.
• Removed `onConflict('name').ignore()` in `packages/shared/lib/services/shared-credentials.service.ts` when creating shared credentials via the service.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/shared/lib/seeders/config.seeder.ts
• packages/shared/lib/services/shared-credentials.service.ts

</details>

---
*This summary was automatically generated by @propel-code-bot*