### PR TITLE
feat(webapp): trigger sync UI tweaks

### DIFF
--- a/packages/webapp/src/pages/Connection/components/SyncRow.tsx
+++ b/packages/webapp/src/pages/Connection/components/SyncRow.tsx
@@ -300,7 +300,7 @@ export const SyncRow: React.FC<{ sync: SyncResponse; connection: ApiConnectionFu
                                                                         <br />
                                                                         Your backend should reprocess all records.{' '}
                                                                         <Link
-                                                                            to="https://nango.dev/docs/implementation-guides/use-cases/syncs/large-datasets#incremental-syncing"
+                                                                            to="https://nango.dev/docs/implementation-guides/use-cases/syncs/records-cache"
                                                                             className="underline"
                                                                         >
                                                                             Learn more


### PR DESCRIPTION
in preparation of adding checkpointing and deprecating the concept of incremental vs full run, we are tweaking the trigger sync UI and replace `sync_mode` with a `resync` option that would support both legacy logic of nullifying `lastSyncDate` and clearing the checkpoint.

<img width="600" height="366" alt="Screenshot 2026-02-10 at 10 13 43" src="https://github.com/user-attachments/assets/d8504abf-ce9c-4fe5-aa38-828d94bc72b5" />


<!-- Summary by @propel-code-bot -->

---

The trigger dialog now relies on two independent checkboxes—one to switch between RUN and RUN_FULL executions and another to request cache deletion—supported by refreshed helper copy, IconInfoCircle-tooltips, and toast messaging that explain the updated behavior.

<details>
<summary><strong>Possible Issues</strong></summary>

• `resyncEntireDataset` defaulting to `false` causes `RUN` to be issued for full-only syncs, which the orchestrator rejects.
• `delete_records` is sent for both `RUN` and `RUN_FULL`, so toggling "Empty cache" without resync results in a misleading UI promise with no backend effect.

</details>

---
*This summary was automatically generated by @propel-code-bot*