### PR TITLE
fix: pro-rated charging of base fee

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5382,22 +5382,6 @@
                 "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
         "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -26454,9 +26438,9 @@
             }
         },
         "node_modules/orb-billing": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/orb-billing/-/orb-billing-5.0.0.tgz",
-            "integrity": "sha512-cIq3EZOB9ZfM3iuXhkad/voueA9Cm3KuWcTCDmiR5j840WGGPbodPlpUCNT9cMsiqs2EICxc7a8oVDTTT0P/RA==",
+            "version": "5.44.0",
+            "resolved": "https://registry.npmjs.org/orb-billing/-/orb-billing-5.44.0.tgz",
+            "integrity": "sha512-Gqn05REsXPVM/Up9kSWQUAHxprfT8zPch3KZNXcYd+7xvmCgpqve8+4+CefxSc4UVPd4ecwLKmkKG5WwfbVIfA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@types/node": "^18.11.18",
@@ -27460,22 +27444,6 @@
             },
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/raw-body/node_modules/iconv-lite": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/rc": {
@@ -33486,7 +33454,7 @@
             "dependencies": {
                 "@nangohq/types": "file:../types",
                 "@nangohq/utils": "file:../utils",
-                "orb-billing": "5.0.0",
+                "orb-billing": "5.44.0",
                 "stripe": "18.2.1",
                 "uuidv7": "1.0.2"
             },

--- a/packages/billing/lib/clients/orb.ts
+++ b/packages/billing/lib/clients/orb.ts
@@ -238,16 +238,14 @@ export class OrbClient implements BillingClient {
 
             // Invoices created are ordered by due date
             // The first one is the pending one (if there was one) and the second is what we will charge
-            // Since the order and numbers are unreliable, we need to find the one that is due today
+            // The following ones are for coming months
+            // Since the order and numbers are unreliable, we look for the one that is payable now, and is not 0
             let amountDue = 0;
             for (const invoice of pendingUpgrade.changed_resources?.created_invoices || []) {
-                if (!invoice.due_date) {
-                    continue;
-                }
-                if (new Date(invoice.due_date).getTime() > Date.now()) {
-                    continue;
-                }
                 if (invoice.amount_due === '0.00') {
+                    continue;
+                }
+                if (!invoice.is_payable_now) {
                     continue;
                 }
                 amountDue = Number(invoice.amount_due) * 100;

--- a/packages/billing/package.json
+++ b/packages/billing/package.json
@@ -12,11 +12,11 @@
         "directory": "packages/billing"
     },
     "dependencies": {
-        "@nangohq/utils": "file:../utils",
         "@nangohq/types": "file:../types",
-        "orb-billing": "5.0.0",
-        "uuidv7": "1.0.2",
-        "stripe": "18.2.1"
+        "@nangohq/utils": "file:../utils",
+        "orb-billing": "5.44.0",
+        "stripe": "18.2.1",
+        "uuidv7": "1.0.2"
     },
     "devDependencies": {
         "vitest": "3.2.4"


### PR DESCRIPTION
`due_date` is now coming as null, which breaks this. I've asked orb for the recommended way to get the pro-rated amount, but I'm going for something that works until then.

<!-- Summary by @propel-code-bot -->

---

**Fix pro-rated invoice selection by using Orb’s payable flag**

Updates the billing client to identify the correct proration invoice now that `due_date` may be null. The change filters Orb invoices by `invoice.is_payable_now` and non-zero `invoice.amount_due`, preventing missed charges when due dates are unavailable.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced `due_date` filtering with `invoice.is_payable_now` checks in `packages/billing/lib/clients/orb.ts` to pick the currently payable invoice
• Upgraded `orb-billing` dependency from version `5.0.0` to `5.44.0` in `packages/billing/package.json` and synchronized `package-lock.json` entries
• Reordered dependency declarations in `packages/billing/package.json` for consistency

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• If Orb returns amounts as `'0'` or other zero representations, the strict `'0.00'` check could miss them.
• Assumes all relevant invoices expose `invoice.is_payable_now`; older API responses might omit the flag.

</details>

---
*This summary was automatically generated by @propel-code-bot*