### PR TITLE
fix(persist): set qs array limit to 100

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35013,6 +35013,7 @@
                 "@nangohq/utils": "file:../utils",
                 "dd-trace": "5.52.0",
                 "express": "5.1.0",
+                "qs": "6.14.1",
                 "zod": "4.0.5"
             },
             "devDependencies": {

--- a/packages/persist/lib/server.ts
+++ b/packages/persist/lib/server.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import qs from 'qs';
 
 import { createRoute } from '@nangohq/utils';
 
@@ -30,7 +31,9 @@ const maxSizeJsonRecords = '100mb';
 
 export const server = express();
 
-server.set('query parser', 'extended');
+server.set('query parser', (str: string) => {
+    return qs.parse(str, { arrayLimit: 100 });
+});
 
 server.use('/environment/:environmentId/*splat', authMiddleware);
 server.use('/environment/:environmentId/log', express.json({ limit: maxSizeJsonLog }));

--- a/packages/persist/package.json
+++ b/packages/persist/package.json
@@ -26,6 +26,7 @@
         "@nangohq/pubsub": "file:../pubsub",
         "dd-trace": "5.52.0",
         "express": "5.1.0",
+        "qs": "6.14.1",
         "zod": "4.0.5"
     },
     "devDependencies": {


### PR DESCRIPTION
qs, the query parsing library persist is using, has a default array limit size of 20, which means any array parameters with more than 20 elements will be parsed as an indexed object, which break the zod validation of getRecordIds query

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Configure Persist query parser to allow larger arrays**

The PR replaces the default `express` extended query parser with an explicit `qs` parser configured to accept arrays up to length 100. It also adds `qs` as an explicit dependency so the custom parser is available at runtime.

<details>
<summary><strong>Key Changes</strong></summary>

• Import `qs` in `packages/persist/lib/server.ts` and replace `server.set('query parser', 'extended')` with a custom parser that calls `qs.parse(str, { arrayLimit: 100 })`
• Add the `qs@6.14.1` dependency in `packages/persist/package.json` and lockfile

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/persist/lib/server.ts`
• `packages/persist/package.json`
• `package-lock.json`

</details>

---
*This summary was automatically generated by @propel-code-bot*