### PR TITLE
fix(runner): distributed conflict tracking

### DIFF
--- a/packages/runner/lib/monitor.ts
+++ b/packages/runner/lib/monitor.ts
@@ -53,11 +53,12 @@ export class RunnerMonitor {
         }
     }
 
-    async untrack(nangoProps: NangoProps, taskId: string): Promise<void> {
-        this.tracked.delete(taskId);
-        if (this.conflictTracking.functionTypes.includes(nangoProps.scriptType)) {
+    async untrack(taskId: string): Promise<void> {
+        const nangoProps = this.tracked.get(taskId)?.nangoProps;
+        if (nangoProps && this.conflictTracking.functionTypes.includes(nangoProps.scriptType)) {
             await this.conflictTracking.tracker.delete(`function:${nangoProps.scriptType}:${nangoProps.syncId}`);
         }
+        this.tracked.delete(taskId);
     }
 
     resetIdleMaxDurationMs(): void {

--- a/packages/runner/lib/monitor.ts
+++ b/packages/runner/lib/monitor.ts
@@ -51,11 +51,12 @@ export class RunnerMonitor {
             try {
                 await this.conflictTracking.tracker.set(this.generateConflictKey(nangoProps), '1', {
                     canOverride: opts.refresh,
-                    ttlMs: envs.RUNNER_HEARTBEAT_INTERVAL_MS * envs.RUNNER_HEARTBEAT_INTERVAL_MULTIPLIER
+                    ttlMs: envs.RUNNER_HEARTBEAT_INTERVAL_MS * envs.RUNNER_SYNC_CONFLICT_HEARTBEAT_INTERVAL_MULTIPLIER
                 });
             } catch (err) {
+                logger.error('Failed to track sync for conflicts', { error: err });
                 if (err instanceof Error && err.message.includes('set_key_already_exists')) {
-                    throw new Error('conflicting_sync');
+                    throw new Error('Conflicting sync detected');
                 }
                 throw err;
             }
@@ -159,15 +160,6 @@ export class RunnerMonitor {
             }
             this.checkIdle(nextTimeout);
         }, timeoutMs);
-    }
-
-    async hasConflictingSync(newTask: NangoProps): Promise<boolean> {
-        if (newTask.scriptType == 'sync') {
-            const key = `function:${newTask.scriptType}:${newTask.syncId}`;
-            const exists = await this.conflictTracking.tracker.exists(key);
-            return exists;
-        }
-        return false;
     }
 }
 

--- a/packages/runner/lib/monitor.ts
+++ b/packages/runner/lib/monitor.ts
@@ -8,11 +8,13 @@ import { envs } from './env.js';
 import { idle } from './idle.js';
 import { logger } from './logger.js';
 
-import type { NangoProps } from '@nangohq/types';
+import type { KVStore } from '@nangohq/kvstore';
+import type { NangoProps, ScriptType } from '@nangohq/types';
 
 const regexRunnerUrl = /^http:\/\/(production|staging)-runner-account-(\d+|default)-\d+/;
 export class RunnerMonitor {
     private runnerId: number;
+    private conflictTracking: { tracker: KVStore; functionTypes: ScriptType[] };
     private tracked = new Map<string, { nangoProps: NangoProps }>();
     private persistClient: PersistClient | null = null;
     private idleMaxDurationMs = envs.IDLE_MAX_DURATION_MS;
@@ -22,8 +24,9 @@ export class RunnerMonitor {
     private memoryInterval: NodeJS.Timeout | null = null;
     private runnerAccountId: string | null = null;
 
-    constructor({ runnerId }: { runnerId: number }) {
+    constructor({ runnerId, conflictTracking }: { runnerId: number; conflictTracking: { tracker: KVStore; functionTypes: ScriptType[] } }) {
         this.runnerId = runnerId;
+        this.conflictTracking = conflictTracking;
         this.memoryInterval = this.checkMemoryUsage();
         this.idleInterval = this.checkIdle();
         process.on('SIGTERM', this.onExit.bind(this));
@@ -39,16 +42,22 @@ export class RunnerMonitor {
         }
     }
 
-    track(nangoProps: NangoProps, taskId: string): void {
+    async track(nangoProps: NangoProps, taskId: string): Promise<void> {
         this.lastIdleTrackingDate = Date.now();
         this.tracked.set(taskId, { nangoProps });
         if (!this.persistClient) {
             this.persistClient = new PersistClient({ secretKey: nangoProps.secretKey });
         }
+        if (this.conflictTracking.functionTypes.includes(nangoProps.scriptType)) {
+            await this.conflictTracking.tracker.set(`function:${nangoProps.scriptType}:${nangoProps.syncId}`, '1');
+        }
     }
 
-    untrack(taskId: string): void {
+    async untrack(nangoProps: NangoProps, taskId: string): Promise<void> {
         this.tracked.delete(taskId);
+        if (this.conflictTracking.functionTypes.includes(nangoProps.scriptType)) {
+            await this.conflictTracking.tracker.delete(`function:${nangoProps.scriptType}:${nangoProps.syncId}`);
+        }
     }
 
     resetIdleMaxDurationMs(): void {
@@ -129,17 +138,11 @@ export class RunnerMonitor {
         }, timeoutMs);
     }
 
-    hasConflictingSync(newTask: NangoProps): boolean {
-        if (newTask.scriptType !== 'sync') {
-            return false;
-        }
-
-        for (const task of this.tracked.values()) {
-            // Should cover sync and sync variant
-            // Webhooks have the same syncId so we allow them to run in parallel
-            if (task.nangoProps.syncId === newTask.syncId && task.nangoProps.scriptType === 'sync') {
-                return true;
-            }
+    async hasConflictingSync(newTask: NangoProps): Promise<boolean> {
+        if (this.conflictTracking.functionTypes.includes(newTask.scriptType)) {
+            const key = `function:${newTask.scriptType}:${newTask.syncId}`;
+            const exists = await this.conflictTracking.tracker.exists(key);
+            return exists;
         }
         return false;
     }

--- a/packages/runner/lib/monitor.ts
+++ b/packages/runner/lib/monitor.ts
@@ -46,7 +46,7 @@ export class RunnerMonitor {
         return `function:${nangoProps.environmentId}:${nangoProps.scriptType}:${nangoProps.syncId}`;
     }
 
-    async trackForConflicts(nangoProps: NangoProps, _taskId: string, opts = { refresh: false }): Promise<void> {
+    async trackForConflicts(nangoProps: NangoProps, opts = { refresh: false }): Promise<void> {
         if (nangoProps.scriptType == 'sync') {
             try {
                 await this.conflictTracking.tracker.set(this.generateConflictKey(nangoProps), '1', {
@@ -64,7 +64,7 @@ export class RunnerMonitor {
     }
 
     async track(nangoProps: NangoProps, taskId: string): Promise<void> {
-        await this.trackForConflicts(nangoProps, taskId);
+        await this.trackForConflicts(nangoProps);
         this.lastIdleTrackingDate = Date.now();
         this.tracked.set(taskId, { nangoProps });
         if (!this.persistClient) {

--- a/packages/runner/lib/monitor.ts
+++ b/packages/runner/lib/monitor.ts
@@ -9,12 +9,12 @@ import { idle } from './idle.js';
 import { logger } from './logger.js';
 
 import type { KVStore } from '@nangohq/kvstore';
-import type { NangoProps, ScriptType } from '@nangohq/types';
+import type { NangoProps } from '@nangohq/types';
 
 const regexRunnerUrl = /^http:\/\/(production|staging)-runner-account-(\d+|default)-\d+/;
 export class RunnerMonitor {
     private runnerId: number;
-    private conflictTracking: { tracker: KVStore; functionTypes: ScriptType[] };
+    private conflictTracking: { tracker: KVStore };
     private tracked = new Map<string, { nangoProps: NangoProps }>();
     private persistClient: PersistClient | null = null;
     private idleMaxDurationMs = envs.IDLE_MAX_DURATION_MS;
@@ -24,7 +24,7 @@ export class RunnerMonitor {
     private memoryInterval: NodeJS.Timeout | null = null;
     private runnerAccountId: string | null = null;
 
-    constructor({ runnerId, conflictTracking }: { runnerId: number; conflictTracking: { tracker: KVStore; functionTypes: ScriptType[] } }) {
+    constructor({ runnerId, conflictTracking }: { runnerId: number; conflictTracking: { tracker: KVStore } }) {
         this.runnerId = runnerId;
         this.conflictTracking = conflictTracking;
         this.memoryInterval = this.checkMemoryUsage();
@@ -43,19 +43,22 @@ export class RunnerMonitor {
     }
 
     async track(nangoProps: NangoProps, taskId: string): Promise<void> {
+        if (nangoProps.scriptType == 'sync') {
+            await this.conflictTracking.tracker.set(`function:${nangoProps.scriptType}:${nangoProps.syncId}`, '1', {
+                canOverride: false,
+                ttlMs: 1000 * 60 * 60 * 24 * 7 // 1 week
+            });
+        }
         this.lastIdleTrackingDate = Date.now();
         this.tracked.set(taskId, { nangoProps });
         if (!this.persistClient) {
             this.persistClient = new PersistClient({ secretKey: nangoProps.secretKey });
         }
-        if (this.conflictTracking.functionTypes.includes(nangoProps.scriptType)) {
-            await this.conflictTracking.tracker.set(`function:${nangoProps.scriptType}:${nangoProps.syncId}`, '1');
-        }
     }
 
     async untrack(taskId: string): Promise<void> {
         const nangoProps = this.tracked.get(taskId)?.nangoProps;
-        if (nangoProps && this.conflictTracking.functionTypes.includes(nangoProps.scriptType)) {
+        if (nangoProps && nangoProps.scriptType == 'sync') {
             await this.conflictTracking.tracker.delete(`function:${nangoProps.scriptType}:${nangoProps.syncId}`);
         }
         this.tracked.delete(taskId);
@@ -140,7 +143,7 @@ export class RunnerMonitor {
     }
 
     async hasConflictingSync(newTask: NangoProps): Promise<boolean> {
-        if (this.conflictTracking.functionTypes.includes(newTask.scriptType)) {
+        if (newTask.scriptType == 'sync') {
             const key = `function:${newTask.scriptType}:${newTask.syncId}`;
             const exists = await this.conflictTracking.tracker.exists(key);
             return exists;

--- a/packages/runner/lib/monitor.ts
+++ b/packages/runner/lib/monitor.ts
@@ -42,13 +42,28 @@ export class RunnerMonitor {
         }
     }
 
-    async track(nangoProps: NangoProps, taskId: string): Promise<void> {
+    generateConflictKey(nangoProps: NangoProps): string {
+        return `function:${nangoProps.environmentId}:${nangoProps.scriptType}:${nangoProps.syncId}`;
+    }
+
+    async trackForConflicts(nangoProps: NangoProps, _taskId: string, opts = { refresh: false }): Promise<void> {
         if (nangoProps.scriptType == 'sync') {
-            await this.conflictTracking.tracker.set(`function:${nangoProps.scriptType}:${nangoProps.syncId}`, '1', {
-                canOverride: false,
-                ttlMs: 1000 * 60 * 60 * 24 * 7 // 1 week
-            });
+            try {
+                await this.conflictTracking.tracker.set(this.generateConflictKey(nangoProps), '1', {
+                    canOverride: opts.refresh,
+                    ttlMs: envs.RUNNER_HEARTBEAT_INTERVAL_MS * envs.RUNNER_HEARTBEAT_INTERVAL_MULTIPLIER
+                });
+            } catch (err) {
+                if (err instanceof Error && err.message.includes('set_key_already_exists')) {
+                    throw new Error('conflicting_sync');
+                }
+                throw err;
+            }
         }
+    }
+
+    async track(nangoProps: NangoProps, taskId: string): Promise<void> {
+        await this.trackForConflicts(nangoProps, taskId);
         this.lastIdleTrackingDate = Date.now();
         this.tracked.set(taskId, { nangoProps });
         if (!this.persistClient) {
@@ -59,7 +74,11 @@ export class RunnerMonitor {
     async untrack(taskId: string): Promise<void> {
         const nangoProps = this.tracked.get(taskId)?.nangoProps;
         if (nangoProps && nangoProps.scriptType == 'sync') {
-            await this.conflictTracking.tracker.delete(`function:${nangoProps.scriptType}:${nangoProps.syncId}`);
+            try {
+                await this.conflictTracking.tracker.delete(this.generateConflictKey(nangoProps));
+            } catch (err) {
+                logger.error('Failed to untrack sync', { error: err });
+            }
         }
         this.tracked.delete(taskId);
     }

--- a/packages/runner/lib/monitor.unit.test.ts
+++ b/packages/runner/lib/monitor.unit.test.ts
@@ -91,33 +91,4 @@ describe('RunnerMonitor conflict tracking', () => {
             expect(await tracker.exists('function:sync:sync-untrack')).toBe(false);
         });
     });
-
-    describe('hasConflictingSync', () => {
-        it('returns true when same syncId is already tracked', async () => {
-            const nangoProps = createNangoProps({ scriptType: 'sync', syncId: 'conflict-sync' });
-            await monitor.track(nangoProps, 'task-a');
-
-            const newTask = createNangoProps({ scriptType: 'sync', syncId: 'conflict-sync' });
-            const hasConflict = await monitor.hasConflictingSync(newTask);
-            expect(hasConflict).toBe(true);
-        });
-
-        it('returns false when syncId differs', async () => {
-            const nangoProps = createNangoProps({ scriptType: 'sync', syncId: 'sync-one' });
-            await monitor.track(nangoProps, 'task-b');
-
-            const newTask = createNangoProps({ scriptType: 'sync', syncId: 'sync-two' });
-            const hasConflict = await monitor.hasConflictingSync(newTask);
-            expect(hasConflict).toBe(false);
-        });
-
-        it('returns false when scriptType is not sync', async () => {
-            const nangoProps = createNangoProps({ scriptType: 'webhook', syncId: 'webhook-1' });
-            await monitor.track(nangoProps, 'task-c');
-
-            const newTask = createNangoProps({ scriptType: 'webhook', syncId: 'webhook-1' });
-            const hasConflict = await monitor.hasConflictingSync(newTask);
-            expect(hasConflict).toBe(false);
-        });
-    });
 });

--- a/packages/runner/lib/monitor.unit.test.ts
+++ b/packages/runner/lib/monitor.unit.test.ts
@@ -6,19 +6,19 @@ import { RunnerMonitor } from './monitor.js';
 
 import type { DBSyncConfig, NangoProps, ScriptType } from '@nangohq/types';
 
-function createNangoProps(overrides: { scriptType: ScriptType; syncId?: string }): NangoProps {
+function createNangoProps(overrides: { scriptType: ScriptType; syncId: string; environmentId: number }): NangoProps {
     return {
         scriptType: overrides.scriptType,
         host: 'http://localhost:3003',
         connectionId: 'connection-id',
-        environmentId: 1,
+        environmentId: overrides.environmentId,
         environmentName: 'dev',
         providerConfigKey: 'provider-config-key',
         provider: 'provider',
         activityLogId: '1',
         secretKey: 'secret-key',
         nangoConnectionId: 1,
-        syncId: overrides.syncId ?? 'sync-id',
+        syncId: overrides.syncId,
         syncJobId: 1,
         lastSyncDate: new Date(),
         attributes: {},
@@ -62,10 +62,10 @@ describe('RunnerMonitor conflict tracking', () => {
 
     describe('track', () => {
         it('writes conflict key to KV store when scriptType is sync', async () => {
-            const nangoProps = createNangoProps({ scriptType: 'sync', syncId: 'sync-123' });
+            const nangoProps = createNangoProps({ scriptType: 'sync', syncId: 'sync-123', environmentId: 1 });
             await monitor.track(nangoProps, 'task-1');
 
-            const key = 'function:sync:sync-123';
+            const key = 'function:1:sync:sync-123';
             const exists = await tracker.exists(key);
             expect(exists).toBe(true);
 
@@ -74,21 +74,21 @@ describe('RunnerMonitor conflict tracking', () => {
         });
 
         it('does not write to KV store when scriptType is not sync', async () => {
-            const nangoProps = createNangoProps({ scriptType: 'webhook', syncId: 'webhook-789' });
+            const nangoProps = createNangoProps({ scriptType: 'webhook', syncId: 'webhook-789', environmentId: 1 });
             await monitor.track(nangoProps, 'task-3');
 
-            expect(await tracker.exists('function:webhook:webhook-789')).toBe(false);
+            expect(await tracker.exists('function:1:webhook:webhook-789')).toBe(false);
         });
     });
 
     describe('untrack', () => {
         it('removes conflict key from KV store when task had tracked sync', async () => {
-            const nangoProps = createNangoProps({ scriptType: 'sync', syncId: 'sync-untrack' });
+            const nangoProps = createNangoProps({ scriptType: 'sync', syncId: 'sync-untrack', environmentId: 1 });
             await monitor.track(nangoProps, 'task-untrack');
-            expect(await tracker.exists('function:sync:sync-untrack')).toBe(true);
+            expect(await tracker.exists('function:1:sync:sync-untrack')).toBe(true);
 
             await monitor.untrack('task-untrack');
-            expect(await tracker.exists('function:sync:sync-untrack')).toBe(false);
+            expect(await tracker.exists('function:1:sync:sync-untrack')).toBe(false);
         });
     });
 });

--- a/packages/runner/lib/monitor.unit.test.ts
+++ b/packages/runner/lib/monitor.unit.test.ts
@@ -50,8 +50,7 @@ describe('RunnerMonitor conflict tracking', () => {
         monitor = new RunnerMonitor({
             runnerId: 1,
             conflictTracking: {
-                tracker,
-                functionTypes: ['sync', 'action']
+                tracker
             }
         });
     });
@@ -62,7 +61,7 @@ describe('RunnerMonitor conflict tracking', () => {
     });
 
     describe('track', () => {
-        it('writes conflict key to KV store when scriptType is in functionTypes', async () => {
+        it('writes conflict key to KV store when scriptType is sync', async () => {
             const nangoProps = createNangoProps({ scriptType: 'sync', syncId: 'sync-123' });
             await monitor.track(nangoProps, 'task-1');
 
@@ -74,31 +73,16 @@ describe('RunnerMonitor conflict tracking', () => {
             expect(value).toBe('1');
         });
 
-        it('uses key format function:scriptType:syncId', async () => {
-            const nangoProps = createNangoProps({ scriptType: 'action', syncId: 'action-456' });
-            await monitor.track(nangoProps, 'task-2');
-
-            expect(await tracker.exists('function:action:action-456')).toBe(true);
-            expect(await tracker.get('function:action:action-456')).toBe('1');
-        });
-
-        it('does not write to KV store when scriptType is not in functionTypes', async () => {
+        it('does not write to KV store when scriptType is not sync', async () => {
             const nangoProps = createNangoProps({ scriptType: 'webhook', syncId: 'webhook-789' });
             await monitor.track(nangoProps, 'task-3');
 
             expect(await tracker.exists('function:webhook:webhook-789')).toBe(false);
         });
-
-        it('does not write to KV store for on-event when not in functionTypes', async () => {
-            const nangoProps = createNangoProps({ scriptType: 'on-event', syncId: 'on-event-1' });
-            await monitor.track(nangoProps, 'task-4');
-
-            expect(await tracker.exists('function:on-event:on-event-1')).toBe(false);
-        });
     });
 
     describe('untrack', () => {
-        it('removes conflict key from KV store when task had tracked scriptType', async () => {
+        it('removes conflict key from KV store when task had tracked sync', async () => {
             const nangoProps = createNangoProps({ scriptType: 'sync', syncId: 'sync-untrack' });
             await monitor.track(nangoProps, 'task-untrack');
             expect(await tracker.exists('function:sync:sync-untrack')).toBe(true);
@@ -106,17 +90,10 @@ describe('RunnerMonitor conflict tracking', () => {
             await monitor.untrack('task-untrack');
             expect(await tracker.exists('function:sync:sync-untrack')).toBe(false);
         });
-
-        it('does not delete key for scriptType not in functionTypes', async () => {
-            const nangoProps = createNangoProps({ scriptType: 'webhook', syncId: 'wh-1' });
-            await monitor.track(nangoProps, 'task-w');
-            await monitor.untrack('task-w');
-            expect(await tracker.exists('function:webhook:wh-1')).toBe(false);
-        });
     });
 
     describe('hasConflictingSync', () => {
-        it('returns true when same scriptType and syncId are already tracked', async () => {
+        it('returns true when same syncId is already tracked', async () => {
             const nangoProps = createNangoProps({ scriptType: 'sync', syncId: 'conflict-sync' });
             await monitor.track(nangoProps, 'task-a');
 
@@ -125,7 +102,7 @@ describe('RunnerMonitor conflict tracking', () => {
             expect(hasConflict).toBe(true);
         });
 
-        it('returns false when syncId differs for same scriptType', async () => {
+        it('returns false when syncId differs', async () => {
             const nangoProps = createNangoProps({ scriptType: 'sync', syncId: 'sync-one' });
             await monitor.track(nangoProps, 'task-b');
 
@@ -134,22 +111,12 @@ describe('RunnerMonitor conflict tracking', () => {
             expect(hasConflict).toBe(false);
         });
 
-        it('returns false when scriptType is not in functionTypes', async () => {
+        it('returns false when scriptType is not sync', async () => {
             const nangoProps = createNangoProps({ scriptType: 'webhook', syncId: 'webhook-1' });
             await monitor.track(nangoProps, 'task-c');
 
             const newTask = createNangoProps({ scriptType: 'webhook', syncId: 'webhook-1' });
             const hasConflict = await monitor.hasConflictingSync(newTask);
-            expect(hasConflict).toBe(false);
-        });
-
-        it('returns false after untrack for same scriptType and syncId', async () => {
-            const nangoProps = createNangoProps({ scriptType: 'action', syncId: 'action-x' });
-            await monitor.track(nangoProps, 'task-d');
-            expect(await monitor.hasConflictingSync(createNangoProps({ scriptType: 'action', syncId: 'action-x' }))).toBe(true);
-
-            await monitor.untrack('task-d');
-            const hasConflict = await monitor.hasConflictingSync(createNangoProps({ scriptType: 'action', syncId: 'action-x' }));
             expect(hasConflict).toBe(false);
         });
     });

--- a/packages/runner/lib/monitor.unit.test.ts
+++ b/packages/runner/lib/monitor.unit.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { InMemoryKVStore } from '@nangohq/kvstore';
+
+import { RunnerMonitor } from './monitor.js';
+
+import type { DBSyncConfig, NangoProps, ScriptType } from '@nangohq/types';
+
+function createNangoProps(overrides: { scriptType: ScriptType; syncId?: string }): NangoProps {
+    return {
+        scriptType: overrides.scriptType,
+        host: 'http://localhost:3003',
+        connectionId: 'connection-id',
+        environmentId: 1,
+        environmentName: 'dev',
+        providerConfigKey: 'provider-config-key',
+        provider: 'provider',
+        activityLogId: '1',
+        secretKey: 'secret-key',
+        nangoConnectionId: 1,
+        syncId: overrides.syncId ?? 'sync-id',
+        syncJobId: 1,
+        lastSyncDate: new Date(),
+        attributes: {},
+        track_deletes: false,
+        syncConfig: {} as DBSyncConfig,
+        debug: false,
+        startedAt: new Date(),
+        team: { id: 1, name: 'dev' },
+        logger: { level: 'off' },
+        runnerFlags: {
+            validateActionInput: false,
+            validateActionOutput: false,
+            validateSyncMetadata: false,
+            validateSyncRecords: false
+        },
+        endUser: null,
+        heartbeatTimeoutSecs: 30
+    };
+}
+
+describe('RunnerMonitor conflict tracking', () => {
+    let tracker: InMemoryKVStore;
+    let monitor: RunnerMonitor;
+
+    beforeEach(() => {
+        tracker = new InMemoryKVStore();
+        vi.spyOn(global, 'setInterval').mockImplementation(() => null as unknown as NodeJS.Timeout);
+        vi.spyOn(global, 'setTimeout').mockImplementation(() => null as unknown as NodeJS.Timeout);
+        monitor = new RunnerMonitor({
+            runnerId: 1,
+            conflictTracking: {
+                tracker,
+                functionTypes: ['sync', 'action']
+            }
+        });
+    });
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+        await tracker.destroy();
+    });
+
+    describe('track', () => {
+        it('writes conflict key to KV store when scriptType is in functionTypes', async () => {
+            const nangoProps = createNangoProps({ scriptType: 'sync', syncId: 'sync-123' });
+            await monitor.track(nangoProps, 'task-1');
+
+            const key = 'function:sync:sync-123';
+            const exists = await tracker.exists(key);
+            expect(exists).toBe(true);
+
+            const value = await tracker.get(key);
+            expect(value).toBe('1');
+        });
+
+        it('uses key format function:scriptType:syncId', async () => {
+            const nangoProps = createNangoProps({ scriptType: 'action', syncId: 'action-456' });
+            await monitor.track(nangoProps, 'task-2');
+
+            expect(await tracker.exists('function:action:action-456')).toBe(true);
+            expect(await tracker.get('function:action:action-456')).toBe('1');
+        });
+
+        it('does not write to KV store when scriptType is not in functionTypes', async () => {
+            const nangoProps = createNangoProps({ scriptType: 'webhook', syncId: 'webhook-789' });
+            await monitor.track(nangoProps, 'task-3');
+
+            expect(await tracker.exists('function:webhook:webhook-789')).toBe(false);
+        });
+
+        it('does not write to KV store for on-event when not in functionTypes', async () => {
+            const nangoProps = createNangoProps({ scriptType: 'on-event', syncId: 'on-event-1' });
+            await monitor.track(nangoProps, 'task-4');
+
+            expect(await tracker.exists('function:on-event:on-event-1')).toBe(false);
+        });
+    });
+
+    describe('untrack', () => {
+        it('removes conflict key from KV store when task had tracked scriptType', async () => {
+            const nangoProps = createNangoProps({ scriptType: 'sync', syncId: 'sync-untrack' });
+            await monitor.track(nangoProps, 'task-untrack');
+            expect(await tracker.exists('function:sync:sync-untrack')).toBe(true);
+
+            await monitor.untrack('task-untrack');
+            expect(await tracker.exists('function:sync:sync-untrack')).toBe(false);
+        });
+
+        it('does not delete key for scriptType not in functionTypes', async () => {
+            const nangoProps = createNangoProps({ scriptType: 'webhook', syncId: 'wh-1' });
+            await monitor.track(nangoProps, 'task-w');
+            await monitor.untrack('task-w');
+            expect(await tracker.exists('function:webhook:wh-1')).toBe(false);
+        });
+    });
+
+    describe('hasConflictingSync', () => {
+        it('returns true when same scriptType and syncId are already tracked', async () => {
+            const nangoProps = createNangoProps({ scriptType: 'sync', syncId: 'conflict-sync' });
+            await monitor.track(nangoProps, 'task-a');
+
+            const newTask = createNangoProps({ scriptType: 'sync', syncId: 'conflict-sync' });
+            const hasConflict = await monitor.hasConflictingSync(newTask);
+            expect(hasConflict).toBe(true);
+        });
+
+        it('returns false when syncId differs for same scriptType', async () => {
+            const nangoProps = createNangoProps({ scriptType: 'sync', syncId: 'sync-one' });
+            await monitor.track(nangoProps, 'task-b');
+
+            const newTask = createNangoProps({ scriptType: 'sync', syncId: 'sync-two' });
+            const hasConflict = await monitor.hasConflictingSync(newTask);
+            expect(hasConflict).toBe(false);
+        });
+
+        it('returns false when scriptType is not in functionTypes', async () => {
+            const nangoProps = createNangoProps({ scriptType: 'webhook', syncId: 'webhook-1' });
+            await monitor.track(nangoProps, 'task-c');
+
+            const newTask = createNangoProps({ scriptType: 'webhook', syncId: 'webhook-1' });
+            const hasConflict = await monitor.hasConflictingSync(newTask);
+            expect(hasConflict).toBe(false);
+        });
+
+        it('returns false after untrack for same scriptType and syncId', async () => {
+            const nangoProps = createNangoProps({ scriptType: 'action', syncId: 'action-x' });
+            await monitor.track(nangoProps, 'task-d');
+            expect(await monitor.hasConflictingSync(createNangoProps({ scriptType: 'action', syncId: 'action-x' }))).toBe(true);
+
+            await monitor.untrack('task-d');
+            const hasConflict = await monitor.hasConflictingSync(createNangoProps({ scriptType: 'action', syncId: 'action-x' }));
+            expect(hasConflict).toBe(false);
+        });
+    });
+});

--- a/packages/runner/lib/server.ts
+++ b/packages/runner/lib/server.ts
@@ -60,16 +60,9 @@ function startProcedure() {
                 input: codeParams
             });
 
-            try {
-                // The update to sync tracking is atomic, so we can safely try to track and if it fails, we know there is a conflicting sync
-                await usage.track(nangoProps, taskId);
-            } catch (err) {
-                if (err instanceof Error && err.message.includes('conflicting_sync')) {
-                    logger.error('Conflicting sync detected', { syncId: nangoProps.syncId });
-                    throw new Error('Conflicting sync detected');
-                }
-                throw err;
-            }
+            // The update to sync tracking is atomic, so we can safely try to track and if it fails, we know there is a conflicting sync
+            await usage.track(nangoProps, taskId);
+
             // executing in the background and returning immediately
             // sending the result to the jobs service when done
             setImmediate(async () => {

--- a/packages/runner/lib/server.ts
+++ b/packages/runner/lib/server.ts
@@ -60,14 +60,16 @@ function startProcedure() {
                 input: codeParams
             });
 
-            // Sometimes we can receive the same job (http retry) or a job for the same sync (orchestrator miss scheduling)
-            // Here is the last safety net to be sure nothing runs in parallel
-            if (await usage.hasConflictingSync(nangoProps)) {
-                logger.error('Conflicting sync detected', { syncId: nangoProps.syncId });
-                throw new Error('Conflicting sync detected');
+            try {
+                // The update to sync tracking is atomic, so we can safely try to track and if it fails, we know there is a conflicting sync
+                await usage.track(nangoProps, taskId);
+            } catch (err) {
+                if (err instanceof Error && err.message.includes('conflicting_sync')) {
+                    logger.error('Conflicting sync detected', { syncId: nangoProps.syncId });
+                    throw new Error('Conflicting sync detected');
+                }
+                throw err;
             }
-
-            await usage.track(nangoProps, taskId);
             // executing in the background and returning immediately
             // sending the result to the jobs service when done
             setImmediate(async () => {
@@ -91,6 +93,11 @@ function startProcedure() {
                     const res = await jobsClient.postHeartbeat({ taskId });
                     if (res.isOk()) {
                         lastSuccessHeartbeatAt = Date.now();
+                    }
+                    try {
+                        await usage.trackForConflicts(nangoProps, taskId, { refresh: true });
+                    } catch (err) {
+                        logger.error('Failed to update conflict tracking with new ttl', { error: err });
                     }
                 }, heartbeatIntervalMs);
 

--- a/packages/runner/lib/server.ts
+++ b/packages/runner/lib/server.ts
@@ -47,7 +47,7 @@ function healthProcedure() {
 function startProcedure() {
     return publicProcedure
         .input((input) => input as StartParams)
-        .mutation((arg): boolean => {
+        .mutation(async (arg): Promise<boolean> => {
             const startTime = Date.now();
             const { taskId, nangoProps, code, codeParams } = arg.input;
             logger.info('Received task', {
@@ -62,12 +62,12 @@ function startProcedure() {
 
             // Sometimes we can receive the same job (http retry) or a job for the same sync (orchestrator miss scheduling)
             // Here is the last safety net to be sure nothing runs in parallel
-            if (usage.hasConflictingSync(nangoProps)) {
+            if (await usage.hasConflictingSync(nangoProps)) {
                 logger.error('Conflicting sync detected', { syncId: nangoProps.syncId });
                 throw new Error('Conflicting sync detected');
             }
 
-            usage.track(nangoProps, taskId);
+            await usage.track(nangoProps, taskId);
             // executing in the background and returning immediately
             // sending the result to the jobs service when done
             setImmediate(async () => {
@@ -108,7 +108,7 @@ function startProcedure() {
                 } finally {
                     clearInterval(heartbeat);
                     abortControllers.delete(taskId);
-                    usage.untrack(taskId);
+                    await usage.untrack(nangoProps, taskId);
                     logger.info(`Task ${taskId} completed`);
                 }
             });

--- a/packages/runner/lib/server.ts
+++ b/packages/runner/lib/server.ts
@@ -88,7 +88,7 @@ function startProcedure() {
                         lastSuccessHeartbeatAt = Date.now();
                     }
                     try {
-                        await usage.trackForConflicts(nangoProps, taskId, { refresh: true });
+                        await usage.trackForConflicts(nangoProps, { refresh: true });
                     } catch (err) {
                         logger.error('Failed to update conflict tracking with new ttl', { error: err });
                     }

--- a/packages/runner/lib/server.ts
+++ b/packages/runner/lib/server.ts
@@ -108,7 +108,7 @@ function startProcedure() {
                 } finally {
                     clearInterval(heartbeat);
                     abortControllers.delete(taskId);
-                    await usage.untrack(nangoProps, taskId);
+                    await usage.untrack(taskId);
                     logger.info(`Task ${taskId} completed`);
                 }
             });

--- a/packages/runner/lib/state.ts
+++ b/packages/runner/lib/state.ts
@@ -18,8 +18,7 @@ if (envs.RUNNER_CONFLICT_RESOLUTION_MODE === 'REDIS') {
 export const usage = new RunnerMonitor({
     runnerId: envs.RUNNER_NODE_ID,
     conflictTracking: {
-        tracker: conflictTracker,
-        functionTypes: envs.RUNNER_CONFLICT_FUNCTION_TYPES
+        tracker: conflictTracker
     }
 });
 export const locks = new MapLocks();

--- a/packages/runner/lib/state.ts
+++ b/packages/runner/lib/state.ts
@@ -1,8 +1,25 @@
+import { InMemoryKVStore, getKVStore } from '@nangohq/kvstore';
+
 import { envs } from './env.js';
 import { RunnerMonitor } from './monitor.js';
 import { MapLocks } from './sdk/locks.js';
 
+import type { KVStore } from '@nangohq/kvstore';
+
 export const abortControllers = new Map<string, AbortController>();
 
-export const usage = new RunnerMonitor({ runnerId: envs.RUNNER_NODE_ID });
+let conflictTracker: KVStore;
+
+if (envs.RUNNER_CONFLICT_RESOLUTION_MODE === 'REDIS') {
+    conflictTracker = await getKVStore('customer');
+} else {
+    conflictTracker = new InMemoryKVStore();
+}
+export const usage = new RunnerMonitor({
+    runnerId: envs.RUNNER_NODE_ID,
+    conflictTracking: {
+        tracker: conflictTracker,
+        functionTypes: envs.RUNNER_CONFLICT_FUNCTION_TYPES
+    }
+});
 export const locks = new MapLocks();

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -18,6 +18,7 @@
     },
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
+        "@nangohq/kvstore": "file:../kvstore",
         "@nangohq/node": "file:../node-client",
         "@nangohq/runner-sdk": "file:../runner-sdk",
         "@nangohq/shared": "file:../shared",

--- a/packages/runner/tsconfig.json
+++ b/packages/runner/tsconfig.json
@@ -9,6 +9,9 @@
             "path": "../database"
         },
         {
+            "path": "../kvstore"
+        },
+        {
             "path": "../node-client"
         },
         {

--- a/packages/types/lib/runner/sdk.ts
+++ b/packages/types/lib/runner/sdk.ts
@@ -9,6 +9,8 @@ export interface SdkLogger {
     level: LogLevel | 'off';
 }
 
+export type ConflictResolutionMode = 'IN_MEMORY' | 'REDIS';
+
 export type ScriptType = 'sync' | 'action' | 'webhook' | 'on-event';
 
 export interface NangoProps {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -172,7 +172,7 @@ export const ENVS = z.object({
     RUNNER_REQUEST_MEMORY_MULTIPLIER: z.coerce.number().optional().default(1.4),
     RUNNER_ABORT_CHECK_INTERVAL_MS: z.coerce.number().optional().default(1_000),
     RUNNER_HEARTBEAT_INTERVAL_MS: z.coerce.number().optional().default(30_000),
-    RUNNER_HEARTBEAT_INTERVAL_MULTIPLIER: z.coerce.number().optional().default(3.1),
+    RUNNER_SYNC_CONFLICT_HEARTBEAT_INTERVAL_MULTIPLIER: z.coerce.number().optional().default(3.1),
 
     // FLEET
     RUNNERS_DATABASE_URL: z.url().optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -172,6 +172,7 @@ export const ENVS = z.object({
     RUNNER_REQUEST_MEMORY_MULTIPLIER: z.coerce.number().optional().default(1.4),
     RUNNER_ABORT_CHECK_INTERVAL_MS: z.coerce.number().optional().default(1_000),
     RUNNER_HEARTBEAT_INTERVAL_MS: z.coerce.number().optional().default(30_000),
+    RUNNER_HEARTBEAT_INTERVAL_MULTIPLIER: z.coerce.number().optional().default(3.1),
 
     // FLEET
     RUNNERS_DATABASE_URL: z.url().optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -156,7 +156,6 @@ export const ENVS = z.object({
     IDLE_MAX_DURATION_MS: z.coerce.number().default(0),
     RUNNER_NODE_ID: z.coerce.number().default(1),
     RUNNER_CONFLICT_RESOLUTION_MODE: z.enum(['IN_MEMORY', 'REDIS']).default('IN_MEMORY'),
-    RUNNER_CONFLICT_FUNCTION_TYPES: z.enum(['sync', 'action', 'webhook', 'on-event']).array().default(['sync']),
     RUNNER_URL: z.url().optional(),
     RUNNER_MEMORY_WARNING_THRESHOLD: z.coerce.number().optional().default(85),
     RUNNER_NAMESPACE: z.string().optional().default('nango'),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -155,6 +155,8 @@ export const ENVS = z.object({
     RUNNER_OWNER_ID: z.string().optional(),
     IDLE_MAX_DURATION_MS: z.coerce.number().default(0),
     RUNNER_NODE_ID: z.coerce.number().default(1),
+    RUNNER_CONFLICT_RESOLUTION_MODE: z.enum(['IN_MEMORY', 'REDIS']).default('IN_MEMORY'),
+    RUNNER_CONFLICT_FUNCTION_TYPES: z.enum(['sync', 'action', 'webhook', 'on-event']).array().default(['sync']),
     RUNNER_URL: z.url().optional(),
     RUNNER_MEMORY_WARNING_THRESHOLD: z.coerce.number().optional().default(85),
     RUNNER_NAMESPACE: z.string().optional().default('nango'),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Distributed conflict tracking for runner sync tasks via KV store**

This PR replaces in-memory-only conflict detection in the runner with KV-backed tracking to avoid concurrent sync conflicts across distributed runners. `RunnerMonitor` now writes conflict keys to a `KVStore` with TTL, refreshes them during heartbeats, and removes them on completion; start flow now awaits tracking and treats key set failures as the conflict signal.

It adds configuration for conflict tracking mode and heartbeat TTL multiplier, introduces the `@nangohq/kvstore` dependency, and includes unit tests verifying `track`/`untrack` behavior for sync tasks.

---
*This summary was automatically generated by @propel-code-bot*