### PR TITLE
fix(lambda): enable lambda for webhooks for new accounts

### DIFF
--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -29,7 +29,8 @@ export const freePlan: PlanDefinition = {
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: false,
         can_disable_connect_ui_watermark: false,
-        action_function_runtime: 'lambda'
+        action_function_runtime: 'lambda',
+        webhook_function_runtime: 'lambda'
     }
 };
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Enable lambda runtime for webhook functions on new accounts**

Sets the `freePlan.flags` to include `webhook_function_runtime: 'lambda'`, aligning webhook executions for newly provisioned accounts with the existing `action_function_runtime` default. This ensures new tenants use the lambda runtime for webhook functions without extra configuration.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `webhook_function_runtime: 'lambda'` to `freePlan.flags` in `packages/shared/lib/services/plans/definitions.ts`

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Existing accounts may retain prior webhook runtime defaults unless a separate migration handles them.

</details>

---
*This summary was automatically generated by @propel-code-bot*