### PR TITLE
feat(fleet): add support for runner replicas

### DIFF
--- a/packages/fleet/lib/db/migrations/20260305000000_add_replicas.ts
+++ b/packages/fleet/lib/db/migrations/20260305000000_add_replicas.ts
@@ -3,12 +3,8 @@ import { NODES_TABLE } from '../../models/nodes.js';
 import { NODE_CONFIG_OVERRIDES_TABLE } from '../../models/node_config_overrides.js';
 
 export async function up(knex: Knex): Promise<void> {
-    await knex.schema.alterTable(NODES_TABLE, (table) => {
-        table.integer('replicas').notNullable().defaultTo(1);
-    });
-    await knex.schema.alterTable(NODE_CONFIG_OVERRIDES_TABLE, (table) => {
-        table.integer('replicas').nullable().defaultTo(null);
-    });
+    await knex.raw(`ALTER TABLE ${NODES_TABLE} ADD COLUMN IF NOT EXISTS replicas INTEGER NOT NULL DEFAULT 1`);
+    await knex.raw(`ALTER TABLE ${NODE_CONFIG_OVERRIDES_TABLE} ADD COLUMN IF NOT EXISTS replicas INTEGER DEFAULT NULL`);
 }
 
 export async function down(_knex: Knex): Promise<void> {}

--- a/packages/fleet/lib/db/migrations/20260305000000_add_replicas.ts
+++ b/packages/fleet/lib/db/migrations/20260305000000_add_replicas.ts
@@ -1,0 +1,14 @@
+import type { Knex } from 'knex';
+import { NODES_TABLE } from '../../models/nodes.js';
+import { NODE_CONFIG_OVERRIDES_TABLE } from '../../models/node_config_overrides.js';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(NODES_TABLE, (table) => {
+        table.integer('replicas').notNullable().defaultTo(1);
+    });
+    await knex.schema.alterTable(NODE_CONFIG_OVERRIDES_TABLE, (table) => {
+        table.integer('replicas').nullable().defaultTo(null);
+    });
+}
+
+export async function down(_knex: Knex): Promise<void> {}

--- a/packages/fleet/lib/fleet.integration.test.ts
+++ b/packages/fleet/lib/fleet.integration.test.ts
@@ -49,7 +49,8 @@ describe('fleet', () => {
                 isProfilingEnabled: false,
                 idleMaxDurationMs: 1_800_000,
                 executionTimeoutSecs: -1,
-                provisionedConcurrency: -1
+                provisionedConcurrency: -1,
+                replicas: 2
             };
             await nodeConfigOverrides.upsert(dbClient.db, props);
             const image = generateImage();
@@ -67,6 +68,7 @@ describe('fleet', () => {
                 idleMaxDurationMs: props.idleMaxDurationMs,
                 executionTimeoutSecs: props.executionTimeoutSecs,
                 provisionedConcurrency: props.provisionedConcurrency,
+                replicas: props.replicas,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });
@@ -131,7 +133,8 @@ describe('fleet', () => {
                 isProfilingEnabled: false,
                 idleMaxDurationMs: 1_800_000,
                 executionTimeoutSecs: -1,
-                provisionedConcurrency: -1
+                provisionedConcurrency: -1,
+                replicas: null
             };
             const nodeConfigOverride = (await fleet.overrideNodeConfig(props)).unwrap();
             expect(nodeConfigOverride).toStrictEqual({
@@ -146,6 +149,7 @@ describe('fleet', () => {
                 idleMaxDurationMs: props.idleMaxDurationMs,
                 executionTimeoutSecs: props.executionTimeoutSecs,
                 provisionedConcurrency: props.provisionedConcurrency,
+                replicas: props.replicas,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });
@@ -161,7 +165,8 @@ describe('fleet', () => {
                 isProfilingEnabled: true,
                 idleMaxDurationMs: 1_800_000,
                 executionTimeoutSecs: -1,
-                provisionedConcurrency: -1
+                provisionedConcurrency: -1,
+                replicas: null
             };
             await fleet.overrideNodeConfig(props);
             const updatedProps = {
@@ -189,6 +194,7 @@ describe('fleet', () => {
                 idleMaxDurationMs: updatedProps.idleMaxDurationMs,
                 executionTimeoutSecs: updatedProps.executionTimeoutSecs,
                 provisionedConcurrency: updatedProps.provisionedConcurrency,
+                replicas: updatedProps.replicas,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });
@@ -204,7 +210,8 @@ describe('fleet', () => {
                 isProfilingEnabled: false,
                 idleMaxDurationMs: 1_800_000,
                 executionTimeoutSecs: -1,
-                provisionedConcurrency: -1
+                provisionedConcurrency: -1,
+                replicas: null
             };
             await fleet.overrideNodeConfig(props);
 
@@ -229,7 +236,8 @@ describe('fleet', () => {
                 isProfilingEnabled: false,
                 idleMaxDurationMs: 1_800_000,
                 executionTimeoutSecs: -1,
-                provisionedConcurrency: -1
+                provisionedConcurrency: -1,
+                replicas: null
             };
             await fleet.overrideNodeConfig(props);
 
@@ -243,7 +251,8 @@ describe('fleet', () => {
                 isProfilingEnabled: false,
                 idleMaxDurationMs: 1_800_000,
                 executionTimeoutSecs: -1,
-                provisionedConcurrency: -1
+                provisionedConcurrency: -1,
+                replicas: null
             };
             await fleet.overrideNodeConfig(defaultProps);
 
@@ -260,6 +269,7 @@ describe('fleet', () => {
                 idleMaxDurationMs: 1_800_000,
                 executionTimeoutSecs: -1,
                 provisionedConcurrency: -1,
+                replicas: null,
                 createdAt: expect.any(Date),
                 updatedAt: expect.any(Date)
             });

--- a/packages/fleet/lib/fleet.ts
+++ b/packages/fleet/lib/fleet.ts
@@ -220,7 +220,8 @@ export class Fleet {
                 defaultConfig.isProfilingEnabled === override.isProfilingEnabled &&
                 defaultConfig.idleMaxDurationMs === override.idleMaxDurationMs &&
                 defaultConfig.executionTimeoutSecs === override.executionTimeoutSecs &&
-                defaultConfig.provisionedConcurrency === override.provisionedConcurrency;
+                defaultConfig.provisionedConcurrency === override.provisionedConcurrency &&
+                defaultConfig.replicas === override.replicas;
 
             if (isDefault) {
                 return nodeConfigOverrides.remove(trx, override.routingId);

--- a/packages/fleet/lib/models/helpers.test.ts
+++ b/packages/fleet/lib/models/helpers.test.ts
@@ -60,7 +60,8 @@ async function createNode(db: knex.Knex, { routingId, deploymentId, fleetId }: {
         isProfilingEnabled: false,
         idleMaxDurationMs: 1_800_000,
         executionTimeoutSecs: -1,
-        provisionedConcurrency: -1
+        provisionedConcurrency: -1,
+        replicas: 1
     });
     return node.unwrap();
 }

--- a/packages/fleet/lib/models/node_config_overrides.integration.test.ts
+++ b/packages/fleet/lib/models/node_config_overrides.integration.test.ts
@@ -24,7 +24,8 @@ describe('NodeConfgOverrides', () => {
         isProfilingEnabled: false,
         idleMaxDurationMs: 1_800_000,
         executionTimeoutSecs: -1,
-        provisionedConcurrency: -1
+        provisionedConcurrency: -1,
+        replicas: 3
     };
 
     it('should be successfully created', async () => {
@@ -41,6 +42,7 @@ describe('NodeConfgOverrides', () => {
             idleMaxDurationMs: props.idleMaxDurationMs,
             executionTimeoutSecs: props.executionTimeoutSecs,
             provisionedConcurrency: props.provisionedConcurrency,
+            replicas: props.replicas,
             createdAt: expect.any(Date),
             updatedAt: expect.any(Date)
         });
@@ -58,7 +60,8 @@ describe('NodeConfgOverrides', () => {
                 isProfilingEnabled: null,
                 idleMaxDurationMs: null,
                 executionTimeoutSecs: null,
-                provisionedConcurrency: null
+                provisionedConcurrency: null,
+                replicas: null
             })
         ).unwrap();
         expect(nodeConfigOverride).toStrictEqual({
@@ -73,6 +76,7 @@ describe('NodeConfgOverrides', () => {
             idleMaxDurationMs: null,
             executionTimeoutSecs: null,
             provisionedConcurrency: null,
+            replicas: null,
             createdAt: expect.any(Date),
             updatedAt: expect.any(Date)
         });
@@ -90,7 +94,8 @@ describe('NodeConfgOverrides', () => {
             isProfilingEnabled: true,
             idleMaxDurationMs: 1_800_000,
             executionTimeoutSecs: -1,
-            provisionedConcurrency: -1
+            provisionedConcurrency: -1,
+            replicas: 5
         };
         const updatedNodeConfigOverride = (await node_config_overrides.upsert(dbClient.db, updatedProps)).unwrap();
         expect(updatedNodeConfigOverride).toStrictEqual({
@@ -104,6 +109,7 @@ describe('NodeConfgOverrides', () => {
             idleMaxDurationMs: updatedProps.idleMaxDurationMs,
             executionTimeoutSecs: updatedProps.executionTimeoutSecs,
             provisionedConcurrency: updatedProps.provisionedConcurrency,
+            replicas: updatedProps.replicas,
             updatedAt: expect.any(Date)
         });
     });

--- a/packages/fleet/lib/models/node_config_overrides.ts
+++ b/packages/fleet/lib/models/node_config_overrides.ts
@@ -21,6 +21,7 @@ interface DBNodeConfigOverride {
     readonly idle_max_duration_ms: number | null;
     readonly execution_timeout_secs: number | null;
     readonly provisioned_concurrency: number | null;
+    readonly replicas: number | null;
     readonly created_at: Date;
     readonly updated_at: Date;
 }
@@ -40,7 +41,8 @@ const DBNodeConfigOverride = {
             created_at: nodeConfigOverride.createdAt,
             updated_at: nodeConfigOverride.updatedAt,
             execution_timeout_secs: nodeConfigOverride.executionTimeoutSecs,
-            provisioned_concurrency: nodeConfigOverride.provisionedConcurrency
+            provisioned_concurrency: nodeConfigOverride.provisionedConcurrency,
+            replicas: nodeConfigOverride.replicas
         };
     },
     from: (dbNodeConfigOverride: DBNodeConfigOverride): NodeConfigOverride => {
@@ -56,6 +58,7 @@ const DBNodeConfigOverride = {
             idleMaxDurationMs: dbNodeConfigOverride.idle_max_duration_ms,
             executionTimeoutSecs: dbNodeConfigOverride.execution_timeout_secs,
             provisionedConcurrency: dbNodeConfigOverride.provisioned_concurrency,
+            replicas: dbNodeConfigOverride.replicas,
             createdAt: dbNodeConfigOverride.created_at,
             updatedAt: dbNodeConfigOverride.updated_at
         };
@@ -80,6 +83,7 @@ export async function upsert(
             idle_max_duration_ms: props.idleMaxDurationMs ?? null,
             execution_timeout_secs: props.executionTimeoutSecs ?? null,
             provisioned_concurrency: props.provisionedConcurrency ?? null,
+            replicas: props.replicas ?? null,
             created_at: now,
             updated_at: now
         };
@@ -92,6 +96,7 @@ export async function upsert(
             ...(props.isTracingEnabled !== undefined ? { is_tracing_enabled: props.isTracingEnabled } : {}),
             ...(props.isProfilingEnabled !== undefined ? { is_profiling_enabled: props.isProfilingEnabled } : {}),
             ...(props.idleMaxDurationMs !== undefined ? { idle_max_duration_ms: props.idleMaxDurationMs } : {}),
+            ...(props.replicas !== undefined ? { replicas: props.replicas } : {}),
             updated_at: now
         };
 

--- a/packages/fleet/lib/models/nodes.integration.test.ts
+++ b/packages/fleet/lib/models/nodes.integration.test.ts
@@ -40,7 +40,8 @@ describe('Nodes', () => {
                 isProfilingEnabled: false,
                 idleMaxDurationMs: 1_800_000,
                 executionTimeoutSecs: -1,
-                provisionedConcurrency: -1
+                provisionedConcurrency: -1,
+                replicas: 1
             })
         ).unwrap();
         expect(node).toStrictEqual({
@@ -59,6 +60,7 @@ describe('Nodes', () => {
             idleMaxDurationMs: 1_800_000,
             executionTimeoutSecs: -1,
             provisionedConcurrency: -1,
+            replicas: 1,
             error: null,
             createdAt: expect.any(Date),
             lastStateTransitionAt: expect.any(Date)

--- a/packages/fleet/lib/models/nodes.ts
+++ b/packages/fleet/lib/models/nodes.ts
@@ -57,6 +57,7 @@ interface DBNode {
     readonly idle_max_duration_ms: number | null;
     readonly execution_timeout_secs: number | null;
     readonly provisioned_concurrency: number | null;
+    readonly replicas: number;
     readonly error: string | null;
     readonly created_at: Date;
     readonly last_state_transition_at: Date;
@@ -80,6 +81,7 @@ const DBNode = {
             idle_max_duration_ms: node.idleMaxDurationMs,
             execution_timeout_secs: node.executionTimeoutSecs,
             provisioned_concurrency: node.provisionedConcurrency,
+            replicas: node.replicas,
             error: node.error,
             created_at: node.createdAt,
             last_state_transition_at: node.lastStateTransitionAt
@@ -102,6 +104,7 @@ const DBNode = {
             idleMaxDurationMs: dbNode.idle_max_duration_ms,
             executionTimeoutSecs: dbNode.execution_timeout_secs,
             provisionedConcurrency: dbNode.provisioned_concurrency,
+            replicas: dbNode.replicas,
             error: dbNode.error,
             createdAt: dbNode.created_at,
             lastStateTransitionAt: dbNode.last_state_transition_at
@@ -128,6 +131,7 @@ export async function create(
         idle_max_duration_ms: nodeProps.idleMaxDurationMs,
         execution_timeout_secs: nodeProps.executionTimeoutSecs,
         provisioned_concurrency: nodeProps.provisionedConcurrency,
+        replicas: nodeProps.replicas,
         error: null,
         created_at: now,
         last_state_transition_at: now

--- a/packages/fleet/lib/node-providers/noop.ts
+++ b/packages/fleet/lib/node-providers/noop.ts
@@ -11,7 +11,8 @@ export const noopNodeProvider: NodeProvider = {
         isProfilingEnabled: false,
         idleMaxDurationMs: 1_800_000,
         executionTimeoutSecs: -1,
-        provisionedConcurrency: -1
+        provisionedConcurrency: -1,
+        replicas: 1
     },
     start: () => {
         return Promise.resolve(Ok(undefined));

--- a/packages/fleet/lib/supervisor/supervisor.integration.test.ts
+++ b/packages/fleet/lib/supervisor/supervisor.integration.test.ts
@@ -23,7 +23,8 @@ const mockNodeProvider = {
         isProfilingEnabled: false,
         idleMaxDurationMs: 1_800_000,
         executionTimeoutSecs: -1,
-        provisionedConcurrency: -1
+        provisionedConcurrency: -1,
+        replicas: 1
     },
     start: vi.fn().mockResolvedValue(Ok(undefined)),
     terminate: vi.fn().mockResolvedValue(Ok(undefined)),
@@ -151,7 +152,30 @@ describe('Supervisor', () => {
             error: null,
             idleMaxDurationMs: 1_800_000,
             executionTimeoutSecs: -1,
-            provisionedConcurrency: -1
+            provisionedConcurrency: -1,
+            replicas: 1
+        });
+    });
+
+    it('should mark nodes with replicas override as OUTDATED', async () => {
+        const node = await createNodeWithAttributes(dbClient.db, { state: 'RUNNING', deploymentId: activeDeployment.id, fleetId: 'fleet_id' });
+        await nodeConfigOverrides.upsert(dbClient.db, {
+            routingId: node.routingId,
+            replicas: 3
+        });
+
+        await supervisor.tick();
+
+        const nodeAfter = (await nodes.get(dbClient.db, node.id)).unwrap();
+        expect(nodeAfter.state).toBe('OUTDATED');
+
+        await supervisor.tick();
+
+        const newNode = (await nodes.search(dbClient.db, { states: ['PENDING'] })).unwrap().get(node.routingId)?.PENDING[0];
+        expect(newNode).toMatchObject({
+            state: 'PENDING',
+            routingId: node.routingId,
+            replicas: 3
         });
     });
 

--- a/packages/fleet/lib/supervisor/supervisor.ts
+++ b/packages/fleet/lib/supervisor/supervisor.ts
@@ -209,6 +209,9 @@ export class Supervisor {
                     if (configOverride.idleMaxDurationMs && configOverride.idleMaxDurationMs !== node.idleMaxDurationMs) {
                         return true;
                     }
+                    if (configOverride.replicas !== null && configOverride.replicas !== node.replicas) {
+                        return true;
+                    }
                     return false;
                 };
                 plan.push(
@@ -358,7 +361,8 @@ export class Supervisor {
                 isProfilingEnabled: nodeConfigOverrideValue.isProfilingEnabled || newNodeConfig.isProfilingEnabled,
                 idleMaxDurationMs: nodeConfigOverrideValue.idleMaxDurationMs || newNodeConfig.idleMaxDurationMs,
                 executionTimeoutSecs: nodeConfigOverrideValue.executionTimeoutSecs || newNodeConfig.executionTimeoutSecs,
-                provisionedConcurrency: nodeConfigOverrideValue.provisionedConcurrency || newNodeConfig.provisionedConcurrency
+                provisionedConcurrency: nodeConfigOverrideValue.provisionedConcurrency || newNodeConfig.provisionedConcurrency,
+                replicas: nodeConfigOverrideValue.replicas || newNodeConfig.replicas
             };
         }
 
@@ -374,7 +378,8 @@ export class Supervisor {
             isProfilingEnabled: newNodeConfig.isProfilingEnabled,
             idleMaxDurationMs: newNodeConfig.idleMaxDurationMs,
             executionTimeoutSecs: newNodeConfig.executionTimeoutSecs,
-            provisionedConcurrency: newNodeConfig.provisionedConcurrency
+            provisionedConcurrency: newNodeConfig.provisionedConcurrency,
+            replicas: newNodeConfig.replicas
         });
     }
 

--- a/packages/fleet/lib/types.ts
+++ b/packages/fleet/lib/types.ts
@@ -17,8 +17,9 @@ export interface Node {
     readonly isTracingEnabled: NodeConfig['isTracingEnabled'];
     readonly isProfilingEnabled: NodeConfig['isProfilingEnabled'];
     readonly idleMaxDurationMs: NodeConfig['idleMaxDurationMs'] | null;
-    readonly executionTimeoutSecs: number | null;
-    readonly provisionedConcurrency: number | null;
+    readonly executionTimeoutSecs: NodeConfig['executionTimeoutSecs'] | null;
+    readonly provisionedConcurrency: NodeConfig['provisionedConcurrency'] | null;
+    readonly replicas: NodeConfig['replicas'];
     readonly error: string | null;
     readonly createdAt: Date;
     readonly lastStateTransitionAt: Date;
@@ -34,8 +35,9 @@ export interface NodeConfigOverride {
     readonly isTracingEnabled: NodeConfig['isTracingEnabled'] | null;
     readonly isProfilingEnabled: NodeConfig['isProfilingEnabled'] | null;
     readonly idleMaxDurationMs: NodeConfig['idleMaxDurationMs'] | null;
-    readonly executionTimeoutSecs: number | null;
-    readonly provisionedConcurrency: number | null;
+    readonly executionTimeoutSecs: NodeConfig['executionTimeoutSecs'] | null;
+    readonly provisionedConcurrency: NodeConfig['provisionedConcurrency'] | null;
+    readonly replicas: NodeConfig['replicas'] | null;
     readonly createdAt: Date;
     readonly updatedAt: Date;
 }

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -184,7 +184,7 @@ class Kubernetes {
                 labels: { app: name }
             },
             spec: {
-                replicas: 1,
+                replicas: node.replicas,
                 selector: { matchLabels: { app: name } },
                 template: {
                     metadata: {
@@ -462,7 +462,8 @@ export const kubernetesNodeProvider: NodeProvider = {
         isProfilingEnabled: false,
         idleMaxDurationMs: 1_800_000,
         executionTimeoutSecs: -1,
-        provisionedConcurrency: -1
+        provisionedConcurrency: -1,
+        replicas: 1
     },
     start: async (node: Node) => {
         const kubernetes = Kubernetes.getInstance();

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -424,7 +424,8 @@ class Kubernetes {
             { name: 'DD_TRACE_ENABLED', value: String(node.isTracingEnabled || node.isProfilingEnabled) },
             { name: 'JOBS_SERVICE_URL', value: getJobsUrl() },
             { name: 'PROVIDERS_URL', value: getProvidersUrl() },
-            { name: 'PROVIDERS_RELOAD_INTERVAL', value: envs.PROVIDERS_RELOAD_INTERVAL.toString() }
+            { name: 'PROVIDERS_RELOAD_INTERVAL', value: envs.PROVIDERS_RELOAD_INTERVAL.toString() },
+            ...(node.replicas > 1 ? [{ name: 'RUNNER_CONFLICT_FUNCTION_MODE', value: 'REDIS' }] : [])
         ];
     }
 

--- a/packages/jobs/lib/runner/lambda.ts
+++ b/packages/jobs/lib/runner/lambda.ts
@@ -224,7 +224,8 @@ export const lambdaNodeProvider: NodeProvider = {
         isProfilingEnabled: false,
         idleMaxDurationMs: 0,
         executionTimeoutSecs: 900,
-        provisionedConcurrency: 1
+        provisionedConcurrency: 1,
+        replicas: 1
     },
     start: async (node: Node) => {
         return Lambda.getInstance().createFunction(node);

--- a/packages/jobs/lib/runner/local.ts
+++ b/packages/jobs/lib/runner/local.ts
@@ -24,7 +24,8 @@ export const localNodeProvider: NodeProvider = {
         isProfilingEnabled: false,
         idleMaxDurationMs: 0, // No auto-shutdown for local runners
         executionTimeoutSecs: -1,
-        provisionedConcurrency: -1
+        provisionedConcurrency: -1,
+        replicas: 1
     },
     start: async (node) => {
         try {

--- a/packages/jobs/lib/runner/render.ts
+++ b/packages/jobs/lib/runner/render.ts
@@ -32,7 +32,8 @@ export const renderNodeProvider: NodeProvider = {
         isProfilingEnabled: false,
         idleMaxDurationMs: 1_800_000,
         executionTimeoutSecs: -1,
-        provisionedConcurrency: -1
+        provisionedConcurrency: -1,
+        replicas: 1
     },
     waitUntilHealthy: async (opts: { nodeId: number; url: string; timeoutMs: number }) => {
         return waitUntilHealthy({ url: `${opts.url}/health`, timeoutMs: opts.timeoutMs });

--- a/packages/types/lib/fleet/index.ts
+++ b/packages/types/lib/fleet/index.ts
@@ -19,4 +19,5 @@ export interface NodeConfig {
     readonly idleMaxDurationMs: number;
     readonly executionTimeoutSecs: number;
     readonly provisionedConcurrency: number;
+    readonly replicas: number;
 }


### PR DESCRIPTION
Allow runner instances to have more than one replicas

Warning: requires runner to be updated to use shared kvstore for conflict detection before we can make a runner instance have more than one replica

<!-- Summary by @propel-code-bot -->

---

This change also extends fleet configuration to support replica counts via shared types, database schemas, and model mappings, and updates providers and supervisor logic so replica overrides are treated as configuration differences and applied when creating or updating nodes.

<details>
<summary><strong>Key Changes</strong></summary>

• Added `replicas` columns via migration in `packages/fleet/lib/db/migrations/20260305000000_add_replicas.ts` for `nodes` and `node_config_overrides`
• Extended `NodeConfig`, `Node`, and `NodeConfigOverride` types with `replicas` in `packages/types/lib/fleet/index.ts` and `packages/fleet/lib/types.ts`
• Propagated `replicas` through model mappings and creation paths in `packages/fleet/lib/models/nodes.ts` and `packages/fleet/lib/models/node_config_overrides.ts`
• Updated supervisor logic in `packages/fleet/lib/supervisor/supervisor.ts` to outdate nodes on replica changes and apply replica overrides when creating nodes
• Adjusted runner providers to default `replicas: 1` and use replica counts in `packages/jobs/lib/runner/kubernetes.ts` plus conflict mode env var when `replicas > 1`

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Replica override application uses `||` fallback in `packages/fleet/lib/supervisor/supervisor.ts`, which could treat `0` as falsy if ever allowed for `replicas`

</details>

---
*This summary was automatically generated by @propel-code-bot*