### PR TITLE
fix(recruitcrm): use correct API base URL (api.recruitcrm.io)

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -12861,7 +12861,7 @@ recruitcrm:
         - hr
     auth_mode: API_KEY
     proxy:
-        base_url: https://api.recruitcrm.com
+        base_url: https://api.recruitcrm.io
         headers:
             authorization: Bearer ${apiKey}
         verification:


### PR DESCRIPTION
## Summary
RecruitCRM's API base URL in the provider config is incorrect. The API is served at `api.recruitcrm.io`, not `api.recruitcrm.com`.

## Change
- **File:** `packages/providers/providers.yaml`
- **Update:** `proxy.base_url` for `recruitcrm` from `https://api.recruitcrm.com` to `https://api.recruitcrm.io`

## Reference
- [RecruitCRM API documentation](https://docs.recruitcrm.io/docs/rcrm-api-reference/ZG9jOjMyNzk0NA-getting-started) uses `api.recruitcrm.io`
- Connection/verification requests were failing with the `.com` domain

<!-- Summary by @propel-code-bot -->

---

Please verify that no other components still assume the api.recruitcrm.com host, in case RecruitCRM later aliases both domains.

<details>
<summary><strong>Possible Issues</strong></summary>

• If RecruitCRM ever aliases both domains, ensure no other parts of the system assume the `.com` host.

</details>

---
*This summary was automatically generated by @propel-code-bot*