### PR TITLE
feat(migrations): Increase `oauth_client_id` size limit

### DIFF
--- a/packages/database/lib/migrations/20260302120000_oauth_client_id_to_text.cjs
+++ b/packages/database/lib/migrations/20260302120000_oauth_client_id_to_text.cjs
@@ -1,0 +1,20 @@
+exports.config = { transaction: false };
+const tableName = '_nango_configs';
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.schema.alterTable(tableName, (table) => {
+        table.text('oauth_client_id').nullable().defaultTo(null).alter({ alterType: true });
+    });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.schema.alterTable(tableName, (table) => {
+        table.string('oauth_client_id', 255).nullable().defaultTo(null).alter({ alterType: true });
+    });
+};

--- a/packages/database/lib/migrations/20260302120000_oauth_client_id_to_text.cjs
+++ b/packages/database/lib/migrations/20260302120000_oauth_client_id_to_text.cjs
@@ -6,7 +6,7 @@ const tableName = '_nango_configs';
  */
 exports.up = async function (knex) {
     await knex.schema.alterTable(tableName, (table) => {
-        table.text('oauth_client_id').nullable().defaultTo(null).alter({ alterType: true });
+        table.string('oauth_client_id', 512).nullable().defaultTo(null).alter({ alterType: true });
     });
 };
 


### PR DESCRIPTION
## Describe the problem and your solution

- Increase `oauth_client_id`  size limit to `512`.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

This adds a database migration that expands the `_nango_configs.oauth_client_id` column to a longer length and includes a reversible down migration back to 255 characters, configured to run without a transaction and using `alterType` for the schema change.

<details>
<summary><strong>Possible Issues</strong></summary>

• Down migration may truncate or fail if existing `oauth_client_id` values exceed 255 characters.

</details>

---
*This summary was automatically generated by @propel-code-bot*