### PR TITLE
docs: replace incremental/full sync concepts with checkpoints

### DIFF
--- a/docs/guides/primitives/functions.mdx
+++ b/docs/guides/primitives/functions.mdx
@@ -129,7 +129,7 @@ const result = await nango.trigger({
 Functions are a powerful & flexible primitive to support any complex integration use-case:
 
 - **[Tool calling & MCP servers](/implementation-guides/use-cases/tool-calling/overview)**
-- **[Data syncing & incremental updates](/implementation-guides/use-cases/syncs/implement-a-sync)**
+- **[Data syncing with checkpoints](/implementation-guides/use-cases/syncs/implement-a-sync)**
 - **[RAG pipelines and large dataset ingestion](/implementation-guides/use-cases/syncs/implement-a-sync)**
 - **[Triggers and change detection](/implementation-guides/use-cases/syncs/implement-a-sync)**
 - **[Webhook ingestion and processing](/implementation-guides/use-cases/webhooks-from-external-apis)**

--- a/docs/implementation-guides/platform/functions/testing.mdx
+++ b/docs/implementation-guides/platform/functions/testing.mdx
@@ -49,9 +49,6 @@ nango dryrun fetch-tickets abc-123 -e prod
 # For actions: pass input data
 nango dryrun create-ticket abc-123 --input '{"title": "Test ticket"}'
 
-# For syncs: specify a last sync date for incremental syncs
-nango dryrun fetch-tickets abc-123 --lastSyncDate "2024-01-01"
-
 # Use a specific integration when sync names overlap
 nango dryrun fetch-tickets abc-123 --integration-id github
 
@@ -526,24 +523,33 @@ it('should fetch all pages of results', async () => {
 });
 ```
 
-### Testing incremental syncs
+### Testing syncs with checkpoints
 
-Test that incremental sync logic works:
+Test that checkpoint logic works:
 
 ```typescript
-it('should only fetch tickets after last sync date', async () => {
+it('should only fetch tickets after checkpoint date', async () => {
   const getSpy = vi.spyOn(nangoMock, 'get');
+  const saveCheckpointSpy = vi.spyOn(nangoMock, 'saveCheckpoint');
+
+  // Mock getCheckpoint to return a previous checkpoint
+  vi.spyOn(nangoMock, 'getCheckpoint').mockResolvedValue({
+    lastModifiedISO: '2024-01-01T00:00:00Z'
+  });
 
   await createSync.exec(nangoMock);
 
-  // Verify the API request included the lastSyncDate parameter
+  // Verify the API request used the checkpoint value
   expect(getSpy).toHaveBeenCalledWith(
     expect.objectContaining({
       params: expect.objectContaining({
-        since: expect.any(String)
+        since: '2024-01-01T00:00:00Z'
       })
     })
   );
+
+  // Verify checkpoint was saved
+  expect(saveCheckpointSpy).toHaveBeenCalled();
 });
 ```
 

--- a/docs/implementation-guides/platform/migrations/migrate-to-zero-yaml.mdx
+++ b/docs/implementation-guides/platform/migrations/migrate-to-zero-yaml.mdx
@@ -126,7 +126,6 @@ models:
 const sync = createSync({
     description: 'Fetches GitHub issues',
     frequency: 'every hour',
-    syncType: 'full',
     endpoints: [{ method: 'GET', path: '/issues', group: 'Issues' }],
     models: { GithubIssue: issueSchema }
 });
@@ -190,7 +189,6 @@ const issueSchema = z.object({
 const sync = createSync({
     description: 'Fetches GitHub issues',
     frequency: 'every hour',
-    syncType: 'full',
     endpoints: [{ method: 'GET', path: '/issues', group: 'Issues' }],
     models: { GithubIssue: issueSchema },
     exec: async (nango) => {

--- a/docs/implementation-guides/use-cases/syncs/deletion-detection.mdx
+++ b/docs/implementation-guides/use-cases/syncs/deletion-detection.mdx
@@ -7,11 +7,11 @@ description: "Guide on how to detect deleted records with syncs"
 Sometimes you need to know when an object you are syncing has been deleted in the external system.
 
 Detecting deletes is not a universal switch.
-It differs significantly between full refresh and incremental syncs. Pick the strategy that matches your sync type.
+It differs significantly between syncs that use checkpoints (fetching only changed data) and syncs that fetch all data on every run. Pick the strategy that matches your sync approach.
 
-## Detecting deletes in incremental syncs
+## Detecting deletes in syncs with checkpoints
 
-Incremental syncs only fetch the delta (new/updated records) since the previous run, so Nango has no built-in way to know which records disappeared on the provider side.
+When using checkpoints to only fetch changed data since the previous run, Nango has no built-in way to know which records disappeared on the provider side.
 
 You must actively tell Nango which IDs have been removed by calling `nango.batchDelete()` ([full reference](/reference/functions#delete-records)) inside the sync functions.
 
@@ -19,17 +19,17 @@ You must actively tell Nango which IDs have been removed by calling `nango.batch
 
 You can use `nango.batchDelete()` if the external API supports one of the following:
 
-- A dedicated “recently deleted” endpoint (e.g. `GET /entities/deleted?since=...`)
+- A dedicated "recently deleted" endpoint (e.g. `GET /entities/deleted?since=...`)
 - The ability to filter or sort by a deletion timestamp
 - The ability to filter or sort by last-modified timestamp _and_ records include a flag like `is_deleted`, `archived`, etc.
 
-If none of these are available, you cannot detect deletes with an incremental sync.
+If none of these are available, you cannot detect deletes with a checkpoint-based sync.
 
-You'll either need to switch to a full refresh sync or skip deletion detection.
+You'll either need to switch to a sync that fetches all data or skip deletion detection.
 
-Switching to a full refresh sync should not be done lightly. Make sure you [understand the tradeoffs](/implementation-guides/use-cases/syncs/large-datasets).
+Switching to fetching all data should not be done lightly. Make sure you [understand the tradeoffs](/implementation-guides/use-cases/syncs/large-datasets).
 
-### Example incremental sync with deletion detection
+### Example sync with checkpoint and deletion detection
 
 ```ts
 import { createSync } from 'nango';
@@ -41,45 +41,56 @@ const AccountSchema = z.object({
 });
 
 export default createSync({
-  description: 'Incrementally sync Accounts & handle deletions',
+  description: 'Sync Accounts with checkpoint & handle deletions',
   frequency: 'every 2 hours',
-  syncType: 'incremental',
   endpoints: [{ method: 'GET', path: '/accounts', group: 'Accounts' }],
   models: { Account: AccountSchema },
+  checkpoint: z.object({
+    lastSyncedISO: z.string(),
+  }),
 
   exec: async (nango) => {
+    const checkpoint = await nango.getCheckpoint();
+    const now = new Date().toISOString();
+
     // (1) Fetch newly created / updated accounts
-    // Save them with await nango.batchSave(...);
+    const res = await nango.get({
+        endpoint: '/accounts',
+        params: { ...(checkpoint && { since: checkpoint.lastSyncedISO }) }
+    });
+    await nango.batchSave(res.data, 'Account');
 
     // (2) Fetch deletions since the last run (if this is not the first run)
-    const last = nango.lastSyncDate;
-    if (last) {
-        const res = await nango.get({
+    if (checkpoint) {
+        const deletedRes = await nango.get({
             endpoint: '/accounts/deleted',
-            params: { since: last.toISOString() }
+            params: { since: checkpoint.lastSyncedISO }
         });
 
         // (3) Tell Nango which IDs have been deleted in the external system
-        const toDelete = res.data.map((row: any) => ({ id: row.id }));
+        const toDelete = deletedRes.data.map((row: any) => ({ id: row.id }));
         if (toDelete.length) {
             await nango.batchDelete(toDelete, 'Account');
         }
     }
+
+    // (4) Save checkpoint for next run
+    await nango.saveCheckpoint({ lastSyncedISO: now });
   }
 });
 ```
 
-## Detecting deletes in full refresh syncs
+## Detecting deletes in syncs without checkpoints
 
-Full refresh syncs download all records when they run.
+Syncs that fetch all records on every run can automatically detect deletions.
 
 Nango can therefore detect removals by computing the diff between two consecutive result sets. Enable this behaviour by calling the `deleteRecordsFromPreviousExecutions` function. ([full reference](/reference/functions#detect-deletions-automatically)).
 
 <Note>
-  `deleteRecordsFromPreviousExecutions` does not work with incremental syncs because fetching the data incrementally prevents performing a diff and automatically detecting deletions.
+  `deleteRecordsFromPreviousExecutions` does not work with checkpoint-based syncs because fetching the data incrementally prevents performing a diff and automatically detecting deletions.
 </Note>
 
-### Example full refresh sync with deletion detection
+### Example sync with deletion detection
 
 ```ts
 import { createSync } from 'nango';
@@ -94,13 +105,10 @@ const TicketSchema = z.object({
 export default createSync({
   description: 'Fetch all help-desk tickets',
   frequency: 'every day',
-  syncType: 'full',
   endpoints: [{ method: 'GET', path: '/tickets', group: 'Tickets' }],
   models: { Ticket: TicketSchema },
 
   exec: async (nango) => {
-    // Unlike incremental syncs, the execution logic
-    // doesn't need any changes for deletion detection in full refresh syncs
     const tickets = await nango.paginate<{ id: string; subject: string; status: string }>({
       endpoint: '/tickets',
       paginate: { type: 'cursor', cursorPathInResponse: 'next', cursorNameInRequest: 'cursor', responsePath: 'tickets' }

--- a/docs/implementation-guides/use-cases/syncs/implement-a-sync.mdx
+++ b/docs/implementation-guides/use-cases/syncs/implement-a-sync.mdx
@@ -26,7 +26,7 @@ You can implement two-way syncs by combining syncs with [Actions](/implementatio
 - You control the code: which data to fetch, transformations, data models, etc.
 - All platform features are available: data validation, per-customer config, retries, rate-limit handling, and pagination
 - Syncs run in the context of each [Connection](/guides/primitives/auth#overview) (API key or access token of your user)
-- Syncs can be **incremental** (only fetch changed data) or **full refresh** (always fetch all data)
+- Syncs can use **checkpoints** to save progress and avoid re-fetching all data on every run
 - Synced data is cached in Nango (encrypted at rest and in transit)
 - Nango detects changes (additions, updates, deletes) and sends webhooks to your app
 - You set the polling frequency (15 seconds minimum interval)
@@ -42,20 +42,20 @@ If you are using a pre-built reference implementation sync, you can [skip to usi
 
 ## Syncs in detail
 
-### Incremental vs. full-refresh syncs
+### Checkpoints
 
-Nango supports both modes and automatically detects changes to records in either.
+Checkpoints allow syncs to save their progress and resume from where they left off. This enables syncs to fetch only new or changed data instead of re-fetching everything on each run.
 
-| Mode | Description | Best for |
-|------|-------------|----------|
-| **Incremental** | Only fetches data changed since last execution | Large datasets; requires API support for querying modified records |
-| **Full refresh** | Retrieves entire dataset each execution | APIs without last-modified filtering; fallback option |
+| Approach | Description | Best for |
+|----------|-------------|----------|
+| **With checkpoints** | Saves progress (e.g., last page, cursor, timestamp) and resumes from there | Large datasets; APIs that support filtering by date or cursor |
+| **Without checkpoints** | Fetches the entire dataset on each run | Small datasets; APIs without filtering support |
 
-Set `syncType: 'incremental'` or `syncType: 'full'` in your sync definition.
+Define a `checkpoint` schema in your sync to enable checkpoint support.
 
 ### Deletion detection
 
-Nango can detect deleted records on external APIs. For incremental syncs, this requires specific API support. For full-refresh syncs, deletes are always detectable.
+Nango can detect deleted records on external APIs. For syncs using checkpoints, this requires specific API support. For syncs that fetch all data, deletes are always detectable.
 
 Follow the [deletion detection guide](/implementation-guides/use-cases/syncs/deletion-detection) for implementation details.
 
@@ -125,8 +125,11 @@ export default createSync({
     endpoints: [{ method: 'GET', path: '/<integration>/<object-name>', group: '<Group>' }],
     frequency: 'every hour', // Default sync interval
     autoStart: true, // Should the sync start immediately when a new connection is created?
-    syncType: 'full', // incremental or full (full refresh or incremental sync)
     trackDeletes: true, // detect deletes? See separate implementation guide
+    // Optional: define a checkpoint schema to save progress and avoid re-fetching all data
+    checkpoint: z.object({
+        lastModifiedISO: z.string(),
+    }),
     models: {
         MyObject: MyObject,
     },
@@ -162,6 +165,8 @@ const SalesforceContact = z.object({
   first_name: z.string(),
   last_name: z.string(),
   email: z.string(),
+  account_id: z.string().nullable(),
+  last_modified_date: z.string(),
 });
 
 export default createSync({
@@ -170,24 +175,32 @@ export default createSync({
   endpoints: [{ method: 'GET', path: '/salesforce/contacts', group: 'Contacts' }],
   frequency: 'every hour',
   autoStart: true,
-  syncType: 'full',
+  // Define checkpoint schema to track sync progress
+  checkpoint: z.object({
+    lastModifiedISO: z.string(),
+  }),
   models: {
     SalesforceContact: SalesforceContact,
   },
   exec: async (nango) => {
-    const query = buildQuery(nango.lastSyncDate);
+    // Get checkpoint to resume from where we left off
+    const checkpoint = await nango.getCheckpoint();
+    const query = buildQuery(checkpoint?.lastModifiedISO);
+
     await fetchAndSaveRecords(nango, query);
+
     await nango.log('Sync run completed!');
   },
 });
 export type NangoSyncLocal = Parameters<(typeof sync)['exec']>[0];
 
-function buildQuery(lastSyncDate?: Date): string {
+function buildQuery(lastModifiedISO?: string): string {
     let baseQuery = `SELECT Id, FirstName, LastName, Email, AccountId, LastModifiedDate FROM Contact`;
 
-    if (lastSyncDate) { // Only fetch the new data.
-        baseQuery += ` WHERE LastModifiedDate > ${lastSyncDate.toISOString()}`;
+    if (lastModifiedISO) { // Only fetch data modified since last sync
+        baseQuery += ` WHERE LastModifiedDate > ${lastModifiedISO}`;
     }
+    baseQuery += ` ORDER BY LastModifiedDate ASC`;
 
     return baseQuery;
 }
@@ -205,13 +218,15 @@ async function fetchAndSaveRecords(nango: NangoSyncLocal, query: string) {
 
         await nango.batchSave(mappedRecords, 'SalesforceContact'); // Saves records to Nango cache.
 
+        // Save checkpoint for next run
+        await nango.saveCheckpoint({ lastModifiedISO: mappedRecords[mappedRecords.length - 1].last_modified_date });
+
         if (response.data.done) {
             break;
         }
 
         endpoint = response.data.nextRecordsUrl;
     }
-    await nango.deleteRecordsFromPreviousExecutions('SalesforceContact')
 }
 
 function mapContacts(records: any[]): SalesforceContact[] {
@@ -229,7 +244,8 @@ function mapContacts(records: any[]): SalesforceContact[] {
 ```
 
 In this integration function, the following Nango utilities are used:
-- `nango.lastSyncDate` is the last date at which the sync has run
+- `await nango.getCheckpoint()` retrieves the saved checkpoint (returns `null` on first run)
+- `await nango.saveCheckpoint()` saves progress to resume from on next run
 - `await nango.batchSave()` to persist external data in Nango's cache
 - `await nango.get()` to perform an API request (automatically authenticated by Nango)
 - `await nango.log()` to write custom log messages

--- a/docs/implementation-guides/use-cases/syncs/large-datasets.mdx
+++ b/docs/implementation-guides/use-cases/syncs/large-datasets.mdx
@@ -16,13 +16,13 @@ Your app syncs with Nango in the same way regardless of the volume of the datase
 
 Below, we explore various approaches on how to sync data from the external system to Nango, even for large datasets.
 
-## Full refresh syncing (small datasets only)
+## Syncing without checkpoints (small datasets only)
 
-For small datasets (e.g., a list of Slack users for organizations with less than 100 employees), you can instruct Nango to periodically poll for the entire dataset. This method is known as a ["full refresh" sync](/implementation-guides/use-cases/syncs/implement-a-sync#incremental-vs-full-refresh-syncs).
+For small datasets (e.g., a list of Slack users for organizations with less than 100 employees), you can instruct Nango to periodically poll for the entire dataset.
 
-Once the sync run finishes, Nango computes which records have been changed during the latest sync run, and sends a webhook to your backend. This lets you fetch only the incremental changes from Nango to your application.
+Once the sync run finishes, Nango computes which records have been changed during the latest sync run, and sends a webhook to your backend. This lets you fetch only the changes from Nango to your application.
 
-As datasets increase in size, full refresh syncs become unscalable, taking longer to run, triggering rate limiting from external APIs, and consuming more compute and memory resources.
+As datasets increase in size, syncs that fetch all data become unscalable, taking longer to run, triggering rate limiting from external APIs, and consuming more compute and memory resources.
 
 Here is an example of a sync script which refreshes the entire list of Slack user on each execution:
 
@@ -41,29 +41,37 @@ export default createSync({
 });
 ```
 
-## Incremental syncing
+## Syncing with checkpoints
 
-The preferred method for syncing larger datasets is to fetch only the incremental changes from the external API. This method is known as an ["incremental" sync](/implementation-guides/use-cases/syncs/implement-a-sync#incremental-vs-full-refresh-syncs).
+The preferred method for syncing larger datasets is to use checkpoints to fetch only changes from the external API since the last sync.
 
-Sync functions expose the timestamp of the last sync execution start under `nango.lastSyncDate`. You can use this timestamp to instruct the external API to send only the changes since that date. This way, you only receive and persist the modified records in the Nango cache.
+Checkpoints allow you to save progress (e.g., a timestamp or cursor) and resume from there on the next run. This way, you only receive and persist the modified records in the Nango cache.
 
-For example, if you are syncing tens of thousands of contacts from a Salesforce account on an hourly basis, only a small portion of the contacts will be updated or created in any given hour. If you were doing a full refresh sync, you would need to fetch the entire contact list every hour, which is inefficient. With an incremental sync, you can fetch only the modified contacts from the past hour.
+For example, if you are syncing tens of thousands of contacts from a Salesforce account on an hourly basis, only a small portion of the contacts will be updated or created in any given hour. Without checkpoints, you would need to fetch the entire contact list every hour, which is inefficient. With checkpoints, you can fetch only the modified contacts from the past hour.
 
-Not all APIs, and not all endpoints on most APIs, support this. If the endpoint you need does not let you filter or sort by last modified date, you will need to use a full refresh sync.
+Not all APIs, and not all endpoints on most APIs, support this. If the endpoint you need does not let you filter or sort by last modified date, you will need to sync without checkpoints.
 
-Here is an example of a sync script that updates the list of Salesforce contact incrementally on each execution, leveraging `nango.lastSyncDate`:
+Here is an example of a sync script that updates the list of Salesforce contacts using checkpoints:
 
 ```ts
 export default createSync({
+  checkpoint: z.object({
+    lastModifiedISO: z.string(),
+  }),
   exec: async (nango) => {
+    const checkpoint = await nango.getCheckpoint();
     // ...
     // Paginate API requests.
     while (nextPage) {
         // Pass in a timestamp to Salesforce to fetch only the recently modified data.
-        const res = getContactsFromSalesforceAPI(nango.lastSyncDate, nextPage);
+        const res = getContactsFromSalesforceAPI(checkpoint?.lastModifiedISO, nextPage);
         // ...
+        const contacts = mapContacts(res.data.records);
         // Save Salesforce contacts.
-        await nango.batchSave(mapContacts(res.data.records), 'Contact');
+        await nango.batchSave(contacts, 'Contact');
+        // Save checkpoint with the last record's LastModifiedDate
+        const lastContact = contacts[contacts.length - 1];
+        await nango.saveCheckpoint({ lastModifiedISO: lastContact.LastModifiedDate });
     }
   },
 });
@@ -71,7 +79,7 @@ export default createSync({
 
 ### Initial sync execution
 
-Even with incremental syncing, the very first sync execution has to be a full refresh sync since there is no previous data. This initial sync fetches all historical data and is more resource-intensive than subsequent executions.
+Even with checkpoints, the very first sync execution has to fetch all data since there is no previous checkpoint. This initial sync fetches all historical data and is more resource-intensive than subsequent executions.
 
 One strategy to manage this is to limit the period you are backfilling. For example, if you are syncing a Notion workspace, you can inform users that you will only sync Notion pages modified in the last three months, assuming these are most relevant.
 
@@ -83,12 +91,14 @@ The most common cause of excessive memory use is fetching a large number of reco
 
 ```ts
 export default createSync({
+  checkpoint: z.object({ lastModifiedISO: z.string() }),
   exec: async (nango) => {
+    const checkpoint = await nango.getCheckpoint();
     // ...
     const responses: any[] = [];
     // Paginate API requests.
     while (nextPage) {
-        const res = getContactsFromSalesforceAPI(nango.lastSyncDate, nextPage);
+        const res = getContactsFromSalesforceAPI(checkpoint?.lastModifiedISO, nextPage);
         // ...
         // Save all dataset in memory (memory intensive).
         responses.push(...res.data.records);
@@ -103,21 +113,26 @@ A simple fix is to store records as you fetch them, allowing them to be released
 
 ```ts
 export default createSync({
+  checkpoint: z.object({ lastModifiedISO: z.string() }),
   exec: async (nango) => {
+    const checkpoint = await nango.getCheckpoint();
     // ...
     // Paginate API requests.
     while (nextPage) {
         // Releases the previous page results from memory.
-        const res = getContactsFromSalesforceAPI(nango.lastSyncDate, nextPage);
+        const res = getContactsFromSalesforceAPI(checkpoint?.lastModifiedISO, nextPage);
         // ...
+        const contacts = mapContacts(res.data.records);
         // Save Salesforce contacts after each page.
-        await nango.batchSave(mapContacts(res.data.records), 'Contact');
+        await nango.batchSave(contacts, 'Contact');
+        // Save checkpoint
+        await nango.saveCheckpoint({ lastModifiedISO: contacts[contacts.length - 1].LastModifiedDate });
     }
   },
 });
 ```
 
-Combining a large dataset with a full refresh sync while storing the entire dataset in memory will likely cause periodic VM crashes.
+Combining a large dataset while storing the entire dataset in memory will likely cause periodic VM crashes.
 
 You can monitor the memory consumption of your functions executions in the Logs tab within the Nango UI.
 
@@ -125,7 +140,7 @@ You can monitor the memory consumption of your functions executions in the Logs 
 
 Another strategy for handling large datasets successfully is to filter the data you need as early as possible, either using filters available from the external API or by discarding data in the functions, i.e., not saving it to the Nango cache.
 
-This approach uses the external system as a source of truth, allowing you to sync additional data in the future by editing your Nango function and triggering a full refresh to backfill any missing historical data.
+This approach uses the external system as a source of truth, allowing you to sync additional data in the future by editing your Nango function and triggering a sync with `reset: true` to backfill any missing historical data.
 
 Because of the flexibility of integration functions, Nango allows you to perform transformations early in the data sync process, optimizing resource use and enabling faster syncing.
 

--- a/docs/reference/functions.mdx
+++ b/docs/reference/functions.mdx
@@ -21,7 +21,6 @@ description: "Full reference of the SDK available in Nango functions"
       endpoints: [{ method: 'GET', path: '/example/github/issues', group: 'Issues' }],
       frequency: 'every hour',
       autoStart: true,
-      syncType: 'full',
 
       metadata: z.void(),
       models: {
@@ -134,8 +133,15 @@ Read more about [integration functions](/guides/primitives/functions) to underst
   ```
 </ResponseField>
 
-<ResponseField name="syncType" type="'full' | 'incremental'" required>
-  The type of the sync.
+<ResponseField name="checkpoint" type="ZodSchema">
+  Optional schema defining the shape of checkpoint data for this sync.
+  Use checkpoints to save progress and avoid re-fetching all data on every run.
+
+  ```ts
+  checkpoint: z.object({
+      cursor: z.string(),
+  }),
+  ```
 </ResponseField>
 
 <ResponseField name="autoStart" type="boolean">
@@ -772,6 +778,55 @@ await nango.getConnection();
 ## Sync-specific helper methods
 
 Sync functions persist data updates to the Nango cache, which your app later fetches (cf. [step-by-step guide](/implementation-guides/use-cases/syncs/implement-a-sync)).
+
+### Checkpoints
+
+Checkpoints allow syncs to save their progress and resume from where they left off. This is useful for:
+- Resuming after failures without re-fetching all data
+- Tracking pagination state across sync runs
+- Storing custom cursor/offset values
+
+To use checkpoints, define a `checkpoint` schema in your sync configuration (see [Configuration](#createsync)).
+
+#### getCheckpoint()
+
+Retrieves the current checkpoint. Returns `null` on first run or after a reset.
+
+```ts
+const checkpoint = await nango.getCheckpoint();
+if (checkpoint) {
+    // Resume from checkpoint
+    startCursor = checkpoint.cursor;
+}
+```
+
+**Response**
+
+Returns the checkpoint object matching your schema, or `null` if no checkpoint exists.
+
+#### saveCheckpoint()
+
+Saves the current progress. Call this after processing each batch of data to enable resumption if the sync fails.
+
+```ts
+await nango.saveCheckpoint({ cursor: nextCursor });
+```
+
+**Parameters**
+
+<Expandable>
+  <ResponseField name="checkpoint" type="object" required>
+    The checkpoint data matching your defined schema.
+  </ResponseField>
+</Expandable>
+
+#### clearCheckpoint()
+
+Clears the checkpoint. Rarely needed as checkpoints are automatically cleared when triggering a sync with `reset: true`.
+
+```ts
+await nango.clearCheckpoint();
+```
 
 ### Save records
 

--- a/docs/reference/sdks/node.mdx
+++ b/docs/reference/sdks/node.mdx
@@ -861,7 +861,6 @@ const scriptsConfig = await nango.getScriptsConfig();
                         ]
                     }
                 ],
-                "sync_type": "FULL",
                 "runs": "every half hour",
                 "track_deletes": false,
                 "auto_start": false,
@@ -874,7 +873,7 @@ const scriptsConfig = await nango.getScriptsConfig();
                 "returns": [
                     "GithubIssue"
                 ],
-                "description": "Fetches the Github issues from all a user's repositories.\nDetails: full sync, doesn't track deletes, metadata is not required.\n",
+                "description": "Fetches the Github issues from all a user's repositories.\nDetails: doesn't track deletes, metadata is not required.\n",
                 "scopes": [
                     "public_repo"
                 ],
@@ -1441,13 +1440,13 @@ console.log(`Pruned ${result.count} records. More records available: ${result.ha
 Triggers an additional, one-off execution of specified sync(s) for a given connection or all applicable connections if no connection is specified.
 
 ```ts
-// Incremental sync (default, preserves lastSyncDate)
+// Simple usage - trigger sync preserving checkpoint
 await nango.triggerSync('<INTEGRATION-ID>', ['SYNC_NAME1', 'SYNC_NAME2'], '<CONNECTION_ID>');
 
-// Full resync (resets lastSyncDate)
+// Reset checkpoint and start fresh
 await nango.triggerSync('<INTEGRATION-ID>', ['SYNC_NAME1'], '<CONNECTION_ID>', { reset: true });
 
-// Full resync with cache clear (resets lastSyncDate and deletes all records)
+// Reset checkpoint and clear all cached records
 await nango.triggerSync('<INTEGRATION-ID>', ['SYNC_NAME1'], '<CONNECTION_ID>', { reset: true, emptyCache: true });
 
 // Using variants
@@ -1473,15 +1472,15 @@ await nango.triggerSync('<INTEGRATION-ID>', [
         The connection ID. If omitted, the sync will trigger for all relevant connections.
     </ResponseField>
     <ResponseField name="opts" type="object">
-        Options for the sync trigger.
-        - `reset`: If `true`, resets the "lastSyncDate" before triggering (full resync). Defaults to `false` (incremental).
-        - `emptyCache`: If `true`, deletes all records associated with the sync before triggering. Defaults to `false`.
-    </ResponseField>
-    <ResponseField name="sync_mode (deprecated)" type="'incremental' | 'full_refresh' | 'full_refresh_and_clear_cache'">
-        Deprecated. Use `opts` instead.
-        - `incremental`: equivalent to `{ reset: false }`
-        - `full_refresh`: equivalent to `{ reset: true }`
-        - `full_refresh_and_clear_cache`: equivalent to `{ reset: true, emptyCache: true }`
+        Options for triggering the sync.
+        <Expandable>
+            <ResponseField name="reset" type="boolean">
+                If `true`, clears the checkpoint before triggering the sync, causing it to start fresh.
+            </ResponseField>
+            <ResponseField name="emptyCache" type="boolean">
+                If `true`, deletes all cached records associated with the sync before triggering. Must be used with `reset: true`.
+            </ResponseField>
+        </Expandable>
     </ResponseField>
 </Expandable>
 

--- a/docs/snippets/generated/cloudflare/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/cloudflare/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/platform/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -1191,9 +1191,6 @@ paths:
                                                     example: 'sync'
                                                 json_schema:
                                                     type: object
-                                                sync_type:
-                                                    type: string
-                                                    example: 'full'
                                                 runs:
                                                     type: string
                                                     example: 'every 30 minutes'
@@ -1222,7 +1219,7 @@ paths:
                                                         example: 'GithubIssue'
                                                 description:
                                                     type: string
-                                                    example: "Fetches the Github issues from all a user's repositories.\nDetails: full sync, doesn't track deletes, metadata is not required.\n"
+                                                    example: "Fetches the Github issues from all a user's repositories.\nDetails: doesn't track deletes, metadata is not required.\n"
                                                 scopes:
                                                     type: array
                                                     items:
@@ -1280,7 +1277,7 @@ paths:
                                                     type: object
                                                 description:
                                                     type: string
-                                                    example: "Fetches the Github issues from all a user's repositories.\nDetails: full sync, doesn't track deletes, metadata is not required.\n"
+                                                    example: "Fetches the Github issues from all a user's repositories.\nDetails: doesn't track deletes, metadata is not required.\n"
                                                 scopes:
                                                     type: array
                                                     items:
@@ -1564,28 +1561,14 @@ paths:
                                               example: { 'name': 'github-issues', 'variant': 'custom-variant' }
                                 opts:
                                     type: object
-                                    description: Options for the sync trigger.
+                                    description: Options for triggering the sync.
                                     properties:
                                         reset:
                                             type: boolean
-                                            description: If true, resets the "lastSyncDate" before triggering (equivalent to a full resync).
+                                            description: If true, clears the checkpoint and lastSyncDate before triggering the sync, causing it to start fresh.
                                         emptyCache:
                                             type: boolean
-                                            description: If true, deletes all records associated with the sync before triggering.
-                                sync_mode:
-                                    deprecated: true
-                                    type: string
-                                    enum: ['incremental', 'full_refresh', 'full_refresh_and_clear_cache']
-                                    description: |
-                                        Deprecated. Use `opts` instead.
-                                        The mode in which to trigger the syncs.
-                                        - `incremental`: Triggers a new sync job while preserving the "lastSyncDate".
-                                        - `full_refresh`: Resets the "lastSyncDate" associated with the sync before triggering a new sync job.
-                                        - `full_refresh_and_clear_cache`: Resets the "lastSyncDate" and deletes all records associated with the sync before triggering a new sync job.
-                                full_resync:
-                                    deprecated: true
-                                    type: boolean
-                                    description: Deprecated. Use `opts.reset` instead. Reset the "lastSyncDate" associated with the sync before triggering a new sync job.
+                                            description: If true, deletes all cached records associated with the sync before triggering. Must be used with reset=true.
 
             responses:
                 '200':

--- a/docs/updates/product.mdx
+++ b/docs/updates/product.mdx
@@ -54,7 +54,7 @@ Access the Connect UI settings in your [Environment settings](https://app.nango.
 
 ## Improved deletion detection when syncing data
 
-For APIs that don't support deletion detection, we've added a new interface to detect deletions on Nango's side when syncing data ([docs](/implementation-guides/use-cases/syncs/deletion-detection#detecting-deletes-in-full-refresh-syncs)).
+For APIs that don't support deletion detection, we've added a new interface to detect deletions on Nango's side when syncing data ([docs](/implementation-guides/use-cases/syncs/deletion-detection#detecting-deletes-in-syncs-without-checkpoints)).
 
 Inside your sync function, you can now call `nango.deleteRecordsFromPreviousExecutions('ModelName')` to detect deletions.
 


### PR DESCRIPTION
Update docs to replace the concepts of incremental and full sync with checkpoints.

<!-- Summary by @propel-code-bot -->

---

The documentation now frames checkpoints as the primary mental model across guides, API references, SDK docs, and product updates, replacing the incremental/full sync narrative for deletion detection, testing workflows, API schemas, and reset semantics with checkpoint-specific explanations and helper flows.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `docs/implementation-guides/use-cases/syncs/deletion-detection.mdx`, `large-datasets.mdx`, and `implement-a-sync.mdx` to describe sync strategies through checkpoints vs. no-checkpoint fetching, including refreshed code samples that use `nango.getCheckpoint()`/`nango.saveCheckpoint()`.
• Expanded `docs/reference/functions.mdx`, `docs/reference/sdks/node.mdx`, and `docs/spec.yaml` with checkpoint configuration fields and clarified sync trigger/reset options, removing `syncType` terminology.
• Adjusted ancillary docs (`docs/implementation-guides/platform/functions/testing.mdx`, `docs/guides/primitives/functions.mdx`, `docs/updates/product.mdx`, and `docs/implementation-guides/platform/migrations/migrate-to-zero-yaml.mdx`) plus Cloudflare snippet to align links and messaging with the checkpoint model.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Docs now imply track-delete automation only works without checkpoints; if product soon supports both, messaging may need rework.
• CLI dry-run section removed `--lastSyncDate` guidance without offering an alternative for checkpointed syncs, which could confuse readers.

</details>

---
*This summary was automatically generated by @propel-code-bot*