### PR TITLE
feat: make track deletes work across execution

### DIFF
--- a/docs/implementation-guides/use-cases/syncs/checkpoints.mdx
+++ b/docs/implementation-guides/use-cases/syncs/checkpoints.mdx
@@ -152,7 +152,7 @@ After the initial run completes, subsequent runs are fast and incremental — on
 Not every sync can be incremental. You need to fetch the full dataset when:
 
 - **The external API doesn't support filtering by modification date** — Some APIs have no way to ask "give me everything that changed since X." In this case, you must fetch all records on every run.
-- **You need automated delete detection** — To detect deleted records automatically using [`deleteRecordsFromPreviousExecutions()`](/reference/functions#detect-deletions-automatically), Nango must compare the full current dataset against the previous one. This requires a full sync. (If the external API exposes deleted records, you can use [`batchDelete()`](/reference/functions#delete-records) with checkpoints instead — see [deletion detection guide](/implementation-guides/use-cases/syncs/deletion-detection).)
+- **You need automated delete detection** — To detect deleted records automatically using [`trackDeletesStart`/`trackDeletesEnd`](/reference/functions#detect-deletions-automatically), Nango compares the records that existed before `trackDeletesStart` against what was saved between `trackDeletesStart` and `trackDeletesEnd`. This requires fetching the complete dataset between the two calls. (If the external API exposes deleted records, you can use [`batchDelete()`](/reference/functions#delete-records) instead — see [deletion detection guide](/implementation-guides/use-cases/syncs/deletion-detection).)
 
 For small datasets (e.g., a list of Slack users for an organization with fewer than 100 employees), a full sync on every run is perfectly fine:
 
@@ -173,7 +173,7 @@ export default createSync({
 As datasets grow, full syncs become unscalable — taking longer to run, triggering rate limits, and consuming more compute and memory. If your dataset has more than a few thousand records and the API supports filtering by date or cursor, use checkpoints.
 
 <Warning>
-Checkpoints are currently incompatible with `deleteRecordsFromPreviousExecutions()` because that function requires comparing the full dataset between consecutive runs. Support for checkpoints with full syncs is coming soon.
+`deleteRecordsFromPreviousExecutions()` is incompatible with checkpoints because it requires comparing the full dataset between consecutive runs. Use `trackDeletesStart`/`trackDeletesEnd` instead, which explicitly bounds the deletion detection window and supports checkpointed syncs.
 </Warning>
 
 # Avoiding memory overuse

--- a/docs/implementation-guides/use-cases/syncs/deletion-detection.mdx
+++ b/docs/implementation-guides/use-cases/syncs/deletion-detection.mdx
@@ -84,17 +84,13 @@ export default createSync({
 
 Syncs that fetch all records on every run can automatically detect deletions.
 
-Nango can therefore detect removals by computing the diff between two consecutive result sets. Enable this behaviour by calling the `deleteRecordsFromPreviousExecutions` function. ([full reference](/reference/functions#detect-deletions-automatically)).
-
-<Note>
-  `deleteRecordsFromPreviousExecutions` does not work with checkpoint-based syncs because fetching the data incrementally prevents performing a diff and automatically detecting deletions.
-</Note>
+Nango detects removals by computing the diff between what existed before `trackDeletesStart` and what was saved between `trackDeletesStart` and `trackDeletesEnd`. ([full reference](/reference/functions#detect-deletions-automatically)).
 
 ### Example sync with deletion detection
 
 ```ts
-import { createSync } from 'nango';
-import * as z from 'zod';
+import { createSync } from ‘nango’;
+import * as z from ‘zod’;
 
 const TicketSchema = z.object({
   id: z.string(),
@@ -103,55 +99,57 @@ const TicketSchema = z.object({
 });
 
 export default createSync({
-  description: 'Fetch all help-desk tickets',
-  frequency: 'every day',
-  endpoints: [{ method: 'GET', path: '/tickets', group: 'Tickets' }],
+  description: ‘Fetch all help-desk tickets’,
+  frequency: ‘every day’,
+  endpoints: [{ method: ‘GET’, path: ‘/tickets’, group: ‘Tickets’ }],
   models: { Ticket: TicketSchema },
 
   exec: async (nango) => {
+    // Mark the start of deletion tracking
+    await nango.trackDeletesStart(‘Ticket’);
+
     const tickets = await nango.paginate<{ id: string; subject: string; status: string }>({
-      endpoint: '/tickets',
-      paginate: { type: 'cursor', cursorPathInResponse: 'next', cursorNameInRequest: 'cursor', responsePath: 'tickets' }
+      endpoint: ‘/tickets’,
+      paginate: { type: ‘cursor’, cursorPathInResponse: ‘next’, cursorNameInRequest: ‘cursor’, responsePath: ‘tickets’ }
     });
 
     for await (const page of tickets) {
-      await nango.batchSave(page, 'Ticket');
+      await nango.batchSave(page, ‘Ticket’);
     }
 
-    // Delete records that don't exist anymore
-    await nango.deleteRecordsFromPreviousExecutions('Ticket');
+    // Detect and mark deleted records
+    await nango.trackDeletesEnd(‘Ticket’);
   }
 });
 ```
 
 ### How the algorithm works
 
-1. During the execution, Nango stores the list of record IDs.
-2. When calling `deleteRecordsFromPreviousExecutions`, Nango compares the new list with the old one.
-3. Any records missing in the new list are marked as deleted (soft delete). They remain accessible from the Nango cache, but with `record._metadata.deleted === true`.
+1. When `trackDeletesStart` is called, Nango marks the beginning of the deletion tracking window for the model.
+2. Records saved with `batchSave` between `trackDeletesStart` and `trackDeletesEnd` are tracked.
+3. When `trackDeletesEnd` is called, Nango compares what existed before `trackDeletesStart` with what was saved in the window.
+4. Any records missing from the new dataset are marked as deleted (soft delete). They remain accessible from the Nango cache, but with `record._metadata.deleted === true`.
 
 <Warning>
-**Be careful with exception handling when using** `deleteRecordsFromPreviousExecutions`
+**Be careful with exception handling when using** `trackDeletesStart`/`trackDeletesEnd`
 
 Nango only performs deletion detection (the “diff”) if a sync run completes successfully without any uncaught exceptions.
 
-If you’re using `deleteRecordsFromPreviousExecutions`, exception handling becomes critical:
-- If your sync doesn’t fetch the full dataset, but still call `deleteRecordsFromPreviousExecutions` (e.g. you catch and swallow an exception), Nango will attempt the diff on an incomplete dataset.
+Exception handling is critical:
+- If your sync doesn’t fetch the full dataset between the two calls (e.g. you catch and swallow an exception), Nango will attempt the diff on an incomplete dataset.
 - This leads to false positives, where valid records are mistakenly considered deleted.
 
 **What You Should Do**
 
-If a failure prevents full data retrieval, make sure the sync run fails and `deleteRecordsFromPreviousExecutions` is not being called:
+If a failure prevents full data retrieval, make sure the sync run fails and `trackDeletesEnd` is not being called:
 - Let exceptions bubble up and interrupt the run.
 - If you’re using `try/catch`, re-throw exceptions that indicate incomplete data.
 </Warning>
 
 <Tip>
-**How to use** `deleteRecordsFromPreviousExecutions` **safely**
+**How to use** `trackDeletesStart`/`trackDeletesEnd` **safely**
 
-If some records are incorrectly marked as deleted due to calling `deleteRecordsFromPreviousExecutions` improperly, you can trigger a full resync (via the UI or API) to restore the correct data state.
-
-However, because `deleteRecordsFromPreviousExecutions` relies on logic in your sync functions, mistakes there can lead to false deletions.
+If some records are incorrectly marked as deleted, you can trigger a full resync (via the UI or API) to restore the correct data state.
 
 We strongly recommend not performing irreversible destructive actions (like hard-deleting records in your system) based solely on deletions reported by Nango. A full resync should always be able to recover from issues.
 </Tip>
@@ -160,7 +158,7 @@ We strongly recommend not performing irreversible destructive actions (like hard
 
 | Symptom                                                                    | Likely cause                                                                             |
 | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Records that still exist in the source API are shown as `deleted` in Nango | sync didn't save all records (silent failures) before calling `deleteRecordsFromPreviousExecutions` |
+| Records that still exist in the source API are shown as `deleted` in Nango | sync didn’t save all records (silent failures) between `trackDeletesStart` and `trackDeletesEnd` |
 | You never see deleted records                                              | Check if deletion detection is implemented for the sync.                                 |
 
 <Tip>

--- a/docs/reference/api/sync/prune-records.mdx
+++ b/docs/reference/api/sync/prune-records.mdx
@@ -15,7 +15,7 @@ This is useful for compliance requirements, ensuring Nango doesn't hold onto you
 Pruning is not the same as marking a record as deleted from the external API.
 This endpoint prunes data from Nango’s cache only. It does not delete anything on the external API, and it is not the same as [detecting a deletion from the source](/implementation-guides/use-cases/syncs/implement-a-sync#deletion-detection).
 
-If you need to tell your customers that a record was deleted on the external API while keeping its last-known payload in cache, use `batchDelete` or `deleteRecordsFromPreviousExecutions` in your sync functions instead.
+If you need to tell your customers that a record was deleted on the external API while keeping its last-known payload in cache, use `batchDelete` or `trackDeletesStart`/`trackDeletesEnd` in your sync functions instead.
 </Tip>
 
 ## Cursor behavior

--- a/docs/reference/functions.mdx
+++ b/docs/reference/functions.mdx
@@ -27,6 +27,9 @@ description: "Full reference of the SDK available in Nango Functions."
       },
 
       exec: async (nango) => {
+        // Mark the start of deletion tracking
+        await nango.trackDeletesStart('GithubIssueDemo');
+
         // Fetch issues from GitHub.
         const res = await nango.get({
             endpoint: '/repos/NangoHQ/interactive-demo/issues?labels=demo&sort=created&direction=asc'
@@ -40,8 +43,8 @@ description: "Full reference of the SDK available in Nango Functions."
         // Persist issues to the Nango cache.
         await nango.batchSave(issues, 'GithubIssueDemo');
 
-        // Delete records that don't exist anymore
-        await nango.deleteRecordsFromPreviousExecutions('GithubIssueDemo')
+        // Detect and mark deleted records
+        await nango.trackDeletesEnd('GithubIssueDemo');
       },
     });
     ```
@@ -172,7 +175,7 @@ Read more about [integration functions](/guides/primitives/functions) to underst
 </ResponseField>
 
 <ResponseField name="trackDeletes" type="boolean" deprecated>
-  [DEPRECATED] Instead use `await nango.deleteRecordsFromPreviousExecutions('modelName')` inside the sync `exec` function.
+  [DEPRECATED] Instead use `await nango.trackDeletesStart('modelName')` and `await nango.trackDeletesEnd('modelName')` inside the sync `exec` function.
 
   When `trackDeletes` is set to `true`, Nango automatically detects deleted records **during full syncs only** and marks them as deleted in each record’s metadata (soft delete). These records remain stored in the cache.
 
@@ -883,23 +886,27 @@ await nango.batchDelete(githubIssuesToDelete, 'GitHubIssue');
 
 ### Detect deletions automatically
 
-Automatically detects and marks records as deleted by comparing the current sync execution with the previous one.
+Automatically detects and marks records as deleted by comparing what existed before `trackDeletesStart` with what was saved between `trackDeletesStart` and `trackDeletesEnd`.
 
 <Tip>
 This does not remove cached payloads.
 
-`nango.deleteRecordsFromPreviousExecutions()` is used to mark records as deleted in Nango because they were not returned by the external API. Nango may still keep the last-known payload so your customer can react to the deletion event.
+`nango.trackDeletesStart()`/`nango.trackDeletesEnd()` are used to mark records as deleted in Nango because they were not returned by the external API. Nango may still keep the last-known payload so your customer can react to the deletion event.
 
 If you want to permanently remove data from Nango storage for cost or compliance reasons, use [record pruning instead](/reference/api/sync/prune-records).
 </Tip>
 
 ```js
-await nango.deleteRecordsFromPreviousExecutions('ModelName');
+await nango.trackDeletesStart('ModelName');
+
+// ... fetch and save all records ...
+
+await nango.trackDeletesEnd('ModelName');
 ```
 
-This function should be called at the end of your sync execution, after all records have been saved with `batchSave`. Nango will compare the records saved in the current execution with those from the previous execution and mark any missing records as deleted.
+Call `trackDeletesStart` at the beginning of your sync execution, before fetching any data. Call `trackDeletesEnd` after all records have been saved with `batchSave`. Nango will compare the records that existed before `trackDeletesStart` with those saved in the window and mark any missing records as deleted.
 
-**Parameters**
+**Parameters** (both functions)
 
 <Expandable>
   <ResponseField name="modelType" type="string" required>
@@ -909,10 +916,13 @@ This function should be called at the end of your sync execution, after all reco
 
 **Important considerations:**
 
-- Only use within syncs that fetch the complete dataset
-- Call this function only after successfully saving all records
-- If your sync fails or doesn't fetch the complete dataset, avoid calling this function as it may cause false deletions
+- Only use within syncs that fetch the complete dataset between `trackDeletesStart` and `trackDeletesEnd`
+- If your sync fails or doesn't fetch the complete dataset, avoid calling `trackDeletesEnd` as it may cause false deletions
 - Records are soft deleted (marked with `_metadata.deleted = true`) and remain in the cache
+
+<Note>
+`deleteRecordsFromPreviousExecutions` is deprecated. Use `trackDeletesStart`/`trackDeletesEnd` instead.
+</Note>
 
 For more details on deletion detection strategies, see the [detecting deletes guide](/implementation-guides/use-cases/syncs/deletion-detection.mdx).
 

--- a/packages/cli/example/github/syncs/fetchIssues.ts
+++ b/packages/cli/example/github/syncs/fetchIssues.ts
@@ -32,6 +32,8 @@ const sync = createSync({
 
     // Sync execution
     exec: async (nango) => {
+        await nango.trackDeletesStart('GithubIssue');
+
         const repos = await getAllRepositories(nango);
 
         for (const repo of repos) {
@@ -65,7 +67,7 @@ const sync = createSync({
             }
         }
 
-        await nango.deleteRecordsFromPreviousExecutions('GithubIssue');
+        await nango.trackDeletesEnd('GithubIssue');
     },
 
     // Webhook handler

--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -474,7 +474,12 @@ export declare class NangoSync<TCheckpoint = Checkpoint> extends NangoAction {
     batchUpdate<T extends object>(results: T[], model: string): Promise<boolean | null>;
     getMetadata<T = Metadata>(): Promise<T>;
     setMergingStrategy(merging: { strategy: 'ignore_if_modified_after' | 'override' }, model: string): Promise<void>;
+    /**
+     * @deprecated please use trackDeletesStart and trackDeletesEnd
+     */
     deleteRecordsFromPreviousExecutions(model: string): Promise<{ deletedKeys: string[] }>;
+    trackDeletesStart(model: string): Promise<void>;
+    trackDeletesEnd(model: string): Promise<{ deletedKeys: string[] }>;
     getRecordsByIds<K = string | number, T = any>(ids: K[], model: string): Promise<Map<K, T>>;
     getCheckpoint(): Promise<TCheckpoint | null>;
     saveCheckpoint(checkpoint: TCheckpoint): Promise<void>;

--- a/packages/cli/lib/services/parser.service.ts
+++ b/packages/cli/lib/services/parser.service.ts
@@ -308,6 +308,14 @@ class ParserService {
                 );
                 usedCorrectly = false;
             }
+            if (endLines.length > 0 && batchingRecordsLines.some((line) => line > Math.min(...endLines))) {
+                console.log(
+                    chalk.red(
+                        `trackDeletesEnd for model '${model}' should be called after all batching records functions in "${filePath}:${Math.min(...endLines)}".`
+                    )
+                );
+                usedCorrectly = false;
+            }
         }
 
         return areAwaited && usedCorrectly && noReturnUsed && retryOnUsedCorrectly;

--- a/packages/cli/lib/services/parser.service.ts
+++ b/packages/cli/lib/services/parser.service.ts
@@ -290,6 +290,10 @@ class ParserService {
         }
 
         for (const [model, { startLines, endLines }] of trackDeletesByModel) {
+            if (startLines.length > 1) {
+                console.log(chalk.red(`trackDeletesStart for model '${model}' should be called only once in "${filePath}:${Math.max(...startLines)}".`));
+                usedCorrectly = false;
+            }
             if (endLines.length > 1) {
                 console.log(chalk.red(`trackDeletesEnd for model '${model}' should be called only once in "${filePath}:${Math.max(...endLines)}".`));
                 usedCorrectly = false;
@@ -305,6 +309,14 @@ class ParserService {
             if (startLines.length > 0 && endLines.length > 0 && startLines.some((line) => line > Math.min(...endLines))) {
                 console.log(
                     chalk.red(`trackDeletesStart for model '${model}' should be called before trackDeletesEnd in "${filePath}:${Math.min(...startLines)}".`)
+                );
+                usedCorrectly = false;
+            }
+            if (startLines.length > 0 && batchingRecordsLines.some((line) => line < Math.max(...startLines))) {
+                console.log(
+                    chalk.red(
+                        `trackDeletesStart for model '${model}' should be called before all batching records functions in "${filePath}:${Math.max(...startLines)}".`
+                    )
                 );
                 usedCorrectly = false;
             }

--- a/packages/cli/lib/services/sdk.ts
+++ b/packages/cli/lib/services/sdk.ts
@@ -381,7 +381,19 @@ export class NangoSyncCLI extends NangoSyncBase<never, never, ZodCheckpoint> {
     }
 
     public override async deleteRecordsFromPreviousExecutions(_model: string): Promise<{ deletedKeys: string[] }> {
-        this.log(`This has no effect but on a remote Nango instance would delete records that were not added or updated during the current execution.`);
+        this.log(
+            `This has no effect locally. On a remote Nango instance, it would mark as deleted any records that were not saved during this sync execution.`
+        );
+        return Promise.resolve({ deletedKeys: [] });
+    }
+
+    public override async trackDeletesStart(model: string): Promise<void> {
+        this.log(`This has no effect locally, but on a remote Nango instance it marks the start of deletion tracking for model '${model}'.`);
+        return Promise.resolve();
+    }
+
+    public override async trackDeletesEnd(_model: string): Promise<{ deletedKeys: string[] }> {
+        this.log(`This has no effect locally. On a remote Nango instance, it would mark as deleted any records that were not saved since trackDeletesStart.`);
         return Promise.resolve({ deletedKeys: [] });
     }
 }

--- a/packages/cli/lib/zeroYaml/compile.ts
+++ b/packages/cli/lib/zeroYaml/compile.ts
@@ -318,6 +318,15 @@ export async function bundleFile({ entryPoint, projectRootPath }: { entryPoint: 
                     })
                 );
             }
+            if (endLines.length > 0 && bag.batchingRecordsLines.some((line) => line > Math.min(...endLines))) {
+                return Err(
+                    fileErrorToText({
+                        filePath: friendlyPath,
+                        msg: `trackDeletesEnd for model '${model}' should be called after any batching records function`,
+                        line: Math.min(...endLines)
+                    })
+                );
+            }
         }
 
         const output = res.outputFiles?.[0]?.text || '';

--- a/packages/cli/lib/zeroYaml/compile.ts
+++ b/packages/cli/lib/zeroYaml/compile.ts
@@ -282,6 +282,15 @@ export async function bundleFile({ entryPoint, projectRootPath }: { entryPoint: 
         }
 
         for (const [model, { startLines, endLines }] of bag.trackDeletesByModel) {
+            if (startLines.length > 1) {
+                return Err(
+                    fileErrorToText({
+                        filePath: friendlyPath,
+                        msg: `trackDeletesStart for model '${model}' should be called only once per sync`,
+                        line: Math.max(...startLines)
+                    })
+                );
+            }
             if (endLines.length > 1) {
                 return Err(
                     fileErrorToText({
@@ -314,6 +323,15 @@ export async function bundleFile({ entryPoint, projectRootPath }: { entryPoint: 
                     fileErrorToText({
                         filePath: friendlyPath,
                         msg: `trackDeletesStart for model '${model}' should be called before trackDeletesEnd`,
+                        line: Math.min(...startLines)
+                    })
+                );
+            }
+            if (startLines.length > 0 && bag.batchingRecordsLines.some((line) => line < Math.min(...startLines))) {
+                return Err(
+                    fileErrorToText({
+                        filePath: friendlyPath,
+                        msg: `trackDeletesStart for model '${model}' should be called before any batching records function`,
                         line: Math.min(...startLines)
                     })
                 );

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -330,7 +330,7 @@ export async function handleSyncSuccess({
             let deletedKeys: string[] = [];
             if (nangoProps.syncConfig.track_deletes) {
                 void logCtx.warn(
-                    `'track_deletes' is deprecated and will be removed in future versions. To detect deletions please call 'nango.deleteRecordsFromPreviousExecutions()' in your sync script.`
+                    `'track_deletes' is deprecated and will be removed in future versions. To detect deletions please call 'nango.trackDeletesStart()' and 'nango.trackDeletesEnd()' in your sync function.`
                 );
                 const res = await records.deleteOutdatedRecords({
                     environmentId: nangoProps.environmentId,

--- a/packages/runner-sdk/lib/scripts.ts
+++ b/packages/runner-sdk/lib/scripts.ts
@@ -79,7 +79,7 @@ export interface CreateSyncProps<TModels extends Record<string, ZodModel>, TMeta
     /**
      * If `true`, automatically detects deleted records and removes them when you fetch the latest data.
      *
-     * @deprecated This option will be removed in future versions. Please automatically detect deletions by calling `nango.deleteRecordsFromPreviousExecutions()` in your sync script.
+     * @deprecated This option will be removed in future versions. Please automatically detect deletions by calling `nango.trackDeletesStart()` and `nango.trackDeletesEnd()` in your sync function.
      * @default false
      */
     trackDeletes?: boolean;

--- a/packages/runner-sdk/lib/sync.ts
+++ b/packages/runner-sdk/lib/sync.ts
@@ -66,7 +66,13 @@ export abstract class NangoSyncBase<
         model: TModelName
     ): MaybePromise<Map<TKey, TModel>>;
 
+    /**
+     * @deprecated please use trackDeletesStart and trackDeletesEnd
+     */
     public abstract deleteRecordsFromPreviousExecutions(model: TModelName): MaybePromise<{ deletedKeys: string[] }>;
+
+    public abstract trackDeletesStart(model: TModelName): MaybePromise<void>;
+    public abstract trackDeletesEnd(model: TModelName): MaybePromise<{ deletedKeys: string[] }>;
 
     public abstract setMergingStrategy(merging: { strategy: 'ignore_if_modified_after' | 'override' }, model: TModelName): Promise<void>;
 

--- a/packages/runner-sdk/lib/sync.ts
+++ b/packages/runner-sdk/lib/sync.ts
@@ -71,7 +71,16 @@ export abstract class NangoSyncBase<
      */
     public abstract deleteRecordsFromPreviousExecutions(model: TModelName): MaybePromise<{ deletedKeys: string[] }>;
 
+    /*
+     * Mark the start of a deletes tracking phase for a given model, if not already started.
+     * During this phase, the sync will keep track of all records that are not present anymore in the saved data.
+     */
     public abstract trackDeletesStart(model: TModelName): MaybePromise<void>;
+
+    /*
+     * Mark the end of a deletes tracking phase for a given model
+     * All the records that are not present anymore in the saved data since the start of the tracking phase will be marked as deleted, and their keys will be returned.
+     */
     public abstract trackDeletesEnd(model: TModelName): MaybePromise<{ deletedKeys: string[] }>;
 
     public abstract setMergingStrategy(merging: { strategy: 'ignore_if_modified_after' | 'override' }, model: TModelName): Promise<void>;

--- a/packages/runner-sdk/models.d.ts
+++ b/packages/runner-sdk/models.d.ts
@@ -431,7 +431,12 @@ export declare class NangoSync<TCheckpoint = Checkpoint> extends NangoAction {
     batchUpdate<T extends object>(results: T[], model: string): Promise<boolean | null>;
     getMetadata<T = Metadata>(): Promise<T>;
     setMergingStrategy(merging: { strategy: 'ignore_if_modified_after' | 'override' }, model: string): Promise<void>;
+    /**
+     * @deprecated please use trackDeletesStart and trackDeletesEnd
+     */
     deleteRecordsFromPreviousExecutions(model: string): Promise<{ deletedKeys: string[] }>;
+    trackDeletesStart(model: string): Promise<void>;
+    trackDeletesEnd(model: string): Promise<{ deletedKeys: string[] }>;
     getRecordsByIds<K = string | number, T = any>(ids: K[], model: string): Promise<Map<K, T>>;
     getCheckpoint(): Promise<TCheckpoint | null>;
     saveCheckpoint(checkpoint: TCheckpoint): Promise<void>;

--- a/packages/runner/lib/sdk/checkpointing.ts
+++ b/packages/runner/lib/sdk/checkpointing.ts
@@ -9,30 +9,31 @@ type CheckpointState = {
     deletedAt: string | null;
 } | null;
 
+interface KeyState {
+    from: CheckpointState;
+    last: CheckpointState;
+}
+
 export class Checkpointing {
     private persistClient: PersistClient;
     private environmentId: number;
     private nangoConnectionId: number;
-    private key: string;
+    private stateByKey = new Map<string, KeyState>();
 
-    public from: CheckpointState = null; // checkpoint at first checkpointing call
-    public last: CheckpointState = null; // last saved checkpoint
-
-    constructor(props: { persistClient: PersistClient; environmentId: number; nangoConnectionId: number; key: string }) {
+    constructor(props: { persistClient: PersistClient; environmentId: number; nangoConnectionId: number }) {
         this.persistClient = props.persistClient;
         this.environmentId = props.environmentId;
         this.nangoConnectionId = props.nangoConnectionId;
-        this.key = props.key;
     }
 
-    public async getCheckpoint(): Promise<Checkpoint | null> {
+    public async getCheckpoint<T = Checkpoint>(key: string): Promise<T | null> {
         const res = await this.persistClient.getCheckpoint({
             environmentId: this.environmentId,
             nangoConnectionId: this.nangoConnectionId,
-            key: this.key
+            key
         });
 
-        this.last = res.isErr()
+        const current: CheckpointState = res.isErr()
             ? {
                   version: 1, // If no checkpoint, we initialize the version to 1 for optimistic locking on creation.
                   checkpoint: null,
@@ -44,56 +45,63 @@ export class Checkpointing {
                   version: res.value.version
               };
 
-        if (!this.from) this.from = this.last;
+        const existing = this.stateByKey.get(key);
+        this.stateByKey.set(key, { from: existing?.from ?? current, last: current });
 
-        return this.last.deletedAt ? null : this.last.checkpoint;
+        return current.deletedAt ? null : (current.checkpoint as T);
     }
 
-    public async saveCheckpoint(checkpoint: Checkpoint): Promise<void> {
-        const { version } = await this.ensureVersion();
+    public async saveCheckpoint(key: string, checkpoint: Checkpoint): Promise<void> {
+        const { version } = await this.ensureVersion(key);
 
         const res = await this.persistClient.putCheckpoint({
             environmentId: this.environmentId,
             nangoConnectionId: this.nangoConnectionId,
-            key: this.key,
+            key,
             checkpoint,
             expectedVersion: version
         });
         if (res.isErr()) {
             throw new Error(`Error saving checkpoint: ${res.error.message}`, { cause: res.error });
         }
-        this.last = {
-            checkpoint: validateCheckpoint(res.value.checkpoint),
-            version: res.value.version,
-            deletedAt: null
-        };
+        const existing = this.stateByKey.get(key);
+        this.stateByKey.set(key, {
+            from: existing?.from ?? null,
+            last: {
+                checkpoint: validateCheckpoint(res.value.checkpoint),
+                version: res.value.version,
+                deletedAt: null
+            }
+        });
     }
 
-    public async clearCheckpoint(): Promise<void> {
-        const { version } = await this.ensureVersion();
+    public async clearCheckpoint(key: string): Promise<void> {
+        const { version } = await this.ensureVersion(key);
 
         const res = await this.persistClient.deleteCheckpoint({
             environmentId: this.environmentId,
             nangoConnectionId: this.nangoConnectionId,
-            key: this.key,
+            key,
             expectedVersion: version
         });
         if (res.isErr()) {
             throw new Error(`Error deleting checkpoint: ${res.error.message}`, { cause: res.error });
         }
-        this.last = null;
+        const existing = this.stateByKey.get(key);
+        this.stateByKey.set(key, { from: existing?.from ?? null, last: null });
     }
 
-    private async ensureVersion(): Promise<{ version: number }> {
+    private async ensureVersion(key: string): Promise<{ version: number }> {
         // If we haven't loaded the checkpoint yet, load it to get the version for optimistic locking.
-        if (!this.last) {
-            await this.getCheckpoint();
+        if (!this.stateByKey.get(key)?.last) {
+            await this.getCheckpoint(key);
         }
 
-        if (!this.last?.version) {
+        const version = this.stateByKey.get(key)?.last?.version;
+        if (!version) {
             throw new Error('Missing checkpoint version'); // defensive check - this should never happen
         }
 
-        return { version: this.last.version };
+        return { version };
     }
 }

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -522,6 +522,28 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
         return res.value;
     }
 
+    // eslint-disable-next-line @typescript-eslint/require-await
+    public async trackDeletesStart(_model: string): Promise<void> {
+        this.throwIfAborted();
+        // TODO
+    }
+
+    public async trackDeletesEnd(model: string): Promise<{ deletedKeys: string[] }> {
+        this.throwIfAborted();
+        const res = await this.persistClient.deleteOutdatedRecords({
+            model: this.modelFullName(model),
+            environmentId: this.environmentId,
+            nangoConnectionId: this.nangoConnectionId!,
+            syncId: this.syncId!,
+            syncJobId: this.syncJobId!,
+            activityLogId: this.activityLogId
+        });
+        if (res.isErr()) {
+            throw res.error;
+        }
+        return res.value;
+    }
+
     public async getRecordsByIds<K = string | number, T = any>(ids: K[], model: string): Promise<Map<K, T>> {
         this.throwIfAborted();
 

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -23,6 +23,10 @@ import type { ProxyConfiguration, ZodCheckpoint } from '@nangohq/runner-sdk';
 import type { ApiPublicConnectionFull, Checkpoint, MergingStrategy, MessageRowInsert, NangoProps, PostPublicTrigger, UserLogParameters } from '@nangohq/types';
 import type { AxiosResponse } from 'axios';
 
+interface TrackDeletesCheckpoint {
+    syncJobId: number;
+}
+
 export const oldLevelToNewLevel = {
     debug: 'debug',
     info: 'info',
@@ -44,6 +48,7 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
     protected persistClient: PersistClient;
     protected locking: Locking;
     protected checkpointing: Checkpointing;
+    protected checkpointKey: string;
     protected httpLogSample: number = 0;
 
     constructor(props: NangoProps, runnerProps: { persistClient?: PersistClient; locks: Locks }) {
@@ -75,11 +80,11 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
 
         this.persistClient = runnerProps?.persistClient || new PersistClient({ secretKey: props.secretKey });
         this.locking = new Locking({ locks: runnerProps.locks, owner: this.activityLogId });
+        this.checkpointKey = getCheckpointKey({ type: this.scriptType, name: this.syncConfig.sync_name });
         this.checkpointing = new Checkpointing({
             persistClient: this.persistClient,
             environmentId: this.environmentId,
-            nangoConnectionId: this.nangoConnectionId,
-            key: getCheckpointKey({ type: this.scriptType, name: this.syncConfig.sync_name })
+            nangoConnectionId: this.nangoConnectionId
         });
     }
 
@@ -290,15 +295,15 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
     }
 
     public override async getCheckpoint(): Promise<Checkpoint | null> {
-        return this.checkpointing.getCheckpoint();
+        return this.checkpointing.getCheckpoint(this.checkpointKey);
     }
 
     public override async saveCheckpoint(checkpoint: Checkpoint): Promise<void> {
-        return this.checkpointing.saveCheckpoint(checkpoint);
+        return this.checkpointing.saveCheckpoint(this.checkpointKey, checkpoint);
     }
 
     public override async clearCheckpoint(): Promise<void> {
-        return this.checkpointing.clearCheckpoint();
+        return this.checkpointing.clearCheckpoint(this.checkpointKey);
     }
 }
 
@@ -311,6 +316,7 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
     protected persistClient: PersistClient;
     protected locking: Locking;
     protected checkpointing: Checkpointing;
+    protected checkpointKey: string;
     private batchSize = 1000;
     private getRecordsBatchSize = 100;
     private mergingByModel = new Map<string, MergingStrategy>();
@@ -345,11 +351,11 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
 
         this.persistClient = runnerProps?.persistClient || new PersistClient({ secretKey: props.secretKey });
         this.locking = new Locking({ locks: runnerProps.locks, owner: this.activityLogId });
+        this.checkpointKey = getCheckpointKey({ type: this.scriptType, name: this.syncConfig.sync_name, variant: this.variant });
         this.checkpointing = new Checkpointing({
             persistClient: this.persistClient,
             environmentId: this.environmentId,
-            nangoConnectionId: this.nangoConnectionId,
-            key: getCheckpointKey({ type: this.scriptType, name: this.syncConfig.sync_name, variant: this.variant })
+            nangoConnectionId: this.nangoConnectionId
         });
     }
 
@@ -522,25 +528,37 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
         return res.value;
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    public async trackDeletesStart(_model: string): Promise<void> {
+    public async trackDeletesStart(model: string): Promise<void> {
         this.throwIfAborted();
-        // TODO
+        const key = `${this.checkpointKey}:trackDeletes:${model}`;
+        const stored = await this.checkpointing.getCheckpoint(key);
+        if (stored === null) {
+            await this.checkpointing.saveCheckpoint(key, { syncJobId: this.syncJobId! });
+        }
     }
 
     public async trackDeletesEnd(model: string): Promise<{ deletedKeys: string[] }> {
         this.throwIfAborted();
+        const key = `${this.checkpointKey}:trackDeletes:${model}`;
+        const stored = await this.checkpointing.getCheckpoint<TrackDeletesCheckpoint>(key);
+        if (stored === null) {
+            throw new Error(`No track deletes starting point found for model '${model}'.`);
+        }
+
         const res = await this.persistClient.deleteOutdatedRecords({
             model: this.modelFullName(model),
             environmentId: this.environmentId,
             nangoConnectionId: this.nangoConnectionId!,
             syncId: this.syncId!,
-            syncJobId: this.syncJobId!,
+            syncJobId: stored.syncJobId,
             activityLogId: this.activityLogId
         });
         if (res.isErr()) {
             throw res.error;
         }
+
+        await this.checkpointing.clearCheckpoint(key);
+
         return res.value;
     }
 
@@ -597,15 +615,15 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
     }
 
     public override async getCheckpoint(): Promise<Checkpoint | null> {
-        return this.checkpointing.getCheckpoint();
+        return this.checkpointing.getCheckpoint(this.checkpointKey);
     }
 
     public override async saveCheckpoint(checkpoint: Checkpoint): Promise<void> {
-        return this.checkpointing.saveCheckpoint(checkpoint);
+        return this.checkpointing.saveCheckpoint(this.checkpointKey, checkpoint);
     }
 
     public override async clearCheckpoint(): Promise<void> {
-        return this.checkpointing.clearCheckpoint();
+        return this.checkpointing.clearCheckpoint(this.checkpointKey);
     }
 }
 

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -528,9 +528,13 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
         return res.value;
     }
 
+    private trackDeletesKey(model: string): string {
+        return `${this.checkpointKey}:trackDeletes:${model}`;
+    }
+
     public async trackDeletesStart(model: string): Promise<void> {
         this.throwIfAborted();
-        const key = `${this.checkpointKey}:trackDeletes:${model}`;
+        const key = this.trackDeletesKey(model);
         const stored = await this.checkpointing.getCheckpoint(key);
         if (stored === null) {
             await this.checkpointing.saveCheckpoint(key, { syncJobId: this.syncJobId! });
@@ -539,7 +543,7 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
 
     public async trackDeletesEnd(model: string): Promise<{ deletedKeys: string[] }> {
         this.throwIfAborted();
-        const key = `${this.checkpointKey}:trackDeletes:${model}`;
+        const key = this.trackDeletesKey(model);
         const stored = await this.checkpointing.getCheckpoint<TrackDeletesCheckpoint>(key);
         if (stored === null) {
             throw new Error(`No track deletes starting point found for model '${model}'.`);

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -593,11 +593,14 @@ export class Orchestrator {
 
                     await clearLastSyncDate(syncId);
                     // Delete all checkpoint (including the trackDeletes ones)
-                    hardDeleteCheckpoints(db.knex, {
+                    const deletedCheckpoints = await hardDeleteCheckpoints(db.knex, {
                         environmentId,
                         connectionId,
                         keyPrefix: getCheckpointKey({ type: 'sync', name: syncName, variant: syncVariant })
                     });
+                    if (deletedCheckpoints.isErr()) {
+                        return Err(deletedCheckpoints.error);
+                    }
 
                     if (delete_records) {
                         const syncConfig = await getSyncConfigBySyncId(syncId);

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -6,7 +6,7 @@ import db from '@nangohq/database';
 import { OtlpSpan } from '@nangohq/logs';
 import { Err, Ok, errorToObject, getCheckpointKey, getFrequencyMs, stringifyError } from '@nangohq/utils';
 
-import { deleteCheckpoint } from '../index.js';
+import { hardDeleteCheckpoints } from '../index.js';
 import { LogActionEnum } from '../models/Telemetry.js';
 import { SyncCommand, SyncStatus } from '../models/index.js';
 import accountService from '../services/account.service.js';
@@ -592,11 +592,11 @@ export class Orchestrator {
                     await cancelling(syncId);
 
                     await clearLastSyncDate(syncId);
-                    deleteCheckpoint(db.knex, {
+                    // Delete all checkpoint (including the trackDeletes ones)
+                    hardDeleteCheckpoints(db.knex, {
                         environmentId,
                         connectionId,
-                        key: getCheckpointKey({ type: 'sync', name: syncName, variant: syncVariant }),
-                        force: true
+                        keyPrefix: getCheckpointKey({ type: 'sync', name: syncName, variant: syncVariant })
                     });
 
                     if (delete_records) {


### PR DESCRIPTION
The track deletes features currently assume the entire dataset is being fetched/saved within a single execution. 
Which means it isn't compatible with checkpoints and fetching/saving across multiple executions. 
To solve this problem, this PR is introducing a way to explicitly define the start and the end of the track deletes interval, storing the starting point in a special checkpoint that survive across executions, instead of assuming the start is always the beginning of the current execution

cc @bastienbeurier to agree on the naming `trackDeletesStart/trackDeletesEnd`

ex:
```
exec: async (nango) => {
        await nango.trackDeletesStart('MyModel');

        ...
        await nango.batchSave([...], 'MyModel');
        ...

        const deleted = await nango.trackDeletesEnd('MyModel');
}
```

<!-- Summary by @propel-code-bot -->

---

The runner stores a per-model delete-window checkpoint keyed off the sync checkpoint and, when the window closes, uses it to invoke deletion of outdated records before clearing the checkpoint.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `trackDeletesStart`/`trackDeletesEnd` to `NangoSyncBase` and `NangoSyncRunner`, with per-model checkpoint keys and `deleteOutdatedRecords` using stored `syncJobId`
• Refactored `Checkpointing` in `packages/runner/lib/sdk/checkpointing.ts` to manage per-key state and accept `key` arguments for checkpoint operations
• Expanded CLI parser/compiler validations to track `trackDeletes` calls per model and enforce ordering around `batchSave`
• Updated docs and examples to use `trackDeletesStart`/`trackDeletesEnd` and mark `deleteRecordsFromPreviousExecutions` as deprecated
• Reset behavior in `packages/shared/lib/clients/orchestrator.ts` now hard-deletes all checkpoints with a key prefix

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• A run that calls `trackDeletesStart` but exits before `trackDeletesEnd` will leave the delete-window checkpoint in place for future runs
• The per-key `stateByKey` map in `Checkpointing` is not pruned, which could grow in long-lived processes with many dynamic keys
• Full reset now returns an error if `hardDeleteCheckpoints` fails, which could block user-initiated resets

</details>

---
*This summary was automatically generated by @propel-code-bot*