### PR TITLE
fix: lower autoprune limit

### DIFF
--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -55,7 +55,7 @@ export const ENVS = z.object({
     // Persist
     PERSIST_SERVICE_URL: z.url().optional(),
     PERSIST_AUTO_PRUNING_INTERVAL_MS: z.coerce.number().optional().default(5_000), // set to 0 to disable
-    PERSIST_AUTO_PRUNING_LIMIT: z.coerce.number().optional().default(1_000),
+    PERSIST_AUTO_PRUNING_LIMIT: z.coerce.number().optional().default(200),
     PERSIST_AUTO_PRUNING_STALE_AFTER_MS: z.coerce
         .number()
         .optional()


### PR DESCRIPTION
autoprune query is timing out a lot when trying to prune records. Lowering the limit (1000 -> 200) while I am looking into ways to speed up the query

<!-- Summary by @propel-code-bot -->

---

The change specifically updates the default `PERSIST_AUTO_PRUNING_LIMIT` value in `packages/utils/lib/environment/parse.ts`, and it keeps the rest of the configuration unchanged so the timeout mitigation comes solely from the smaller batch size.

<details>
<summary><strong>Possible Issues</strong></summary>

• Lower limit could let stale data accumulate faster if autoprune frequency is not adjusted in environments with large datasets.

</details>

---
*This summary was automatically generated by @propel-code-bot*