### PR TITLE
feat(runner-sdk): add execution lifecycle with interrupt and kill timeouts

### DIFF
--- a/packages/runner-sdk/lib/action.ts
+++ b/packages/runner-sdk/lib/action.ts
@@ -1,6 +1,6 @@
 import { getProvider } from '@nangohq/providers';
 
-import { AbortedSDKError, ActionError, UnknownProviderSDKError } from './errors.js';
+import { ActionError, ExecutionAbortedSDKError, ExecutionInterruptedSDKError, ExecutionTimeoutSDKError, UnknownProviderSDKError } from './errors.js';
 import paginateService from './paginate.service.js';
 
 import type { ZodCheckpoint, ZodMetadata } from './types.js';
@@ -66,7 +66,12 @@ export abstract class NangoActionBase<
     syncConfig?: NangoProps['syncConfig'];
     runnerFlags: NangoProps['runnerFlags'];
     scriptType: NangoProps['scriptType'];
-    startTime: number;
+    lifecycle?:
+        | {
+              interruptAfter?: Date | undefined;
+              killAfter?: Date | undefined;
+          }
+        | undefined;
 
     public isCLI: NangoProps['isCLI'];
     public connectionId: string;
@@ -94,7 +99,6 @@ export abstract class NangoActionBase<
         this.activityLogId = config.activityLogId;
         this.scriptType = config.scriptType;
         this.isCLI = config.isCLI;
-        this.startTime = Date.now();
 
         if (config.syncId) {
             this.syncId = config.syncId;
@@ -135,6 +139,13 @@ export abstract class NangoActionBase<
         this.logger = config.logger || {
             level: 'warn'
         };
+
+        if (config.lifecycle) {
+            this.lifecycle = {
+                interruptAfter: config.lifecycle?.interruptAfterMs ? new Date(Date.now() + config.lifecycle.interruptAfterMs) : undefined,
+                killAfter: config.lifecycle?.killAfterMs ? new Date(Date.now() + config.lifecycle.killAfterMs) : undefined
+            };
+        }
     }
 
     protected getProxyConfig(config: ProxyConfiguration): UserProvidedProxyConfiguration {
@@ -149,9 +160,21 @@ export abstract class NangoActionBase<
         };
     }
 
-    protected throwIfAborted(): void {
+    protected throwIfAbortedOrKilled(): void {
+        // function was cancelled
         if (this.abortSignal?.aborted) {
-            throw new AbortedSDKError();
+            throw new ExecutionAbortedSDKError();
+        }
+        // function exceeded its maximum execution time
+        if (this.lifecycle?.killAfter && new Date() > this.lifecycle.killAfter) {
+            throw new ExecutionTimeoutSDKError();
+        }
+    }
+
+    protected throwIfInterrupted(): void {
+        // function exceeded its recommended execution time
+        if (this.lifecycle?.interruptAfter && new Date() > this.lifecycle.interruptAfter) {
+            throw new ExecutionInterruptedSDKError();
         }
     }
 
@@ -221,7 +244,7 @@ export abstract class NangoActionBase<
         | SignatureCredentials
         | InstallPluginCredentials
     > {
-        this.throwIfAborted();
+        this.throwIfAbortedOrKilled();
         return this.nango.getToken(this.providerConfigKey, this.connectionId);
     }
 
@@ -229,7 +252,7 @@ export abstract class NangoActionBase<
      * Get current integration
      */
     public async getIntegration(queries?: GetPublicIntegration['Querystring']): Promise<GetPublicIntegration['Success']['data']> {
-        this.throwIfAborted();
+        this.throwIfAbortedOrKilled();
 
         const key = queries?.include?.join(',') || 'default';
         const has = this.memoizedIntegration.get(key);
@@ -247,7 +270,7 @@ export abstract class NangoActionBase<
         connectionIdOverride?: string,
         options?: { refreshToken?: boolean; refreshGithubAppJwtToken?: boolean; forceRefresh?: boolean }
     ): Promise<GetPublicConnection['Success']> {
-        this.throwIfAborted();
+        this.throwIfAbortedOrKilled();
 
         const providerConfigKey = providerConfigKeyOverride || this.providerConfigKey;
         const connectionId = connectionIdOverride || this.connectionId;
@@ -278,7 +301,7 @@ export abstract class NangoActionBase<
     }
 
     public async setMetadata(metadata: TMetadataInferred): Promise<AxiosResponse<SetMetadata['Success']>> {
-        this.throwIfAborted();
+        this.throwIfAbortedOrKilled();
         try {
             return await this.nango.setMetadata(this.providerConfigKey, this.connectionId, metadata as Record<string, unknown>);
         } finally {
@@ -287,7 +310,7 @@ export abstract class NangoActionBase<
     }
 
     public async updateMetadata(metadata: Partial<TMetadataInferred>): Promise<AxiosResponse<UpdateMetadata['Success']>> {
-        this.throwIfAborted();
+        this.throwIfAbortedOrKilled();
         try {
             return await this.nango.updateMetadata(this.providerConfigKey, this.connectionId, metadata);
         } finally {
@@ -304,12 +327,12 @@ export abstract class NangoActionBase<
     }
 
     public async getMetadata<T = TMetadataInferred>(): Promise<T> {
-        this.throwIfAborted();
+        this.throwIfAbortedOrKilled();
         return (await this.getConnection(this.providerConfigKey, this.connectionId)).metadata as T;
     }
 
     public async getWebhookURL(): Promise<string | null | undefined> {
-        this.throwIfAborted();
+        this.throwIfAbortedOrKilled();
         const integration = await this.getIntegration({ include: ['webhook'] });
         return integration.webhook_url;
     }

--- a/packages/runner-sdk/lib/errors.ts
+++ b/packages/runner-sdk/lib/errors.ts
@@ -10,8 +10,16 @@ export abstract class SDKError extends Error {
     }
 }
 
-export class AbortedSDKError extends SDKError {
+export class ExecutionAbortedSDKError extends SDKError {
     code = 'script_aborted';
+}
+
+export class ExecutionInterruptedSDKError extends SDKError {
+    code = 'execution_interrupted';
+}
+
+export class ExecutionTimeoutSDKError extends SDKError {
+    code = 'execution_timeout';
 }
 
 export class UnknownProviderSDKError extends SDKError {

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -89,7 +89,7 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
     }
 
     public override async proxy<T = any>(config: ProxyConfiguration): Promise<AxiosResponse<T>> {
-        this.throwIfAborted();
+        this.throwIfAbortedOrKilled();
 
         const { connectionId, providerConfigKey } = config;
 
@@ -150,7 +150,7 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
     }
 
     public override async log(...args: [...any]): Promise<void> {
-        this.throwIfAborted();
+        this.throwIfAbortedOrKilled();
 
         // if logging is turned off, we bail early
         if (this.logger.level === 'off') {
@@ -218,7 +218,7 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
         sync: string | { name: string; variant: string },
         optsOrSyncMode?: PostPublicTrigger['Body']['opts'] | PostPublicTrigger['Body']['sync_mode'] | PostPublicTrigger['Body']['full_resync']
     ): Promise<void> {
-        this.throwIfAborted();
+        this.throwIfAbortedOrKilled();
         // helping typescript to differentiate between the two overloads, we check if the parameter is an object (opts) or not (syncMode/full_resync)
         const isLegacy = typeof optsOrSyncMode !== 'object';
         if (isLegacy) {
@@ -228,6 +228,7 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
     }
 
     public async startSync(providerConfigKey: string, syncs: (string | { name: string; variant: string })[], connectionId?: string): Promise<void> {
+        this.throwIfAbortedOrKilled();
         await this.nango.startSync(providerConfigKey, syncs, connectionId);
     }
 
@@ -305,26 +306,36 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
     }
 
     public override async tryAcquireLock(props: { key: string; ttlMs: number }): Promise<boolean> {
+        this.throwIfAbortedOrKilled();
         return this.locking.tryAcquireLock(props);
     }
 
     public override async releaseLock(props: { key: string }): Promise<boolean> {
-        return this.locking.releaseLock(props);
+        const res = await this.locking.releaseLock(props);
+        this.throwIfAbortedOrKilled();
+        return res;
     }
 
     public override async releaseAllLocks(): Promise<void> {
-        return this.locking.releaseAllLocks();
+        const res = await this.locking.releaseAllLocks();
+        this.throwIfAbortedOrKilled();
+        return res;
     }
 
     public override async getCheckpoint(): Promise<Checkpoint | null> {
+        this.throwIfAbortedOrKilled();
         return this.checkpointing.getCheckpoint(this.checkpointKey);
     }
 
     public override async saveCheckpoint(checkpoint: Checkpoint): Promise<void> {
-        return this.checkpointing.saveCheckpoint(this.checkpointKey, checkpoint);
+        const res = await this.checkpointing.saveCheckpoint(this.checkpointKey, checkpoint);
+        this.throwIfAbortedOrKilled();
+        this.throwIfInterrupted();
+        return res;
     }
 
     public override async clearCheckpoint(): Promise<void> {
+        this.throwIfAbortedOrKilled();
         return this.checkpointing.clearCheckpoint(this.checkpointKey);
     }
 }
@@ -390,6 +401,7 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
     logAPICall = NangoActionRunner['prototype']['logAPICall'];
 
     public async setMergingStrategy(merging: { strategy: 'ignore_if_modified_after' | 'override' }, model: string): Promise<void> {
+        this.throwIfAbortedOrKilled();
         const now = new Date();
         const modelFullName = this.modelFullName(model);
         if (this.mergingByModel.has(modelFullName)) {
@@ -441,7 +453,7 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
     }
 
     public async batchSave<T extends object>(results: T[], model: string) {
-        this.throwIfAborted();
+        this.throwIfAbortedOrKilled();
         if (!results || results.length === 0) {
             return true;
         }
@@ -472,7 +484,7 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
     }
 
     public async batchDelete<T extends object>(results: T[], model: string) {
-        this.throwIfAborted();
+        this.throwIfAbortedOrKilled();
         if (!results || results.length === 0) {
             return true;
         }
@@ -504,7 +516,7 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
     }
 
     public async batchUpdate<T extends object>(results: T[], model: string) {
-        this.throwIfAborted();
+        this.throwIfAbortedOrKilled();
         if (!results || results.length === 0) {
             return true;
         }
@@ -535,7 +547,7 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
     }
 
     public async deleteRecordsFromPreviousExecutions(model: string): Promise<{ deletedKeys: string[] }> {
-        this.throwIfAborted();
+        this.throwIfAbortedOrKilled();
         const res = await this.persistClient.deleteOutdatedRecords({
             model: this.modelFullName(model),
             environmentId: this.environmentId,
@@ -555,7 +567,7 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
     }
 
     public async trackDeletesStart(model: string): Promise<void> {
-        this.throwIfAborted();
+        this.throwIfAbortedOrKilled();
         const key = this.trackDeletesKey(model);
         const stored = await this.checkpointing.getCheckpoint(key);
         if (stored === null) {
@@ -564,7 +576,7 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
     }
 
     public async trackDeletesEnd(model: string): Promise<{ deletedKeys: string[] }> {
-        this.throwIfAborted();
+        this.throwIfAbortedOrKilled();
         const key = this.trackDeletesKey(model);
         const stored = await this.checkpointing.getCheckpoint<TrackDeletesCheckpoint>(key);
         if (stored === null) {
@@ -589,7 +601,7 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
     }
 
     public async getRecordsByIds<K = string | number, T = any>(ids: K[], model: string): Promise<Map<K, T>> {
-        this.throwIfAborted();
+        this.throwIfAbortedOrKilled();
 
         const objects = new Map<K, T>();
 
@@ -629,26 +641,36 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
     }
 
     public override async tryAcquireLock(props: { key: string; ttlMs: number }): Promise<boolean> {
+        this.throwIfAbortedOrKilled();
         return this.locking.tryAcquireLock(props);
     }
 
     public override async releaseLock(props: { key: string }): Promise<boolean> {
-        return this.locking.releaseLock(props);
+        const res = await this.locking.releaseLock(props);
+        this.throwIfAbortedOrKilled();
+        return res;
     }
 
     public override async releaseAllLocks(): Promise<void> {
-        return this.locking.releaseAllLocks();
+        const res = await this.locking.releaseAllLocks();
+        this.throwIfAbortedOrKilled();
+        return res;
     }
 
     public override async getCheckpoint(): Promise<Checkpoint | null> {
+        this.throwIfAbortedOrKilled();
         return this.checkpointing.getCheckpoint(this.checkpointKey);
     }
 
     public override async saveCheckpoint(checkpoint: Checkpoint): Promise<void> {
-        return this.checkpointing.saveCheckpoint(this.checkpointKey, checkpoint);
+        const res = await this.checkpointing.saveCheckpoint(this.checkpointKey, checkpoint);
+        this.throwIfAbortedOrKilled();
+        this.throwIfInterrupted();
+        return res;
     }
 
     public override async clearCheckpoint(): Promise<void> {
+        this.throwIfAbortedOrKilled();
         return this.checkpointing.clearCheckpoint(this.checkpointKey);
     }
 }

--- a/packages/runner/lib/sdk/sdk.unit.test.ts
+++ b/packages/runner/lib/sdk/sdk.unit.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Nango } from '@nangohq/node';
-import { AbortedSDKError } from '@nangohq/runner-sdk';
+import { ExecutionAbortedSDKError } from '@nangohq/runner-sdk';
 import { ProxyRequest } from '@nangohq/shared';
 import { Ok } from '@nangohq/utils';
 
@@ -476,7 +476,7 @@ describe('Aborted script', () => {
         const ac = new AbortController();
         const nango = new NangoSyncRunner({ ...nangoProps, abortSignal: ac.signal }, { locks });
         ac.abort();
-        await expect(nango.log('hello')).rejects.toThrowError(new AbortedSDKError());
+        await expect(nango.log('hello')).rejects.toThrowError(new ExecutionAbortedSDKError());
     });
 });
 
@@ -485,7 +485,7 @@ describe('getRecordsById', () => {
         const ac = new AbortController();
         const nango = new NangoSyncRunner({ ...nangoProps, abortSignal: ac.signal }, { locks });
         ac.abort();
-        await expect(nango.getRecordsByIds(['a', 'b', 'c'], 'hello')).rejects.toThrowError(new AbortedSDKError());
+        await expect(nango.getRecordsByIds(['a', 'b', 'c'], 'hello')).rejects.toThrowError(new ExecutionAbortedSDKError());
     });
 
     it('should return empty map if no ids', async () => {

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -554,6 +554,11 @@ export class NangoError extends NangoInternalError {
                 this.message = 'An unknown error occurred with the function runtime';
                 break;
 
+            case 'execution_timeout':
+                this.status = 500;
+                this.message = 'The function was killed because it exceeded the maximum execution time allowed without completing or saving a checkpoint';
+                break;
+
             default:
                 this.status = 500;
                 this.type = 'unhandled_' + type;

--- a/packages/types/lib/runner/sdk.ts
+++ b/packages/types/lib/runner/sdk.ts
@@ -40,6 +40,12 @@ export interface NangoProps {
     startedAt: Date;
     endUser: { id: number; endUserId: string | null; orgId: string | null } | null;
     heartbeatTimeoutSecs?: number | undefined;
+    lifecycle?:
+        | {
+              interruptAfterMs: number;
+              killAfterMs: number;
+          }
+        | undefined;
     isCLI?: boolean | undefined;
     integrationConfig?: IntegrationConfigForProxy;
 


### PR DESCRIPTION
AWS lambda runtime has a 15mins time limit. We want to avoid as much as possible for the AWS Lambda to timeout in order to prevent race conditions and undefined behaviors. (Ex: lambda times out after the exec function has returned but before or while the runner is sending back the output)

This commit extends the cancellation mechanism and introduces the concept of lifecycle timeouts:
- hard timeout checked on every runner-sdk public function (same as checking the abort signal)
- soft timeout on `saveCheckpoint` so we can treat it as a partial success that needs immediate rescheduling.

The idea will be to set the lifecycle when using Lambda runtime to something like 12mins for the soft timeout and 14mins for the hard one, allowing the function to gracefully terminate if hitting a `saveCheckpoint` or at least halt before the AWS lambda time limit.
It doesn't fully prevent any AWS Lambda timeout (ex: super long processing without calling any `nango.` function or unresponsive API) but it would greatly reduce the likelihood of the AWS Lambda to reach its 15mins limit.

The lifecycle isn't set yet so those timeouts don't trigger for now. 
In order to enable the soft timeout we need to be able to treat it as a partial success that requires a new task to be immediately scheduled to continue syncing.

