### PR TITLE
fix: upgrade body-parser package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4676,22 +4676,6 @@
                 }
             }
         },
-        "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
-            "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
         "node_modules/@inquirer/figures": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.2.tgz",
@@ -16608,28 +16592,34 @@
             "license": "MIT"
         },
         "node_modules/body-parser": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-            "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
+            "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
+            "license": "MIT",
             "dependencies": {
                 "bytes": "^3.1.2",
                 "content-type": "^1.0.5",
-                "debug": "^4.4.0",
+                "debug": "^4.4.3",
                 "http-errors": "^2.0.0",
-                "iconv-lite": "^0.6.3",
+                "iconv-lite": "^0.7.0",
                 "on-finished": "^2.4.1",
                 "qs": "^6.14.0",
-                "raw-body": "^3.0.0",
-                "type-is": "^2.0.0"
+                "raw-body": "^3.0.1",
+                "type-is": "^2.0.1"
             },
             "engines": {
                 "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/body-parser/node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -16672,7 +16662,8 @@
         "node_modules/body-parser/node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/body-parser/node_modules/type-is": {
             "version": "2.0.1",
@@ -22591,17 +22582,23 @@
             }
         },
         "node_modules/http-errors": {
-            "version": "2.0.0",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
             "license": "MIT",
             "dependencies": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
             },
             "engines": {
                 "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/http-proxy-agent": {
@@ -22687,15 +22684,19 @@
             "dev": true
         },
         "node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
             "engines": {
                 "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/ieee754": {
@@ -27246,17 +27247,18 @@
             "license": "ISC"
         },
         "node_modules/raw-body": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-            "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+            "license": "MIT",
             "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.6.3",
-                "unpipe": "1.0.0"
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
             },
             "engines": {
-                "node": ">= 0.8"
+                "node": ">= 0.10"
             }
         },
         "node_modules/rc": {
@@ -29501,7 +29503,9 @@
             }
         },
         "node_modules/statuses": {
-            "version": "2.0.1",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -35264,7 +35268,7 @@
                 "@nangohq/webhooks": "file:../webhooks",
                 "@workos-inc/node": "6.2.0",
                 "axios": "1.12.0",
-                "body-parser": "2.2.0",
+                "body-parser": "2.2.1",
                 "connect-session-knex": "4.0.0",
                 "cookie-parser": "1.4.7",
                 "cors": "2.8.5",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -38,7 +38,7 @@
         "@nangohq/pubsub": "file:../pubsub",
         "@workos-inc/node": "6.2.0",
         "axios": "1.12.0",
-        "body-parser": "2.2.0",
+        "body-parser": "2.2.1",
         "connect-session-knex": "4.0.0",
         "cookie-parser": "1.4.7",
         "cors": "2.8.5",


### PR DESCRIPTION
addresses https://github.com/NangoHQ/nango/security/dependabot/241

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Upgrade `body-parser` to patched version 2.2.1**

This PR bumps the `body-parser` dependency in `packages/server/package.json` to version `2.2.1` to address Dependabot security alert 241 and refreshes the relevant sections of `package-lock.json`. The lockfile now captures the updated `body-parser` release as well as its transitive dependencies (`debug`, `iconv-lite`, `raw-body`, `http-errors`, `statuses`, etc.), including new metadata such as funding links and license fields.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `packages/server/package.json` to require `body-parser` version `2.2.1`.
• Regenerated `package-lock.json` so that `body-parser@2.2.1` and its transitive dependencies (`debug@4.4.3`, `iconv-lite@0.7.2`, `raw-body@3.0.2`, `http-errors@2.0.1`, `statuses@2.0.2`, etc.) are locked with new integrity hashes and metadata.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• If other services rely on older transitive versions (e.g., `raw-body@3.0.0`), confirm there are no implicit compatibility constraints.

</details>

---
*This summary was automatically generated by @propel-code-bot*