### PR TITLE
fix(errors): error parsing was broken

### DIFF
--- a/packages/utils/lib/errors.ts
+++ b/packages/utils/lib/errors.ts
@@ -42,7 +42,7 @@ export function stringifyError(err: unknown, opts?: { pretty?: boolean; stack?: 
             const responseData = anyErr.response.data;
 
             // If error field exists, filter it to only include message-related fields
-            if (responseData && typeof responseData === 'object') {
+            if (responseData.error && typeof responseData.error === 'object') {
                 const filteredError: Record<string, unknown> = {};
                 for (const field of PROVIDER_ERROR_MESSAGE_FIELDS) {
                     if (field in responseData.error) {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Ensure provider error payload parsing checks `responseData.error`**

Adjusts the guard in `stringifyError` so the provider error payload is only inspected when `responseData.error` exists and is an object. This prevents accessing `responseData.error` when the parent response body lacks an `error` field, which previously caused runtime failures during axios error serialization.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated the guard in `packages/utils/lib/errors.ts` to require `responseData.error` to be an object before iterating over `PROVIDER_ERROR_MESSAGE_FIELDS`

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• If some providers return non-object error payloads (e.g., strings) that were previously parsed, they will now be ignored; validate this aligns with desired behavior.

</details>

---
*This summary was automatically generated by @propel-code-bot*