### PR TITLE
fix(webapp): integrations cache invalidation

### DIFF
--- a/packages/webapp/src/hooks/useIntegration.tsx
+++ b/packages/webapp/src/hooks/useIntegration.tsx
@@ -3,7 +3,6 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { APIError, apiFetch } from '../utils/api';
 
 import type { DeleteIntegration, GetIntegration, GetIntegrationFlows, GetIntegrations, PatchIntegration, PostIntegration } from '@nangohq/types';
-import type { Cache, useSWRConfig } from 'swr';
 
 export function useListIntegrations(env: string) {
     return useQuery<GetIntegrations['Success'], APIError>({
@@ -110,13 +109,4 @@ export function useGetIntegrationFlows(env: string, integrationId: string) {
         },
         enabled: Boolean(env && integrationId)
     });
-}
-
-// TODO: Remove after migrating all connection operations to tanstack query
-export function clearIntegrationsCache(cache: Cache, mutate: ReturnType<typeof useSWRConfig>['mutate']) {
-    for (const key of cache.keys()) {
-        if (key.includes('/api/v1/integrations')) {
-            void mutate(key, undefined);
-        }
-    }
 }

--- a/packages/webapp/src/hooks/useIntegration.tsx
+++ b/packages/webapp/src/hooks/useIntegration.tsx
@@ -112,6 +112,7 @@ export function useGetIntegrationFlows(env: string, integrationId: string) {
     });
 }
 
+// TODO: Remove after migrating all connection operations to tanstack query
 export function clearIntegrationsCache(cache: Cache, mutate: ReturnType<typeof useSWRConfig>['mutate']) {
     for (const key of cache.keys()) {
         if (key.includes('/api/v1/integrations')) {

--- a/packages/webapp/src/pages/Connection/Create.tsx
+++ b/packages/webapp/src/pages/Connection/Create.tsx
@@ -12,7 +12,7 @@ import { CreateConnectionSelector } from './components/CreateConnectionSelector'
 import { Skeleton } from '../../components/ui/Skeleton';
 import { ButtonLink } from '../../components/ui/button/Button';
 import { Form } from '../../components-v2/ui/form';
-import { useListIntegration } from '../../hooks/useIntegration';
+import { useListIntegrations } from '../../hooks/useIntegration';
 import { useUser } from '../../hooks/useUser';
 import DashboardLayout from '../../layout/DashboardLayout';
 import { useStore } from '../../store';
@@ -40,7 +40,8 @@ export const ConnectionCreate: React.FC = () => {
     const analyticsTrack = useAnalyticsTrack();
 
     const { user } = useUser(true);
-    const { list: listIntegration, loading } = useListIntegration(env);
+    const { data: listIntegrationData, isLoading } = useListIntegrations(env);
+    const listIntegration = listIntegrationData?.data;
 
     const [integration, setIntegration] = useState<ApiIntegrationList | undefined>();
     const { data: provider } = useProvider(env, integration?.provider);
@@ -103,7 +104,7 @@ export const ConnectionCreate: React.FC = () => {
         return integration && ['OAUTH2', 'MCP_OAUTH2', 'MCP_OAUTH2_GENERIC'].includes(integration.meta.authMode);
     }, [integration]);
 
-    if (loading) {
+    if (isLoading) {
         return (
             <DashboardLayout>
                 <Helmet>

--- a/packages/webapp/src/pages/Connection/CreateLegacy.tsx
+++ b/packages/webapp/src/pages/Connection/CreateLegacy.tsx
@@ -14,7 +14,7 @@ import SecretInput from '../../components/ui/input/SecretInput';
 import { SecretTextArea } from '../../components/ui/input/SecretTextArea';
 import TagsInput from '../../components/ui/input/TagsInput';
 import { useEnvironment } from '../../hooks/useEnvironment';
-import { useListIntegration } from '../../hooks/useIntegration';
+import { useListIntegrations } from '../../hooks/useIntegration';
 import useSet from '../../hooks/useSet';
 import DashboardLayout from '../../layout/DashboardLayout';
 import { useStore } from '../../store';
@@ -29,7 +29,8 @@ export const ConnectionCreateLegacy: React.FC = () => {
     const { mutate } = useSWRConfig();
     const env = useStore((state) => state.env);
 
-    const { list: integrations } = useListIntegration(env);
+    const { data: integrationsData } = useListIntegrations(env);
+    const integrations = integrationsData?.data;
 
     const [loaded, setLoaded] = useState(false);
     const [serverErrorMessage, setServerErrorMessage] = useState('');

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -19,7 +19,7 @@ import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components-v2/ui
 import { Skeleton } from '@/components-v2/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components-v2/ui/table';
 import { useConnections } from '@/hooks/useConnections';
-import { useListIntegration } from '@/hooks/useIntegration';
+import { useListIntegrations } from '@/hooks/useIntegration';
 import DashboardLayout from '@/layout/DashboardLayout';
 import { useStore } from '@/store';
 import { getConnectionDisplayName, getEndUserEmail } from '@/utils/endUser';
@@ -151,7 +151,7 @@ export const ConnectionList = () => {
 
     useDebounce(() => setDebouncedSearch(search || ''), 300, [search]);
 
-    const { list: listIntegration, loading: integrationsLoading } = useListIntegration(env);
+    const { data: listIntegrationData, isLoading: integrationsLoading } = useListIntegrations(env);
 
     const withError = useMemo(() => {
         if (selectedErrors && selectedErrors.length === 1) {
@@ -197,13 +197,14 @@ export const ConnectionList = () => {
     });
 
     const integrationsOptions = useMemo(() => {
-        if (!listIntegration) {
+        const list = listIntegrationData?.data;
+        if (!list) {
             return [];
         }
-        return listIntegration.map((integration) => {
+        return list.map((integration) => {
             return { name: integration.unique_key, value: integration.unique_key };
         });
-    }, [listIntegration]);
+    }, [listIntegrationData?.data]);
 
     if (connectionsError) {
         return <ErrorPageComponent title="Connections" error={connectionsError.json as GetConnections['Errors']} />;

--- a/packages/webapp/src/pages/Connection/Show.tsx
+++ b/packages/webapp/src/pages/Connection/Show.tsx
@@ -19,7 +19,6 @@ import { Skeleton } from '../../components/ui/Skeleton';
 import { Button } from '../../components/ui/button/Button';
 import { apiDeleteConnection, clearConnectionsCache, useConnection } from '../../hooks/useConnections';
 import { useEnvironment } from '../../hooks/useEnvironment';
-import { clearIntegrationsCache } from '../../hooks/useIntegration';
 import { GetUsageQueryKey } from '../../hooks/usePlan';
 import { useSyncs } from '../../hooks/useSyncs';
 import { useToast } from '../../hooks/useToast';
@@ -93,8 +92,9 @@ export const ConnectionShow: React.FC = () => {
                 undefined,
                 { revalidate: false }
             );
+            // TODO: remove after migrating all connection operations to tanstack query
             clearConnectionsCache(cache, mutate);
-            clearIntegrationsCache(cache, mutate);
+            queryClient.invalidateQueries({ queryKey: ['integrations', env] });
             queryClient.invalidateQueries({ queryKey: GetUsageQueryKey });
 
             navigate(`/${env}/connections`, { replace: true });

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -13,7 +13,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../../../components-v2/
 import { apiConnectSessions } from '../../../hooks/useConnect';
 import { clearConnectionsCache } from '../../../hooks/useConnections';
 import { useEnvironment } from '../../../hooks/useEnvironment';
-import { clearIntegrationsCache, useListIntegrations } from '../../../hooks/useIntegration';
+import { useListIntegrations } from '../../../hooks/useIntegration';
 import { GetUsageQueryKey, useApiGetUsage } from '../../../hooks/usePlan';
 import { useToast } from '../../../hooks/useToast';
 import { useStore } from '../../../store';
@@ -218,8 +218,9 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
                     navigate(`/${env}/connections/${integration?.unique_key || hasConnected.current.providerConfigKey}/${hasConnected.current.connectionId}`);
                 }
             } else if (event.type === 'connect') {
+                // TODO: remove after migrating all connection operations to tanstack query
                 clearConnectionsCache(cache, mutate);
-                clearIntegrationsCache(cache, mutate);
+                queryClient.invalidateQueries({ queryKey: ['integrations', env] });
                 queryClient.invalidateQueries({ queryKey: GetUsageQueryKey });
                 hasConnected.current = event.payload;
                 analyticsTrack('web:connection_created', { provider: integration?.provider || 'unknown' });

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -13,7 +13,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../../../components-v2/
 import { apiConnectSessions } from '../../../hooks/useConnect';
 import { clearConnectionsCache } from '../../../hooks/useConnections';
 import { useEnvironment } from '../../../hooks/useEnvironment';
-import { clearIntegrationsCache, useListIntegration } from '../../../hooks/useIntegration';
+import { clearIntegrationsCache, useListIntegrations } from '../../../hooks/useIntegration';
 import { GetUsageQueryKey, useApiGetUsage } from '../../../hooks/usePlan';
 import { useToast } from '../../../hooks/useToast';
 import { useStore } from '../../../store';
@@ -65,7 +65,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
 
     const env = useStore((state) => state.env);
     const { environmentAndAccount } = useEnvironment(env);
-    const { list: listIntegration, mutate: listIntegrationMutate, loading } = useListIntegration(env);
+    const { data: listIntegrationData, isLoading: listIntegrationPending } = useListIntegrations(env);
 
     const connectUI = useRef<ConnectUI>();
     const hasConnected = useRef<AuthResult | undefined>();
@@ -213,13 +213,11 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
     const onEvent: OnConnectEvent = useCallback(
         (event) => {
             if (event.type === 'close') {
-                void listIntegrationMutate();
                 if (hasConnected.current) {
                     toast.toast({ title: `Connected to ${hasConnected.current.providerConfigKey}`, variant: 'success' });
                     navigate(`/${env}/connections/${integration?.unique_key || hasConnected.current.providerConfigKey}/${hasConnected.current.connectionId}`);
                 }
             } else if (event.type === 'connect') {
-                void listIntegrationMutate();
                 clearConnectionsCache(cache, mutate);
                 clearIntegrationsCache(cache, mutate);
                 queryClient.invalidateQueries({ queryKey: GetUsageQueryKey });
@@ -233,7 +231,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
                 });
             }
         },
-        [toast, queryClient, env, navigate, integration, listIntegrationMutate, cache, mutate, analyticsTrack]
+        [toast, queryClient, env, navigate, integration, cache, mutate, analyticsTrack]
     );
 
     useUnmount(() => {
@@ -280,10 +278,10 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
             <CardContent className={'flex flex-col rounded gap-2.5'}>
                 <div className="flex flex-col w-full">
                     <IntegrationDropdown
-                        integrations={listIntegration || []}
+                        integrations={listIntegrationData?.data ?? []}
                         selectedIntegration={integration}
                         onSelect={setIntegration}
-                        loading={loading}
+                        loading={listIntegrationPending}
                         disabled={Boolean(paramIntegrationId)}
                     />
                 </div>

--- a/packages/webapp/src/pages/Integrations/Create.tsx
+++ b/packages/webapp/src/pages/Integrations/Create.tsx
@@ -9,7 +9,7 @@ import { IntegrationLogo } from '@/components-v2/IntegrationLogo';
 import { Badge } from '@/components-v2/ui/badge';
 import { ButtonLink } from '@/components-v2/ui/button';
 import { Skeleton } from '@/components-v2/ui/skeleton';
-import { apiPostIntegration } from '@/hooks/useIntegration';
+import { usePostIntegration } from '@/hooks/useIntegration';
 import { useProvider } from '@/hooks/useProvider';
 import { useToast } from '@/hooks/useToast';
 import DashboardLayout from '@/layout/DashboardLayout';
@@ -21,6 +21,7 @@ export const CreateIntegration = () => {
     const env = useStore((state) => state.env);
     const { toast } = useToast();
     const navigate = useNavigate();
+    const { mutateAsync: postIntegration } = usePostIntegration(env);
 
     const { providerConfigKey } = useParams();
     const { data: providerData, isLoading: loadingProvider } = useProvider(env, providerConfigKey);
@@ -32,14 +33,12 @@ export const CreateIntegration = () => {
             return;
         }
 
-        const response = await apiPostIntegration(env, data);
-
-        if ('error' in response.json) {
-            toast({ title: response.json.error.message || 'Failed to create integration', variant: 'error' });
-            return;
+        try {
+            const response = await postIntegration(data);
+            navigate(`/${env}/integrations/${response.data.unique_key}/settings`);
+        } catch {
+            toast({ title: 'Failed to create integration', variant: 'error' });
         }
-
-        navigate(`/${env}/integrations/${response.json.data.unique_key}/settings`);
     };
 
     if (loadingProvider || !provider) {

--- a/packages/webapp/src/pages/Integrations/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/Show.tsx
@@ -14,22 +14,22 @@ import { ButtonLink } from '@/components-v2/ui/button';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components-v2/ui/input-group';
 import { Skeleton } from '@/components-v2/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components-v2/ui/table';
-import { useListIntegration } from '@/hooks/useIntegration';
+import { useListIntegrations } from '@/hooks/useIntegration';
 import DashboardLayout from '@/layout/DashboardLayout';
 import { useStore } from '@/store';
 
-import type { ApiIntegrationList } from '@nangohq/types';
+import type { ApiIntegrationList, GetIntegrations } from '@nangohq/types';
 
 export const IntegrationsList = () => {
     const navigate = useNavigate();
 
     const env = useStore((state) => state.env);
-    const { list, loading, error } = useListIntegration(env);
+    const { data, isPending, error } = useListIntegrations(env);
     const [integrations, setIntegrations] = useState<ApiIntegrationList[] | null>(null);
 
     const initialIntegrations = useMemo(() => {
-        return list ?? null;
-    }, [list]);
+        return data?.data ?? null;
+    }, [data?.data]);
 
     useEffect(() => {
         if (initialIntegrations) {
@@ -87,7 +87,7 @@ export const IntegrationsList = () => {
     );
 
     if (error) {
-        return <ErrorPageComponent title="Integrations" error={error.json} />;
+        return <ErrorPageComponent title="Integrations" error={error.json as GetIntegrations['Errors']} />;
     }
 
     return (
@@ -111,7 +111,7 @@ export const IntegrationsList = () => {
 
             <AutoIdlingBanner />
 
-            {loading && (
+            {isPending && (
                 <div className="flex flex-col gap-1">
                     <Skeleton className="h-10 w-full" />
                     {Array.from({ length: 4 }).map((_, index) => (
@@ -120,7 +120,7 @@ export const IntegrationsList = () => {
                 </div>
             )}
 
-            {list && list.length === 0 && (
+            {data?.data && data.data.length === 0 && (
                 <div className="flex flex-col gap-5 p-20 items-center justify-center bg-bg-elevated rounded">
                     <h3 className="text-title-body text-text-primary">No available integrations</h3>
                     <p className="text-text-secondary text-body-medium-regular">You don’t have any integrations set up yet with Nango.</p>
@@ -130,7 +130,7 @@ export const IntegrationsList = () => {
                 </div>
             )}
 
-            {list && list.length > 0 && integrations && integrations.length === 0 && (
+            {data?.data && data.data.length > 0 && integrations && integrations.length === 0 && (
                 <div className="flex flex-col gap-5 p-20 items-center justify-center bg-bg-elevated rounded">
                     <h3 className="text-title-body text-text-primary">No integrations found</h3>
                     <p className="text-text-secondary text-body-medium-regular">Could not find any integrations matching your search.</p>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -31,7 +31,7 @@ export const FunctionsOne: React.FC = () => {
     const { providerConfigKey, functionName } = useParams();
 
     const env = useStore((state) => state.env);
-    const { data: integrationResponse, isPending: integrationLoading } = useGetIntegration(env, providerConfigKey!);
+    const { data: integrationResponse, isLoading: integrationLoading } = useGetIntegration(env, providerConfigKey!);
     const integrationData = integrationResponse?.data;
     const { data: flowsResponse, isLoading: flowsLoading } = useGetIntegrationFlows(env, providerConfigKey!);
     const flowsData = flowsResponse?.data;

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -33,9 +33,10 @@ export const FunctionsOne: React.FC = () => {
     const env = useStore((state) => state.env);
     const { data: integrationResponse, isPending: integrationLoading } = useGetIntegration(env, providerConfigKey!);
     const integrationData = integrationResponse?.data;
-    const { data, loading: flowsLoading } = useGetIntegrationFlows(env, providerConfigKey!);
+    const { data: flowsResponse, isLoading: flowsLoading } = useGetIntegrationFlows(env, providerConfigKey!);
+    const flowsData = flowsResponse?.data;
 
-    const func = data?.flows.find((flow) => flow.name === functionName);
+    const func = flowsData?.flows.find((flow) => flow.name === functionName);
 
     const inputSchema: JSONSchema7 | null = useMemo(() => {
         if (!func || !func.input || !func.json_schema) {

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -31,7 +31,8 @@ export const FunctionsOne: React.FC = () => {
     const { providerConfigKey, functionName } = useParams();
 
     const env = useStore((state) => state.env);
-    const { data: integrationData, loading: integrationLoading } = useGetIntegration(env, providerConfigKey!);
+    const { data: integrationResponse, isPending: integrationLoading } = useGetIntegration(env, providerConfigKey!);
+    const integrationData = integrationResponse?.data;
     const { data, loading: flowsLoading } = useGetIntegrationFlows(env, providerConfigKey!);
 
     const func = data?.flows.find((flow) => flow.name === functionName);

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/Tab.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/Tab.tsx
@@ -40,17 +40,18 @@ interface FunctionsTabProps {
 export const FunctionsTab: React.FC<FunctionsTabProps> = ({ integration }) => {
     const navigate = useNavigate();
     const env = useStore((state) => state.env);
-    const { data, loading } = useGetIntegrationFlows(env, integration.unique_key);
+    const { data, isLoading } = useGetIntegrationFlows(env, integration.unique_key);
+    const flowsData = data?.data;
 
     const [activeTab, setActiveTab] = useHashNavigation('actions');
 
     const { actions, actionsByGroup, syncs, syncsByGroup } = useMemo(() => {
-        const actions = data?.flows.filter((flow) => flow.type === 'action') ?? [];
-        const syncs = data?.flows.filter((flow) => flow.type === 'sync') ?? [];
+        const actions = flowsData?.flows.filter((flow) => flow.type === 'action') ?? [];
+        const syncs = flowsData?.flows.filter((flow) => flow.type === 'sync') ?? [];
         const actionsByGroup = groupByGroup(actions);
         const syncsByGroup = groupByGroup(syncs);
         return { actions, actionsByGroup, syncs, syncsByGroup };
-    }, [data?.flows]);
+    }, [flowsData?.flows]);
 
     const onFunctionClick = useCallback(
         (func: NangoSyncConfig) => {
@@ -59,7 +60,7 @@ export const FunctionsTab: React.FC<FunctionsTabProps> = ({ integration }) => {
         [env, integration.unique_key, navigate]
     );
 
-    if (loading) {
+    if (isLoading) {
         return <Skeleton className="w-full max-w-2xl h-50" />;
     }
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/Tab.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/Tab.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { EmptyCard } from '../../components/EmptyCard.js';
 import { FunctionSwitch } from '../../components/FunctionSwitch.js';
 import { CopyButton } from '@/components-v2/CopyButton';
+import { CriticalErrorAlert } from '@/components-v2/CriticalErrorAlert.js';
 import { Navigation, NavigationContent, NavigationList, NavigationTrigger } from '@/components-v2/Navigation';
 import { Badge } from '@/components-v2/ui/badge';
 import { ButtonLink } from '@/components-v2/ui/button';
@@ -40,7 +41,7 @@ interface FunctionsTabProps {
 export const FunctionsTab: React.FC<FunctionsTabProps> = ({ integration }) => {
     const navigate = useNavigate();
     const env = useStore((state) => state.env);
-    const { data, isLoading } = useGetIntegrationFlows(env, integration.unique_key);
+    const { data, isLoading, error: flowsError } = useGetIntegrationFlows(env, integration.unique_key);
     const flowsData = data?.data;
 
     const [activeTab, setActiveTab] = useHashNavigation('actions');
@@ -59,6 +60,10 @@ export const FunctionsTab: React.FC<FunctionsTabProps> = ({ integration }) => {
         },
         [env, integration.unique_key, navigate]
     );
+
+    if (flowsError) {
+        return <CriticalErrorAlert message="Something went wrong while loading the flows" />;
+    }
 
     if (isLoading) {
         return <Skeleton className="w-full max-w-2xl h-50" />;

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/AppAuthSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/AppAuthSettings.tsx
@@ -4,10 +4,11 @@ import { EditableInput } from '@/components-v2/EditableInput';
 import { InfoTooltip } from '@/components-v2/InfoTooltip';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components-v2/ui/input-group';
 import { Label } from '@/components-v2/ui/label';
-import { apiPatchIntegration } from '@/hooks/useIntegration';
+import { usePatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
 import { validateNotEmpty, validateUrl } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
+import { APIError } from '@/utils/api';
 import { defaultCallback } from '@/utils/utils';
 
 import type { ApiEnvironment, GetIntegration, PatchIntegration } from '@nangohq/types';
@@ -18,20 +19,24 @@ export const AppAuthSettings: React.FC<{ data: GetIntegration['Success']['data']
 }) => {
     const env = useStore((state) => state.env);
     const { toast } = useToast();
+    const { mutateAsync: patchIntegration } = usePatchIntegration(env, integration.unique_key);
 
     const setupUrl = (environment.callback_url || defaultCallback()).replace('oauth/callback', 'app-auth/connect');
 
     const onSave = async (field: Partial<PatchIntegration['Body']>) => {
-        const updated = await apiPatchIntegration(env, integration.unique_key, {
-            authType: template.auth_mode as Extract<typeof template.auth_mode, 'APP'>,
-            ...field
-        });
-        if ('error' in updated.json) {
-            const errorMessage = updated.json.error.message || 'Failed to update, an error occurred';
+        try {
+            await patchIntegration({
+                authType: template.auth_mode as Extract<typeof template.auth_mode, 'APP'>,
+                ...field
+            });
+            toast({ title: 'Successfully updated', variant: 'success' });
+        } catch (err) {
+            let errorMessage = 'Failed to update, an error occurred';
+            if (err instanceof APIError) {
+                errorMessage = err.message;
+            }
             toast({ title: errorMessage, variant: 'error' });
             throw new Error(errorMessage);
-        } else {
-            toast({ title: 'Successfully updated', variant: 'success' });
         }
     };
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/AppAuthSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/AppAuthSettings.tsx
@@ -8,7 +8,6 @@ import { usePatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
 import { validateNotEmpty, validateUrl } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
-import { APIError } from '@/utils/api';
 import { defaultCallback } from '@/utils/utils';
 
 import type { ApiEnvironment, GetIntegration, PatchIntegration } from '@nangohq/types';
@@ -30,13 +29,10 @@ export const AppAuthSettings: React.FC<{ data: GetIntegration['Success']['data']
                 ...field
             });
             toast({ title: 'Successfully updated', variant: 'success' });
-        } catch (err) {
-            let errorMessage = 'Failed to update, an error occurred';
-            if (err instanceof APIError) {
-                errorMessage = err.message;
-            }
-            toast({ title: errorMessage, variant: 'error' });
-            throw new Error(errorMessage);
+        } catch {
+            const message = 'Failed to update, an error occurred';
+            toast({ title: message, variant: 'error' });
+            throw new Error(message);
         }
     };
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/CustomAuthSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/CustomAuthSettings.tsx
@@ -9,10 +9,11 @@ import { Alert, AlertDescription } from '@/components-v2/ui/alert';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components-v2/ui/input-group';
 import { Label } from '@/components-v2/ui/label';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
-import { apiPatchIntegration } from '@/hooks/useIntegration';
+import { usePatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
 import { validateNotEmpty, validateUrl } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
+import { APIError } from '@/utils/api';
 import { defaultCallback } from '@/utils/utils';
 
 import type { ApiEnvironment, GetIntegration, PatchIntegration } from '@nangohq/types';
@@ -24,26 +25,27 @@ export const CustomAuthSettings: React.FC<{ data: GetIntegration['Success']['dat
     const env = useStore((state) => state.env);
     const { toast } = useToast();
     const { confirm, DialogComponent } = useConfirmDialog();
+    const { mutateAsync: patchIntegration } = usePatchIntegration(env, integration.unique_key);
     const [isEditingClientId, setIsEditingClientId] = useState(false);
 
     const callbackUrl = environment.callback_url || defaultCallback();
     const hasExistingClientId = Boolean(integration.oauth_client_id);
 
     const onSave = async (field: Partial<PatchIntegration['Body']>, supressToast = false) => {
-        const updated = await apiPatchIntegration(env, integration.unique_key, {
-            authType: 'CUSTOM',
-            ...field
-        } as any);
-        if ('error' in updated.json) {
-            const errorMessage = updated.json.error.message || 'Failed to update, an error occurred';
+        try {
+            await patchIntegration({ authType: 'CUSTOM', ...field } as PatchIntegration['Body']);
+            if (!supressToast) {
+                toast({ title: 'Successfully updated', variant: 'success' });
+            }
+        } catch (err) {
+            let errorMessage = 'Failed to update, an error occurred';
+            if (err instanceof APIError) {
+                errorMessage = err.message;
+            }
             if (!supressToast) {
                 toast({ title: errorMessage, variant: 'error' });
             }
             throw new Error(errorMessage);
-        } else {
-            if (!supressToast) {
-                toast({ title: 'Successfully updated', variant: 'success' });
-            }
         }
     };
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/CustomAuthSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/CustomAuthSettings.tsx
@@ -13,7 +13,6 @@ import { usePatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
 import { validateNotEmpty, validateUrl } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
-import { APIError } from '@/utils/api';
 import { defaultCallback } from '@/utils/utils';
 
 import type { ApiEnvironment, GetIntegration, PatchIntegration } from '@nangohq/types';
@@ -37,15 +36,12 @@ export const CustomAuthSettings: React.FC<{ data: GetIntegration['Success']['dat
             if (!supressToast) {
                 toast({ title: 'Successfully updated', variant: 'success' });
             }
-        } catch (err) {
-            let errorMessage = 'Failed to update, an error occurred';
-            if (err instanceof APIError) {
-                errorMessage = err.message;
-            }
+        } catch {
+            const message = 'Failed to update, an error occurred';
             if (!supressToast) {
-                toast({ title: errorMessage, variant: 'error' });
+                toast({ title: message, variant: 'error' });
             }
-            throw new Error(errorMessage);
+            throw new Error(message);
         }
     };
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/DeleteIntegrationButton.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/DeleteIntegrationButton.tsx
@@ -1,10 +1,10 @@
-import { Loader2, Trash2 } from 'lucide-react';
+import { Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSWRConfig } from 'swr';
 
 import { clearConnectionsCache } from '../../../../../hooks/useConnections.js';
-import { apiDeleteIntegration } from '../../../../../hooks/useIntegration.js';
+import { useDeleteIntegration } from '../../../../../hooks/useIntegration.js';
 import { useToast } from '../../../../../hooks/useToast.js';
 import { Button } from '@/components-v2/ui/button.js';
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogTitle, DialogTrigger } from '@/components-v2/ui/dialog.js';
@@ -15,32 +15,25 @@ export const DeleteIntegrationButton: React.FC<{ env: string; integration: ApiIn
     const { toast } = useToast();
     const navigate = useNavigate();
     const [open, setOpen] = useState(false);
-    const [loading, setLoading] = useState(false);
     const { mutate, cache } = useSWRConfig();
+    const { mutateAsync: deleteIntegration, isPending } = useDeleteIntegration(env, integration.unique_key);
 
     const onDelete = async () => {
-        setLoading(true);
-
-        const deleted = await apiDeleteIntegration(env, integration.unique_key);
-
-        setLoading(false);
-        if ('error' in deleted.json) {
-            toast({ title: deleted.json.error.message || 'Failed to delete, an error occurred', variant: 'error' });
-        } else {
+        try {
+            await deleteIntegration();
             toast({ title: `Integration "${integration.unique_key}" has been deleted`, variant: 'success' });
-            void mutate((key) => typeof key === 'string' && key.startsWith(`/api/v1/integrations`), undefined);
-
             clearConnectionsCache(cache, mutate);
-
             navigate(`/${env}/integrations`);
+        } catch {
+            toast({ title: 'Failed to delete integration', variant: 'error' });
         }
     };
 
     return (
         <Dialog open={open} onOpenChange={setOpen}>
             <DialogTrigger asChild>
-                <Button variant="destructive" size="lg" disabled={loading} className={className}>
-                    {loading ? <Loader2 className="animate-spin" /> : <Trash2 />}
+                <Button variant="destructive" size="lg" loading={isPending} className={className}>
+                    <Trash2 />
                     Delete integration
                 </Button>
             </DialogTrigger>
@@ -54,8 +47,7 @@ export const DeleteIntegrationButton: React.FC<{ env: string; integration: ApiIn
                     <DialogClose asChild>
                         <Button variant="secondary">Cancel</Button>
                     </DialogClose>
-                    <Button variant="destructive" onClick={onDelete} disabled={loading}>
-                        {loading && <Loader2 className="animate-spin" />}
+                    <Button variant="destructive" onClick={onDelete} disabled={isPending}>
                         Delete integration, connections and records
                     </Button>
                 </DialogFooter>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/GeneralSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/GeneralSettings.tsx
@@ -14,7 +14,6 @@ import { usePatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
 import { validateNotEmpty } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
-import { APIError } from '@/utils/api';
 
 import type { ApiEnvironment, GetIntegration, PatchIntegration } from '@nangohq/types';
 
@@ -36,16 +35,10 @@ export const GeneralSettings: React.FC<{ data: GetIntegration['Success']['data']
         try {
             await patchIntegration(field);
             toast({ title: 'Successfully updated', variant: 'success' });
-        } catch (err) {
-            let errorMessage = 'Failed to update, an error occurred';
-            if (err instanceof APIError) {
-                errorMessage = err.message;
-            }
-
-            toast({ title: errorMessage, variant: 'error' });
-
-            // Editable input expects an error to be thrown to re-enable editing
-            throw new Error(errorMessage);
+        } catch {
+            const message = 'Failed to update, an error occurred';
+            toast({ title: message, variant: 'error' });
+            throw new Error(message);
         }
     };
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/InstallPluginSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/InstallPluginSettings.tsx
@@ -1,9 +1,10 @@
 import { EditableInput } from '@/components-v2/EditableInput';
 import { Label } from '@/components-v2/ui/label';
-import { apiPatchIntegration } from '@/hooks/useIntegration';
+import { usePatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
 import { validateNotEmpty, validateUrl } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
+import { APIError } from '@/utils/api';
 
 import type { ApiEnvironment, GetIntegration, PatchIntegration, ProviderInstallPlugin } from '@nangohq/types';
 
@@ -12,18 +13,19 @@ export const InstallPluginSettings: React.FC<{ data: GetIntegration['Success']['
 }) => {
     const env = useStore((state) => state.env);
     const { toast } = useToast();
+    const { mutateAsync: patchIntegration } = usePatchIntegration(env, integration.unique_key);
 
     const onSave = async (field: Partial<PatchIntegration['Body']>) => {
-        const updated = await apiPatchIntegration(env, integration.unique_key, {
-            authType: 'INSTALL_PLUGIN',
-            ...field
-        } as any);
-        if ('error' in updated.json) {
-            const errorMessage = updated.json.error.message || 'Failed to update, an error occurred';
+        try {
+            await patchIntegration({ authType: 'INSTALL_PLUGIN', ...field } as PatchIntegration['Body']);
+            toast({ title: 'Successfully updated', variant: 'success' });
+        } catch (err) {
+            let errorMessage = 'Failed to update, an error occurred';
+            if (err instanceof APIError) {
+                errorMessage = err.message;
+            }
             toast({ title: errorMessage, variant: 'error' });
             throw new Error(errorMessage);
-        } else {
-            toast({ title: 'Successfully updated', variant: 'success' });
         }
     };
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/InstallPluginSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/InstallPluginSettings.tsx
@@ -4,7 +4,6 @@ import { usePatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
 import { validateNotEmpty, validateUrl } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
-import { APIError } from '@/utils/api';
 
 import type { ApiEnvironment, GetIntegration, PatchIntegration, ProviderInstallPlugin } from '@nangohq/types';
 
@@ -19,13 +18,10 @@ export const InstallPluginSettings: React.FC<{ data: GetIntegration['Success']['
         try {
             await patchIntegration({ authType: 'INSTALL_PLUGIN', ...field } as PatchIntegration['Body']);
             toast({ title: 'Successfully updated', variant: 'success' });
-        } catch (err) {
-            let errorMessage = 'Failed to update, an error occurred';
-            if (err instanceof APIError) {
-                errorMessage = err.message;
-            }
-            toast({ title: errorMessage, variant: 'error' });
-            throw new Error(errorMessage);
+        } catch {
+            const message = 'Failed to update, an error occurred';
+            toast({ title: message, variant: 'error' });
+            throw new Error(message);
         }
     };
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/McpGenericSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/McpGenericSettings.tsx
@@ -2,10 +2,11 @@ import { CopyButton } from '@/components-v2/CopyButton';
 import { EditableInput } from '@/components-v2/EditableInput';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components-v2/ui/input-group';
 import { Label } from '@/components-v2/ui/label';
-import { apiPatchIntegration } from '@/hooks/useIntegration';
+import { usePatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
 import { validateNotEmpty, validateUrl } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
+import { APIError } from '@/utils/api';
 import { defaultCallback } from '@/utils/utils';
 
 import type { ApiEnvironment, GetIntegration, PatchIntegration } from '@nangohq/types';
@@ -16,20 +17,24 @@ export const McpGenericSettings: React.FC<{ data: GetIntegration['Success']['dat
 }) => {
     const env = useStore((state) => state.env);
     const { toast } = useToast();
+    const { mutateAsync: patchIntegration } = usePatchIntegration(env, integration.unique_key);
 
     const callbackUrl = environment.callback_url || defaultCallback();
 
     const onSave = async (field: Partial<PatchIntegration['Body']>) => {
-        const updated = await apiPatchIntegration(env, integration.unique_key, {
-            authType: template.auth_mode as Extract<typeof template.auth_mode, 'MCP_OAUTH2_GENERIC'>,
-            ...field
-        } as any);
-        if ('error' in updated.json) {
-            const errorMessage = updated.json.error.message || 'Failed to update, an error occurred';
+        try {
+            await patchIntegration({
+                authType: template.auth_mode as Extract<typeof template.auth_mode, 'MCP_OAUTH2_GENERIC'>,
+                ...field
+            } as PatchIntegration['Body']);
+            toast({ title: 'Successfully updated', variant: 'success' });
+        } catch (err) {
+            let errorMessage = 'Failed to update, an error occurred';
+            if (err instanceof APIError) {
+                errorMessage = err.message;
+            }
             toast({ title: errorMessage, variant: 'error' });
             throw new Error(errorMessage);
-        } else {
-            toast({ title: 'Successfully updated', variant: 'success' });
         }
     };
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/McpGenericSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/McpGenericSettings.tsx
@@ -6,7 +6,6 @@ import { usePatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
 import { validateNotEmpty, validateUrl } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
-import { APIError } from '@/utils/api';
 import { defaultCallback } from '@/utils/utils';
 
 import type { ApiEnvironment, GetIntegration, PatchIntegration } from '@nangohq/types';
@@ -28,13 +27,10 @@ export const McpGenericSettings: React.FC<{ data: GetIntegration['Success']['dat
                 ...field
             } as PatchIntegration['Body']);
             toast({ title: 'Successfully updated', variant: 'success' });
-        } catch (err) {
-            let errorMessage = 'Failed to update, an error occurred';
-            if (err instanceof APIError) {
-                errorMessage = err.message;
-            }
-            toast({ title: errorMessage, variant: 'error' });
-            throw new Error(errorMessage);
+        } catch {
+            const message = 'Failed to update, an error occurred';
+            toast({ title: message, variant: 'error' });
+            throw new Error(message);
         }
     };
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/McpOAuthSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/McpOAuthSettings.tsx
@@ -30,13 +30,10 @@ export const McpOAuthSettings: React.FC<{ data: GetIntegration['Success']['data'
                 ...field
             });
             toast({ title: 'Successfully updated', variant: 'success' });
-        } catch (err) {
-            let errorMessage = 'Failed to update credentials';
-            if (err instanceof APIError) {
-                errorMessage = err.message;
-            }
-            toast({ title: errorMessage, variant: 'error' });
-            throw new Error(errorMessage);
+        } catch {
+            const message = 'Failed to update, an error occurred';
+            toast({ title: message, variant: 'error' });
+            throw new Error(message);
         }
     };
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/McpOAuthSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/McpOAuthSettings.tsx
@@ -3,10 +3,11 @@ import { EditableInput } from '@/components-v2/EditableInput';
 import { ScopesInput } from '@/components-v2/ScopesInput';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components-v2/ui/input-group';
 import { Label } from '@/components-v2/ui/label';
-import { apiPatchIntegration } from '@/hooks/useIntegration';
+import { usePatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
 import { validateNotEmpty } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
+import { APIError } from '@/utils/api';
 import { defaultCallback } from '@/utils/utils';
 
 import type { ApiEnvironment, GetIntegration } from '@nangohq/types';
@@ -17,39 +18,46 @@ export const McpOAuthSettings: React.FC<{ data: GetIntegration['Success']['data'
 }) => {
     const env = useStore((state) => state.env);
     const { toast } = useToast();
+    const { mutateAsync: patchIntegration } = usePatchIntegration(env, integration.unique_key);
 
     const callbackUrl = environment.callback_url || defaultCallback();
     const useUserCredentials = 'client_registration' in template && template.client_registration === 'static';
 
     const onSaveCredentials = async (field: { clientId?: string; clientSecret?: string }) => {
-        const updated = await apiPatchIntegration(env, integration.unique_key, {
-            authType: template.auth_mode as Extract<typeof template.auth_mode, 'MCP_OAUTH2'>,
-            ...field
-        });
-        if ('error' in updated.json) {
-            const errorMessage = updated.json.error.message || 'Failed to update credentials';
+        try {
+            await patchIntegration({
+                authType: template.auth_mode as Extract<typeof template.auth_mode, 'MCP_OAUTH2'>,
+                ...field
+            });
+            toast({ title: 'Successfully updated', variant: 'success' });
+        } catch (err) {
+            let errorMessage = 'Failed to update credentials';
+            if (err instanceof APIError) {
+                errorMessage = err.message;
+            }
             toast({ title: errorMessage, variant: 'error' });
             throw new Error(errorMessage);
         }
-        toast({ title: 'Successfully updated', variant: 'success' });
     };
 
     const handleScopesChange = async (scopes: string, countDifference: number) => {
-        const updated = await apiPatchIntegration(env, integration.unique_key, {
-            authType: template.auth_mode as Extract<typeof template.auth_mode, 'MCP_OAUTH2'>,
-            scopes
-        });
-
-        if ('error' in updated.json) {
-            const errorMessage = updated.json.error.message || 'Failed to update scopes';
+        try {
+            await patchIntegration({
+                authType: template.auth_mode as Extract<typeof template.auth_mode, 'MCP_OAUTH2'>,
+                scopes
+            });
+            if (countDifference > 0) {
+                const plural = countDifference > 1 ? 'scopes' : 'scope';
+                toast({ title: `Added ${countDifference} new ${plural}`, variant: 'success' });
+            } else {
+                toast({ title: `Scope successfully removed`, variant: 'success' });
+            }
+        } catch (err) {
+            let errorMessage = 'Failed to update scopes';
+            if (err instanceof APIError) {
+                errorMessage = err.message;
+            }
             throw new Error(errorMessage);
-        }
-
-        if (countDifference > 0) {
-            const plural = countDifference > 1 ? 'scopes' : 'scope';
-            toast({ title: `Added ${countDifference} new ${plural}`, variant: 'success' });
-        } else {
-            toast({ title: `Scope successfully removed`, variant: 'success' });
         }
     };
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuthSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuthSettings.tsx
@@ -13,7 +13,6 @@ import { useToast } from '@/hooks/useToast';
 import { NangoProvidedInput } from '@/pages/Integrations/components/NangoProvidedInput';
 import { validateNotEmpty } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
-import { APIError } from '@/utils/api';
 import { defaultCallback } from '@/utils/utils';
 
 import type { ApiEnvironment, GetIntegration, PatchIntegration } from '@nangohq/types';
@@ -41,15 +40,10 @@ export const OAuthSettings: React.FC<{ data: GetIntegration['Success']['data']; 
             if (!supressToast) {
                 toast({ title: 'Successfully updated', variant: 'success' });
             }
-        } catch (err) {
-            let errorMessage = 'Failed to update, an error occurred';
-            if (err instanceof APIError) {
-                errorMessage = err.message;
-            }
-            if (!supressToast) {
-                toast({ title: errorMessage, variant: 'error' });
-            }
-            throw new Error(errorMessage);
+        } catch {
+            const message = 'Failed to update, an error occurred';
+            toast({ title: message, variant: 'error' });
+            throw new Error(message);
         }
     };
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuthSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuthSettings.tsx
@@ -8,11 +8,12 @@ import { Alert, AlertDescription } from '@/components-v2/ui/alert';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components-v2/ui/input-group';
 import { Label } from '@/components-v2/ui/label';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
-import { apiPatchIntegration } from '@/hooks/useIntegration';
+import { usePatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
 import { NangoProvidedInput } from '@/pages/Integrations/components/NangoProvidedInput';
 import { validateNotEmpty } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
+import { APIError } from '@/utils/api';
 import { defaultCallback } from '@/utils/utils';
 
 import type { ApiEnvironment, GetIntegration, PatchIntegration } from '@nangohq/types';
@@ -24,6 +25,7 @@ export const OAuthSettings: React.FC<{ data: GetIntegration['Success']['data']; 
     const env = useStore((state) => state.env);
     const { toast } = useToast();
     const { confirm, DialogComponent } = useConfirmDialog();
+    const { mutateAsync: patchIntegration } = usePatchIntegration(env, integration.unique_key);
     const [isEditingClientId, setIsEditingClientId] = useState(false);
 
     const callbackUrl = environment.callback_url || defaultCallback();
@@ -31,20 +33,23 @@ export const OAuthSettings: React.FC<{ data: GetIntegration['Success']['data']; 
     const isSharedCredentials = Boolean(integration.shared_credentials_id);
 
     const onSave = async (field: Partial<PatchIntegration['Body']>, supressToast = false) => {
-        const updated = await apiPatchIntegration(env, integration.unique_key, {
-            authType: template.auth_mode as Extract<typeof template.auth_mode, 'OAUTH1' | 'OAUTH2' | 'TBA'>,
-            ...field
-        });
-        if ('error' in updated.json) {
-            const errorMessage = updated.json.error.message || 'Failed to update, an error occurred';
+        try {
+            await patchIntegration({
+                authType: template.auth_mode as Extract<typeof template.auth_mode, 'OAUTH1' | 'OAUTH2' | 'TBA'>,
+                ...field
+            });
+            if (!supressToast) {
+                toast({ title: 'Successfully updated', variant: 'success' });
+            }
+        } catch (err) {
+            let errorMessage = 'Failed to update, an error occurred';
+            if (err instanceof APIError) {
+                errorMessage = err.message;
+            }
             if (!supressToast) {
                 toast({ title: errorMessage, variant: 'error' });
             }
             throw new Error(errorMessage);
-        } else {
-            if (!supressToast) {
-                toast({ title: 'Successfully updated', variant: 'success' });
-            }
         }
     };
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Show.tsx
@@ -23,7 +23,7 @@ export const ShowIntegration: React.FC = () => {
     const [activeTab, setActiveTab] = usePathNavigation(`/${env}/integrations/${providerConfigKey}`, 'functions');
 
     const { environmentAndAccount, loading: loadingEnvironment, error: environmentError } = useEnvironment(env);
-    const { data, isPending: loadingIntegration, error: integrationError } = useGetIntegration(env, providerConfigKey!);
+    const { data, isLoading: loadingIntegration, error: integrationError } = useGetIntegration(env, providerConfigKey!);
     const integration = data?.data;
 
     if (integrationError || environmentError) {

--- a/packages/webapp/src/utils/api.tsx
+++ b/packages/webapp/src/utils/api.tsx
@@ -180,12 +180,3 @@ export class APIError extends Error {
         this.res = res;
     }
 }
-
-/** Get a user-facing error message from an unknown error, with a fallback. */
-export function getErrorMessage(err: unknown, fallback: string): string {
-    if (err instanceof APIError && err.json && typeof err.json === 'object' && 'error' in err.json) {
-        const msg = (err.json as ApiError<unknown>).error?.message;
-        if (typeof msg === 'string' && msg) return msg;
-    }
-    return fallback;
-}

--- a/packages/webapp/src/utils/api.tsx
+++ b/packages/webapp/src/utils/api.tsx
@@ -180,3 +180,12 @@ export class APIError extends Error {
         this.res = res;
     }
 }
+
+/** Get a user-facing error message from an unknown error, with a fallback. */
+export function getErrorMessage(err: unknown, fallback: string): string {
+    if (err instanceof APIError && err.json && typeof err.json === 'object' && 'error' in err.json) {
+        const msg = (err.json as ApiError<unknown>).error?.message;
+        if (typeof msg === 'string' && msg) return msg;
+    }
+    return fallback;
+}


### PR DESCRIPTION
This PR migrates all the integration related hooks and methods to use tanstack-query, which we have been defaulting to. Mutation queries also invalidate cache for their related resources, so everything stays up to date with every update.

Fixes these problems reported by Robin https://nangohq.slack.com/archives/C06MTTJHHL1/p1771537801407719

<!-- Summary by @propel-code-bot -->

---

It also propagates the TanStack Query contracts through connection creation and settings flows so that list, detail, flow, and other dependent screens remain synchronized without manual cache clearing.

<details>
<summary><strong>Possible Issues</strong></summary>

• `CriticalErrorAlert` now hides underlying API error details on the integration show page, reducing debuggability compared to the prior `ErrorPageComponent`.
• `CreateConnectionSelector` still uses SWR cache flushing for connections while relying on TanStack invalidations for integrations, which could lead to inconsistent refresh behavior.
• Detail (`useGetIntegration`) and flow (`useGetIntegrationFlows`) queries no longer refetch on intervals, so long-lived pages may show stale data unless another mutation invalidates them.
• Most toast messages now use a generic fallback string and do not expose server-provided error messages, potentially obscuring actionable feedback.

</details>

---
*This summary was automatically generated by @propel-code-bot*