### PR TITLE
chore: remove records autopruning dryrun

### DIFF
--- a/packages/persist/lib/daemons/autopruning.daemon.ts
+++ b/packages/persist/lib/daemons/autopruning.daemon.ts
@@ -20,8 +20,7 @@ export function autoPruningDaemon(): Awaited<ReturnType<typeof cancellableDaemon
     return cancellableDaemon({
         tickIntervalMs: envs.PERSIST_AUTO_PRUNING_INTERVAL_MS,
         tick: async (): Promise<void> => {
-            const dryRun = true; // TODO: removed after grace period given to customer (Feb 8th 2026)
-            return tracer.trace('nango.persist.daemon.autopruning', { tags: { dryRun } }, async (span) => {
+            return tracer.trace('nango.persist.daemon.autopruning', async (span) => {
                 try {
                     const candidate = await records.autoPruningCandidate({ staleAfterMs: envs.PERSIST_AUTO_PRUNING_STALE_AFTER_MS });
                     if (candidate.isErr()) {
@@ -61,8 +60,7 @@ export function autoPruningDaemon(): Awaited<ReturnType<typeof cancellableDaemon
                         model: candidate.value.model,
                         mode: 'prune',
                         toCursorIncluded: candidate.value.cursor,
-                        limit: envs.PERSIST_AUTO_PRUNING_LIMIT,
-                        dryRun
+                        limit: envs.PERSIST_AUTO_PRUNING_LIMIT
                     });
                     if (res.isErr()) {
                         span?.addTags({ error: res.error.message });


### PR DESCRIPTION
The grace period given to customers is up. Removing dryrun for records autopruning

<!-- Summary by @propel-code-bot -->

---

The change removes the dryRun flag both from the autopruning daemon’s tracer context and the deleteRecords invocation, so each pruning execution now carries out real deletions instead of being tagged as a dry run.

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/persist/lib/daemons/autopruning.daemon.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*