### PR TITLE
docs: improve CLI dependency management guidance for CI and monorepos

### DIFF
--- a/docs/implementation-guides/platform/functions/ci-cd.mdx
+++ b/docs/implementation-guides/platform/functions/ci-cd.mdx
@@ -135,6 +135,27 @@ npm test
 
 See more in the [Testing integrations guide](/implementation-guides/platform/functions/testing).
 
+## Dependency-safe CI and monorepos
+
+When running Nango in CI or monorepos, you often want to avoid modifying `package.json` or running extra package installs from within Nango commands.
+
+Use:
+
+- `--no-dependency-update` on CLI commands
+- or `NANGO_CLI_DEPENDENCY_UPDATE=false` as an environment variable
+
+Example:
+
+```bash
+npx nango@latest deploy dev --no-dependency-update
+```
+
+This is useful when dependency installation is already handled by an earlier CI step (for example at the workspace root).
+
+<Info>
+In CI environments, Nango automatically disables dependency updates to prevent the CI pipeline from modifying the `package.json` file. Passing `--no-dependency-update` explicitly is still helpful for clarity and to silence warning messages.
+</Info>
+
 ## Related resources
 
 - [Testing integrations](/implementation-guides/platform/functions/testing) - A comprehensive guide to testing your Nango integrations.

--- a/docs/implementation-guides/platform/functions/ci-cd.mdx
+++ b/docs/implementation-guides/platform/functions/ci-cd.mdx
@@ -152,6 +152,10 @@ npx nango@latest deploy dev --no-dependency-update
 
 This is useful when dependency installation is already handled by an earlier CI step (for example at the workspace root).
 
+<Warning>
+With `--no-dependency-update` (and in CI by default), Nango will not run dependency installation. Make sure your pipeline installs dependencies first (for example with `npm ci`, `pnpm install --frozen-lockfile`, `yarn install --immutable`, or `bun install --frozen-lockfile`) before running Nango commands.
+</Warning>
+
 <Info>
 In CI environments, Nango automatically disables dependency updates to prevent the CI pipeline from modifying the `package.json` file. Passing `--no-dependency-update` explicitly is still helpful for clarity and to silence warning messages.
 </Info>

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -133,8 +133,7 @@ NANGO_CLI_UPGRADE_MODE=prompt # Default value
 # Note: Destructive changes (like removing a sync or renaming a model) requires confirmation, even when NANGO_DEPLOY_AUTO_CONFIRM is set to true. To bypass this restriction, the --allow-destructive flag can be passed to nango deploy.
 NANGO_DEPLOY_AUTO_CONFIRM=false # Default value
 
-# Skip automatic dependency updates and package installation.
-# Equivalent to passing --no-dependency-update.
+# Control automatic dependency updates. Set to "false" to skip installs (equivalent to --no-dependency-update).
 NANGO_CLI_DEPENDENCY_UPDATE=true # Default value
 ```
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -109,6 +109,10 @@ Global command flags:
 
 # Command flag to disable interactive mode.
 --no-interactive
+
+# Command flag to skip automatic package.json updates and package installs.
+# Recommended in CI and monorepos where dependency updates are managed elsewhere.
+--no-dependency-update
 ```
 
 Environment variables:
@@ -128,7 +132,41 @@ NANGO_CLI_UPGRADE_MODE=prompt # Default value
 # Whether to prompt before deployments.
 # Note: Destructive changes (like removing a sync or renaming a model) requires confirmation, even when NANGO_DEPLOY_AUTO_CONFIRM is set to true. To bypass this restriction, the --allow-destructive flag can be passed to nango deploy.
 NANGO_DEPLOY_AUTO_CONFIRM=false # Default value
+
+# Skip automatic dependency updates and package installation.
+# Equivalent to passing --no-dependency-update.
+NANGO_CLI_DEPENDENCY_UPDATE=true # Default value
 ```
+
+## Dependency management
+
+For Zero YAML projects, the CLI can keep required dev dependencies (for example `nango` and related tooling) in sync and run package installation when needed.
+
+### `--no-dependency-update`
+
+Use `--no-dependency-update` to disable automatic `package.json` updates and dependency installs:
+
+```bash
+nango deploy dev --no-dependency-update
+```
+
+This is especially useful when:
+
+- your CI pipeline should not modify files
+- your monorepo manages dependencies at the workspace root
+- you want full control over when `install` runs
+
+In CI, dependency updates are automatically disabled to avoid hanging. Passing `--no-dependency-update` explicitly is still recommended to make intent clear and silence the warning.
+
+## Package manager support
+
+Nango supports all major JavaScript package managers. The CLI automatically detects and uses your package manager for installs. Detection works from the current directory upward (monorepo-aware), in this order:
+
+1. `package.json` `packageManager` field (Corepack standard)
+2. lock files (`pnpm-lock.yaml`, `yarn.lock`, `bun.lockb` / `bun.lock`)
+3. fallback to `npm`
+
+Supported managers are `npm`, `pnpm`, `yarn`, and `bun`.
 
 <Tip>
 **Questions, problems, feedback?** Please reach out in the [Slack community](https://nango.dev/slack).

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -158,6 +158,10 @@ This is especially useful when:
 
 In CI, dependency updates are automatically disabled to avoid hanging. Passing `--no-dependency-update` explicitly is still recommended to make intent clear and silence the warning.
 
+<Warning>
+When dependency updates are disabled, Nango will not install dependencies for you. Ensure dependencies are already installed before running commands.
+</Warning>
+
 ## Package manager support
 
 Nango supports all major JavaScript package managers. The CLI automatically detects and uses your package manager for installs. Detection works from the current directory upward (monorepo-aware), in this order:


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
This PR improves the CLI documentation around dependency management with a focus on CI and monorepo workflows.

- Documents `--no-dependency-update` in CLI reference and CI/CD docs
- Clarifies that when dependency updates are disabled (and in CI by default), pipelines must install dependencies before running Nango commands
- Adds package manager guidance for `npm`, `pnpm`, `yarn`, and `bun`
- Adds monorepo-specific notes and examples for safer, explicit CI behavior

Recent CLI improvements added better package manager + monorepo support and introduced `--no-dependency-update`. These docs updates make expected pipeline behavior explicit and reduce confusion/regressions in existing setups.

<!-- Issue ticket number and link (if applicable) -->
NAN-4856
<!-- Testing instructions (skip if just adding/editing providers) -->
[CLI changes](https://nango-agus-nan-4856-cli-dependency-management-docs.mintlify.app/reference/cli)
[CI/CD changes](https://nango-agus-nan-4856-cli-dependency-management-docs.mintlify.app/implementation-guides/platform/functions/ci-cd)


<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/nango/nango/editor/agus%2FNAN-4856%2Fcli-dependency-management-docs?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->

<!-- Summary by @propel-code-bot -->

---

The updates also surface the `NANGO_CLI_DEPENDENCY_UPDATE` environment variable, outline how the new dependency-management section covers zero-YAML workflows and CI defaults, and clarify the CLI’s package-manager detection order across npm, pnpm, yarn, and bun so automation behaves predictably.

<details>
<summary><strong>Possible Issues</strong></summary>

• If the CLI default for `NANGO_CLI_DEPENDENCY_UPDATE` differs from `true`, the documentation will mislead users about when installs run.

</details>

---
*This summary was automatically generated by @propel-code-bot*