### PR TITLE
fix(providers): fix timify refresh token

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -15979,6 +15979,7 @@ timify:
     auth_mode: TWO_STEP
     body_format: json
     token_url: https://${connectionConfig.subdomain}.timify.com/v1/auth/token
+    refresh_url: https://${connectionConfig.subdomain}.timify.com/v1/auth/refreshtoken
     token_params:
         appid: ${credentials.appId}
         appsecret: ${credentials.appSecret}

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1306,7 +1306,7 @@ class ConnectionService {
 
         const tokenUrl = isRefresh ? (provider.refresh_url ?? provider.token_url) : provider.token_url;
         const tokenParams = isRefresh ? provider.refresh_token_params : provider.token_params;
-        const tokenHeaders = isRefresh ? provider.refresh_token_headers : provider.token_headers;
+        const tokenHeaders = isRefresh ? (provider.refresh_token_headers ?? provider.token_headers) : provider.token_headers;
 
         const strippedTokenUrl = typeof tokenUrl === 'string' ? tokenUrl.replace(/connectionConfig\./g, '') : '';
         const urlWithConnectionConfig = interpolateString(strippedTokenUrl, connectionConfig);


### PR DESCRIPTION
## Describe the problem and your solution

- Timify was initially added without testing. The customer reports that a connection is being created but token refresh is failing. Since the same headers are used to request tokens, they should also be used when refreshing tokens.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Ensure Timify OAuth refresh reuses correct headers**

Updates the generic connection service to fall back to `provider.token_headers` when a provider lacks explicit `refresh_token_headers`, ensuring refresh requests reuse the same headers as initial token requests. The Timify provider metadata now declares its `refresh_url`, allowing the platform to target the correct refresh endpoint.

<details>
<summary><strong>Key Changes</strong></summary>

• Changed `packages/shared/lib/services/connection.service.ts` so `tokenHeaders` defaults to `provider.token_headers` when `provider.refresh_token_headers` is undefined during refresh flows.
• Added `refresh_url: https://${connectionConfig.subdomain}.timify.com/v1/auth/refreshtoken` to the Timify entry in `packages/providers/providers.yaml`.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• If a provider truly needs distinct refresh headers, it must still define `refresh_token_headers`; fallback could otherwise send initial headers unexpectedly.

</details>

---
*This summary was automatically generated by @propel-code-bot*