### PR TITLE
fix(cli): NAN-4702: improve package manager support

### DIFF
--- a/packages/cli/lib/utils.unit.test.ts
+++ b/packages/cli/lib/utils.unit.test.ts
@@ -1,0 +1,85 @@
+import fs from 'fs';
+import path from 'path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { detectPackageManager } from './utils.js';
+
+describe('detectPackageManager', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    function mockFs(dirs: Record<string, { files?: string[]; packageManager?: string }>) {
+        vi.spyOn(fs, 'readdirSync').mockImplementation((dir) => {
+            return (dirs[dir as string]?.files ?? []) as any;
+        });
+        vi.spyOn(fs, 'readFileSync').mockImplementation((filePath) => {
+            const dir = path.dirname(filePath as string);
+            const pm = dirs[dir]?.packageManager;
+            return JSON.stringify(pm ? { packageManager: pm } : {});
+        });
+    }
+
+    it('detects pnpm via lock file', () => {
+        mockFs({ '/project': { files: ['pnpm-lock.yaml'] } });
+        expect(detectPackageManager({ fullPath: '/project' })).toBe('pnpm');
+    });
+
+    it('detects yarn via lock file', () => {
+        mockFs({ '/project': { files: ['yarn.lock'] } });
+        expect(detectPackageManager({ fullPath: '/project' })).toBe('yarn');
+    });
+
+    it('detects bun via bun.lockb', () => {
+        mockFs({ '/project': { files: ['bun.lockb'] } });
+        expect(detectPackageManager({ fullPath: '/project' })).toBe('bun');
+    });
+
+    it('detects bun via bun.lock', () => {
+        mockFs({ '/project': { files: ['bun.lock'] } });
+        expect(detectPackageManager({ fullPath: '/project' })).toBe('bun');
+    });
+
+    it('falls back to npm when no signals found', () => {
+        mockFs({ '/project': { files: [] } });
+        expect(detectPackageManager({ fullPath: '/project' })).toBe('npm');
+    });
+
+    it('detects package manager via packageManager field in package.json', () => {
+        mockFs({ '/project': { files: ['package.json'], packageManager: 'pnpm@9.0.0' } });
+        expect(detectPackageManager({ fullPath: '/project' })).toBe('pnpm');
+    });
+
+    it('packageManager field takes priority over lock files', () => {
+        mockFs({ '/project': { files: ['package.json', 'pnpm-lock.yaml'], packageManager: 'yarn@4.1.0' } });
+        expect(detectPackageManager({ fullPath: '/project' })).toBe('yarn');
+    });
+
+    it('detects pnpm lock file in a parent directory (monorepo)', () => {
+        mockFs({
+            '/project/apps/integrations': { files: [] },
+            '/project/apps': { files: [] },
+            '/project': { files: ['pnpm-lock.yaml'] }
+        });
+        expect(detectPackageManager({ fullPath: '/project/apps/integrations' })).toBe('pnpm');
+    });
+
+    it('detects packageManager field in a parent package.json (monorepo)', () => {
+        mockFs({
+            '/project/apps/integrations': { files: [] },
+            '/project/apps': { files: [] },
+            '/project': { files: ['package.json'], packageManager: 'pnpm@9.0.0' }
+        });
+        expect(detectPackageManager({ fullPath: '/project/apps/integrations' })).toBe('pnpm');
+    });
+
+    it('nearest package.json wins over parent lock file', () => {
+        mockFs({
+            '/project/apps/integrations': { files: ['package.json'], packageManager: 'yarn@4.1.0' },
+            '/project/apps': { files: [] },
+            '/project': { files: ['pnpm-lock.yaml'] }
+        });
+        expect(detectPackageManager({ fullPath: '/project/apps/integrations' })).toBe('yarn');
+    });
+});

--- a/packages/cli/lib/zeroYaml/init.ts
+++ b/packages/cli/lib/zeroYaml/init.ts
@@ -91,6 +91,14 @@ export async function initZero({
             printDebug(`Running package manager install`, debug);
 
             const packageManager = detectPackageManager({ fullPath: absolutePath });
+
+            // Yarn: seed a standalone project so it's not treated as part of the
+            // parent workspace, and use node-modules linker so tsc can resolve packages.
+            if (packageManager === 'yarn' && !fs.existsSync(path.join(absolutePath, 'yarn.lock'))) {
+                await fs.promises.writeFile(path.join(absolutePath, 'yarn.lock'), '');
+                await fs.promises.writeFile(path.join(absolutePath, '.yarnrc.yml'), 'nodeLinker: node-modules\n');
+            }
+
             await execAsync(`${packageManager} install`, { cwd: absolutePath });
             spinner.succeed();
         } catch (err) {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Improve non-npm package manager support and detection. Package manager detection should now work on monorepo setups.
- Changed the logic to detect the package manager by traversing to parent if we fail to detect package manager at dir (until one is found or we reach root, in which case we default to npm)
- `nango init` for `yarn` now works out of the box, it correctly flags the nango project as standalone and uses node-modules linker
<!-- Issue ticket number and link (if applicable) -->
NAN-4702
<!-- Testing instructions (skip if just adding/editing providers) -->
Manual test:
- Create a `yarn|bun|pnpm` project. Create a subdirectory on that project. Run `nango init` on the subdirectory. After the setup is done, dependencies should have been installed with the correct package manager at the parent directory.
<!-- Summary by @propel-code-bot -->

---

The detection flow now explicitly honors the package.json#packageManager hint ahead of any lockfiles before falling back to npm, and the update introduces Vitest coverage to exercise the monorepo scenarios and priority rules.

<details>
<summary><strong>Possible Issues</strong></summary>

• `detectPackageManager` calls `fs.readdirSync` without guarding against ENOENT/EACCES, which can crash if `absolutePath` or ancestors are missing or unreadable.
• `.yarnrc.yml` is overwritten whenever Yarn is detected and no `yarn.lock` exists, potentially discarding prior configuration.

</details>

---
*This summary was automatically generated by @propel-code-bot*