### PR TITLE
fix: upgrade lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24718,7 +24718,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
             "license": "MIT"
         },
         "node_modules/lodash-es": {
@@ -35682,7 +35684,7 @@
                 "fuse.js": "7.1.0",
                 "httpsnippet-lite": "3.0.5",
                 "json-schema": "^0.4.0",
-                "lodash": "4.17.21",
+                "lodash": "4.17.23",
                 "lucide-react": "0.542.0",
                 "nuqs": "2.4.1",
                 "postcss": "8.5.1",

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -75,7 +75,7 @@
         "fuse.js": "7.1.0",
         "httpsnippet-lite": "3.0.5",
         "json-schema": "^0.4.0",
-        "lodash": "4.17.21",
+        "lodash": "4.17.23",
         "lucide-react": "0.542.0",
         "nuqs": "2.4.1",
         "postcss": "8.5.1",


### PR DESCRIPTION
addresses https://github.com/NangoHQ/nango/security/dependabot/289

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Upgrade `lodash` to patched release**

Bumps the webapp’s `lodash` dependency from `4.17.21` to `4.17.23` to address Dependabot alert 289. Updates both `packages/webapp/package.json` and the root `package-lock.json`, adding the new tarball URL and integrity hash so the lockfile matches the upgraded version.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `lodash` entry in `packages/webapp/package.json` from `4.17.21` to `4.17.23`.
• Regenerated the corresponding sections of `package-lock.json`, including `version`, `resolved`, and `integrity` for `node_modules/lodash`.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• If other workspaces still pin `lodash` elsewhere, they may continue to pull the vulnerable version; verify there are no additional references outside the webapp package.

</details>

---
*This summary was automatically generated by @propel-code-bot*