### PR TITLE
feat: update trigger sync to support new opts {reset, emptyCache} param

### DIFF
--- a/docs/api-integrations/google-drive/how-to-use-google-drive-files-sync.mdx
+++ b/docs/api-integrations/google-drive/how-to-use-google-drive-files-sync.mdx
@@ -52,24 +52,22 @@ Or for folders:
 }
 ```
 
-### Step 3: Start the sync with metadata
+### Step 3: Set metadata and trigger the sync
 
-Use the Nango SDK to start or update the sync with the selected file/folder IDs:
+Use the Nango SDK to set the metadata with the selected file/folder IDs, then trigger the sync:
 
 ```typescript
 import { Nango } from '@nangohq/node';
 
 const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
 
-// Start sync with specific files
-await nango.triggerSync({
-  providerConfigKey: '<INTEGRATION-ID>',
-  connectionId: '<CONNECTION-ID>',
-  syncs: ['documents'],
-  metadata: {
-    files: ['file-id-from-picker']
-  }
+// Set metadata with specific files to sync
+await nango.setMetadata('<INTEGRATION-ID>', '<CONNECTION-ID>', {
+  files: ['file-id-from-picker']
 });
+
+// Trigger the sync
+await nango.triggerSync('<INTEGRATION-ID>', ['documents'], '<CONNECTION-ID>');
 ```
 
 ### Step 4: Access synced data
@@ -78,7 +76,7 @@ Once the sync runs, access the synced file metadata:
 
 ```typescript
 // Get synced documents
-const records = await nango.getRecords({
+const { records } = await nango.listRecords({
   providerConfigKey: '<INTEGRATION-ID>',
   connectionId: '<CONNECTION-ID>',
   model: 'GoogleDriveFile'
@@ -108,15 +106,11 @@ You can also:
 The `folders` sync is simpler and syncs all root-level folders automatically without requiring metadata:
 
 ```typescript
-// Enable and trigger the folders sync
-await nango.triggerSync({
-  providerConfigKey: '<INTEGRATION-ID>',
-  connectionId: '<CONNECTION-ID>',
-  syncs: ['folders']
-});
+// Trigger the folders sync
+await nango.triggerSync('<INTEGRATION-ID>', ['folders'], '<CONNECTION-ID>');
 
 // Access synced folders
-const folders = await nango.getRecords({
+const { records: folders } = await nango.listRecords({
   providerConfigKey: '<INTEGRATION-ID>',
   connectionId: '<CONNECTION-ID>',
   model: 'GoogleDriveFolder'

--- a/docs/reference/sdks/node.mdx
+++ b/docs/reference/sdks/node.mdx
@@ -1441,14 +1441,20 @@ console.log(`Pruned ${result.count} records. More records available: ${result.ha
 Triggers an additional, one-off execution of specified sync(s) for a given connection or all applicable connections if no connection is specified.
 
 ```ts
-// Simple usage with sync names
-const result = await nango.triggerSync('<INTEGRATION-ID>', ['SYNC_NAME1', 'SYNC_NAME2'], '<CONNECTION_ID>', 'incremental');
+// Incremental sync (default, preserves lastSyncDate)
+await nango.triggerSync('<INTEGRATION-ID>', ['SYNC_NAME1', 'SYNC_NAME2'], '<CONNECTION_ID>');
+
+// Full resync (resets lastSyncDate)
+await nango.triggerSync('<INTEGRATION-ID>', ['SYNC_NAME1'], '<CONNECTION_ID>', { reset: true });
+
+// Full resync with cache clear (resets lastSyncDate and deletes all records)
+await nango.triggerSync('<INTEGRATION-ID>', ['SYNC_NAME1'], '<CONNECTION_ID>', { reset: true, emptyCache: true });
 
 // Using variants
-const resultWithVariants = await nango.triggerSync('<INTEGRATION-ID>', [
+await nango.triggerSync('<INTEGRATION-ID>', [
   { name: 'SYNC_NAME1', variant: 'VARIANT_A' },
   'SYNC_NAME2' // Uses default base variant
-], '<CONNECTION_ID>', 'incremental');
+], '<CONNECTION_ID>', { reset: true });
 ```
 
 **Parameters**
@@ -1466,11 +1472,16 @@ const resultWithVariants = await nango.triggerSync('<INTEGRATION-ID>', [
     <ResponseField name="connectionId" type="string">
         The connection ID. If omitted, the sync will trigger for all relevant connections.
     </ResponseField>
-    <ResponseField name="sync_mode" type="'incremental' | 'full_refresh' | 'full_refresh_and_clear_cache'">
-        The mode in which to trigger the syncs.
-        - `incremental`: Triggers a new sync job while preserving the "lastSyncDate".
-        - `full_refresh`: Resets the "lastSyncDate" associated with the sync before triggering a new sync job.
-        - `full_refresh_and_clear_cache`: Resets the "lastSyncDate" and deletes all records associated with the sync before triggering a new sync job.
+    <ResponseField name="opts" type="object">
+        Options for the sync trigger.
+        - `reset`: If `true`, resets the "lastSyncDate" before triggering (full resync). Defaults to `false` (incremental).
+        - `emptyCache`: If `true`, deletes all records associated with the sync before triggering. Defaults to `false`.
+    </ResponseField>
+    <ResponseField name="sync_mode (deprecated)" type="'incremental' | 'full_refresh' | 'full_refresh_and_clear_cache'">
+        Deprecated. Use `opts` instead.
+        - `incremental`: equivalent to `{ reset: false }`
+        - `full_refresh`: equivalent to `{ reset: true }`
+        - `full_refresh_and_clear_cache`: equivalent to `{ reset: true, emptyCache: true }`
     </ResponseField>
 </Expandable>
 

--- a/docs/snippets/generated/cloudflare/PreBuiltTooling.mdx
+++ b/docs/snippets/generated/cloudflare/PreBuiltTooling.mdx
@@ -23,7 +23,7 @@
 | Tools | Status |
 | - | - |
 | HTTP request logging | ✅ |
-| End-to-type type safety | ✅ |
+| End-to-end type safety | ✅ |
 | Data runtime validation | ✅ |
 | OpenTelemetry export | ✅ |
 | Slack alerts on errors | ✅ |

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -1562,10 +1562,22 @@ paths:
                                                       type: string
                                                       description: The variant name
                                               example: { 'name': 'github-issues', 'variant': 'custom-variant' }
+                                opts:
+                                    type: object
+                                    description: Options for the sync trigger.
+                                    properties:
+                                        reset:
+                                            type: boolean
+                                            description: If true, resets the "lastSyncDate" before triggering (equivalent to a full resync).
+                                        emptyCache:
+                                            type: boolean
+                                            description: If true, deletes all records associated with the sync before triggering.
                                 sync_mode:
+                                    deprecated: true
                                     type: string
                                     enum: ['incremental', 'full_refresh', 'full_refresh_and_clear_cache']
                                     description: |
+                                        Deprecated. Use `opts` instead.
                                         The mode in which to trigger the syncs.
                                         - `incremental`: Triggers a new sync job while preserving the "lastSyncDate".
                                         - `full_refresh`: Resets the "lastSyncDate" associated with the sync before triggering a new sync job.
@@ -1573,7 +1585,7 @@ paths:
                                 full_resync:
                                     deprecated: true
                                     type: boolean
-                                    description: Reset the "lastSyncDate" associated with the sync before triggering a new sync job.
+                                    description: Deprecated. Use `opts.reset` instead. Reset the "lastSyncDate" associated with the sync before triggering a new sync job.
 
             responses:
                 '200':

--- a/packages/node-client/lib/index.unit.test.ts
+++ b/packages/node-client/lib/index.unit.test.ts
@@ -61,8 +61,23 @@ describe('triggerSync', () => {
         );
     });
 
-    it('should default to incremental sync_mode when not provided', async () => {
-        await nango.triggerSync('test-provider', ['test-sync']);
+    it('should handle opts with reset: true', async () => {
+        await nango.triggerSync('test-provider', ['test-sync'], 'conn-123', { reset: true });
+
+        expect(mockHttp.post).toHaveBeenCalledWith(
+            expect.any(String),
+            {
+                syncs: ['test-sync'],
+                provider_config_key: 'test-provider',
+                connection_id: 'conn-123',
+                opts: { reset: true }
+            },
+            expect.any(Object)
+        );
+    });
+
+    it('should handle opts with emptyCache: true', async () => {
+        await nango.triggerSync('test-provider', ['test-sync'], undefined, { emptyCache: true });
 
         expect(mockHttp.post).toHaveBeenCalledWith(
             expect.any(String),
@@ -70,7 +85,22 @@ describe('triggerSync', () => {
                 syncs: ['test-sync'],
                 provider_config_key: 'test-provider',
                 connection_id: undefined,
-                sync_mode: 'incremental'
+                opts: { emptyCache: true }
+            },
+            expect.any(Object)
+        );
+    });
+
+    it('should handle opts with both reset and emptyCache', async () => {
+        await nango.triggerSync('test-provider', ['test-sync'], undefined, { reset: true, emptyCache: true });
+
+        expect(mockHttp.post).toHaveBeenCalledWith(
+            expect.any(String),
+            {
+                syncs: ['test-sync'],
+                provider_config_key: 'test-provider',
+                connection_id: undefined,
+                opts: { reset: true, emptyCache: true }
             },
             expect.any(Object)
         );

--- a/packages/types/lib/sync/api.ts
+++ b/packages/types/lib/sync/api.ts
@@ -6,11 +6,13 @@ export type PostPublicTrigger = Endpoint<{
     Path: '/sync/trigger';
     Body: {
         syncs: (string | { name: string; variant: string })[];
-        sync_mode?: 'incremental' | 'full_refresh' | 'full_refresh_and_clear_cache' | undefined;
         provider_config_key?: string | undefined;
         connection_id?: string | undefined;
-        // @deprecrated in favor of sync_mode
+        opts?: { reset?: boolean | undefined; emptyCache?: boolean | undefined } | undefined;
+        // @deprecated in favor of opts.reset
         full_resync?: boolean | undefined;
+        // @deprecated in favor of opts
+        sync_mode?: 'incremental' | 'full_refresh' | 'full_refresh_and_clear_cache' | undefined;
     };
     Headers: {
         'provider-config-key'?: string | undefined;


### PR DESCRIPTION
As part of the effort to deprecate the concept of full vs incremental, adding a `opts` parameters to trigger sync api/function
Keeping backward compatibility for legacy params

```
await nango.triggerSync('github-abc', 'pulls', 'connectionA', { reset: true, emptyCache: true })

// vs current (will of course still work for backward compatibility reason
await nango.triggerSync('github-abc', 'pulls', 'connectionA', 'full_refresh_and_clear_cache')
```

<!-- Summary by @propel-code-bot -->

---

**Support new trigger sync options and document updated flow**

Introduces an `opts` object to the `/sync/trigger` API, server controller, and Node SDK so callers can explicitly request reset/full-cache-clearing behavior without using deprecated `sync_mode`/`full_resync` flags. Adds validation to block mixed usage, propagates the new flags to `syncManager`, updates type definitions, refreshes SDK docs/specs, and expands integration/unit tests plus product docs/snippets to reflect the new call pattern and metadata workflow.

<details>
<summary><strong>Key Changes</strong></summary>

• Extended `postTrigger` validation schema with optional `opts.reset`/`opts.emptyCache`, reject combinations with legacy `sync_mode`/`full_resync`, and drive `SyncCommand`/`deleteRecords` from the new structure before invoking `syncManager` (`packages/server/lib/controllers/sync/postTrigger.ts`).
• Augmented integration tests to cover opts-only success paths, mixed-parameter 400s, and propagation of `deleteRecords` to `runSyncCommand` (`packages/server/lib/controllers/sync/postTrigger.integration.test.ts`).
• Overloaded `Nango.triggerSync` to accept either the new options object or legacy signatures, ensuring request bodies are serialized appropriately and keeping backward compatibility (`packages/node-client/lib/index.ts` + `index.unit.test.ts`).
• Updated public types, API reference docs, Google Drive guide, Cloudflare snippet, and OpenAPI spec to document the new options-centric workflow and revised metadata instructions (`packages/types/lib/sync/api.ts`, `docs/reference/sdks/node.mdx`, `docs/api-integrations/google-drive/how-to-use-google-drive-files-sync.mdx`, `docs/spec.yaml`, `docs/snippets/generated/cloudflare/PreBuiltTooling.mdx`).

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `packages/server/lib/controllers/sync/postTrigger.ts`
• `packages/node-client/lib/index.ts`
• `packages/types/lib/sync/api.ts`
• Docs (Node SDK reference, Google Drive integration guide, Cloudflare snippet, API spec)
• Tests covering triggerSync controller and Node client

</details>

---
*This summary was automatically generated by @propel-code-bot*