### PR TITLE
fix jira webhook routing paths

### DIFF
--- a/packages/server/lib/webhook/jira-webhook-routing.ts
+++ b/packages/server/lib/webhook/jira-webhook-routing.ts
@@ -8,8 +8,8 @@ const route: WebhookHandler = async (nango, _headers, body) => {
         for (const event of body) {
             const response = await nango.executeScriptForWebhooks({
                 body: event,
-                webhookType: 'payload.webhookEvent',
-                connectionIdentifier: 'payload.user.accountId',
+                webhookType: 'webhookEvent',
+                connectionIdentifier: 'user.accountId',
                 propName: 'accountId'
             });
             if (response && response.connectionIds?.length > 0) {
@@ -25,8 +25,8 @@ const route: WebhookHandler = async (nango, _headers, body) => {
     } else {
         const response = await nango.executeScriptForWebhooks({
             body,
-            webhookType: 'payload.webhookEvent',
-            connectionIdentifier: 'payload.user.accountId',
+            webhookType: 'webhookEvent',
+            connectionIdentifier: 'user.accountId',
             propName: 'accountId'
         });
         return Ok({

--- a/packages/server/lib/webhook/jira-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/jira-webhook-routing.unit.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import route from './jira-webhook-routing.js';
+
+import type { InternalNango } from './internal-nango.js';
+
+function createNangoMock() {
+    const mock = vi.fn();
+    const nango = { executeScriptForWebhooks: mock } as unknown as InternalNango;
+    return { nango, mock };
+}
+
+describe('Jira webhook routing', () => {
+    it('Should pass correct paths for a single payload', async () => {
+        const { nango, mock } = createNangoMock();
+        mock.mockResolvedValue({ connectionIds: ['conn-1'], connectionMetadata: {} });
+
+        const body = {
+            webhookEvent: 'jira:issue_updated',
+            user: { accountId: 'abc-123', displayName: 'Test' },
+            issue: { key: 'PROJ-1' }
+        };
+
+        const result = await route(nango, {}, body, '');
+
+        expect(mock).toHaveBeenCalledTimes(1);
+        expect(mock).toHaveBeenCalledWith({
+            body,
+            webhookType: 'webhookEvent',
+            connectionIdentifier: 'user.accountId',
+            propName: 'accountId'
+        });
+        expect(result.isOk()).toBe(true);
+        const value = result.unwrap();
+        expect('connectionIds' in value && value.connectionIds).toEqual(['conn-1']);
+    });
+
+    it('Should handle array payloads and aggregate connectionIds', async () => {
+        const { nango, mock } = createNangoMock();
+        mock.mockResolvedValueOnce({ connectionIds: ['conn-1'], connectionMetadata: {} }).mockResolvedValueOnce({
+            connectionIds: ['conn-2'],
+            connectionMetadata: {}
+        });
+
+        const body = [
+            { webhookEvent: 'jira:issue_created', user: { accountId: 'abc-1' } },
+            { webhookEvent: 'jira:issue_updated', user: { accountId: 'abc-2' } }
+        ];
+
+        const result = await route(nango, {}, body, '');
+
+        expect(mock).toHaveBeenCalledTimes(2);
+        expect(mock).toHaveBeenNthCalledWith(1, {
+            body: body[0],
+            webhookType: 'webhookEvent',
+            connectionIdentifier: 'user.accountId',
+            propName: 'accountId'
+        });
+        expect(mock).toHaveBeenNthCalledWith(2, {
+            body: body[1],
+            webhookType: 'webhookEvent',
+            connectionIdentifier: 'user.accountId',
+            propName: 'accountId'
+        });
+        expect(result.isOk()).toBe(true);
+        const value = result.unwrap();
+        expect('connectionIds' in value && value.connectionIds).toEqual(['conn-1', 'conn-2']);
+    });
+
+    it('Should return empty connectionIds when executeScriptForWebhooks returns null', async () => {
+        const { nango, mock } = createNangoMock();
+        mock.mockResolvedValue(null);
+
+        const body = { webhookEvent: 'jira:issue_deleted', user: { accountId: 'abc-1' } };
+        const result = await route(nango, {}, body, '');
+
+        expect(result.isOk()).toBe(true);
+        const value = result.unwrap();
+        expect('connectionIds' in value && value.connectionIds).toEqual([]);
+    });
+
+    it('Should skip events with empty connectionIds in array payload', async () => {
+        const { nango, mock } = createNangoMock();
+        mock.mockResolvedValueOnce({ connectionIds: ['conn-1'], connectionMetadata: {} })
+            .mockResolvedValueOnce({ connectionIds: [], connectionMetadata: {} })
+            .mockResolvedValueOnce({ connectionIds: ['conn-3'], connectionMetadata: {} });
+
+        const body = [
+            { webhookEvent: 'jira:issue_created', user: { accountId: 'abc-1' } },
+            { webhookEvent: 'jira:issue_updated', user: { accountId: 'abc-2' } },
+            { webhookEvent: 'jira:issue_deleted', user: { accountId: 'abc-3' } }
+        ];
+
+        const result = await route(nango, {}, body, '');
+
+        expect(mock).toHaveBeenCalledTimes(3);
+        const value = result.unwrap();
+        expect('connectionIds' in value && value.connectionIds).toEqual(['conn-1', 'conn-3']);
+    });
+
+    it('Should return empty connectionIds for empty array payload', async () => {
+        const { nango, mock } = createNangoMock();
+
+        const result = await route(nango, {}, [], '');
+
+        expect(mock).not.toHaveBeenCalled();
+        const value = result.unwrap();
+        expect('connectionIds' in value && value.connectionIds).toEqual([]);
+    });
+});


### PR DESCRIPTION
fixes #5400

fixed jira webhook routing passing incorrect lodash `get()` paths (`payload.webhookEvent`, `payload.user.accountId`) that caused connection matching to fail. the `payload.` prefix was wrong since jira sends `webhookEvent` and `user.accountId` at the root level. added unit tests covering both single and array payloads plus edge cases.

- removed incorrect `payload.` prefix from `webhookType` and `connectionIdentifier` paths in both array and single-payload branches
- added unit tests for single payload, array payload aggregation, null responses, partial empty responses, and empty array input

<!-- Summary by @propel-code-bot -->

---

Adds vitest coverage to lock in correct routing behavior for both single and batched Jira payloads, even when null or empty responses are returned.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/webhook/jira-webhook-routing.ts`
• `packages/server/lib/webhook/jira-webhook-routing.unit.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*