### PR TITLE
feat(cli): add --checkpoint option to dryrun command

### DIFF
--- a/docs/implementation-guides/platform/functions/testing.mdx
+++ b/docs/implementation-guides/platform/functions/testing.mdx
@@ -49,6 +49,9 @@ nango dryrun fetch-tickets abc-123 -e prod
 # For actions: pass input data
 nango dryrun create-ticket abc-123 --input '{"title": "Test ticket"}'
 
+# For syncs: specify an initial checkpoint
+nango dryrun fetch-tickets abc-123 --checkpoint '{ "lastModifiedAt": "2026-02-01T01:00:00.000Z" }'
+
 # Use a specific integration when sync names overlap
 nango dryrun fetch-tickets abc-123 --integration-id github
 

--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -301,6 +301,11 @@ program
             'You can also pass a file path prefixed with `@` to the metadata and appended by `json`, for example @fixtures/metadata.json. Note that only json files can be passed.'
     )
     .option(
+        '-c, --checkpoint [checkpoint]',
+        'Optional (for syncs only): checkpoint to stub for the sync script supplied in JSON format, for example --checkpoint \'{"lastPage": "3"}\'. ' +
+            'You can also pass a file path prefixed with `@` to the checkpoint and appended by `json`, for example @fixtures/checkpoint.json. Note that only json files can be passed.'
+    )
+    .option(
         '--integration-id [integrationId]',
         'Optional: The integration id to use for the dryrun. If not provided, the integration id will be retrieved from the nango.yaml file. This is useful using nested directories and script names are repeated'
     )
@@ -320,6 +325,7 @@ program
             lastSyncDate,
             variant,
             metadata,
+            checkpoint,
             diagnostics
         } = this.opts();
         const shouldValidate = validation || saveResponses;
@@ -396,6 +402,7 @@ program
             lastSyncDate,
             variant,
             metadata,
+            checkpoint,
             diagnostics
         });
     });

--- a/packages/runner-sdk/lib/checkpoint.ts
+++ b/packages/runner-sdk/lib/checkpoint.ts
@@ -2,22 +2,14 @@ import * as z from 'zod';
 
 import type { Checkpoint } from '@nangohq/types';
 
-export const checkpointSchema = z.record(
-    z.string(),
-    z.union([z.string(), z.number(), z.boolean(), z.date()]).transform((d) => {
-        if (typeof d === 'string' && z.string().datetime().safeParse(d).success) {
-            return new Date(d);
-        }
-        return d;
-    })
-);
+export const checkpointSchema = z.record(z.string(), z.union([z.string(), z.number(), z.boolean()]));
 
 /*
- * Runtime validtion for checkpoints.
- * Checkpoints must be an object with string keys and values that are either strings, numbers, booleans, or ISO date strings.
+ * Runtime validation for checkpoints.
+ * Checkpoints must be an object with string keys and values that are either strings, numbers or booleans.
  */
-export function validateCheckpoint(sample: Checkpoint): Checkpoint {
-    const result = checkpointSchema.safeParse(sample);
+export function validateCheckpoint(data: any): Checkpoint {
+    const result = checkpointSchema.safeParse(data);
     if (!result.success) {
         throw new Error(`Invalid checkpoint: ${result.error.message}`);
     }

--- a/packages/runner-sdk/lib/checkpoint.ts
+++ b/packages/runner-sdk/lib/checkpoint.ts
@@ -1,0 +1,22 @@
+import * as z from 'zod';
+
+import type { Checkpoint } from '@nangohq/types';
+
+/*
+ * The checkpoint can contain date strings.
+ * This function recursively checks the checkpoint object and converts any string that is a valid datetime to a Date object.
+ */
+export function validateCheckpoint(checkpoint: Checkpoint): Checkpoint {
+    const validated: Checkpoint = {};
+    for (const [key, value] of Object.entries(checkpoint)) {
+        if (typeof value === 'string') {
+            const parsed = z.string().datetime().safeParse(value);
+            if (parsed.success) {
+                validated[key] = new Date(value);
+                continue;
+            }
+        }
+        validated[key] = value;
+    }
+    return validated;
+}

--- a/packages/runner-sdk/lib/index.ts
+++ b/packages/runner-sdk/lib/index.ts
@@ -4,6 +4,7 @@ export * from './dataValidation.js';
 export * from './errors.js';
 export * from './sync.js';
 export * from './scripts.js';
+export * from './checkpoint.js';
 import PaginationService from './paginate.service.js';
 
 export { PaginationService };

--- a/packages/runner-sdk/lib/scripts.ts
+++ b/packages/runner-sdk/lib/scripts.ts
@@ -118,7 +118,7 @@ export interface CreateSyncProps<TModels extends Record<string, ZodModel>, TMeta
 
     /**
      * The checkpoint schema for storing sync progress and resume state.
-     * Checkpoint must be an object with string, number, boolean, or Date values.
+     * Checkpoint must be an object with string, number or boolean values.
      * Nested objects or arrays are not supported.
      *
      * @example
@@ -280,7 +280,7 @@ export interface CreateActionProps<
 
     /**
      * The checkpoint schema for storing action progress and resume state.
-     * Checkpoint must be an object with string, number, boolean, or Date values.
+     * Checkpoint must be an object with string, number or boolean values.
      * Nested objects or arrays are not supported.
      *
      * @example
@@ -391,7 +391,7 @@ export interface CreateOnEventProps<TMetadata extends ZodMetadata = undefined, T
 
     /**
      * The checkpoint schema for storing OnEvent script progress and resume state.
-     * Checkpoint must be an object with string, number, boolean, or Date values.
+     * Checkpoint must be an object with string, number or boolean values.
      * Nested objects or arrays are not supported.
      *
      * @example

--- a/packages/runner-sdk/lib/scripts.ts
+++ b/packages/runner-sdk/lib/scripts.ts
@@ -5,7 +5,10 @@ import type { NangoSyncEndpointV2 } from '@nangohq/types';
 import type { MaybePromise } from 'rollup';
 import type * as z from 'zod';
 
-export type CreateAnyResponse = CreateSyncResponse<any, any> | CreateActionResponse<any, any> | CreateOnEventResponse;
+export type CreateAnyResponse =
+    | CreateSyncResponse<any, ZodMetadata, ZodCheckpoint>
+    | CreateActionResponse<any, any, ZodMetadata, ZodCheckpoint>
+    | CreateOnEventResponse<ZodMetadata, ZodCheckpoint>;
 
 export type { ActionError } from './errors.js';
 export type { NangoActionBase as NangoAction, ProxyConfiguration } from './action.js';

--- a/packages/runner-sdk/lib/types.ts
+++ b/packages/runner-sdk/lib/types.ts
@@ -2,7 +2,7 @@ import type * as z from 'zod';
 
 export type ZodMetadata = z.ZodObject | z.ZodVoid | undefined;
 
-export type ZodCheckpoint = z.ZodObject<Record<string, z.ZodString | z.ZodNumber | z.ZodBoolean | z.ZodDate>> | undefined;
+export type ZodCheckpoint = z.ZodObject<Record<string, z.ZodString | z.ZodNumber | z.ZodBoolean>> | undefined;
 
 export type ZodModel = z.ZodObject<{ id: z.ZodString }>;
 export interface RawModel {

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -168,7 +168,7 @@ export async function exec({
                     if (!payload.exec) {
                         throw new Error(`Missing exec function`);
                     }
-                    output = await payload.exec(nango as any, codeParams);
+                    output = await payload.exec(nango, codeParams);
                 } else {
                     output = await def(nango, inputParams);
                 }

--- a/packages/runner/lib/sdk/checkpointing.ts
+++ b/packages/runner/lib/sdk/checkpointing.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { validateCheckpoint } from '@nangohq/runner-sdk';
 
 import type { PersistClient } from '../clients/persist.js';
 import type { Checkpoint } from '@nangohq/types';
@@ -96,23 +96,4 @@ export class Checkpointing {
 
         return { version: this.last.version };
     }
-}
-
-/*
- * The checkpoint can contain date strings.
- * This function recursively checks the checkpoint object and converts any string that is a valid datetime to a Date object.
- */
-function validateCheckpoint(checkpoint: Checkpoint): Checkpoint {
-    const validated: Checkpoint = {};
-    for (const [key, value] of Object.entries(checkpoint)) {
-        if (typeof value === 'string') {
-            const parsed = z.string().datetime().safeParse(value);
-            if (parsed.success) {
-                validated[key] = new Date(value);
-                continue;
-            }
-        }
-        validated[key] = value;
-    }
-    return validated;
 }

--- a/packages/types/lib/checkpoint/types.ts
+++ b/packages/types/lib/checkpoint/types.ts
@@ -1,21 +1,19 @@
 /**
  * Allowed types for checkpoint values.
  * Only flat key-value structures are supported (no nested objects or arrays).
- * Date values are automatically converted to ISO strings when stored.
  */
-export type CheckpointValue = string | number | boolean | Date;
+export type CheckpointValue = string | number | boolean;
 
 /**
  * A checkpoint is a flat key-value object that can be used to store
  * progress or state during function execution.
- * Date values are automatically converted to ISO strings when stored.
  *
  * @example
  * ```typescript
  * const checkpoint: Checkpoint = {
  *     lastProcessedPage: 5,
  *     lastCursor: "abc123",
- *     lastRunAt: new Date(), // stored as ISO string
+ *     lastRunAt: "2024-01-15T00:00:00Z",
  * };
  * ```
  */


### PR DESCRIPTION
adding dryrun option `--checkpoint` to be able to test checkpointing in function (similar to the already existig --metadata option)
The object passed via this option would become the initial checkpoint when dry-running the function

```
// Example
nango dryrun mySync myConn --checkpoint '{"lastModifiedAt": "2026-02-11T22:04:30.803Z"}'
```

<!-- Summary by @propel-code-bot -->

---

The CLI now accepts checkpoint payloads via inline JSON or @file inputs, runs them through the shared JSON parser and central checkpoint validator, threads the seeded state through the sync/action CLIs so dry runs exercise get/save/clear checkpoint logic, and documents the workflow while aligning the SDK’s checkpoint types—removing Date values—around the new validator.

<details>
<summary><strong>Possible Issues</strong></summary>

• Removing `Date` from `CheckpointValue` is a breaking change for any existing checkpoints that stored Date instances—migrations or release notes may be required
• CLI still surfaces the raw `Invalid checkpoint: ...` message from Zod, which may be noisy for common mistakes (arrays, null)

</details>

---
*This summary was automatically generated by @propel-code-bot*