### PR TITLE
fix(autoprune): records for deleted connections were not pruned

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1828,15 +1828,6 @@ class ConnectionService {
             .limit(limit);
     }
 
-    async hardDeleteByIntegration({ integrationId, limit }: { integrationId: number; limit: number }): Promise<number> {
-        return await db.knex
-            .from<DBConnection>('_nango_connections')
-            .whereIn('id', function (sub) {
-                sub.select('id').from<DBConnection>('_nango_connections').where('config_id', integrationId).limit(limit);
-            })
-            .delete();
-    }
-
     async hardDelete(id: number): Promise<number> {
         return await db.knex.from<DBConnection>('_nango_connections').where('id', id).delete();
     }


### PR DESCRIPTION
We were fetching the records connection in order to get the environment.
However deleted connection weren't returned and autopruning was bailing out without pruning the records.
This commit, instead of making an extra query to fetch the connection, is directly getting the environment by joining with the records count table.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

The candidate selection query now enforces the presence of a matching record_counts row, surfacing an error when it is missing, and the daemon threads the supplied environment ID through its plan checks and pruning requests so these cleanups continue to work even after the connection itself has been removed.

<details>
<summary><strong>Possible Issues</strong></summary>

• New `Err` return when `record_counts` is missing will stop pruning for that partition; ensure this is desired and that the error is actionable.

</details>

---
*This summary was automatically generated by @propel-code-bot*