### PR TITLE
chore(runner): expose error.cause in http client

### DIFF
--- a/packages/runner/lib/clients/http.ts
+++ b/packages/runner/lib/clients/http.ts
@@ -81,7 +81,7 @@ export async function httpFetch(url: string | URL, options?: HttpFetchOptions, b
                 }
 
                 // Non-retryable error
-                return new Response(JSON.stringify({ error: stringifyError(err) }), {
+                return new Response(JSON.stringify({ error: stringifyError(err, { cause: true }) }), {
                     status: 502,
                     headers: { 'Content-Type': 'application/json' }
                 });
@@ -89,7 +89,7 @@ export async function httpFetch(url: string | URL, options?: HttpFetchOptions, b
         }, backoffOptions);
     } catch (err) {
         // All retries exhausted
-        return new Response(JSON.stringify({ error: stringifyError(err) }), {
+        return new Response(JSON.stringify({ error: stringifyError(err, { cause: true }) }), {
             status: 502,
             headers: { 'Content-Type': 'application/json' }
         });

--- a/packages/utils/lib/errors.ts
+++ b/packages/utils/lib/errors.ts
@@ -26,9 +26,9 @@ export function errorToObject(err: unknown): ErrorObject {
 /**
  * Transform any Error or primitive to a string
  */
-export function stringifyError(err: unknown, opts?: { pretty?: boolean; stack?: boolean }) {
+export function stringifyError(err: unknown, opts?: { pretty?: boolean; stack?: boolean; cause?: boolean }): string {
     const serialized = serializeError(err);
-    const allowedErrorProperties = ['name', 'message', 'provider_error_payload', ...(opts?.stack ? ['stack', 'cause'] : [])];
+    const allowedErrorProperties = ['name', 'message', 'provider_error_payload', ...(opts?.stack ? ['stack'] : []), ...(opts?.cause ? ['cause'] : [])];
 
     const enriched: Record<string, unknown> = {
         ...(serialized && typeof serialized === 'object' ? serialized : {})
@@ -88,7 +88,7 @@ export function initSentry({ dsn, hash, applicationName }: { dsn: string | undef
 const logger = getLogger('err');
 export function report(err: unknown, extra?: Record<string, unknown>) {
     if (!sentry) {
-        logger.error(stringifyError(err, { stack: true, pretty: true }), extra);
+        logger.error(stringifyError(err, { stack: true, cause: true, pretty: true }), extra);
         return;
     }
 

--- a/packages/utils/lib/errors.unit.test.ts
+++ b/packages/utils/lib/errors.unit.test.ts
@@ -20,6 +20,14 @@ describe('stringifyError', () => {
             expect(parsed).toHaveProperty('stack');
         });
 
+        it('should include cause when opts.cause is true', () => {
+            const err = new Error('Test error');
+            err.cause = 'Underlying cause';
+            const parsed = JSON.parse(stringifyError(err, { cause: true }));
+
+            expect(parsed).toHaveProperty('cause');
+        });
+
         it('should handle non-Error values without throwing', () => {
             expect(() => stringifyError('String error')).not.toThrow();
             expect(() => stringifyError(null)).not.toThrow();


### PR DESCRIPTION
Expose error cause when http request from runner is failing.
Right now we only report the parent error (`fetch failed`) which doesn't give any details about why the request failed
<!-- Summary by @propel-code-bot -->

BEFORE
<img width="1017" height="714" alt="Screenshot 2026-02-24 at 13 56 40" src="https://github.com/user-attachments/assets/a354bf29-0f03-4e75-a761-dcdf709ac56f" />

AFTER
<img width="1016" height="800" alt="Screenshot 2026-02-24 at 13 55 12" src="https://github.com/user-attachments/assets/25f1fd7c-3751-485f-942a-01e1771f10c7" />

---

It introduces an optional cause-aware serialization path through stringifyError so the runner’s HTTP client and report logger surface nested failure details in responses and logs, with accompanying tests ensuring the behavior.

<details>
<summary><strong>Key Changes</strong></summary>

• Extended `stringifyError` signature to accept `{ cause?: boolean }` and only include the `cause` field when requested.
• Updated `report` in `packages/utils/lib/errors.ts` to log errors with both stack traces and causes when Sentry is disabled.
• Modified `packages/runner/lib/clients/http.ts` to include serialized `error.cause` in 502 responses returned after HTTP failures.
• Added a unit test ensuring `stringifyError` includes `cause` when the new option is enabled.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• `error.cause` may contain large or sensitive structures, so exposing it externally could require additional filtering.

</details>

---
*This summary was automatically generated by @propel-code-bot*