### PR TITLE
feat(OAuth): add more context to errors during exchange code for token

### DIFF
--- a/packages/connect-ui/src/lib/utils.ts
+++ b/packages/connect-ui/src/lib/utils.ts
@@ -47,3 +47,12 @@ export function getAllowedCallbackOrigin(apiURL: string): string | null {
         return null;
     }
 }
+
+export function compactErrorDisplay(message: string): string {
+    try {
+        const parsed = JSON.parse(message);
+        return JSON.stringify(parsed);
+    } catch {
+        return message;
+    }
+}

--- a/packages/connect-ui/src/views/Go.tsx
+++ b/packages/connect-ui/src/views/Go.tsx
@@ -18,7 +18,7 @@ import { useI18n } from '@/lib/i18n';
 import { useNango } from '@/lib/nango';
 import { useGlobal } from '@/lib/store';
 import { telemetry } from '@/lib/telemetry';
-import { cn, getAllowedCallbackOrigin, jsonSchemaToZod } from '@/lib/utils';
+import { cn, compactErrorDisplay, getAllowedCallbackOrigin, jsonSchemaToZod } from '@/lib/utils';
 
 import type { AuthResult } from '@nangohq/frontend';
 import type { AuthModeType } from '@nangohq/types';
@@ -459,7 +459,9 @@ export const Go: React.FC = () => {
                                 </button>
                                 {showErrorDetails && (
                                     <div className="border-t border-subtle px-4 py-3 bg-muted/30">
-                                        <pre className="text-xs font-mono text-red-600 whitespace-pre-wrap break-all overflow-x-hidden">{error}</pre>
+                                        <pre className="text-xs font-mono text-red-600 whitespace-pre-wrap break-all overflow-x-hidden">
+                                            {compactErrorDisplay(error)}
+                                        </pre>
                                     </div>
                                 )}
                             </div>
@@ -514,7 +516,7 @@ export const Go: React.FC = () => {
                 {error && (
                     <p className="p-4 py-2 rounded-md flex gap-2 text-sm bg-yellow-100 border border-yellow-300 text-yellow-700">
                         <TriangleAlert className="w-5 h-5" />
-                        {error}
+                        {compactErrorDisplay(error)}
                     </p>
                 )}
 

--- a/packages/utils/lib/errors.ts
+++ b/packages/utils/lib/errors.ts
@@ -42,7 +42,7 @@ export function stringifyError(err: unknown, opts?: { pretty?: boolean; stack?: 
             const responseData = anyErr.response.data;
 
             // If error field exists, filter it to only include message-related fields
-            if (responseData.error && typeof responseData.error === 'object') {
+            if (responseData && typeof responseData === 'object') {
                 const filteredError: Record<string, unknown> = {};
                 for (const field of PROVIDER_ERROR_MESSAGE_FIELDS) {
                     if (field in responseData.error) {

--- a/packages/utils/lib/errors.unit.test.ts
+++ b/packages/utils/lib/errors.unit.test.ts
@@ -52,6 +52,28 @@ describe('stringifyError', () => {
             });
         });
 
+        it('should extract provider_error_payload from response.data.error object', () => {
+            const err: any = {
+                response: {
+                    data: {
+                        error: {
+                            reason: 'token_expired',
+                            description: 'The access token has expired',
+                            timestamp: '2024-01-01',
+                            request_id: 'abc123'
+                        }
+                    }
+                }
+            };
+
+            const parsed = JSON.parse(stringifyError(err));
+
+            expect(parsed.provider_error_payload).toEqual({
+                reason: 'token_expired',
+                description: 'The access token has expired'
+            });
+        });
+
         it('should not include provider_error_payload if no whitelisted fields match', () => {
             const err: any = {
                 response: {
@@ -68,8 +90,8 @@ describe('stringifyError', () => {
             expect(parsed).not.toHaveProperty('provider_error_payload');
         });
 
-        it('should not extract provider_error_payload for invalid error structures', () => {
-            const cases = [{ response: { data: { error: 'string' } } }, { response: { data: { error: null } } }, { response: { data: { status: 'ok' } } }];
+        it('should not extract provider_error_payload for invalid response.data structures', () => {
+            const cases = [{ response: { data: null } }, { response: { data: 'string response' } }, { response: { data: { error: {} } } }];
 
             cases.forEach((err) => {
                 expect(JSON.parse(stringifyError(err))).not.toHaveProperty('provider_error_payload');


### PR DESCRIPTION
## Describe the problem and your solution

- add more context to errors during exchange code for token step.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Enhance OAuth error serialization and display context**

The PR routes all OAuth controller error reporting through the shared `stringifyError` helper so that publisher notifications, activity logs, and failure hooks now transmit the full pretty-printed payload, including any `provider_error_payload`. The Connect UI adds a `compactErrorDisplay` helper to render JSON error strings in a normalized single-line format for both inline alerts and the expandable details panel, improving readability for end users.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `packages/utils/lib/errors.ts` so `stringifyError` attempts to build `provider_error_payload` whenever `response.data` exists, and extended the unit suite in `packages/utils/lib/errors.unit.test.ts` to cover more provider payload permutations.
• Replaced `stringifyEnrichedError` usage inside `packages/server/lib/controllers/oauth.controller.ts` with the shared `stringifyError`, propagated the formatted string to `logCtx.error`, `connectionCreationFailedHook`, and `publisher.notifyErr`, and standardized WebSocket errors to `{ type: 'unknown_err', message: prettyError }`.
• Added `compactErrorDisplay` to `packages/connect-ui/src/lib/utils.ts` and wired it into `packages/connect-ui/src/views/Go.tsx` so OAuth failure banners and detail drawers render normalized JSON when possible.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• `stringifyError` now accesses `responseData.error[field]` without verifying that `responseData.error` is defined, so Axios responses that omit the nested `error` object will trigger `TypeError: Cannot use 'in' operator to search for 'message' in undefined`.
• Changing the websocket error payload to `{ type: 'unknown_err', message }` may break consumers relying on the previous `{ type: 'unknown', description }` schema.

</details>

---
*This summary was automatically generated by @propel-code-bot*