### PR TITLE
feat(webhooks): add support for ms teams bot webhooks

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -9866,6 +9866,7 @@ microsoft-teams-bot:
         base_url: https://smba.trafficmanager.net/teams
         connection_config:
             botHostTenantId: ${connectionConfig.botHostTenantId}
+    webhook_routing_script: microsoftTeamsWebhookRouting
     post_connection_script: microsoftTeamsBotPostConnection
     docs: https://nango.dev/docs/integrations/all/microsoft-teams-bot
     docs_connect: https://nango.dev/docs/integrations/all/microsoft-teams-bot/connect


### PR DESCRIPTION
## Describe the problem and your solution

- add support for ms teams bot webhooks, untested.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

This is achieved by updating the provider configuration to include a webhook routing script reference for the Microsoft Teams Bot provider.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `webhook_routing_script: microsoftTeamsWebhookRouting` to the `microsoft-teams-bot` provider in `packages/providers/providers.yaml`

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• If `microsoftTeamsWebhookRouting` is not defined or is misnamed, webhook routing will fail for this provider.

</details>

---
*This summary was automatically generated by @propel-code-bot*