### PR TITLE
fix(providers): remove authorization_url_replacements from monday

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -9952,8 +9952,6 @@ monday:
     disable_pkce: true
     authorization_params:
         force_install_if_needed: true
-    authorization_url_replacements:
-        response_type: ''
     proxy:
         base_url: https://api.monday.com
     docs: https://nango.dev/docs/api-integrations/monday


### PR DESCRIPTION
## Describe the problem and your solution

PR #5222 added `authorization_url_replacements: { response_type: '' }` to the Monday provider
config, intending to support Monday's friction-free install flow. However, this breaks Monday OAuth
because:

1. `authorization_url_replacements` does a naive `String.replace('response_type', '')` on the full
   authorization URL
2. This strips `response_type=code` — a parameter Monday.com requires for proper `redirect_uri`
   callback routing
3. Without `response_type=code`, Monday completes the install flow but redirects to the workspace
   URL instead of the OAuth callback URL
4. Nango never receives the callback, so the connection fails

**Fix:** Remove the `authorization_url_replacements` section from the Monday provider config. The
other additions from #5222 (`disable_pkce: true`, `force_install_if_needed: true`, updated docs)
remain intact and work correctly.

**Tested:** Verified end-to-end Monday OAuth flow completes successfully after removing these lines.

Screenshot of the workaround we applied on our side to get this working/confirm the oAuth flow completes as expected for monday.com:
<img width="2586" height="1572" alt="CleanShot 2026-02-09 at 13 36 57@2x" src="https://github.com/user-attachments/assets/24e9caf7-bc9b-4776-85fc-c6a2ec694157" />



<!-- Summary by @propel-code-bot -->

---

This adjustment is confined to the Monday entry in packages/providers/providers.yaml, ensuring the faulty authorization_url_replacements block is removed while preserving the other Monday-specific settings that already function correctly.

<details>
<summary><strong>Affected Areas</strong></summary>

• packages/providers/providers.yaml

</details>

---
*This summary was automatically generated by @propel-code-bot*