### PR TITLE
fix(persist): accept `externalIds` as an object in getRecords

### DIFF
--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/validate.unit.test.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/validate.unit.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { getRecordsRequestParser } from './validate.js';
+
+describe('getRecordsRequestParser.parseQuery', () => {
+    const baseQuery = { model: 'foo' };
+
+    it('accepts externalIds as array of strings (normal case)', () => {
+        const query = { ...baseQuery, externalIds: ['23591406', '23658002', '23897742'] };
+        const result = getRecordsRequestParser.parseQuery(query);
+        expect(result.model).toBe('foo');
+        expect(result.externalIds).toEqual(['23591406', '23658002', '23897742']);
+    });
+
+    it('accepts externalIds as single string', () => {
+        const query = { ...baseQuery, externalIds: '23591406' };
+        const result = getRecordsRequestParser.parseQuery(query);
+        expect(result.externalIds).toEqual(['23591406']);
+    });
+
+    it('accepts query without externalIds (optional)', () => {
+        const result = getRecordsRequestParser.parseQuery(baseQuery);
+        expect(result.externalIds).toBeUndefined();
+    });
+
+    it('accepts externalIds as empty array (unchanged)', () => {
+        const query = { ...baseQuery, externalIds: [] };
+        const result = getRecordsRequestParser.parseQuery(query);
+        expect(result.externalIds).toEqual([]);
+    });
+
+    it('fails when externalIds is empty string', () => {
+        const query = { ...baseQuery, externalIds: '' };
+        expect(() => getRecordsRequestParser.parseQuery(query)).toThrow();
+    });
+
+    it('fails when externalIds is array of numbers (wrong type)', () => {
+        const query = { ...baseQuery, externalIds: [23591406, 23658002] };
+        expect(() => getRecordsRequestParser.parseQuery(query)).toThrow();
+    });
+
+    it('accepts externalIds as object with >20 keys and normalizes to array (qs arrayLimit)', () => {
+        const ids = Array.from({ length: 25 }, (_, i) => `id-${i}`);
+        const externalIds = Object.fromEntries(ids.map((id, i) => [String(i), id]));
+        const query = { ...baseQuery, externalIds };
+        const result = getRecordsRequestParser.parseQuery(query);
+        expect(result.externalIds).toHaveLength(25);
+        expect(result.externalIds).toEqual(ids);
+    });
+});


### PR DESCRIPTION
## Describe the problem and your solution

- Fixes `getRecords` failing with invalid_union on `externalIds` when the runner sends more than 20 items. qs uses a default arrayLimit of 20, so indices > 20 are parsed as an object instead of an array, [reference](https://www.npmjs.com/package/qs/v/6.2.4)

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

It now broadens input handling so externalIds may arrive as a single string, a bounded array, or the numeric-keyed objects emitted once qs surpasses its array limit, normalizing every accepted variant into a consistent string array and documenting each path with dedicated unit tests.

<details>
<summary><strong>Key Changes</strong></summary>

• Extended `getRecordsQuerySchema.externalIds` union in `packages/persist/lib/routes/environment/environmentId/connection/connectionId/validate.ts` to accept `z.record(z.string(), z.string())` inputs generated by `qs` when more than 20 entries are sent
• Added transformer that normalizes strings, arrays, and numeric-keyed objects into a filtered, ordered string array while leaving the field optional
• Created new `getRecordsRequestParser.parseQuery` unit tests in `packages/persist/lib/routes/environment/environmentId/connection/connectionId/validate.unit.test.ts` covering valid strings, arrays, objects, absence, and rejection of empty/typed-invalid inputs

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/persist/lib/routes/environment/environmentId/connection/connectionId/validate.ts`
• `packages/persist/lib/routes/environment/environmentId/connection/connectionId/validate.unit.test.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*