### PR TITLE
fix(lambda): add lambda destination for failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -583,19 +583,6 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-ecr": {
             "version": "3.993.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.993.0.tgz",
@@ -641,19 +628,6 @@
                 "@smithy/util-retry": "^4.2.8",
                 "@smithy/util-utf8": "^4.2.0",
                 "@smithy/util-waiter": "^4.2.8",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-ecr/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -709,19 +683,6 @@
                 "@smithy/util-stream": "^4.5.12",
                 "@smithy/util-utf8": "^4.2.0",
                 "@smithy/util-waiter": "^4.2.8",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -794,13 +755,52 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
+        "node_modules/@aws-sdk/client-sqs": {
+            "version": "3.993.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.993.0.tgz",
+            "integrity": "sha512-DKtONDUt568hbs4VrnBoK2VJGPXMvkm3Plef/gdsyRjWUMXcCuiLeWi9ru10YN2wAJeGxKMSBoedcuQS9wt2Pg==",
             "license": "Apache-2.0",
             "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.973.11",
+                "@aws-sdk/credential-provider-node": "^3.972.10",
+                "@aws-sdk/middleware-host-header": "^3.972.3",
+                "@aws-sdk/middleware-logger": "^3.972.3",
+                "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+                "@aws-sdk/middleware-sdk-sqs": "^3.972.8",
+                "@aws-sdk/middleware-user-agent": "^3.972.11",
+                "@aws-sdk/region-config-resolver": "^3.972.3",
+                "@aws-sdk/types": "^3.973.1",
+                "@aws-sdk/util-endpoints": "3.993.0",
+                "@aws-sdk/util-user-agent-browser": "^3.972.3",
+                "@aws-sdk/util-user-agent-node": "^3.972.9",
+                "@smithy/config-resolver": "^4.4.6",
+                "@smithy/core": "^3.23.2",
+                "@smithy/fetch-http-handler": "^5.3.9",
+                "@smithy/hash-node": "^4.2.8",
+                "@smithy/invalid-dependency": "^4.2.8",
+                "@smithy/md5-js": "^4.2.8",
+                "@smithy/middleware-content-length": "^4.2.8",
+                "@smithy/middleware-endpoint": "^4.4.16",
+                "@smithy/middleware-retry": "^4.4.33",
+                "@smithy/middleware-serde": "^4.2.9",
+                "@smithy/middleware-stack": "^4.2.8",
+                "@smithy/node-config-provider": "^4.3.8",
+                "@smithy/node-http-handler": "^4.4.10",
+                "@smithy/protocol-http": "^5.3.8",
+                "@smithy/smithy-client": "^4.11.5",
                 "@smithy/types": "^4.12.0",
+                "@smithy/url-parser": "^4.2.8",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.32",
+                "@smithy/util-defaults-mode-node": "^4.2.35",
+                "@smithy/util-endpoints": "^3.2.8",
+                "@smithy/util-middleware": "^4.2.8",
+                "@smithy/util-retry": "^4.2.8",
+                "@smithy/util-utf8": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -856,19 +856,6 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@aws-sdk/core": {
             "version": "3.973.11",
             "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.11.tgz",
@@ -887,19 +874,6 @@
                 "@smithy/util-base64": "^4.3.0",
                 "@smithy/util-middleware": "^4.2.8",
                 "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/core/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -935,19 +909,6 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@aws-sdk/credential-provider-http": {
             "version": "3.972.11",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.11.tgz",
@@ -963,19 +924,6 @@
                 "@smithy/smithy-client": "^4.11.5",
                 "@smithy/types": "^4.12.0",
                 "@smithy/util-stream": "^4.5.12",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1007,19 +955,6 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@aws-sdk/credential-provider-login": {
             "version": "3.972.9",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.9.tgz",
@@ -1032,19 +967,6 @@
                 "@smithy/property-provider": "^4.2.8",
                 "@smithy/protocol-http": "^5.3.8",
                 "@smithy/shared-ini-file-loader": "^4.4.3",
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "@smithy/types": "^4.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1075,19 +997,6 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@aws-sdk/credential-provider-process": {
             "version": "3.972.9",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.9.tgz",
@@ -1098,19 +1007,6 @@
                 "@aws-sdk/types": "^3.973.1",
                 "@smithy/property-provider": "^4.2.8",
                 "@smithy/shared-ini-file-loader": "^4.4.3",
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "@smithy/types": "^4.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1137,19 +1033,6 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
             "version": "3.972.9",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.9.tgz",
@@ -1161,19 +1044,6 @@
                 "@aws-sdk/types": "^3.973.1",
                 "@smithy/property-provider": "^4.2.8",
                 "@smithy/shared-ini-file-loader": "^4.4.3",
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "@smithy/types": "^4.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1199,19 +1069,6 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@aws-sdk/middleware-expect-continue": {
             "version": "3.972.3",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.3.tgz",
@@ -1220,19 +1077,6 @@
             "dependencies": {
                 "@aws-sdk/types": "^3.973.1",
                 "@smithy/protocol-http": "^5.3.8",
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "@smithy/types": "^4.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1265,19 +1109,6 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.972.3",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.3.tgz",
@@ -1286,19 +1117,6 @@
             "dependencies": {
                 "@aws-sdk/types": "^3.973.1",
                 "@smithy/protocol-http": "^5.3.8",
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "@smithy/types": "^4.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1320,19 +1138,6 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@aws-sdk/middleware-logger": {
             "version": "3.972.3",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.3.tgz",
@@ -1340,19 +1145,6 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "^3.973.1",
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-logger/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "@smithy/types": "^4.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1369,19 +1161,6 @@
                 "@aws-sdk/types": "^3.973.1",
                 "@aws/lambda-invoke-store": "^0.2.2",
                 "@smithy/protocol-http": "^5.3.8",
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "@smithy/types": "^4.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1414,13 +1193,17 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
+        "node_modules/@aws-sdk/middleware-sdk-sqs": {
+            "version": "3.972.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.8.tgz",
+            "integrity": "sha512-KhwktzM8+EPoOkh+92WO2Fq6Ibk9GXr9eEh0nBOd/ZO83z7i8a7BF+mTNN6k8+eKAhLerbMWRT196u5JhKe0QA==",
             "license": "Apache-2.0",
             "dependencies": {
+                "@aws-sdk/types": "^3.973.1",
+                "@smithy/smithy-client": "^4.11.5",
                 "@smithy/types": "^4.12.0",
+                "@smithy/util-hex-encoding": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1441,19 +1224,6 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@aws-sdk/middleware-user-agent": {
             "version": "3.972.11",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.11.tgz",
@@ -1465,19 +1235,6 @@
                 "@aws-sdk/util-endpoints": "3.993.0",
                 "@smithy/core": "^3.23.2",
                 "@smithy/protocol-http": "^5.3.8",
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "@smithy/types": "^4.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1534,19 +1291,6 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@aws-sdk/region-config-resolver": {
             "version": "3.972.3",
             "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.3.tgz",
@@ -1556,19 +1300,6 @@
                 "@aws-sdk/types": "^3.973.1",
                 "@smithy/config-resolver": "^4.4.6",
                 "@smithy/node-config-provider": "^4.3.8",
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/region-config-resolver/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "@smithy/types": "^4.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1586,19 +1317,6 @@
                 "@aws-sdk/types": "^3.973.1",
                 "@smithy/protocol-http": "^5.3.8",
                 "@smithy/signature-v4": "^5.3.8",
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "@smithy/types": "^4.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1624,7 +1342,7 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
+        "node_modules/@aws-sdk/types": {
             "version": "3.973.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
             "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
@@ -1635,19 +1353,6 @@
             },
             "engines": {
                 "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/types": {
-            "version": "3.922.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.922.0.tgz",
-            "integrity": "sha512-eLA6XjVobAUAMivvM7DBL79mnHyrm+32TkXNWZua5mnxF+6kQCfblKKJvxMZLGosO53/Ex46ogim8IY5Nbqv2w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.8.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
             }
         },
         "node_modules/@aws-sdk/util-arn-parser": {
@@ -1678,19 +1383,6 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@aws-sdk/util-locate-window": {
             "version": "3.568.0",
             "license": "Apache-2.0",
@@ -1711,19 +1403,6 @@
                 "@smithy/types": "^4.12.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
@@ -1748,19 +1427,6 @@
                 "aws-crt": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@aws-sdk/util-user-agent-node/node_modules/@aws-sdk/types": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-            "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/xml-builder": {
@@ -33025,8 +32691,8 @@
                 "@radix-ui/react-label": "2.1.1",
                 "@radix-ui/react-slot": "1.1.1",
                 "@tabler/icons-react": "3.21.0",
-                "@tailwindcss/postcss": "^4.2.0",
-                "@tailwindcss/vite": "^4.2.0",
+                "@tailwindcss/postcss": "4.2.0",
+                "@tailwindcss/vite": "4.2.0",
                 "@tanstack/react-query": "5.65.1",
                 "@tanstack/react-router": "1.98.3",
                 "@types/react": "18.3.3",
@@ -33035,7 +32701,7 @@
                 "class-variance-authority": "0.7.1",
                 "clsx": "2.1.1",
                 "globals": "15.14.0",
-                "lucide-react": "^0.542.0",
+                "lucide-react": "0.542.0",
                 "postcss": "8.5.1",
                 "react": "18.3.1",
                 "react-dom": "18.3.1",
@@ -33270,6 +32936,7 @@
             "dependencies": {
                 "@aws-sdk/client-application-auto-scaling": "3.993.0",
                 "@aws-sdk/client-lambda": "3.993.0",
+                "@aws-sdk/client-sqs": "3.993.0",
                 "@kubernetes/client-node": "1.3.0",
                 "@nangohq/account-usage": "file:../account-usage",
                 "@nangohq/data-ingestion": "file:../data-ingestion",

--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -36,6 +36,7 @@ try {
     const srv = server.listen(port);
     logger.info(`🚀 service ready at http://localhost:${port}`);
     const processor = new Processor(orchestratorUrl);
+    const invocationsProcessor = new LambdaInvocationsProcessor();
 
     // We are using a setTimeout because we don't want overlapping setInterval if the DB is down
     let healthCheck: NodeJS.Timeout | undefined;
@@ -77,6 +78,7 @@ try {
             await db.knex.destroy();
             await db.readOnly.destroy();
             await destroyKvstore();
+            await invocationsProcessor.stop();
 
             console.info('Closed');
 
@@ -105,7 +107,6 @@ try {
 
     processor.start();
 
-    const invocationsProcessor = new LambdaInvocationsProcessor();
     await invocationsProcessor.start();
 
     void otlp.register(getOtlpRoutes);

--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -8,6 +8,7 @@ import { getOtlpRoutes } from '@nangohq/shared';
 import { getLogger, initSentry, once, report, stringifyError } from '@nangohq/utils';
 
 import { envs } from './env.js';
+import { InvocationsProcessor } from './invocations/processor.js';
 import { Processor } from './processor/processor.js';
 import { getDefaultFleet, startFleets, stopFleets } from './runtime/runtimes.js';
 import { server } from './server.js';
@@ -103,6 +104,9 @@ try {
     await startFleets();
 
     processor.start();
+
+    const invocationsProcessor = new InvocationsProcessor();
+    await invocationsProcessor.start();
 
     void otlp.register(getOtlpRoutes);
 } catch (err) {

--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -8,7 +8,7 @@ import { getOtlpRoutes } from '@nangohq/shared';
 import { getLogger, initSentry, once, report, stringifyError } from '@nangohq/utils';
 
 import { envs } from './env.js';
-import { InvocationsProcessor } from './invocations/processor.js';
+import { LambdaInvocationsProcessor } from './invocations/lambda.processor.js';
 import { Processor } from './processor/processor.js';
 import { getDefaultFleet, startFleets, stopFleets } from './runtime/runtimes.js';
 import { server } from './server.js';
@@ -105,7 +105,7 @@ try {
 
     processor.start();
 
-    const invocationsProcessor = new InvocationsProcessor();
+    const invocationsProcessor = new LambdaInvocationsProcessor();
     await invocationsProcessor.start();
 
     void otlp.register(getOtlpRoutes);

--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -107,7 +107,7 @@ try {
 
     processor.start();
 
-    await invocationsProcessor.start();
+    invocationsProcessor.start();
 
     void otlp.register(getOtlpRoutes);
 } catch (err) {

--- a/packages/jobs/lib/events/listener.ts
+++ b/packages/jobs/lib/events/listener.ts
@@ -6,4 +6,6 @@ export interface QueueMessage {
 
 export interface EventListener {
     listen(queue: string, onMessage?: (message: QueueMessage) => Promise<void>): Promise<void>;
+
+    stop(): Promise<void>;
 }

--- a/packages/jobs/lib/events/listener.ts
+++ b/packages/jobs/lib/events/listener.ts
@@ -1,0 +1,9 @@
+// Interface for listening to a queue for events
+
+export interface QueueMessage {
+    body: string;
+}
+
+export interface EventListener {
+    listen(queue: string, onMessage?: (message: QueueMessage) => Promise<void>): Promise<void>;
+}

--- a/packages/jobs/lib/events/noop.listener.ts
+++ b/packages/jobs/lib/events/noop.listener.ts
@@ -1,0 +1,11 @@
+import type { EventListener, QueueMessage } from './listener.js';
+
+export class NoopEventListener implements EventListener {
+    listen(_queue: string, _onMessage?: (message: QueueMessage) => Promise<void>): Promise<void> {
+        return Promise.resolve();
+    }
+
+    stop(): Promise<void> {
+        return Promise.resolve();
+    }
+}

--- a/packages/jobs/lib/events/sqs.listener.ts
+++ b/packages/jobs/lib/events/sqs.listener.ts
@@ -66,8 +66,10 @@ export class SqsEventListener implements EventListener {
                                 await onMessage({ body: msg.Body });
                             }
                         } catch (err) {
-                            logger.error('SQS message handler error', err);
-                            continue;
+                            report(new Error('SQS message handler error'), {
+                                queueName,
+                                error: err
+                            });
                         }
 
                         await this.client.send(

--- a/packages/jobs/lib/events/sqs.listener.ts
+++ b/packages/jobs/lib/events/sqs.listener.ts
@@ -1,0 +1,86 @@
+import { DeleteMessageCommand, GetQueueUrlCommand, ReceiveMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
+
+import { getLogger, report } from '@nangohq/utils';
+
+import type { EventListener, QueueMessage } from './listener.js';
+
+const logger = getLogger('jobs.events.sqs');
+
+const getRegion = (): string => {
+    const env = typeof process !== 'undefined' ? process.env['LAMBDA_REGION'] : undefined;
+    return env ?? 'us-west-2';
+};
+
+export class SqsEventListener implements EventListener {
+    private readonly client: SQSClient;
+
+    constructor() {
+        this.client = new SQSClient({ region: getRegion() });
+    }
+
+    async listen(queue: string, onMessage?: (message: QueueMessage) => void | Promise<void>): Promise<void> {
+        const queueUrlRes = await this.getQueueUrl(queue);
+        if (queueUrlRes === null) {
+            throw new Error(`SQS: could not get queue URL for ${queue}`);
+        }
+        const queueUrl = queueUrlRes;
+
+        logger.info(`SQS: subscribing to queue ${queue}`);
+
+        while (true) {
+            try {
+                const result = await this.client.send(
+                    new ReceiveMessageCommand({
+                        QueueUrl: queueUrl,
+                        MaxNumberOfMessages: 10,
+                        WaitTimeSeconds: 20,
+                        VisibilityTimeout: 60
+                    })
+                );
+
+                const messages = result.Messages ?? [];
+                for (const msg of messages) {
+                    if (!msg.Body || !msg.ReceiptHandle) continue;
+
+                    try {
+                        if (onMessage) {
+                            await onMessage({ body: msg.Body });
+                        }
+                    } catch (err) {
+                        report(new Error('SQS message handler error'), {
+                            queue,
+                            error: err
+                        });
+                        continue;
+                    }
+
+                    await this.client.send(
+                        new DeleteMessageCommand({
+                            QueueUrl: queueUrl,
+                            ReceiptHandle: msg.ReceiptHandle
+                        })
+                    );
+                }
+            } catch (err) {
+                report(new Error('SQS receive message error'), {
+                    queue,
+                    error: err
+                });
+                await new Promise((r) => setTimeout(r, 1000));
+            }
+        }
+    }
+
+    private async getQueueUrl(queueName: string): Promise<string | null> {
+        try {
+            const result = await this.client.send(new GetQueueUrlCommand({ QueueName: queueName }));
+            return result.QueueUrl ?? null;
+        } catch (err) {
+            report(new Error('SQS get queue URL failed'), {
+                queueName,
+                error: err
+            });
+            return null;
+        }
+    }
+}

--- a/packages/jobs/lib/events/sqs.listener.ts
+++ b/packages/jobs/lib/events/sqs.listener.ts
@@ -57,10 +57,7 @@ export class SqsEventListener implements EventListener {
                             await onMessage({ body: msg.Body });
                         }
                     } catch (err) {
-                        report(new Error('SQS message handler error'), {
-                            queueName,
-                            error: err
-                        });
+                        logger.error('SQS message handler error', err);
                         continue;
                     }
 

--- a/packages/jobs/lib/events/sqs.listener.ts
+++ b/packages/jobs/lib/events/sqs.listener.ts
@@ -1,8 +1,9 @@
 import { DeleteMessageCommand, GetQueueUrlCommand, ReceiveMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
 
-import { getLogger, report } from '@nangohq/utils';
+import { Err, Ok, getLogger, report } from '@nangohq/utils';
 
 import type { EventListener, QueueMessage } from './listener.js';
+import type { Result } from '@nangohq/utils';
 
 const logger = getLogger('jobs.events.sqs');
 
@@ -22,90 +23,88 @@ const getRegion = (): string => {
 
 export class SqsEventListener implements EventListener {
     private readonly client: SQSClient;
-    private abortController: AbortController | null = null;
+    private abortController: AbortController = new AbortController();
 
     constructor() {
         this.client = new SQSClient({ region: getRegion() });
     }
 
-    async listen(queue: string, onMessage?: (message: QueueMessage) => void | Promise<void>): Promise<void> {
+    async listen(queue: string, onMessage?: (message: QueueMessage) => Promise<void>): Promise<void> {
         const queueName = queueNameFromArn(queue);
         const queueUrlRes = await this.getQueueUrl(queueName);
-        if (queueUrlRes === null) {
-            throw new Error(`SQS: could not get queue URL for ${queueName}`);
+        if (queueUrlRes.isErr()) {
+            throw new Error(`SQS: could not get queue URL for ${queueName}`, { cause: queueUrlRes.error });
         }
-        const queueUrl = queueUrlRes;
+        const queueUrl = queueUrlRes.value;
 
-        this.abortController = new AbortController();
         const signal = this.abortController.signal;
 
         logger.info(`SQS: subscribing to queue ${queueName}`);
 
-        try {
-            while (true) {
-                if (signal.aborted) break;
+        while (true) {
+            if (signal.aborted) break;
 
-                try {
-                    const result = await this.client.send(
-                        new ReceiveMessageCommand({
+            try {
+                const result = await this.client.send(
+                    new ReceiveMessageCommand({
+                        QueueUrl: queueUrl,
+                        MaxNumberOfMessages: 10,
+                        WaitTimeSeconds: 20,
+                        VisibilityTimeout: 60
+                    }),
+                    { abortSignal: signal }
+                );
+
+                const messages = result.Messages ?? [];
+                for (const msg of messages) {
+                    if (signal.aborted) break;
+                    if (!msg.Body || !msg.ReceiptHandle) continue;
+
+                    try {
+                        if (onMessage) {
+                            await onMessage({ body: msg.Body });
+                        }
+                    } catch (err) {
+                        report(new Error('SQS message handler error'), {
+                            queueName,
+                            error: err
+                        });
+                    }
+
+                    await this.client.send(
+                        new DeleteMessageCommand({
                             QueueUrl: queueUrl,
-                            MaxNumberOfMessages: 10,
-                            WaitTimeSeconds: 20,
-                            VisibilityTimeout: 60
+                            ReceiptHandle: msg.ReceiptHandle
                         }),
                         { abortSignal: signal }
                     );
-
-                    const messages = result.Messages ?? [];
-                    for (const msg of messages) {
-                        if (signal.aborted) break;
-                        if (!msg.Body || !msg.ReceiptHandle) continue;
-
-                        try {
-                            if (onMessage) {
-                                await onMessage({ body: msg.Body });
-                            }
-                        } catch (err) {
-                            report(new Error('SQS message handler error'), {
-                                queueName,
-                                error: err
-                            });
-                        }
-
-                        await this.client.send(
-                            new DeleteMessageCommand({
-                                QueueUrl: queueUrl,
-                                ReceiptHandle: msg.ReceiptHandle
-                            }),
-                            { abortSignal: signal }
-                        );
-                    }
-                } catch (err) {
-                    if (err instanceof Error && err.name === 'AbortError') {
-                        break;
-                    }
-                    report(new Error('SQS receive message error'), {
-                        queueName,
-                        error: err
-                    });
-                    await new Promise((r) => setTimeout(r, 1000));
                 }
+            } catch (err) {
+                if (err instanceof Error && err.name === 'AbortError') {
+                    break;
+                }
+                report(new Error('SQS receive message error'), {
+                    queueName,
+                    error: err
+                });
+                await new Promise((r) => setTimeout(r, 1000));
             }
-        } finally {
-            this.abortController = null;
         }
     }
 
-    private async getQueueUrl(queueName: string): Promise<string | null> {
+    private async getQueueUrl(queueName: string): Promise<Result<string>> {
         try {
             const result = await this.client.send(new GetQueueUrlCommand({ QueueName: queueName }));
-            return result.QueueUrl ?? null;
+            if (result.QueueUrl) {
+                return Ok(result.QueueUrl);
+            }
+            return Err(new Error('SQS queue URL was undefined'));
         } catch (err) {
             report(new Error('SQS get queue URL failed'), {
                 queueName,
                 error: err
             });
-            return null;
+            return Err(new Error('SQS get queue URL failed'));
         }
     }
 

--- a/packages/jobs/lib/events/sqs.listener.ts
+++ b/packages/jobs/lib/events/sqs.listener.ts
@@ -71,13 +71,20 @@ export class SqsEventListener implements EventListener {
                         });
                     }
 
-                    await this.client.send(
-                        new DeleteMessageCommand({
-                            QueueUrl: queueUrl,
-                            ReceiptHandle: msg.ReceiptHandle
-                        }),
-                        { abortSignal: signal }
-                    );
+                    try {
+                        await this.client.send(
+                            new DeleteMessageCommand({
+                                QueueUrl: queueUrl,
+                                ReceiptHandle: msg.ReceiptHandle
+                            }),
+                            { abortSignal: signal }
+                        );
+                    } catch (err) {
+                        report(new Error('SQS delete message error'), {
+                            queueName,
+                            error: err
+                        });
+                    }
                 }
             } catch (err) {
                 if (err instanceof Error && err.name === 'AbortError') {

--- a/packages/jobs/lib/events/sqs.listener.unit.test.ts
+++ b/packages/jobs/lib/events/sqs.listener.unit.test.ts
@@ -1,0 +1,137 @@
+// Unit tests for SqsEventListener
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSend = vi.fn();
+const mockDestroy = vi.fn();
+
+vi.mock('@aws-sdk/client-sqs', () => ({
+    SQSClient: vi.fn().mockImplementation(() => ({
+        send: mockSend,
+        destroy: mockDestroy
+    })),
+    GetQueueUrlCommand: vi.fn().mockImplementation((input: Record<string, unknown>) => ({ input })),
+    ReceiveMessageCommand: vi.fn().mockImplementation((input: Record<string, unknown>) => ({ input })),
+    DeleteMessageCommand: vi.fn().mockImplementation((input: Record<string, unknown>) => ({ input }))
+}));
+
+vi.mock('@nangohq/utils', () => ({
+    getLogger: vi.fn(() => ({
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn()
+    })),
+    report: vi.fn()
+}));
+
+import { SqsEventListener } from './sqs.listener.js';
+
+const queueUrl = 'https://sqs.us-west-2.amazonaws.com/123456789/test-queue';
+
+function abortError(): Error {
+    const err = new Error('aborted');
+    err.name = 'AbortError';
+    return err;
+}
+
+describe('SqsEventListener', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('extracts queue name from ARN and requests queue URL with it', async () => {
+        mockSend.mockResolvedValueOnce({ QueueUrl: queueUrl }).mockRejectedValueOnce(abortError());
+
+        const listener = new SqsEventListener();
+        await listener.listen('arn:aws:sqs:us-west-2:123456789:my-queue-name');
+
+        expect(mockSend).toHaveBeenNthCalledWith(1, expect.anything());
+        const firstCall = mockSend.mock.calls[0]!;
+        const cmd = firstCall[0];
+        expect(cmd.input).toMatchObject({ QueueName: 'my-queue-name' });
+    });
+
+    it('exits listen loop when ReceiveMessage throws AbortError', async () => {
+        mockSend.mockResolvedValueOnce({ QueueUrl: queueUrl }).mockRejectedValueOnce(abortError());
+
+        const listener = new SqsEventListener();
+        await listener.listen('test-queue');
+        expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
+    it('invokes onMessage for each received message and deletes after processing', async () => {
+        const onMessage = vi.fn().mockResolvedValue(undefined);
+        mockSend
+            .mockResolvedValueOnce({ QueueUrl: queueUrl })
+            .mockResolvedValueOnce({
+                Messages: [
+                    { Body: '{"foo":1}', ReceiptHandle: 'handle-1' },
+                    { Body: '{"bar":2}', ReceiptHandle: 'handle-2' }
+                ]
+            })
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce(undefined)
+            .mockRejectedValueOnce(abortError());
+
+        const listener = new SqsEventListener();
+        await listener.listen('test-queue', onMessage);
+
+        expect(onMessage).toHaveBeenCalledTimes(2);
+        expect(onMessage).toHaveBeenNthCalledWith(1, { body: '{"foo":1}' });
+        expect(onMessage).toHaveBeenNthCalledWith(2, { body: '{"bar":2}' });
+        expect(mockSend).toHaveBeenCalledTimes(5);
+        const deleteCalls = mockSend.mock.calls.filter((call) => call[0].input?.ReceiptHandle != null);
+        expect(deleteCalls).toHaveLength(2);
+        expect(deleteCalls[0]![0].input).toMatchObject({ ReceiptHandle: 'handle-1', QueueUrl: queueUrl });
+        expect(deleteCalls[1]![0].input).toMatchObject({ ReceiptHandle: 'handle-2', QueueUrl: queueUrl });
+    });
+
+    it('passes abortSignal to ReceiveMessage and DeleteMessage send calls', async () => {
+        mockSend
+            .mockResolvedValueOnce({ QueueUrl: queueUrl })
+            .mockImplementation((cmd: { input?: { ReceiptHandle?: string } }, options?: { abortSignal?: AbortSignal }) => {
+                if (cmd.input?.ReceiptHandle != null) {
+                    return Promise.resolve(undefined);
+                }
+                return new Promise((_, reject) => {
+                    options?.abortSignal?.addEventListener('abort', () => reject(abortError()));
+                });
+            });
+
+        const listener = new SqsEventListener();
+        const listenPromise = listener.listen('test-queue');
+        await new Promise((r) => setTimeout(r, 10));
+        await listener.stop();
+        await listenPromise;
+
+        expect(mockDestroy).toHaveBeenCalledTimes(1);
+    });
+
+    it('stop() aborts and destroys client', async () => {
+        mockSend.mockResolvedValueOnce({ QueueUrl: queueUrl }).mockRejectedValueOnce(abortError());
+
+        const listener = new SqsEventListener();
+        await listener.listen('test-queue');
+        await listener.stop();
+
+        expect(mockDestroy).toHaveBeenCalledTimes(1);
+    });
+
+    it('skip message when Body or ReceiptHandle is missing', async () => {
+        const onMessage = vi.fn().mockResolvedValue(undefined);
+        mockSend
+            .mockResolvedValueOnce({ QueueUrl: queueUrl })
+            .mockResolvedValueOnce({
+                Messages: [{ Body: 'valid', ReceiptHandle: 'h1' }, { Body: '', ReceiptHandle: 'h2' }, { ReceiptHandle: 'h3' }, { Body: 'only-body' }]
+            })
+            .mockResolvedValueOnce(undefined)
+            .mockRejectedValueOnce(abortError());
+
+        const listener = new SqsEventListener();
+        await listener.listen('test-queue', onMessage);
+
+        expect(onMessage).toHaveBeenCalledTimes(1);
+        expect(onMessage).toHaveBeenCalledWith({ body: 'valid' });
+    });
+});

--- a/packages/jobs/lib/events/sqs.listener.unit.test.ts
+++ b/packages/jobs/lib/events/sqs.listener.unit.test.ts
@@ -15,15 +15,19 @@ vi.mock('@aws-sdk/client-sqs', () => ({
     DeleteMessageCommand: vi.fn().mockImplementation((input: Record<string, unknown>) => ({ input }))
 }));
 
-vi.mock('@nangohq/utils', () => ({
-    getLogger: vi.fn(() => ({
-        info: vi.fn(),
-        error: vi.fn(),
-        warn: vi.fn(),
-        debug: vi.fn()
-    })),
-    report: vi.fn()
-}));
+vi.mock('@nangohq/utils', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...(actual as Record<string, unknown>),
+        getLogger: vi.fn(() => ({
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+            debug: vi.fn()
+        })),
+        report: vi.fn()
+    };
+});
 
 import { SqsEventListener } from './sqs.listener.js';
 

--- a/packages/jobs/lib/execution/operations/abort.ts
+++ b/packages/jobs/lib/execution/operations/abort.ts
@@ -56,7 +56,7 @@ export async function abortTaskWithId({ taskId, teamId }: { taskId: string; team
     }
 }
 
-async function setAbortFlag(taskId: string): Promise<void> {
+export async function setAbortFlag(taskId: string): Promise<void> {
     try {
         const kvStore = await getKVStore('customer');
         await kvStore.set(`function:${taskId}:abort`, '1', { ttlMs: envs.RUNNER_ABORT_CHECK_INTERVAL_MS * 5 });

--- a/packages/jobs/lib/execution/operations/abort.ts
+++ b/packages/jobs/lib/execution/operations/abort.ts
@@ -56,11 +56,13 @@ export async function abortTaskWithId({ taskId, teamId }: { taskId: string; team
     }
 }
 
-export async function setAbortFlag(taskId: string): Promise<void> {
+export async function setAbortFlag(taskId: string): Promise<Result<void>> {
     try {
         const kvStore = await getKVStore('customer');
         await kvStore.set(`function:${taskId}:abort`, '1', { ttlMs: envs.RUNNER_ABORT_CHECK_INTERVAL_MS * 5 });
+        return Ok(undefined);
     } catch (err) {
         logger.error(`Error setting abort flag for task: ${taskId}`, err);
+        return Err(new Error(`Error setting abort flag for task: ${taskId}`, { cause: err }));
     }
 }

--- a/packages/jobs/lib/invocations/lambda.processor.ts
+++ b/packages/jobs/lib/invocations/lambda.processor.ts
@@ -27,6 +27,10 @@ export class LambdaInvocationsProcessor {
         }
     }
 
+    async stop() {
+        await this.eventListener.stop();
+    }
+
     private async processFailureMessage(message: QueueMessage) {
         const parsedMessage = z
             .object({

--- a/packages/jobs/lib/invocations/lambda.processor.ts
+++ b/packages/jobs/lib/invocations/lambda.processor.ts
@@ -14,7 +14,7 @@ function lambdaErrorTypeFromMessage(errorMessage: string): 'function_runtime_out
     return 'function_runtime_other';
 }
 
-export class InvocationsProcessor {
+export class LambdaInvocationsProcessor {
     private eventListener: EventListener;
 
     constructor() {
@@ -23,11 +23,11 @@ export class InvocationsProcessor {
 
     async start() {
         if (envs.LAMBDA_FAILURE_DESTINATION) {
-            await this.eventListener.listen(envs.LAMBDA_FAILURE_DESTINATION, async (message) => await this.processMessage(message));
+            await this.eventListener.listen(envs.LAMBDA_FAILURE_DESTINATION, async (message) => await this.processFailureMessage(message));
         }
     }
 
-    private async processMessage(message: QueueMessage) {
+    private async processFailureMessage(message: QueueMessage) {
         const parsedMessage = z
             .object({
                 responseContext: z.object({

--- a/packages/jobs/lib/invocations/lambda.processor.ts
+++ b/packages/jobs/lib/invocations/lambda.processor.ts
@@ -31,17 +31,20 @@ const parsedMessageSchema = z.object({
 
 export class LambdaInvocationsProcessor {
     private eventListener: EventListener;
+    private queueName: string;
 
     constructor() {
         if (envs.LAMBDA_FAILURE_DESTINATION) {
             this.eventListener = new SqsEventListener();
+            this.queueName = envs.LAMBDA_FAILURE_DESTINATION;
         } else {
             this.eventListener = new NoopEventListener();
+            this.queueName = 'noop';
         }
     }
 
     async start() {
-        await this.eventListener.listen(envs.LAMBDA_FAILURE_DESTINATION, async (message) => await this.processFailureMessage(message));
+        await this.eventListener.listen(this.queueName, async (message) => await this.processFailureMessage(message));
     }
 
     async stop() {

--- a/packages/jobs/lib/invocations/lambda.processor.ts
+++ b/packages/jobs/lib/invocations/lambda.processor.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { envs } from '../env.js';
+import { NoopEventListener } from '../events/noop.listener.js';
 import { SqsEventListener } from '../events/sqs.listener.js';
 import { handleError } from '../execution/operations/handler.js';
 import { nangoPropsSchema } from '../schemas/nango-props.js';
@@ -14,17 +15,33 @@ function lambdaErrorTypeFromMessage(errorMessage: string): 'function_runtime_out
     return 'function_runtime_other';
 }
 
+const parsedMessageSchema = z.object({
+    responseContext: z.object({
+        functionError: z.string(),
+        statusCode: z.number()
+    }),
+    responsePayload: z.object({
+        errorMessage: z.string()
+    }),
+    requestPayload: z.object({
+        taskId: z.string(),
+        nangoProps: nangoPropsSchema
+    })
+});
+
 export class LambdaInvocationsProcessor {
     private eventListener: EventListener;
 
     constructor() {
-        this.eventListener = new SqsEventListener();
+        if (envs.LAMBDA_FAILURE_DESTINATION) {
+            this.eventListener = new SqsEventListener();
+        } else {
+            this.eventListener = new NoopEventListener();
+        }
     }
 
     async start() {
-        if (envs.LAMBDA_FAILURE_DESTINATION) {
-            await this.eventListener.listen(envs.LAMBDA_FAILURE_DESTINATION, async (message) => await this.processFailureMessage(message));
-        }
+        await this.eventListener.listen(envs.LAMBDA_FAILURE_DESTINATION, async (message) => await this.processFailureMessage(message));
     }
 
     async stop() {
@@ -32,21 +49,7 @@ export class LambdaInvocationsProcessor {
     }
 
     private async processFailureMessage(message: QueueMessage) {
-        const parsedMessage = z
-            .object({
-                responseContext: z.object({
-                    functionError: z.string(),
-                    statusCode: z.number()
-                }),
-                responsePayload: z.object({
-                    errorMessage: z.string()
-                }),
-                requestPayload: z.object({
-                    taskId: z.string(),
-                    nangoProps: nangoPropsSchema
-                })
-            })
-            .parse(JSON.parse(message.body));
+        const parsedMessage = parsedMessageSchema.parse(JSON.parse(message.body));
 
         if (parsedMessage.responseContext.functionError === 'Unhandled') {
             const errorMessage = parsedMessage.responsePayload.errorMessage;

--- a/packages/jobs/lib/invocations/lambda.processor.unit.test.ts
+++ b/packages/jobs/lib/invocations/lambda.processor.unit.test.ts
@@ -1,0 +1,211 @@
+// Unit tests for LambdaInvocationsProcessor
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockListen = vi.fn();
+vi.mock('../events/sqs.listener.js', () => ({
+    SqsEventListener: vi.fn().mockImplementation(() => ({
+        listen: mockListen
+    }))
+}));
+
+vi.mock('../execution/operations/handler.js', () => ({
+    handleError: vi.fn().mockResolvedValue(undefined)
+}));
+
+let mockLambdaFailureDestination: string | undefined = 'https://sqs.us-west-2.amazonaws.com/123456789/lambda-failures';
+vi.mock('../env.js', () => ({
+    get envs() {
+        return { LAMBDA_FAILURE_DESTINATION: mockLambdaFailureDestination };
+    }
+}));
+
+import { LambdaInvocationsProcessor } from './lambda.processor.js';
+import { handleError } from '../execution/operations/handler.js';
+
+function minimalNangoProps() {
+    return {
+        scriptType: 'action' as const,
+        connectionId: 'conn-1',
+        nangoConnectionId: 1,
+        environmentId: 1,
+        environmentName: 'dev',
+        providerConfigKey: 'google',
+        provider: 'google',
+        team: { id: 1, name: 'team' },
+        syncConfig: {
+            id: 1,
+            sync_name: 'test-sync',
+            type: 'action' as const,
+            environment_id: 1,
+            models: [],
+            file_location: '/tmp',
+            nango_config_id: 1,
+            active: true,
+            runs: null,
+            track_deletes: false,
+            auto_start: false,
+            enabled: true,
+            webhook_subscriptions: [],
+            model_schema: null,
+            models_json_schema: {},
+            created_at: new Date(),
+            updated_at: new Date(),
+            version: '1',
+            attributes: {},
+            pre_built: false,
+            is_public: false,
+            input: null,
+            sync_type: null,
+            metadata: {},
+            sdk_version: null
+        },
+        activityLogId: 'aaaaaaaaaaaaaaaaaaaa',
+        secretKey: 'sk',
+        debug: false,
+        startedAt: new Date(),
+        endUser: null,
+        runnerFlags: {
+            validateActionInput: false,
+            validateActionOutput: false,
+            validateWebhookInput: false,
+            validateWebhookOutput: false,
+            validateSyncRecords: false,
+            validateSyncMetadata: false
+        }
+    };
+}
+
+function failureMessage(
+    overrides: {
+        functionError?: string;
+        statusCode?: number;
+        errorMessage?: string;
+        taskId?: string;
+        nangoProps?: ReturnType<typeof minimalNangoProps>;
+    } = {}
+) {
+    const {
+        functionError = 'Unhandled',
+        statusCode = 500,
+        errorMessage = 'Something went wrong',
+        taskId = 'task-123',
+        nangoProps = minimalNangoProps()
+    } = overrides;
+    const payload = {
+        responseContext: { functionError, statusCode },
+        responsePayload: { errorMessage },
+        requestPayload: { taskId, nangoProps }
+    };
+    return {
+        body: JSON.stringify(payload)
+    };
+}
+
+describe('LambdaInvocationsProcessor', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should call listen with LAMBDA_FAILURE_DESTINATION when start() is called', async () => {
+        const processor = new LambdaInvocationsProcessor();
+        await processor.start();
+        expect(mockListen).toHaveBeenCalledTimes(1);
+        expect(mockListen).toHaveBeenCalledWith('https://sqs.us-west-2.amazonaws.com/123456789/lambda-failures', expect.any(Function));
+    });
+
+    it('should process Unhandled failure and call handleError with function_runtime_other for generic error message', async () => {
+        let onMessage: (message: { body: string }) => Promise<void> = undefined!;
+        mockListen.mockImplementation((_queue: string, cb: (m: { body: string }) => Promise<void>) => {
+            onMessage = cb;
+        });
+
+        const processor = new LambdaInvocationsProcessor();
+        await processor.start();
+        expect(onMessage).toBeDefined();
+
+        const message = failureMessage({ errorMessage: 'Random error' });
+        await onMessage(message);
+
+        expect(handleError).toHaveBeenCalledTimes(1);
+        expect(handleError).toHaveBeenCalledWith(
+            expect.objectContaining({
+                taskId: 'task-123',
+                error: expect.objectContaining({
+                    type: 'function_runtime_other',
+                    payload: { errorMessage: 'Random error' },
+                    status: 500
+                }),
+                telemetryBag: { customLogs: 0, proxyCalls: 0, durationMs: 0, memoryGb: 0 },
+                functionRuntime: 'lambda'
+            })
+        );
+    });
+
+    it('should map "signal: killed" error message to function_runtime_out_of_memory', async () => {
+        let onMessage: (message: { body: string }) => Promise<void> = undefined!;
+        mockListen.mockImplementation((_queue: string, cb: (m: { body: string }) => Promise<void>) => {
+            onMessage = cb;
+        });
+
+        const processor = new LambdaInvocationsProcessor();
+        await processor.start();
+
+        await onMessage(failureMessage({ errorMessage: 'Process exited with signal: killed' }));
+
+        expect(handleError).toHaveBeenCalledWith(
+            expect.objectContaining({
+                error: expect.objectContaining({
+                    type: 'function_runtime_out_of_memory',
+                    payload: { errorMessage: 'Process exited with signal: killed' }
+                })
+            })
+        );
+    });
+
+    it('should map "Task timed out" error message to function_runtime_timed_out', async () => {
+        let onMessage: (message: { body: string }) => Promise<void> = undefined!;
+        mockListen.mockImplementation((_queue: string, cb: (m: { body: string }) => Promise<void>) => {
+            onMessage = cb;
+        });
+
+        const processor = new LambdaInvocationsProcessor();
+        await processor.start();
+
+        await onMessage(failureMessage({ errorMessage: 'Task timed out after 30.00 seconds' }));
+
+        expect(handleError).toHaveBeenCalledWith(
+            expect.objectContaining({
+                error: expect.objectContaining({
+                    type: 'function_runtime_timed_out',
+                    payload: { errorMessage: 'Task timed out after 30.00 seconds' }
+                })
+            })
+        );
+    });
+
+    it('should not call handleError when functionError is not Unhandled', async () => {
+        let onMessage: (message: { body: string }) => Promise<void> = undefined!;
+        mockListen.mockImplementation((_queue: string, cb: (m: { body: string }) => Promise<void>) => {
+            onMessage = cb;
+        });
+
+        const processor = new LambdaInvocationsProcessor();
+        await processor.start();
+
+        await onMessage(failureMessage({ functionError: 'Handled', statusCode: 400, errorMessage: 'Validation failed', taskId: 'task-456' }));
+
+        expect(handleError).not.toHaveBeenCalled();
+    });
+
+    it('should not call listen when LAMBDA_FAILURE_DESTINATION is not set', async () => {
+        const url = mockLambdaFailureDestination;
+        mockLambdaFailureDestination = undefined;
+        vi.resetModules();
+        const { LambdaInvocationsProcessor: Processor } = await import('./lambda.processor.js');
+        const processor = new Processor();
+        await processor.start();
+        expect(mockListen).not.toHaveBeenCalled();
+        mockLambdaFailureDestination = url;
+    });
+});

--- a/packages/jobs/lib/invocations/lambda.processor.unit.test.ts
+++ b/packages/jobs/lib/invocations/lambda.processor.unit.test.ts
@@ -3,9 +3,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockListen = vi.fn();
+const mockStop = vi.fn().mockResolvedValue(undefined);
 vi.mock('../events/sqs.listener.js', () => ({
     SqsEventListener: vi.fn().mockImplementation(() => ({
-        listen: mockListen
+        listen: mockListen,
+        stop: mockStop
     }))
 }));
 
@@ -207,5 +209,14 @@ describe('LambdaInvocationsProcessor', () => {
         await processor.start();
         expect(mockListen).not.toHaveBeenCalled();
         mockLambdaFailureDestination = url;
+    });
+
+    it('should call eventListener.stop() when stop() is called', async () => {
+        const processor = new LambdaInvocationsProcessor();
+        await processor.start();
+        expect(mockListen).toHaveBeenCalled();
+
+        await processor.stop();
+        expect(mockStop).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/jobs/lib/invocations/processor.ts
+++ b/packages/jobs/lib/invocations/processor.ts
@@ -8,9 +8,9 @@ import { nangoPropsSchema } from '../schemas/nango-props.js';
 import type { EventListener, QueueMessage } from '../events/listener.js';
 import type { NangoProps } from '@nangohq/types';
 
-function lambdaErrorTypeFromMessage(errorMessage: string): 'function_runtime_out_of_memory' | 'function_runtime_timed_oud' | 'function_runtime_other' {
+function lambdaErrorTypeFromMessage(errorMessage: string): 'function_runtime_out_of_memory' | 'function_runtime_timed_out' | 'function_runtime_other' {
     if (errorMessage.includes('signal: killed')) return 'function_runtime_out_of_memory';
-    if (errorMessage.includes('Task timed out')) return 'function_runtime_timed_oud';
+    if (errorMessage.includes('Task timed out')) return 'function_runtime_timed_out';
     return 'function_runtime_other';
 }
 

--- a/packages/jobs/lib/invocations/processor.ts
+++ b/packages/jobs/lib/invocations/processor.ts
@@ -1,0 +1,23 @@
+import { envs } from '../env.js';
+import { SqsEventListener } from '../events/sqs.listener.js';
+
+import type { EventListener, QueueMessage } from '../events/listener.js';
+
+export class InvocationsProcessor {
+    private eventListener: EventListener;
+
+    constructor() {
+        this.eventListener = new SqsEventListener();
+    }
+
+    async start() {
+        if (envs.LAMBDA_FAILURE_DESTINATION) {
+            await this.eventListener.listen(envs.LAMBDA_FAILURE_DESTINATION, (message) => this.processMessage(message));
+        }
+    }
+
+    private async processMessage(message: QueueMessage) {
+        //just log the message for now
+        return Promise.resolve(console.log(JSON.stringify(message, null, 2)));
+    }
+}

--- a/packages/jobs/lib/invocations/processor.ts
+++ b/packages/jobs/lib/invocations/processor.ts
@@ -8,10 +8,10 @@ import { nangoPropsSchema } from '../schemas/nango-props.js';
 import type { EventListener, QueueMessage } from '../events/listener.js';
 import type { NangoProps } from '@nangohq/types';
 
-function lambdaErrorTypeFromMessage(errorMessage: string): 'lambda_out_of_memory' | 'lambda_timeout' | 'lambda_other' {
-    if (errorMessage.includes('signal: killed')) return 'lambda_out_of_memory';
-    if (errorMessage.includes('Task timed out')) return 'lambda_timeout';
-    return 'lambda_other';
+function lambdaErrorTypeFromMessage(errorMessage: string): 'function_runtime_out_of_memory' | 'function_runtime_timed_oud' | 'function_runtime_other' {
+    if (errorMessage.includes('signal: killed')) return 'function_runtime_out_of_memory';
+    if (errorMessage.includes('Task timed out')) return 'function_runtime_timed_oud';
+    return 'function_runtime_other';
 }
 
 export class InvocationsProcessor {

--- a/packages/jobs/lib/invocations/processor.ts
+++ b/packages/jobs/lib/invocations/processor.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { envs } from '../env.js';
 import { SqsEventListener } from '../events/sqs.listener.js';
 import { handleError } from '../execution/operations/handler.js';
+import { nangoPropsSchema } from '../schemas/nango-props.js';
 
 import type { EventListener, QueueMessage } from '../events/listener.js';
 import type { NangoProps } from '@nangohq/types';
@@ -38,7 +39,7 @@ export class InvocationsProcessor {
                 }),
                 requestPayload: z.object({
                     taskId: z.string(),
-                    nangoProps: z.record(z.string(), z.unknown())
+                    nangoProps: nangoPropsSchema
                 })
             })
             .parse(JSON.parse(message.body));
@@ -47,7 +48,7 @@ export class InvocationsProcessor {
             const errorMessage = parsedMessage.responsePayload.errorMessage;
             await handleError({
                 taskId: parsedMessage.requestPayload.taskId,
-                nangoProps: { ...(parsedMessage.requestPayload.nangoProps as unknown as NangoProps) },
+                nangoProps: parsedMessage.requestPayload.nangoProps as unknown as NangoProps,
                 error: {
                     type: lambdaErrorTypeFromMessage(errorMessage),
                     payload: { errorMessage },

--- a/packages/jobs/lib/invocations/processor.ts
+++ b/packages/jobs/lib/invocations/processor.ts
@@ -22,7 +22,7 @@ export class InvocationsProcessor {
 
     async start() {
         if (envs.LAMBDA_FAILURE_DESTINATION) {
-            await this.eventListener.listen(envs.LAMBDA_FAILURE_DESTINATION, (message) => this.processMessage(message));
+            await this.eventListener.listen(envs.LAMBDA_FAILURE_DESTINATION, async (message) => await this.processMessage(message));
         }
     }
 
@@ -44,8 +44,6 @@ export class InvocationsProcessor {
             .parse(JSON.parse(message.body));
 
         if (parsedMessage.responseContext.functionError === 'Unhandled') {
-            console.log('UNHANDLED ERROR:', parsedMessage.responsePayload.errorMessage);
-
             const errorMessage = parsedMessage.responsePayload.errorMessage;
             await handleError({
                 taskId: parsedMessage.requestPayload.taskId,

--- a/packages/jobs/lib/routes/tasks/putTask.ts
+++ b/packages/jobs/lib/routes/tasks/putTask.ts
@@ -1,9 +1,9 @@
 import * as z from 'zod';
 
-import { operationIdRegex } from '@nangohq/logs';
 import { validateRequest } from '@nangohq/utils';
 
 import { handleError, handleSuccess } from '../../execution/operations/handler.js';
+import { nangoPropsSchema } from '../../schemas/nango-props.js';
 
 import type { PutTask } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, RouteHandler } from '@nangohq/utils';
@@ -11,70 +11,6 @@ import type { JsonValue } from 'type-fest';
 
 const jsonLiteralSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
 export const jsonSchema: z.ZodType<JsonValue> = z.lazy(() => z.union([jsonLiteralSchema, z.array(jsonSchema), z.record(z.string(), jsonSchema)]));
-const nangoPropsSchema = z.looseObject({
-    scriptType: z.enum(['action', 'webhook', 'sync', 'on-event']),
-    connectionId: z.string().min(1),
-    nangoConnectionId: z.number(),
-    environmentId: z.number(),
-    environmentName: z.string().min(1),
-    providerConfigKey: z.string().min(1),
-    provider: z.string().min(1),
-    team: z.object({
-        id: z.number(),
-        name: z.string().min(1)
-    }),
-    heartbeatTimeoutSecs: z.number().optional(),
-    syncConfig: z.looseObject({
-        id: z.number(),
-        sync_name: z.string().min(1),
-        type: z.enum(['sync', 'action', 'on-event']),
-        environment_id: z.number(),
-        models: z.array(z.string()),
-        file_location: z.string(),
-        nango_config_id: z.number(),
-        active: z.boolean(),
-        runs: z.string().nullable(),
-        track_deletes: z.boolean(),
-        auto_start: z.boolean(),
-        enabled: z.boolean(),
-        webhook_subscriptions: z.array(z.string()).or(z.null()),
-        model_schema: z.array(z.any()).optional().nullable(),
-        models_json_schema: z.object({}).nullable(),
-        created_at: z.coerce.date(),
-        updated_at: z.coerce.date(),
-        version: z.string(),
-        attributes: z.record(z.string(), z.any()),
-        pre_built: z.boolean(),
-        is_public: z.boolean(),
-        input: z.string().nullable(),
-        sync_type: z.enum(['full', 'incremental']).nullable(),
-        metadata: z.record(z.string(), z.any()),
-        sdk_version: z.string().nullable()
-        // TODO: fix this missing fields
-        // deleted: z.boolean().optional(),
-        // deleted_at: z.coerce.date().optional().nullable(),
-    }),
-    syncId: z.string().uuid().optional(),
-    syncJobId: z.number().optional(),
-    activityLogId: operationIdRegex,
-    secretKey: z.string().min(1),
-    debug: z.boolean(),
-    startedAt: z.coerce.date(),
-    endUser: z.object({ id: z.number(), endUserId: z.string().nullable(), orgId: z.string().nullable() }).nullable(),
-    runnerFlags: z.looseObject({
-        validateActionInput: z.boolean().default(false),
-        validateActionOutput: z.boolean().default(false),
-        validateWebhookInput: z.boolean().default(false),
-        validateWebhookOutput: z.boolean().default(false),
-        validateSyncRecords: z.boolean().default(false),
-        validateSyncMetadata: z.boolean().default(false)
-    }),
-    logger: z
-        .looseObject({
-            level: z.enum(['debug', 'info', 'warn', 'error', 'off'])
-        })
-        .default({ level: 'info' })
-});
 
 const bodySchema = z.object({
     nangoProps: nangoPropsSchema,

--- a/packages/jobs/lib/runner/lambda.ts
+++ b/packages/jobs/lib/runner/lambda.ts
@@ -11,6 +11,7 @@ import {
     DeleteFunctionCommand,
     LambdaClient,
     PublishVersionCommand,
+    PutFunctionEventInvokeConfigCommand,
     waitUntilFunctionActive,
     waitUntilPublishedVersionActive
 } from '@aws-sdk/client-lambda';
@@ -104,6 +105,19 @@ class Lambda {
                         FunctionVersion: pvResult.Version
                     })
                 );
+                if (envs.LAMBDA_FAILURE_DESTINATION) {
+                    await lambdaClient.send(
+                        new PutFunctionEventInvokeConfigCommand({
+                            FunctionName: pvResult.FunctionName,
+                            MaximumRetryAttempts: 0,
+                            DestinationConfig: {
+                                OnFailure: {
+                                    Destination: envs.LAMBDA_FAILURE_DESTINATION
+                                }
+                            }
+                        })
+                    );
+                }
                 const resourceId = `function:${pvResult.FunctionName}:${envs.LAMBDA_FUNCTION_ALIAS}`;
                 await applicationAutoScalingClient.send(
                     new RegisterScalableTargetCommand({

--- a/packages/jobs/lib/runner/lambda.ts
+++ b/packages/jobs/lib/runner/lambda.ts
@@ -109,6 +109,7 @@ class Lambda {
                     await lambdaClient.send(
                         new PutFunctionEventInvokeConfigCommand({
                             FunctionName: pvResult.FunctionName,
+                            Qualifier: envs.LAMBDA_FUNCTION_ALIAS,
                             MaximumRetryAttempts: 0,
                             DestinationConfig: {
                                 OnFailure: {

--- a/packages/jobs/lib/runtime/lambda.adapter.ts
+++ b/packages/jobs/lib/runtime/lambda.adapter.ts
@@ -2,6 +2,7 @@ import { InvokeCommand, LambdaClient } from '@aws-sdk/client-lambda';
 
 import { Err, Ok } from '@nangohq/utils';
 
+import { setAbortFlag } from '../execution/operations/abort.js';
 import { getRoutingId } from '../utils/lambda.js';
 
 import type { RuntimeAdapter } from './adapter.js';
@@ -36,9 +37,6 @@ export class LambdaRuntimeAdapter implements RuntimeAdapter {
             const func = await this.getFunction(params.nangoProps);
             const command = new InvokeCommand({
                 FunctionName: func.arn,
-                ClientContext: JSON.stringify({
-                    taskId: params.taskId
-                }),
                 Payload: JSON.stringify({
                     taskId: params.taskId,
                     nangoProps: params.nangoProps,
@@ -55,7 +53,12 @@ export class LambdaRuntimeAdapter implements RuntimeAdapter {
         }
     }
 
-    async cancel(_params: { taskId: string; nangoProps: NangoProps }): Promise<Result<boolean>> {
-        return Promise.resolve(Err(new Error('Lambda functions do not support cancellation')));
+    async cancel(params: { taskId: string; nangoProps: NangoProps }): Promise<Result<boolean>> {
+        try {
+            await setAbortFlag(params.taskId);
+            return Ok(true);
+        } catch (err) {
+            return Err(new Error(`Error setting abort flag for task: ${params.taskId}`, { cause: err }));
+        }
     }
 }

--- a/packages/jobs/lib/runtime/lambda.adapter.ts
+++ b/packages/jobs/lib/runtime/lambda.adapter.ts
@@ -36,6 +36,9 @@ export class LambdaRuntimeAdapter implements RuntimeAdapter {
             const func = await this.getFunction(params.nangoProps);
             const command = new InvokeCommand({
                 FunctionName: func.arn,
+                ClientContext: JSON.stringify({
+                    taskId: params.taskId
+                }),
                 Payload: JSON.stringify({
                     taskId: params.taskId,
                     nangoProps: params.nangoProps,

--- a/packages/jobs/lib/runtime/lambda.adapter.ts
+++ b/packages/jobs/lib/runtime/lambda.adapter.ts
@@ -54,11 +54,10 @@ export class LambdaRuntimeAdapter implements RuntimeAdapter {
     }
 
     async cancel(params: { taskId: string; nangoProps: NangoProps }): Promise<Result<boolean>> {
-        try {
-            await setAbortFlag(params.taskId);
-            return Ok(true);
-        } catch (err) {
-            return Err(new Error(`Error setting abort flag for task: ${params.taskId}`, { cause: err }));
+        const result = await setAbortFlag(params.taskId);
+        if (result.isErr()) {
+            return Err(new Error(`Error setting abort flag for task: ${params.taskId}`, { cause: result.error }));
         }
+        return Ok(true);
     }
 }

--- a/packages/jobs/lib/schemas/nango-props.ts
+++ b/packages/jobs/lib/schemas/nango-props.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+
+import { operationIdRegex } from '@nangohq/logs';
+
+/**
+ * Zod schema for NangoProps, matching the shape from @nangohq/types (packages/types/lib/runner/sdk.ts).
+ * Used when parsing serialized nangoProps (e.g. from Lambda request payloads or task callbacks).
+ */
+export const nangoPropsSchema = z.looseObject({
+    scriptType: z.enum(['sync', 'action', 'webhook', 'on-event']),
+    host: z.string().optional(),
+    secretKey: z.string().min(1),
+    team: z.object({
+        id: z.number(),
+        name: z.string().min(1)
+    }),
+    connectionId: z.string().min(1),
+    environmentId: z.number(),
+    environmentName: z.string().min(1),
+    activityLogId: operationIdRegex,
+    providerConfigKey: z.string().min(1),
+    provider: z.string().min(1),
+    lastSyncDate: z.coerce.date().optional(),
+    syncId: z.string().uuid().optional(),
+    syncVariant: z.string().optional(),
+    nangoConnectionId: z.number(),
+    syncJobId: z.number().optional(),
+    track_deletes: z.boolean().optional(),
+    attributes: z.record(z.string(), z.unknown()).optional(),
+    syncConfig: z.looseObject({
+        id: z.number(),
+        sync_name: z.string().min(1),
+        type: z.enum(['sync', 'action', 'on-event']),
+        environment_id: z.number(),
+        models: z.array(z.string()),
+        file_location: z.string(),
+        nango_config_id: z.number(),
+        active: z.boolean(),
+        runs: z.string().nullable(),
+        track_deletes: z.boolean(),
+        auto_start: z.boolean(),
+        enabled: z.boolean(),
+        webhook_subscriptions: z.array(z.string()).nullable(),
+        model_schema: z.array(z.unknown()).optional().nullable(),
+        models_json_schema: z.record(z.string(), z.unknown()).nullable(),
+        created_at: z.coerce.date(),
+        updated_at: z.coerce.date(),
+        version: z.string(),
+        attributes: z.record(z.string(), z.unknown()),
+        pre_built: z.boolean(),
+        is_public: z.boolean(),
+        input: z.string().nullable(),
+        sync_type: z.enum(['full', 'incremental']).nullable(),
+        metadata: z.record(z.string(), z.unknown()),
+        sdk_version: z.string().nullable()
+    }),
+    runnerFlags: z.looseObject({
+        validateActionInput: z.boolean().default(false),
+        validateActionOutput: z.boolean().default(false),
+        validateSyncRecords: z.boolean().default(false),
+        validateSyncMetadata: z.boolean().default(false)
+    }),
+    logger: z
+        .looseObject({
+            level: z.enum(['debug', 'info', 'warn', 'error', 'off'])
+        })
+        .default({ level: 'info' }),
+    debug: z.boolean(),
+    startedAt: z.coerce.date(),
+    endUser: z
+        .object({
+            id: z.number(),
+            endUserId: z.string().nullable(),
+            orgId: z.string().nullable()
+        })
+        .nullable(),
+    heartbeatTimeoutSecs: z.number().optional(),
+    isCLI: z.boolean().optional(),
+    integrationConfig: z.record(z.string(), z.unknown()).optional()
+});

--- a/packages/jobs/lib/schemas/nango-props.ts
+++ b/packages/jobs/lib/schemas/nango-props.ts
@@ -2,31 +2,19 @@ import { z } from 'zod';
 
 import { operationIdRegex } from '@nangohq/logs';
 
-/**
- * Zod schema for NangoProps, matching the shape from @nangohq/types (packages/types/lib/runner/sdk.ts).
- * Used when parsing serialized nangoProps (e.g. from Lambda request payloads or task callbacks).
- */
 export const nangoPropsSchema = z.looseObject({
-    scriptType: z.enum(['sync', 'action', 'webhook', 'on-event']),
-    host: z.string().optional(),
-    secretKey: z.string().min(1),
+    scriptType: z.enum(['action', 'webhook', 'sync', 'on-event']),
+    connectionId: z.string().min(1),
+    nangoConnectionId: z.number(),
+    environmentId: z.number(),
+    environmentName: z.string().min(1),
+    providerConfigKey: z.string().min(1),
+    provider: z.string().min(1),
     team: z.object({
         id: z.number(),
         name: z.string().min(1)
     }),
-    connectionId: z.string().min(1),
-    environmentId: z.number(),
-    environmentName: z.string().min(1),
-    activityLogId: operationIdRegex,
-    providerConfigKey: z.string().min(1),
-    provider: z.string().min(1),
-    lastSyncDate: z.coerce.date().optional(),
-    syncId: z.string().uuid().optional(),
-    syncVariant: z.string().optional(),
-    nangoConnectionId: z.number(),
-    syncJobId: z.number().optional(),
-    track_deletes: z.boolean().optional(),
-    attributes: z.record(z.string(), z.unknown()).optional(),
+    heartbeatTimeoutSecs: z.number().optional(),
     syncConfig: z.looseObject({
         id: z.number(),
         sync_name: z.string().min(1),
@@ -40,23 +28,35 @@ export const nangoPropsSchema = z.looseObject({
         track_deletes: z.boolean(),
         auto_start: z.boolean(),
         enabled: z.boolean(),
-        webhook_subscriptions: z.array(z.string()).nullable(),
-        model_schema: z.array(z.unknown()).optional().nullable(),
-        models_json_schema: z.record(z.string(), z.unknown()).nullable(),
+        webhook_subscriptions: z.array(z.string()).or(z.null()),
+        model_schema: z.array(z.any()).optional().nullable(),
+        models_json_schema: z.object({}).nullable(),
         created_at: z.coerce.date(),
         updated_at: z.coerce.date(),
         version: z.string(),
-        attributes: z.record(z.string(), z.unknown()),
+        attributes: z.record(z.string(), z.any()),
         pre_built: z.boolean(),
         is_public: z.boolean(),
         input: z.string().nullable(),
         sync_type: z.enum(['full', 'incremental']).nullable(),
-        metadata: z.record(z.string(), z.unknown()),
+        metadata: z.record(z.string(), z.any()),
         sdk_version: z.string().nullable()
+        // TODO: fix this missing fields
+        // deleted: z.boolean().optional(),
+        // deleted_at: z.coerce.date().optional().nullable(),
     }),
+    syncId: z.string().uuid().optional(),
+    syncJobId: z.number().optional(),
+    activityLogId: operationIdRegex,
+    secretKey: z.string().min(1),
+    debug: z.boolean(),
+    startedAt: z.coerce.date(),
+    endUser: z.object({ id: z.number(), endUserId: z.string().nullable(), orgId: z.string().nullable() }).nullable(),
     runnerFlags: z.looseObject({
         validateActionInput: z.boolean().default(false),
         validateActionOutput: z.boolean().default(false),
+        validateWebhookInput: z.boolean().default(false),
+        validateWebhookOutput: z.boolean().default(false),
         validateSyncRecords: z.boolean().default(false),
         validateSyncMetadata: z.boolean().default(false)
     }),
@@ -64,17 +64,5 @@ export const nangoPropsSchema = z.looseObject({
         .looseObject({
             level: z.enum(['debug', 'info', 'warn', 'error', 'off'])
         })
-        .default({ level: 'info' }),
-    debug: z.boolean(),
-    startedAt: z.coerce.date(),
-    endUser: z
-        .object({
-            id: z.number(),
-            endUserId: z.string().nullable(),
-            orgId: z.string().nullable()
-        })
-        .nullable(),
-    heartbeatTimeoutSecs: z.number().optional(),
-    isCLI: z.boolean().optional(),
-    integrationConfig: z.record(z.string(), z.unknown()).optional()
+        .default({ level: 'info' })
 });

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -17,6 +17,7 @@
     "dependencies": {
         "@aws-sdk/client-application-auto-scaling": "3.993.0",
         "@aws-sdk/client-lambda": "3.993.0",
+        "@aws-sdk/client-sqs": "3.993.0",
         "@kubernetes/client-node": "1.3.0",
         "@nangohq/account-usage": "file:../account-usage",
         "@nangohq/data-ingestion": "file:../data-ingestion",

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -539,7 +539,7 @@ export class NangoError extends NangoInternalError {
                 this.message = 'The function runtime ran out of memory';
                 break;
 
-            case 'function_runtime_timed_oud':
+            case 'function_runtime_timed_out':
                 this.status = 500;
                 this.message = 'The function runtime timed out';
                 break;

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -534,6 +534,21 @@ export class NangoError extends NangoInternalError {
                 this.message = 'Environment does not have a default API secret';
                 break;
 
+            case 'function_runtime_out_of_memory':
+                this.status = 500;
+                this.message = 'The function runtime ran out of memory';
+                break;
+
+            case 'function_runtime_timed_oud':
+                this.status = 500;
+                this.message = 'The function runtime timed out';
+                break;
+
+            case 'function_runtime_other':
+                this.status = 500;
+                this.message = 'An unknown error occurred with the function runtime';
+                break;
+
             default:
                 this.status = 500;
                 this.type = 'unhandled_' + type;

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -417,6 +417,7 @@ export const ENVS = z.object({
     LAMBDA_FUNCTION_ALIAS: z.string().optional().default('latest'),
     LAMBDA_PROVISIONED_CONCURRENCY: z.coerce.number().optional().default(1),
     LAMBDA_PROVISIONED_CONCURRENCY_SCALING_TARGET: z.coerce.number().optional().default(0.7),
+    LAMBDA_FAILURE_DESTINATION: z.url().optional(),
 
     // WEBHOOK DELIVERY CIRCUIT BREAKER
     NANGO_WEBHOOK_TIMEOUT_MS: z.coerce.number().optional().default(20_000),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -417,7 +417,7 @@ export const ENVS = z.object({
     LAMBDA_FUNCTION_ALIAS: z.string().optional().default('latest'),
     LAMBDA_PROVISIONED_CONCURRENCY: z.coerce.number().optional().default(1),
     LAMBDA_PROVISIONED_CONCURRENCY_SCALING_TARGET: z.coerce.number().optional().default(0.7),
-    LAMBDA_FAILURE_DESTINATION: z.url().optional(),
+    LAMBDA_FAILURE_DESTINATION: z.string().optional(),
 
     // WEBHOOK DELIVERY CIRCUIT BREAKER
     NANGO_WEBHOOK_TIMEOUT_MS: z.coerce.number().optional().default(20_000),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add Lambda async failure destination processing via SQS listener**

This PR introduces a Lambda async failure handling pipeline by configuring Lambda failure destinations to SQS, adding a new SQS event listener, and a Lambda invocation processor that parses failure payloads and routes them into existing error handling. It also wires the new processor into the jobs service lifecycle and adds support for the `LAMBDA_FAILURE_DESTINATION` environment variable.

Supporting changes include centralizing `nangoProps` validation into a shared schema, extending error typing for Lambda runtime failures, improving Lambda cancellation to set abort flags, and adding unit tests for the SQS listener and invocation processor. A new dependency on `@aws-sdk/client-sqs` is added.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `SqsEventListener` and `EventListener` interface to consume SQS failure messages with abort handling in `packages/jobs/lib/events/sqs.listener.ts` and `packages/jobs/lib/events/listener.ts`
• Implemented `LambdaInvocationsProcessor` to parse Lambda failure payloads and call `handleError` in `packages/jobs/lib/invocations/lambda.processor.ts`
• Configured Lambda async failure destinations via `PutFunctionEventInvokeConfigCommand` in `packages/jobs/lib/runner/lambda.ts` and added `LAMBDA_FAILURE_DESTINATION` env parsing in `packages/utils/lib/environment/parse.ts`
• Centralized `nangoPropsSchema` in `packages/jobs/lib/schemas/nango-props.ts` and reused it in `packages/jobs/lib/routes/tasks/putTask.ts`
• Updated Lambda cancellation to set abort flags via `setAbortFlag` in `packages/jobs/lib/runtime/lambda.adapter.ts` and exported `setAbortFlag` in `packages/jobs/lib/execution/operations/abort.ts`
• Extended runtime error types for Lambda failures in `packages/shared/lib/utils/error.ts`
• Added unit tests in `packages/jobs/lib/events/sqs.listener.unit.test.ts` and `packages/jobs/lib/invocations/lambda.processor.unit.test.ts`

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• SQS messages are deleted even when `onMessage` throws, which can drop failures and prevent retries in `packages/jobs/lib/events/sqs.listener.ts`
• `invocationsProcessor.start()` is fire-and-forget; listener startup failures could be unhandled unless explicitly caught in `packages/jobs/lib/app.ts`
• Lambda failure type mapping relies on string matching (`signal: killed`, `Task timed out`), which could misclassify other failure modes

</details>

---
*This summary was automatically generated by @propel-code-bot*