### PR TITLE
feat(integrations): add support for hubspot mcp

### DIFF
--- a/docs/api-integrations/hubspot-mcp.mdx
+++ b/docs/api-integrations/hubspot-mcp.mdx
@@ -1,0 +1,101 @@
+---
+title: 'HubSpot (MCP)'
+sidebarTitle: 'HubSpot (MCP)'
+description: 'Integrate your application with the HubSpot MCP API'
+---
+
+## 🚀 Quickstart
+
+Connect to HubSpot (MCP) with Nango and start calling tools in minutes.
+
+<Steps>
+    <Step title="Create the integration">
+    In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _HubSpot (MCP)_.
+    </Step>
+    <Step title="Authorize HubSpot">
+    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then log in to HubSpot. Later, you'll let your users do the same directly from your app.
+    </Step>
+    <Step title="Call a HubSpot MCP tool">
+    Make your first MCP request to HubSpot (e.g. fetch user details). Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+    <Tabs>
+        <Tab title="cURL">
+
+            ```bash
+            curl "https://api.nango.dev/proxy//" \
+              -X POST \
+              -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+              -H "Provider-Config-Key: <INTEGRATION-ID>" \
+              -H "Connection-Id: <CONNECTION-ID>" \
+              -H "Content-Type: application/json" \
+              -d '{
+                "method": "tools/call",
+                "params": {
+                    "name": "get_user_details",
+                    "_meta": {
+                        "progressToken": 1
+                    }
+                },
+                "jsonrpc": "2.0",
+                "id": 1
+            }'
+            ```
+
+        </Tab>
+
+        <Tab title="Node">
+
+        Install Nango's backend SDK with `npm i @nangohq/node`. Then run:
+
+        ```typescript
+        import { Nango } from '@nangohq/node';
+
+        const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+
+        const res = await nango.post({
+            endpoint: '/',
+            providerConfigKey: '<INTEGRATION-ID>',
+            connectionId: '<CONNECTION-ID>',
+            body: {
+                method: 'tools/call',
+                params: {
+                    name: 'get_user_details',
+                    _meta: { progressToken: 1 }
+                },
+                jsonrpc: '2.0',
+                id: 1
+            }
+        });
+
+        console.log(res.data);
+        ```
+        </Tab>
+
+    </Tabs>
+    ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+    </Step>
+
+    <Step title="Implement Nango in your app">
+        Follow our [Auth implementation guide](/implementation-guides/platform/auth/implement-api-auth) to integrate Nango in your app.
+
+        To obtain your own production credentials, follow the setup guide linked below.
+    </Step>
+</Steps>
+
+## 📚 HubSpot (MCP) Integration Guides
+
+Nango-maintained guides for common MCP use cases.
+
+- [How to register your own HubSpot MCP OAuth app](/api-integrations/hubspot-mcp/how-to-register-your-own-hubspot-api-oauth-app)  
+Register an MCP auth app with HubSpot and obtain credentials to connect it to Nango.
+
+Official docs: [HubSpot MCP server](https://developers.hubspot.com/docs/apps/developer-platform/build-apps/integrate-with-the-remote-hubspot-mcp-server)
+
+## 🧩 Pre-built syncs & actions for HubSpot (MCP)
+
+Enable them in your dashboard. [Extend and customize](/implementation-guides/platform/functions/customize-template) to fit your needs.
+
+import PreBuiltUseCases from "/snippets/generated/hubspot-mcp/PreBuiltUseCases.mdx"
+
+<PreBuiltUseCases />
+
+---

--- a/docs/api-integrations/hubspot-mcp.mdx
+++ b/docs/api-integrations/hubspot-mcp.mdx
@@ -85,7 +85,7 @@ Connect to HubSpot (MCP) with Nango and start calling tools in minutes.
 
 Nango-maintained guides for common MCP use cases.
 
-- [How to register your own HubSpot MCP OAuth app](/api-integrations/hubspot-mcp/how-to-register-your-own-hubspot-api-oauth-app)  
+- [How to register your own HubSpot MCP OAuth app](/api-integrations/hubspot-mcp/how-to-register-your-own-hubspot-mcp-api-oauth-app)  
 Register an MCP auth app with HubSpot and obtain credentials to connect it to Nango.
 
 Official docs: [HubSpot MCP server](https://developers.hubspot.com/docs/apps/developer-platform/build-apps/integrate-with-the-remote-hubspot-mcp-server)

--- a/docs/api-integrations/hubspot-mcp/how-to-register-your-own-hubspot-api-oauth-app.mdx
+++ b/docs/api-integrations/hubspot-mcp/how-to-register-your-own-hubspot-api-oauth-app.mdx
@@ -1,0 +1,29 @@
+---
+title: 'How to register your own HubSpot MCP OAuth app'
+sidebarTitle: 'HubSpot MCP Setup'
+description: 'Create an MCP auth app in HubSpot and connect it to Nango'
+---
+
+This guide shows you how to create an **MCP auth app** in your HubSpot account and obtain your OAuth credentials (client ID and secret). These are required so your users can grant your app access to their HubSpot account via Nango.
+
+## Create an MCP auth app in HubSpot
+
+<Steps>
+ <Step title="Create a developer account">
+    If you dont have an account go to [HubSpot's developer signup page](https://app.hubspot.com/signup-hubspot/developers) and create an account.
+  </Step>
+  <Step title="Open MCP Auth Apps">
+    In your HubSpot account, go to **Development**. In the left sidebar, select **MCP Auth Apps**.
+  </Step>
+  <Step title="Create a new MCP auth app">
+    In the upper right, click **Create MCP auth app**.
+  </Step>
+  <Step title="Enter your app details">
+    In the dialog, fill in all your required information. For the **Redirect URL** add `https://api.nango.dev/oauth/callback`
+  </Step>
+  <Step title="Create and copy credentials">
+    Click **Create**. After the app is created, copy your **Client ID** and **Client Secret**. You will enter these when configuring the HubSpot (MCP) integration in Nango.
+  </Step>
+</Steps>
+
+You're now ready to connect HubSpot MCP to Nango. For more on the HubSpot MCP server and OAuth, see [HubSpot's guide to integrating with the MCP server](https://developers.hubspot.com/docs/apps/developer-platform/build-apps/integrate-with-the-remote-hubspot-mcp-server).

--- a/docs/api-integrations/hubspot-mcp/how-to-register-your-own-hubspot-mcp-api-oauth-app.mdx
+++ b/docs/api-integrations/hubspot-mcp/how-to-register-your-own-hubspot-mcp-api-oauth-app.mdx
@@ -10,7 +10,7 @@ This guide shows you how to create an **MCP auth app** in your HubSpot account a
 
 <Steps>
  <Step title="Create a developer account">
-    If you dont have an account go to [HubSpot's developer signup page](https://app.hubspot.com/signup-hubspot/developers) and create an account.
+    If you don't have an account go to [HubSpot's developer signup page](https://app.hubspot.com/signup-hubspot/developers) and create an account.
   </Step>
   <Step title="Open MCP Auth Apps">
     In your HubSpot account, go to **Development**. In the left sidebar, select **MCP Auth Apps**.

--- a/docs/snippets/generated/hubspot-mcp/PreBuiltTooling.mdx
+++ b/docs/snippets/generated/hubspot-mcp/PreBuiltTooling.mdx
@@ -1,0 +1,41 @@
+## Pre-built tooling
+<AccordionGroup>
+<Accordion title="✅ Authorization">
+| Tools | Status |
+| - | - |
+| Pre-built authorization (undefined) | ✅ |
+| Auth parameters validation | ✅ |
+| Pre-built authorization UI | ✅ |
+| Custom authorization UI | ✅ |
+| End-user authorization guide | 🚫 |
+| Expired credentials detection | ✅ |
+</Accordion>
+<Accordion title="✅ Read & write data">
+| Tools | Status |
+| - | - |
+| Pre-built integrations | 🚫 (time to contribute: &lt;48h) |
+| API unification | ✅ |
+| 2-way sync | ✅ |
+| Webhooks from Nango on data modifications | ✅ |
+| Real-time webhooks from 3rd-party API | 🚫 (time to contribute: &lt;48h) |
+| Proxy requests | ✅ |
+</Accordion>
+<Accordion title="✅ Observability & data quality">
+| Tools | Status |
+| - | - |
+| HTTP request logging | ✅ |
+| End-to-end type safety | ✅ |
+| Data runtime validation | ✅ |
+| OpenTelemetry export | ✅ |
+| Slack alerts on errors | ✅ |
+| Integration status API | ✅ |
+</Accordion>
+<Accordion title="✅ Customization">
+| Tools | Status |
+| - | - |
+| Create or customize use-cases | ✅ |
+| Pre-configured pagination | 🚫 (time to contribute: &lt;48h) |
+| Pre-configured rate-limit handling | 🚫 (time to contribute: &lt;48h) |
+| Per-customer configurations | ✅ |
+</Accordion>
+</AccordionGroup>

--- a/docs/snippets/generated/hubspot-mcp/PreBuiltTooling.mdx
+++ b/docs/snippets/generated/hubspot-mcp/PreBuiltTooling.mdx
@@ -3,7 +3,7 @@
 <Accordion title="✅ Authorization">
 | Tools | Status |
 | - | - |
-| Pre-built authorization (undefined) | ✅ |
+| Pre-built authorization (MCP OAuth2) | ✅ |
 | Auth parameters validation | ✅ |
 | Pre-built authorization UI | ✅ |
 | Custom authorization UI | ✅ |

--- a/docs/snippets/generated/hubspot-mcp/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/hubspot-mcp/PreBuiltUseCases.mdx
@@ -1,0 +1,3 @@
+_No pre-built syncs or actions available yet._
+
+<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -1170,6 +1170,7 @@ asana-mcp:
         - ticketing
         - mcp
     auth_mode: MCP_OAUTH2
+    client_registration: dynamic
     authorization_url: https://mcp.asana.com/authorize
     token_url: https://mcp.asana.com/token
     registration_url: https://mcp.asana.com/register
@@ -7909,6 +7910,28 @@ hubspot:
     docs: https://nango.dev/docs/api-integrations/hubspot
     setup_guide_url: https://nango.dev/docs/api-integrations/hubspot/how-to-register-your-own-hubspot-api-oauth-app
 
+hubspot-mcp:
+    display_name: HubSpot (MCP)
+    categories:
+        - marketing
+        - support
+        - crm
+        - mcp
+    auth_mode: MCP_OAUTH2
+    client_registration: static
+    authorization_url: https://mcp.hubspot.com/oauth/authorize/user
+    token_url: https://mcp.hubspot.com/oauth/v3/token
+    authorization_params:
+        response_type: code
+    token_params:
+        grant_type: authorization_code
+    refresh_params:
+        grant_type: refresh_token
+    proxy:
+        base_url: https://mcp.hubspot.com
+    docs: https://nango.dev/docs/api-integrations/hubspot-mcp
+    setup_guide_url: https://nango.dev/docs/api-integrations/hubspot-mcp/how-to-register-your-own-hubspot-mcp-api-oauth-app
+
 incident-io:
     display_name: Incident.io
     categories:
@@ -9140,6 +9163,7 @@ linear-mcp:
         - ticketing
         - mcp
     auth_mode: MCP_OAUTH2
+    client_registration: dynamic
     authorization_url: https://mcp.linear.app/authorize
     token_url: https://mcp.linear.app/token
     registration_url: https://mcp.linear.app/register
@@ -10663,6 +10687,7 @@ notion-mcp:
         - productivity
         - mcp
     auth_mode: MCP_OAUTH2
+    client_registration: dynamic
     authorization_url: https://mcp.notion.com/authorize
     token_url: https://mcp.notion.com/token
     registration_url: https://mcp.notion.com/register

--- a/packages/server/lib/controllers/config.controller.ts
+++ b/packages/server/lib/controllers/config.controller.ts
@@ -26,26 +26,24 @@ class ConfigController {
         try {
             const sharedCredentials = await sharedCredentialsService.getPreConfiguredProviderScopes();
 
-            const list = Object.entries(providers)
-                .filter(([, properties]) => properties.auth_mode !== 'MCP_OAUTH2')
-                .map((providerProperties) => {
-                    const [provider, properties] = providerProperties;
-                    // check if provider has nango's preconfigured credentials
-                    const preConfiguredInfo = sharedCredentials.isOk() ? sharedCredentials.value[provider] : undefined;
-                    const isPreConfigured = preConfiguredInfo ? preConfiguredInfo.preConfigured : false;
-                    const preConfiguredScopes = preConfiguredInfo ? preConfiguredInfo.scopes : [];
+            const list = Object.entries(providers).map((providerProperties) => {
+                const [provider, properties] = providerProperties;
+                // check if provider has nango's preconfigured credentials
+                const preConfiguredInfo = sharedCredentials.isOk() ? sharedCredentials.value[provider] : undefined;
+                const isPreConfigured = preConfiguredInfo ? preConfiguredInfo.preConfigured : false;
+                const preConfiguredScopes = preConfiguredInfo ? preConfiguredInfo.scopes : [];
 
-                    return {
-                        name: provider,
-                        displayName: properties.display_name,
-                        defaultScopes: properties.default_scopes,
-                        authMode: properties.auth_mode,
-                        categories: properties.categories,
-                        docs: properties.docs,
-                        preConfigured: isPreConfigured,
-                        preConfiguredScopes: preConfiguredScopes
-                    };
-                });
+                return {
+                    name: provider,
+                    displayName: properties.display_name,
+                    defaultScopes: properties.default_scopes,
+                    authMode: properties.auth_mode,
+                    categories: properties.categories,
+                    docs: properties.docs,
+                    preConfigured: isPreConfigured,
+                    preConfiguredScopes: preConfiguredScopes
+                };
+            });
             const sortedList = list.sort((a, b) => a.name.localeCompare(b.name));
             res.status(200).send(sortedList);
         } catch (err) {

--- a/packages/server/lib/controllers/providers/getProviders.integration.test.ts
+++ b/packages/server/lib/controllers/providers/getProviders.integration.test.ts
@@ -53,21 +53,46 @@ describe(`GET ${route}`, () => {
         const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(route, {
             token: secret.secret,
-            query: { search: 'hubspot' }
+            query: { search: 'outreach' }
         });
 
         isSuccess(res.json);
         expect(res.json).toMatchObject<typeof res.json>({
             data: [
                 {
-                    display_name: 'HubSpot',
-                    docs: 'https://nango.dev/docs/api-integrations/hubspot',
-                    logo_url: 'http://localhost:3003/images/template-logos/hubspot.svg',
-                    name: 'hubspot',
+                    display_name: 'Outreach',
+                    docs: 'https://nango.dev/docs/integrations/all/outreach',
+                    logo_url: 'http://localhost:3003/images/template-logos/outreach.svg',
+                    name: 'outreach',
                     auth_mode: 'OAUTH2'
                 }
             ]
         });
+    });
+
+    it('should return multiple results when search matches several providers', async () => {
+        const { secret } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(route, {
+            token: secret.secret,
+            query: { search: 'hubspot' }
+        });
+
+        isSuccess(res.json);
+        expect(res.json.data.length).toBe(2);
+        expect(res.json.data).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    display_name: 'HubSpot',
+                    name: 'hubspot',
+                    auth_mode: 'OAUTH2'
+                }),
+                expect.objectContaining({
+                    display_name: 'HubSpot (MCP)',
+                    name: 'hubspot-mcp',
+                    auth_mode: 'MCP_OAUTH2'
+                })
+            ])
+        );
     });
 
     it('should return empty array when search has no results', async () => {

--- a/packages/server/lib/controllers/v1/integrations/buildIntegrationConfig.ts
+++ b/packages/server/lib/controllers/v1/integrations/buildIntegrationConfig.ts
@@ -69,8 +69,8 @@ export async function buildIntegrationConfig(body: PostIntegration['Body'], envi
                 };
             }
         } else if (auth.authType === 'MCP_OAUTH2') {
-            config.oauth_client_id = null;
-            config.oauth_client_secret = null;
+            config.oauth_client_id = auth.clientId ?? null;
+            config.oauth_client_secret = auth.clientSecret ?? null;
             config.oauth_scopes = auth.scopes ?? null;
         } else if (auth.authType === 'MCP_OAUTH2_GENERIC') {
             const { clientName, clientUri, clientLogoUri } = auth;

--- a/packages/server/lib/controllers/v1/integrations/postIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/postIntegration.ts
@@ -6,7 +6,7 @@ import { postIntegrationBodySchema } from './validation.js';
 import { integrationToApi } from '../../../formatters/integration.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 
-import type { IntegrationConfig, PostIntegration } from '@nangohq/types';
+import type { IntegrationConfig, PostIntegration, ProviderMcpOAUTH2 } from '@nangohq/types';
 
 export const postIntegration = asyncWrapper<PostIntegration>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
@@ -78,8 +78,13 @@ export const postIntegration = asyncWrapper<PostIntegration>(async (req, res) =>
         const config = await buildIntegrationConfig(body, environment.id);
 
         if (provider.auth_mode === 'MCP_OAUTH2') {
-            const mcpClientId = await mcpClient.registerClientId({ provider, environment, team: account });
-            config.oauth_client_id = mcpClientId;
+            const clientRegistration = (provider as ProviderMcpOAUTH2).client_registration;
+            if (clientRegistration === 'dynamic') {
+                const mcpClientId = await mcpClient.registerClientId({ provider, environment, team: account });
+                config.oauth_client_id = mcpClientId;
+            }
+            // static: client_id/secret come from body.auth
+            // metadata: not implemented (TODO)
         }
 
         const createdIntegration = await configService.createProviderConfig(config, provider);

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
@@ -119,6 +119,12 @@ export const patchIntegration = asyncWrapper<PatchIntegration>(async (req, res) 
                 ...(body.privateKey !== undefined && { private_key: Buffer.from(body.privateKey).toString('base64') })
             };
         } else if (body.authType === 'MCP_OAUTH2') {
+            if (body.clientId !== undefined) {
+                integration.oauth_client_id = body.clientId;
+            }
+            if (body.clientSecret !== undefined) {
+                integration.oauth_client_secret = body.clientSecret;
+            }
             if (body.scopes !== undefined) {
                 integration.oauth_scopes = body.scopes || '';
             }

--- a/packages/server/lib/controllers/v1/integrations/validation.ts
+++ b/packages/server/lib/controllers/v1/integrations/validation.ts
@@ -45,6 +45,8 @@ export const integrationAuthTypeCustomSchema = z
 export const integrationAuthTypeMcpOAuth2Schema = z
     .object({
         authType: z.enum(['MCP_OAUTH2']),
+        clientId: z.string().min(1).max(255).optional(),
+        clientSecret: z.string().min(1).optional(),
         scopes: scopesSchema
     })
     .strict();

--- a/packages/server/lib/controllers/v1/providers/getProviders.ts
+++ b/packages/server/lib/controllers/v1/providers/getProviders.ts
@@ -22,16 +22,14 @@ export const getProvidersList = asyncWrapper<GetProviders>(async (req, res) => {
     try {
         const sharedCredentials = await sharedCredentialsService.getPreConfiguredProviderScopes();
 
-        const list = Object.entries(providers)
-            .filter(([, properties]) => properties.auth_mode !== 'MCP_OAUTH2')
-            .map(([provider, properties]) => {
-                // check if provider has nango's preconfigured credentials
-                const preConfiguredInfo = sharedCredentials.isOk() ? sharedCredentials.value[provider] : undefined;
-                const isPreConfigured = preConfiguredInfo ? preConfiguredInfo.preConfigured : false;
-                const preConfiguredScopes = preConfiguredInfo ? preConfiguredInfo.scopes : [];
+        const list = Object.entries(providers).map(([provider, properties]) => {
+            // check if provider has nango's preconfigured credentials
+            const preConfiguredInfo = sharedCredentials.isOk() ? sharedCredentials.value[provider] : undefined;
+            const isPreConfigured = preConfiguredInfo ? preConfiguredInfo.preConfigured : false;
+            const preConfiguredScopes = preConfiguredInfo ? preConfiguredInfo.scopes : [];
 
-                return providerListItemToAPI(provider, properties, isPreConfigured, preConfiguredScopes);
-            });
+            return providerListItemToAPI(provider, properties, isPreConfigured, preConfiguredScopes);
+        });
         const sortedList = list.sort((a, b) => a.name.localeCompare(b.name));
         res.status(200).send({ data: sortedList });
     } catch (err) {

--- a/packages/server/lib/formatters/provider.ts
+++ b/packages/server/lib/formatters/provider.ts
@@ -1,7 +1,7 @@
-import type { ApiProviderListItem, Provider } from '@nangohq/types';
+import type { ApiProviderListItem, Provider, ProviderMcpOAUTH2 } from '@nangohq/types';
 
 export function providerListItemToAPI(providerName: string, properties: Provider, preConfigured: boolean, preConfiguredScopes: string[]): ApiProviderListItem {
-    return {
+    const item: ApiProviderListItem = {
         name: providerName,
         displayName: properties.display_name,
         defaultScopes: properties.default_scopes,
@@ -10,6 +10,10 @@ export function providerListItemToAPI(providerName: string, properties: Provider
         docs: properties.docs,
         docs_connect: properties.docs_connect,
         preConfigured,
-        preConfiguredScopes
+        preConfiguredScopes,
+        ...(properties.auth_mode === 'MCP_OAUTH2' && {
+            clientRegistration: (properties as ProviderMcpOAUTH2).client_registration
+        })
     };
+    return item;
 }

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -130,6 +130,8 @@ export interface CustomAuthBody {
 
 export interface MCPOAuth2AuthBody {
     authType: Extract<AuthModeType, 'MCP_OAUTH2'>;
+    clientId?: string | undefined;
+    clientSecret?: string | undefined;
     scopes?: string | undefined;
 }
 

--- a/packages/types/lib/providers/api.ts
+++ b/packages/types/lib/providers/api.ts
@@ -32,6 +32,7 @@ export interface ApiProviderListItem {
     docs_connect?: string | undefined;
     preConfigured: boolean;
     preConfiguredScopes: string[];
+    clientRegistration?: 'dynamic' | 'static' | 'metadata';
 }
 
 export type GetProviders = Endpoint<{

--- a/packages/types/lib/providers/provider.ts
+++ b/packages/types/lib/providers/provider.ts
@@ -135,9 +135,14 @@ export interface ProviderCustom extends Omit<ProviderOAuth2, 'auth_mode'> {
     };
 }
 
+// currently MCP supports 3 types of client registration
+// https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-registration-approaches
+export type McpOAuth2ClientRegistration = 'dynamic' | 'static' | 'metadata';
+
 export interface ProviderMcpOAUTH2 extends Omit<BaseProvider, 'body_format'> {
     auth_mode: 'MCP_OAUTH2';
     registration_url?: string;
+    client_registration: McpOAuth2ClientRegistration;
 }
 
 export interface ProviderMcpOAuth2Generic extends Omit<BaseProvider, 'body_format'> {

--- a/packages/webapp/public/images/template-logos/hubspot-mcp.svg
+++ b/packages/webapp/public/images/template-logos/hubspot-mcp.svg
@@ -1,0 +1,1 @@
+hubspot.svg

--- a/packages/webapp/src/pages/Integrations/components/forms/McpOAuthCreateForm.tsx
+++ b/packages/webapp/src/pages/Integrations/components/forms/McpOAuthCreateForm.tsx
@@ -4,12 +4,16 @@ import { useForm } from 'react-hook-form';
 import z from 'zod';
 
 import { ScopesInput } from '@/components-v2/ScopesInput';
+import { SecretInput } from '@/components-v2/SecretInput';
 import { Button } from '@/components-v2/ui/button';
-import { Form, FormControl, FormField, FormItem, FormLabel } from '@/components-v2/ui/form';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components-v2/ui/form';
+import { InputGroupInput } from '@/components-v2/ui/input-group';
 
 import type { ApiProviderListItem, PostIntegration } from '@nangohq/types';
 
 const formSchema = z.object({
+    clientId: z.string().optional(),
+    clientSecret: z.string().optional(),
     scopes: z.string().optional()
 });
 
@@ -19,6 +23,8 @@ export const McpOAuthCreateForm: React.FC<{ provider: ApiProviderListItem; onSub
     provider,
     onSubmit
 }) => {
+    const useUserCredentials = provider.clientRegistration === 'static';
+
     const form = useForm({
         resolver: zodResolver(formSchema)
     });
@@ -33,6 +39,8 @@ export const McpOAuthCreateForm: React.FC<{ provider: ApiProviderListItem; onSub
                 useSharedCredentials: false,
                 auth: {
                     authType: provider.authMode as Extract<typeof provider.authMode, 'MCP_OAUTH2'>,
+                    ...(useUserCredentials && formData.clientId && { clientId: formData.clientId }),
+                    ...(useUserCredentials && formData.clientSecret && { clientSecret: formData.clientSecret }),
                     scopes: formData.scopes
                 }
             });
@@ -46,6 +54,36 @@ export const McpOAuthCreateForm: React.FC<{ provider: ApiProviderListItem; onSub
             <Form {...form}>
                 <form onSubmit={form.handleSubmit(onSubmitForm)} className="flex flex-col gap-8">
                     <div className="flex flex-col gap-5">
+                        {useUserCredentials && (
+                            <>
+                                <FormField
+                                    control={form.control}
+                                    name="clientId"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>Client ID</FormLabel>
+                                            <FormControl>
+                                                <InputGroupInput {...field} placeholder="Enter your OAuth Client ID" value={field.value ?? ''} />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name="clientSecret"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>Client Secret</FormLabel>
+                                            <FormControl>
+                                                <SecretInput {...field} value={field.value ?? ''} placeholder="Enter your OAuth Client Secret" />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                            </>
+                        )}
                         <FormField
                             control={form.control}
                             name="scopes"

--- a/scripts/docs-gen-snippets.ts
+++ b/scripts/docs-gen-snippets.ts
@@ -16,7 +16,8 @@ const prettyAuthModes: Record<string, string> = {
     SIGNATURE: 'Signature',
     JWT: 'JWT',
     TWO_STEP: 'Two Step',
-    TABLEAU: 'Tableau'
+    TABLEAU: 'Tableau',
+    MCP_OAUTH2: 'MCP OAuth2'
 };
 
 const flowsPath = 'packages/shared/flows.zero.json';

--- a/scripts/validation/providers/schema.json
+++ b/scripts/validation/providers/schema.json
@@ -396,6 +396,10 @@
                 "registration_url": {
                     "type": "string"
                 },
+                "client_registration": {
+                    "type": "string",
+                    "enum": ["dynamic", "static", "metadata"]
+                },
                 "request_params": {
                     "type": "object",
                     "patternProperties": {


### PR DESCRIPTION
## Describe the problem and your solution

- add support for hubspot mcp

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add HubSpot MCP integration with static credential support**

Introduces HubSpot MCP as a first-class provider across backend, webapp, and docs while extending the MCP OAuth flows to handle provider-declared client-registration modes. MCP providers now appear in `/providers` responses with a `clientRegistration` hint, and integration creation/patch flows persist user-supplied `clientId`/`clientSecret` when the template specifies `client_registration: 'static'`. The web UI surfaces editable credential inputs in both the creation modal and settings page when required, and documentation/snippets cover the new integration, quickstart, and setup instructions.

<details>
<summary><strong>Key Changes</strong></summary>

• Expose MCP providers (including the new `hubspot-mcp`) in `providers.yaml`, JSON schema, script snippets, and `/api/v1/providers` responses with the `clientRegistration` attribute
• Update server-side integration build/post/patch logic so MCP_OAUTH2 configs persist provided `clientId`/`clientSecret`, only auto-registering clients when `client_registration === 'dynamic'`
• Enhance `McpOAuthCreateForm` and `McpOAuthSettings` to conditionally collect and edit credentials via `EditableInput`/`SecretInput` when the provider template requires static registration
• Add comprehensive HubSpot MCP docs (quickstart, setup guide, pre-built tooling/use cases) and assets, plus adjust doc tooling generator to recognize the MCP OAuth2 auth mode

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Static MCP integrations can be saved without credentials because both the schema and UI treat `clientId`/`clientSecret` as optional, leading to runtime auth failures later
• HubSpot MCP quickstart cURL sample uses `https://api.nango.dev/proxy//`, which may resolve but is unconventional and could confuse users
• Generated tooling snippet shows `Pre-built authorization (undefined)`—likely missing interpolation for the auth mode label

</details>

---
*This summary was automatically generated by @propel-code-bot*