### PR TITLE
fix(orchestrator): enforce group max concurrency when dequeuing with wildcard pattern

### DIFF
--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -126,7 +126,7 @@ describe('Task', () => {
         const dequeued = (await tasks.dequeue(db, { groupKeyPattern: task.groupKey, limit: 1 })).unwrap();
         expect(dequeued).toHaveLength(0);
     });
-    it('should be dequeued according to group max concurrency ', async () => {
+    it('should be dequeued according to group max concurrency', async () => {
         const groupKey = nanoid();
         const groupMaxConcurrency = 2;
         const t0 = await createTask(db, { groupKey, groupMaxConcurrency });
@@ -154,6 +154,39 @@ describe('Task', () => {
 
         // group should be able to dequeue again
         dequeued = (await tasks.dequeue(db, { groupKeyPattern: groupKey, limit: 10 })).unwrap();
+        expect(dequeued).toHaveLength(1);
+        expect(dequeued[0]).toMatchObject({ id: t2.id, state: 'STARTED' });
+    });
+    it('should be dequeued according to group pattern max concurrency', async () => {
+        const groupPrefix = nanoid();
+        const groupKey = `${groupPrefix}${nanoid()}`;
+        const groupMaxConcurrency = 2;
+        const t0 = await createTask(db, { groupKey, groupMaxConcurrency });
+        const t1 = await createTask(db, { groupKey, groupMaxConcurrency });
+
+        const groupKeyPattern = `${groupPrefix}*`;
+        let dequeued = (await tasks.dequeue(db, { groupKeyPattern, limit: 10 })).unwrap();
+        expect(dequeued).toHaveLength(2);
+        expect(dequeued[0]).toMatchObject({ id: t0.id, state: 'STARTED' });
+        expect(dequeued[1]).toMatchObject({ id: t1.id, state: 'STARTED' });
+
+        // group has reached its max concurrency, so no more tasks should be dequeued
+        const t2 = await createTask(db, { groupKey, groupMaxConcurrency });
+        dequeued = (await tasks.dequeue(db, { groupKeyPattern, limit: 10 })).unwrap();
+        expect(dequeued).toHaveLength(0);
+
+        // dequeuing tasks with different group key should not be affected
+        const t3 = await createTask(db, { groupKey: nanoid(), groupMaxConcurrency });
+        dequeued = (await tasks.dequeue(db, { groupKeyPattern: t3.groupKey, limit: 10 })).unwrap();
+        expect(dequeued).toHaveLength(1);
+        expect(dequeued[0]).toMatchObject({ id: t3.id, state: 'STARTED' });
+
+        // tasks now completes
+        await succeedTask(db, t0.id);
+        await succeedTask(db, t1.id);
+
+        // group should be able to dequeue again
+        dequeued = (await tasks.dequeue(db, { groupKeyPattern, limit: 10 })).unwrap();
         expect(dequeued).toHaveLength(1);
         expect(dequeued[0]).toMatchObject({ id: t2.id, state: 'STARTED' });
     });

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -261,6 +261,7 @@ export async function transitionState(
 
 export async function dequeue(db: knex.Knex, { groupKeyPattern, limit }: { groupKeyPattern: string; limit: number }): Promise<Result<Task[]>> {
     try {
+        const groupKeyLikePattern = groupKeyPattern.replace(/\*/g, '%');
         const tasks = await db.transaction(async (trx) => {
             // Acquire a lock to prevent concurrent dequeueing of the same group
             // in order to ensure max concurrency is respected
@@ -274,7 +275,7 @@ export async function dequeue(db: knex.Knex, { groupKeyPattern, limit }: { group
                         qb.select('id', 'group_key', 'created_at', 'group_max_concurrency')
                             .from(TASKS_TABLE)
                             .where('state', 'CREATED')
-                            .whereLike('group_key', groupKeyPattern.replace(/\*/g, '%'))
+                            .whereLike('group_key', groupKeyLikePattern)
                             .where('starts_after', '<=', db.fn.now())
                             .forUpdate()
                             .skipLocked();
@@ -284,7 +285,7 @@ export async function dequeue(db: knex.Knex, { groupKeyPattern, limit }: { group
                         qb.select(db.raw('count(id) as running_count'), 'group_key')
                             .from(TASKS_TABLE)
                             .where('state', 'STARTED')
-                            .whereLike('group_key', groupKeyPattern)
+                            .whereLike('group_key', groupKeyLikePattern)
                             .groupBy('group_key');
                     })
                     // 3. rank the candidate tasks by created_at for each group

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -123,9 +123,9 @@ export const ENVS = z.object({
                 maxConcurrency: 50
             }
         ]),
-    SYNC_ENVIRONMENT_MAX_CONCURRENCY: z.coerce.number().optional().default(100),
-    ACTION_ENVIRONMENT_MAX_CONCURRENCY: z.coerce.number().optional().default(100),
-    WEBHOOK_ENVIRONMENT_MAX_CONCURRENCY: z.coerce.number().optional().default(50),
+    SYNC_ENVIRONMENT_MAX_CONCURRENCY: z.coerce.number().optional().default(200),
+    ACTION_ENVIRONMENT_MAX_CONCURRENCY: z.coerce.number().optional().default(200),
+    WEBHOOK_ENVIRONMENT_MAX_CONCURRENCY: z.coerce.number().optional().default(200),
     ON_EVENT_ENVIRONMENT_MAX_CONCURRENCY: z.coerce.number().optional().default(50),
 
     // Runner


### PR DESCRIPTION
The running count subquery in the dequeue query used the raw groupKeyPattern (with `*`) instead of the SQL LIKE pattern (with `%`), causing it to never match any rows. 
Running count was then always 0 and max concurrency was never enforced when dequeueing with a wildcard group key pattern.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

This update also ensures wildcard patterns are consistently converted from `*` to SQL `%` across all `LIKE` clauses in `dequeue`, adds integration validation for wildcard group concurrency, and adjusts default environment concurrency limits for sync, action, and webhook workloads.

<details>
<summary><strong>Possible Issues</strong></summary>

• `groupKeyPattern` characters that are SQL wildcards (e.g., `_` or `%`) are not escaped, which could expand matching beyond intended `*` behavior.

</details>

---
*This summary was automatically generated by @propel-code-bot*