### PR TITLE
fix(runner-sdk): triggerSync to support new opts param

### DIFF
--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -669,7 +669,7 @@ export class Nango {
         providerConfigKey: string,
         syncs?: (string | { name: string; variant: string })[],
         connectionId?: string,
-        opts?: { reset?: boolean; emptyCache?: boolean }
+        opts?: PostPublicTrigger['Body']['opts']
     ): Promise<void>;
 
     /**
@@ -680,14 +680,14 @@ export class Nango {
         syncs?: (string | { name: string; variant: string })[],
         connectionId?: string,
         // eslint-disable-next-line @typescript-eslint/unified-signatures
-        syncMode?: PostPublicTrigger['Body']['sync_mode'] | boolean
+        syncMode?: PostPublicTrigger['Body']['sync_mode'] | PostPublicTrigger['Body']['full_resync']
     ): Promise<void>;
 
     public async triggerSync(
         providerConfigKey: string,
         syncs?: (string | { name: string; variant: string })[],
         connectionId?: string,
-        optsOrSyncMode?: { reset?: boolean; emptyCache?: boolean } | PostPublicTrigger['Body']['sync_mode'] | boolean
+        optsOrSyncMode?: PostPublicTrigger['Body']['opts'] | PostPublicTrigger['Body']['sync_mode'] | PostPublicTrigger['Body']['full_resync']
     ): Promise<void> {
         const url = `${this.serverUrl}/sync/trigger`;
 

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -190,14 +190,36 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
         this.telemetryBag.customLogs += 1;
     }
 
+    /**
+     * @deprecated Use opts parameter instead of syncMode
+     */
     public triggerSync(
         providerConfigKey: string,
         connectionId: string,
         sync: string | { name: string; variant: string },
-        syncMode?: PostPublicTrigger['Body']['sync_mode'] | boolean
-    ): Promise<void | string> {
+        syncMode?: PostPublicTrigger['Body']['sync_mode'] | PostPublicTrigger['Body']['full_resync']
+    ): Promise<void | string>;
+
+    public triggerSync(
+        providerConfigKey: string,
+        connectionId: string,
+        sync: string | { name: string; variant: string },
+        opts?: PostPublicTrigger['Body']['opts']
+    ): Promise<void>;
+
+    public triggerSync(
+        providerConfigKey: string,
+        connectionId: string,
+        sync: string | { name: string; variant: string },
+        optsOrSyncMode?: PostPublicTrigger['Body']['opts'] | PostPublicTrigger['Body']['sync_mode'] | PostPublicTrigger['Body']['full_resync']
+    ): Promise<void> {
         this.throwIfAborted();
-        return this.nango.triggerSync(providerConfigKey, [sync], connectionId, syncMode);
+        // helping typescript to differentiate between the two overloads, we check if the parameter is an object (opts) or not (syncMode/full_resync)
+        const isLegacy = typeof optsOrSyncMode !== 'object';
+        if (isLegacy) {
+            return this.nango.triggerSync(providerConfigKey, [sync], connectionId, optsOrSyncMode);
+        }
+        return this.nango.triggerSync(providerConfigKey, [sync], connectionId, optsOrSyncMode);
     }
 
     public async startSync(providerConfigKey: string, syncs: (string | { name: string; variant: string })[], connectionId?: string): Promise<void> {


### PR DESCRIPTION
When deprecating `syncMode` and refactoring `triggerSync` parameter, I forgot to update the runner-sdk `triggerSync` function. 🙈 

<!-- Summary by @propel-code-bot -->

---

**Fix `triggerSync` overloads to support new `opts` parameter**

This PR updates the runner SDK and node client `triggerSync` overloads to accept the new `opts` parameter while preserving legacy `sync_mode`/`full_resync` signatures. It adds a deprecated overload for legacy usage and aligns type definitions to the shared `PostPublicTrigger['Body']['opts']` shape.

<details>
<summary><strong>Key Changes</strong></summary>

• Added overloads and internal handling in `NangoActionRunner.triggerSync()` to support `PostPublicTrigger['Body']['opts']` with a deprecated legacy signature in `packages/runner/lib/sdk/sdk.ts`
• Updated node client `triggerSync` method signatures to use `PostPublicTrigger['Body']['opts']` and include `full_resync` in legacy types in `packages/node-client/lib/index.ts`

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• The legacy detection treats `null` as an object; if `optsOrSyncMode` can be `null`, it will be treated as `opts`.

</details>

---
*This summary was automatically generated by @propel-code-bot*