### PR TITLE
feat(webapp): change font to geist

### DIFF
--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -1,6 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@300;400;500;600;700&display=swap') layer(base);
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,100..700;1,100..700&family=Roboto:ital,wght@0,100..900;1,100..900&display=swap')
-layer(base);
+/* prettier-ignore */
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,100..700;1,100..700&family=Roboto:ital,wght@0,100..900;1,100..900&display=swap') layer(base);
+@import url('https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap') layer(base);
 
 @import 'tailwindcss';
 
@@ -16,7 +17,7 @@ layer(base);
 
 @theme {
     --font-*: initial;
-    --font-sans: Inter, sans-serif;
+    --font-sans: Geist, sans-serif;
     --font-mono: 'Roboto Mono', 'Source Code Pro', sans-serif;
     --font-code: 'Roboto Mono', 'Source Code Pro', system-ui, sans-serif;
 

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -1,7 +1,5 @@
-@import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@300;400;500;600;700&display=swap') layer(base);
 /* prettier-ignore */
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,100..700;1,100..700&family=Roboto:ital,wght@0,100..900;1,100..900&display=swap') layer(base);
-@import url('https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap') layer(base);
+@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&family=Geist:wght@100..900&display=swap') layer(base);
 
 @import 'tailwindcss';
 
@@ -18,8 +16,8 @@
 @theme {
     --font-*: initial;
     --font-sans: Geist, sans-serif;
-    --font-mono: 'Roboto Mono', 'Source Code Pro', sans-serif;
-    --font-code: 'Roboto Mono', 'Source Code Pro', system-ui, sans-serif;
+    --font-mono: 'Geist Mono', 'Source Code Pro', sans-serif;
+    --font-code: 'Geist Mono', 'Source Code Pro', system-ui, sans-serif;
 
     --breakpoint-xl: 1280px;
     --breakpoint-2xl: 1440px;
@@ -642,7 +640,7 @@
 @utility text-code-body-small-regular {
     font-size: 12px;
     line-height: 14px;
-    font-family: 'Roboto Mono';
+    font-family: 'Geist Mono';
     font-weight: 400;
     letter-spacing: -0.04em;
 }
@@ -693,6 +691,6 @@
 }
 
 .mantine-Prism-code {
-    font-family: 'Roboto Mono';
+    font-family: 'Geist Mono';
     background-color: var(--color-bg-surface) !important;
 }


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Switch webapp typography to Geist**

Global typography in the webapp now imports the Geist family (standard and mono weights 100–900) from Google Fonts and applies it as the base sans-serif face. CSS variables `--font-sans`, `--font-mono`, `--font-code`, along with utility selectors such as `.mantine-Prism-code` and `@utility text-code-body-small-regular`, were updated to reference Geist so code and UI text remain consistent across components.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced the Google Fonts import with a combined `Geist`/`Geist Mono` request and added `/* prettier-ignore */` to keep the long statement on one line.
• Updated `--font-sans`, `--font-mono`, and `--font-code` in `@theme` to use the new families with `Source Code Pro` as fallback for mono contexts.
• Pointed `@utility text-code-body-small-regular` and `.mantine-Prism-code` to `Geist Mono` to align code styling with the new mono font.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Relying on remote Geist assets introduces a new external dependency; lack of local fallbacks could cause noticeable font fallback flashes if the CDN is blocked.
• Including the full 100–900 weight range may be excessive if only a subset is used, increasing download size.

</details>

---
*This summary was automatically generated by @propel-code-bot*