### PR TITLE
fix(timify): use the correct param for refreshing tokens

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -15983,7 +15983,7 @@ timify:
         appid: ${credentials.appId}
         appsecret: ${credentials.appSecret}
     refresh_token_params:
-        refreshToken: ${refresh_token}
+        refreshtoken: ${refresh_token}
     token_headers:
         content-type: application/json
         accept: application/json


### PR DESCRIPTION
## Describe the problem and your solution

- We were correctly interpolating the refresh token, but using an incorrect parameter key for refreshing tokens.


<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

This PR updates the Timify provider’s refresh_token_params so the key name matches the casing expected by the Timify API, while leaving other providers and settings untouched.

<details>
<summary><strong>Possible Issues</strong></summary>

• If Timify is case-insensitive the change is harmless, but if it actually requires `refreshToken`, refreshes could now fail—confirm against the official spec.

</details>

---
*This summary was automatically generated by @propel-code-bot*