### PR TITLE
fix(cli): Fix hash calculation in unified mocks when pagination took place

### DIFF
--- a/packages/cli/lib/services/response-collector.service.ts
+++ b/packages/cli/lib/services/response-collector.service.ts
@@ -46,7 +46,7 @@ interface UnifiedMock {
     api: Record<string, Record<string, ApiMockResponse | ApiMockResponse[]>>;
 }
 
-const FILTER_HEADERS = [
+export const FILTER_HEADERS: string[] = [
     'authorization',
     'user-agent',
     'nango-proxy-user-agent',

--- a/packages/cli/lib/testMocks/utils.unified.unit.cli-test.ts
+++ b/packages/cli/lib/testMocks/utils.unified.unit.cli-test.ts
@@ -127,6 +127,42 @@ describe('UnifiedFixtureProvider matching behavior', () => {
         expect(response.data).toEqual({ ok: true });
     });
 
+    it('matches query params embedded in the endpoint string', async () => {
+        const testsDir = await createTestDir('nango-unified-query-in-endpoint-');
+        await fs.writeFile(
+            path.join(testsDir, 'query-in-endpoint.test.json'),
+            JSON.stringify(
+                {
+                    api: {
+                        get: {
+                            '/foo': {
+                                request: {
+                                    params: {
+                                        a: '1',
+                                        b: '2'
+                                    }
+                                },
+                                response: { ok: true },
+                                hash: ''
+                            }
+                        }
+                    }
+                },
+                null,
+                2
+            )
+        );
+
+        const nangoMock = new NangoActionMock({
+            dirname: testsDir,
+            name: 'query-in-endpoint',
+            Model: 'QueryInEndpointModel'
+        });
+
+        const response = await nangoMock.get({ endpoint: '/foo?a=1&b=2' });
+        expect(response.data).toEqual({ ok: true });
+    });
+
     it('matches both single-object and array API entries', async () => {
         const testsDir = await createTestDir('nango-unified-shapes-');
         await fs.writeFile(


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
`nango dryrun --save` records (and hashes) unified mocks from the final request URL by storing the path as endpoint and the query string as params, but link pagination at runtime rewrites subsequent requests by putting the query into endpoint and clearing params. That representation mismatch makes the computed request identity/hash differ, so the test runner can’t find the saved mock for paginated requests.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Align unified mock hashing with response collector**

Updates the CLI mock utilities so unified mock identities are built the same way as the response collector, addressing failures where paginated requests rewrote query strings into the endpoint and broke hash matching. The change introduces unified-specific URL/param/header normalization logic, switches proxy requests to choose the correct identity builder per fixture type, and exports the response collector’s header filter so both paths stay consistent. A regression test now verifies that a mock recorded for `'/foo'` with params still matches a request made to `'/foo?a=1&b=2'`.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced the single `computeConfigIdentity` with `computeUnifiedConfigIdentity` and `computeLegacyConfigIdentity`, selecting between them in `NangoActionMock.proxyData()` based on `fixtureProvider.isUnifiedMocks()`.
• Added unified-specific helpers (`parseUnifiedEndpointAsUrl`, `applyParamsToUrl`, `normalizeHeadersForUnifiedIdentity`) to merge params into URLs, trim `/proxy/` prefixes, and filter headers identically to the response collector.
• Exported `FILTER_HEADERS` from `packages/cli/lib/services/response-collector.service.ts` and introduced `FILTER_HEADERS_LEGACY` to keep legacy behavior unchanged.
• Extended `packages/cli/lib/testMocks/utils.unified.unit.cli-test.ts` with a Vitest case ensuring mocks recorded with params match requests whose query is embedded in the endpoint.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• `applyParamsToUrl` replaces array params by joining with commas, which may diverge from APIs expecting repeated query keys.
• If both the endpoint string and `params` contain the same key, the final value depends on insertion order; reviewers should confirm this matches proxy construction.
• `normalizeHeadersForUnifiedIdentity` drops duplicate headers after lower-casing; ensure no scenarios rely on distinct casing or repeated headers.

</details>

---
*This summary was automatically generated by @propel-code-bot*