### PR TITLE
fix: upgrade undici package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11882,16 +11882,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/@redocly/cli/node_modules/undici": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-            "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.17"
-            }
-        },
         "node_modules/@redocly/cli/node_modules/yargs": {
             "version": "17.0.1",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
@@ -31472,9 +31462,9 @@
             "license": "MIT"
         },
         "node_modules/undici": {
-            "version": "6.21.2",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
-            "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
+            "version": "6.23.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+            "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.17"
@@ -35109,7 +35099,7 @@
                 "express": "5.1.0",
                 "soap": "1.2.1",
                 "superjson": "2.2.1",
-                "undici": "6.21.2",
+                "undici": "6.23.0",
                 "unzipper": "0.12.3",
                 "zod": "4.0.5"
             },
@@ -35400,7 +35390,7 @@
                 "qs": "6.14.1",
                 "semver": "7.5.4",
                 "simple-oauth2": "5.1.0",
-                "undici": "6.21.2",
+                "undici": "6.23.0",
                 "uuid": "9.0.0",
                 "webflow-api": "3.2.1",
                 "xml-crypto": "6.1.2",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -32,7 +32,7 @@
         "express": "5.1.0",
         "soap": "1.2.1",
         "superjson": "2.2.1",
-        "undici": "6.21.2",
+        "undici": "6.23.0",
         "unzipper": "0.12.3",
         "zod": "4.0.5"
     },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -47,7 +47,7 @@
         "qs": "6.14.1",
         "semver": "7.5.4",
         "simple-oauth2": "5.1.0",
-        "undici": "6.21.2",
+        "undici": "6.23.0",
         "uuid": "9.0.0",
         "webflow-api": "3.2.1",
         "xml-crypto": "6.1.2",


### PR DESCRIPTION
addresses https://github.com/NangoHQ/nango/security/dependabot/273

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Upgrade `undici` to `6.23.0`**

Upgrades the HTTP client dependency `undici` from `6.21.2` to `6.23.0` in `packages/runner` and `packages/shared`, aligning with Dependabot security advisory 273. The root `package-lock.json` is updated to lock the new version (and remove a redundant nested `@redocly/cli` copy), ensuring consistent resolution across the workspace.

<details>
<summary><strong>Key Changes</strong></summary>

• Bumped `undici` dependency to `6.23.0` in `packages/runner/package.json` and `packages/shared/package.json`.
• Updated `package-lock.json` to reflect the new `undici` version and eliminate the older nested entry.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• If any runtime still expects `undici` features specific to `6.21.x`, regressions could occur; validate compatibility.

</details>

---
*This summary was automatically generated by @propel-code-bot*