### PR TITLE
fix(deploy): set cache-control for index.html for replit

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -79,6 +79,10 @@ jobs:
               if: inputs.stage == 'replit'
               run: |
                   gsutil -m rsync -r -d packages/webapp/dist/ gs://${{ vars.APP_UI_BUCKET }}
+            - name: Set cache-control for index.html
+              if: inputs.stage == 'replit'
+              run: |
+                  gsutil setmeta -h "Cache-Control:no-store, no-cache, must-revalidate, max-age=0" "gs://${{ vars.APP_UI_BUCKET }}/index.html"
             - name: Invalidate Cloud CDN cache
               if: inputs.stage == 'replit'
               run: |
@@ -129,6 +133,10 @@ jobs:
               if: inputs.stage == 'replit'
               run: |
                   gsutil -m rsync -r -d packages/connect-ui/dist/ gs://${{ vars.CONNECT_UI_BUCKET }}
+            - name: Set cache-control for index.html
+              if: inputs.stage == 'replit'
+              run: |
+                  gsutil setmeta -h "Cache-Control:no-store, no-cache, must-revalidate, max-age=0" "gs://${{ vars.CONNECT_UI_BUCKET }}/index.html"
             - name: Invalidate Cloud CDN cache
               if: inputs.stage == 'replit'
               run: |


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Cache-control metadata added for Replit index deployments**

Adds explicit cache-control metadata setting for Replit-stage deployments of both `packages/webapp` and `packages/connect-ui` so that `index.html` is always served fresh. The workflow now calls `gsutil setmeta` before the existing CDN invalidation step to ensure browsers do not cache outdated entrypoints.

<details>
<summary><strong>Key Changes</strong></summary>

• Inserted a new workflow step in `.github/workflows/deploy.yaml` to run `gsutil setmeta -h "Cache-Control:no-store, no-cache, must-revalidate, max-age=0"` on `gs://${{ vars.APP_UI_BUCKET }}/index.html` when deploying Replit `app_ui`.
• Mirrored the same cache-control step for `gs://${{ vars.CONNECT_UI_BUCKET }}/index.html` in the Replit `connect_ui` deployment path.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• If buckets host localized copies (e.g., `index.html` in subdirectories), those files remain untouched and could still be cached.

</details>

---
*This summary was automatically generated by @propel-code-bot*