### PR TITLE
feat(orch): allow overriding next execution when completing a task

### DIFF
--- a/packages/jobs/lib/execution/operations/abort.ts
+++ b/packages/jobs/lib/execution/operations/abort.ts
@@ -2,6 +2,7 @@ import { getKVStore } from '@nangohq/kvstore';
 import { accountService } from '@nangohq/shared';
 import { Err, Ok } from '@nangohq/utils';
 
+import { setTaskSuccess } from './state.js';
 import { orchestratorClient } from '../../clients.js';
 import { envs } from '../../env.js';
 import { logger } from '../../logger.js';
@@ -28,10 +29,8 @@ export async function abortTask(task: TaskAbort): Promise<Result<void>> {
         }
     }
 
-    const setSuccess = await orchestratorClient.succeed({ taskId: task.id, output: {} });
-    if (setSuccess.isErr()) {
-        logger.error(`failed to set cancel task ${task.id} as succeeded`, setSuccess.error);
-    }
+    await setTaskSuccess({ taskId: task.id, output: {} });
+
     return abortedScript;
 }
 

--- a/packages/jobs/lib/execution/operations/state.ts
+++ b/packages/jobs/lib/execution/operations/state.ts
@@ -7,8 +7,16 @@ import type { ClientError, OrchestratorTask } from '@nangohq/nango-orchestrator'
 import type { ApiError, Result } from '@nangohq/types';
 import type { JsonValue } from 'type-fest';
 
-export async function setTaskSuccess({ taskId, output }: { taskId: string; output: JsonValue }): Promise<Result<OrchestratorTask>> {
-    const setSuccess = await orchestratorClient.succeed({ taskId, output: output });
+export async function setTaskSuccess({
+    taskId,
+    output,
+    nextExecutionInMs
+}: {
+    taskId: string;
+    output: JsonValue;
+    nextExecutionInMs?: number;
+}): Promise<Result<OrchestratorTask>> {
+    const setSuccess = await orchestratorClient.succeed({ taskId, output: output, nextExecutionInMs });
     if (setSuccess.isErr()) {
         await handlePayloadTooBigError({ taskId, error: setSuccess.error });
         logger.error(`failed to set task ${taskId} as succeeded`, setSuccess.error);
@@ -16,8 +24,16 @@ export async function setTaskSuccess({ taskId, output }: { taskId: string; outpu
     return setSuccess;
 }
 
-export async function setTaskFailed({ taskId, error }: { taskId: string; error: NangoError }): Promise<Result<OrchestratorTask>> {
-    const setFailed = await orchestratorClient.failed({ taskId, error });
+export async function setTaskFailed({
+    taskId,
+    error,
+    nextExecutionInMs
+}: {
+    taskId: string;
+    error: NangoError;
+    nextExecutionInMs?: number;
+}): Promise<Result<OrchestratorTask>> {
+    const setFailed = await orchestratorClient.failed({ taskId, error, nextExecutionInMs });
     if (setFailed.isErr()) {
         await handlePayloadTooBigError({ taskId, error: setFailed.error });
         logger.error(`failed to set task ${taskId} as failed`, setFailed.error);

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -737,10 +737,7 @@ export async function abortSync(task: TaskSyncAbort): Promise<Result<void>> {
             lastSyncDate: lastSyncDate || undefined,
             startedAt: new Date()
         });
-        const setSuccess = await orchestratorClient.succeed({ taskId: task.id, output: {} });
-        if (setSuccess.isErr()) {
-            logger.error(`failed to set cancel task ${task.id} as succeeded`, setSuccess.error);
-        }
+        await setTaskSuccess({ taskId: task.id, output: {} });
         return Ok(undefined);
     } catch (err) {
         const error = new Error(`Failed to cancel`, { cause: err });

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -426,10 +426,18 @@ export class OrchestratorClient {
         }
     }
 
-    public async succeed({ taskId, output }: { taskId: string; output: JsonValue }): Promise<Result<OrchestratorTask, ClientError>> {
+    public async succeed({
+        taskId,
+        output,
+        nextExecutionInMs
+    }: {
+        taskId: string;
+        output: JsonValue;
+        nextExecutionInMs?: number | undefined;
+    }): Promise<Result<OrchestratorTask, ClientError>> {
         const res = await this.routeFetch(putTaskRoute)({
             params: { taskId },
-            body: { output, state: 'SUCCEEDED' }
+            body: { output, state: 'SUCCEEDED', nextExecutionInMs }
         });
         if ('error' in res) {
             return Err({
@@ -446,7 +454,15 @@ export class OrchestratorClient {
         }
     }
 
-    public async failed({ taskId, error }: { taskId: string; error: Error }): Promise<Result<OrchestratorTask, ClientError>> {
+    public async failed({
+        taskId,
+        error,
+        nextExecutionInMs
+    }: {
+        taskId: string;
+        error: Error;
+        nextExecutionInMs?: number | undefined;
+    }): Promise<Result<OrchestratorTask, ClientError>> {
         const output = {
             name: error.name,
             type: 'type' in error ? (error.type as string) : 'unknown_error',
@@ -456,7 +472,7 @@ export class OrchestratorClient {
         };
         const res = await this.routeFetch(putTaskRoute)({
             params: { taskId },
-            body: { output, state: 'FAILED' }
+            body: { output, state: 'FAILED', nextExecutionInMs }
         });
         if ('error' in res) {
             return Err({
@@ -473,10 +489,18 @@ export class OrchestratorClient {
         }
     }
 
-    public async cancel({ taskId, reason }: { taskId: string; reason: string }): Promise<Result<OrchestratorTask, ClientError>> {
+    public async cancel({
+        taskId,
+        reason,
+        nextExecutionInMs
+    }: {
+        taskId: string;
+        reason: string;
+        nextExecutionInMs?: number;
+    }): Promise<Result<OrchestratorTask, ClientError>> {
         const res = await this.routeFetch(putTaskRoute)({
             params: { taskId },
-            body: { output: reason, state: 'CANCELLED' }
+            body: { output: reason, state: 'CANCELLED', nextExecutionInMs }
         });
         if ('error' in res) {
             return Err({

--- a/packages/orchestrator/lib/routes/v1/tasks/putTaskId.ts
+++ b/packages/orchestrator/lib/routes/v1/tasks/putTaskId.ts
@@ -18,6 +18,7 @@ type PutTask = Endpoint<{
     Body: {
         output: JsonValue;
         state: 'SUCCEEDED' | 'FAILED' | 'CANCELLED';
+        nextExecutionInMs?: number | undefined;
     };
     Error: ApiError<'put_task_failed' | 'invalid_state'>;
     Success: Task;
@@ -26,7 +27,13 @@ type PutTask = Endpoint<{
 const path = '/v1/tasks/:taskId';
 const method = 'PUT';
 
-const bodySchema = z.object({ output: jsonSchema, state: z.enum(['SUCCEEDED', 'FAILED', 'CANCELLED']) }).strict();
+const bodySchema = z
+    .object({
+        output: jsonSchema,
+        state: z.enum(['SUCCEEDED', 'FAILED', 'CANCELLED']),
+        nextExecutionInMs: z.number().int().nonnegative().optional()
+    })
+    .strict();
 const paramsSchema = z.object({ taskId: z.string().uuid() }).strict();
 
 const validate = validateRequest<PutTask>({
@@ -37,17 +44,17 @@ const validate = validateRequest<PutTask>({
 const handler = (scheduler: Scheduler) => {
     return async (_req: EndpointRequest, res: EndpointResponse<PutTask>) => {
         const { taskId } = res.locals.parsedParams;
-        const { state, output } = res.locals.parsedBody;
+        const { state, output, nextExecutionInMs } = res.locals.parsedBody;
         let updated: Result<Task>;
         switch (state) {
             case 'SUCCEEDED':
-                updated = await scheduler.succeed({ taskId: taskId, output: output });
+                updated = await scheduler.succeed({ taskId: taskId, output: output, nextExecutionInMs });
                 break;
             case 'FAILED':
-                updated = await scheduler.fail({ taskId: taskId, error: output });
+                updated = await scheduler.fail({ taskId: taskId, error: output, nextExecutionInMs });
                 break;
             case 'CANCELLED':
-                updated = await scheduler.cancel({ taskId: taskId, reason: output });
+                updated = await scheduler.cancel({ taskId: taskId, reason: output, nextExecutionInMs });
                 break;
             default:
                 res.status(400).json({ error: { code: 'invalid_state', message: `Invalid state ${state}` } });

--- a/packages/scheduler/lib/daemons/expiring/expiring.daemon.ts
+++ b/packages/scheduler/lib/daemons/expiring/expiring.daemon.ts
@@ -49,7 +49,7 @@ export class ExpiringDaemon extends SchedulerDaemon {
                 }
                 if (expired.value.length > 0) {
                     // update schedules to reflect the expired tasks
-                    const scheduleRes = await schedules.updateLastScheduledTaskState(trx, {
+                    const scheduleRes = await schedules.scheduleNextExecution(trx, {
                         taskIds: expired.value.filter((t) => t.scheduleId).map((t) => t.id),
                         taskState: 'EXPIRED'
                     });

--- a/packages/scheduler/lib/models/schedules.integration.test.ts
+++ b/packages/scheduler/lib/models/schedules.integration.test.ts
@@ -115,11 +115,20 @@ describe('Schedules', () => {
         await schedules.setLastScheduledTask(db, [{ id: schedule.id, taskId, taskState: 'CREATED' }]);
 
         const taskState = 'SUCCEEDED';
-        const [updated] = (await schedules.updateLastScheduledTaskState(db, { taskIds: [taskId], taskState })).unwrap();
+        const [updated] = (await schedules.scheduleNextExecution(db, { taskIds: [taskId], taskState })).unwrap();
         expect(updated?.updatedAt.getTime()).toBeGreaterThan(schedule.updatedAt.getTime());
         expect(updated?.lastScheduledTaskState).toBe(taskState);
         // The next execution should be set to the next due date based on the frequency
         expect(updated?.nextExecutionAt).toBeWithinMs(new Date(schedule.startsAt.getTime() + schedule.frequencyMs), 3_000);
+    });
+    it('should override next execution when nextExecutionInMs is provided', async () => {
+        const schedule = await createSchedule(db);
+        const taskId = uuidv7();
+        await schedules.setLastScheduledTask(db, [{ id: schedule.id, taskId, taskState: 'CREATED' }]);
+
+        const nextExecutionInMs = 9_999_999;
+        const [updated] = (await schedules.scheduleNextExecution(db, { taskIds: [taskId], taskState: 'SUCCEEDED', nextExecutionInMs })).unwrap();
+        expect(updated?.nextExecutionAt).toBeWithinMs(new Date(Date.now() + nextExecutionInMs), 3_000);
     });
 });
 

--- a/packages/scheduler/lib/models/schedules.ts
+++ b/packages/scheduler/lib/models/schedules.ts
@@ -249,25 +249,31 @@ export async function setLastScheduledTask(db: knex.Knex, updates: { id: string;
     }
 }
 
-export async function updateLastScheduledTaskState(
+export async function scheduleNextExecution(
     db: knex.Knex,
-    { taskIds, taskState }: { taskIds: string[]; taskState: TaskState }
+    { taskIds, taskState, nextExecutionInMs }: { taskIds: string[]; taskState: TaskState; nextExecutionInMs?: number | undefined }
 ): Promise<Result<Schedule[]>> {
     try {
         if (taskIds.length <= 0) {
             return Ok([]);
         }
+        if (nextExecutionInMs !== undefined && nextExecutionInMs < 0) {
+            return Err(new Error(`Invalid nextExecutionInMs: ${nextExecutionInMs}. Must be a positive integer.`));
+        }
         const updated = await db(SCHEDULES_TABLE)
             .update({
                 updated_at: db.fn.now(),
                 last_scheduled_task_state: taskState,
-                next_execution_at: db.raw('starts_at + CEILING(EXTRACT(EPOCH FROM (NOW() - starts_at)) / EXTRACT(EPOCH FROM frequency)) * frequency')
+                next_execution_at:
+                    nextExecutionInMs !== undefined
+                        ? db.raw(`NOW() + ? * INTERVAL '1 millisecond'`, [nextExecutionInMs])
+                        : db.raw('starts_at + CEILING(EXTRACT(EPOCH FROM (NOW() - starts_at)) / EXTRACT(EPOCH FROM frequency)) * frequency')
             })
             .whereIn('last_scheduled_task_id', taskIds)
             .returning('*');
         return Ok(updated.map(DbSchedule.from));
     } catch (err) {
-        return Err(new Error(`Error updating last scheduled tasks ${taskIds.join(', ')}: ${stringifyError(err)}`));
+        return Err(new Error(`Error scheduling next execution for tasks ${taskIds.join(', ')}: ${stringifyError(err)}`));
     }
 }
 

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -161,6 +161,33 @@ describe('Scheduler', () => {
         expect(scheduleAfter?.lastScheduledTaskState).toBe('CANCELLED');
         expect(scheduleAfter?.nextExecutionAt).toEqual(new Date((scheduleAfter?.startsAt.getTime() || 0) + (scheduleAfter?.frequencyMs || 0)));
     });
+    it('should override next execution when succeed is called with nextExecutionInMs', async () => {
+        const schedule = await recurring({ scheduler });
+        const task = await immediate(scheduler, { schedule });
+        (await scheduler.dequeue({ groupKeyPattern: task.groupKey, limit: 1 })).unwrap();
+        const nextExecutionInMs = 9_999_999;
+        (await scheduler.succeed({ taskId: task.id, output: {}, nextExecutionInMs })).unwrap();
+        const [scheduleAfter] = (await scheduler.searchSchedules({ id: schedule.id, limit: 1 })).unwrap();
+        expect(scheduleAfter?.nextExecutionAt).toBeWithinMs(new Date(Date.now() + nextExecutionInMs), 3_000);
+    });
+    it('should override next execution when fail is called with nextExecutionInMs', async () => {
+        const schedule = await recurring({ scheduler });
+        const task = await immediate(scheduler, { schedule });
+        (await scheduler.dequeue({ groupKeyPattern: task.groupKey, limit: 1 })).unwrap();
+        const nextExecutionInMs = 9_999_999;
+        (await scheduler.fail({ taskId: task.id, error: { message: 'failure' }, nextExecutionInMs })).unwrap();
+        const [scheduleAfter] = (await scheduler.searchSchedules({ id: schedule.id, limit: 1 })).unwrap();
+        expect(scheduleAfter?.nextExecutionAt).toBeWithinMs(new Date(Date.now() + nextExecutionInMs), 3_000);
+    });
+    it('should override next execution when cancel is called with nextExecutionInMs', async () => {
+        const schedule = await recurring({ scheduler });
+        const task = await immediate(scheduler, { schedule });
+        (await scheduler.dequeue({ groupKeyPattern: task.groupKey, limit: 1 })).unwrap();
+        const nextExecutionInMs = 9_999_999;
+        (await scheduler.cancel({ taskId: task.id, reason: 'cancelled', nextExecutionInMs })).unwrap();
+        const [scheduleAfter] = (await scheduler.searchSchedules({ id: schedule.id, limit: 1 })).unwrap();
+        expect(scheduleAfter?.nextExecutionAt).toBeWithinMs(new Date(Date.now() + nextExecutionInMs), 3_000);
+    });
     it('should not run an immediate task for a schedule if another task is already running', async () => {
         const schedule = await recurring({ scheduler });
         await immediate(scheduler, { schedule }); // first task: OK

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -270,12 +270,24 @@ export class Scheduler {
      * @example
      * const succeed = await scheduler.succeed({ taskId: '00000000-0000-0000-0000-000000000000', output: {foo: 'bar'} });
      */
-    public async succeed({ taskId, output }: { taskId: string; output: JsonValue }): Promise<Result<Task>> {
+    public async succeed({
+        taskId,
+        output,
+        nextExecutionInMs
+    }: {
+        taskId: string;
+        output: JsonValue;
+        nextExecutionInMs?: number | undefined;
+    }): Promise<Result<Task>> {
         const newState: TaskState = 'SUCCEEDED';
         const succeeded: Result<Task> = await this.db.transaction(async (trx) => {
             const res = await tasks.transitionState(trx, { taskId, newState, output });
             if (res.isOk()) {
-                const scheduleRes = await schedules.updateLastScheduledTaskState(trx, { taskIds: [taskId], taskState: newState });
+                const scheduleRes = await schedules.scheduleNextExecution(trx, {
+                    taskIds: [taskId],
+                    taskState: newState,
+                    nextExecutionInMs
+                });
                 if (scheduleRes.isErr()) {
                     return Err(`Error updating last scheduled task state for task '${taskId}': ${stringifyError(scheduleRes.error)}`);
                 }
@@ -297,7 +309,15 @@ export class Scheduler {
      * @example
      * const failed = await scheduler.fail({ taskId: '00000000-0000-0000-0000-000000000000', error: {message: 'error'});
      */
-    public async fail({ taskId, error }: { taskId: string; error: JsonValue }): Promise<Result<Task>> {
+    public async fail({
+        taskId,
+        error,
+        nextExecutionInMs
+    }: {
+        taskId: string;
+        error: JsonValue;
+        nextExecutionInMs?: number | undefined;
+    }): Promise<Result<Task>> {
         const newState: TaskState = 'FAILED';
         return await this.db.transaction(async (trx) => {
             const task = await tasks.get(trx, taskId);
@@ -313,7 +333,11 @@ export class Scheduler {
 
             const failed = await tasks.transitionState(trx, { taskId, newState, output: error });
             if (failed.isOk()) {
-                const scheduleRes = await schedules.updateLastScheduledTaskState(trx, { taskIds: [taskId], taskState: newState });
+                const scheduleRes = await schedules.scheduleNextExecution(trx, {
+                    taskIds: [taskId],
+                    taskState: newState,
+                    nextExecutionInMs
+                });
                 if (scheduleRes.isErr()) {
                     return Err(`Error updating last scheduled task state for task '${taskId}': ${stringifyError(scheduleRes.error)}`);
                 }
@@ -352,7 +376,15 @@ export class Scheduler {
      * @example
      * const cancelled = await scheduler.cancel({ taskId: '00000000-0000-0000-0000-000000000000' });
      */
-    public async cancel({ taskId, reason }: { taskId: string; reason: JsonValue }): Promise<Result<Task>> {
+    public async cancel({
+        taskId,
+        reason,
+        nextExecutionInMs
+    }: {
+        taskId: string;
+        reason: JsonValue;
+        nextExecutionInMs?: number | undefined;
+    }): Promise<Result<Task>> {
         const newState: TaskState = 'CANCELLED';
         const cancelled: Result<Task> = await this.db.transaction(async (trx) => {
             const res = await tasks.transitionState(this.db, {
@@ -361,7 +393,11 @@ export class Scheduler {
                 output: { reason }
             });
             if (res.isOk()) {
-                const scheduleRes = await schedules.updateLastScheduledTaskState(trx, { taskIds: [taskId], taskState: newState });
+                const scheduleRes = await schedules.scheduleNextExecution(trx, {
+                    taskIds: [taskId],
+                    taskState: newState,
+                    nextExecutionInMs
+                });
                 if (scheduleRes.isErr()) {
                     return Err(`Error updating last scheduled task state for task '${taskId}': ${stringifyError(scheduleRes.error)}`);
                 }
@@ -417,7 +453,7 @@ export class Scheduler {
                     if (t.isErr()) {
                         return Err(`Error cancelling task '${task.id}': ${stringifyError(t.error)}`);
                     }
-                    const scheduleRes = await schedules.updateLastScheduledTaskState(trx, { taskIds: [task.id], taskState: newState });
+                    const scheduleRes = await schedules.scheduleNextExecution(trx, { taskIds: [task.id], taskState: newState });
                     if (scheduleRes.isErr()) {
                         return Err(`Error updating last scheduled task state for task '${task.id}': ${stringifyError(scheduleRes.error)}`);
                     }


### PR DESCRIPTION
Currently the orchestrator set the next execution date based on the schedule frequency when a task complete.
This change allows to pass a interval in Ms to force the next execution.

It is not used yet. It will be used so syncs that runs on AWS lambda and have been interrupted could run again asap.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Add `nextExecutionInMs` override for task completion scheduling**

This PR introduces an optional `nextExecutionInMs` parameter to override the next scheduled execution time when completing tasks in the orchestrator and scheduler. The parameter is threaded through the tasks PUT API, `OrchestratorClient` methods, scheduler task transitions, and schedule update logic to allow rescheduling based on a supplied millisecond offset rather than the schedule frequency.

It also renames the schedule update helper to `scheduleNextExecution` with validation, updates job execution paths to use shared task completion helpers, and adds integration tests covering override behavior for succeed/fail/cancel scenarios and schedule model updates.

<details>
<summary><strong>Key Changes</strong></summary>

• Added optional `nextExecutionInMs` to `PUT /v1/tasks/:taskId` request body and validation in `packages/orchestrator/lib/routes/v1/tasks/putTaskId.ts`
• Propagated `nextExecutionInMs` through `orchestratorClient.succeed()`, `orchestratorClient.failed()`, and `orchestratorClient.cancel()` in `packages/orchestrator/lib/clients/client.ts` and through task completion helpers in `packages/jobs/lib/execution/operations/state.ts`
• Replaced `updateLastScheduledTaskState` with `scheduleNextExecution` in `packages/scheduler/lib/models/schedules.ts` to support override scheduling and validation
• Extended scheduler methods `succeed()`, `fail()`, and `cancel()` to accept `nextExecutionInMs` and call `scheduleNextExecution` in `packages/scheduler/lib/scheduler.ts`
• Added integration tests for override scheduling in `packages/scheduler/lib/models/schedules.integration.test.ts` and `packages/scheduler/lib/scheduler.integration.test.ts`

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Clients passing large `nextExecutionInMs` values may schedule far-future executions without additional constraints beyond nonnegative validation.
• Use of `NOW()` for overrides depends on database time; ensure expected behavior if time skew is a concern.

</details>

---
*This summary was automatically generated by @propel-code-bot*