### PR TITLE
feat: Add DoltHub provider

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -4791,6 +4791,23 @@ docuware:
             description: The Password to your DocuWare account
             doc_section: '#step-2-finding-your-credentials'
 
+dolthub:
+    display_name: DoltHub
+    categories:
+        - dev-tools
+    auth_mode: API_KEY
+    proxy:
+        base_url: https://www.dolthub.com/api/v1alpha1
+        headers:
+            authorization: token ${apiKey}
+    docs: https://docs.dolthub.com/guides/dolthub-api
+    credentials:
+        apiKey:
+            type: string
+            title: API Token
+            description: Your DoltHub API token from Settings > API Tokens
+            doc_section: '#api-tokens'
+
 domo:
     display_name: Domo
     categories:


### PR DESCRIPTION
Add DoltHub as a built-in provider with API_KEY authentication.

[DoltHub](https://www.dolthub.com/) is a collaborative SQL database platform built on [Dolt](https://github.com/dolthub/dolt), the version-controlled MySQL-compatible database. Its API enables programmatic access to databases, pull requests, and collaboration features.

Key details:
- Auth mode: `API_KEY` with `token ${apiKey}` authorization header prefix (not `Bearer`), matching DoltHub's API authentication scheme
- Base URL: `https://www.dolthub.com/api/v1alpha1`
- [DoltHub API documentation](https://docs.dolthub.com/guides/dolthub-api/authentication)

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->