### PR TITLE
fix(webapp): fix 404 after login when default env is missing

### DIFF
--- a/packages/webapp/src/pages/Root.tsx
+++ b/packages/webapp/src/pages/Root.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
+import { PROD_ENVIRONMENT_NAME } from '../constants';
 import { useMeta } from '../hooks/useMeta';
 import { useStore } from '../store';
 
@@ -29,7 +30,11 @@ export const Root: React.FC = () => {
         }
 
         if (location.pathname === '/' && env) {
-            navigate(`/${env}`, { replace: true });
+            // Redirect to an env that exists; prefer prod (cannot be deleted/renamed)
+            const targetEnv = meta.environments?.some((e) => e.name === env)
+                ? env
+                : (meta.environments?.find((e) => e.name === PROD_ENVIRONMENT_NAME)?.name ?? meta.environments?.[0]?.name ?? env);
+            navigate(`/${targetEnv}`, { replace: true });
             return;
         }
 


### PR DESCRIPTION
## Describe the problem and your solution

- fix 404 after login when env is missing. If the current env is in the env list, redirect to it, If not, redirect to `prod` if it exists, otherwise to the first env in the list as a last fallback.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

The root redirect now explicitly checks the requested environment against the available list, loading the configured production environment name and falling back to that or the first available option before routing so users always land on a valid environment.

<details>
<summary><strong>Key Changes</strong></summary>

• Import `PROD_ENVIRONMENT_NAME` into `packages/webapp/src/pages/Root.tsx`
• When `location.pathname === '/'`, compute `targetEnv` by checking the requested `env`, falling back to prod, then to the first available environment
• Use the computed `targetEnv` in the `navigate` call to avoid 404s caused by stale defaults

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• If `meta.environments` is an empty array, the fallback reuses the missing `env`, which might still yield a 404.

</details>

---
*This summary was automatically generated by @propel-code-bot*