### PR TITLE
docs: Add Share Connect link docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -168,6 +168,7 @@
                 "pages": [
                   "implementation-guides/platform/auth/configure-integration",
                   "implementation-guides/platform/auth/implement-api-auth",
+                  "implementation-guides/platform/auth/share-connect-link",
                   "implementation-guides/platform/auth/connection-tags",
                   "implementation-guides/platform/auth/customize-connect-ui",
                   "implementation-guides/platform/auth/contribute-new-api"

--- a/docs/implementation-guides/platform/auth/implement-api-auth.mdx
+++ b/docs/implementation-guides/platform/auth/implement-api-auth.mdx
@@ -117,6 +117,36 @@ const res = await fetch('/sessionToken', { method: 'POST' }); // Retrieve the se
 connect.setSessionToken(res.sessionToken); // A loading indicator is shown until this is set.
 ```
 
+### Share a connect link
+
+If you want to let a user authenticate later or on another device, your backend can return the `connect_link` from the connect session and share that URL directly.
+
+You can also do this from the Nango dashboard: in the Connections page, use the **Share connect link** button to generate a link, then send it to the end user.
+
+`connect_link` is short-lived and expires after 30 minutes, just like the session token.
+
+```ts
+import { Nango } from '@nangohq/node';
+
+const nango = new Nango({ secretKey: process.env['<NANGO-SECRET-KEY>'] });
+
+api.post('/connectLink', async (req, res) => {
+  const { data } = await nango.createConnectSession({
+    tags: {
+      end_user_id: '<END-USER-ID>',
+      end_user_email: '<END-USER-EMAIL>',
+      organization_id: '<ORGANIZATION-ID>'
+    },
+    allowed_integrations: ['<INTEGRATION-ID>']
+  });
+
+  res.status(200).send({
+    connectLink: data.connect_link,
+    expiresAt: data.expires_at
+  });
+});
+```
+
 For more details refer to our [Frontend SDK reference](/reference/sdks/frontend#connect-using-nango-connect-ui).
 
 The pre-built Connect UI is recommended, but optional. If you want full control over the connection UX, follow the [Customize Connect UI](/implementation-guides/platform/auth/customize-connect-ui) guide.

--- a/docs/implementation-guides/platform/auth/implement-api-auth.mdx
+++ b/docs/implementation-guides/platform/auth/implement-api-auth.mdx
@@ -117,36 +117,6 @@ const res = await fetch('/sessionToken', { method: 'POST' }); // Retrieve the se
 connect.setSessionToken(res.sessionToken); // A loading indicator is shown until this is set.
 ```
 
-### Share a connect link
-
-If you want to let a user authenticate later or on another device, your backend can return the `connect_link` from the connect session and share that URL directly.
-
-You can also do this from the Nango dashboard: in the Connections page, use the **Share connect link** button to generate a link, then send it to the end user.
-
-`connect_link` is short-lived and expires after 30 minutes, just like the session token.
-
-```ts
-import { Nango } from '@nangohq/node';
-
-const nango = new Nango({ secretKey: process.env['<NANGO-SECRET-KEY>'] });
-
-api.post('/connectLink', async (req, res) => {
-  const { data } = await nango.createConnectSession({
-    tags: {
-      end_user_id: '<END-USER-ID>',
-      end_user_email: '<END-USER-EMAIL>',
-      organization_id: '<ORGANIZATION-ID>'
-    },
-    allowed_integrations: ['<INTEGRATION-ID>']
-  });
-
-  res.status(200).send({
-    connectLink: data.connect_link,
-    expiresAt: data.expires_at
-  });
-});
-```
-
 For more details refer to our [Frontend SDK reference](/reference/sdks/frontend#connect-using-nango-connect-ui).
 
 The pre-built Connect UI is recommended, but optional. If you want full control over the connection UX, follow the [Customize Connect UI](/implementation-guides/platform/auth/customize-connect-ui) guide.

--- a/docs/implementation-guides/platform/auth/share-connect-link.mdx
+++ b/docs/implementation-guides/platform/auth/share-connect-link.mdx
@@ -1,0 +1,65 @@
+---
+title: 'Share a connect link'
+sidebarTitle: 'Share a connect link'
+description: 'Generate a short-lived connect link and share it with your end user.'
+---
+
+Use a connect link when you want to trigger authorization without opening Connect UI immediately in your app (for example: email-based onboarding, support-assisted setup, or cross-device flows).
+
+## Option 1: Generate a link from your backend
+
+Create a connect session and return the `connect_link` to your frontend or internal tools:
+
+<Tabs>
+  <Tab title="Node">
+    ```ts
+    import { Nango } from '@nangohq/node';
+
+    const nango = new Nango({ secretKey: process.env['<NANGO-SECRET-KEY>'] });
+
+    api.post('/connectLink', async (req, res) => {
+      const { data } = await nango.createConnectSession({
+        tags: {
+          end_user_id: '<END-USER-ID>',
+          end_user_email: '<END-USER-EMAIL>',
+          organization_id: '<ORGANIZATION-ID>'
+        },
+        allowed_integrations: ['<INTEGRATION-ID>']
+      });
+
+      res.status(200).send({
+        connectLink: data.connect_link,
+        expiresAt: data.expires_at
+      });
+    });
+    ```
+  </Tab>
+  <Tab title="cURL">
+    ```bash
+    curl --request POST \
+      --url https://api.nango.dev/connect/sessions \
+      --header 'Authorization: Bearer <NANGO-SECRET-KEY>' \
+      --header 'Content-Type: application/json' \
+      --data '{
+        "tags": {
+          "end_user_id": "<END-USER-ID>",
+          "end_user_email": "<END-USER-EMAIL>",
+          "organization_id": "<ORGANIZATION-ID>"
+        },
+        "allowed_integrations": [
+          "<INTEGRATION-ID>"
+        ]
+      }'
+    ```
+  </Tab>
+</Tabs>
+
+The returned `connect_link` expires after 30 minutes.
+
+## Option 2: Generate a link from the dashboard
+
+In the Nango dashboard, open the Connections page and use the **Share connect link** button. This generates a link that you can share directly with the end user.
+
+## Notes
+
+- For the API details, see [Create a connect session](/reference/api/connect/sessions/create).

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -199,7 +199,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
                 await navigator.clipboard.writeText(shareUrl.toString());
                 toast.toast({
                     title: 'Shareable link copied',
-                    description: `Session expires at ${formatDateToPreciseUSFormat(expiresAt)}`,
+                    description: `Session expires in 30 mins (${formatDateToPreciseUSFormat(expiresAt)})`,
                     variant: 'success'
                 });
             } catch (_) {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Add share Connect link docs
<!-- Issue ticket number and link (if applicable) -->
NAN-4898
<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- Summary by @propel-code-bot -->

---

**Add `share-connect-link` guide and clarify share link expiry toast**

This PR adds a new documentation page describing how to generate and share a `connect_link`, including backend and dashboard workflows with Node and cURL examples, and registers it in the docs navigation. It also updates the web app toast message when copying a share link to explicitly call out the 30‑minute expiry alongside the formatted timestamp.

<details>
<summary><strong>Key Changes</strong></summary>

• Added new guide `docs/implementation-guides/platform/auth/share-connect-link.mdx` with usage notes and examples for `connect_link` sharing
• Registered the new guide in `docs/docs.json` under the Auth implementation guides
• Updated share-link toast message in `packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx` to mention the 30‑minute expiry

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• The snippet uses `process.env['<NANGO-SECRET-KEY>']`, which will resolve to `undefined` unless replaced with a real env var name.

</details>

---
*This summary was automatically generated by @propel-code-bot*