### PR TITLE
fix(webapp): overflowing models cause sync table to be scrollable

### DIFF
--- a/packages/webapp/src/pages/Connection/components/SyncsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/SyncsTab.tsx
@@ -142,6 +142,8 @@ const SyncRow = ({ sync, connection, provider }: { sync: SyncResponse; connectio
         });
     }, [connection?.connection_id, env, provider, sync.latest_sync?.updated_at, sync.name]);
 
+    const models = Array.isArray(sync.models) ? sync.models.join(', ') : sync.models;
+
     return (
         <>
             <TableRow key={sync.id}>
@@ -167,11 +169,9 @@ const SyncRow = ({ sync, connection, provider }: { sync: SyncResponse; connectio
                 <TableCell className="max-w-38">
                     <Tooltip>
                         <TooltipTrigger asChild>
-                            <span className="text-body-small-semi text-text-primary truncate block">
-                                {Array.isArray(sync.models) ? sync.models.join(', ') : sync.models}
-                            </span>
+                            <span className="text-body-small-semi text-text-primary truncate block">{models}</span>
                         </TooltipTrigger>
-                        <TooltipContent className="p-2">{Array.isArray(sync.models) ? sync.models.join(', ') : sync.models}</TooltipContent>
+                        <TooltipContent className="p-2">{models}</TooltipContent>
                     </Tooltip>
                 </TableCell>
 

--- a/packages/webapp/src/pages/Connection/components/SyncsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/SyncsTab.tsx
@@ -164,8 +164,15 @@ const SyncRow = ({ sync, connection, provider }: { sync: SyncResponse; connectio
                 </TableCell>
 
                 {/* Models */}
-                <TableCell>
-                    <span className="text-body-small-semi text-text-primary">{Array.isArray(sync.models) ? sync.models.join(', ') : sync.models}</span>
+                <TableCell className="max-w-38">
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span className="text-body-small-semi text-text-primary truncate block">
+                                {Array.isArray(sync.models) ? sync.models.join(', ') : sync.models}
+                            </span>
+                        </TooltipTrigger>
+                        <TooltipContent className="p-2">{Array.isArray(sync.models) ? sync.models.join(', ') : sync.models}</TooltipContent>
+                    </Tooltip>
                 </TableCell>
 
                 {/* Last Execution */}


### PR DESCRIPTION
Truncates the "Models" column (and adds full list on a tooltip) to prevent the table from becoming horizontally scrollable.

<img width="1104" height="317" alt="image" src="https://github.com/user-attachments/assets/9c47048d-c882-4611-9611-91d0bc968a8f" />
<!-- Summary by @propel-code-bot -->

---

It also centralizes the models text into a reusable `models` variable to avoid duplication.

<details>
<summary><strong>Possible Issues</strong></summary>

• Tooltip may display `undefined` if `sync.models` is missing; consider defaulting `models` to an empty string

</details>

---
*This summary was automatically generated by @propel-code-bot*