### PR TITLE
revert: oauth callback session validation

### DIFF
--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -1,5 +1,4 @@
 import bodyParser from 'body-parser';
-import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import express from 'express';
 import multer from 'multer';
@@ -125,7 +124,7 @@ publicAPI.options('/', publicAPICorsHandler); // Pre-flight
 publicAPI.use('/connect/telemetry', publicAPITelemetryCors);
 
 // API routes (Public key auth).
-publicAPI.route('/oauth/callback').get(cookieParser(), oauthController.oauthCallback.bind(oauthController));
+publicAPI.route('/oauth/callback').get(oauthController.oauthCallback.bind(oauthController));
 publicAPI.route('/app-auth/connect').get(appAuthController.connect.bind(appAuthController));
 
 publicAPI.use('/oauth', jsonContentTypeMiddleware);


### PR DESCRIPTION
## Describe the problem and your solution

- Revert OAuth callback session validation. It turns out this approach is not compatible with all of our customers, as some extract the code and state from the callback and forward them to the Nango callback instead of using a permanent redirect to Nango's callback.

Reverting prs:
https://github.com/NangoHQ/nango/pull/5366

https://github.com/NangoHQ/nango/pull/5488
https://github.com/NangoHQ/nango/pull/5491

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

