### PR TITLE
fix(github): race condition in npm publish action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.69.37] - 2026-02-24
+
+### Added
+
+- *(metrics)* Add function runtime to function executions metric (#5466)
+- *(integrations)* Add support for ms teams bot (#5463)
+- *(integrations)* Add support for tally (#5486)
+- *(OAuth)* Add more context to errors during exchange code for token (#5485)
+- *(integrations)* Add support for hubspot mcp (#5477)
+- *(integrations)* Add subdomain interpolation for timify (#5492)
+- *(webapp)* Change font to geist (#5497)
+- *(integrations)* Add support for salesmsg (#5490)
+- *(integrations)* Okta-cc support (#5482)
+
+### Changed
+
+- *(deps)* Upgrade deps (#5484)
+- Oauth callback session validation (#5493)
+
+### Fixed
+
+- Pro-rated charging of base fee (#5479)
+- *(oauth)* Validate state session ID in Oauth2 callback (#5366)
+- *(webapp)* Env-agnostic routes (#5481)
+- Set cookies to custom and mcp_oauth2 redirect (#5488)
+- *(server)* Set state cookie sameSite for cross-site redirects callbacks to nango (#5491)
+- *(validations)* Fix api key validations (#5495)
+- *(errors)* Error parsing was broken (#5499)
+- *(lambda)* Enable lambda for webhooks for new accounts (#5502)
+- *(cli)* NAN-4702: improve package manager support (#5504)
+- *(providers)* Fix timify refresh token (#5508)
+- *(timify)* Use the correct param for refreshing tokens (#5509)
+
 ## [v0.69.36] - 2026-02-18
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@nangohq/nango",
-    "version": "0.69.36",
+    "version": "0.69.37",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@nangohq/nango",
-            "version": "0.69.36",
+            "version": "0.69.37",
             "workspaces": [
                 "packages/*",
                 "scripts"
@@ -32681,7 +32681,7 @@
         },
         "packages/cli": {
             "name": "nango",
-            "version": "0.69.36",
+            "version": "0.69.37",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@babel/core": "7.28.0",
@@ -32689,10 +32689,10 @@
                 "@babel/preset-typescript": "7.27.1",
                 "@babel/traverse": "7.28.0",
                 "@babel/types": "7.28.2",
-                "@nangohq/nango-yaml": "0.69.36",
-                "@nangohq/node": "0.69.36",
-                "@nangohq/providers": "0.69.36",
-                "@nangohq/runner-sdk": "0.69.36",
+                "@nangohq/nango-yaml": "0.69.37",
+                "@nangohq/node": "0.69.37",
+                "@nangohq/providers": "0.69.37",
+                "@nangohq/runner-sdk": "0.69.37",
                 "@swc/core": "1.13.2",
                 "@types/unzipper": "0.10.11",
                 "ajv": "8.17.1",
@@ -32730,7 +32730,7 @@
                 "nango": "dist/index.js"
             },
             "devDependencies": {
-                "@nangohq/types": "0.69.36",
+                "@nangohq/types": "0.69.37",
                 "@types/babel__core": "7.20.5",
                 "@types/babel__traverse": "7.20.7",
                 "@types/columnify": "1.5.4",
@@ -33258,10 +33258,10 @@
         },
         "packages/frontend": {
             "name": "@nangohq/frontend",
-            "version": "0.69.36",
+            "version": "0.69.37",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@nangohq/types": "0.69.36"
+                "@nangohq/types": "0.69.37"
             }
         },
         "packages/jobs": {
@@ -33838,13 +33838,13 @@
         },
         "packages/nango-yaml": {
             "name": "@nangohq/nango-yaml",
-            "version": "0.69.36",
+            "version": "0.69.37",
             "dependencies": {
                 "js-yaml": "4.1.1",
                 "ms": "3.0.0-canary.1"
             },
             "devDependencies": {
-                "@nangohq/types": "0.69.36",
+                "@nangohq/types": "0.69.37",
                 "vitest": "3.2.4"
             }
         },
@@ -33857,10 +33857,10 @@
         },
         "packages/node-client": {
             "name": "@nangohq/node",
-            "version": "0.69.36",
+            "version": "0.69.37",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@nangohq/types": "0.69.36",
+                "@nangohq/types": "0.69.37",
                 "axios": "1.13.5"
             },
             "devDependencies": {
@@ -33950,12 +33950,12 @@
         },
         "packages/providers": {
             "name": "@nangohq/providers",
-            "version": "0.69.36",
+            "version": "0.69.37",
             "dependencies": {
                 "js-yaml": "4.1.1"
             },
             "devDependencies": {
-                "@nangohq/types": "0.69.36",
+                "@nangohq/types": "0.69.37",
                 "vitest": "3.2.4"
             }
         },
@@ -34070,17 +34070,17 @@
         },
         "packages/runner-sdk": {
             "name": "@nangohq/runner-sdk",
-            "version": "0.69.36",
+            "version": "0.69.37",
             "dependencies": {
-                "@nangohq/node": "0.69.36",
-                "@nangohq/providers": "0.69.36",
+                "@nangohq/node": "0.69.37",
+                "@nangohq/providers": "0.69.37",
                 "ajv": "8.17.1",
                 "ajv-formats": "3.0.1",
                 "lodash-es": "4.17.21",
                 "parse-link-header": "2.0.0"
             },
             "devDependencies": {
-                "@nangohq/types": "0.69.36",
+                "@nangohq/types": "0.69.37",
                 "@types/json-schema": "7.0.15",
                 "axios": "1.13.5",
                 "json-schema": "0.4.0",
@@ -34471,7 +34471,7 @@
         },
         "packages/types": {
             "name": "@nangohq/types",
-            "version": "0.69.36",
+            "version": "0.69.37",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "axios": "1.13.5",
@@ -34551,7 +34551,7 @@
                 "@hookform/resolvers": "5.2.2",
                 "@mantine/core": "7.12.1",
                 "@mantine/prism": "5.10.5",
-                "@nangohq/frontend": "0.69.36",
+                "@nangohq/frontend": "0.69.37",
                 "@nangohq/types": "file:../types",
                 "@radix-ui/react-accordion": "1.2.2",
                 "@radix-ui/react-avatar": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@nangohq/nango",
     "type": "module",
-    "version": "0.69.36",
+    "version": "0.69.37",
     "workspaces": [
         "packages/*",
         "scripts"

--- a/packages/cli/lib/version.ts
+++ b/packages/cli/lib/version.ts
@@ -1,1 +1,1 @@
-export const NANGO_VERSION = '0.69.36';
+export const NANGO_VERSION = '0.69.37';

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nango",
-    "version": "0.69.36",
+    "version": "0.69.37",
     "description": "Nango's CLI tool.",
     "type": "module",
     "bin": {
@@ -40,10 +40,10 @@
         "@babel/preset-typescript": "7.27.1",
         "@babel/traverse": "7.28.0",
         "@babel/types": "7.28.2",
-        "@nangohq/nango-yaml": "0.69.36",
-        "@nangohq/node": "0.69.36",
-        "@nangohq/providers": "0.69.36",
-        "@nangohq/runner-sdk": "0.69.36",
+        "@nangohq/nango-yaml": "0.69.37",
+        "@nangohq/node": "0.69.37",
+        "@nangohq/providers": "0.69.37",
+        "@nangohq/runner-sdk": "0.69.37",
         "@swc/core": "1.13.2",
         "@types/unzipper": "0.10.11",
         "ajv": "8.17.1",
@@ -78,7 +78,7 @@
         "zod": "4.0.5"
     },
     "devDependencies": {
-        "@nangohq/types": "0.69.36",
+        "@nangohq/types": "0.69.37",
         "@types/babel__core": "7.20.5",
         "@types/babel__traverse": "7.20.7",
         "@types/columnify": "1.5.4",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nangohq/frontend",
-    "version": "0.69.36",
+    "version": "0.69.37",
     "description": "Nango's frontend library for OAuth handling.",
     "type": "module",
     "main": "dist/index.js",
@@ -15,7 +15,7 @@
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "scripts": {},
     "dependencies": {
-        "@nangohq/types": "0.69.36"
+        "@nangohq/types": "0.69.37"
     },
     "files": [
         "dist/**/*.js",

--- a/packages/nango-yaml/package.json
+++ b/packages/nango-yaml/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nangohq/nango-yaml",
-    "version": "0.69.36",
+    "version": "0.69.37",
     "type": "module",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
@@ -17,7 +17,7 @@
         "ms": "3.0.0-canary.1"
     },
     "devDependencies": {
-        "@nangohq/types": "0.69.36",
+        "@nangohq/types": "0.69.37",
         "vitest": "3.2.4"
     },
     "files": [

--- a/packages/node-client/lib/version.ts
+++ b/packages/node-client/lib/version.ts
@@ -1,1 +1,1 @@
-export const NANGO_VERSION = '0.69.36';
+export const NANGO_VERSION = '0.69.37';

--- a/packages/node-client/package.json
+++ b/packages/node-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nangohq/node",
-    "version": "0.69.36",
+    "version": "0.69.37",
     "description": "Nango's Node client.",
     "type": "module",
     "main": "dist/index.js",
@@ -25,7 +25,7 @@
     },
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
-        "@nangohq/types": "0.69.36",
+        "@nangohq/types": "0.69.37",
         "axios": "1.13.5"
     },
     "engines": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nangohq/providers",
-    "version": "0.69.36",
+    "version": "0.69.37",
     "description": "Nango's providers.yaml and getters",
     "type": "module",
     "main": "./dist/index.js",
@@ -16,7 +16,7 @@
         "js-yaml": "4.1.1"
     },
     "devDependencies": {
-        "@nangohq/types": "0.69.36",
+        "@nangohq/types": "0.69.37",
         "vitest": "3.2.4"
     },
     "files": [

--- a/packages/runner-sdk/package.json
+++ b/packages/runner-sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nangohq/runner-sdk",
-    "version": "0.69.36",
+    "version": "0.69.37",
     "description": "Nango's Runner SDK",
     "type": "module",
     "main": "dist/index.js",
@@ -10,15 +10,15 @@
         "directory": "packages/runner-sdk"
     },
     "dependencies": {
-        "@nangohq/node": "0.69.36",
-        "@nangohq/providers": "0.69.36",
+        "@nangohq/node": "0.69.37",
+        "@nangohq/providers": "0.69.37",
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
         "lodash-es": "4.17.21",
         "parse-link-header": "2.0.0"
     },
     "devDependencies": {
-        "@nangohq/types": "0.69.36",
+        "@nangohq/types": "0.69.37",
         "@types/json-schema": "7.0.15",
         "axios": "1.13.5",
         "json-schema": "0.4.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nangohq/types",
-    "version": "0.69.36",
+    "version": "0.69.37",
     "description": "Types used in Nango applications",
     "type": "module",
     "typings": "dist/index.d.ts",

--- a/packages/utils/lib/version.ts
+++ b/packages/utils/lib/version.ts
@@ -1,1 +1,1 @@
-export const NANGO_VERSION = '0.69.36';
+export const NANGO_VERSION = '0.69.37';

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -28,7 +28,7 @@
         "@hookform/resolvers": "5.2.2",
         "@mantine/core": "7.12.1",
         "@mantine/prism": "5.10.5",
-        "@nangohq/frontend": "0.69.36",
+        "@nangohq/frontend": "0.69.37",
         "@nangohq/types": "file:../types",
         "@radix-ui/react-accordion": "1.2.2",
         "@radix-ui/react-avatar": "1.1.2",

--- a/scripts/gitrelease.mjs
+++ b/scripts/gitrelease.mjs
@@ -36,8 +36,12 @@ echo`Creating tag`;
 await $`git tag -a ${nextTag} HEAD -m ${releaseMessage}`;
 
 echo`Pushing`;
-await $`git push --follow-tags origin HEAD:refs/heads/${branch}`;
-await $`git push --tags origin`;
+// Rebase on latest to handle commits that landed on ${branch} during publish
+await $`git fetch origin ${branch}`;
+await $`git rebase origin/${branch}`;
+// Push branch and tag separately — tag intentionally points to the pre-rebase commit
+await $`git push origin HEAD:refs/heads/${branch}`;
+await $`git push origin ${nextTag}`;
 
 echo`Commit pushed, publishing release...`;
 // Push GitHub release


### PR DESCRIPTION
## What happened

The NPM publish action for `0.69.37` failed because a PR was merged into master while the publish step was running. By the time `gitrelease.mjs` tried to push the release commit, master had moved forward and the push was rejected (non-fast-forward). The tag `v0.69.37` was pushed successfully but the release commit never made it to master.

## Fix

`gitrelease.mjs` now rebases the release commit on top of the latest `origin/master` before pushing, handling any commits that landed during the npm publish step.

The tag is created before the rebase so it always points to the exact commit that was built and published, not a rebased copy that might include unrelated changes. Branch and tag are then pushed separately.

- In the normal case (no race) the behavior is identical.
- In the race case: the tag points to the release commit (off master's linear history), and master's tip is the rebased copy.

This PR also includes the `0.69.37` version bump and changelog that failed to land.

<!-- Summary by @propel-code-bot -->

---

It also reapplies every 0.69.37 release artifact that was published but failed to land—covering the lockfile and the rest of the release metadata—so the repository once again mirrors the state that was shipped.

<details>
<summary><strong>Possible Issues</strong></summary>

• If the rebase encounters conflicts, the script currently has no handling and will exit; operators may need guidance on manual recovery.
• Because the tag is created before the rebase, the tagged commit can diverge from the rebased commit on `master`, which might surprise anyone expecting the tag to point into `master`’s history.

</details>

---
*This summary was automatically generated by @propel-code-bot*