### PR TITLE
feat(integrations): add support for granola-mcp

### DIFF
--- a/docs/api-integrations/granola-mcp.mdx
+++ b/docs/api-integrations/granola-mcp.mdx
@@ -1,0 +1,96 @@
+---
+title: 'Granola (MCP)'
+sidebarTitle: 'Granola (MCP)'
+description: 'Integrate your application with the Granola MCP API'
+---
+
+## 🚀 Quickstart
+
+Connect to Granola (MCP) with Nango and start calling tools in minutes. Granola MCP uses OAuth 2.0 with dynamic client registration, meaning no app registration is required.
+
+<Steps>
+    <Step title="Create the integration">
+    In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Granola (MCP)_.
+    </Step>
+    <Step title="Authorize Granola">
+    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then log in to Granola. Later, you'll let your users do the same directly from your app.
+    </Step>
+    <Step title="Call a Granola MCP tool">
+    Make your first MCP request to Granola (e.g. call a tool). Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+    <Tabs>
+        <Tab title="cURL">
+
+            ```bash
+            curl "https://api.nango.dev/mcp" \
+              -X POST \
+              -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+              -H "Provider-Config-Key: <INTEGRATION-ID>" \
+              -H "Connection-Id: <CONNECTION-ID>" \
+              -H "Content-Type: application/json" \
+              -d '{
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "list_meetings",
+                    "arguments": {
+                        "limit": 10
+                    }
+                }
+            }'
+            ```
+
+        </Tab>
+
+        <Tab title="Node">
+
+        Install Nango's backend SDK with `npm i @nangohq/node`. Then run:
+
+        ```typescript
+        import { Nango } from '@nangohq/node';
+
+        const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+
+        const res = await nango.post({
+            endpoint: '/mcp',
+            providerConfigKey: '<INTEGRATION-ID>',
+            connectionId: '<CONNECTION-ID>',
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: {
+                    name: 'list_meetings',
+                    arguments: { limit: 10 }
+                }
+            }
+        });
+
+        console.log(res.data);
+        ```
+        </Tab>
+
+    </Tabs>
+    ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+    </Step>
+
+    <Step title="Implement Nango in your app">
+        Follow our [Auth implementation guide](/implementation-guides/platform/auth/implement-api-auth) to integrate Nango in your app.
+    </Step>
+</Steps>
+
+## 📚 Granola (MCP) Integration Guides
+
+Nango uses **dynamic client registration** with Granola's OAuth server. You do not need to register an MCP application, just create the integration in Nango and authorize with your Granola account.
+
+Official docs: [Granola MCP](https://docs.granola.ai/help-center/sharing/integrations/mcp)
+
+## 🧩 Pre-built syncs & actions for Granola (MCP)
+
+Enable them in your dashboard. [Extend and customize](/implementation-guides/platform/functions/customize-template) to fit your needs.
+
+import PreBuiltUseCases from "/snippets/generated/granola-mcp/PreBuiltUseCases.mdx"
+
+<PreBuiltUseCases />
+
+---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -486,6 +486,7 @@
               "api-integrations/google-search-console",
               "api-integrations/google-sheet",
               "api-integrations/granola",
+              "api-integrations/granola-mcp",
               "api-integrations/glyphic",
               "api-integrations/grist",
               "integrations/all/google-slides",

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -6432,6 +6432,32 @@ granola:
             pattern: '^grn_[A-Za-z0-9]+_[A-Za-z0-9]+$'
             doc_section: '#step-1-generating-your-granola-api-token'
 
+granola-mcp:
+    display_name: Granola (MCP)
+    categories:
+        - productivity
+        - knowledge-base
+        - mcp
+    auth_mode: MCP_OAUTH2
+    client_registration: dynamic
+    authorization_url: https://mcp-auth.granola.ai/oauth2/authorize
+    token_url: https://mcp-auth.granola.ai/oauth2/token
+    registration_url: https://mcp-auth.granola.ai/oauth2/register
+    default_scopes:
+        - offline_access
+    authorization_params:
+        response_type: code
+        resource: https://mcp.granola.ai/
+    token_params:
+        grant_type: authorization_code
+    refresh_params:
+        grant_type: refresh_token
+    proxy:
+        headers:
+            accept: application/json,text/event-stream
+        base_url: https://mcp.granola.ai
+    docs: https://nango.dev/docs/api-integrations/granola-mcp
+
 guru:
     display_name: Guru
     categories:

--- a/packages/server/lib/controllers/v1/integrations/postIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/postIntegration.ts
@@ -82,6 +82,9 @@ export const postIntegration = asyncWrapper<PostIntegration>(async (req, res) =>
             if (clientRegistration === 'dynamic') {
                 const mcpClientId = await mcpClient.registerClientId({ provider, environment, team: account });
                 config.oauth_client_id = mcpClientId;
+                // currently, dynamic client registration sets "token_endpoint_auth_method" to "none".
+                // This results in no `client_secret` being issued, as the flow uses PKCE instead of passing the client secret in the request body or headers.
+                config.oauth_client_secret = '';
             }
             // static: client_id/secret come from body.auth
             // metadata: not implemented (TODO)

--- a/packages/webapp/public/images/template-logos/granola-mcp.svg
+++ b/packages/webapp/public/images/template-logos/granola-mcp.svg
@@ -1,0 +1,1 @@
+granola.svg


### PR DESCRIPTION
## Describe the problem and your solution

- add support for granola-mcp

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Adds Granola MCP integration with docs and config tweaks**

Introduces a new `granola-mcp` provider definition, associated documentation, and UI assets so users can authorize and call Granola MCP tools through Nango. Also adapts the dynamic MCP OAuth flow to explicitly clear `config.oauth_client_secret`, matching the provider’s `token_endpoint_auth_method: none` behavior.

<details>
<summary><strong>Key Changes</strong></summary>

• Registered `granola-mcp` in `packages/providers/providers.yaml` with MCP OAuth endpoints, scopes, proxy headers, and documentation link
• Documented setup, quickstart, and prebuilt syncs in `docs/api-integrations/granola-mcp.mdx` and surfaced the page via `docs/docs.json`
• Ensured `postIntegration` assigns an empty `oauth_client_secret` when MCP dynamic registration returns no secret
• Added placeholder logo reference `granola-mcp.svg` under `packages/webapp/public/images/template-logos/`

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Logo asset may be invalid since the file is plain text referencing another SVG rather than actual SVG content.
• Setting an empty string secret might still serialize to storage columns expecting `NULL`; verify DB schema tolerates this.

</details>

---
*This summary was automatically generated by @propel-code-bot*