### PR TITLE
feat(server): support flow-level json-schema

### DIFF
--- a/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
@@ -57,6 +57,55 @@ describe(`POST ${endpoint}`, () => {
         expect(res.res.status).toBe(400);
     });
 
+    it('should reject models_json_schema missing definitions for declared models', async () => {
+        const { secret } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: secret.secret,
+            body: {
+                debug: false,
+                flowConfigs: [
+                    {
+                        syncName: 'test',
+                        fileBody: { js: 'js file', ts: 'ts file' },
+                        providerConfigKey: 'unauthenticated',
+                        endpoints: [],
+                        runs: 'every day',
+                        type: 'sync',
+                        track_deletes: false,
+                        models: ['Output'],
+                        input: 'Input',
+                        models_json_schema: {
+                            $schema: 'http://json-schema.org/draft-07/schema#',
+                            definitions: {
+                                // Output and Input are missing
+                                Unrelated: { type: 'object' }
+                            }
+                        }
+                    }
+                ],
+                nangoYamlBody: '',
+                reconcile: false,
+                singleDeployMode: false
+            }
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'invalid_body',
+                errors: [
+                    {
+                        code: 'custom',
+                        message: 'models_json_schema is missing definitions for some models or input',
+                        path: ['flowConfigs', '0', 'models_json_schema']
+                    }
+                ]
+            }
+        });
+    });
+
     it('should accept empty body', async () => {
         const { secret } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {
@@ -228,6 +277,135 @@ describe(`POST ${endpoint}`, () => {
             // Check that everything was inserted in DB
             const syncConfigs = await getSyncConfigsAsStandardConfig(env!.id);
             expect(syncConfigs).toBeNull();
+        });
+    });
+
+    describe('models_json_schema handling', () => {
+        it('should use per-flow models_json_schema directly', async () => {
+            const { env, secret } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
+
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: secret.secret,
+                body: {
+                    debug: false,
+                    flowConfigs: [
+                        {
+                            syncName: 'test',
+                            fileBody: { js: 'js file', ts: 'ts file' },
+                            providerConfigKey: 'unauthenticated',
+                            endpoints: [{ method: 'GET', path: '/path' }],
+                            runs: 'every day',
+                            type: 'sync',
+                            attributes: {},
+                            auto_start: false,
+                            metadata: { description: 'a' },
+                            sync_type: 'full',
+                            track_deletes: false,
+                            input: 'Input',
+                            models: ['Output'],
+                            models_json_schema: {
+                                $schema: 'http://json-schema.org/draft-07/schema#',
+                                definitions: {
+                                    Input: { type: 'object', properties: { id: { type: 'number' } }, required: ['id'], additionalProperties: false },
+                                    Output: {
+                                        type: 'object',
+                                        properties: { ref: { $ref: '#/definitions/Ref' } },
+                                        required: ['ref'],
+                                        additionalProperties: false
+                                    },
+                                    Ref: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'], additionalProperties: false }
+                                }
+                            }
+                        }
+                    ],
+                    nangoYamlBody: '',
+                    onEventScriptsByProvider: [],
+                    reconcile: false,
+                    singleDeployMode: false,
+                    sdkVersion: '0.61.3-yaml'
+                }
+            });
+
+            isSuccess(res.json);
+            expect(res.res.status).toBe(200);
+
+            const syncConfigs = await getSyncConfigsAsStandardConfig(env.id);
+            expect(syncConfigs).toHaveLength(1);
+            expect(syncConfigs?.[0]?.syncs[0]?.json_schema).toStrictEqual({
+                $schema: 'http://json-schema.org/draft-07/schema#',
+                definitions: {
+                    Input: { type: 'object', properties: { id: { type: 'number' } }, required: ['id'], additionalProperties: false },
+                    Output: { type: 'object', properties: { ref: { $ref: '#/definitions/Ref' } }, required: ['ref'], additionalProperties: false },
+                    Ref: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'], additionalProperties: false }
+                }
+            });
+        });
+
+        it('should filter top-level jsonSchema to only the models used by a flow (legacy format)', async () => {
+            const { env, secret } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
+
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: secret.secret,
+                body: {
+                    debug: false,
+                    jsonSchema: {
+                        $comment: '',
+                        $schema: 'http://json-schema.org/draft-07/schema#',
+                        definitions: {
+                            Input: { type: 'object', properties: { id: { type: 'number' } }, required: ['id'], additionalProperties: false },
+                            Output: {
+                                type: 'object',
+                                properties: { ref: { $ref: '#/definitions/Ref' } },
+                                required: ['ref'],
+                                additionalProperties: false
+                            },
+                            Ref: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'], additionalProperties: false },
+                            // This model is in the aggregated schema but not used by the flow — it should be filtered out
+                            Unrelated: { type: 'object', properties: { name: { type: 'string' } }, additionalProperties: false }
+                        }
+                    },
+                    flowConfigs: [
+                        {
+                            syncName: 'test',
+                            fileBody: { js: 'js file', ts: 'ts file' },
+                            providerConfigKey: 'unauthenticated',
+                            endpoints: [{ method: 'GET', path: '/path' }],
+                            runs: 'every day',
+                            type: 'sync',
+                            attributes: {},
+                            auto_start: false,
+                            metadata: { description: 'a' },
+                            sync_type: 'full',
+                            track_deletes: false,
+                            input: 'Input',
+                            models: ['Output']
+                        }
+                    ],
+                    nangoYamlBody: '',
+                    onEventScriptsByProvider: [],
+                    reconcile: false,
+                    singleDeployMode: false,
+                    sdkVersion: '0.61.3-yaml'
+                }
+            });
+
+            isSuccess(res.json);
+            expect(res.res.status).toBe(200);
+
+            const syncConfigs = await getSyncConfigsAsStandardConfig(env.id);
+            expect(syncConfigs).toHaveLength(1);
+            expect(syncConfigs?.[0]?.syncs[0]?.json_schema).toStrictEqual({
+                definitions: {
+                    Input: { type: 'object', properties: { id: { type: 'number' } }, required: ['id'], additionalProperties: false },
+                    Output: { type: 'object', properties: { ref: { $ref: '#/definitions/Ref' } }, required: ['ref'], additionalProperties: false },
+                    Ref: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'], additionalProperties: false }
+                    // Unrelated is absent
+                }
+            });
         });
     });
 });

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.ts
@@ -60,7 +60,7 @@ export const postDeploy = asyncWrapper<PostDeploy>(async (req, res) => {
         nangoYamlBody: body.nangoYamlBody,
         onEventScriptsByProvider: body.onEventScriptsByProvider,
         debug: body.debug,
-        jsonSchema: body.jsonSchema,
+        aggregatedJsonSchema: body.jsonSchema,
         logContextGetter,
         sdkVersion: body.sdkVersion,
         orchestrator

--- a/packages/server/lib/controllers/sync/deploy/postDeployInternal.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeployInternal.integration.test.ts
@@ -1,0 +1,189 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { envs } from '@nangohq/logs';
+import { getSyncConfigsAsStandardConfig, seeders } from '@nangohq/shared';
+
+import { isError, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+const endpoint = '/sync/deploy/internal';
+
+describe(`POST ${endpoint}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+        envs.NANGO_LOGS_ENABLED = false;
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+    afterEach(() => {
+        delete process.env['NANGO_SHARED_DEV_ACCOUNT_UUID'];
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            query: { customEnvironment: 'dev' },
+            // @ts-expect-error don't care
+            body: {}
+        });
+
+        shouldBeProtected(res);
+    });
+
+    it('should be forbidden for non-internal accounts', async () => {
+        const { secret } = await seeders.seedAccountEnvAndUser();
+
+        // NANGO_SHARED_DEV_ACCOUNT_UUID is not set, so no account matches
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: secret.secret,
+            query: { customEnvironment: 'dev' },
+            body: {
+                debug: false,
+                flowConfigs: [],
+                nangoYamlBody: '',
+                reconcile: false,
+                singleDeployMode: false
+            }
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(403);
+        expect(res.json).toStrictEqual({ error: { code: 'forbidden', message: 'This endpoint is only available for Nango internal use' } });
+    });
+
+    describe('models_json_schema handling', () => {
+        it('should use per-flow models_json_schema directly', async () => {
+            const { account, env, secret } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
+            process.env['NANGO_SHARED_DEV_ACCOUNT_UUID'] = account.uuid;
+
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: secret.secret,
+                query: { customEnvironment: 'dev' },
+                body: {
+                    debug: false,
+                    flowConfigs: [
+                        {
+                            syncName: 'test',
+                            fileBody: { js: 'js file', ts: 'ts file' },
+                            providerConfigKey: 'unauthenticated',
+                            endpoints: [{ method: 'GET', path: '/path' }],
+                            runs: 'every day',
+                            type: 'sync',
+                            attributes: {},
+                            auto_start: false,
+                            metadata: { description: 'a' },
+                            sync_type: 'full',
+                            track_deletes: false,
+                            input: 'Input',
+                            models: ['Output'],
+                            models_json_schema: {
+                                $schema: 'http://json-schema.org/draft-07/schema#',
+                                definitions: {
+                                    Input: { type: 'object', properties: { id: { type: 'number' } }, required: ['id'], additionalProperties: false },
+                                    Output: {
+                                        type: 'object',
+                                        properties: { ref: { $ref: '#/definitions/Ref' } },
+                                        required: ['ref'],
+                                        additionalProperties: false
+                                    },
+                                    Ref: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'], additionalProperties: false }
+                                }
+                            }
+                        }
+                    ],
+                    nangoYamlBody: '',
+                    onEventScriptsByProvider: [],
+                    reconcile: false,
+                    singleDeployMode: false,
+                    sdkVersion: '0.61.3-yaml'
+                }
+            });
+
+            isSuccess(res.json);
+            expect(res.res.status).toBe(200);
+
+            const syncConfigs = await getSyncConfigsAsStandardConfig(env.id);
+            expect(syncConfigs).toHaveLength(1);
+            expect(syncConfigs?.[0]?.syncs[0]?.json_schema).toStrictEqual({
+                $schema: 'http://json-schema.org/draft-07/schema#',
+                definitions: {
+                    Input: { type: 'object', properties: { id: { type: 'number' } }, required: ['id'], additionalProperties: false },
+                    Output: { type: 'object', properties: { ref: { $ref: '#/definitions/Ref' } }, required: ['ref'], additionalProperties: false },
+                    Ref: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'], additionalProperties: false }
+                }
+            });
+        });
+
+        it('should filter top-level jsonSchema to only the models used by a flow (legacy format)', async () => {
+            const { account, env, secret } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
+            process.env['NANGO_SHARED_DEV_ACCOUNT_UUID'] = account.uuid;
+
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                token: secret.secret,
+                query: { customEnvironment: 'dev' },
+                body: {
+                    debug: false,
+                    jsonSchema: {
+                        $comment: '',
+                        $schema: 'http://json-schema.org/draft-07/schema#',
+                        definitions: {
+                            Input: { type: 'object', properties: { id: { type: 'number' } }, required: ['id'], additionalProperties: false },
+                            Output: {
+                                type: 'object',
+                                properties: { ref: { $ref: '#/definitions/Ref' } },
+                                required: ['ref'],
+                                additionalProperties: false
+                            },
+                            Ref: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'], additionalProperties: false },
+                            // This model is in the aggregated schema but not used by the flow — it should be filtered out
+                            Unrelated: { type: 'object', properties: { name: { type: 'string' } }, additionalProperties: false }
+                        }
+                    },
+                    flowConfigs: [
+                        {
+                            syncName: 'test',
+                            fileBody: { js: 'js file', ts: 'ts file' },
+                            providerConfigKey: 'unauthenticated',
+                            endpoints: [{ method: 'GET', path: '/path' }],
+                            runs: 'every day',
+                            type: 'sync',
+                            attributes: {},
+                            auto_start: false,
+                            metadata: { description: 'a' },
+                            sync_type: 'full',
+                            track_deletes: false,
+                            input: 'Input',
+                            models: ['Output']
+                        }
+                    ],
+                    nangoYamlBody: '',
+                    onEventScriptsByProvider: [],
+                    reconcile: false,
+                    singleDeployMode: false,
+                    sdkVersion: '0.61.3-yaml'
+                }
+            });
+
+            isSuccess(res.json);
+            expect(res.res.status).toBe(200);
+
+            const syncConfigs = await getSyncConfigsAsStandardConfig(env.id);
+            expect(syncConfigs).toHaveLength(1);
+            expect(syncConfigs?.[0]?.syncs[0]?.json_schema).toStrictEqual({
+                definitions: {
+                    Input: { type: 'object', properties: { id: { type: 'number' } }, required: ['id'], additionalProperties: false },
+                    Output: { type: 'object', properties: { ref: { $ref: '#/definitions/Ref' } }, required: ['ref'], additionalProperties: false },
+                    Ref: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'], additionalProperties: false }
+                    // Unrelated is absent
+                }
+            });
+        });
+    });
+});

--- a/packages/server/lib/controllers/sync/deploy/postDeployInternal.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeployInternal.ts
@@ -91,7 +91,7 @@ export const postDeployInternal = asyncWrapper<PostDeployInternal>(async (req, r
         nangoYamlBody: body.nangoYamlBody,
         onEventScriptsByProvider: body.onEventScriptsByProvider,
         debug: body.debug,
-        jsonSchema: body.jsonSchema,
+        aggregatedJsonSchema: body.jsonSchema,
         logContextGetter,
         sdkVersion: body.sdkVersion,
         orchestrator

--- a/packages/server/lib/controllers/sync/deploy/validation.ts
+++ b/packages/server/lib/controllers/sync/deploy/validation.ts
@@ -81,7 +81,13 @@ export const flowConfig = z
         version: z.string().optional(),
         track_deletes: z.boolean().optional().default(false),
         sync_type: z.enum(['incremental', 'full']).optional(),
-        webhookSubscriptions: z.array(z.string().max(255)).optional()
+        webhookSubscriptions: z.array(z.string().max(255)).optional(),
+        models_json_schema: z
+            .object({
+                $schema: z.literal('http://json-schema.org/draft-07/schema#'),
+                definitions: z.record(z.string(), z.looseObject({}))
+            })
+            .optional()
     })
     .refine(
         (data) => {
@@ -91,6 +97,15 @@ export const flowConfig = z
             return true;
         },
         { message: 'Track deletes is not supported for incremental syncs', path: ['track_deletes'] }
+    )
+    .refine(
+        (data) => {
+            if (!data.models_json_schema) return true;
+            const definitions = data.models_json_schema.definitions;
+            const topLevelModels = [...data.models, ...(typeof data.input === 'string' ? [data.input] : [])];
+            return topLevelModels.every((model) => model in definitions);
+        },
+        { message: 'models_json_schema is missing definitions for some models or input', path: ['models_json_schema'] }
     )
     .strict();
 const flowConfigs = z.array(flowConfig);

--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -2,13 +2,13 @@ import db, { dbNamespace } from '@nangohq/database';
 import { nangoConfigFile } from '@nangohq/nango-yaml';
 import { env, filterJsonSchemaForModels } from '@nangohq/utils';
 
-import configService from '../../config.service.js';
-import remoteFileService from '../../file/remote.service.js';
-import { getSyncsByProviderConfigKey } from '../sync.service.js';
 import { getSyncAndActionConfigByParams, getSyncAndActionConfigsBySyncNameAndConfigId, increment } from './config.service.js';
 import { NangoError } from '../../../utils/error.js';
+import configService from '../../config.service.js';
 import { switchActiveSyncConfig } from '../../deploy/utils.js';
+import remoteFileService from '../../file/remote.service.js';
 import { onEventScriptService } from '../../on-event-scripts.service.js';
+import { getSyncsByProviderConfigKey } from '../sync.service.js';
 
 import type { Orchestrator } from '../../../clients/orchestrator.js';
 import type { ServiceResponse } from '../../../models/Generic.js';
@@ -66,7 +66,7 @@ export async function deploy({
     environment,
     account,
     flows,
-    jsonSchema,
+    aggregatedJsonSchema,
     onEventScriptsByProvider,
     nangoYamlBody,
     logContextGetter,
@@ -77,7 +77,8 @@ export async function deploy({
     environment: DBEnvironment;
     account: DBTeam;
     flows: CleanedIncomingFlowConfig[];
-    jsonSchema?: JSONSchema7 | undefined;
+    /** @deprecated */
+    aggregatedJsonSchema?: JSONSchema7 | undefined;
     onEventScriptsByProvider?: OnEventScriptsByProvider[] | undefined;
     nangoYamlBody: string;
     logContextGetter: LogContextGetter;
@@ -105,7 +106,7 @@ export async function deploy({
 
         const { success, error, response } = await compileDeployInfo({
             flow,
-            jsonSchema,
+            aggregatedJsonSchema,
             env,
             environment_id: environment.id,
             account,
@@ -212,7 +213,7 @@ export async function deploy({
 
 async function compileDeployInfo({
     flow,
-    jsonSchema,
+    aggregatedJsonSchema,
     env,
     environment_id,
     account,
@@ -222,7 +223,8 @@ async function compileDeployInfo({
     sdkVersion
 }: {
     flow: FlowParsed;
-    jsonSchema?: JSONSchema7 | undefined;
+    /** @deprecated */
+    aggregatedJsonSchema?: JSONSchema7 | undefined;
     env: string;
     environment_id: number;
     account: DBTeam;
@@ -327,10 +329,11 @@ async function compileDeployInfo({
         }
     }
 
-    let models_json_schema: JSONSchema7 | null = null;
-    if (jsonSchema) {
+    let models_json_schema: JSONSchema7 | null = flow.models_json_schema ?? null;
+    if (!models_json_schema && aggregatedJsonSchema) {
+        // Legacy: jsonSchema for all functions were sent at the root of the body
         const allModels = [...models, flow.input].filter(Boolean) as string[];
-        const result = filterJsonSchemaForModels(jsonSchema, allModels);
+        const result = filterJsonSchemaForModels(aggregatedJsonSchema, allModels);
         if (result.isErr()) {
             return { success: false, error: new NangoError('deploy_missing_json_schema_model', result.error), response: null };
         }

--- a/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
@@ -10,10 +10,12 @@ import { getTestTeam } from '../../../seeders/account.seeder.js';
 import { getTestEnvironment } from '../../../seeders/environment.seeder.js';
 import accountService from '../../account.service.js';
 import configService from '../../config.service.js';
+import remoteFileService from '../../file/remote.service.js';
 import * as SyncService from '../sync.service.js';
 
 import type { OrchestratorClientInterface } from '../../../clients/orchestrator.js';
 import type { CleanedIncomingFlowConfig, DBTeam } from '@nangohq/types';
+import type { JSONSchema7 } from 'json-schema';
 
 const orchestratorClientNoop: OrchestratorClientInterface = {
     recurring: () => Promise.resolve({}) as any,
@@ -254,5 +256,161 @@ describe('Sync config create', () => {
                 onEventScriptsByProvider: []
             })
         ).rejects.toThrowError('Error creating sync config from a deploy. Please contact support with the sync name and connection details');
+    });
+});
+
+describe('Sync config models_json_schema handling', () => {
+    const environment = getTestEnvironment();
+    const account = getTestTeam();
+
+    const baseFlow: CleanedIncomingFlowConfig = {
+        syncName: 'test-sync',
+        type: 'sync',
+        providerConfigKey: 'google',
+        fileBody: { js: 'integrations.js', ts: 'integrations.ts' },
+        models: ['Model_1'],
+        runs: null,
+        version: '1',
+        track_deletes: false,
+        endpoints: []
+    };
+
+    const mockProviderConfig = {
+        id: 1,
+        unique_key: 'google',
+        display_name: null,
+        provider: 'google',
+        oauth_client_id: '123',
+        oauth_client_secret: '123',
+        post_connection_scripts: null,
+        environment_id: 1,
+        created_at: new Date(),
+        updated_at: new Date(),
+        missing_fields: [],
+        forward_webhooks: true,
+        shared_credentials_id: null
+    };
+
+    function setupInfrastructureMocks(capturedSyncConfigs: any[]) {
+        vi.spyOn(configService, 'getProviderConfig').mockResolvedValue(mockProviderConfig as any);
+        vi.spyOn(SyncConfigService, 'getSyncAndActionConfigByParams').mockResolvedValue(null);
+        vi.spyOn(SyncConfigService, 'getSyncAndActionConfigsBySyncNameAndConfigId').mockResolvedValue([]);
+        vi.spyOn(remoteFileService, 'upload').mockResolvedValue('https://example.com/file.js' as any);
+        // Mock the transaction to capture the sync config being inserted into the database
+        vi.spyOn(db.knex, 'transaction').mockImplementation(async (callback: any) => {
+            const mockTrx = {
+                from: (_table: string) => ({
+                    update: () => ({ whereIn: () => Promise.resolve() }),
+                    insert: (data: any) => {
+                        capturedSyncConfigs.push(...(Array.isArray(data) ? data : [data]));
+                        return { returning: () => Promise.resolve([{ id: 1 }]) };
+                    }
+                })
+            };
+            await callback(mockTrx);
+        });
+    }
+
+    it('Uses flow.models_json_schema directly when provided (new format)', async () => {
+        const capturedSyncConfigs: any[] = [];
+        setupInfrastructureMocks(capturedSyncConfigs);
+
+        const flowJsonSchema: JSONSchema7 = {
+            definitions: {
+                Model_1: { type: 'object', properties: { id: { type: 'string' } } }
+            }
+        };
+
+        const { success, error } = await DeployConfigService.deploy({
+            account,
+            environment,
+            flows: [{ ...baseFlow, models_json_schema: flowJsonSchema }],
+            nangoYamlBody: '',
+            logContextGetter,
+            orchestrator: mockOrchestrator,
+            sdkVersion: '0.0.0-yaml'
+        });
+
+        expect(success).toBe(true);
+        expect(error).toBeNull();
+        expect(capturedSyncConfigs).toHaveLength(1);
+        expect(capturedSyncConfigs[0].models_json_schema).toEqual(flowJsonSchema);
+    });
+
+    it('Filters aggregatedJsonSchema for the flow models (legacy format)', async () => {
+        const capturedSyncConfigs: any[] = [];
+        setupInfrastructureMocks(capturedSyncConfigs);
+
+        const aggregatedJsonSchema: JSONSchema7 = {
+            definitions: {
+                Model_1: { type: 'object', properties: { id: { type: 'string' } } },
+                Model_2: { type: 'object', properties: { name: { type: 'string' } } }
+            }
+        };
+
+        const { success, error } = await DeployConfigService.deploy({
+            account,
+            environment,
+            flows: [baseFlow], // models: ['Model_1'], no models_json_schema
+            aggregatedJsonSchema,
+            nangoYamlBody: '',
+            logContextGetter,
+            orchestrator: mockOrchestrator,
+            sdkVersion: '0.0.0-yaml'
+        });
+
+        expect(success).toBe(true);
+        expect(error).toBeNull();
+        expect(capturedSyncConfigs).toHaveLength(1);
+        // Only Model_1 should be present, Model_2 filtered out
+        expect(capturedSyncConfigs[0].models_json_schema).toEqual({
+            definitions: {
+                Model_1: { type: 'object', properties: { id: { type: 'string' } } }
+            }
+        });
+    });
+
+    it('Returns an error when a model is missing from aggregatedJsonSchema (legacy format)', async () => {
+        setupInfrastructureMocks([]);
+
+        const aggregatedJsonSchema: JSONSchema7 = {
+            definitions: {
+                Other_Model: { type: 'object', properties: { id: { type: 'string' } } }
+            }
+        };
+
+        const { success, error } = await DeployConfigService.deploy({
+            account,
+            environment,
+            flows: [baseFlow], // models: ['Model_1'], not present in aggregatedJsonSchema
+            aggregatedJsonSchema,
+            nangoYamlBody: '',
+            logContextGetter,
+            orchestrator: mockOrchestrator,
+            sdkVersion: '0.0.0-yaml'
+        });
+
+        expect(success).toBe(false);
+        expect(error?.type).toBe('deploy_missing_json_schema_model');
+    });
+
+    it('Sets models_json_schema to null when neither format provides a schema', async () => {
+        const capturedSyncConfigs: any[] = [];
+        setupInfrastructureMocks(capturedSyncConfigs);
+
+        const { success, error } = await DeployConfigService.deploy({
+            account,
+            environment,
+            flows: [baseFlow], // no models_json_schema, no aggregatedJsonSchema
+            nangoYamlBody: '',
+            logContextGetter,
+            orchestrator: mockOrchestrator,
+            sdkVersion: '0.0.0-yaml'
+        });
+
+        expect(success).toBe(true);
+        expect(error).toBeNull();
+        expect(capturedSyncConfigs).toHaveLength(1);
+        expect(capturedSyncConfigs[0].models_json_schema).toBeNull();
     });
 });

--- a/packages/types/lib/deploy/api.ts
+++ b/packages/types/lib/deploy/api.ts
@@ -29,6 +29,7 @@ export type PostDeploy = Endpoint<{
         reconcile: boolean;
         debug: boolean;
         singleDeployMode?: boolean;
+        /** @deprecated Use CLIDeployFlowConfig.models_json_schema */
         jsonSchema?: JSONSchema7 | undefined;
         sdkVersion?: string | undefined;
     };
@@ -48,6 +49,7 @@ export type PostDeployInternal = Endpoint<{
         reconcile: boolean;
         debug: boolean;
         singleDeployMode?: boolean;
+        /** @deprecated Use CLIDeployFlowConfig.models_json_schema */
         jsonSchema?: JSONSchema7 | undefined;
         sdkVersion?: string | undefined;
     };

--- a/packages/types/lib/deploy/incomingFlow.ts
+++ b/packages/types/lib/deploy/incomingFlow.ts
@@ -1,5 +1,6 @@
 import type { NangoSyncEndpointOld, NangoSyncEndpointV2, ScriptTypeLiteral, SyncTypeLiteral } from '../nangoYaml/index.js';
 import type { OnEventType } from '../scripts/on-events/api.js';
+import type { JSONSchema7 } from 'json-schema';
 import type { Merge } from 'type-fest';
 
 export interface IncomingScriptFiles {
@@ -88,6 +89,7 @@ export interface CLIDeployFlowConfig {
     /** @deprecated **/
     sync_type?: SyncTypeLiteral | undefined;
     webhookSubscriptions?: string[] | undefined;
+    models_json_schema?: JSONSchema7 | undefined;
 }
 
 /**


### PR DESCRIPTION
For context, each sync_config (flow) is saved in DB with a `models_json_schema` column representing it's used models.
The `POST /sync/deploy` (and `POST /sync/deploy/internal`) endpoint takes a list of flows, and a single top-level json-schema object with all the schemas used by the flows. This PR adds the option to pass a `models_json_schema` at a flow level, and marks the top-level json-schema as deprecated.

<!-- Summary by @propel-code-bot -->

---

The deploy flow now prefers the per-flow `models_json_schema`, falling back to filtering the aggregated schema for legacy requests, with validation to ensure required model definitions are present; test coverage was also expanded for both deploy endpoints and deploy service behavior.

<details>
<summary><strong>Possible Issues</strong></summary>

• Validation requires `models_json_schema.definitions` to include `input` when `input` is a string; confirm this matches intended behavior for all syncs.
• Legacy `jsonSchema` filtering assumes `definitions` structure; non-standard schema formats may still be rejected.

</details>

---
*This summary was automatically generated by @propel-code-bot*