### PR TITLE
fix(validations): fix api key validations

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -2582,8 +2582,8 @@ builder-io-private:
             type: string
             title: API Key
             description: The API key for your Builder.io account
-            pattern: '^[a-zA-Z0-9]+$'
-            example: bb209fb71eh2412dbe0114bdae18fd15
+            pattern: '^bpk-[a-f0-9]+$'
+            example: bpk-****************************
             doc_section: '#step-2-finding-your-api-key'
 
 builder-io-public:
@@ -11809,8 +11809,8 @@ perplexity:
             type: string
             title: API Key
             description: The API key for your Perplexity account
-            pattern: '^pplx-[a-f0-9]+$'
-            example: pplx-xxxxxx
+            pattern: '^pplx-[a-zA-Z0-9]+$'
+            example: pplx-****************************
 
 perimeter81:
     display_name: Perimeter81


### PR DESCRIPTION
## Describe the problem and your solution

-  fix api key validations for perplexity and perplexity, I'll open docs migration pr later.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Adjust Builder.io and Perplexity API key validation regexes**

Updates `packages/providers/providers.yaml` to tighten the API key validation for `builder-io-public` credentials and broaden the allowed characters for `perplexity` credentials. Examples accompanying the patterns were also refreshed to reflect the expected formats.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced the Builder.io public API key validation from `^[a-zA-Z0-9]+$` to `^bpk-[a-f0-9]+$` and updated the example token.
• Expanded the Perplexity API key regex from `^pplx-[a-f0-9]+$` to `^pplx-[a-zA-Z0-9]+$`, along with a new masked example string.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Builder.io keys will now fail validation if their suffix contains uppercase hex characters; verify this matches real-world keys.

</details>

---
*This summary was automatically generated by @propel-code-bot*