### PR TITLE
feat(docker): add multi-arch builds for amd64 and arm64

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -77,15 +77,15 @@ jobs:
               if: needs.should-run.outputs.should_skip != 'true'
               uses: crazy-max/ghaction-github-runtime@v2
 
-            - name: Build image
-              if: needs.should-run.outputs.should_skip != 'true'
+            - name: Build image (PR only)
+              if: needs.should-run.outputs.should_skip != 'true' && env.CAN_PUSH != 'true'
               run: |
                   ./scripts/build_docker.sh build ${{ env.SHA }}
 
-            - name: Push image
+            - name: Build and push image
               if: needs.should-run.outputs.should_skip != 'true' && env.CAN_PUSH == 'true'
               run: |
-                  docker push nangohq/nango:${{ env.SHA }}
+                  ./scripts/build_docker.sh push ${{ env.SHA }}
 
             - name: (self-hosted) Build and push
               if: needs.should-run.outputs.should_skip != 'true' && github.event_name != 'pull_request'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,6 @@ services:
         # https://hub.docker.com/r/nangohq/nango-server/tags
         image: nangohq/nango-server:hosted
         container_name: nango-server
-        platform: linux/amd64
         environment:
             - NANGO_ENCRYPTION_KEY
             - NANGO_DB_USER
@@ -49,8 +48,8 @@ services:
             - './packages/providers/providers.yaml:/app/nango/packages/providers/providers.yaml'
         restart: always
         ports:
-            - '${SERVER_PORT:-3003}:${SERVER_PORT:-3003}'
-            - '${CONNECT_UI_PORT:-3009}:${CONNECT_UI_PORT:-3009}'
+            - '${SERVER_PORT:-3003}:3003'
+            - '${CONNECT_UI_PORT:-3009}:3009'
         depends_on:
             - nango-db
             # - nango-elasticsearch

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,8 +48,8 @@ services:
             - './packages/providers/providers.yaml:/app/nango/packages/providers/providers.yaml'
         restart: always
         ports:
-            - '${SERVER_PORT:-3003}:3003'
-            - '${CONNECT_UI_PORT:-3009}:3009'
+            - '${SERVER_PORT:-3003}:${SERVER_PORT:-3003}'
+            - '${CONNECT_UI_PORT:-3009}:${CONNECT_UI_PORT:-3009}'
         depends_on:
             - nango-db
             # - nango-elasticsearch

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -28,15 +28,17 @@ tags="-t nangohq/nango:${GIT_HASH}"
 
 if [ $ACTION == 'build' ]; then
   tags+=" --output=type=docker"
+  PLATFORM="linux/amd64"
 else
   tags+=" --output=type=registry"
+  PLATFORM="linux/amd64,linux/arm64"
 fi
 
 echo ""
 echo -e "Building nangohq/nango\n"
 
 docker buildx build \
-  --platform linux/amd64 \
+  --platform "$PLATFORM" \
   --build-arg git_hash="$GIT_HASH" \
   --cache-from type=gha \
   --cache-to type=gha,mode=max \

--- a/scripts/build_docker_self_hosted.sh
+++ b/scripts/build_docker_self_hosted.sh
@@ -23,8 +23,18 @@ echo -e "Building self-hosted nangohq/nango-server:hosted-$GIT_HASH"
 
 VERSION=$(node -p "require('../package.json').version")
 
+if [ "$PUSH" == "true" ]; then
+  PLATFORM="linux/amd64,linux/arm64"
+  OUTPUT="--output=type=registry"
+  echo "Building and pushing"
+else
+  PLATFORM="linux/amd64"
+  OUTPUT="--output=type=docker"
+  echo "Building only"
+fi
+
 docker buildx build \
-  --platform linux/amd64 \
+  --platform "$PLATFORM" \
   --build-arg BASE_IMAGE_HASH="$GIT_HASH" \
   --cache-from type=gha \
   --cache-to type=gha,mode=max \
@@ -32,14 +42,5 @@ docker buildx build \
   -t "nangohq/nango-server:hosted-$GIT_HASH" \
   -t "nangohq/nango-server:hosted-$VERSION" \
   --file ../Dockerfile.self_hosted \
-  --output=type=docker \
+  $OUTPUT \
   ../
-
-if [ $PUSH ]; then
-  echo "Pushing"
-  docker push nangohq/nango-server:hosted
-  docker push "nangohq/nango-server:hosted-$GIT_HASH"
-  docker push "nangohq/nango-server:hosted-$VERSION"
-else
-  echo "Not pushing"
-fi


### PR DESCRIPTION
## Summary
- Build and push multi-platform Docker images (`linux/amd64` + `linux/arm64`) so images work natively on ARM hosts (e.g. Apple Silicon Macs)
- Local builds stay single-platform due to `buildx type=docker` limitation; multi-arch only applies when pushing to registry
- Remove hardcoded `platform: linux/amd64` from `docker-compose.yaml`

Closes #5576 and closes NAN-4926

## Changes
- `scripts/build_docker.sh` — `push` action now builds `linux/amd64,linux/arm64` via `type=registry`
- `scripts/build_docker_self_hosted.sh` — restructured to build+push multi-arch in one step when `PUSH=true`
- `.github/workflows/build-image.yaml` — split build step so authenticated builds use `push` (multi-arch)
- `docker-compose.yaml` — removed `platform: linux/amd64` from nango-server

## Test plan
- [x] Local `build` action succeeds (amd64, `type=docker`)
- [x] Self-hosted local build succeeds
- [ ] CI builds both platforms and pushes multi-arch manifest to Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Summary by @propel-code-bot -->

---

This PR updates Docker build scripts and CI to produce multi-architecture images for `linux/amd64` and `linux/arm64` when pushing to a registry, while keeping local builds single-arch due to `buildx` output constraints. It also removes the hardcoded platform override from `docker-compose.yaml` so the hosted image can run natively on ARM hosts.

<details>
<summary><strong>Possible Issues</strong></summary>

• If `PUSH` is not passed as `true`, `scripts/build_docker_self_hosted.sh` will default to amd64-only builds, which may surprise callers expecting multi-arch.
• CI multi-arch builds require `buildx` and registry auth; failures will now block multi-arch push paths.

</details>

---
*This summary was automatically generated by @propel-code-bot*