### PR TITLE
feat(integrations): add support for campfire via simple api key

### DIFF
--- a/docs/api-integrations/campfire.mdx
+++ b/docs/api-integrations/campfire.mdx
@@ -1,0 +1,79 @@
+---
+title: 'Campfire'
+sidebarTitle: 'Campfire'
+description: 'Integrate your application with the Campfire API'
+---
+
+## Quickstart
+
+Connect to Campfire with Nango and see data flow in 2 minutes.
+
+<Steps>
+    <Step title="Create the integration">
+    In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Campfire_.
+    </Step>
+    <Step title="Authorize Campfire">
+    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then enter your API key. Later, you'll let your users do the same directly from your app.
+    </Step>
+    <Step title="Call the Campfire API">
+    Let's make your first request to the Campfire API. Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+    <Tabs>
+        <Tab title="cURL">
+
+            ```bash
+            curl "https://api.nango.dev/proxy/v1/accounts" \
+              -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+              -H "Provider-Config-Key: <INTEGRATION-ID>" \
+              -H "Connection-Id: <CONNECTION-ID>"
+            ```
+
+        </Tab>
+
+        <Tab title="Node">
+
+        Install Nango's backend SDK with `npm i @nangohq/node`. Then run:
+
+        ```typescript
+        import { Nango } from '@nangohq/node';
+
+        const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+
+        const res = await nango.get({
+            endpoint: '/v1/accounts',
+            providerConfigKey: '<INTEGRATION-ID>',
+            connectionId: '<CONNECTION-ID>'
+        });
+
+        console.log(res.data);
+        ```
+        </Tab>
+
+    </Tabs>
+    Or fetch credentials with the [Node SDK](/reference/sdks/node#get-a-connection-with-credentials) or [API](/reference/api/connection/get).
+
+    You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+    </Step>
+
+    <Step title="Implement Nango in your app">
+        Follow our [Auth implementation guide](/implementation-guides/platform/auth/implement-api-auth) to integrate Nango in your app.
+
+        To obtain your own production credentials, follow the setup guide linked below.
+    </Step>
+</Steps>
+
+## Campfire Integration Guides
+
+Nango-maintained guides for common use cases.
+
+- [How to obtain your Campfire API key](/api-integrations/campfire/connect)
+Get your Campfire API key to connect it to Nango
+
+## Pre-built syncs & actions for Campfire
+
+Enable them in your dashboard. [Extend and customize](/implementation-guides/platform/functions/customize-template) to fit your needs.
+
+import PreBuiltUseCases from "/snippets/generated/campfire/PreBuiltUseCases.mdx"
+
+<PreBuiltUseCases />
+
+---

--- a/docs/api-integrations/campfire/connect.mdx
+++ b/docs/api-integrations/campfire/connect.mdx
@@ -1,0 +1,35 @@
+---
+title: Campfire - How do I link my account?
+sidebarTitle: Campfire
+---
+
+# Overview
+
+To authenticate with Campfire, you will need:
+1. **API Key** - Your Campfire API key for authentication.
+
+This guide will walk you through generating your **API key** in Campfire.
+
+### Prerequisites
+
+- You must have a registered Campfire account with API access enabled.
+
+### Instructions
+
+#### Step 1: Generating your Campfire API key
+
+1. Sign in to your [Campfire](https://www.meetcampfire.com/) account.
+2. Navigate to your account **Settings**.
+3. Select the **API** or **Integrations** section.
+4. Click **Generate API Key** or copy your existing API key.
+
+For detailed instructions, refer to the [Campfire API documentation](https://docs.campfire.ai).
+
+#### Step 2: Enter credentials in the Connect UI
+
+Once you have your **API Key**:
+1. Open the form where you need to authenticate with Campfire.
+2. Enter your **API Key** in the respective field.
+3. Submit the form, and you should be successfully authenticated.
+
+You are now connected to Campfire.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -298,6 +298,7 @@
               "api-integrations/cal-com-oauth",
               "api-integrations/calendly",
               "integrations/all/callrail",
+              "api-integrations/campfire",
               "integrations/all/canny",
               "integrations/all/canva",
               "api-integrations/canvas-lms",

--- a/docs/snippets/generated/campfire/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/campfire/PreBuiltUseCases.mdx
@@ -1,0 +1,3 @@
+_No pre-built syncs or actions available yet._
+
+<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -2837,6 +2837,22 @@ callrail:
             doc_section: '#step-1-finding-your-api-key'
     docs: https://nango.dev/docs/integrations/all/callrail
 
+campfire:
+    display_name: Campfire
+    categories:
+        - accounting
+    auth_mode: API_KEY
+    proxy:
+      base_url: https://api.meetcampfire.com
+      headers:
+        Authorization: Token ${apiKey}
+    credentials:
+      apiKey:
+        type: string
+        title: API Key
+        description: "The API key for your Campfire account"
+    docs: https://docs.campfire.ai
+
 canny:
     display_name: Canny
     categories:


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

We would like to integrate with Campfire.ai, which uses API Keys for auth. 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Campfire API-key integration and docs**

Introduces a new `campfire` provider that proxies requests to `https://api.meetcampfire.com` using a user-supplied API key and categorizes it under `accounting`. Companion documentation includes a main integration guide, a Connect walkthrough, and a placeholder snippet for pre-built syncs, along with an update to `docs/docs.json` so the new page appears in navigation.

<details>
<summary><strong>Key Changes</strong></summary>

• Registered the `campfire` provider in `packages/providers/providers.yaml` with API-key auth, proxy base URL, and credential schema.
• Added `docs/api-integrations/campfire.mdx` and `docs/api-integrations/campfire/connect.mdx` detailing setup, quickstart, and credential acquisition.
• Published `docs/snippets/generated/campfire/PreBuiltUseCases.mdx` placeholder and linked the integration within `docs/docs.json` navigation.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/providers/providers.yaml`
• `docs/api-integrations/campfire.mdx`
• `docs/api-integrations/campfire/connect.mdx`
• `docs/snippets/generated/campfire/PreBuiltUseCases.mdx`
• `docs/docs.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*