### PR TITLE
fix(server): early exit on failing refresh token connections

### DIFF
--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -147,13 +147,13 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
         });
         if (credentialResponse.isErr()) {
             const err = credentialResponse.error;
+            void logCtx.error('Failed to get connection credentials', { error: err });
+            await logCtx.failed();
             if (err.type === 'connection_refresh_backoff') {
                 res.status(err.status).send({ error: { code: err.type, message: err.message } });
             } else {
-                void logCtx.error('Failed to get connection credentials', { error: err });
-                await logCtx.failed();
                 metrics.increment(metrics.Types.PROXY_FAILURE);
-                res.status(400).send({ error: { code: 'server_error', message: `Failed to get connection credentials: '${err.message}'` } });
+                res.status(err.status).send({ error: { code: 'server_error', message: `Failed to get connection credentials: '${err.message}'` } });
             }
             return;
         }

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -146,12 +146,15 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
             onRefreshFailed: connectionRefreshFailed
         });
         if (credentialResponse.isErr()) {
-            void logCtx.error('Failed to get connection credentials', { error: credentialResponse.error });
-            await logCtx.failed();
-            metrics.increment(metrics.Types.PROXY_FAILURE);
-            res.status(400).send({
-                error: { code: 'server_error', message: `Failed to get connection credentials: '${credentialResponse.error.message}'` }
-            });
+            const err = credentialResponse.error;
+            if (err.type === 'connection_refresh_backoff') {
+                res.status(err.status).send({ error: { code: err.type, message: err.message } });
+            } else {
+                void logCtx.error('Failed to get connection credentials', { error: err });
+                await logCtx.failed();
+                metrics.increment(metrics.Types.PROXY_FAILURE);
+                res.status(400).send({ error: { code: 'server_error', message: `Failed to get connection credentials: '${err.message}'` } });
+            }
             return;
         }
 

--- a/packages/shared/lib/services/connections/credentials/refresh.integration.test.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.integration.test.ts
@@ -9,6 +9,7 @@ import { createConfigSeed, createConnectionSeed, seedAccountEnvAndUser } from '.
 import encryptionManager from '../../../utils/encryption.manager.js';
 import { NangoError } from '../../../utils/error.js';
 import connectionService from '../../connection.service.js';
+import { REFRESH_FAILURE_COOLDOWN_MS } from '../utils.js';
 
 describe('refreshOrTestCredentials', () => {
     beforeAll(async () => {
@@ -364,7 +365,7 @@ describe('refreshOrTestCredentials', () => {
             expect(res.error.type).toBe('connection_refresh_backoff');
         }
 
-        // Hooks should NOT be called — we returned early before attempting the refresh
+        // Hooks should NOT be called, we returned early before attempting the refresh
         expect(onFailed).not.toHaveBeenCalled();
         expect(onSuccess).not.toHaveBeenCalled();
         expect(onTest).not.toHaveBeenCalled();
@@ -404,5 +405,86 @@ describe('refreshOrTestCredentials', () => {
         expect(res.isErr()).toBe(true);
         expect(onFailed).toHaveBeenCalled();
         expect(onTest).toHaveBeenCalled();
+    });
+
+    it('should backoff within cooldown window and retry after cooldown expires', async () => {
+        const { env, account } = await seedAccountEnvAndUser();
+        const integration = await createConfigSeed(env, 'algolia', 'algolia');
+        const connection = await createConnectionSeed({ env, provider: 'algolia', rawCredentials: { type: 'API_KEY', apiKey: 'foobar' } });
+        const decryptedConnection = encryptionManager.decryptConnection(connection);
+        if (!decryptedConnection) {
+            throw new Error('Failed to decrypt connection');
+        }
+
+        // First call: refresh fails, sets last_refresh_failure
+        const res1 = await refreshOrTestCredentials({
+            account,
+            environment: env,
+            integration,
+            instantRefresh: false,
+            connection: decryptedConnection,
+            onRefreshFailed: vi.fn(),
+            onRefreshSuccess: vi.fn(),
+            connectionTestHook: vi.fn(() => Promise.resolve(Err(new NangoError('test')))) as any,
+            logContextGetter
+        });
+        expect(res1.isErr()).toBe(true);
+
+        // Second call: within cooldown window, should not attempt refresh
+        const connectionAfterFailure = encryptionManager.decryptConnection((await connectionService.getConnectionById(connection.id))!);
+        if (!connectionAfterFailure) {
+            throw new Error('Failed to decrypt connection');
+        }
+        const onTest2 = vi.fn();
+        const onFailed2 = vi.fn();
+        const res2 = await refreshOrTestCredentials({
+            account,
+            environment: env,
+            integration,
+            instantRefresh: false,
+            connection: connectionAfterFailure,
+            onRefreshFailed: onFailed2,
+            onRefreshSuccess: vi.fn(),
+            connectionTestHook: onTest2,
+            logContextGetter
+        });
+        expect(res2.isErr()).toBe(true);
+        if (res2.isErr()) {
+            expect(res2.error.type).toBe('connection_refresh_backoff');
+        }
+        expect(onTest2).not.toHaveBeenCalled();
+        expect(onFailed2).not.toHaveBeenCalled();
+
+        // Simulate cooldown expiry by backdating last_refresh_failure
+        const connectionForBackdate = encryptionManager.decryptConnection((await connectionService.getConnectionById(connection.id))!);
+        if (!connectionForBackdate) {
+            throw new Error('Failed to decrypt connection');
+        }
+        await connectionService.updateConnection({
+            ...connectionForBackdate,
+            last_refresh_failure: new Date(Date.now() - REFRESH_FAILURE_COOLDOWN_MS - 1000)
+        });
+
+        // Third call: after cooldown, refresh is attempted and succeeds
+        const connectionAfterCooldown = encryptionManager.decryptConnection((await connectionService.getConnectionById(connection.id))!);
+        if (!connectionAfterCooldown) {
+            throw new Error('Failed to decrypt connection');
+        }
+        const onTest3 = vi.fn(() => Promise.resolve(Ok({ tested: true }))) as any;
+        const onSuccess3 = vi.fn();
+        const res3 = await refreshOrTestCredentials({
+            account,
+            environment: env,
+            integration,
+            instantRefresh: false,
+            connection: connectionAfterCooldown,
+            onRefreshFailed: vi.fn(),
+            onRefreshSuccess: onSuccess3,
+            connectionTestHook: onTest3,
+            logContextGetter
+        });
+        expect(res3.isOk()).toBe(true);
+        expect(onTest3).toHaveBeenCalled();
+        expect(onSuccess3).toHaveBeenCalled();
     });
 });

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -9,7 +9,7 @@ import providerClient from '../../../clients/provider.client.js';
 import { NangoError } from '../../../utils/error.js';
 import { isTokenExpired } from '../../../utils/utils.js';
 import connectionService from '../../connection.service.js';
-import { REFRESH_FAILURE_COOLDOWN_MS, REFRESH_MARGIN_S, getExpiresAtFromCredentials } from '../utils.js';
+import { REFRESH_FAILURE_COOLDOWN_MS, REFRESH_MARGIN_MS, getExpiresAtFromCredentials } from '../utils.js';
 
 import type { Config, Config as ProviderConfig } from '../../../models/index.js';
 import type { NangoInternalError } from '../../../utils/error.js';
@@ -536,13 +536,14 @@ export async function shouldRefreshCredentials({
     instantRefresh: boolean;
     refreshGithubAppJwtToken?: boolean | undefined;
 }): Promise<{ should: boolean; reason: string }> {
+    const expirationBufferInSeconds = provider.token_expiration_buffer || REFRESH_MARGIN_MS / 1000;
     if (refreshGithubAppJwtToken && (providerConfig.provider === 'github-app' || providerConfig.provider === 'github-app-oauth')) {
         if (connection.connection_config['jwtToken']) {
             const tokenValue = connection.connection_config['jwtToken'];
             const decodedValue = decodeJwt(tokenValue);
             if (decodedValue && decodedValue['exp']) {
                 const exp = new Date(decodedValue['exp'] * 1000);
-                if (isTokenExpired(exp, provider.token_expiration_buffer || REFRESH_MARGIN_S)) {
+                if (isTokenExpired(exp, expirationBufferInSeconds)) {
                     return { should: true, reason: 'expired_jwt_token' };
                 }
             }
@@ -553,7 +554,7 @@ export async function shouldRefreshCredentials({
         if (connection.connection_config['sharepointAccessToken']) {
             if (connection.connection_config['sharepointAccessToken']['expires_at']) {
                 const exp = new Date(connection.connection_config['sharepointAccessToken']['expires_at']);
-                if (isTokenExpired(exp, provider.token_expiration_buffer || REFRESH_MARGIN_S)) {
+                if (isTokenExpired(exp, expirationBufferInSeconds)) {
                     return { should: true, reason: 'expired_sharepoint_access_token' };
                 }
             }
@@ -564,11 +565,15 @@ export async function shouldRefreshCredentials({
         if (connection.connection_config['botFrameworkAccessToken']) {
             if (connection.connection_config['botFrameworkAccessToken']['expires_at']) {
                 const exp = new Date(connection.connection_config['botFrameworkAccessToken']['expires_at']);
-                if (isTokenExpired(exp, provider.token_expiration_buffer || REFRESH_MARGIN_S)) {
+                if (isTokenExpired(exp, expirationBufferInSeconds)) {
                     return { should: true, reason: 'expired_bot_framework_access_token' };
                 }
             }
         }
+    }
+
+    if (providerConfig.provider === 'facebook' || providerConfig.provider === 'instagram') {
+        return { should: instantRefresh, reason: providerConfig.provider };
     }
 
     if (!instantRefresh) {
@@ -581,16 +586,12 @@ export async function shouldRefreshCredentials({
 
         if (!credentials.expires_at) {
             return { should: false, reason: 'no_expires_at' };
-        } else if (!isTokenExpired(credentials.expires_at, provider.token_expiration_buffer || REFRESH_MARGIN_S)) {
+        } else if (!isTokenExpired(credentials.expires_at, expirationBufferInSeconds)) {
             return { should: false, reason: 'fresh' };
         }
     }
 
     // -- At this stage credentials need a refresh whether it's forced or because they are expired
-
-    if (providerConfig.provider === 'facebook' || providerConfig.provider === 'instagram') {
-        return { should: instantRefresh, reason: providerConfig.provider };
-    }
 
     if (credentials.type === 'OAUTH2') {
         // normally we refresh using a refresh_token for OAUTH2 providers, but microsoft-admin uses the client_credentials flow and doesn't return a refresh_token.

--- a/packages/shared/lib/services/connections/credentials/refresh.unit.test.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.unit.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { shouldRefreshCredentials } from './refresh.js';
 import { getTestConnection } from '../../../seeders/connection.seeder.js';
-import { REFRESH_MARGIN_S } from '../utils.js';
+import { REFRESH_MARGIN_MS } from '../utils.js';
 
 import type { Config } from '../../../models/index.js';
 import type { ProviderOAuth2 } from '@nangohq/types';
@@ -128,7 +128,7 @@ describe('shouldRefreshCredentials', () => {
                     client_id: '',
                     client_secret: '',
                     token: '',
-                    expires_at: new Date(Date.now() + REFRESH_MARGIN_S * 2000),
+                    expires_at: new Date(Date.now() + REFRESH_MARGIN_MS * 2),
                     raw: {}
                 },
                 instantRefresh: false,

--- a/packages/shared/lib/services/connections/utils.ts
+++ b/packages/shared/lib/services/connections/utils.ts
@@ -7,7 +7,7 @@ export const DEFAULT_OAUTHCC_EXPIRES_AT_MS = ms('55minutes'); // This ensures we
 export const DEFAULT_INFINITE_EXPIRES_AT_MS = ms('99years');
 export const MAX_CONSECUTIVE_DAYS_FAILED_REFRESH = 4;
 export const REFRESH_FAILURE_COOLDOWN_MS = ms('30seconds');
-export const REFRESH_MARGIN_MS = ms('15minutes') / 1000;
+export const REFRESH_MARGIN_MS = ms('15minutes');
 
 export function getExpiresAtFromCredentials(credentials: AllAuthCredentials): Date | null {
     if (credentials.type === 'CUSTOM' && 'app' in credentials) {

--- a/packages/shared/lib/services/connections/utils.ts
+++ b/packages/shared/lib/services/connections/utils.ts
@@ -6,6 +6,7 @@ export const DEFAULT_EXPIRES_AT_MS = ms('1day');
 export const DEFAULT_OAUTHCC_EXPIRES_AT_MS = ms('55minutes'); // This ensures we have an expiresAt value
 export const DEFAULT_INFINITE_EXPIRES_AT_MS = ms('99years');
 export const MAX_CONSECUTIVE_DAYS_FAILED_REFRESH = 4;
+export const REFRESH_FAILURE_COOLDOWN_MS = ms('30seconds');
 export const REFRESH_MARGIN_S = ms('15minutes') / 1000;
 
 export function getExpiresAtFromCredentials(credentials: AllAuthCredentials): Date | null {

--- a/packages/shared/lib/services/connections/utils.ts
+++ b/packages/shared/lib/services/connections/utils.ts
@@ -7,7 +7,7 @@ export const DEFAULT_OAUTHCC_EXPIRES_AT_MS = ms('55minutes'); // This ensures we
 export const DEFAULT_INFINITE_EXPIRES_AT_MS = ms('99years');
 export const MAX_CONSECUTIVE_DAYS_FAILED_REFRESH = 4;
 export const REFRESH_FAILURE_COOLDOWN_MS = ms('30seconds');
-export const REFRESH_MARGIN_S = ms('15minutes') / 1000;
+export const REFRESH_MARGIN_MS = ms('15minutes') / 1000;
 
 export function getExpiresAtFromCredentials(credentials: AllAuthCredentials): Date | null {
     if (credentials.type === 'CUSTOM' && 'app' in credentials) {

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -292,6 +292,11 @@ export class NangoError extends NangoInternalError {
                 this.message = 'The refresh limit has been reached for this connection.';
                 break;
 
+            case 'connection_refresh_backoff':
+                this.status = 424;
+                this.message = 'A recent refresh attempt failed. Backing off before retrying.';
+                break;
+
             case 'connection_test_failed':
                 this.status = status || 400;
                 this.message = `The given credentials were found to be invalid${status ? ` and received a ${status} on a test API call` : ''}. Please check the credentials and try again.`;


### PR DESCRIPTION
<!-- Describe the problem and your solution -->

When a connection refresh fails, subsequent refresh attempts are skipped for 30 seconds after the last failure. This prevents high-frequency syncs and action calls from hammering a failing connection on every request. After 30 seconds, the refresh is attempted again normally. Force refreshes (manual) always bypass this cooldown.

During the cooldown window, the proxy returns HTTP 424 with error code connection_refresh_backoff instead of counting it as a PROXY_FAILURE, keeping metrics clean.

- Why 30 seconds?
Short enough to recover quickly from transient provider outages, while still dramatically reducing the blast radius of a burst failure. A 30s cooldown reduces ~60k daily attempts down to ~3k.

**Context: INC-88**
A customer had a single connection generating ~60k failed refresh attempts in a day. Their sync was retrying the refresh on every request after receiving a failed auth webhook. With this change, only ~3k of those attempts will actually hit the provider, and those will be returned as 424s rather than counted as server errors in metrics.

What changed:
  - `connection_refresh_backoff`: new error type for the cooldown early-exit, distinct from the existing `connection_refresh_exhausted` (which fires after 4 consecutive days of failures)
  - `REFRESH_FAILURE_COOLDOWN_MS`: configurable constant for the cooldown window (currently 30s)
  - Proxy returns 424 with `connection_refresh_backoff` code and skips `PROXY_FAILURE` metric increment during the cooldown window

<!-- Issue ticket number and link (if applicable) -->
NAN-4634
INC-88
<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

Supporting timing constants were standardized to milliseconds, and the rollout is backed by integration and unit tests that validate cooldown expiry, refresh exhaustion handling, and the instant-refresh exceptions to ensure the backoff behaves reliably.

<details>
<summary><strong>Possible Issues</strong></summary>

• Services other than the proxy that call `refreshOrTestCredentials` may need explicit handling for `connection_refresh_backoff` to avoid surfacing generic 5xxs.
• Cooldown responses skip `metrics.Types.PROXY_FAILURE`; ensure alternative metrics capture frequency of backoffs for observability.

</details>

---
*This summary was automatically generated by @propel-code-bot*