### PR TITLE
feat: add checkpoint to sync status response

### DIFF
--- a/docs/reference/sdks/node.mdx
+++ b/docs/reference/sdks/node.mdx
@@ -1622,6 +1622,10 @@ await nango.syncStatus('<INTEGRATION-ID>', '*', '<CONNECTION_ID>');
             "recordCount": {
                 "<string>": <number>
                 ...
+            },
+            "checkpoint": {
+                "<string>": "<string | number | boolean>"
+                ...
             }
         }
     ]

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -1805,6 +1805,11 @@ paths:
                                                 recordCount:
                                                     type: object
                                                     description: Total count of records for each model synced by the sync
+                                                checkpoint:
+                                                    anyOf:
+                                                        - type: object
+                                                        - type: 'null'
+                                                    description: Last checkpoint saved during sync execution. Null if no checkpoint exists.
                 '400':
                     $ref: '#/components/responses/BadRequest'
                 '401':

--- a/packages/node-client/lib/types.ts
+++ b/packages/node-client/lib/types.ts
@@ -11,6 +11,7 @@ import type {
     AuthOperationType,
     BasicApiCredentials,
     BillCredentials,
+    Checkpoint,
     CredentialsCommon,
     CustomCredentials,
     GetPublicConnection,
@@ -174,6 +175,7 @@ export interface SyncStatus {
     frequency: string;
     latestResult: Record<string, StatusAction>;
     recordCount: Record<string, number>;
+    checkpoint: Checkpoint | null;
 }
 
 export interface StatusAction {

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -564,7 +564,7 @@ export class SyncManagerService {
             latestResult: latestJob?.result,
             latestExecutionStatus: latestJob?.status,
             recordCount,
-            checkpoint: checkpoint.value?.checkpoint || null,
+            checkpoint: checkpoint.value && !checkpoint.value.deleted_at ? checkpoint.value.checkpoint : null,
             ...(includeJobStatus ? { jobStatus: latestJob?.status as SyncStatus } : {})
         };
     }

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -1,4 +1,5 @@
-import { getLogger, stringifyError } from '@nangohq/utils';
+import db from '@nangohq/database';
+import { getCheckpointKey, getLogger, stringifyError } from '@nangohq/utils';
 
 import connectionService from '../connection.service.js';
 import { deleteSyncConfig, deleteSyncFilesForConfig, getSyncConfig, getSyncConfigByParams } from './config/config.service.js';
@@ -7,6 +8,7 @@ import { createSync, getSync, getSyncsByConnectionId, getSyncsByProviderConfigKe
 import { SyncJobsType, SyncStatus } from '../../models/Sync.js';
 import { NangoError } from '../../utils/error.js';
 import accountService from '../account.service.js';
+import { getCheckpoint } from '../checkpoints/checkpoints.js';
 import configService from '../config.service.js';
 import { errorNotificationService } from '../notification/error.service.js';
 
@@ -538,6 +540,17 @@ export class SyncManagerService {
                 {} as Record<string, number>
             ) || {};
 
+        const checkpoint = await getCheckpoint(db.knex, {
+            environmentId,
+            connectionId: sync.nango_connection_id,
+            key: getCheckpointKey({ type: 'sync', name: sync.name, variant: sync.variant })
+        });
+        if (checkpoint.isErr()) {
+            throw new Error(
+                `Failed to get checkpoint for sync ${sync.name} (variant: ${sync.variant}) in environment ${environmentId}: ${stringifyError(checkpoint.error)}`
+            );
+        }
+
         return {
             id: sync.id,
             connection_id: sync.connection_id,
@@ -551,6 +564,7 @@ export class SyncManagerService {
             latestResult: latestJob?.result,
             latestExecutionStatus: latestJob?.status,
             recordCount,
+            checkpoint: checkpoint.value?.checkpoint || null,
             ...(includeJobStatus ? { jobStatus: latestJob?.status as SyncStatus } : {})
         };
     }

--- a/packages/types/lib/sync/index.ts
+++ b/packages/types/lib/sync/index.ts
@@ -1,3 +1,5 @@
+import type { Checkpoint } from '../checkpoint/types.js';
+
 export type SyncStatus = 'RUNNING' | 'PAUSED' | 'STOPPED' | 'SUCCESS' | 'ERROR';
 
 export type SyncJobsType = 'INCREMENTAL' | 'FULL' | 'WEBHOOK' | 'ON_EVENT_SCRIPT' | 'ACTION';
@@ -24,4 +26,5 @@ export interface ReportedSyncJobStatus {
     nextScheduledSyncAt: Date | null;
     latestExecutionStatus: SyncStatus | undefined;
     recordCount: Record<string, number>;
+    checkpoint: Checkpoint | null;
 }


### PR DESCRIPTION
Example:
```
{
  "syncs": [
    {
      "id": "6ec3be19-e91e-403d-b209-5299af4019a2",
      "name": "syncA",
      ...
      "checkpoint": {
        "lastPage": 3
      }
    },
    {
      "id": "4a08b79b-9501-418a-8d98-d0302fb37f99",
      "name": "syncB",
      ...
      "checkpoint": null
    }
  ]
}
```

<!-- Summary by @propel-code-bot -->

---

**Expose sync checkpoints in `syncStatus` responses**

Adds checkpoint data to the sync-status pipeline so clients can inspect the last persisted checkpoint for each sync. The sync manager now loads the checkpoint record for every sync, surfaces it in `ReportedSyncJobStatus`, and propagates the field through the Node SDK types and public documentation (reference docs and OpenAPI spec). Soft-deleted checkpoints are filtered out so consumers only see active metadata.

<details>
<summary><strong>Key Changes</strong></summary>

• Load per-sync checkpoints in `packages/shared/lib/services/sync/manager.service.ts` and include `checkpoint: checkpoint.value && !checkpoint.value.deleted_at ? checkpoint.value.checkpoint : null` in the returned status payload.
• Extend `ReportedSyncJobStatus` in `packages/types/lib/sync/index.ts` and Node SDK `SyncStatus` in `packages/node-client/lib/types.ts` with an optional `checkpoint: Checkpoint | null` field imported from `@nangohq/types`.
• Document the new response property in `docs/reference/sdks/node.mdx` and `docs/spec.yaml`, describing the checkpoint object in both the SDK reference and OpenAPI schema.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• `syncStatus` now fails entirely if `getCheckpoint` errors for any sync, which may regress behavior compared to returning partial statuses.

</details>

---
*This summary was automatically generated by @propel-code-bot*