### PR TITLE
feat(integrations): migrate asana-mcp to v2

### DIFF
--- a/docs/api-integrations/asana-mcp.mdx
+++ b/docs/api-integrations/asana-mcp.mdx
@@ -76,14 +76,15 @@ Connect to Asana (MCP) with Nango and see data flow in 2 minutes.
         ```
         </Tab>
 
-    </Tabs>
+     </Tabs>
+    Or fetch credentials with the [Node SDK](/reference/sdks/node#get-a-connection-with-credentials) or [API](/reference/api/connection/get).
     ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
     </Step>
 
     <Step title="Implement Nango in your app">
         Follow our [Auth implementation guide](/implementation-guides/platform/auth/implement-api-auth) to integrate Nango in your app.
 
-        To obtain your own OAuth credentials, follow the setup guide linked below.
+        To obtain your own production credentials, follow the setup guide linked below.
     </Step>
 </Steps>
 

--- a/docs/api-integrations/asana-mcp.mdx
+++ b/docs/api-integrations/asana-mcp.mdx
@@ -1,0 +1,107 @@
+---
+title: 'Asana (MCP)'
+sidebarTitle: 'Asana (MCP)'
+description: 'Integrate your application with the Asana MCP API'
+---
+
+## 🚀 Quickstart
+
+Connect to Asana (MCP) with Nango and see data flow in 2 minutes.
+
+<Steps>
+    <Step title="Create the integration">
+    In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Asana (MCP)_.
+    </Step>
+    <Step title="Authorize Asana">
+    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then log in to Asana. Later, you'll let your users do the same directly from your app.
+    </Step>
+    <Step title="Initialize the Asana MCP connection">
+    Make your first MCP request to Asana (initialize handshake). Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+    <Tabs>
+        <Tab title="cURL">
+
+            ```bash
+            curl "https://api.nango.dev/v2/mcp" \
+              -X POST \
+              -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+              -H "Provider-Config-Key: <INTEGRATION-ID>" \
+              -H "Connection-Id: <CONNECTION-ID>" \
+              -H "Content-Type: application/json" \
+              -d '{
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "nango-client",
+                        "version": "1.0.0"
+                    }
+                }
+            }'
+            ```
+
+        </Tab>
+
+        <Tab title="Node">
+
+        Install Nango's backend SDK with `npm i @nangohq/node`. Then run:
+
+        ```typescript
+        import { Nango } from '@nangohq/node';
+
+        const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+
+        const res = await nango.post({
+            endpoint: '/v2/mcp',
+            providerConfigKey: '<INTEGRATION-ID>',
+            connectionId: '<CONNECTION-ID>',
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'initialize',
+                params: {
+                    protocolVersion: '2024-11-05',
+                    capabilities: {},
+                    clientInfo: {
+                        name: 'nango-client',
+                        version: '1.0.0'
+                    }
+                }
+            }
+        });
+
+        console.log(res.data);
+        ```
+        </Tab>
+
+    </Tabs>
+    ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+    </Step>
+
+    <Step title="Implement Nango in your app">
+        Follow our [Auth implementation guide](/implementation-guides/platform/auth/implement-api-auth) to integrate Nango in your app.
+
+        To obtain your own OAuth credentials, follow the setup guide linked below.
+    </Step>
+</Steps>
+
+## 📚 Asana (MCP) Integration Guides
+
+Nango-maintained guides for Asana MCP.
+
+- [How to register your own Asana MCP OAuth app](/api-integrations/asana-mcp/how-to-register-your-own-asana-mcp-oauth-app)  
+Register an OAuth app with Asana for MCP and obtain credentials to connect it to Nango.
+
+Official docs: [Integrating with Asana's MCP Server](https://developers.asana.com/docs/integrating-with-asanas-mcp-server)
+
+## 🧩 Pre-built syncs & actions for Asana (MCP)
+
+Enable them in your dashboard. [Extend and customize](/implementation-guides/platform/functions/customize-template) to fit your needs.
+
+import PreBuiltUseCases from "/snippets/generated/asana-mcp/PreBuiltUseCases.mdx"
+
+<PreBuiltUseCases />
+
+---

--- a/docs/api-integrations/asana-mcp/how-to-register-your-own-asana-mcp-oauth-app.mdx
+++ b/docs/api-integrations/asana-mcp/how-to-register-your-own-asana-mcp-oauth-app.mdx
@@ -16,7 +16,7 @@ This guide shows you how to register your own app with Asana to obtain your OAut
     3. Enter your app name (e.g., "My MCP Client").
     4. Select **MCP app** as the app type.
     5. Click **Create app**.
-    You'll see your app's **Client ID** and **Client secret**. Keep these handy, you'll need them for authentication.
+    You'll see your app's **Client ID** and **Client secret**. Keep these handy; you'll need them for authentication.
   </Step>
   <Step title="Configure OAuth settings">
     1. In the left sidebar, click **OAuth**.
@@ -38,3 +38,5 @@ This guide shows you how to register your own app with Asana to obtain your OAut
 </Steps>
 
 For more details, see [Integrating with Asana's MCP Server](https://developers.asana.com/docs/integrating-with-asanas-mcp-server).
+
+---

--- a/docs/api-integrations/asana-mcp/how-to-register-your-own-asana-mcp-oauth-app.mdx
+++ b/docs/api-integrations/asana-mcp/how-to-register-your-own-asana-mcp-oauth-app.mdx
@@ -1,0 +1,40 @@
+---
+title: 'How to register your own Asana MCP OAuth app'
+sidebarTitle: 'Asana MCP Setup'
+description: 'Register an OAuth app with Asana for MCP and connect it to Nango'
+---
+
+This guide shows you how to register your own app with Asana to obtain your OAuth credentials (client ID and client secret) for the Asana MCP server. These are required to let your users grant your app access to their Asana account via Nango.
+
+<Steps>
+<Step title="Create an account">
+    If you don't already have one, sign up for a free trial [Asana account](https://asana.com/create-account).
+  </Step>
+  <Step title="Create your app">
+    1. Navigate to [My apps](https://app.asana.com/0/my-apps).
+    2. Click the **Create new app** button.
+    3. Enter your app name (e.g., "My MCP Client").
+    4. Select **MCP app** as the app type.
+    5. Click **Create app**.
+    You'll see your app's **Client ID** and **Client secret**. Keep these handy, you'll need them for authentication.
+  </Step>
+  <Step title="Configure OAuth settings">
+    1. In the left sidebar, click **OAuth**.
+    2. Add your **Redirect URL**—the callback URL where Asana will send authorization codes. Use `https://api.nango.dev/oauth/callback` for Nango.
+  </Step>
+  <Step title="Configure workspace access">
+    Configure which workspaces can use your app:
+    1. In the left sidebar, click **Manage distribution**.
+    2. Under **Distribution method**, choose one of the following:
+       - **Specific workspaces:** Select individual workspaces where you want the MCP integration to be usable.
+       - **Any workspace:** Allow the app to be used in any workspace.
+    3. If you selected **Specific workspaces**, add the workspace(s) where you want to test.
+    4. Click **Save changes**.
+    **Important:** If you choose "Specific workspaces" but don't select any workspaces, users will see an error saying "This app is not available to your Asana workspace or organization." Make sure to select at least one workspace before testing.
+  </Step>
+  <Step title="Next">
+    Enter your **Client ID** and **Client secret** in the integration settings in Nango, then follow the [_Quickstart_](/getting-started/quickstart) to connect your first account.
+  </Step>
+</Steps>
+
+For more details, see [Integrating with Asana's MCP Server](https://developers.asana.com/docs/integrating-with-asanas-mcp-server).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -261,6 +261,7 @@
               "integrations/all/apple-app-store",
               "integrations/all/appstle-subscriptions",
               "api-integrations/asana",
+              "api-integrations/asana-mcp",
               "integrations/all/asana-scim",
               "integrations/all/ashby",
               "integrations/all/atlas-so",

--- a/docs/snippets/generated/asana-mcp/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/asana-mcp/PreBuiltUseCases.mdx
@@ -1,0 +1,3 @@
+_No pre-built syncs or actions available yet._
+
+<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -1170,17 +1170,24 @@ asana-mcp:
         - ticketing
         - mcp
     auth_mode: MCP_OAUTH2
-    client_registration: dynamic
-    authorization_url: https://mcp.asana.com/authorize
-    token_url: https://mcp.asana.com/token
-    registration_url: https://mcp.asana.com/register
+    client_registration: static
+    authorization_url: https://app.asana.com/-/oauth_authorize
+    token_url: https://app.asana.com/-/oauth_token
     authorization_params:
         response_type: code
+        resource: https://mcp.asana.com/v2
     token_params:
         grant_type: authorization_code
     refresh_params:
         grant_type: refresh_token
-    docs: https://nango.dev/docs/api-integrations/asana
+    default_scopes:
+        - default
+    proxy:
+        headers:
+            accept: application/json,text/event-stream
+        base_url: https://mcp.asana.com/
+    docs: https://nango.dev/docs/api-integrations/asana-mcp
+    setup_guide_url: https://nango.dev/docs/api-integrations/asana-mcp/how-to-register-your-own-asana-mcp-oauth-app
 
 asana-scim:
     display_name: Asana (SCIM API)


### PR DESCRIPTION
## Describe the problem and your solution

- For security reasons, and to take advantage of the benefits of statically registering clients, Asana is [migrating](https://forum.asana.com/t/new-v2-mcp-server-now-generally-available/1122647)
 their MCP implementation from `dynamic` to `static` client registration.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Migrate `asana-mcp` integration to MCP v2 static registration with updated docs**

This PR updates the `asana-mcp` provider configuration to use static client registration and Asana MCP v2 OAuth endpoints, including the `resource` authorization parameter, `default_scopes`, and MCP proxy header requirements. It also refreshes the documentation by adding a new Asana MCP quickstart page, a setup guide for registering OAuth apps, and a generated snippet placeholder, plus navigation updates to surface the new docs.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `asana-mcp` configuration in `packages/providers/providers.yaml` to `client_registration: static`, new `authorization_url`/`token_url`, `resource` param, `default_scopes`, and proxy headers
• Added new documentation pages in `docs/api-integrations/asana-mcp.mdx` and `docs/api-integrations/asana-mcp/how-to-register-your-own-asana-mcp-oauth-app.mdx`
• Added docs navigation entry in `docs/docs.json` and placeholder snippet in `docs/snippets/generated/asana-mcp/PreBuiltUseCases.mdx`

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Existing `asana-mcp` connections may need reauthorization due to static registration changes.
• The `default_scopes` value `default` must be valid for Asana MCP v2 to avoid auth failures.

</details>

---
*This summary was automatically generated by @propel-code-bot*