### PR TITLE
fix(lambda): better logging and error message

### DIFF
--- a/packages/jobs/lib/runtime/lambda.adapter.ts
+++ b/packages/jobs/lib/runtime/lambda.adapter.ts
@@ -1,12 +1,14 @@
 import { InvokeCommand, LambdaClient } from '@aws-sdk/client-lambda';
 
-import { Err, Ok } from '@nangohq/utils';
+import { Err, Ok, getLogger } from '@nangohq/utils';
 
 import { getRoutingId } from '../utils/lambda.js';
 
 import type { RuntimeAdapter } from './adapter.js';
 import type { Fleet } from '@nangohq/fleet';
 import type { NangoProps, Result } from '@nangohq/types';
+
+const logger = getLogger('LambdaRuntimeAdapter');
 
 const client = new LambdaClient();
 
@@ -48,7 +50,8 @@ export class LambdaRuntimeAdapter implements RuntimeAdapter {
             await client.send(command);
             return Ok(true);
         } catch (err) {
-            return Err(new Error(`Lambda was unable to execute the function`, { cause: err }));
+            logger.error('Lambda was unable to execute the function', err);
+            return Err(new Error(`The function runtime was unable to execute the function`, { cause: err }));
         }
     }
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Improved Lambda runtime adapter logging**

Adds structured logging to the Lambda runtime adapter by introducing a component-level logger created via `getLogger('LambdaRuntimeAdapter')`. Invocation failures now emit an explicit `logger.error` entry and return an updated error message clarifying that the function runtime failed to execute the function.

<details>
<summary><strong>Key Changes</strong></summary>

• Imported `getLogger` from `@nangohq/utils` and instantiated `logger` with the `LambdaRuntimeAdapter` scope
• Logged invocation failures via `logger.error('Lambda was unable to execute the function', err)` before returning
• Reworded the thrown error message to `The function runtime was unable to execute the function` while preserving the original error as `cause`

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• New error message omits the word 'Lambda', which might complicate filtering for AWS-specific issues unless the log is reviewed.

</details>

---
*This summary was automatically generated by @propel-code-bot*