### PR TITLE
fix(slack): use environment id for slack connection id with legacy fallback

### DIFF
--- a/packages/server/lib/controllers/v1/environment/getEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.integration.test.ts
@@ -64,7 +64,15 @@ describe(`GET ${route}`, () => {
     });
 
     describe('slack_notifications_channel', () => {
+        let adminProdEnv: Awaited<ReturnType<typeof seeders.createEnvironmentSeed>>;
         let originalAdminUUID: string | undefined;
+
+        beforeAll(async () => {
+            const { account: adminAccount } = await seeders.seedAccountEnvAndUser();
+            adminProdEnv = await seeders.createEnvironmentSeed(adminAccount.id, 'prod');
+            await seeders.createConfigSeed(adminProdEnv, 'slack', 'slack');
+            (envs as any).NANGO_ADMIN_UUID = adminAccount.uuid;
+        });
 
         beforeEach(() => {
             originalAdminUUID = envs.NANGO_ADMIN_UUID;
@@ -75,10 +83,6 @@ describe(`GET ${route}`, () => {
         });
 
         it('should return channel using new ID-based connection', async () => {
-            const { account: adminAccount } = await seeders.seedAccountEnvAndUser();
-            const adminProdEnv = await seeders.createEnvironmentSeed(adminAccount.id, 'prod');
-            await seeders.createConfigSeed(adminProdEnv, 'slack', 'slack');
-
             const { account: customerAccount, env: customerEnv, user } = await seeders.seedAccountEnvAndUser();
             await db.knex('_nango_environments').where({ id: customerEnv.id }).update({ slack_notifications: true });
 
@@ -89,7 +93,6 @@ describe(`GET ${route}`, () => {
                 connectionConfig: { 'incoming_webhook.channel': '#new-format-alerts' }
             });
 
-            (envs as any).NANGO_ADMIN_UUID = adminAccount.uuid;
             const session = await authenticateUser(api, user);
             const res = await api.fetch(route, {
                 method: 'GET',
@@ -104,10 +107,6 @@ describe(`GET ${route}`, () => {
         });
 
         it('should return channel using legacy name-based connection', async () => {
-            const { account: adminAccount } = await seeders.seedAccountEnvAndUser();
-            const adminProdEnv = await seeders.createEnvironmentSeed(adminAccount.id, 'prod');
-            await seeders.createConfigSeed(adminProdEnv, 'slack', 'slack');
-
             const { account: customerAccount, env: customerEnv, user } = await seeders.seedAccountEnvAndUser();
             await db.knex('_nango_environments').where({ id: customerEnv.id }).update({ slack_notifications: true });
 
@@ -118,7 +117,6 @@ describe(`GET ${route}`, () => {
                 connectionConfig: { 'incoming_webhook.channel': '#legacy-format-alerts' }
             });
 
-            (envs as any).NANGO_ADMIN_UUID = adminAccount.uuid;
             const session = await authenticateUser(api, user);
             const res = await api.fetch(route, {
                 method: 'GET',

--- a/packages/server/lib/controllers/v1/environment/getEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.integration.test.ts
@@ -27,6 +27,7 @@ describe(`GET ${route}`, () => {
     it('should enforce env query params', async () => {
         const { secret } = await seeders.seedAccountEnvAndUser();
 
+        // @ts-expect-error intentionally missing query to test enforcement
         const res = await api.fetch(route, {
             method: 'GET',
             token: secret.secret

--- a/packages/server/lib/controllers/v1/environment/getEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.integration.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { seeders } from '@nangohq/shared';
+
+import { envs } from '../../../env.js';
+import { authenticateUser, isSuccess, runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../utils/tests.js';
+
+const route = '/api/v1/environments/current';
+let api: Awaited<ReturnType<typeof runServer>>;
+
+describe(`GET ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(route, { method: 'GET', query: { env: 'dev' } });
+
+        shouldBeProtected(res);
+    });
+
+    it('should enforce env query params', async () => {
+        const { secret } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            token: secret.secret
+        });
+
+        shouldRequireQueryEnv(res);
+    });
+
+    it('should return environment and account data', async () => {
+        const { env, account, user } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            query: { env: env.name },
+            session
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json).toMatchObject({
+            environmentAndAccount: {
+                environment: expect.objectContaining({
+                    name: env.name
+                }),
+                env_variables: [],
+                uuid: account.uuid,
+                name: account.name,
+                email: user.email,
+                slack_notifications_channel: ''
+            }
+        });
+    });
+
+    describe('slack_notifications_channel', () => {
+        let originalAdminUUID: string | undefined;
+
+        beforeEach(() => {
+            originalAdminUUID = envs.NANGO_ADMIN_UUID;
+        });
+
+        afterEach(() => {
+            (envs as any).NANGO_ADMIN_UUID = originalAdminUUID;
+        });
+
+        it('should return channel using new ID-based connection', async () => {
+            const { account: adminAccount } = await seeders.seedAccountEnvAndUser();
+            const adminProdEnv = await seeders.createEnvironmentSeed(adminAccount.id, 'prod');
+            await seeders.createConfigSeed(adminProdEnv, 'slack', 'slack');
+
+            const { account: customerAccount, env: customerEnv, user } = await seeders.seedAccountEnvAndUser();
+            await db.knex('_nango_environments').where({ id: customerEnv.id }).update({ slack_notifications: true });
+
+            await seeders.createConnectionSeed({
+                env: adminProdEnv,
+                provider: 'slack',
+                connectionId: `account-${customerAccount.uuid}-${customerEnv.id}`,
+                connectionConfig: { 'incoming_webhook.channel': '#new-format-alerts' }
+            });
+
+            (envs as any).NANGO_ADMIN_UUID = adminAccount.uuid;
+            const session = await authenticateUser(api, user);
+            const res = await api.fetch(route, { method: 'GET', query: { env: customerEnv.name }, session });
+
+            expect(res.res.status).toBe(200);
+            isSuccess(res.json);
+            expect(res.json.environmentAndAccount.slack_notifications_channel).toBe('#new-format-alerts');
+        });
+
+        it('should return channel using legacy name-based connection', async () => {
+            const { account: adminAccount } = await seeders.seedAccountEnvAndUser();
+            const adminProdEnv = await seeders.createEnvironmentSeed(adminAccount.id, 'prod');
+            await seeders.createConfigSeed(adminProdEnv, 'slack', 'slack');
+
+            const { account: customerAccount, env: customerEnv, user } = await seeders.seedAccountEnvAndUser();
+            await db.knex('_nango_environments').where({ id: customerEnv.id }).update({ slack_notifications: true });
+
+            await seeders.createConnectionSeed({
+                env: adminProdEnv,
+                provider: 'slack',
+                connectionId: `account-${customerAccount.uuid}-${customerEnv.name}`,
+                connectionConfig: { 'incoming_webhook.channel': '#legacy-format-alerts' }
+            });
+
+            (envs as any).NANGO_ADMIN_UUID = adminAccount.uuid;
+            const session = await authenticateUser(api, user);
+            const res = await api.fetch(route, { method: 'GET', query: { env: customerEnv.name }, session });
+
+            expect(res.res.status).toBe(200);
+            isSuccess(res.json);
+            expect(res.json.environmentAndAccount.slack_notifications_channel).toBe('#legacy-format-alerts');
+        });
+    });
+});

--- a/packages/server/lib/controllers/v1/environment/getEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.integration.test.ts
@@ -19,6 +19,7 @@ describe(`GET ${route}`, () => {
     });
 
     it('should be protected', async () => {
+        // @ts-expect-error query params are required
         const res = await api.fetch(route, { method: 'GET', query: { env: 'dev' } });
 
         shouldBeProtected(res);
@@ -27,7 +28,6 @@ describe(`GET ${route}`, () => {
     it('should enforce env query params', async () => {
         const { secret } = await seeders.seedAccountEnvAndUser();
 
-        // @ts-expect-error intentionally missing query to test enforcement
         const res = await api.fetch(route, {
             method: 'GET',
             token: secret.secret
@@ -42,6 +42,7 @@ describe(`GET ${route}`, () => {
 
         const res = await api.fetch(route, {
             method: 'GET',
+            // @ts-expect-error query params are required
             query: { env: env.name },
             session
         });
@@ -90,7 +91,12 @@ describe(`GET ${route}`, () => {
 
             (envs as any).NANGO_ADMIN_UUID = adminAccount.uuid;
             const session = await authenticateUser(api, user);
-            const res = await api.fetch(route, { method: 'GET', query: { env: customerEnv.name }, session });
+            const res = await api.fetch(route, {
+                method: 'GET',
+                // @ts-expect-error query params are required
+                query: { env: customerEnv.name },
+                session
+            });
 
             expect(res.res.status).toBe(200);
             isSuccess(res.json);
@@ -114,7 +120,12 @@ describe(`GET ${route}`, () => {
 
             (envs as any).NANGO_ADMIN_UUID = adminAccount.uuid;
             const session = await authenticateUser(api, user);
-            const res = await api.fetch(route, { method: 'GET', query: { env: customerEnv.name }, session });
+            const res = await api.fetch(route, {
+                method: 'GET',
+                // @ts-expect-error query params are required
+                query: { env: customerEnv.name },
+                session
+            });
 
             expect(res.res.status).toBe(200);
             isSuccess(res.json);

--- a/packages/server/lib/controllers/v1/environment/getEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.ts
@@ -3,6 +3,7 @@ import {
     connectionService,
     environmentService,
     externalWebhookService,
+    generateLegacySlackConnectionId,
     generateSlackConnectionId,
     getGlobalWebhookReceiveUrl,
     getWebsocketsPath
@@ -45,16 +46,23 @@ export const getEnvironment = asyncWrapper<GetEnvironment>(async (req, res) => {
 
     let slack_notifications_channel = '';
     if (environment.slack_notifications) {
-        const connectionId = generateSlackConnectionId(account.uuid, environment.name);
         const integrationId = envs.NANGO_SLACK_INTEGRATION_KEY;
         const env = 'prod';
         const info = await accountService.getAccountAndEnvironmentIdByUUID(envs.NANGO_ADMIN_UUID!, env);
         if (info) {
-            const connectionConfig = await connectionService.getConnectionConfig({
+            // Try new ID-based connection ID first, fall back to legacy name-based for existing installations
+            let connectionConfig = await connectionService.getConnectionConfig({
                 provider_config_key: integrationId,
                 environment_id: info.environmentId,
-                connection_id: connectionId
+                connection_id: generateSlackConnectionId(account.uuid, environment.id)
             });
+            if (!connectionConfig) {
+                connectionConfig = await connectionService.getConnectionConfig({
+                    provider_config_key: integrationId,
+                    environment_id: info.environmentId,
+                    connection_id: generateLegacySlackConnectionId(account.uuid, environment.name)
+                });
+            }
             if (connectionConfig && connectionConfig['incoming_webhook.channel']) {
                 slack_notifications_channel = connectionConfig['incoming_webhook.channel'];
             }

--- a/packages/server/lib/controllers/v1/environment/getEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.ts
@@ -56,7 +56,7 @@ export const getEnvironment = asyncWrapper<GetEnvironment>(async (req, res) => {
                 environment_id: info.environmentId,
                 connection_id: generateSlackConnectionId(account.uuid, environment.id)
             });
-            if (!connectionConfig) {
+            if (!connectionConfig['incoming_webhook.channel']) {
                 connectionConfig = await connectionService.getConnectionConfig({
                     provider_config_key: integrationId,
                     environment_id: info.environmentId,

--- a/packages/server/lib/controllers/v1/environment/getEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.ts
@@ -56,7 +56,7 @@ export const getEnvironment = asyncWrapper<GetEnvironment>(async (req, res) => {
                 environment_id: info.environmentId,
                 connection_id: generateSlackConnectionId(account.uuid, environment.id)
             });
-            if (!connectionConfig['incoming_webhook.channel']) {
+            if (!connectionConfig || !connectionConfig['incoming_webhook.channel']) {
                 connectionConfig = await connectionService.getConnectionConfig({
                     provider_config_key: integrationId,
                     environment_id: info.environmentId,

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -11,7 +11,7 @@ import remoteFileService from './services/file/remote.service.js';
 import flowService from './services/flow.service.js';
 import hmacService from './services/hmac.service.js';
 import { errorNotificationService } from './services/notification/error.service.js';
-import { SlackService, generateSlackConnectionId } from './services/notification/slack.service.js';
+import { SlackService, generateLegacySlackConnectionId, generateSlackConnectionId } from './services/notification/slack.service.js';
 import secretService from './services/secret.service.js';
 import sharedCredentialsService from './services/shared-credentials.service.js';
 import syncManager, { syncCommandToOperation } from './services/sync/manager.service.js';
@@ -73,6 +73,7 @@ export {
     errorNotificationService,
     externalWebhookService,
     flowService,
+    generateLegacySlackConnectionId,
     generateSlackConnectionId,
     hmacService,
     localFileService,

--- a/packages/shared/lib/services/notification/slack.service.ts
+++ b/packages/shared/lib/services/notification/slack.service.ts
@@ -604,7 +604,7 @@ export class SlackService {
             this.integrationKey,
             adminRes.environment.id
         );
-        if (!slackConnectionResult.success && slackConnectionResult.error?.type === 'unknown_connection') {
+        if (slackConnectionResult.error?.type === 'unknown_connection') {
             slackConnectionResult = await connectionService.getConnection(
                 generateLegacySlackConnectionId(account.uuid, environment.name),
                 this.integrationKey,

--- a/packages/shared/lib/services/notification/slack.service.ts
+++ b/packages/shared/lib/services/notification/slack.service.ts
@@ -69,7 +69,8 @@ interface PostSlackMessageResponse {
     };
 }
 
-export const generateSlackConnectionId = (accountUUID: string, environmentName: string) => `account-${accountUUID}-${environmentName}`;
+export const generateSlackConnectionId = (accountUUID: string, environmentId: number) => `account-${accountUUID}-${environmentId}`;
+export const generateLegacySlackConnectionId = (accountUUID: string, environmentName: string) => `account-${accountUUID}-${environmentName}`;
 
 /**
  * _nango_slack_notifications
@@ -597,14 +598,21 @@ export class SlackService {
             return Err('failed_to_get_integration');
         }
 
-        const slackConnectionId = generateSlackConnectionId(account.uuid, environment.name);
+        // Try new ID-based connection ID first, fall back to legacy name-based for existing installations
+        let slackConnectionResult = await connectionService.getConnection(
+            generateSlackConnectionId(account.uuid, environment.id),
+            this.integrationKey,
+            adminRes.environment.id
+        );
+        if (!slackConnectionResult.success) {
+            slackConnectionResult = await connectionService.getConnection(
+                generateLegacySlackConnectionId(account.uuid, environment.name),
+                this.integrationKey,
+                adminRes.environment.id
+            );
+        }
 
-        // we get the connection on the nango admin account to be able to send the notification
-        const {
-            success: connectionSuccess,
-            error: slackConnectionError,
-            response: slackConnection
-        } = await connectionService.getConnection(slackConnectionId, this.integrationKey, adminRes.environment.id);
+        const { success: connectionSuccess, error: slackConnectionError, response: slackConnection } = slackConnectionResult;
 
         if (!connectionSuccess || !slackConnection) {
             logger.error(slackConnectionError);

--- a/packages/shared/lib/services/notification/slack.service.ts
+++ b/packages/shared/lib/services/notification/slack.service.ts
@@ -604,7 +604,7 @@ export class SlackService {
             this.integrationKey,
             adminRes.environment.id
         );
-        if (!slackConnectionResult.success) {
+        if (!slackConnectionResult.success && slackConnectionResult.error?.type === 'unknown_connection') {
             slackConnectionResult = await connectionService.getConnection(
                 generateLegacySlackConnectionId(account.uuid, environment.name),
                 this.integrationKey,

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -46,7 +46,7 @@ import type {
 } from './connection/api/get.js';
 import type { SetMetadata, UpdateMetadata } from './connection/api/metadata.js';
 import type { PostDeploy, PostDeployConfirmation, PostDeployInternal } from './deploy/api.js';
-import type { DeleteEnvironment, GetEnvironments, PatchEnvironment, PostEnvironment } from './environment/api/index.js';
+import type { DeleteEnvironment, GetEnvironment, GetEnvironments, PatchEnvironment, PostEnvironment } from './environment/api/index.js';
 import type { PatchWebhook } from './environment/api/webhook.js';
 import type { PostEnvironmentVariables } from './environment/variable/api.js';
 import type { PatchFlowDisable, PatchFlowEnable, PatchFlowFrequency, PostPreBuiltDeploy, PutUpgradePreBuiltFlow } from './flow/http.api.js';
@@ -174,6 +174,7 @@ export type PrivateApiEndpoints =
     | PatchEnvironment
     | DeleteEnvironment
     | GetEnvironments
+    | GetEnvironment
     | PatchWebhook
     | PostEnvironmentVariables
     | PostImpersonate

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -28,6 +28,7 @@ export type PostEnvironment = Endpoint<{
 export type GetEnvironment = Endpoint<{
     Method: 'GET';
     Path: '/api/v1/environments/current';
+    Querystring: { env: string };
     Success: {
         plan: ApiPlan | null;
         environmentAndAccount: {

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -28,7 +28,6 @@ export type PostEnvironment = Endpoint<{
 export type GetEnvironment = Endpoint<{
     Method: 'GET';
     Path: '/api/v1/environments/current';
-    Querystring: { env: string };
     Success: {
         plan: ApiPlan | null;
         environmentAndAccount: {

--- a/packages/webapp/src/pages/Environment/Settings/SlackAlerts.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/SlackAlerts.tsx
@@ -43,9 +43,16 @@ export const SlackAlertsSettings: React.FC = () => {
     };
 
     const slackDisconnect = async () => {
-        const res = await apiFetch(`/api/v1/connections/admin/account-${environmentAndAccount?.uuid}-${environmentAndAccount?.environment.id}?env=${env}`, {
+        let res = await apiFetch(`/api/v1/connections/admin/account-${environmentAndAccount?.uuid}-${environmentAndAccount?.environment.id}?env=${env}`, {
             method: 'DELETE'
         });
+
+        // Fall back to legacy name-based connection id for existing installations
+        if (res.status === 404) {
+            res = await apiFetch(`/api/v1/connections/admin/account-${environmentAndAccount?.uuid}-${env}?env=${env}`, {
+                method: 'DELETE'
+            });
+        }
 
         if (res.status !== 204) {
             toast({ title: 'There was a problem when disconnecting Slack', variant: 'error' });

--- a/packages/webapp/src/pages/Environment/Settings/SlackAlerts.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/SlackAlerts.tsx
@@ -32,11 +32,18 @@ export const SlackAlertsSettings: React.FC = () => {
         const onFailure = () => {
             setSlackIsConnecting(false);
         };
-        await connectSlack({ accountUUID: environmentAndAccount.uuid, env, hostUrl: globalEnv.apiUrl, onFinish, onFailure });
+        await connectSlack({
+            accountUUID: environmentAndAccount.uuid,
+            envId: environmentAndAccount.environment.id,
+            env,
+            hostUrl: globalEnv.apiUrl,
+            onFinish,
+            onFailure
+        });
     };
 
     const slackDisconnect = async () => {
-        const res = await apiFetch(`/api/v1/connections/admin/account-${environmentAndAccount?.uuid}-${env}?env=${env}`, {
+        const res = await apiFetch(`/api/v1/connections/admin/account-${environmentAndAccount?.uuid}-${environmentAndAccount?.environment.id}?env=${env}`, {
             method: 'DELETE'
         });
 

--- a/packages/webapp/src/utils/slack-connection.tsx
+++ b/packages/webapp/src/utils/slack-connection.tsx
@@ -5,18 +5,20 @@ import { apiPatchEnvironment } from '../hooks/useEnvironment';
 
 export const connectSlack = async ({
     accountUUID,
+    envId,
     env,
     hostUrl,
     onFinish,
     onFailure
 }: {
     accountUUID: string;
+    envId: number;
     env: string;
     hostUrl: string;
     onFinish: () => void;
     onFailure: () => void;
 }) => {
-    const connectionId = `account-${accountUUID}-${env}`;
+    const connectionId = `account-${accountUUID}-${envId}`;
 
     const res = await apiFetch(`/api/v1/environment/admin-auth?connection_id=${connectionId}&env=${env}`, {
         method: 'GET'


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Renaming an environment broke Slack alerts because the connection id was built using the environment name. Switch to environment id (stable) for new installations and add a fallback to the legacy name-based id for existing ones.

Tests run in local:
- [x] Test that new slack alerts are resilient to an environment name change
- [x] Test that legacy slack alerts are still working when they did not suffer an environment name change
- [x] Test that once legacy slack alerts once renamed they work

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

The update also applies the dual-lookup behavior across server-side Slack channel resolution, notification sending, and webapp disconnect flows, with `connectSlack` now constructing IDs from `envId`, and it expands API typing plus adds integration tests for the current-environment endpoint to validate Slack channel resolution for both new and legacy formats.

<details>
<summary><strong>Possible Issues</strong></summary>

• Legacy disconnect retry in `slackDisconnect` only triggers on `404`; other failure statuses may leave legacy connections undeleted.

</details>

---
*This summary was automatically generated by @propel-code-bot*