### PR TITLE
fix: Bump axios to 1.13.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16502,13 +16502,13 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.13.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
-            "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
+            "version": "1.13.5",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+            "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
                 "proxy-from-env": "^1.1.0"
             }
         },
@@ -16522,6 +16522,22 @@
                 "des.js": "^1.1.0",
                 "dev-null": "^0.1.1",
                 "js-md4": "^0.3.2"
+            }
+        },
+        "node_modules/axios/node_modules/form-data": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/b4a": {
@@ -33504,7 +33520,7 @@
                 "@types/unzipper": "0.10.11",
                 "ajv": "8.17.1",
                 "ajv-errors": "3.0.0",
-                "axios": "1.13.4",
+                "axios": "1.13.5",
                 "chalk": "5.4.1",
                 "chokidar": "3.5.3",
                 "columnify": "1.6.0",
@@ -34021,7 +34037,7 @@
                 "@nangohq/shared": "file:../shared",
                 "@nangohq/utils": "file:../utils",
                 "@nangohq/webhooks": "file:../webhooks",
-                "axios": "1.13.4",
+                "axios": "1.13.5",
                 "dd-trace": "5.52.0",
                 "express": "5.1.0",
                 "get-port": "7.1.0",
@@ -35120,7 +35136,7 @@
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@nangohq/types": "0.69.34",
-                "axios": "1.13.4"
+                "axios": "1.13.5"
             },
             "devDependencies": {
                 "tsup": "8.5.0",
@@ -35307,7 +35323,7 @@
                 "@nangohq/utils": "file:../utils",
                 "@trpc/client": "10.45.3",
                 "@trpc/server": "10.45.3",
-                "axios": "1.13.4",
+                "axios": "1.13.5",
                 "botbuilder": "4.23.2",
                 "connect-timeout": "1.9.1",
                 "dd-trace": "5.52.0",
@@ -35341,7 +35357,7 @@
             "devDependencies": {
                 "@nangohq/types": "0.69.34",
                 "@types/json-schema": "7.0.15",
-                "axios": "1.13.4",
+                "axios": "1.13.5",
                 "json-schema": "0.4.0",
                 "vitest": "3.2.4"
             },
@@ -35468,7 +35484,7 @@
                 "@nangohq/utils": "file:../utils",
                 "@nangohq/webhooks": "file:../webhooks",
                 "@workos-inc/node": "6.2.0",
-                "axios": "1.13.4",
+                "axios": "1.13.5",
                 "body-parser": "2.2.1",
                 "connect-session-knex": "4.0.0",
                 "cookie-parser": "1.4.7",
@@ -35588,7 +35604,7 @@
                 "ajv": "8.17.1",
                 "ajv-formats": "3.0.1",
                 "archiver": "7.0.1",
-                "axios": "1.13.4",
+                "axios": "1.13.5",
                 "braintree": "3.15.0",
                 "dd-trace": "5.52.0",
                 "exponential-backoff": "3.1.1",
@@ -35763,7 +35779,7 @@
             "version": "0.69.34",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "axios": "1.13.4",
+                "axios": "1.13.5",
                 "json-schema": "0.4.0",
                 "type-fest": "4.41.0"
             },
@@ -35796,33 +35812,6 @@
                 "express": "5.1.0",
                 "ms": "3.0.0-canary.1",
                 "vitest": "3.2.4"
-            }
-        },
-        "packages/utils/node_modules/axios": {
-            "version": "1.13.5",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-            "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.11",
-                "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
-        "packages/utils/node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "packages/utils/node_modules/ms": {
@@ -36401,7 +36390,7 @@
                 "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/logs": "file:../logs",
                 "@nangohq/utils": "file:../utils",
-                "axios": "1.13.4",
+                "axios": "1.13.5",
                 "dayjs": "1.11.7",
                 "dayjs-plugin-utc": "0.1.2",
                 "rate-limiter-flexible": "5.0.3"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
         "@types/unzipper": "0.10.11",
         "ajv": "8.17.1",
         "ajv-errors": "3.0.0",
-        "axios": "1.13.4",
+        "axios": "1.13.5",
         "chalk": "5.4.1",
         "chokidar": "3.5.3",
         "columnify": "1.6.0",

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -31,7 +31,7 @@
         "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",
         "@nangohq/webhooks": "file:../webhooks",
-        "axios": "1.13.4",
+        "axios": "1.13.5",
         "dd-trace": "5.52.0",
         "express": "5.1.0",
         "get-port": "7.1.0",

--- a/packages/node-client/package.json
+++ b/packages/node-client/package.json
@@ -26,7 +26,7 @@
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
         "@nangohq/types": "0.69.34",
-        "axios": "1.13.4"
+        "axios": "1.13.5"
     },
     "engines": {
         "node": ">=20.0"

--- a/packages/runner-sdk/package.json
+++ b/packages/runner-sdk/package.json
@@ -20,7 +20,7 @@
     "devDependencies": {
         "@nangohq/types": "0.69.34",
         "@types/json-schema": "7.0.15",
-        "axios": "1.13.4",
+        "axios": "1.13.5",
         "json-schema": "0.4.0",
         "vitest": "3.2.4"
     },

--- a/packages/runner/lib/exec.unit.test.ts
+++ b/packages/runner/lib/exec.unit.test.ts
@@ -328,6 +328,7 @@ describe('Exec', () => {
                         transitional: {
                             clarifyTimeoutError: false,
                             forcedJSONParsing: true,
+                            legacyInterceptorReqResOrdering: true,
                             silentJSONParsing: true
                         },
                         url: 'http://localhost:3003/connections/connection-id',

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -25,7 +25,7 @@
         "@nangohq/utils": "file:../utils",
         "@trpc/client": "10.45.3",
         "@trpc/server": "10.45.3",
-        "axios": "1.13.4",
+        "axios": "1.13.5",
         "botbuilder": "4.23.2",
         "connect-timeout": "1.9.1",
         "dd-trace": "5.52.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,7 +37,7 @@
         "@nangohq/webhooks": "file:../webhooks",
         "@nangohq/pubsub": "file:../pubsub",
         "@workos-inc/node": "6.2.0",
-        "axios": "1.13.4",
+        "axios": "1.13.5",
         "body-parser": "2.2.1",
         "connect-session-knex": "4.0.0",
         "cookie-parser": "1.4.7",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -30,7 +30,7 @@
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
         "archiver": "7.0.1",
-        "axios": "1.13.4",
+        "axios": "1.13.5",
         "braintree": "3.15.0",
         "dd-trace": "5.52.0",
         "exponential-backoff": "3.1.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -12,7 +12,7 @@
         "directory": "packages/utils"
     },
     "dependencies": {
-        "axios": "1.13.4",
+        "axios": "1.13.5",
         "json-schema": "0.4.0",
         "type-fest": "4.41.0"
     },

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -18,7 +18,7 @@
         "@nangohq/logs": "file:../logs",
         "@nangohq/utils": "file:../utils",
         "@nangohq/kvstore": "file:../kvstore",
-        "axios": "1.13.4",
+        "axios": "1.13.5",
         "dayjs": "1.11.7",
         "dayjs-plugin-utc": "0.1.2",
         "rate-limiter-flexible": "5.0.3"


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Bump `axios` to `1.13.5` across packages**

This PR upgrades every workspace package that depends on `axios` from `1.13.4` to `1.13.5` and regenerates the root `package-lock.json` to capture the new tarball metadata plus updated transitive dependencies (`follow-redirects@^1.15.11`, `form-data@^4.0.5`). The only source change is a unit test expectation in `packages/runner/lib/exec.unit.test.ts`, which now accounts for the additional `legacyInterceptorReqResOrdering` flag emitted by `axios` 1.13.5 when serializing request configs.

<details>
<summary><strong>Key Changes</strong></summary>

• Pinned `axios` to `1.13.5` in `packages/cli`, `packages/jobs`, `packages/node-client`, `packages/runner`, `packages/runner-sdk`, `packages/server`, `packages/shared`, `packages/types`, and `packages/webhooks`.
• Regenerated `package-lock.json` to lock the new `axios` tarball, integrity hash, and transitive dependency versions, and removed the duplicated `packages/utils` scoped entry for `axios`/`form-data`.
• Updated `packages/runner/lib/exec.unit.test.ts` expectation to include the new `axios` `transitional.legacyInterceptorReqResOrdering` field.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Unknown compatibility with any custom interceptor ordering logic now that `legacyInterceptorReqResOrdering` defaults to true.
• Need to ensure environments that patch `axios` configs (e.g., runner SDK) are re-tested for subtle behavior shifts.

</details>

---
*This summary was automatically generated by @propel-code-bot*