### PR TITLE
fix(webapp): invalidate flows when toggling function

### DIFF
--- a/packages/webapp/src/hooks/useFlow.tsx
+++ b/packages/webapp/src/hooks/useFlow.tsx
@@ -1,17 +1,27 @@
-import { apiFetch } from '../utils/api';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { APIError, apiFetch } from '../utils/api';
 
 import type { PatchFlowDisable, PatchFlowEnable, PatchFlowFrequency, PostPreBuiltDeploy, PutUpgradePreBuiltFlow } from '@nangohq/types';
 
-export async function apiPreBuiltDeployFlow(env: string, body: PostPreBuiltDeploy['Body']) {
-    const res = await apiFetch(`/api/v1/flows/pre-built/deploy/?env=${env}`, {
-        method: 'POST',
-        body: JSON.stringify(body)
+export function usePreBuiltDeployFlow(env: string, integrationId: string) {
+    const queryClient = useQueryClient();
+    return useMutation<PostPreBuiltDeploy['Success'], APIError, PostPreBuiltDeploy['Body']>({
+        mutationFn: async (body) => {
+            const res = await apiFetch(`/api/v1/flows/pre-built/deploy/?env=${env}`, {
+                method: 'POST',
+                body: JSON.stringify(body)
+            });
+            const json = (await res.json()) as PostPreBuiltDeploy['Reply'];
+            if (!res.ok || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+            return json;
+        },
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: ['integrations', env, integrationId, 'flows'] });
+        }
     });
-
-    return {
-        res,
-        json: (await res.json()) as PostPreBuiltDeploy['Reply']
-    };
 }
 
 export async function apiPreBuiltUpgrade(env: string, body: PutUpgradePreBuiltFlow['Body']) {
@@ -26,28 +36,44 @@ export async function apiPreBuiltUpgrade(env: string, body: PutUpgradePreBuiltFl
     };
 }
 
-export async function apiFlowEnable(env: string, params: PatchFlowEnable['Params'], body: PatchFlowEnable['Body']) {
-    const res = await apiFetch(`/api/v1/flows/${params.id}/enable?env=${env}`, {
-        method: 'PATCH',
-        body: JSON.stringify(body)
+export function useFlowEnable(env: string, integrationId: string) {
+    const queryClient = useQueryClient();
+    return useMutation<PatchFlowEnable['Success'], APIError, { params: PatchFlowEnable['Params']; body: PatchFlowEnable['Body'] }>({
+        mutationFn: async ({ params, body }) => {
+            const res = await apiFetch(`/api/v1/flows/${params.id}/enable?env=${env}`, {
+                method: 'PATCH',
+                body: JSON.stringify(body)
+            });
+            const json = (await res.json()) as PatchFlowEnable['Reply'];
+            if (!res.ok || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+            return json;
+        },
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: ['integrations', env, integrationId, 'flows'] });
+        }
     });
-
-    return {
-        res,
-        json: (await res.json()) as PatchFlowEnable['Reply']
-    };
 }
 
-export async function apiFlowDisable(env: string, params: PatchFlowDisable['Params'], body: PatchFlowDisable['Body']) {
-    const res = await apiFetch(`/api/v1/flows/${params.id}/disable?env=${env}`, {
-        method: 'PATCH',
-        body: JSON.stringify(body)
+export function useFlowDisable(env: string, integrationId: string) {
+    const queryClient = useQueryClient();
+    return useMutation<PatchFlowDisable['Success'], APIError, { params: PatchFlowDisable['Params']; body: PatchFlowDisable['Body'] }>({
+        mutationFn: async ({ params, body }) => {
+            const res = await apiFetch(`/api/v1/flows/${params.id}/disable?env=${env}`, {
+                method: 'PATCH',
+                body: JSON.stringify(body)
+            });
+            const json = (await res.json()) as PatchFlowDisable['Reply'];
+            if (!res.ok || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+            return json;
+        },
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: ['integrations', env, integrationId, 'flows'] });
+        }
     });
-
-    return {
-        res,
-        json: (await res.json()) as PatchFlowDisable['Reply']
-    };
 }
 
 export async function apiFlowUpdateFrequency(env: string, params: PatchFlowFrequency['Params'], body: PatchFlowFrequency['Body']) {


### PR DESCRIPTION
I migrated useGetIntegrationFlows to useQuery, but I missed this place that mutated something in flows and didn't invalidate it properly (it was still invalidating swr keys).

<!-- Summary by @propel-code-bot -->

---

It also shifts flow enable/disable and pre-built deploy behavior in the UI to React Query mutation hooks, improving loading and API error handling while ensuring flow data is refreshed after toggling.

<details>
<summary><strong>Key Changes</strong></summary>

• Replaced SWR `mutate` and manual API calls in `packages/webapp/src/pages/Integrations/components/FunctionSwitch.tsx` with React Query mutations from `packages/webapp/src/hooks/useFlow.tsx`
• Added `usePreBuiltDeployFlow`, `useFlowEnable`, and `useFlowDisable` hooks that wrap `apiFetch` and invalidate `['integrations', env, integrationId, 'flows']` on success
• Updated enable/disable logic to use `APIError`-based error handling and shared request body creation

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Only `['integrations', env, integrationId, 'flows']` is invalidated; if other UI relies on broader integration queries, those views may remain stale.

</details>

---
*This summary was automatically generated by @propel-code-bot*