### PR TITLE
fix(webhooks): add na, eu, au to trusted ConnectWise PSA subdomains

### DIFF
--- a/packages/server/lib/webhook/connectwise-psa-webhook-routing.ts
+++ b/packages/server/lib/webhook/connectwise-psa-webhook-routing.ts
@@ -13,7 +13,7 @@ interface SigningKeyResponse {
  * Known trusted ConnectWise subdomains.
  * These are the official ConnectWise PSA API endpoints.
  */
-const TRUSTED_CONNECTWISE_SUBDOMAINS = new Set(['api-au', 'api-eu', 'api-na', 'sandbox-au', 'sandbox-eu', 'sandbox-na']);
+const TRUSTED_CONNECTWISE_SUBDOMAINS = new Set(['api-au', 'api-eu', 'api-na', 'sandbox-au', 'sandbox-eu', 'sandbox-na', 'na', 'eu', 'au']);
 
 /**
  * Validates that a URL is from a trusted ConnectWise subdomain.


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Add additional ConnectWise PSA trusted subdomains**

Updates the trusted ConnectWise PSA subdomain allowlist to include regional roots `na`, `eu`, and `au` in addition to existing `api-*` and `sandbox-*` entries. This ensures webhook key URL validation accepts additional official ConnectWise endpoints.

<details>
<summary><strong>Key Changes</strong></summary>

• Expanded `TRUSTED_CONNECTWISE_SUBDOMAINS` to include `na`, `eu`, and `au`
• Adjusted trusted subdomain validation in `packages/server/lib/webhook/connectwise-psa-webhook-routing.ts` via the allowlist update

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• If `na`, `eu`, `au` are not valid ConnectWise PSA key URL hosts, this could permit unintended sources under `*.myconnectwise.net`.

</details>

---
*This summary was automatically generated by @propel-code-bot*