### PR TITLE
chore: Fix release github action breaking package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33355,53 +33355,6 @@
                 "node": ">=20.0"
             }
         },
-        "packages/cli/node_modules/@nangohq/node/node_modules/@nangohq/types": {
-            "version": "0.69.30",
-            "resolved": "https://registry.npmjs.org/@nangohq/types/-/types-0.69.30.tgz",
-            "integrity": "sha512-dtKDsN6nAMbzv7B+Qtax9yXJ/v17n8bYUPW0hyg3Otc+Jp/mW6nlQUoExadegnBvzN0eWasZf2joHhuKZKa+SA==",
-            "extraneous": true,
-            "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
-            "dependencies": {
-                "axios": "1.12.0",
-                "json-schema": "0.4.0",
-                "type-fest": "4.41.0"
-            }
-        },
-        "packages/cli/node_modules/@nangohq/runner-sdk/node_modules/@nangohq/node": {
-            "version": "0.69.30",
-            "resolved": "https://registry.npmjs.org/@nangohq/node/-/node-0.69.30.tgz",
-            "integrity": "sha512-6lvqCchnbpPdjJDllFg+c7BZoSK7fT7v80uCgryJnpsOdJ1FUNJ2iDQWlJZgEp3caFGQbHIKot0r6U6UFf9Kwg==",
-            "extraneous": true,
-            "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
-            "dependencies": {
-                "@nangohq/types": "0.69.30",
-                "axios": "1.12.0"
-            },
-            "engines": {
-                "node": ">=20.0"
-            }
-        },
-        "packages/cli/node_modules/@nangohq/runner-sdk/node_modules/@nangohq/providers": {
-            "version": "0.69.30",
-            "resolved": "https://registry.npmjs.org/@nangohq/providers/-/providers-0.69.30.tgz",
-            "integrity": "sha512-vlng8GllhUPc6ECsCOTMvIxmkFcU87ek3ZuA/IB7kciv7FpS0cKVsK4s5A+tANURPyx8w1a23KSolqF3+1J+tA==",
-            "extraneous": true,
-            "dependencies": {
-                "js-yaml": "4.1.1"
-            }
-        },
-        "packages/cli/node_modules/@nangohq/runner-sdk/node_modules/@nangohq/types": {
-            "version": "0.69.30",
-            "resolved": "https://registry.npmjs.org/@nangohq/types/-/types-0.69.30.tgz",
-            "integrity": "sha512-dtKDsN6nAMbzv7B+Qtax9yXJ/v17n8bYUPW0hyg3Otc+Jp/mW6nlQUoExadegnBvzN0eWasZf2joHhuKZKa+SA==",
-            "extraneous": true,
-            "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
-            "dependencies": {
-                "axios": "1.12.0",
-                "json-schema": "0.4.0",
-                "type-fest": "4.41.0"
-            }
-        },
         "packages/cli/node_modules/ajv": {
             "version": "8.17.1",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -35841,18 +35794,6 @@
             "peer": true,
             "peerDependencies": {
                 "react": "^18.2.0"
-            }
-        },
-        "packages/webapp/node_modules/@nangohq/frontend/node_modules/@nangohq/types": {
-            "version": "0.69.30",
-            "resolved": "https://registry.npmjs.org/@nangohq/types/-/types-0.69.30.tgz",
-            "integrity": "sha512-dtKDsN6nAMbzv7B+Qtax9yXJ/v17n8bYUPW0hyg3Otc+Jp/mW6nlQUoExadegnBvzN0eWasZf2joHhuKZKa+SA==",
-            "extraneous": true,
-            "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
-            "dependencies": {
-                "axios": "1.12.0",
-                "json-schema": "0.4.0",
-                "type-fest": "4.41.0"
             }
         },
         "packages/webapp/node_modules/@radix-ui/number": {

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -7,6 +7,16 @@ const argv = minimist(process.argv.slice(2));
 const nextVersion = argv.version;
 const skipCli = argv['skip-cli'] === true;
 const dryRun = argv['dry-run'] === true;
+const publishedPackageNames = new Set([
+    '@nangohq/types',
+    '@nangohq/nango-yaml',
+    '@nangohq/providers',
+    '@nangohq/node',
+    '@nangohq/runner-sdk',
+    '@nangohq/frontend',
+    'nango'
+]);
+const lockfileDependencyFields = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
 
 if (!nextVersion) {
     echo`${chalk.red(`Please specify a version: "node publish.mjs 0.0.1"`)}`;
@@ -30,42 +40,42 @@ await bumpVersionTs();
 await tsBuild();
 
 // ---- Publish
+await bumpWorkspacePackageVersion('@nangohq/types');
 await npmPublish('@nangohq/types');
 await bumpReference('@nangohq/types');
-await npmInstall();
 
+await bumpWorkspacePackageVersion('@nangohq/nango-yaml');
 await npmPublish('@nangohq/nango-yaml');
 await bumpReference('@nangohq/nango-yaml');
-await npmInstall();
 
+await bumpWorkspacePackageVersion('@nangohq/providers');
 await npmPublish('@nangohq/providers');
 await bumpReference('@nangohq/providers');
-await npmInstall();
 
+await bumpWorkspacePackageVersion('@nangohq/node');
 await npmPublish('@nangohq/node');
 await bumpReference('@nangohq/node');
-await npmInstall();
 
+await bumpWorkspacePackageVersion('@nangohq/runner-sdk');
 await npmPublish('@nangohq/runner-sdk');
 await bumpReference('@nangohq/runner-sdk');
-await npmInstall();
 
 // TODO: to delete maybe, seems unnecessary
+await bumpWorkspacePackageVersion('@nangohq/frontend');
 await npmPublish('@nangohq/frontend');
 await bumpReference('@nangohq/frontend');
-await npmInstall();
 
 if (!skipCli) {
+    await bumpWorkspacePackageVersion('nango');
     await npmPublish('nango');
-    await npmInstall();
 }
 // ---- /Publish
 
-await $`npm version "${nextVersion}" --no-git-tag-version --allow-same-version`;
+await bumpRootVersion();
 
 echo``;
-await npmInstall();
-echo(chalk.green(`${figures.tick} npm install`));
+await bumpLockfileVersions();
+echo(chalk.green(`${figures.tick} package-lock.json`));
 echo(chalk.grey('done'));
 
 // Output for post deploy debug
@@ -110,13 +120,45 @@ async function npmPublish(packageName) {
             process.exit(1);
         }
 
-        await $`npm version ${nextVersion} -w "${packageName}"`;
-        if (!dryRun) {
-            await $`npm publish --access public --provenance -w "${packageName}"`;
+        if (dryRun) {
+            echo(chalk.yellow(`${figures.tick} Dry run, skipping publish ${packageName}`));
+            return;
         }
+
+        await $`npm publish --access public --provenance -w "${packageName}"`;
 
         echo(chalk.green(`${figures.tick} Published ${packageName}      `));
     });
+}
+
+async function bumpWorkspacePackageVersion(packageName) {
+    const packagesJson = await glob('packages/*/package.json');
+    for (const packageJson of packagesJson) {
+        const content = JSON.parse((await fs.readFile(packageJson)).toString());
+        if (content.name !== packageName) {
+            continue;
+        }
+
+        if (content.version !== nextVersion) {
+            content.version = nextVersion;
+            await fs.writeFile(packageJson, `${JSON.stringify(content, null, 4)}\n`);
+            echo(chalk.grey(`  ${figures.tick} Bumped ${packageName} version in ${packageJson}`));
+        }
+        return;
+    }
+
+    echo`${chalk.red(`Could not find workspace package ${packageName}`)}`;
+    process.exit(1);
+}
+
+async function bumpRootVersion() {
+    const rootPackageJson = 'package.json';
+    const content = JSON.parse((await fs.readFile(rootPackageJson)).toString());
+    if (content.version !== nextVersion) {
+        content.version = nextVersion;
+        await fs.writeFile(rootPackageJson, `${JSON.stringify(content, null, 4)}\n`);
+        echo(chalk.grey(`  ${figures.tick} Bumped root package version in ${rootPackageJson}`));
+    }
 }
 
 async function bumpReference(packageName) {
@@ -135,8 +177,47 @@ async function bumpReference(packageName) {
     }
 }
 
-async function npmInstall() {
-    await spinner('npm install', async () => {
-        await $`npm i`;
+async function bumpLockfileVersions() {
+    await spinner('update package-lock versions', async () => {
+        const lockfilePath = 'package-lock.json';
+        const lock = JSON.parse((await fs.readFile(lockfilePath)).toString());
+
+        if (lock.version) {
+            lock.version = nextVersion;
+        }
+        if (lock.packages?.['']?.version) {
+            lock.packages[''].version = nextVersion;
+        }
+
+        for (const [, packageMetadata] of Object.entries(lock.packages ?? {})) {
+            if (!packageMetadata || typeof packageMetadata !== 'object') {
+                continue;
+            }
+
+            if (
+                typeof packageMetadata.name === 'string' &&
+                typeof packageMetadata.version === 'string' &&
+                publishedPackageNames.has(packageMetadata.name) &&
+                versionRegex.test(packageMetadata.version)
+            ) {
+                packageMetadata.version = nextVersion;
+            }
+
+            for (const field of lockfileDependencyFields) {
+                const dependencies = packageMetadata[field];
+                if (!dependencies || typeof dependencies !== 'object') {
+                    continue;
+                }
+
+                for (const dependencyName of publishedPackageNames) {
+                    const currentValue = dependencies[dependencyName];
+                    if (typeof currentValue === 'string' && versionRegex.test(currentValue)) {
+                        dependencies[dependencyName] = nextVersion;
+                    }
+                }
+            }
+        }
+
+        await fs.writeFile(lockfilePath, `${JSON.stringify(lock, null, 4)}\n`);
     });
 }


### PR DESCRIPTION
## Root cause

The release workflow (`publish.yaml`) runs on `ubuntu-latest` (Linux x64). The old `publish.mjs` called `npm i` **8 times** during the publish sequence (once after each package publish). On Linux, npm strips platform-specific optional dependencies (e.g. `lightningcss-darwin-arm64`, `lightningcss-win32-x64-msvc`, etc.) from `package-lock.json` because they fail the `EBADPLATFORM` check. Then `gitrelease.mjs` commits this corrupted lockfile to master.

This is a long-standing npm bug: [npm/cli#4828](https://github.com/npm/cli/issues/4828) (opened April 2022) and [npm/cli#7961](https://github.com/npm/cli/issues/7961) (regression in npm 10.3.0+).

A fix was merged in [npm/cli#8184](https://github.com/npm/cli/pull/8184) and shipped in npm 11.3.0 (April 2025), but **it does not fully resolve the issue**. Users continue to report the bug on npm [11.5.2](https://github.com/npm/cli/issues/4828#issuecomment-2861929046), [11.6.0](https://github.com/npm/cli/issues/4828#issuecomment-2914428131), and later. Our release that broke ([bca40e6d](https://github.com/NangoHQ/nango/commit/bca40e6d075fc320019a7276b1e444fa8a8fdc44), v0.69.31) was already using npm 11.5.1. There is **no flag** (`--include=optional`, `--package-lock-only`, `--ignore-scripts`, etc.) that prevents the pruning.

I have tested the logic on this PR to verify it works on dryruns. We will need to verify the actual fix once this is merged on master.

## Fix

Replace all `npm i` and `npm version` calls in `publish.mjs` with direct JSON file manipulation:

- **`bumpWorkspacePackageVersion()`** — writes version directly to `packages/*/package.json`
- **`bumpReference()`** — updates cross-workspace dependency references in `package.json` files
- **`bumpRootVersion()`** — writes version to root `package.json`
- **`bumpLockfileVersions()`** — updates version entries in `package-lock.json` for all published packages

npm never modifies the lockfile during the release, so platform-specific optional dependencies are preserved.

## Ghost packages cleanup

Found 5 extraneous registry-resolved entries in `package-lock.json` for workspace packages (`@nangohq/types`, `@nangohq/node`, `@nangohq/providers`). These were nested under `packages/cli/node_modules/` and `packages/webapp/node_modules/` with `"extraneous": true`.

These are artifacts from the old publish flow: the old script would publish a package to npm, then run `npm i` — npm would pull the just-published version from the registry and nest it inside other workspace packages instead of using the workspace link. Each release accumulated more of these ghost entries.

Since we no longer call `npm i` during publish, these entries won't be recreated. They've been removed from the lockfile.

<!-- Summary by @propel-code-bot -->

---

The change also introduces a curated publishedPackageNames set so every workspace package receives deterministic JSON-based version rewrites without depending on npm install/version.

<details>
<summary><strong>Possible Issues</strong></summary>

• `bumpLockfileVersions` only rewrites dependency values that match the strict `versionRegex`, so caret/range specifiers or git refs will not be updated and may drift.
• Any workspace omitted from `publishedPackageNames` will never receive version updates in the lockfile, potentially causing publish inconsistencies.
• Concurrent release runs could race because package versions are written before `npm publish`; a second run might see already-bumped versions and behave unpredictably.

</details>

---
*This summary was automatically generated by @propel-code-bot*