### PR TITLE
fix(security): update to npm@11.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,8 +81,8 @@ RUN true \
 # Resulting new, minimal image
 FROM node:22.21.1-bookworm-slim AS web
 
-# Install a more recent npm
-RUN npm install -g npm@11.6.4
+# Install a more recent npm - remove when node:24.13.1 or later is used
+RUN npm install -g npm@11.8.0
 
 # - Bash is just to be able to log inside the image and have a decent shell
 RUN true \


### PR DESCRIPTION
<!-- Describe the problem and your solution -->

We presently see two vulnerabilities within the npm package at version 11.6.4 (`npm install -g npm@11.6.4`). You can test this by running the following:

```
docker pull nangohq/nango:managed-1.4.11-0.69.31-8b281d6cc88e062f01f8d10040b4bda928443ae4
trivy image nangohq/nango:managed-1.4.11-0.69.31-8b281d6cc88e062f01f8d10040b4bda928443ae4
```

This will reveal two vulnerabilities: CVE-2026-23950 and CVE-2026-23745.


<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

To test you can do the following:

```shell
docker build ./ --tag nango-npm-11-8-0 # this builds successfully
trivy image  nango-npm-11-8-0
```

The build will succeed. This will show those vulnerabilities are no longer present.

<!-- Summary by @propel-code-bot -->

---

This update explicitly overrides the base image’s npm to version 11.8.0 to eliminate the CVEs and documents that the custom installation can be removed once a Node base image of 24.13.1 or later is adopted.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced `npm install -g npm@11.6.4` with `npm install -g npm@11.8.0` in the `Dockerfile`
• Added a clarifying comment to drop the custom npm installation when `node:24.13.1` or later becomes the base image

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• `npm@11.8.0` may introduce behavioral differences; monitor for any regressions in build or install scripts until the base Node image is updated.

</details>

---
*This summary was automatically generated by @propel-code-bot*