### PR TITLE
fix(cli): migration not generating request and hash

### DIFF
--- a/packages/cli/lib/testMocks/utils.legacy.unit.cli-test.ts
+++ b/packages/cli/lib/testMocks/utils.legacy.unit.cli-test.ts
@@ -1,0 +1,351 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { LegacyFixtureProvider, RecordingFixtureProvider } from './utils.js';
+
+describe('RecordingFixtureProvider migration fallback', () => {
+    it('backfills hash and request data from runtime identity when legacy mocks are response-only', async () => {
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nango-migrate-mocks-'));
+        const outputPath = path.join(tempDir, 'change-user-role.test.json');
+
+        const response = {
+            id: '010101',
+            email: 'foo@foo.com',
+            roleIds: [],
+            superAdmin: false
+        };
+
+        const delegate = {
+            getCachedResponse: () => Promise.resolve({ response }),
+            getAllMocksForEndpoint: () =>
+                Promise.resolve([
+                    {
+                        method: 'put',
+                        endpoint: 'settings/v3/users/010101',
+                        requestIdentityHash: '',
+                        requestIdentity: {
+                            method: 'put',
+                            endpoint: 'settings/v3/users/010101',
+                            params: [],
+                            headers: [],
+                            data: undefined
+                        },
+                        response
+                    }
+                ])
+        } as unknown as ConstructorParameters<typeof RecordingFixtureProvider>[0];
+
+        const provider = new RecordingFixtureProvider(delegate, outputPath);
+
+        await provider.getCachedResponse({
+            method: 'put',
+            endpoint: 'settings/v3/users/010101',
+            requestIdentityHash: 'e0b1f69488fe8f65de01cf51fdb2e7a132c08b7c',
+            requestIdentity: {
+                method: 'put',
+                endpoint: 'settings/v3/users/010101',
+                params: [],
+                headers: [],
+                data: '{"superAdmin":false}'
+            }
+        });
+
+        const saved = JSON.parse(await fs.readFile(outputPath, 'utf-8'));
+        const migratedEntry = saved.api.put['settings/v3/users/010101'][0];
+
+        expect(migratedEntry.hash).toBe('e0b1f69488fe8f65de01cf51fdb2e7a132c08b7c');
+        expect(migratedEntry.request).toEqual({
+            data: {
+                superAdmin: false
+            }
+        });
+    });
+
+    it('prefers legacy request identity when the legacy mock already has one', async () => {
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nango-migrate-mocks-'));
+        const outputPath = path.join(tempDir, 'update-user.test.json');
+
+        const response = {
+            id: '010101',
+            superAdmin: true
+        };
+
+        const delegate = {
+            getCachedResponse: () => Promise.resolve({ response }),
+            getAllMocksForEndpoint: () =>
+                Promise.resolve([
+                    {
+                        method: 'put',
+                        endpoint: 'settings/v3/users/010101',
+                        requestIdentityHash: 'legacy-hash',
+                        requestIdentity: {
+                            method: 'put',
+                            endpoint: 'settings/v3/users/010101',
+                            params: [['force', 'true']],
+                            headers: [['x-test', 'legacy']],
+                            data: { superAdmin: true }
+                        },
+                        response
+                    }
+                ])
+        } as unknown as ConstructorParameters<typeof RecordingFixtureProvider>[0];
+
+        const provider = new RecordingFixtureProvider(delegate, outputPath);
+
+        await provider.getCachedResponse({
+            method: 'put',
+            endpoint: 'settings/v3/users/010101',
+            requestIdentityHash: 'runtime-hash',
+            requestIdentity: {
+                method: 'put',
+                endpoint: 'settings/v3/users/010101',
+                params: [],
+                headers: [],
+                data: '{"superAdmin":false}'
+            }
+        });
+
+        const saved = JSON.parse(await fs.readFile(outputPath, 'utf-8'));
+        const migratedEntry = saved.api.put['settings/v3/users/010101'][0];
+
+        expect(migratedEntry.hash).toBe('legacy-hash');
+        expect(migratedEntry.request).toEqual({
+            params: {
+                force: 'true'
+            },
+            headers: {
+                'x-test': 'legacy'
+            },
+            data: {
+                superAdmin: true
+            }
+        });
+    });
+
+    it('keeps non-JSON runtime request data as-is when backfilling', async () => {
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nango-migrate-mocks-'));
+        const outputPath = path.join(tempDir, 'submit-form.test.json');
+
+        const delegate = {
+            getCachedResponse: () => Promise.resolve({ response: { ok: true } }),
+            getAllMocksForEndpoint: () =>
+                Promise.resolve([
+                    {
+                        method: 'post',
+                        endpoint: 'forms/v1/submit',
+                        requestIdentityHash: '',
+                        requestIdentity: {
+                            method: 'post',
+                            endpoint: 'forms/v1/submit',
+                            params: [],
+                            headers: [],
+                            data: undefined
+                        },
+                        response: { ok: true }
+                    }
+                ])
+        } as unknown as ConstructorParameters<typeof RecordingFixtureProvider>[0];
+
+        const provider = new RecordingFixtureProvider(delegate, outputPath);
+
+        await provider.getCachedResponse({
+            method: 'post',
+            endpoint: 'forms/v1/submit',
+            requestIdentityHash: 'runtime-form-hash',
+            requestIdentity: {
+                method: 'post',
+                endpoint: 'forms/v1/submit',
+                params: [],
+                headers: [],
+                data: 'field=name&value=alice'
+            }
+        });
+
+        const saved = JSON.parse(await fs.readFile(outputPath, 'utf-8'));
+        const migratedEntry = saved.api.post['forms/v1/submit'][0];
+
+        expect(migratedEntry.hash).toBe('runtime-form-hash');
+        expect(migratedEntry.request).toEqual({
+            data: 'field=name&value=alice'
+        });
+    });
+
+    it('deduplicates migrated records by hash for the same endpoint', async () => {
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nango-migrate-mocks-'));
+        const outputPath = path.join(tempDir, 'duplicate-hash.test.json');
+
+        const response = { ok: true };
+
+        const delegate = {
+            getCachedResponse: () => Promise.resolve({ response }),
+            getAllMocksForEndpoint: () =>
+                Promise.resolve([
+                    {
+                        method: 'get',
+                        endpoint: 'crm/v3/objects/users',
+                        requestIdentityHash: 'same-hash',
+                        requestIdentity: {
+                            method: 'get',
+                            endpoint: 'crm/v3/objects/users',
+                            params: [],
+                            headers: [],
+                            data: undefined
+                        },
+                        response
+                    },
+                    {
+                        method: 'get',
+                        endpoint: 'crm/v3/objects/users',
+                        requestIdentityHash: 'same-hash',
+                        requestIdentity: {
+                            method: 'get',
+                            endpoint: 'crm/v3/objects/users',
+                            params: [],
+                            headers: [],
+                            data: undefined
+                        },
+                        response
+                    }
+                ])
+        } as unknown as ConstructorParameters<typeof RecordingFixtureProvider>[0];
+
+        const provider = new RecordingFixtureProvider(delegate, outputPath);
+
+        await provider.getCachedResponse({
+            method: 'get',
+            endpoint: 'crm/v3/objects/users',
+            requestIdentityHash: 'same-hash',
+            requestIdentity: {
+                method: 'get',
+                endpoint: 'crm/v3/objects/users',
+                params: [],
+                headers: [],
+                data: undefined
+            }
+        });
+
+        const saved = JSON.parse(await fs.readFile(outputPath, 'utf-8'));
+        const migratedEntries = saved.api.get['crm/v3/objects/users'];
+
+        expect(migratedEntries).toHaveLength(1);
+        expect(migratedEntries[0]?.hash).toBe('same-hash');
+    });
+});
+
+describe('LegacyFixtureProvider migration compatibility', () => {
+    it('includes name-based mocks with falsy responses', async () => {
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nango-legacy-mocks-'));
+        const testsDir = path.join(tempDir, 'tests');
+        const baseDir = path.join(tempDir, 'mocks', 'nango', 'delete', 'proxy', 'settings', 'v3', 'users');
+        await fs.mkdir(testsDir, { recursive: true });
+
+        const cases = [
+            { id: 'empty-string', fileContent: '', expected: '' },
+            { id: 'zero', fileContent: 0, expected: 0 },
+            { id: 'false', fileContent: false, expected: false },
+            { id: 'null', fileContent: null, expected: null }
+        ];
+
+        for (const testCase of cases) {
+            const mockDir = path.join(baseDir, testCase.id);
+            await fs.mkdir(mockDir, { recursive: true });
+            await fs.writeFile(path.join(mockDir, 'delete-user.json'), JSON.stringify(testCase.fileContent));
+
+            const provider = new LegacyFixtureProvider(testsDir, 'delete-user');
+            const allMocks = await provider.getAllMocksForEndpoint('delete', `settings/v3/users/${testCase.id}`);
+
+            expect(allMocks).toHaveLength(1);
+            expect(allMocks[0]?.response).toBe(testCase.expected);
+        }
+    });
+
+    it('returns exact hash match from hash-based directories', async () => {
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nango-legacy-hash-match-'));
+        const testsDir = path.join(tempDir, 'tests');
+        const endpoint = 'crm/v3/objects/contacts';
+        const hash = 'abc123';
+        const hashDir = path.join(tempDir, 'mocks', 'nango', 'get', 'proxy', endpoint, 'contacts');
+        await fs.mkdir(testsDir, { recursive: true });
+        await fs.mkdir(hashDir, { recursive: true });
+
+        await fs.writeFile(
+            path.join(hashDir, `${hash}.json`),
+            JSON.stringify({
+                method: 'get',
+                endpoint,
+                requestIdentityHash: hash,
+                requestIdentity: {
+                    method: 'get',
+                    endpoint,
+                    params: [['limit', '10']],
+                    headers: []
+                },
+                response: { results: [{ id: '1' }] }
+            })
+        );
+
+        const provider = new LegacyFixtureProvider(testsDir, 'contacts');
+        const response = await provider.getCachedResponse({
+            method: 'get',
+            endpoint,
+            requestIdentityHash: hash,
+            requestIdentity: {
+                method: 'get',
+                endpoint,
+                params: [['limit', '10']],
+                headers: []
+            }
+        });
+
+        expect(response.response).toEqual({ results: [{ id: '1' }] });
+    });
+
+    it('falls back to params matching when hash misses in hash-based directories', async () => {
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nango-legacy-params-fallback-'));
+        const testsDir = path.join(tempDir, 'tests');
+        const endpoint = 'crm/v3/objects/contacts';
+        const hashDir = path.join(tempDir, 'mocks', 'nango', 'get', 'proxy', endpoint, 'contacts');
+        await fs.mkdir(testsDir, { recursive: true });
+        await fs.mkdir(hashDir, { recursive: true });
+
+        await fs.writeFile(
+            path.join(hashDir, 'stored-hash.json'),
+            JSON.stringify({
+                method: 'get',
+                endpoint,
+                requestIdentityHash: 'stored-hash',
+                requestIdentity: {
+                    method: 'get',
+                    endpoint,
+                    params: [
+                        ['after', 'cursor-1'],
+                        ['limit', '10']
+                    ],
+                    headers: [['x-tenant', 'tenant-a']]
+                },
+                response: { results: [{ id: '2' }] }
+            })
+        );
+
+        const provider = new LegacyFixtureProvider(testsDir, 'contacts');
+        const response = await provider.getCachedResponse({
+            method: 'get',
+            endpoint,
+            requestIdentityHash: 'missing-hash',
+            requestIdentity: {
+                method: 'get',
+                endpoint,
+                params: [
+                    ['limit', '10'],
+                    ['after', 'cursor-1']
+                ],
+                headers: [['x-tenant', 'tenant-a']]
+            }
+        });
+
+        expect(response.response).toEqual({ results: [{ id: '2' }] });
+    });
+});

--- a/packages/cli/lib/testMocks/utils.unified.unit.cli-test.ts
+++ b/packages/cli/lib/testMocks/utils.unified.unit.cli-test.ts
@@ -1,0 +1,256 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { NangoActionMock } from './utils.js';
+
+async function withMigrateMocksEnv<T>(value: string | undefined, fn: () => Promise<T>): Promise<T> {
+    const previous = process.env['MIGRATE_MOCKS'];
+    if (value === undefined) {
+        delete process.env['MIGRATE_MOCKS'];
+    } else {
+        process.env['MIGRATE_MOCKS'] = value;
+    }
+
+    try {
+        return await fn();
+    } finally {
+        if (previous !== undefined) {
+            process.env['MIGRATE_MOCKS'] = previous;
+        } else {
+            delete process.env['MIGRATE_MOCKS'];
+        }
+    }
+}
+
+async function createTestDir(prefix: string): Promise<string> {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+    const testsDir = path.join(tempDir, 'tests');
+    await fs.mkdir(testsDir, { recursive: true });
+    return testsDir;
+}
+
+describe('UnifiedFixtureProvider precedence', () => {
+    const setupConflictingFixtures = async () => {
+        const testsDir = await createTestDir('nango-unified-precedence-');
+        const legacyDir = path.join(path.dirname(testsDir), 'mocks', 'nango', 'get', 'proxy', 'foo');
+        await fs.mkdir(legacyDir, { recursive: true });
+
+        await fs.writeFile(
+            path.join(testsDir, 'conflict.test.json'),
+            JSON.stringify(
+                {
+                    output: { source: 'unified-output' },
+                    api: {
+                        get: {
+                            foo: {
+                                request: {},
+                                response: { source: 'unified' },
+                                hash: ''
+                            }
+                        }
+                    }
+                },
+                null,
+                2
+            )
+        );
+
+        await fs.writeFile(path.join(legacyDir, 'conflict.json'), JSON.stringify({ source: 'legacy' }));
+
+        return testsDir;
+    };
+
+    it('uses unified mocks over legacy when both exist', async () => {
+        await withMigrateMocksEnv(undefined, async () => {
+            const testsDir = await setupConflictingFixtures();
+            const nangoMock = new NangoActionMock({
+                dirname: testsDir,
+                name: 'conflict',
+                Model: 'ConflictModel'
+            });
+
+            const response = await nangoMock.get({ endpoint: '/foo' });
+            const output = await nangoMock.getOutput();
+
+            expect(response.data).toEqual({ source: 'unified' });
+            expect(output).toEqual({ source: 'unified-output' });
+        });
+    });
+
+    it('still uses unified mocks when MIGRATE_MOCKS is set and both exist', async () => {
+        await withMigrateMocksEnv('V1', async () => {
+            const testsDir = await setupConflictingFixtures();
+            const nangoMock = new NangoActionMock({
+                dirname: testsDir,
+                name: 'conflict',
+                Model: 'ConflictModel'
+            });
+
+            const response = await nangoMock.get({ endpoint: '/foo' });
+            expect(response.data).toEqual({ source: 'unified' });
+        });
+    });
+});
+
+describe('UnifiedFixtureProvider matching behavior', () => {
+    it('matches endpoint keys with or without leading slash', async () => {
+        const testsDir = await createTestDir('nango-unified-endpoint-');
+        await fs.writeFile(
+            path.join(testsDir, 'endpoint.test.json'),
+            JSON.stringify(
+                {
+                    api: {
+                        get: {
+                            '/foo': {
+                                request: {},
+                                response: { ok: true },
+                                hash: ''
+                            }
+                        }
+                    }
+                },
+                null,
+                2
+            )
+        );
+
+        const nangoMock = new NangoActionMock({
+            dirname: testsDir,
+            name: 'endpoint',
+            Model: 'EndpointModel'
+        });
+
+        const response = await nangoMock.get({ endpoint: '/foo' });
+        expect(response.data).toEqual({ ok: true });
+    });
+
+    it('matches both single-object and array API entries', async () => {
+        const testsDir = await createTestDir('nango-unified-shapes-');
+        await fs.writeFile(
+            path.join(testsDir, 'shapes.test.json'),
+            JSON.stringify(
+                {
+                    api: {
+                        get: {
+                            one: {
+                                request: {},
+                                response: { shape: 'object' },
+                                hash: ''
+                            },
+                            many: [
+                                {
+                                    request: {
+                                        params: { page: '1' }
+                                    },
+                                    response: { page: 1 },
+                                    hash: ''
+                                },
+                                {
+                                    request: {
+                                        params: { page: '2' }
+                                    },
+                                    response: { page: 2 },
+                                    hash: ''
+                                }
+                            ]
+                        }
+                    }
+                },
+                null,
+                2
+            )
+        );
+
+        const nangoMock = new NangoActionMock({
+            dirname: testsDir,
+            name: 'shapes',
+            Model: 'ShapesModel'
+        });
+
+        const single = await nangoMock.get({ endpoint: '/one' });
+        const page2 = await nangoMock.get({ endpoint: '/many', params: { page: '2' } });
+
+        expect(single.data).toEqual({ shape: 'object' });
+        expect(page2.data).toEqual({ page: 2 });
+    });
+
+    it('matches headers case-insensitively and params regardless of order', async () => {
+        const testsDir = await createTestDir('nango-unified-request-match-');
+        await fs.writeFile(
+            path.join(testsDir, 'request-matching.test.json'),
+            JSON.stringify(
+                {
+                    api: {
+                        get: {
+                            foo: [
+                                {
+                                    request: {
+                                        params: {
+                                            a: '1',
+                                            b: '2'
+                                        },
+                                        headers: {
+                                            'X-Custom': 'match'
+                                        }
+                                    },
+                                    response: { ok: true },
+                                    hash: ''
+                                }
+                            ]
+                        }
+                    }
+                },
+                null,
+                2
+            )
+        );
+
+        const nangoMock = new NangoActionMock({
+            dirname: testsDir,
+            name: 'request-matching',
+            Model: 'RequestMatchingModel'
+        });
+
+        const response = await nangoMock.get({
+            endpoint: '/foo',
+            params: { b: '2', a: '1' },
+            headers: { 'x-custom': 'match' }
+        });
+
+        expect(response.data).toEqual({ ok: true });
+    });
+
+    it('only applies single-mock fallback when request has no params', async () => {
+        const testsDir = await createTestDir('nango-unified-fallback-');
+        await fs.writeFile(
+            path.join(testsDir, 'fallback.test.json'),
+            JSON.stringify(
+                {
+                    api: {
+                        get: {
+                            foo: {
+                                response: { ok: true }
+                            }
+                        }
+                    }
+                },
+                null,
+                2
+            )
+        );
+
+        const nangoMock = new NangoActionMock({
+            dirname: testsDir,
+            name: 'fallback',
+            Model: 'FallbackModel'
+        });
+
+        const noParams = await nangoMock.get({ endpoint: '/foo' });
+        expect(noParams.data).toEqual({ ok: true });
+
+        await expect(nangoMock.get({ endpoint: '/foo', params: { q: '1' } })).rejects.toThrow('No mock found for GET foo');
+    });
+});


### PR DESCRIPTION
## Problem

The CLI mock migrator was producing incomplete unified mocks for some legacy fixtures:

- `request` ended up empty and `hash` was `""` even when the runtime call had enough info.
- Some endpoints were migrated with an empty array even though a legacy API call existed (notably when legacy response body was falsy, like `""`).
- This caused lookup failures such as:
  - `No mock found for DELETE ... with hash ...`

## Solution

Updated `packages/cli/lib/testMocks/utils.ts` to improve migration behavior:

- **Backfill request/hash from runtime identity** when legacy mock files are response-only (missing `requestIdentity*` fields).
- **Preserve legacy identity when present** (don’t overwrite valid legacy request/hash).
- **Parse JSON request body strings** when possible during backfill (keep raw string when non-JSON).
- **Include falsy legacy name-based responses** by checking `response !== undefined` instead of truthy checks.
- This fixes empty migrated API arrays for cases like `""`, `0`, `false`, `null`.

Also added test coverage:

- Split tests into:
  - `packages/cli/lib/testMocks/utils.legacy.unit.cli-test.ts`
  - `packages/cli/lib/testMocks/utils.unified.unit.cli-test.ts`
- Added regression tests for:
  - response-only legacy backfill
  - legacy-identity precedence
  - non-JSON body fallback
  - hash-based dedupe
  - falsy legacy responses
  - hash-dir exact match + params fallback
  - unified-over-legacy precedence (with and without `MIGRATE_MOCKS`)
  - unified matching behavior (endpoint normalization, object/array entries, header/params matching, fallback semantics)

## Ticket

NAN-4786

## Testing

Run:

- `npx vitest --config vite.cli.config.ts packages/cli/lib/testMocks/utils.legacy.unit.cli-test.ts packages/cli/lib/testMocks/utils.unified.unit.cli-test.ts --run`

Expected:

- 2 test files pass
- 13 tests pass in total
<!-- Summary by @propel-code-bot -->

---

One remaining concern is how the migrator handles partially specified legacy identities—these are treated as complete and therefore skip runtime backfilling, and deduplication now hinges on the runtime-provided hashes when legacy files lacked them, which could affect scenarios with multiple distinct bodies sharing a response-only fixture.

<details>
<summary><strong>Possible Issues</strong></summary>

• When a legacy mock provides only some identity fields (e.g., params but no headers/data), `hasLegacyIdentity` treats it as complete and skips runtime backfill for the missing pieces; verify this matches intended behavior.
• Backfilled hashes rely on runtime `identity.requestIdentityHash`; if multiple runtime requests with different bodies hit the same response-only legacy file within a single migration run, only distinct hashes will deduplicate—ensure this aligns with expected dedupe semantics.

</details>

---
*This summary was automatically generated by @propel-code-bot*