### PR TITLE
fix(webapp): support JWT privateKey as pem string on connection page

### DIFF
--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/JwtCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/JwtCredentials.tsx
@@ -31,10 +31,21 @@ export const JwtCredentialsComponent: React.FC<{
             )}
 
             {/* Special handling for Private key (based on legacy code before redesign) */}
-            {'privateKey' in credentials && 'id' in credentials.privateKey && 'secret' in credentials.privateKey && (
+            {'privateKey' in credentials && credentials.privateKey != null && (
                 <div className="flex flex-col gap-2">
                     <Label htmlFor="privateKey">Private key</Label>
-                    <SecretInput id="privateKey" value={`${credentials.privateKey.id}:${credentials.privateKey.secret}`} disabled copy />
+                    <SecretInput
+                        id="privateKey"
+                        value={
+                            typeof credentials.privateKey === 'object' && 'id' in credentials.privateKey && 'secret' in credentials.privateKey
+                                ? `${credentials.privateKey.id}:${credentials.privateKey.secret}`
+                                : typeof credentials.privateKey === 'string'
+                                  ? credentials.privateKey
+                                  : ''
+                        }
+                        disabled
+                        copy
+                    />
                 </div>
             )}
 

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/TwoStepCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/TwoStepCredentials.tsx
@@ -37,8 +37,8 @@ export const TwoStepCredentialsComponent: React.FC<{
                 </div>
             )}
 
-            {/* Special handling for Private key (based on legacy code before redesign) */}
-            {'privateKey' in credentials && 'id' in credentials.privateKey && 'secret' in credentials.privateKey && (
+            {/* TWO_STEP privateKey is always a string (e.g. PEM). */}
+            {'privateKey' in credentials && typeof credentials.privateKey === 'string' && (
                 <div className="flex flex-col gap-2">
                     <Label htmlFor="privateKey">Private key</Label>
                     <SecretInput id="privateKey" value={credentials.privateKey} disabled copy />

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/TwoStepCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/TwoStepCredentials.tsx
@@ -37,17 +37,9 @@ export const TwoStepCredentialsComponent: React.FC<{
                 </div>
             )}
 
-            {/* TWO_STEP privateKey is always a string (e.g. PEM). */}
-            {'privateKey' in credentials && typeof credentials.privateKey === 'string' && (
-                <div className="flex flex-col gap-2">
-                    <Label htmlFor="privateKey">Private key</Label>
-                    <SecretInput id="privateKey" value={credentials.privateKey} disabled copy />
-                </div>
-            )}
-
             {/* Other free-form strings */}
             {Object.entries(credentials).map(([key, value]) => {
-                if (['type', 'token', 'refresh_token', 'expires_at', 'raw', 'privateKey'].includes(key) || typeof value !== 'string') {
+                if (['type', 'token', 'refresh_token', 'expires_at', 'raw'].includes(key) || typeof value !== 'string') {
                     return null;
                 }
 


### PR DESCRIPTION
## Describe the problem and your solution

- support JWT privateKey as pem string on connection page

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Support JWT PEM `privateKey` rendering on connection page**

This PR updates credential rendering on the connection page to handle JWT `privateKey` values provided as PEM strings as well as legacy object-based keys. It also removes the redundant private key section from two-step credentials so string keys are handled through the generic field rendering.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `JwtCredentialsComponent` in `packages/webapp/src/pages/Connection/components/AuthCredentials/JwtCredentials.tsx` to render `credentials.privateKey` when it is either an object with `id`/`secret` or a string
• Removed special private key block from `TwoStepCredentialsComponent` in `packages/webapp/src/pages/Connection/components/AuthCredentials/TwoStepCredentials.tsx` so string keys render through the generic map

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• None

</details>

---
*This summary was automatically generated by @propel-code-bot*