### PR TITLE
feat: expose function checkpoints (from/to) in Nango logs

### DIFF
--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -28,6 +28,7 @@ import type { LogContext } from '@nangohq/logs';
 import type { OrchestratorTask, TaskAction } from '@nangohq/nango-orchestrator';
 import type { Config } from '@nangohq/shared';
 import type {
+    CheckpointRange,
     ConnectionJobs,
     DBAPISecret,
     DBEnvironment,
@@ -204,13 +205,15 @@ export async function handleActionSuccess({
     nangoProps,
     output,
     telemetryBag,
-    functionRuntime
+    functionRuntime,
+    checkpoints
 }: {
     taskId: string;
     nangoProps: NangoProps;
     output: JsonValue;
     telemetryBag: TelemetryBag;
     functionRuntime: FunctionRuntime;
+    checkpoints: CheckpointRange;
 }): Promise<void> {
     const logCtx = getLogCtx(nangoProps);
     const { environment, account } = (await accountService.getAccountContext({ environmentId: nangoProps.environmentId })) || {
@@ -245,8 +248,10 @@ export async function handleActionSuccess({
     void logCtx.info(`The action was successfully run${formatAttempts(task)}`, {
         action: nangoProps.syncConfig.sync_name,
         connection: nangoProps.connectionId,
-        integration: nangoProps.providerConfigKey
+        integration: nangoProps.providerConfigKey,
+        meta: { checkpoints }
     });
+    void logCtx.enrichOperation({ meta: { checkpoints } });
     void logCtx.success();
 
     const connection: ConnectionJobs = {
@@ -319,13 +324,15 @@ export async function handleActionError({
     nangoProps,
     error,
     telemetryBag,
-    functionRuntime
+    functionRuntime,
+    checkpoints
 }: {
     taskId: string;
     nangoProps: NangoProps;
     error: NangoError;
     telemetryBag: TelemetryBag;
     functionRuntime: FunctionRuntime;
+    checkpoints: CheckpointRange;
 }): Promise<void> {
     const accountAndEnv = await accountService.getAccountContext({ environmentId: nangoProps.environmentId });
     if (!accountAndEnv) {
@@ -364,8 +371,10 @@ export async function handleActionError({
         error,
         action: nangoProps.syncConfig.sync_name,
         connection: nangoProps.connectionId,
-        integration: nangoProps.providerConfigKey
+        integration: nangoProps.providerConfigKey,
+        meta: { checkpoints }
     });
+    void logCtx?.enrichOperation({ meta: { checkpoints } });
 
     if (task.value.attempt === task.value.attemptMax) {
         void logCtx.failed();

--- a/packages/jobs/lib/execution/operations/handler.ts
+++ b/packages/jobs/lib/execution/operations/handler.ts
@@ -5,7 +5,7 @@ import { handleSyncError, handleSyncSuccess } from '../sync.js';
 import { handleWebhookError, handleWebhookSuccess } from '../webhook.js';
 import { toNangoError } from './utils/errors.js';
 
-import type { FunctionRuntime, NangoProps, RunnerOutputError, TelemetryBag } from '@nangohq/types';
+import type { CheckpointRange, FunctionRuntime, NangoProps, RunnerOutputError, TelemetryBag } from '@nangohq/types';
 import type { JsonValue } from 'type-fest';
 
 export async function handleSuccess({
@@ -13,23 +13,25 @@ export async function handleSuccess({
     nangoProps,
     output,
     telemetryBag,
-    functionRuntime
+    functionRuntime,
+    checkpoints
 }: {
     taskId: string;
     nangoProps: NangoProps;
     output: JsonValue;
     telemetryBag: TelemetryBag;
     functionRuntime: FunctionRuntime;
+    checkpoints: CheckpointRange;
 }): Promise<void> {
     switch (nangoProps.scriptType) {
         case 'action':
-            await handleActionSuccess({ taskId, nangoProps, output, telemetryBag, functionRuntime });
+            await handleActionSuccess({ taskId, nangoProps, output, telemetryBag, functionRuntime, checkpoints });
             break;
         case 'sync':
-            await handleSyncSuccess({ taskId, nangoProps, telemetryBag, functionRuntime });
+            await handleSyncSuccess({ taskId, nangoProps, telemetryBag, functionRuntime, checkpoints });
             break;
         case 'webhook':
-            await handleWebhookSuccess({ taskId, nangoProps, telemetryBag, functionRuntime });
+            await handleWebhookSuccess({ taskId, nangoProps, telemetryBag, functionRuntime, checkpoints });
             break;
         case 'on-event':
             await handleOnEventSuccess({ taskId, nangoProps, telemetryBag, functionRuntime });
@@ -42,13 +44,15 @@ export async function handleError({
     nangoProps,
     error,
     telemetryBag,
-    functionRuntime
+    functionRuntime,
+    checkpoints
 }: {
     taskId: string;
     nangoProps: NangoProps;
     error: RunnerOutputError;
     telemetryBag: TelemetryBag;
     functionRuntime: FunctionRuntime;
+    checkpoints: CheckpointRange;
 }): Promise<void> {
     if (error.type === 'script_aborted') {
         // do nothing, the script was aborted and its state already updated
@@ -70,13 +74,13 @@ export async function handleError({
 
     switch (nangoProps.scriptType) {
         case 'action':
-            await handleActionError({ taskId, nangoProps, error: formattedError, telemetryBag, functionRuntime });
+            await handleActionError({ taskId, nangoProps, error: formattedError, telemetryBag, functionRuntime, checkpoints });
             break;
         case 'sync':
-            await handleSyncError({ taskId, nangoProps, error: formattedError, telemetryBag, functionRuntime });
+            await handleSyncError({ taskId, nangoProps, error: formattedError, telemetryBag, functionRuntime, checkpoints });
             break;
         case 'webhook':
-            await handleWebhookError({ taskId, nangoProps, error: formattedError, telemetryBag, functionRuntime });
+            await handleWebhookError({ taskId, nangoProps, error: formattedError, telemetryBag, functionRuntime, checkpoints });
             break;
         case 'on-event':
             await handleOnEventError({ taskId, nangoProps, error: formattedError, telemetryBag, functionRuntime });

--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -256,7 +256,8 @@ const runJob = async (
         taskId: 'abc',
         nangoProps: nangoProps.value,
         telemetryBag: { customLogs: 0, proxyCalls: 0, durationMs: 0, memoryGb: 1 },
-        functionRuntime: 'runner'
+        functionRuntime: 'runner',
+        checkpoints: null
     });
 
     const latestSyncJob = await getLatestSyncJob(sync.id);

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -43,6 +43,7 @@ import type { LogContextOrigin } from '@nangohq/logs';
 import type { TaskSync, TaskSyncAbort } from '@nangohq/nango-orchestrator';
 import type { Config, Job } from '@nangohq/shared';
 import type {
+    CheckpointRange,
     ConnectionJobs,
     DBEnvironment,
     DBSyncConfig,
@@ -259,12 +260,14 @@ export async function handleSyncSuccess({
     taskId,
     nangoProps,
     telemetryBag,
-    functionRuntime
+    functionRuntime,
+    checkpoints
 }: {
     taskId: string;
     nangoProps: NangoProps;
     telemetryBag: TelemetryBag;
     functionRuntime: FunctionRuntime;
+    checkpoints: CheckpointRange;
 }): Promise<void> {
     const logCtx = logContextGetter.get({ id: nangoProps.activityLogId, accountId: nangoProps.team.id });
     logCtx.attachSpan(
@@ -481,12 +484,18 @@ export async function handleSyncSuccess({
         }
 
         await logCtx.enrichOperation({
-            meta: syncPayload
+            meta: {
+                ...syncPayload,
+                checkpoints
+            }
         });
 
         void logCtx.info(
             `${nangoProps.syncConfig.sync_type ? nangoProps.syncConfig.sync_type.replace(/^./, (c) => c.toUpperCase()) : 'The '} sync '${nangoProps.syncConfig.sync_name}' completed successfully`,
-            syncPayload
+            {
+                ...syncPayload,
+                checkpoints
+            }
         );
 
         // set the last sync date to when the sync started in case
@@ -604,13 +613,15 @@ export async function handleSyncError({
     nangoProps,
     error,
     telemetryBag,
-    functionRuntime
+    functionRuntime,
+    checkpoints
 }: {
     taskId: string;
     nangoProps: NangoProps;
     error: NangoError;
     telemetryBag?: TelemetryBag | undefined;
     functionRuntime?: FunctionRuntime | undefined;
+    checkpoints: CheckpointRange;
 }): Promise<void> {
     let team: DBTeam | undefined;
     let environment: DBEnvironment | undefined;
@@ -660,7 +671,8 @@ export async function handleSyncError({
         endUser: nangoProps.endUser,
         startedAt: nangoProps.startedAt,
         telemetryBag,
-        functionRuntime
+        functionRuntime,
+        checkpoints
     });
 }
 
@@ -775,7 +787,8 @@ async function onFailure({
     endUser,
     startedAt,
     telemetryBag,
-    functionRuntime
+    functionRuntime,
+    checkpoints
 }: {
     team?: DBTeam | undefined;
     environment?: DBEnvironment | undefined;
@@ -800,6 +813,7 @@ async function onFailure({
     endUser: NangoProps['endUser'];
     telemetryBag?: TelemetryBag | undefined;
     functionRuntime?: FunctionRuntime | undefined;
+    checkpoints?: CheckpointRange | undefined;
 }): Promise<void> {
     const logCtx = activityLogId && team ? logContextGetter.get({ id: activityLogId, accountId: team.id }) : null;
 
@@ -928,8 +942,8 @@ async function onFailure({
         }
     }
 
-    void logCtx?.error(error.message, { error });
-    await logCtx?.enrichOperation({ error });
+    void logCtx?.error(error.message, { error, checkpoints });
+    await logCtx?.enrichOperation({ error, meta: { checkpoints } });
     if (isCancel) {
         await logCtx?.cancel();
     } else {

--- a/packages/jobs/lib/execution/webhook.ts
+++ b/packages/jobs/lib/execution/webhook.ts
@@ -30,7 +30,18 @@ import { pubsub } from '../utils/pubsub.js';
 
 import type { TaskWebhook } from '@nangohq/nango-orchestrator';
 import type { Config, Job, Sync } from '@nangohq/shared';
-import type { ConnectionJobs, DBEnvironment, DBSyncConfig, DBTeam, FunctionRuntime, NangoProps, RuntimeContext, SdkLogger, TelemetryBag } from '@nangohq/types';
+import type {
+    CheckpointRange,
+    ConnectionJobs,
+    DBEnvironment,
+    DBSyncConfig,
+    DBTeam,
+    FunctionRuntime,
+    NangoProps,
+    RuntimeContext,
+    SdkLogger,
+    TelemetryBag
+} from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 export async function startWebhook(task: TaskWebhook): Promise<Result<void>> {
@@ -211,12 +222,14 @@ export async function handleWebhookSuccess({
     taskId,
     nangoProps,
     telemetryBag,
-    functionRuntime
+    functionRuntime,
+    checkpoints
 }: {
     taskId: string;
     nangoProps: NangoProps;
     telemetryBag: TelemetryBag;
     functionRuntime: FunctionRuntime;
+    checkpoints: CheckpointRange;
 }): Promise<void> {
     const logCtx = logContextGetter.get({ id: nangoProps.activityLogId, accountId: nangoProps.team.id });
 
@@ -336,6 +349,7 @@ export async function handleWebhookSuccess({
         }
     });
 
+    await logCtx.enrichOperation({ meta: { checkpoints } });
     await logCtx.success();
 }
 
@@ -344,13 +358,15 @@ export async function handleWebhookError({
     nangoProps,
     error,
     telemetryBag,
-    functionRuntime
+    functionRuntime,
+    checkpoints
 }: {
     taskId: string;
     nangoProps: NangoProps;
     error: NangoError;
     telemetryBag: TelemetryBag;
     functionRuntime: FunctionRuntime;
+    checkpoints: CheckpointRange;
 }): Promise<void> {
     let team: DBTeam | undefined;
     let environment: DBEnvironment | undefined;
@@ -394,7 +410,8 @@ export async function handleWebhookError({
         syncConfig: nangoProps.syncConfig,
         endUser: nangoProps.endUser,
         telemetryBag,
-        functionRuntime
+        functionRuntime,
+        checkpoints
     });
 }
 
@@ -415,7 +432,8 @@ async function onFailure({
     error,
     endUser,
     telemetryBag,
-    functionRuntime
+    functionRuntime,
+    checkpoints
 }: {
     connection: ConnectionJobs;
     team: DBTeam | undefined;
@@ -434,6 +452,7 @@ async function onFailure({
     endUser: NangoProps['endUser'];
     telemetryBag?: TelemetryBag | undefined;
     functionRuntime?: FunctionRuntime | undefined;
+    checkpoints?: CheckpointRange | undefined;
 }): Promise<void> {
     const logCtx = activityLogId && team ? logContextGetter.get({ id: activityLogId, accountId: team.id }) : null;
 
@@ -531,7 +550,7 @@ async function onFailure({
         });
     }
 
-    void logCtx?.error(error.message, { error });
-    await logCtx?.enrichOperation({ error });
+    void logCtx?.error(error.message, { error, checkpoints });
+    await logCtx?.enrichOperation({ error, meta: { checkpoints } });
     await logCtx?.failed();
 }

--- a/packages/jobs/lib/invocations/lambda.processor.ts
+++ b/packages/jobs/lib/invocations/lambda.processor.ts
@@ -65,7 +65,8 @@ export class LambdaInvocationsProcessor {
                     status: parsedMessage.responseContext.statusCode
                 },
                 telemetryBag: { customLogs: 0, proxyCalls: 0, durationMs: 0, memoryGb: 0 },
-                functionRuntime: 'lambda'
+                functionRuntime: 'lambda',
+                checkpoints: null
             });
         }
     }

--- a/packages/jobs/lib/routes/tasks/putTask.ts
+++ b/packages/jobs/lib/routes/tasks/putTask.ts
@@ -26,7 +26,11 @@ const bodySchema = z.object({
     telemetryBag: z
         .object({ customLogs: z.number(), proxyCalls: z.number(), durationMs: z.number().default(0), memoryGb: z.number().default(1) })
         .default({ customLogs: 0, proxyCalls: 0, durationMs: 0, memoryGb: 1 }),
-    functionRuntime: z.enum(['runner', 'lambda']).default('runner')
+    functionRuntime: z.enum(['runner', 'lambda']).default('runner'),
+    checkpoints: z
+        .object({ from: z.any().default(null), to: z.any().default(null) }) // we assume any for the checkpoints as their shape is enforced by the SDK
+        .nullable()
+        .default(null)
 });
 const paramsSchema = z.object({ taskId: z.string().uuid() }).strict();
 
@@ -37,15 +41,29 @@ const validate = validateRequest<PutTask>({
 
 const handler = async (_req: EndpointRequest, res: EndpointResponse<PutTask>) => {
     const { taskId } = res.locals.parsedParams;
-    const { nangoProps, error, output, telemetryBag, functionRuntime } = res.locals.parsedBody;
+    const { nangoProps, error, output, telemetryBag, functionRuntime, checkpoints } = res.locals.parsedBody;
     if (!nangoProps) {
         res.status(400).json({ error: { code: 'put_task_failed', message: 'missing nangoProps' } });
         return;
     }
     if (error) {
-        await handleError({ taskId, nangoProps, error, telemetryBag, functionRuntime });
+        await handleError({
+            taskId,
+            nangoProps,
+            error,
+            telemetryBag,
+            functionRuntime,
+            checkpoints: checkpoints || null
+        });
     } else {
-        await handleSuccess({ taskId, nangoProps, output: output || null, telemetryBag, functionRuntime });
+        await handleSuccess({
+            taskId,
+            nangoProps,
+            output: output || null,
+            telemetryBag,
+            functionRuntime,
+            checkpoints: checkpoints || null
+        });
     }
     res.status(204).send();
     return;

--- a/packages/runner-sdk/lib/errors.ts
+++ b/packages/runner-sdk/lib/errors.ts
@@ -1,4 +1,4 @@
-import type { RunnerOutputError, TelemetryBag } from '@nangohq/types';
+import type { CheckpointRange, RunnerOutputError, TelemetryBag } from '@nangohq/types';
 
 export abstract class SDKError extends Error {
     abstract code: string;
@@ -52,14 +52,16 @@ export class ExecutionError extends Error {
     status: RunnerOutputError['status'];
     additional_properties: RunnerOutputError['additional_properties'];
     telemetryBag: TelemetryBag;
+    checkpoints?: CheckpointRange | undefined;
 
-    constructor(payload: RunnerOutputError & { telemetryBag: TelemetryBag }) {
+    constructor(payload: RunnerOutputError & { telemetryBag: TelemetryBag; checkpoints?: CheckpointRange | undefined }) {
         super();
         this.type = payload.type;
         this.payload = payload.payload;
         this.status = payload.status;
         this.additional_properties = payload.additional_properties;
         this.telemetryBag = payload.telemetryBag;
+        this.checkpoints = payload.checkpoints;
     }
 
     toJSON(): RunnerOutputError {

--- a/packages/runner/lib/clients/jobs.ts
+++ b/packages/runner/lib/clients/jobs.ts
@@ -35,7 +35,8 @@ class JobsClient {
         error,
         output,
         telemetryBag,
-        functionRuntime
+        functionRuntime,
+        checkpoints
     }: PutTask['Body'] & PutTask['Params']): Promise<Result<PutTask['Success']>> {
         const resp = await httpFetch(
             `${this.baseUrl}/tasks/${taskId}`,
@@ -47,7 +48,8 @@ class JobsClient {
                 body: JSON.stringify({
                     nangoProps: nangoProps,
                     ...(error ? { error, telemetryBag } : { output, telemetryBag }),
-                    functionRuntime
+                    functionRuntime,
+                    checkpoints
                 })
             },
             defaultRetryOptions

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -139,7 +139,11 @@ export async function exec({
                     }
 
                     const output = await payload.onWebhook(nango as any, codeParams);
-                    return Ok({ output, telemetryBag: nango.telemetryBag });
+                    return Ok({
+                        output,
+                        telemetryBag: nango.telemetryBag,
+                        checkpoints: nango.getCheckpointRange()
+                    });
                 } else {
                     if (!scriptExports.onWebhookPayloadReceived) {
                         const content = `There is no onWebhookPayloadReceived export for ${nangoProps.syncId}`;
@@ -148,7 +152,11 @@ export async function exec({
                     }
 
                     const output = await scriptExports.onWebhookPayloadReceived(nango as NangoSyncRunner, codeParams);
-                    return Ok({ output, telemetryBag: nango.telemetryBag });
+                    return Ok({
+                        output,
+                        telemetryBag: nango.telemetryBag,
+                        checkpoints: nango.getCheckpointRange()
+                    });
                 }
             }
 
@@ -187,10 +195,14 @@ export async function exec({
                     }
                 }
 
-                return Ok({ output, telemetryBag: nango.telemetryBag });
+                return Ok({
+                    output,
+                    telemetryBag: nango.telemetryBag,
+                    checkpoints: nango.getCheckpointRange()
+                });
             }
 
-            // Action
+            // On-event
             if (nangoProps.scriptType === 'on-event') {
                 let output: unknown;
                 if (isZeroYaml) {
@@ -219,10 +231,18 @@ export async function exec({
                 }
 
                 await payload.exec(nango as any);
-                return Ok({ output: true, telemetryBag: nango.telemetryBag });
+                return Ok({
+                    output: true,
+                    telemetryBag: nango.telemetryBag,
+                    checkpoints: nango.getCheckpointRange()
+                });
             } else {
                 await def(nango);
-                return Ok({ output: true, telemetryBag: nango.telemetryBag });
+                return Ok({
+                    output: true,
+                    telemetryBag: nango.telemetryBag,
+                    checkpoints: nango.getCheckpointRange()
+                });
             }
         } catch (err) {
             if (err instanceof ActionError) {
@@ -236,7 +256,8 @@ export async function exec({
                             Array.isArray(payload) || (typeof payload !== 'object' && payload !== null) ? { message: payload } : payload || {}
                         ), // TODO: fix ActionError so payload is always an object
                         status: 500,
-                        telemetryBag: nango.telemetryBag
+                        telemetryBag: nango.telemetryBag,
+                        checkpoints: nango.getCheckpointRange()
                     })
                 );
             }
@@ -248,7 +269,8 @@ export async function exec({
                         type: err.code,
                         payload: truncateJson(err.payload),
                         status: 500,
-                        telemetryBag: nango.telemetryBag
+                        telemetryBag: nango.telemetryBag,
+                        checkpoints: nango.getCheckpointRange()
                     })
                 );
             } else if (isAxiosError<unknown, unknown>(err)) {
@@ -297,7 +319,8 @@ export async function exec({
                                     body: responseBody
                                 }
                             },
-                            telemetryBag: nango.telemetryBag
+                            telemetryBag: nango.telemetryBag,
+                            checkpoints: nango.getCheckpointRange()
                         })
                     );
                 } else {
@@ -314,7 +337,8 @@ export async function exec({
                                 ...(stacktrace.length > 0 ? { stacktrace } : {})
                             }),
                             status: 500,
-                            telemetryBag: nango.telemetryBag
+                            telemetryBag: nango.telemetryBag,
+                            checkpoints: nango.getCheckpointRange()
                         })
                     );
                 }
@@ -334,7 +358,8 @@ export async function exec({
                             ...(stacktrace.length > 0 ? { stacktrace } : {})
                         }),
                         status: 500,
-                        telemetryBag: nango.telemetryBag
+                        telemetryBag: nango.telemetryBag,
+                        checkpoints: nango.getCheckpointRange()
                     })
                 );
             } else {
@@ -353,7 +378,8 @@ export async function exec({
                             ...(stacktrace.length > 0 ? { stacktrace } : {})
                         }),
                         status: 500,
-                        telemetryBag: nango.telemetryBag
+                        telemetryBag: nango.telemetryBag,
+                        checkpoints: nango.getCheckpointRange()
                     })
                 );
             }

--- a/packages/runner/lib/sdk/checkpointing.ts
+++ b/packages/runner/lib/sdk/checkpointing.ts
@@ -1,7 +1,7 @@
 import { validateCheckpoint } from '@nangohq/runner-sdk';
 
 import type { PersistClient } from '../clients/persist.js';
-import type { Checkpoint } from '@nangohq/types';
+import type { Checkpoint, CheckpointRange } from '@nangohq/types';
 
 type CheckpointState = {
     checkpoint: Checkpoint | null;
@@ -9,21 +9,27 @@ type CheckpointState = {
     deletedAt: string | null;
 } | null;
 
-interface KeyState {
-    from: CheckpointState;
-    last: CheckpointState;
-}
-
 export class Checkpointing {
     private persistClient: PersistClient;
     private environmentId: number;
     private nangoConnectionId: number;
-    private stateByKey = new Map<string, KeyState>();
+    private rangeByKey = new Map<string, { from: CheckpointState; to: CheckpointState }>();
 
     constructor(props: { persistClient: PersistClient; environmentId: number; nangoConnectionId: number }) {
         this.persistClient = props.persistClient;
         this.environmentId = props.environmentId;
         this.nangoConnectionId = props.nangoConnectionId;
+    }
+
+    public getRange(key: string): CheckpointRange | null {
+        const range = this.rangeByKey.get(key);
+        if (!range) {
+            return null;
+        }
+        return {
+            from: range.from?.checkpoint && range.from?.deletedAt === null ? range.from.checkpoint : null,
+            to: range.to?.checkpoint && range.to?.deletedAt === null ? range.to.checkpoint : null
+        };
     }
 
     public async getCheckpoint<T = Checkpoint>(key: string): Promise<T | null> {
@@ -45,8 +51,8 @@ export class Checkpointing {
                   version: res.value.version
               };
 
-        const existing = this.stateByKey.get(key);
-        this.stateByKey.set(key, { from: existing?.from ?? current, last: current });
+        const existing = this.rangeByKey.get(key);
+        this.rangeByKey.set(key, { from: existing?.from ?? current, to: current });
 
         return current.deletedAt ? null : (current.checkpoint as T);
     }
@@ -64,10 +70,10 @@ export class Checkpointing {
         if (res.isErr()) {
             throw new Error(`Error saving checkpoint: ${res.error.message}`, { cause: res.error });
         }
-        const existing = this.stateByKey.get(key);
-        this.stateByKey.set(key, {
+        const existing = this.rangeByKey.get(key);
+        this.rangeByKey.set(key, {
             from: existing?.from ?? null,
-            last: {
+            to: {
                 checkpoint: validateCheckpoint(res.value.checkpoint),
                 version: res.value.version,
                 deletedAt: null
@@ -87,17 +93,17 @@ export class Checkpointing {
         if (res.isErr()) {
             throw new Error(`Error deleting checkpoint: ${res.error.message}`, { cause: res.error });
         }
-        const existing = this.stateByKey.get(key);
-        this.stateByKey.set(key, { from: existing?.from ?? null, last: null });
+        const existing = this.rangeByKey.get(key);
+        this.rangeByKey.set(key, { from: existing?.from ?? null, to: null });
     }
 
     private async ensureVersion(key: string): Promise<{ version: number }> {
         // If we haven't loaded the checkpoint yet, load it to get the version for optimistic locking.
-        if (!this.stateByKey.get(key)?.last) {
+        if (!this.rangeByKey.get(key)?.to) {
             await this.getCheckpoint(key);
         }
 
-        const version = this.stateByKey.get(key)?.last?.version;
+        const version = this.rangeByKey.get(key)?.to?.version;
         if (!version) {
             throw new Error('Missing checkpoint version'); // defensive check - this should never happen
         }

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -20,7 +20,16 @@ import { logger } from '../logger.js';
 
 import type { Locks } from './locks.js';
 import type { ProxyConfiguration, ZodCheckpoint } from '@nangohq/runner-sdk';
-import type { ApiPublicConnectionFull, Checkpoint, MergingStrategy, MessageRowInsert, NangoProps, PostPublicTrigger, UserLogParameters } from '@nangohq/types';
+import type {
+    ApiPublicConnectionFull,
+    Checkpoint,
+    CheckpointRange,
+    MergingStrategy,
+    MessageRowInsert,
+    NangoProps,
+    PostPublicTrigger,
+    UserLogParameters
+} from '@nangohq/types';
 import type { AxiosResponse } from 'axios';
 
 interface TrackDeletesCheckpoint {
@@ -47,7 +56,7 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
     nango: Nango;
     protected persistClient: PersistClient;
     protected locking: Locking;
-    protected checkpointing: Checkpointing;
+    private checkpointing: Checkpointing;
     protected checkpointKey: string;
     protected httpLogSample: number = 0;
 
@@ -327,6 +336,10 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
     public override async clearCheckpoint(): Promise<void> {
         return this.checkpointing.clearCheckpoint(this.checkpointKey);
     }
+
+    public getCheckpointRange(): CheckpointRange | null {
+        return this.checkpointing.getRange(this.checkpointKey);
+    }
 }
 
 /**
@@ -337,7 +350,7 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
 
     protected persistClient: PersistClient;
     protected locking: Locking;
-    protected checkpointing: Checkpointing;
+    private checkpointing: Checkpointing;
     protected checkpointKey: string;
     private batchSize = 1000;
     private getRecordsBatchSize = 100;
@@ -651,6 +664,10 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
     public override async clearCheckpoint(): Promise<void> {
         return this.checkpointing.clearCheckpoint(this.checkpointKey);
     }
+
+    public getCheckpointRange(): CheckpointRange | null {
+        return this.checkpointing.getRange(this.checkpointKey);
+    }
 }
 
 class Locking {
@@ -689,7 +706,7 @@ class Locking {
     }
 }
 
-const TELEMETRY_ALLOWED_METHODS: (keyof NangoSyncBase)[] = [
+const TELEMETRY_ALLOWED_METHODS: (keyof NangoSyncRunner | keyof NangoActionRunner)[] = [
     'batchDelete',
     'batchSave',
     'batchUpdate',

--- a/packages/runner/lib/server.ts
+++ b/packages/runner/lib/server.ts
@@ -99,11 +99,13 @@ function startProcedure() {
 
                     const telemetryBag = execRes.isErr() ? execRes.error.telemetryBag : execRes.value.telemetryBag;
                     telemetryBag.durationMs = Date.now() - startTime;
+                    const checkpoints = execRes.isErr() ? execRes.error.checkpoints : execRes.value.checkpoints;
                     await jobsClient.putTask({
                         taskId,
                         nangoProps,
                         ...(execRes.isErr() ? { error: execRes.error.toJSON(), telemetryBag } : { output: execRes.value.output as any, telemetryBag }),
-                        functionRuntime: 'runner'
+                        functionRuntime: 'runner',
+                        checkpoints
                     });
                 } finally {
                     clearInterval(heartbeat);

--- a/packages/types/lib/checkpoint/types.ts
+++ b/packages/types/lib/checkpoint/types.ts
@@ -18,3 +18,5 @@ export type CheckpointValue = string | number | boolean;
  * ```
  */
 export type Checkpoint = Record<string, CheckpointValue>;
+
+export type CheckpointRange = { from: Checkpoint | null; to: Checkpoint | null } | null;

--- a/packages/types/lib/jobs/api.ts
+++ b/packages/types/lib/jobs/api.ts
@@ -1,4 +1,5 @@
 import type { ApiError, Endpoint } from '../api.js';
+import type { CheckpointRange } from '../checkpoint/types.js';
 import type { RunnerOutputError } from '../runner/index.js';
 import type { FunctionRuntime, NangoProps, TelemetryBag } from '../runner/sdk.js';
 import type { JsonValue } from 'type-fest';
@@ -26,6 +27,7 @@ export type PutTask = Endpoint<{
         output?: JsonValue | undefined;
         telemetryBag: TelemetryBag;
         functionRuntime: FunctionRuntime;
+        checkpoints?: CheckpointRange | undefined;
     };
     Error: ApiError<'put_task_failed'>;
     Success: never;

--- a/packages/types/lib/runner/index.ts
+++ b/packages/types/lib/runner/index.ts
@@ -1,4 +1,5 @@
 import type { TelemetryBag } from './sdk.js';
+import type { CheckpointRange } from '../checkpoint/types.js';
 import type { DBPlan } from '../plans/db.js';
 
 export interface RunnerOutputError {
@@ -14,6 +15,7 @@ export interface RunnerOutputError {
 export interface RunnerOutput {
     output: unknown;
     telemetryBag: TelemetryBag;
+    checkpoints?: CheckpointRange | undefined;
 }
 
 export interface RunnerFlags {


### PR DESCRIPTION
Runner is now returning from/to checkpoints which is exposed in the logs operation metadata to make it visible for customers for monitoring/debugging purpose

<img width="1009" height="479" alt="Screenshot 2026-03-04 at 14 54 07" src="https://github.com/user-attachments/assets/f70f9468-ce26-4f67-9ae9-4bc2c41aa525" />


`from` is the checkpoint value at the beginning of the execution (aka: last saved checkpoint of the previous execution)
`to` is the last saved checkpoints of this execution

Note: in a followup PR, the checkpoints info will be added to the sync webhook

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

It also propagates these checkpoint ranges through execution results into the jobs service, updating the jobs API contract and task payloads so handlers capture checkpoints on both success and error paths for end-to-end logging and metadata.

<details>
<summary><strong>Possible Issues</strong></summary>

• If `getCheckpoint` is never called, `from` may remain `null` and logs may show an incomplete range; confirm that is acceptable for monitoring expectations.

</details>

---
*This summary was automatically generated by @propel-code-bot*