### PR TITLE
fix(webapp): env-agnostic routes

### DIFF
--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -196,27 +196,27 @@ const router = sentryCreateBrowserRouter([
                         element: <Navigate to="/environment-settings" />
                     }
                 ]
-            },
-            {
-                path: 'account-settings',
-                element: <Navigate to="/team-settings" />
-            },
-            {
-                path: 'team-settings',
-                element: <TeamSettings />,
-                handle: { breadcrumb: 'Team settings' } as BreadcrumbHandle
-            },
-            {
-                path: 'team/billing',
-                element: <TeamBilling />,
-                handle: { breadcrumb: 'Billing' } as BreadcrumbHandle
-            },
-            {
-                path: 'user-settings',
-                element: <UserSettings />,
-                handle: { breadcrumb: 'User settings' } as BreadcrumbHandle
             }
         ]
+    },
+    {
+        path: 'account-settings',
+        element: <Navigate to="/team-settings" />
+    },
+    {
+        path: 'team-settings',
+        element: <TeamSettings />,
+        handle: { breadcrumb: 'Team settings' } as BreadcrumbHandle
+    },
+    {
+        path: 'team/billing',
+        element: <TeamBilling />,
+        handle: { breadcrumb: 'Billing' } as BreadcrumbHandle
+    },
+    {
+        path: 'user-settings',
+        element: <UserSettings />,
+        handle: { breadcrumb: 'User settings' } as BreadcrumbHandle
     },
     {
         path: '/hn-demo',


### PR DESCRIPTION
I must have broken it when rebasing the original PR, or something similar. The routes were supposed to be out of the `/:env` path.

<!-- Summary by @propel-code-bot -->

---

**Ensure settings routes are env-agnostic**

The router configuration in `packages/webapp/src/App.tsx` now defines the settings-related pages outside of the `/:env` subtree so they can be reached without an environment prefix. A redirect from `account-settings` to `team-settings` remains in place, and the individual routes for `team-settings`, `team/billing`, and `user-settings` are registered at the top level of the router.

<details>
<summary><strong>Key Changes</strong></summary>

• Removed `account-settings`, `team-settings`, `team/billing`, and `user-settings` routes from the `/:env` branch inside `packages/webapp/src/App.tsx`
• Added top-level routes for the same settings pages so they are accessible without including the `/:env` segment
• Preserved the existing redirect from `account-settings` to `team-settings`

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Settings routes may now bypass `PrivateRoute`, exposing account/team configuration pages to unauthenticated users.

</details>

---
*This summary was automatically generated by @propel-code-bot*