### PR TITLE
feat(cli): add --no-dependency-update flag to skip automatic dependency management

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -56,7 +56,7 @@ class NangoCommand extends Command {
             const opts = actionCommand.opts<GlobalOptions>();
 
             // opts.interactive is true by default (from the option default), or false if --no-interactive is passed.
-            // We also disable it if we are in a CI environment.
+            // We also disable it and dependency updates if we are in a CI environment.
             if (isCI && opts.interactive) {
                 console.warn(
                     chalk.yellow(
@@ -65,6 +65,15 @@ class NangoCommand extends Command {
                 );
             }
             opts.interactive = opts.interactive && !isCI;
+
+            if (isCI && opts.dependencyUpdate) {
+                console.warn(
+                    chalk.yellow(
+                        "CI environment detected. Dependency updates have been automatically disabled to prevent hanging. Pass '--no-dependency-update' to silence this warning."
+                    )
+                );
+            }
+            opts.dependencyUpdate = opts.dependencyUpdate && !isCI;
 
             printDebug(`Running in ${opts.interactive ? 'interactive' : 'non-interactive'} mode.`, opts.debug);
 

--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -50,6 +50,7 @@ class NangoCommand extends Command {
         // The option name in the code will be 'interactive'.
         // Passing --no-interactive will set it to false.
         cmd.option('--no-interactive', 'Disable interactive prompts for missing arguments.');
+        cmd.option('--no-dependency-update', 'Skip automatic dependency updates and package installation.');
 
         cmd.hook('preAction', async function (this: Command, actionCommand: Command) {
             const opts = actionCommand.opts<GlobalOptions>();
@@ -66,6 +67,11 @@ class NangoCommand extends Command {
             opts.interactive = opts.interactive && !isCI;
 
             printDebug(`Running in ${opts.interactive ? 'interactive' : 'non-interactive'} mode.`, opts.debug);
+
+            if (process.env['NANGO_CLI_DEPENDENCY_UPDATE'] === 'false') {
+                opts.dependencyUpdate = false;
+            }
+            printDebug(`Dependency update: ${opts.dependencyUpdate ? 'enabled' : 'disabled'}`, opts.debug);
 
             if (opts.debug && fs.existsSync('.env')) {
                 printDebug('.env file detected and loaded', opts.debug);
@@ -109,6 +115,9 @@ NANGO_CLI_UPGRADE_MODE=prompt # Default value
 
 # Whether to prompt before deployments.
 NANGO_DEPLOY_AUTO_CONFIRM=false # Default value
+
+# Skip automatic dependency updates and package installation (useful for CI/monorepos).
+NANGO_CLI_DEPENDENCY_UPDATE=true # Default value
 `
     )
     .version(getVersionOutput(), '-v, --version', 'Print the version of the Nango CLI and Nango Server.');
@@ -133,7 +142,7 @@ program
     .option('--ai [claude|cursor...]', 'Optional: Setup AI agent instructions files. Supported: claude code, cursor', [])
     .option('--copy', 'Optional: Only copy files, will not npm install or pre-compile', false)
     .action(async function (this: Command) {
-        const { debug, ai, copy, interactive } = this.opts<GlobalOptions & { ai: string[]; copy: boolean }>();
+        const { debug, ai, copy, interactive, dependencyUpdate } = this.opts<GlobalOptions & { ai: string[]; copy: boolean }>();
         let [projectPath] = this.args;
         const currentPath = process.cwd();
 
@@ -161,7 +170,7 @@ program
             return;
         }
 
-        const res = await initZero({ absolutePath, debug, onlyCopy: copy });
+        const res = await initZero({ absolutePath, debug, onlyCopy: copy, dependencyUpdate });
         if (!res) {
             process.exitCode = 1;
             return;
@@ -224,7 +233,7 @@ program
         'Compile the integration files to JavaScript and update the .nango directory. This is useful for one off changes instead of watching for changes continuously.'
     )
     .action(async function (this: Command) {
-        const { debug, interactive } = this.opts<GlobalOptions>();
+        const { debug, interactive, dependencyUpdate } = this.opts<GlobalOptions>();
         const fullPath = process.cwd();
         const precheck = await verificationService.preCheck({ fullPath, debug });
         if (!precheck.isNango) {
@@ -234,7 +243,7 @@ program
         }
 
         if (precheck.isZeroYaml) {
-            const resCheck = await checkAndSyncPackageJson({ fullPath, debug });
+            const resCheck = await checkAndSyncPackageJson({ fullPath, debug, dependencyUpdate });
             if (resCheck.isErr()) {
                 console.log(chalk.red('Failed to check and sync package.json. Exiting'));
                 process.exitCode = 1;
@@ -290,7 +299,20 @@ program
     .option('--save, --save-responses', 'Optional: Save all dry run responses to <integration>/tests/<name>.test.json for unit tests', false)
     .option('--diagnostics', 'Optional: Display performance diagnostics including memory usage and CPU metrics', false)
     .action(async function (this: Command) {
-        const { autoConfirm, debug, interactive, integrationId, validation, saveResponses, input, lastSyncDate, variant, metadata, diagnostics } = this.opts();
+        const {
+            autoConfirm,
+            debug,
+            interactive,
+            dependencyUpdate,
+            integrationId,
+            validation,
+            saveResponses,
+            input,
+            lastSyncDate,
+            variant,
+            metadata,
+            diagnostics
+        } = this.opts();
         const shouldValidate = validation || saveResponses;
         const fullPath = process.cwd();
         let [name, connectionId] = this.args;
@@ -336,7 +358,7 @@ program
                 return;
             }
         } else {
-            const resCheck = await checkAndSyncPackageJson({ fullPath, debug });
+            const resCheck = await checkAndSyncPackageJson({ fullPath, debug, dependencyUpdate });
             if (resCheck.isErr()) {
                 console.log(chalk.red('Failed to check and sync package.json. Exiting'));
                 process.exitCode = 1;
@@ -355,6 +377,7 @@ program
             autoConfirm,
             debug,
             interactive,
+            dependencyUpdate,
             sync: name,
             connectionId,
             optionalEnvironment: environment,
@@ -373,7 +396,7 @@ program
     .description('Watch tsc files while developing. Set --no-compile-interfaces to disable watching the config file')
     .option('--no-compile-interfaces', `Watch the ${nangoConfigFile} and recompile the interfaces on change`, true)
     .action(async function (this: Command) {
-        const { compileInterfaces, debug } = this.opts();
+        const { compileInterfaces, debug, dependencyUpdate } = this.opts();
         const fullPath = process.cwd();
 
         const precheck = await verificationService.preCheck({ fullPath, debug });
@@ -384,7 +407,7 @@ program
         }
 
         if (precheck.isZeroYaml) {
-            const resCheck = await checkAndSyncPackageJson({ fullPath, debug });
+            const resCheck = await checkAndSyncPackageJson({ fullPath, debug, dependencyUpdate });
             if (resCheck.isErr()) {
                 console.log(chalk.red('Failed to check and sync package.json. Exiting'));
                 process.exitCode = 1;
@@ -410,7 +433,7 @@ program
     .option('--allow-destructive', 'Allow destructive changes to be deployed without confirmation', false)
     .action(async function (this: Command, environment?: string) {
         const options = this.opts<DeployOptions>();
-        const { debug, interactive } = options;
+        const { debug, interactive, dependencyUpdate } = options;
         const fullPath = process.cwd();
 
         try {
@@ -432,7 +455,7 @@ program
         }
 
         if (precheck.isZeroYaml) {
-            const resCheck = await checkAndSyncPackageJson({ fullPath, debug });
+            const resCheck = await checkAndSyncPackageJson({ fullPath, debug, dependencyUpdate });
             if (resCheck.isErr()) {
                 console.log(chalk.red('Failed to check and sync package.json. Exiting'));
                 process.exitCode = 1;
@@ -502,14 +525,14 @@ program
     .command('migrate-to-zero-yaml')
     .description('Migrate from nango.yaml to pure typescript')
     .action(async function (this: Command) {
-        const { debug } = this.opts<DeployOptions>();
+        const { debug, dependencyUpdate } = this.opts<DeployOptions>();
         const fullPath = process.cwd();
         const precheck = await verificationService.ensureNangoYaml({ fullPath, debug });
         if (!precheck) {
             return;
         }
 
-        await migrateToZeroYaml({ fullPath, debug });
+        await migrateToZeroYaml({ fullPath, debug, dependencyUpdate });
     });
 
 program
@@ -518,7 +541,7 @@ program
     .option('--integration-templates', 'Optional: for the nango integration templates repo', false)
     .description('Generate documentation for the integration functions')
     .action(async function (this: Command) {
-        const { debug, path: optionalPath, integrationTemplates } = this.opts();
+        const { debug, dependencyUpdate, path: optionalPath, integrationTemplates } = this.opts();
         const fullPath = path.resolve(process.cwd(), this.args[0] || '');
         const precheck = await verificationService.preCheck({ fullPath, debug });
         if (!precheck.isNango) {
@@ -529,7 +552,7 @@ program
 
         let parsed: NangoYamlParsed;
         if (precheck.isZeroYaml) {
-            const resCheck = await checkAndSyncPackageJson({ fullPath, debug });
+            const resCheck = await checkAndSyncPackageJson({ fullPath, debug, dependencyUpdate });
             if (resCheck.isErr()) {
                 console.log(chalk.red('Failed to check and sync package.json. Exiting'));
                 process.exitCode = 1;
@@ -569,7 +592,7 @@ program
     .option('-a, --action <actionName>', 'Generate tests only for a specific action')
     .description('Generate tests for integration scripts and config files')
     .action(async function (this: Command) {
-        const { debug, integration: integrationId, sync: syncName, action: actionName, autoConfirm } = this.opts();
+        const { debug, dependencyUpdate, integration: integrationId, sync: syncName, action: actionName, autoConfirm } = this.opts();
         const absolutePath = path.resolve(process.cwd(), this.args[0] || '');
 
         const precheck = await verificationService.preCheck({ fullPath: absolutePath, debug });
@@ -584,7 +607,8 @@ program
             syncName,
             actionName,
             debug: Boolean(debug),
-            autoConfirm: Boolean(autoConfirm)
+            autoConfirm: Boolean(autoConfirm),
+            dependencyUpdate
         });
 
         if (success) {

--- a/packages/cli/lib/migrations/toZeroYaml.ts
+++ b/packages/cli/lib/migrations/toZeroYaml.ts
@@ -26,11 +26,13 @@ const methodsWithGenericTypeArguments = ['batchSave', 'batchUpdate', 'batchDelet
 export async function migrateToZeroYaml({
     fullPath,
     debug,
-    interactive = true
+    interactive = true,
+    dependencyUpdate = true
 }: {
     fullPath: string;
     debug: boolean;
     interactive?: boolean;
+    dependencyUpdate?: boolean;
 }): Promise<Result<void>> {
     const spinnerFactory = new Spinner({ interactive });
     const spinner = spinnerFactory.start('Precompiling');
@@ -141,10 +143,13 @@ export async function migrateToZeroYaml({
         await processHelperFiles({ fullPath, parsed, spinnerFactory });
     }
 
-    {
+    if (dependencyUpdate) {
         const spinner = spinnerFactory.start('Installing dependencies');
         await runPackageManagerInstall(fullPath);
         spinner.succeed();
+    } else {
+        const spinner = spinnerFactory.start('Installing dependencies');
+        spinner.warn('Skipping dependency install (--no-dependency-update)');
     }
 
     {

--- a/packages/cli/lib/services/sdk.ts
+++ b/packages/cli/lib/services/sdk.ts
@@ -110,7 +110,8 @@ export class NangoActionCLI extends NangoActionBase {
             connectionId,
             autoConfirm: true,
             debug: false,
-            interactive: false
+            interactive: false,
+            dependencyUpdate: true
         });
     }
 

--- a/packages/cli/lib/types.ts
+++ b/packages/cli/lib/types.ts
@@ -2,6 +2,7 @@ export interface GlobalOptions {
     autoConfirm: boolean;
     debug: boolean;
     interactive: boolean;
+    dependencyUpdate: boolean;
 }
 
 export type ENV = 'local' | 'cloud';

--- a/packages/cli/lib/zeroYaml/check.ts
+++ b/packages/cli/lib/zeroYaml/check.ts
@@ -16,11 +16,13 @@ import type { PackageJson } from 'type-fest';
 export async function checkAndSyncPackageJson({
     fullPath,
     debug,
-    interactive = true
+    interactive = true,
+    dependencyUpdate = true
 }: {
     fullPath: string;
     debug: boolean;
     interactive?: boolean;
+    dependencyUpdate?: boolean;
 }): Promise<Result<{ updated: boolean }>> {
     printDebug('Checking and syncing package.json', debug);
 
@@ -56,6 +58,10 @@ export async function checkAndSyncPackageJson({
     }
 
     if (updated && newPkg) {
+        if (!dependencyUpdate) {
+            console.warn(chalk.yellow('Dependencies are out of date but --no-dependency-update is set. Skipping update.'));
+            return Ok({ updated: false });
+        }
         console.log(chalk.yellow('Your dependencies are out of date. Updating...'));
         const spinnerFactory = new Spinner({ interactive });
         const spinner = spinnerFactory.start('Updating package.json');

--- a/packages/cli/lib/zeroYaml/init.ts
+++ b/packages/cli/lib/zeroYaml/init.ts
@@ -22,12 +22,14 @@ export async function initZero({
     absolutePath,
     debug = false,
     onlyCopy = false,
-    interactive = true
+    interactive = true,
+    dependencyUpdate = true
 }: {
     absolutePath: string;
     debug?: boolean;
     onlyCopy?: boolean;
     interactive?: boolean;
+    dependencyUpdate?: boolean;
 }): Promise<boolean> {
     printDebug(`Creating the nango integrations directory in ${absolutePath}`, debug);
     const spinnerFactory = new Spinner({ interactive });
@@ -83,7 +85,7 @@ export async function initZero({
     }
 
     // Install dependencies
-    {
+    if (dependencyUpdate) {
         const spinner = spinnerFactory.start('Install dependencies');
         try {
             printDebug(`Running package manager install`, debug);
@@ -96,6 +98,9 @@ export async function initZero({
             console.log(chalk.red(`Failed to install dependencies: ${err instanceof Error ? err.message : 'unknown error'}`));
             return false;
         }
+    } else {
+        const spinner = spinnerFactory.start('Install dependencies');
+        spinner.warn('Skipping dependency install (--no-dependency-update)');
     }
 
     {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Users in monorepo environments (pnpm with catalog: versions) and CI pipelines were broken by the CLI automatically modifying package.json and running install. This adds a --no-dependency-update global flag and NANGO_CLI_DEPENDENCY_UPDATE env var to disable this behavior. Also fixes hardcoded npm install in test service to use detectPackageManager.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

The flag and environment override are threaded through the shared GlobalOptions and pre-action hook, which automatically disable dependency updates in CI, document the behavior in the CLI help output, and ensure every zero-yaml workflow that previously edited package metadata or invoked installs now respects the opt-out.

<details>
<summary><strong>Possible Issues</strong></summary>

• `NANGO_CLI_DEPENDENCY_UPDATE` only respects the literal string `'false'`; other falsy values (`0`, `FALSE`) are ignored.
• Skipping dependency updates forces `checkAndSyncPackageJson` to report `updated: false`, so commands that interpret that flag for subsequent behavior might miss expected follow-up actions.

</details>

---
*This summary was automatically generated by @propel-code-bot*