### PR TITLE
docs: Fix rate limit number in docs

### DIFF
--- a/docs/guides/platform/limits.mdx
+++ b/docs/guides/platform/limits.mdx
@@ -18,7 +18,7 @@ Rate limits apply to API requests from your application to Nango:
 | - | - |
 | Free tier | 200 |
 | Starter | 1,000 |
-| Growth | 5,000 |
+| Growth | 2,000 |
 | Enterprise | Custom |
 
 <Info>


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Growth tier rate limit corrected in docs**

Updates `docs/guides/platform/limits.mdx` so the API rate limit table reflects the current Growth plan quota of 2,000 requests per minute instead of the outdated 5,000 figure. No other sections or files are modified.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `docs/guides/platform/limits.mdx` to change the Growth plan rate limit from 5,000 to 2,000 requests per minute.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• docs/guides/platform/limits.mdx

</details>

---
*This summary was automatically generated by @propel-code-bot*