### PR TITLE
fix(cli): Fix nango generate:tests to work with the unified mocks

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -286,9 +286,8 @@ program
         '--integration-id [integrationId]',
         'Optional: The integration id to use for the dryrun. If not provided, the integration id will be retrieved from the nango.yaml file. This is useful using nested directories and script names are repeated'
     )
-    .option('--save-responses', 'Optional: Save all dry run responses to a tests/mocks directory to be used alongside unit tests', false)
     .option('--validate, --validation', 'Optional: Enforce input, output and records validation', false)
-    .option('--save, --save-responses', 'Optional: Save all dry run responses to a tests/mocks directory to be used alongside unit tests', false)
+    .option('--save, --save-responses', 'Optional: Save all dry run responses to <integration>/tests/<name>.test.json for unit tests', false)
     .option('--diagnostics', 'Optional: Display performance diagnostics including memory usage and CPU metrics', false)
     .action(async function (this: Command) {
         const { autoConfirm, debug, interactive, integrationId, validation, saveResponses, input, lastSyncDate, variant, metadata, diagnostics } = this.opts();

--- a/packages/cli/lib/services/test.service.unit.cli-test.ts
+++ b/packages/cli/lib/services/test.service.unit.cli-test.ts
@@ -469,7 +469,7 @@ describe('generateSyncTest', () => {
         expect(content).toContain("describe('github fetch-issues tests'");
 
         // Check NangoSyncMock configuration
-        expect(content).toContain("dirname: 'github'");
+        expect(content).toContain('dirname: __dirname,');
         expect(content).toContain('name: "fetch-issues"');
         expect(content).toContain('Model: "GithubIssue"');
 
@@ -528,7 +528,7 @@ describe('generateActionTest', () => {
         expect(content).toContain("describe('slack send-message tests'");
 
         // Check NangoActionMock configuration
-        expect(content).toContain("dirname: 'slack'");
+        expect(content).toContain('dirname: __dirname,');
         expect(content).toContain('name: "send-message"');
         expect(content).toContain('Model: "SlackMessage"');
 

--- a/packages/cli/lib/templates/action-test-template.ejs
+++ b/packages/cli/lib/templates/action-test-template.ejs
@@ -4,7 +4,7 @@ import createAction from '../actions/<%= actionName %>.js';
 
 describe('<%= integration %> <%= actionName %> tests', () => {
   const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: '<%= integration %>',
+      dirname: __dirname,
       name: "<%= actionName %>",
       Model: "<%= output %>"
   });

--- a/packages/cli/lib/templates/sync-test-template.ejs
+++ b/packages/cli/lib/templates/sync-test-template.ejs
@@ -4,7 +4,7 @@ import createSync from '../syncs/<%= syncName %>.js';
 
 describe('<%= integration %> <%= syncName %> tests', () => {
   const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: '<%= integration %>',
+      dirname: __dirname,
       name: "<%= syncName %>",
       Model: "<%= modelName %>"
   });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Also fix a few other issues with our CLI
- generated tests should use PaginationService from runner-sdk, not from lib
- When looking for mock responses, the wrong case was used for key lookup (uppercase vs lowercase)
<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Align CLI test generation with unified mocks and pagination service**

PR updates the CLI test generation flow so it can consume the new unified mock artifacts produced by `nango dryrun --save`. It introduces a helper to probe multiple mock locations (unified files near tests, legacy colocated mocks) and logs the attempted paths when running with `--debug`, ensuring generated sync/action tests point `Nango*Mock` to the correct directory.
Additionally, the test mocks now import `PaginationService` from the public `@nangohq/runner-sdk` entry point and keep HTTP method keys in their original case to match the serialized mock files. CLI templates and unit tests were adjusted to emit `dirname: __dirname`, and the `dryrun` command description for `--save/--save-responses` now refers to the unified mock location.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `firstExistingPath` in `packages/cli/lib/services/test.service.ts` to probe unified (`tests/*.test.json`) and legacy (`mocks/<name>`) mock locations before generating tests.
• Updated `packages/cli/lib/templates/*-test-template.ejs` to set `dirname: __dirname`, with corresponding unit assertions in `packages/cli/lib/services/test.service.unit.cli-test.ts`.
• Switched `packages/cli/lib/testMocks/utils.ts` to import `PaginationService` from `@nangohq/runner-sdk` and to preserve original HTTP method casing when reading/recording mocks.
• Improved debug messaging when mocks are missing by listing all attempted paths for syncs/actions.
• Tidied `packages/cli/lib/index.ts` CLI options by removing duplicate `--save-responses` and clarifying that `--save/--save-responses` writes unified mock files.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• When both `tests/<name>.test.json` and `tests/<integration>-<name>.test.json` exist, the CLI silently takes the first match; confirm this ordering is intentional and documented for users who maintain both.

</details>

---
*This summary was automatically generated by @propel-code-bot*