### PR TITLE
feat(server): conditional token refresh

### DIFF
--- a/docs/reference/functions.mdx
+++ b/docs/reference/functions.mdx
@@ -332,6 +332,9 @@ await nango.delete(config); // DELETE request
       <ResponseField name="retryOn" type="number[]">
         Array of additional status codes to retry a request in addition to the 5xx, 429, ECONNRESET, ETIMEDOUT, and ECONNABORTED
       </ResponseField>
+      <ResponseField name="refreshTokenOn" type="number[]">
+        Array of status codes that trigger a token refresh before retrying (e.g. <code>[401, 403]</code>). When used with OAuth, Nango will refresh the access token and retry the request. Optional; can also be set per provider in providers.yaml as <code>proxy.refresh_token_on</code>.
+      </ResponseField>
       <ResponseField name="baseUrlOverride" type="string">
         The API base URL. Can be omitted if the base URL is configured for this API in the [providers.yaml](https://nango.dev/providers.yaml).
       </ResponseField>
@@ -365,7 +368,7 @@ await nango.delete(config); // DELETE request
 
 ## HTTP request retries
 
-To configure retries when HTTP requests fail, use the `retries` and `retryOn` parameters in your [HTTP requests](#http-requests).
+To configure retries when HTTP requests fail, use the `retries`, `retryOn`, and `refreshTokenOn` parameters in your [HTTP requests](#http-requests).
 
 The following will apply:
 
@@ -374,6 +377,7 @@ The following will apply:
   - Network error: `ECONNRESET`, `ETIMEDOUT`, and `ECONNABORTED`.
   - Pre-configured headers for providers in ([providers.yaml](https://nango.dev/providers.yaml)).
 - Use the `retryOn` parameter to specify an array of additional status codes to retry on.
+- Use the `refreshTokenOn` parameter to specify status codes that trigger a token refresh before retrying (e.g. `[401, 403]`). When a response has one of these statuses, Nango refreshes the access token and retries the request. Providers can also define this in [providers.yaml](https://nango.dev/providers.yaml) as `proxy.refresh_token_on`.
 - By default, no retries are performed: `retries` default to `0`
 - The retry starting delay is `3000ms`, the delay between attempts is multiplied by `2` each time (exponential backoff) and is capped at `10 minutes`.
 

--- a/docs/reference/sdks/node.mdx
+++ b/docs/reference/sdks/node.mdx
@@ -1979,6 +1979,9 @@ await nango.delete(config); // DELETE request
             <ResponseField name="retryOn" type="number[]">
                 Array of additional status codes to retry a request in addition to the 5xx, 429, ECONNRESET, ETIMEDOUT, and ECONNABORTED
             </ResponseField>
+            <ResponseField name="refreshTokenOn" type="number[]">
+                Array of status codes that trigger a token refresh before retrying (e.g. <code>[401, 403]</code>). When used with OAuth, Nango will refresh the access token and retry the request. Optional; can also be set per provider in providers.yaml as <code>proxy.refresh_token_on</code>.
+            </ResponseField>
             <ResponseField name="baseUrlOverride" type="string">
                 The API base URL. Can be omitted if the base URL is configured for this API in the [providers.yaml](https://nango.dev/providers.yaml).
             </ResponseField>

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -2308,6 +2308,11 @@ paths:
                       type: string
                   description: Comma separated status codes to explicitly retry on in addition to the default 5xx and 429.
                 - in: header
+                  name: Refresh-Token-On
+                  schema:
+                      type: string
+                  description: Comma separated status codes that trigger a token refresh before retrying (e.g. 401,403).
+                - in: header
                   name: Base-Url-Override
                   schema:
                       type: string
@@ -2351,6 +2356,16 @@ paths:
                   schema:
                       type: string
                   description: The number of retries in case of failure (with exponential back-off). Optional, default 0.
+                - in: header
+                  name: Retry-On
+                  schema:
+                      type: string
+                  description: Comma separated status codes to explicitly retry on in addition to the default 5xx and 429.
+                - in: header
+                  name: Refresh-Token-On
+                  schema:
+                      type: string
+                  description: Comma separated status codes that trigger a token refresh before retrying (e.g. 401,403).
                 - in: header
                   name: Base-Url-Override
                   schema:
@@ -2404,6 +2419,16 @@ paths:
                       type: string
                   description: The number of retries in case of failure (with exponential back-off). Optional, default 0.
                 - in: header
+                  name: Retry-On
+                  schema:
+                      type: string
+                  description: Comma separated status codes to explicitly retry on in addition to the default 5xx and 429.
+                - in: header
+                  name: Refresh-Token-On
+                  schema:
+                      type: string
+                  description: Comma separated status codes that trigger a token refresh before retrying (e.g. 401,403).
+                - in: header
                   name: Base-Url-Override
                   schema:
                       type: string
@@ -2455,6 +2480,16 @@ paths:
                   schema:
                       type: string
                   description: The number of retries in case of failure (with exponential back-off). Optional, default 0.
+                - in: header
+                  name: Retry-On
+                  schema:
+                      type: string
+                  description: Comma separated status codes to explicitly retry on in addition to the default 5xx and 429.
+                - in: header
+                  name: Refresh-Token-On
+                  schema:
+                      type: string
+                  description: Comma separated status codes that trigger a token refresh before retrying (e.g. 401,403).
                 - in: header
                   name: Base-Url-Override
                   schema:
@@ -2512,6 +2547,16 @@ paths:
                   schema:
                       type: string
                   description: The number of retries in case of failure (with exponential back-off). Optional, default 0.
+                - in: header
+                  name: Retry-On
+                  schema:
+                      type: string
+                  description: Comma separated status codes to explicitly retry on in addition to the default 5xx and 429.
+                - in: header
+                  name: Refresh-Token-On
+                  schema:
+                      type: string
+                  description: Comma separated status codes that trigger a token refresh before retrying (e.g. 401,403).
                 - in: header
                   name: Base-Url-Override
                   schema:

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -1090,7 +1090,7 @@ export class Nango {
 
         validateProxyConfiguration(config);
 
-        const { providerConfigKey, connectionId, method, retries, headers: customHeaders, baseUrlOverride, decompress, retryOn } = config;
+        const { providerConfigKey, connectionId, method, retries, headers: customHeaders, baseUrlOverride, decompress, retryOn, refreshTokenOn } = config;
 
         let url = `${this.serverUrl}/proxy${config.endpoint[0] === '/' ? '' : '/'}${config.endpoint}`;
 
@@ -1124,6 +1124,10 @@ export class Nango {
 
         if (retryOn) {
             headers['Retry-On'] = retryOn.join(',');
+        }
+
+        if (refreshTokenOn?.length) {
+            headers['Refresh-Token-On'] = refreshTokenOn.join(',');
         }
 
         const options: AxiosRequestConfig = {

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -47,6 +47,10 @@ const schemaHeaders = z.object({
         .string()
         .regex(/^\d+(,\d+)*$/)
         .optional(),
+    'refresh-token-on': z
+        .string()
+        .regex(/^\d+(,\d+)*$/)
+        .optional(),
     'nango-activity-log-id': z.string().max(255).optional(),
     'nango-is-sync': z.enum(['true', 'false']).optional(),
     'nango-is-dry-run': z.enum(['true', 'false']).optional()
@@ -71,6 +75,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
     const baseUrlOverride = parsedHeaders['base-url-override'];
     const decompress = parsedHeaders['decompress'] === 'true';
     const retryOn = parsedHeaders['retry-on'] ? parsedHeaders['retry-on'].split(',').map(Number) : null;
+    const refreshTokenOn = parsedHeaders['refresh-token-on'] ? parsedHeaders['refresh-token-on'].split(',').map(Number) : null;
     const existingActivityLogId = parsedHeaders['nango-activity-log-id'];
     const isSync = parsedHeaders['nango-is-sync'] === 'true';
     const isDryRun = parsedHeaders['nango-is-dry-run'] === 'true';
@@ -184,12 +189,29 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                     decompress,
                     method,
                     retryOn,
+                    refreshTokenOn,
                     responseType: 'stream'
                 },
                 internalConfig
             }).unwrap(),
             logger: (msg) => {
                 void logCtx?.log(msg);
+            },
+            onRefreshToken: async () => {
+                const credentialResponse = await refreshOrTestCredentials({
+                    account,
+                    environment,
+                    connection: freshConnection,
+                    integration,
+                    logContextGetter,
+                    instantRefresh: true,
+                    onRefreshSuccess: connectionRefreshSuccess,
+                    onRefreshFailed: connectionRefreshFailed
+                });
+                if (credentialResponse.isOk()) {
+                    freshConnection = credentialResponse.value;
+                    lastConnectionRefresh = Date.now();
+                }
             },
             getConnection: async () => {
                 if (Date.now() - lastConnectionRefresh < MEMOIZED_CONNECTION_TTL) {

--- a/packages/shared/lib/constants.ts
+++ b/packages/shared/lib/constants.ts
@@ -1,1 +1,6 @@
 export const PROD_ENVIRONMENT_NAME = 'prod';
+
+/**
+ * Auth modes for which connection credentials can be refreshed (re-obtained) via refreshCredentials.
+ */
+export const REFRESHABLE_AUTH_MODES = new Set<string>(['OAUTH2', 'APP', 'OAUTH2_CC', 'JWT', 'BILL', 'TWO_STEP', 'SIGNATURE']);

--- a/packages/shared/lib/services/proxy/request.ts
+++ b/packages/shared/lib/services/proxy/request.ts
@@ -82,8 +82,9 @@ export class ProxyRequest {
     public async request(): Promise<Result<AxiosResponse>> {
         let refreshTokenAttempts = 0;
 
-        const minRetriesForRefresh = this.config.refreshTokenOn?.length && this.onRefreshToken ? MAX_REFRESH_TOKEN_ATTEMPTS + 1 : 0;
-        const maxRetries = Math.max(this.config.retries ?? 0, minRetriesForRefresh);
+        // when refresh-on-error is enabled we need enough attempt slots: 1 initial try + up to MAX_REFRESH_TOKEN_ATTEMPTS refresh-and-retry cycles
+        const minAttemptSlotsForRefresh = this.config.refreshTokenOn?.length && this.onRefreshToken ? MAX_REFRESH_TOKEN_ATTEMPTS + 1 : 0;
+        const maxRetries = Math.max(this.config.retries ?? 0, minAttemptSlotsForRefresh);
 
         try {
             const response = await retryFlexible<Promise<AxiosResponse>>(

--- a/packages/shared/lib/services/proxy/request.ts
+++ b/packages/shared/lib/services/proxy/request.ts
@@ -10,10 +10,13 @@ import type { ApplicationConstructedProxyConfiguration, ConnectionForProxy, Inte
 import type { Result, RetryAttemptArgument } from '@nangohq/utils';
 import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 
+const MAX_REFRESH_TOKEN_ATTEMPTS = 2;
+
 interface Props {
     proxyConfig: ApplicationConstructedProxyConfiguration;
     logger: (msg: MessageRowInsert) => MaybePromise<void>;
     onError?: (args: { err: unknown; max: number; attempt: number; retry: RetryReason }) => RetryReason;
+    onRefreshToken?: () => Promise<void>;
     getConnection: () => MaybePromise<ConnectionForProxy>;
     getIntegrationConfig: () => MaybePromise<IntegrationConfigForProxy>;
 }
@@ -45,6 +48,11 @@ export class ProxyRequest {
     onError?: Props['onError'];
 
     /**
+     * Called when retry reason is refresh_token; use to refresh credentials before the next attempt.
+     */
+    onRefreshToken?: Props['onRefreshToken'];
+
+    /**
      * Build at each iteration
      */
     axiosConfig?: AxiosRequestConfig;
@@ -63,6 +71,7 @@ export class ProxyRequest {
         this.config = props.proxyConfig;
         this.logger = props.logger;
         this.onError = props.onError;
+        this.onRefreshToken = props.onRefreshToken;
         this.getConnection = props.getConnection;
         this.getIntegrationConfig = props.getIntegrationConfig;
     }
@@ -71,6 +80,11 @@ export class ProxyRequest {
      * Send a request to the third-party with retry.
      */
     public async request(): Promise<Result<AxiosResponse>> {
+        let refreshTokenAttempts = 0;
+
+        const minRetriesForRefresh = this.config.refreshTokenOn?.length && this.onRefreshToken ? MAX_REFRESH_TOKEN_ATTEMPTS + 1 : 0;
+        const maxRetries = Math.max(this.config.retries ?? 0, minRetriesForRefresh);
+
         try {
             const response = await retryFlexible<Promise<AxiosResponse>>(
                 async (retryAttempt) => {
@@ -99,9 +113,18 @@ export class ProxyRequest {
                     }
                 },
                 {
-                    max: this.config.retries || 0,
+                    max: maxRetries,
                     onError: async ({ err, nextWait, max, attempt }) => {
                         let retry = getProxyRetryFromErr({ err, proxyConfig: this.config });
+
+                        if (retry.retry && retry.reason === 'refresh_token') {
+                            if (refreshTokenAttempts >= MAX_REFRESH_TOKEN_ATTEMPTS) {
+                                retry = { retry: false, reason: 'refresh_token_max_attempts' };
+                            } else if (this.onRefreshToken) {
+                                await this.onRefreshToken();
+                                refreshTokenAttempts++;
+                            }
+                        }
 
                         // Only call onError if it's an actionable error
                         if (retry.reason !== 'unknown_error' && this.onError) {

--- a/packages/shared/lib/services/proxy/retry.ts
+++ b/packages/shared/lib/services/proxy/retry.ts
@@ -3,6 +3,8 @@ import get from 'lodash-es/get.js';
 
 import { networkError } from '@nangohq/utils';
 
+import { REFRESHABLE_AUTH_MODES } from '../../constants.js';
+
 import type { RetryReason } from './utils.js';
 import type { ApplicationConstructedProxyConfiguration } from '@nangohq/types';
 import type { AxiosError } from 'axios';
@@ -53,6 +55,11 @@ export function getProxyRetryFromErr({ err, proxyConfig }: { err: unknown; proxy
             isRetryable = true;
             reason = `retry_on_${status}`;
         }
+    }
+
+    if (REFRESHABLE_AUTH_MODES.has(proxyConfig.provider.auth_mode) && proxyConfig.refreshTokenOn?.length && proxyConfig.refreshTokenOn.includes(status)) {
+        isRetryable = true;
+        reason = 'refresh_token';
     }
 
     if (!isRetryable && customHeaderConf?.remaining && err.response?.headers[customHeaderConf.remaining] === '0') {

--- a/packages/shared/lib/services/proxy/retry.unit.test.ts
+++ b/packages/shared/lib/services/proxy/retry.unit.test.ts
@@ -110,6 +110,24 @@ describe('getProxyRetryFromErr', () => {
         expect(res).toStrictEqual({ retry: true, reason: 'retry_on_200' });
     });
 
+    it('should return refresh_token when status is in refreshTokenOn and provider supports refresh', () => {
+        const mockAxiosError = getDefaultError({ response: { status: 401 } });
+        const res = getProxyRetryFromErr({
+            err: mockAxiosError,
+            proxyConfig: getDefaultProxy({ refreshTokenOn: [401], provider: { auth_mode: 'OAUTH2' } })
+        });
+        expect(res).toStrictEqual({ retry: true, reason: 'refresh_token' });
+    });
+
+    it('should return status_code_401 not refresh_token when provider does not support refresh', () => {
+        const mockAxiosError = getDefaultError({ response: { status: 401 } });
+        const res = getProxyRetryFromErr({
+            err: mockAxiosError,
+            proxyConfig: getDefaultProxy({ refreshTokenOn: [401] })
+        });
+        expect(res).toStrictEqual({ retry: true, reason: 'status_code_401' });
+    });
+
     describe('provider proxy', () => {
         describe('error_code', () => {
             it('should use custom provider config', () => {

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -133,7 +133,7 @@ export function getProxyConfiguration({
     externalConfig: ApplicationConstructedProxyConfiguration | UserProvidedProxyConfiguration;
     internalConfig: InternalProxyConfiguration;
 }): Result<ApplicationConstructedProxyConfiguration, ProxyError> {
-    const { endpoint: passedEndpoint, providerConfigKey, method, retries, headers, baseUrlOverride, retryOn } = externalConfig;
+    const { endpoint: passedEndpoint, providerConfigKey, method, retries, headers, baseUrlOverride, retryOn, refreshTokenOn } = externalConfig;
     const { providerName } = internalConfig;
     let data = externalConfig.data;
 
@@ -198,7 +198,13 @@ export function getProxyConfiguration({
         decompress: externalConfig.decompress === 'true' || externalConfig.decompress === true,
         params: externalConfig.params as Record<string, string>, // TODO: fix this
         responseType: externalConfig.responseType,
-        retryOn: retryOn && Array.isArray(retryOn) ? retryOn.map(Number) : null
+        retryOn: retryOn && Array.isArray(retryOn) ? retryOn.map(Number) : null,
+        refreshTokenOn:
+            refreshTokenOn && Array.isArray(refreshTokenOn)
+                ? refreshTokenOn.map(Number)
+                : provider.proxy?.refresh_token_on?.length
+                  ? provider.proxy.refresh_token_on.map(Number)
+                  : null
     };
 
     return Ok(configBody);

--- a/packages/types/lib/providers/provider.ts
+++ b/packages/types/lib/providers/provider.ts
@@ -51,6 +51,7 @@ export interface BaseProvider {
         retry?: RetryHeaderConfig;
         decompress?: boolean;
         paginate?: LinkPagination | CursorPagination | OffsetPagination;
+        refresh_token_on?: string[];
         verification?: {
             method: EndpointMethod;
             endpoints: string[];

--- a/packages/types/lib/proxy/api.ts
+++ b/packages/types/lib/proxy/api.ts
@@ -28,6 +28,7 @@ export interface BaseProxyConfiguration {
     responseType?: ResponseType | undefined;
     retryHeader?: RetryHeaderConfig;
     retryOn?: number[] | null;
+    refreshTokenOn?: number[] | null;
 }
 
 export interface UserProvidedProxyConfiguration extends BaseProxyConfiguration {

--- a/packages/types/lib/proxy/http.api.ts
+++ b/packages/types/lib/proxy/http.api.ts
@@ -13,6 +13,7 @@ export type AllPublicProxy = Endpoint<{
         'base-url-override'?: string | undefined;
         decompress?: string | undefined;
         'retry-on'?: string | undefined;
+        'refresh-token-on'?: string | undefined;
         'nango-activity-log-id'?: string | undefined;
         'nango-is-sync'?: string | undefined;
         'nango-is-dry-run'?: string | undefined;


### PR DESCRIPTION
## Describe the problem and your solution

- Conditional token refresh allows tokens to be refreshed on demand, i.e., when a specific error is encountered. This can be defined in the proxy configuration or in the provider's configuration, ensuring that the next call is retried after the token is refreshed.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add conditional refresh-token retries in proxy flow**

This PR introduces configurable conditional token refresh for proxy requests, allowing retries to trigger a credential refresh based on specific HTTP status codes. The new `refreshTokenOn` option flows from provider metadata and SDK configuration through proxy config building, retry logic, and the server controller to call credential refresh before retrying, with expanded unit tests and documentation updates.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `refreshTokenOn` support to proxy configuration types and builder in `packages/types/lib/proxy/api.ts` and `packages/shared/lib/services/proxy/utils.ts`
• Implemented refresh-triggered retries with `onRefreshToken`, `MAX_REFRESH_TOKEN_ATTEMPTS`, and retry budget adjustments in `packages/shared/lib/services/proxy/request.ts`
• Updated proxy controller to parse `refresh-token-on` header and invoke `refreshOrTestCredentials` before retrying in `packages/server/lib/controllers/proxy/allProxy.ts`
• Centralized refreshable auth modes in `packages/shared/lib/constants.ts` and used them in `packages/shared/lib/services/connections/credentials/refresh.ts` and `packages/shared/lib/services/proxy/retry.ts`
• Added tests for refresh-triggered retries and caps in `packages/shared/lib/services/proxy/request.unit.test.ts` and `packages/shared/lib/services/proxy/retry.unit.test.ts`, plus docs updates in `docs/spec.yaml`, `docs/reference/functions.mdx`, and `docs/reference/sdks/node.mdx`

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Refresh failures from `refreshOrTestCredentials` are currently ignored in `packages/server/lib/controllers/proxy/allProxy.ts`, potentially causing wasted retries with stale credentials.
• Documentation grammar for “status codes that triggers” appears in multiple docs sections and may need correction.

</details>

---
*This summary was automatically generated by @propel-code-bot*