### PR TITLE
fix(webapp): env-agnostic routes

### DIFF
--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -194,29 +194,46 @@ const router = sentryCreateBrowserRouter([
                     {
                         path: 'project-settings',
                         element: <Navigate to="/environment-settings" />
+                    },
+                    // Not env-specific, but uses env
+                    {
+                        path: 'account-settings',
+                        element: <Navigate to="/team-settings" />
+                    },
+                    {
+                        path: 'team-settings',
+                        element: <TeamSettings />,
+                        handle: { breadcrumb: 'Team settings' } as BreadcrumbHandle
+                    },
+                    {
+                        path: 'team/billing',
+                        element: <TeamBilling />,
+                        handle: { breadcrumb: 'Billing' } as BreadcrumbHandle
+                    },
+                    {
+                        path: 'user-settings',
+                        element: <UserSettings />,
+                        handle: { breadcrumb: 'User settings' } as BreadcrumbHandle
                     }
                 ]
-            },
-            {
-                path: 'account-settings',
-                element: <Navigate to="/team-settings" />
-            },
-            {
-                path: 'team-settings',
-                element: <TeamSettings />,
-                handle: { breadcrumb: 'Team settings' } as BreadcrumbHandle
-            },
-            {
-                path: 'team/billing',
-                element: <TeamBilling />,
-                handle: { breadcrumb: 'Billing' } as BreadcrumbHandle
-            },
-            {
-                path: 'user-settings',
-                element: <UserSettings />,
-                handle: { breadcrumb: 'User settings' } as BreadcrumbHandle
             }
         ]
+    },
+    {
+        path: '/account-settings',
+        element: <RedirectWithEnv path="/team-settings" />
+    },
+    {
+        path: '/team-settings',
+        element: <RedirectWithEnv path="team-settings" />
+    },
+    {
+        path: '/team/billing',
+        element: <RedirectWithEnv path="team/billing" />
+    },
+    {
+        path: '/user-settings',
+        element: <RedirectWithEnv path="user-settings" />
     },
     {
         path: '/hn-demo',

--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -221,7 +221,7 @@ const router = sentryCreateBrowserRouter([
     },
     {
         path: '/account-settings',
-        element: <RedirectWithEnv path="/team-settings" />
+        element: <RedirectWithEnv path="team-settings" />
     },
     {
         path: '/team-settings',

--- a/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
@@ -12,6 +12,8 @@ import { globalEnv } from '@/utils/env';
 import { useSignout } from '@/utils/user';
 
 export const ProfileDropdown: React.FC = () => {
+    const env = useStore((state) => state.env);
+
     const { meta } = useMeta();
     const navigate = useNavigate();
     const signout = useSignout();
@@ -23,12 +25,12 @@ export const ProfileDropdown: React.FC = () => {
             {
                 label: 'Team',
                 icon: Users,
-                href: `/team-settings`
+                href: `/${env}/team-settings`
             },
             {
                 label: 'Profile',
                 icon: UserRoundCog,
-                href: `/user-settings`
+                href: `/${env}/user-settings`
             }
         ];
 
@@ -44,12 +46,12 @@ export const ProfileDropdown: React.FC = () => {
             list.push({
                 label: 'Billing & usage',
                 icon: CreditCard,
-                href: `/team/billing`
+                href: `/${env}/team/billing`
             });
         }
 
         return list;
-    }, [meta, showGettingStarted]);
+    }, [meta, showGettingStarted, env]);
 
     const initials = user?.name ? toAcronym(user.name) : '';
 

--- a/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
@@ -52,7 +52,7 @@ export default function UsageCard() {
 
     return (
         <Link
-            to={`/team/billing#usage`}
+            to={`/${env}/team/billing#usage`}
             className="flex flex-col gap-4.5 px-3 py-3.5 text-xs rounded-sm bg-bg-surface border-[0.5px] border-border-muted cursor-pointer transition-colors hover:bg-bg-elevated hover:border-transparent"
         >
             {isLoading ? (

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -247,7 +247,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
             return (
                 <p>
                     Connection limit reached.{' '}
-                    <Link to={`/team/billing`} className="underline">
+                    <Link to={`/${env}/team/billing`} className="underline">
                         Upgrade your plan
                     </Link>{' '}
                     to get rid of connection limits.

--- a/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
@@ -231,7 +231,7 @@ export const ConnectUISettings = () => {
                                 {!canCustomizeTheme && <ThemeColorPickers disabled={true} form={form} />}
                                 {!canDisableWatermark && <WatermarkToggle disabled={true} form={form} />}
 
-                                <ButtonLink to={`/team/billing#plans`} variant="secondary" target="_blank">
+                                <ButtonLink to={`/${env}/team/billing#plans`} variant="secondary" target="_blank">
                                     Upgrade to &apos;Growth&apos; plan
                                 </ButtonLink>
                             </div>

--- a/packages/webapp/src/pages/Integrations/components/AutoIdlingBanner.tsx
+++ b/packages/webapp/src/pages/Integrations/components/AutoIdlingBanner.tsx
@@ -46,7 +46,7 @@ export const AutoIdlingBanner: React.FC = () => {
                         {trialLoading && <Loader2 className="size-4 animate-spin" />}
                         Restart
                     </AlertButton>
-                    <AlertButtonLink variant={'warning'} to={`/team/billing`}>
+                    <AlertButtonLink variant={'warning'} to={`/${env}/team/billing`}>
                         Upgrade
                     </AlertButtonLink>
                 </AlertActions>
@@ -64,7 +64,7 @@ export const AutoIdlingBanner: React.FC = () => {
                     {trialLoading && <Loader2 className="size-4 animate-spin" />}
                     Extend
                 </AlertButton>
-                <AlertButtonLink variant={'info'} to={`/team/billing`}>
+                <AlertButtonLink variant={'info'} to={`/${env}/team/billing`}>
                     Upgrade
                 </AlertButtonLink>
             </AlertActions>


### PR DESCRIPTION
Removing the env from these routes actually broke stuff:
- Private routes look for the env in the first path segment
- Backend endpoints used by those pages require env to be passed in (even though it should not have any effect)
- Navigating to one of those pages by clicking in the dashboard worked, but refreshing the page or navigating from a url (eg. `app.nango.dev/team/billing`) would lead to a 404

We have strong dependency on envs, and we should probably fix that, but until then I just want to address the initial problem: **Being able to link these pages to customers without knowing their envs.**

So I've returned the routes to under `/:env`, but created redirects from the top-level, outside of `PrivateRoute` so we don't get a 404. Unauthenticated requests will be also redirected, but then the original route is protected and will redirect to signin.

<!-- Summary by @propel-code-bot -->

---

It also ensures every in-app entry point now derives the active environment from the store when generating settings and billing links, keeping navigation consistent with backend expectations.

<details>
<summary><strong>Possible Issues</strong></summary>

• `RedirectWithEnv` will generate `/undefined/...` if `useStore` has not populated `env` yet, producing another 404; consider waiting for `env` or falling back to last-known env before redirecting.
• Redirecting unauthenticated users from top-level routes straight into `/:env/...` relies on backend authorization to block cross-environment access; confirm server-side checks cover this.

</details>

---
*This summary was automatically generated by @propel-code-bot*