### PR TITLE
chore: add partial index (pruned_at IS NULL) to records table

### DIFF
--- a/packages/records/lib/db/migrations/20260213183500_records_pruned_indexes.ts
+++ b/packages/records/lib/db/migrations/20260213183500_records_pruned_indexes.ts
@@ -1,0 +1,19 @@
+import type { Knex } from 'knex';
+
+export const config = {
+    transaction: false
+};
+
+export async function up(knex: Knex): Promise<void> {
+    // adding a more specific index used to delete pruned records in batches
+    // pg prevents adding index to parent table concurrently - must be done on each partition
+    for (let p = 0; p < 256; p++) {
+        await knex.raw(
+            `CREATE INDEX CONCURRENTLY IF NOT EXISTS records_p${p}_connection_model_updatedat_id_not_pruned
+                ON records_p${p}(connection_id, model, updated_at, id)
+                WHERE pruned_at IS NULL;`
+        );
+    }
+}
+
+export async function down(): Promise<void> {}


### PR DESCRIPTION
Existing index (connection, model, updatedAt, id) isn't optimal when pruning records since pg still has to potentially scan lots of entries to only select the records that aren't pruned yet. This commit adds a partial index to make the autopruning query faster

Note: I am adding the index manually in prod/cloud because it is a very long operation. Once done the migration will be a noop.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Adds partial per-partition index for unpruned records**

Introduces a Knex migration that builds per-partition partial indexes on `records_p*` tables where `pruned_at IS NULL`, targeting faster autopruning queries. Migration runs outside transactions and iterates across 256 partitions to issue `CREATE INDEX CONCURRENTLY IF NOT EXISTS` statements.

<details>
<summary><strong>Key Changes</strong></summary>

• Added migration `packages/records/lib/db/migrations/20260213183500_records_pruned_indexes.ts` that disables transactions and loops through 256 partitions
• Creates partial index `records_p${p}_connection_model_updatedat_id_not_pruned` on `(connection_id, model, updated_at, id)` filtered by `pruned_at IS NULL` using `CREATE INDEX CONCURRENTLY IF NOT EXISTS`
• Leaves `down` migration empty (no automatic index drop)

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Migration cannot be rolled back automatically because `down` is empty, so dropping the indexes would require manual SQL if needed.

</details>

---
*This summary was automatically generated by @propel-code-bot*