### PR TITLE
fix: update axios to v1.13.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16291,9 +16291,9 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
-            "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
+            "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.6",
@@ -16311,17 +16311,6 @@
                 "des.js": "^1.1.0",
                 "dev-null": "^0.1.1",
                 "js-md4": "^0.3.2"
-            }
-        },
-        "node_modules/axios-ntlm/node_modules/axios": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-            "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/b4a": {
@@ -21545,7 +21534,9 @@
             "license": "MIT"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.6",
+            "version": "1.15.11",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
             "funding": [
                 {
                     "type": "individual",
@@ -33295,7 +33286,7 @@
                 "@types/unzipper": "0.10.11",
                 "ajv": "8.17.1",
                 "ajv-errors": "3.0.0",
-                "axios": "1.12.0",
+                "axios": "1.13.4",
                 "chalk": "5.4.1",
                 "chokidar": "3.5.3",
                 "columnify": "1.6.0",
@@ -33812,7 +33803,7 @@
                 "@nangohq/shared": "file:../shared",
                 "@nangohq/utils": "file:../utils",
                 "@nangohq/webhooks": "file:../webhooks",
-                "axios": "1.12.0",
+                "axios": "1.13.4",
                 "dd-trace": "5.52.0",
                 "express": "5.1.0",
                 "get-port": "7.1.0",
@@ -34911,7 +34902,7 @@
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@nangohq/types": "0.69.33",
-                "axios": "1.12.0"
+                "axios": "1.13.4"
             },
             "devDependencies": {
                 "tsup": "8.5.0",
@@ -35098,7 +35089,7 @@
                 "@nangohq/utils": "file:../utils",
                 "@trpc/client": "10.45.3",
                 "@trpc/server": "10.45.3",
-                "axios": "1.12.0",
+                "axios": "1.13.4",
                 "botbuilder": "4.23.2",
                 "connect-timeout": "1.9.1",
                 "dd-trace": "5.52.0",
@@ -35132,7 +35123,7 @@
             "devDependencies": {
                 "@nangohq/types": "0.69.33",
                 "@types/json-schema": "7.0.15",
-                "axios": "1.12.0",
+                "axios": "1.13.4",
                 "json-schema": "0.4.0",
                 "vitest": "3.2.4"
             },
@@ -35259,7 +35250,7 @@
                 "@nangohq/utils": "file:../utils",
                 "@nangohq/webhooks": "file:../webhooks",
                 "@workos-inc/node": "6.2.0",
-                "axios": "1.12.0",
+                "axios": "1.13.4",
                 "body-parser": "2.2.1",
                 "connect-session-knex": "4.0.0",
                 "cookie-parser": "1.4.7",
@@ -35379,7 +35370,7 @@
                 "ajv": "8.17.1",
                 "ajv-formats": "3.0.1",
                 "archiver": "7.0.1",
-                "axios": "1.12.0",
+                "axios": "1.13.4",
                 "braintree": "3.15.0",
                 "dd-trace": "5.52.0",
                 "exponential-backoff": "3.1.1",
@@ -35554,7 +35545,7 @@
             "version": "0.69.33",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "axios": "1.12.0",
+                "axios": "1.13.4",
                 "json-schema": "0.4.0",
                 "type-fest": "4.41.0"
             },
@@ -35569,7 +35560,7 @@
             "dependencies": {
                 "@colors/colors": "1.6.0",
                 "@sentry/node": "9.3.0",
-                "axios": "1.12.0",
+                "axios": "1.13.5",
                 "dd-trace": "5.52.0",
                 "exponential-backoff": "3.1.1",
                 "fast-safe-stringify": "2.1.1",
@@ -35587,6 +35578,33 @@
                 "express": "5.1.0",
                 "ms": "3.0.0-canary.1",
                 "vitest": "3.2.4"
+            }
+        },
+        "packages/utils/node_modules/axios": {
+            "version": "1.13.5",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+            "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
+                "proxy-from-env": "^1.1.0"
+            }
+        },
+        "packages/utils/node_modules/form-data": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "packages/utils/node_modules/ms": {
@@ -36165,7 +36183,7 @@
                 "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/logs": "file:../logs",
                 "@nangohq/utils": "file:../utils",
-                "axios": "1.12.0",
+                "axios": "1.13.4",
                 "dayjs": "1.11.7",
                 "dayjs-plugin-utc": "0.1.2",
                 "rate-limiter-flexible": "5.0.3"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
         "@types/unzipper": "0.10.11",
         "ajv": "8.17.1",
         "ajv-errors": "3.0.0",
-        "axios": "1.12.0",
+        "axios": "1.13.4",
         "chalk": "5.4.1",
         "chokidar": "3.5.3",
         "columnify": "1.6.0",

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -31,7 +31,7 @@
         "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",
         "@nangohq/webhooks": "file:../webhooks",
-        "axios": "1.12.0",
+        "axios": "1.13.4",
         "dd-trace": "5.52.0",
         "express": "5.1.0",
         "get-port": "7.1.0",

--- a/packages/node-client/package.json
+++ b/packages/node-client/package.json
@@ -26,7 +26,7 @@
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
         "@nangohq/types": "0.69.33",
-        "axios": "1.12.0"
+        "axios": "1.13.4"
     },
     "engines": {
         "node": ">=20.0"

--- a/packages/runner-sdk/package.json
+++ b/packages/runner-sdk/package.json
@@ -20,7 +20,7 @@
     "devDependencies": {
         "@nangohq/types": "0.69.33",
         "@types/json-schema": "7.0.15",
-        "axios": "1.12.0",
+        "axios": "1.13.4",
         "json-schema": "0.4.0",
         "vitest": "3.2.4"
     },

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -25,7 +25,7 @@
         "@nangohq/utils": "file:../utils",
         "@trpc/client": "10.45.3",
         "@trpc/server": "10.45.3",
-        "axios": "1.12.0",
+        "axios": "1.13.4",
         "botbuilder": "4.23.2",
         "connect-timeout": "1.9.1",
         "dd-trace": "5.52.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,7 +37,7 @@
         "@nangohq/webhooks": "file:../webhooks",
         "@nangohq/pubsub": "file:../pubsub",
         "@workos-inc/node": "6.2.0",
-        "axios": "1.12.0",
+        "axios": "1.13.4",
         "body-parser": "2.2.1",
         "connect-session-knex": "4.0.0",
         "cookie-parser": "1.4.7",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -30,7 +30,7 @@
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
         "archiver": "7.0.1",
-        "axios": "1.12.0",
+        "axios": "1.13.4",
         "braintree": "3.15.0",
         "dd-trace": "5.52.0",
         "exponential-backoff": "3.1.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -12,7 +12,7 @@
         "directory": "packages/utils"
     },
     "dependencies": {
-        "axios": "1.12.0",
+        "axios": "1.13.4",
         "json-schema": "0.4.0",
         "type-fest": "4.41.0"
     },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@colors/colors": "1.6.0",
         "@sentry/node": "9.3.0",
-        "axios": "1.12.0",
+        "axios": "1.13.5",
         "dd-trace": "5.52.0",
         "exponential-backoff": "3.1.1",
         "fast-safe-stringify": "2.1.1",

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -18,7 +18,7 @@
         "@nangohq/logs": "file:../logs",
         "@nangohq/utils": "file:../utils",
         "@nangohq/kvstore": "file:../kvstore",
-        "axios": "1.12.0",
+        "axios": "1.13.4",
         "dayjs": "1.11.7",
         "dayjs-plugin-utc": "0.1.2",
         "rate-limiter-flexible": "5.0.3"


### PR DESCRIPTION
addressing https://github.com/NangoHQ/nango/security/dependabot/307

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Axios security bump across workspaces**

All packages that depend on `axios` now reference patched releases, addressing Dependabot alert 307. Most workspaces were upgraded from `1.12.0` to `1.13.4`, while `packages/utils` moves to `1.13.5`, and the root `package-lock.json` was regenerated to reflect the new versions along with updated transitive dependencies such as `follow-redirects@1.15.11` and new `form-data`/`proxy-from-env` entries for the utils workspace.

<details>
<summary><strong>Key Changes</strong></summary>

• Bumped `axios` to `1.13.4` in `packages/types`, `packages/webhooks`, `packages/runner-sdk`, `packages/node-client`, `packages/runner`, `packages/jobs`, `packages/shared`, `packages/server`, and `packages/cli`
• Upgraded `packages/utils/package.json` to `axios` `1.13.5`, adding matching scoped entries in `package-lock.json`
• Regenerated `package-lock.json`, which now resolves `axios` to `1.13.4`, updates `follow-redirects` to `1.15.11`, and introduces the `form-data` and `proxy-from-env` dependencies required by the utils workspace copy

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Inconsistent `axios` versions (`1.13.4` vs `1.13.5`) across workspaces may prevent deduplication or introduce subtle differences if multiple copies are bundled.

</details>

---
*This summary was automatically generated by @propel-code-bot*