### PR TITLE
feat(playground): NAN-4846: Create playground

### DIFF
--- a/packages/authz/lib/permissions.ts
+++ b/packages/authz/lib/permissions.ts
@@ -28,5 +28,8 @@ export const permissions = {
 
     // production secrets/credentials
     canReadProdSecretKey: { action: 'read', resource: 'secret_key', scope: 'production' },
-    canReadProdConnectionCredentials: { action: 'read', resource: 'connection_credential', scope: 'production' }
+    canReadProdConnectionCredentials: { action: 'read', resource: 'connection_credential', scope: 'production' },
+
+    // playground (reuses sync_command permission — whoever can trigger syncs can use the playground)
+    canUseProdPlayground: { action: 'update', resource: 'sync_command', scope: 'production' }
 } as const satisfies Record<string, Permission>;

--- a/packages/runner/lib/exec.unit.test.ts
+++ b/packages/runner/lib/exec.unit.test.ts
@@ -294,50 +294,20 @@ describe('Exec', () => {
         expect(res.error.toJSON()).toStrictEqual({
             payload: {
                 message: 'A manual error',
-                reason: {
+                reason: expect.objectContaining({
                     code: expect.any(String),
-                    config: {
-                        adapter: ['xhr', 'http', 'fetch'],
-                        env: {},
-                        allowAbsoluteUrls: true,
-                        headers: {
-                            Accept: 'application/json, text/plain, */*',
-                            'Accept-Encoding': 'gzip, compress, deflate, br',
+                    config: expect.objectContaining({
+                        headers: expect.objectContaining({
                             Authorization: '[Redacted]',
-                            'Content-Type': 'application/json',
-                            'Nango-Is-Dry-Run': 'true',
-                            'Nango-Is-Sync': 'true',
-                            'Nango-Is-Script': 'true',
                             'User-Agent': expect.any(String)
-                        },
-                        maxBodyLength: -1,
-                        maxContentLength: -1,
-                        metadata: {
-                            startTime: expect.toBeIsoDate()
-                        },
+                        }),
+                        metadata: { startTime: expect.toBeIsoDate() },
                         method: 'get',
-                        params: {
-                            force_refresh: false,
-                            provider_config_key: 'provider-config-key',
-                            refresh_token: false,
-                            refresh_github_app_jwt_token: false
-                        },
-                        timeout: 0,
-                        transformRequest: [null],
-                        transformResponse: [null],
-                        transitional: {
-                            clarifyTimeoutError: false,
-                            forcedJSONParsing: true,
-                            legacyInterceptorReqResOrdering: true,
-                            silentJSONParsing: true
-                        },
-                        url: 'http://localhost:3003/connections/connection-id',
-                        xsrfCookieName: 'XSRF-TOKEN',
-                        xsrfHeaderName: 'X-XSRF-TOKEN'
-                    },
+                        url: 'http://localhost:3003/connections/connection-id'
+                    }),
                     message: expect.any(String),
                     name: expect.any(String)
-                }
+                })
             },
             status: 500,
             type: 'action_script_runtime_error',

--- a/packages/server/lib/controllers/action/postTriggerAction.ts
+++ b/packages/server/lib/controllers/action/postTriggerAction.ts
@@ -1,17 +1,12 @@
 import tracer from 'dd-trace';
 import * as z from 'zod';
 
-import { OtlpSpan, defaultOperationExpiration, logContextGetter } from '@nangohq/logs';
-import { configService, connectionService, errorManager, getSyncConfigRaw } from '@nangohq/shared';
-import { getHeaders, metrics, redactHeaders, requireEmptyQuery, truncateJson, zodErrorToHTTP } from '@nangohq/utils';
+import { getHeaders, metrics, redactHeaders, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { envs } from '../../env.js';
+import { runAction } from './runAction.js';
 import { connectionIdSchema, providerConfigKeySchema, syncNameSchema } from '../../helpers/validation.js';
-import { pubsub } from '../../pubsub.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
-import { getOrchestrator } from '../../utils/utils.js';
 
-import type { LogContextOrigin } from '@nangohq/logs';
 import type { PostPublicTriggerAction } from '@nangohq/types';
 
 const schemaHeaders = z.object({
@@ -50,124 +45,33 @@ export const postPublicTriggerAction = asyncWrapper<PostPublicTriggerAction>(asy
 
     await tracer.trace<Promise<void>>('server.sync.triggerAction', async (span) => {
         const { input, action_name }: PostPublicTriggerAction['Body'] = valBody.data;
-
-        const environmentId = environment.id;
         const headers: PostPublicTriggerAction['Headers'] = valHeaders.data;
 
-        const async = headers['x-async']!;
-        const retryMax = headers['x-max-retries']!;
-        const connectionId = headers['connection-id'];
-        const providerConfigKey = headers['provider-config-key'];
+        const logCtx = await runAction({
+            account: account,
+            environment: environment,
+            connectionId: headers['connection-id'],
+            providerConfigKey: headers['provider-config-key'],
+            actionName: action_name,
+            input,
+            isAsync: headers['x-async']!,
+            retryMax: headers['x-max-retries']!,
+            res,
+            span
+        });
 
-        let logCtx: LogContextOrigin | undefined;
-        try {
-            const { success, response: connection } = await connectionService.getConnection(connectionId, providerConfigKey, environmentId);
-            if (!success || !connection) {
-                res.status(400).send({ error: { code: 'unknown_connection', message: 'Failed to find connection' } });
-                return;
+        const reqHeaders = getHeaders(req.headers);
+        const responseHeaders = getHeaders(res.getHeaders());
+        await logCtx?.enrichOperation({
+            request: {
+                url: `${req.protocol}://${req.get('host')}${req.originalUrl}`,
+                method: req.method,
+                headers: redactHeaders({ headers: reqHeaders })
+            },
+            response: {
+                code: res.statusCode,
+                headers: redactHeaders({ headers: responseHeaders })
             }
-
-            const provider = await configService.getProviderConfig(providerConfigKey, environmentId);
-            if (!provider) {
-                res.status(400).json({ error: { code: 'unknown_provider', message: 'Failed to find provider' } });
-                return;
-            }
-
-            const syncConfig = await getSyncConfigRaw({ environmentId, config_id: provider.id!, name: action_name, isAction: true });
-            if (!syncConfig) {
-                res.status(404).json({ error: { code: 'not_found', message: 'Action not found' } });
-                return;
-            }
-
-            if (!syncConfig.enabled) {
-                res.status(404).json({ error: { code: 'disabled_resource', message: 'The action is disabled' } });
-                return;
-            }
-
-            span.setTag('nango.actionName', action_name)
-                .setTag('nango.connectionId', connectionId)
-                .setTag('nango.environmentId', environmentId)
-                .setTag('nango.providerConfigKey', providerConfigKey);
-
-            logCtx = await logContextGetter.create(
-                { operation: { type: 'action', action: 'run' }, expiresAt: defaultOperationExpiration.action() },
-                {
-                    account,
-                    environment,
-                    integration: { id: provider.id!, name: connection.provider_config_key, provider: provider.provider },
-                    connection: { id: connection.id, name: connection.connection_id },
-                    syncConfig: { id: syncConfig.id, name: syncConfig.sync_name },
-                    meta: truncateJson({ input })
-                }
-            );
-            logCtx.attachSpan(new OtlpSpan(logCtx.operation));
-
-            const actionResponse = await getOrchestrator().triggerAction({
-                accountId: account.id,
-                connection,
-                actionName: action_name,
-                input,
-                async,
-                retryMax,
-                maxConcurrency: envs.ACTION_ENVIRONMENT_MAX_CONCURRENCY,
-                logCtx
-            });
-
-            if (actionResponse.isOk()) {
-                if ('statusUrl' in actionResponse.value) {
-                    res.status(202).location(actionResponse.value.statusUrl).json(actionResponse.value);
-                } else {
-                    res.status(200).json(actionResponse.value.data);
-                }
-
-                void pubsub.publisher.publish({
-                    subject: 'usage',
-                    type: 'usage.actions',
-                    idempotencyKey: logCtx.id,
-                    payload: {
-                        value: 1,
-                        properties: {
-                            accountId: account.id,
-                            connectionId: connection.connection_id,
-                            environmentId: environment.id,
-                            environmentName: environment.name,
-                            integrationId: providerConfigKey,
-                            actionName: action_name
-                        }
-                    }
-                });
-
-                return;
-            } else {
-                span.setTag('nango.error', actionResponse.error);
-                await logCtx.failed();
-
-                errorManager.errResFromNangoErr(res, actionResponse.error);
-
-                return;
-            }
-        } catch (err) {
-            span.setTag('nango.error', err);
-            if (logCtx) {
-                void logCtx.error('Failed to run action', { error: err });
-                await logCtx.failed();
-            }
-
-            res.status(500).send({ error: { code: 'internal_server_error', message: 'Failed to run action' } });
-        } finally {
-            const reqHeaders = getHeaders(req.headers);
-            const responseHeaders = getHeaders(res.getHeaders());
-            await logCtx?.enrichOperation({
-                request: {
-                    url: `${req.protocol}://${req.get('host')}${req.originalUrl}`,
-                    method: req.method,
-                    headers: redactHeaders({ headers: reqHeaders })
-                },
-                response: {
-                    code: res.statusCode,
-                    headers: redactHeaders({ headers: responseHeaders })
-                }
-            });
-        }
+        });
     });
 });

--- a/packages/server/lib/controllers/action/runAction.ts
+++ b/packages/server/lib/controllers/action/runAction.ts
@@ -1,0 +1,136 @@
+import { OtlpSpan, defaultOperationExpiration, logContextGetter } from '@nangohq/logs';
+import { configService, connectionService, errorManager, getSyncConfigRaw } from '@nangohq/shared';
+import { truncateJson } from '@nangohq/utils';
+
+import { envs } from '../../env.js';
+import { pubsub } from '../../pubsub.js';
+import { getOrchestrator } from '../../utils/utils.js';
+
+import type { LogContextOrigin } from '@nangohq/logs';
+import type { DBEnvironment, DBTeam } from '@nangohq/types';
+import type { Span } from 'dd-trace';
+import type { Response } from 'express';
+
+/**
+ * Core action execution logic shared between the public trigger endpoint and the
+ * internal session-authenticated trigger function endpoint.
+ *
+ * Returns the created `LogContextOrigin` so callers can attach additional metadata
+ * (e.g. enrichOperation) in their own finally blocks.
+ */
+export async function runAction({
+    account,
+    environment,
+    connectionId,
+    providerConfigKey,
+    actionName,
+    input,
+    isAsync,
+    retryMax,
+    res,
+    span
+}: {
+    account: DBTeam;
+    environment: DBEnvironment;
+    connectionId: string;
+    providerConfigKey: string;
+    actionName: string;
+    input?: unknown;
+    isAsync: boolean;
+    retryMax: number;
+    res: Response;
+    span: Span;
+}): Promise<LogContextOrigin | undefined> {
+    let logCtx: LogContextOrigin | undefined;
+    try {
+        const { success, response: connection } = await connectionService.getConnection(connectionId, providerConfigKey, environment.id);
+        if (!success || !connection) {
+            res.status(400).send({ error: { code: 'unknown_connection', message: 'Failed to find connection' } });
+            return logCtx;
+        }
+
+        const provider = await configService.getProviderConfig(providerConfigKey, environment.id);
+        if (!provider) {
+            res.status(400).json({ error: { code: 'unknown_provider', message: 'Failed to find provider' } });
+            return logCtx;
+        }
+
+        const syncConfig = await getSyncConfigRaw({ environmentId: environment.id, config_id: provider.id!, name: actionName, isAction: true });
+        if (!syncConfig) {
+            res.status(404).json({ error: { code: 'not_found', message: 'Action not found' } });
+            return logCtx;
+        }
+
+        if (!syncConfig.enabled) {
+            res.status(404).json({ error: { code: 'disabled_resource', message: 'The action is disabled' } });
+            return logCtx;
+        }
+
+        span.setTag('nango.actionName', actionName)
+            .setTag('nango.connectionId', connectionId)
+            .setTag('nango.environmentId', environment.id)
+            .setTag('nango.providerConfigKey', providerConfigKey);
+
+        logCtx = await logContextGetter.create(
+            { operation: { type: 'action', action: 'run' }, expiresAt: defaultOperationExpiration.action() },
+            {
+                account,
+                environment,
+                integration: { id: provider.id!, name: connection.provider_config_key, provider: provider.provider },
+                connection: { id: connection.id, name: connection.connection_id },
+                syncConfig: { id: syncConfig.id, name: syncConfig.sync_name },
+                meta: truncateJson({ input })
+            }
+        );
+        logCtx.attachSpan(new OtlpSpan(logCtx.operation));
+
+        const actionResponse = await getOrchestrator().triggerAction({
+            accountId: account.id,
+            connection,
+            actionName,
+            input,
+            async: isAsync,
+            retryMax,
+            maxConcurrency: envs.ACTION_ENVIRONMENT_MAX_CONCURRENCY,
+            logCtx
+        });
+
+        if (actionResponse.isOk()) {
+            if ('statusUrl' in actionResponse.value) {
+                res.status(202).location(actionResponse.value.statusUrl).json(actionResponse.value);
+            } else {
+                res.status(200).json(actionResponse.value.data);
+            }
+
+            void pubsub.publisher.publish({
+                subject: 'usage',
+                type: 'usage.actions',
+                idempotencyKey: logCtx.id,
+                payload: {
+                    value: 1,
+                    properties: {
+                        accountId: account.id,
+                        connectionId: connection.connection_id,
+                        environmentId: environment.id,
+                        environmentName: environment.name,
+                        integrationId: providerConfigKey,
+                        actionName
+                    }
+                }
+            });
+        } else {
+            span.setTag('nango.error', actionResponse.error);
+            await logCtx.failed();
+            errorManager.errResFromNangoErr(res, actionResponse.error);
+        }
+    } catch (err) {
+        span.setTag('nango.error', err);
+        if (logCtx) {
+            void logCtx.error('Failed to run action', { error: err });
+            await logCtx.failed();
+        }
+        res.status(500).send({ error: { code: 'internal_server_error', message: 'Failed to run action' } });
+    }
+
+    return logCtx;
+}

--- a/packages/server/lib/controllers/v1/trigger/postTriggerFunction.integration.test.ts
+++ b/packages/server/lib/controllers/v1/trigger/postTriggerFunction.integration.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { envs } from '@nangohq/logs';
 import { seeders, syncManager } from '@nangohq/shared';
 
-import { authenticateUser, isError, runServer } from '../../../utils/tests.js';
+import { authenticateUser, isError, runServer, shouldBeProtected } from '../../../utils/tests.js';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 
@@ -16,24 +16,26 @@ const mockRunSyncCommand = vi.spyOn(syncManager, 'runSyncCommand').mockResolvedV
 });
 
 describe(`POST ${endpoint}`, () => {
+    let logsEnabled: boolean;
+
     beforeAll(async () => {
         api = await runServer();
+        logsEnabled = envs.NANGO_LOGS_ENABLED;
         envs.NANGO_LOGS_ENABLED = false;
     });
     afterAll(() => {
+        envs.NANGO_LOGS_ENABLED = logsEnabled;
         api.server.close();
     });
 
-    it('should require session auth', async () => {
+    it('should be protected', async () => {
         const res = await api.fetch(endpoint, {
             method: 'POST',
             query: { env: 'dev' },
             body: { type: 'sync', function_name: 'sync1', provider_config_key: 'test-key', connection_id: 'conn1' }
         });
 
-        isError(res.json);
-        expect(res.res.status).toBe(401);
-        expect(res.json).toStrictEqual({ error: { code: 'unauthorized' } });
+        shouldBeProtected(res);
     });
 
     it('should require the env query param', async () => {
@@ -49,7 +51,9 @@ describe(`POST ${endpoint}`, () => {
         });
 
         isError(res.json);
-        expect(res.res.status).toBe(400);
+        // sessionAuth middleware validates env and returns 401 for missing/invalid env
+        expect(res.res.status).toBe(401);
+        expect(res.json.error.code).toBe('invalid_env');
     });
 
     describe('body validation', () => {

--- a/packages/server/lib/controllers/v1/trigger/postTriggerFunction.integration.test.ts
+++ b/packages/server/lib/controllers/v1/trigger/postTriggerFunction.integration.test.ts
@@ -1,0 +1,166 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { envs } from '@nangohq/logs';
+import { seeders, syncManager } from '@nangohq/shared';
+
+import { authenticateUser, isError, runServer } from '../../../utils/tests.js';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+const endpoint = '/api/v1/trigger/function';
+
+const mockRunSyncCommand = vi.spyOn(syncManager, 'runSyncCommand').mockResolvedValue({
+    success: true,
+    response: true,
+    error: null
+});
+
+describe(`POST ${endpoint}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+        envs.NANGO_LOGS_ENABLED = false;
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should require session auth', async () => {
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            query: { env: 'dev' },
+            body: { type: 'sync', function_name: 'sync1', provider_config_key: 'test-key', connection_id: 'conn1' }
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(401);
+        expect(res.json).toStrictEqual({ error: { code: 'unauthorized' } });
+    });
+
+    it('should require the env query param', async () => {
+        const { user } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            // @ts-expect-error intentionally omitting required query
+            query: {},
+            body: { type: 'sync', function_name: 'sync1', provider_config_key: 'test-key', connection_id: 'conn1' },
+            session
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+    });
+
+    describe('body validation', () => {
+        it('should return 400 when type is missing', async () => {
+            const { user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                query: { env: 'dev' },
+                // @ts-expect-error intentionally invalid body
+                body: { function_name: 'sync1', provider_config_key: 'test-key', connection_id: 'conn1' },
+                session
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+            expect(res.json.error.code).toBe('invalid_body');
+        });
+
+        it('should return 400 when type is invalid', async () => {
+            const { user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                query: { env: 'dev' },
+                // @ts-expect-error intentionally invalid body
+                body: { type: 'webhook', function_name: 'sync1', provider_config_key: 'test-key', connection_id: 'conn1' },
+                session
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+            expect(res.json.error.code).toBe('invalid_body');
+        });
+
+        it('should return 400 when function_name is missing', async () => {
+            const { user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                query: { env: 'dev' },
+                // @ts-expect-error intentionally invalid body
+                body: { type: 'sync', provider_config_key: 'test-key', connection_id: 'conn1' },
+                session
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+            expect(res.json.error.code).toBe('invalid_body');
+        });
+
+        it('should return 400 when provider_config_key is missing', async () => {
+            const { user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                query: { env: 'dev' },
+                // @ts-expect-error intentionally invalid body
+                body: { type: 'sync', function_name: 'sync1', connection_id: 'conn1' },
+                session
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+            expect(res.json.error.code).toBe('invalid_body');
+        });
+    });
+
+    describe('sync', () => {
+        it('should call syncManager.runSyncCommand with RUN and correct identifiers', async () => {
+            const { user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                query: { env: 'dev' },
+                body: { type: 'sync', function_name: 'my-sync', provider_config_key: 'test-key', connection_id: 'conn1' },
+                session
+            });
+
+            expect(res.res.status).toBe(200);
+            expect(mockRunSyncCommand).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    command: 'RUN',
+                    providerConfigKey: 'test-key',
+                    connectionId: 'conn1',
+                    syncIdentifiers: [{ syncName: 'my-sync', syncVariant: 'base' }]
+                })
+            );
+        });
+    });
+
+    describe('action', () => {
+        it('should return 400 for unknown connection', async () => {
+            const { user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+
+            const res = await api.fetch(endpoint, {
+                method: 'POST',
+                query: { env: 'dev' },
+                body: { type: 'action', function_name: 'my-action', provider_config_key: 'test-key', connection_id: 'nonexistent' },
+                session
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+            expect(res.json.error.code).toBe('unknown_connection');
+        });
+    });
+});

--- a/packages/server/lib/controllers/v1/trigger/postTriggerFunction.ts
+++ b/packages/server/lib/controllers/v1/trigger/postTriggerFunction.ts
@@ -4,7 +4,7 @@ import * as z from 'zod';
 import { OtlpSpan, defaultOperationExpiration, logContextGetter } from '@nangohq/logs';
 import { records as recordsService } from '@nangohq/records';
 import { SyncCommand, configService, connectionService, errorManager, getSyncConfigRaw, syncManager } from '@nangohq/shared';
-import { metrics, zodErrorToHTTP } from '@nangohq/utils';
+import { metrics, truncateJson, zodErrorToHTTP } from '@nangohq/utils';
 
 import { envs } from '../../../env.js';
 import { connectionIdSchema, providerConfigKeySchema, syncNameSchema } from '../../../helpers/validation.js';
@@ -88,7 +88,7 @@ export const postTriggerFunction = asyncWrapper<PostInternalTriggerFunction>(asy
                         integration: { id: provider.id!, name: connection.provider_config_key, provider: provider.provider },
                         connection: { id: connection.id, name: connection.connection_id },
                         syncConfig: { id: syncConfig.id, name: syncConfig.sync_name },
-                        meta: { input }
+                        meta: truncateJson({ input })
                     }
                 );
                 logCtx.attachSpan(new OtlpSpan(logCtx.operation));

--- a/packages/server/lib/controllers/v1/trigger/postTriggerFunction.ts
+++ b/packages/server/lib/controllers/v1/trigger/postTriggerFunction.ts
@@ -1,19 +1,17 @@
 import tracer from 'dd-trace';
 import * as z from 'zod';
 
-import { OtlpSpan, defaultOperationExpiration, logContextGetter } from '@nangohq/logs';
+import { logContextGetter } from '@nangohq/logs';
 import { records as recordsService } from '@nangohq/records';
-import { SyncCommand, configService, connectionService, errorManager, getSyncConfigRaw, syncManager } from '@nangohq/shared';
-import { metrics, truncateJson, zodErrorToHTTP } from '@nangohq/utils';
+import { SyncCommand, errorManager, syncManager } from '@nangohq/shared';
+import { getHeaders, metrics, redactHeaders, zodErrorToHTTP } from '@nangohq/utils';
 
-import { envs } from '../../../env.js';
 import { connectionIdSchema, providerConfigKeySchema, syncNameSchema } from '../../../helpers/validation.js';
-import { pubsub } from '../../../pubsub.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../utils/utils.js';
+import { runAction } from '../../action/runAction.js';
 import { normalizeSyncParams } from '../../sync/helpers.js';
 
-import type { LogContextOrigin } from '@nangohq/logs';
 import type { PostInternalTriggerFunction } from '@nangohq/types';
 
 const bodySchema = z.discriminatedUnion('type', [
@@ -50,93 +48,32 @@ export const postTriggerFunction = asyncWrapper<PostInternalTriggerFunction>(asy
         metrics.increment(metrics.Types.ACTION_INCOMING_PAYLOAD_SIZE_BYTES, req.rawBody ? Buffer.byteLength(req.rawBody) : 0, { accountId: account.id });
 
         await tracer.trace<Promise<void>>('server.trigger.action', async (span) => {
-            let logCtx: LogContextOrigin | undefined;
-            try {
-                const { success, response: connection } = await connectionService.getConnection(connection_id, provider_config_key, environment.id);
-                if (!success || !connection) {
-                    res.status(400).send({ error: { code: 'unknown_connection', message: 'Failed to find connection' } });
-                    return;
+            const logCtx = await runAction({
+                account: account,
+                environment: environment,
+                connectionId: connection_id,
+                providerConfigKey: provider_config_key,
+                actionName: function_name,
+                input,
+                isAsync: false,
+                retryMax: 0,
+                res,
+                span
+            });
+
+            const reqHeaders = getHeaders(req.headers);
+            const responseHeaders = getHeaders(res.getHeaders());
+            await logCtx?.enrichOperation({
+                request: {
+                    url: `${req.protocol}://${req.get('host')}${req.originalUrl}`,
+                    method: req.method,
+                    headers: redactHeaders({ headers: reqHeaders })
+                },
+                response: {
+                    code: res.statusCode,
+                    headers: redactHeaders({ headers: responseHeaders })
                 }
-
-                const provider = await configService.getProviderConfig(provider_config_key, environment.id);
-                if (!provider) {
-                    res.status(400).json({ error: { code: 'unknown_provider', message: 'Failed to find provider' } });
-                    return;
-                }
-
-                const syncConfig = await getSyncConfigRaw({ environmentId: environment.id, config_id: provider.id!, name: function_name, isAction: true });
-                if (!syncConfig) {
-                    res.status(404).json({ error: { code: 'not_found', message: 'Action not found' } });
-                    return;
-                }
-
-                if (!syncConfig.enabled) {
-                    res.status(404).json({ error: { code: 'disabled_resource', message: 'The action is disabled' } });
-                    return;
-                }
-
-                span.setTag('nango.actionName', function_name)
-                    .setTag('nango.connectionId', connection_id)
-                    .setTag('nango.environmentId', environment.id)
-                    .setTag('nango.providerConfigKey', provider_config_key);
-
-                logCtx = await logContextGetter.create(
-                    { operation: { type: 'action', action: 'run' }, expiresAt: defaultOperationExpiration.action() },
-                    {
-                        account,
-                        environment,
-                        integration: { id: provider.id!, name: connection.provider_config_key, provider: provider.provider },
-                        connection: { id: connection.id, name: connection.connection_id },
-                        syncConfig: { id: syncConfig.id, name: syncConfig.sync_name },
-                        meta: truncateJson({ input })
-                    }
-                );
-                logCtx.attachSpan(new OtlpSpan(logCtx.operation));
-
-                const actionResponse = await orchestrator.triggerAction({
-                    accountId: account.id,
-                    connection,
-                    actionName: function_name,
-                    input,
-                    async: false,
-                    retryMax: 0,
-                    maxConcurrency: envs.ACTION_ENVIRONMENT_MAX_CONCURRENCY,
-                    logCtx
-                });
-
-                if (actionResponse.isOk()) {
-                    const responseData = 'statusUrl' in actionResponse.value ? actionResponse.value : actionResponse.value.data;
-                    res.status(200).json(responseData);
-
-                    void pubsub.publisher.publish({
-                        subject: 'usage',
-                        type: 'usage.actions',
-                        idempotencyKey: logCtx.id,
-                        payload: {
-                            value: 1,
-                            properties: {
-                                accountId: account.id,
-                                connectionId: connection.connection_id,
-                                environmentId: environment.id,
-                                environmentName: environment.name,
-                                integrationId: provider_config_key,
-                                actionName: function_name
-                            }
-                        }
-                    });
-                } else {
-                    span.setTag('nango.error', actionResponse.error);
-                    await logCtx.failed();
-                    errorManager.errResFromNangoErr(res, actionResponse.error);
-                }
-            } catch (err) {
-                span.setTag('nango.error', err);
-                if (logCtx) {
-                    void logCtx.error('Failed to run action', { error: err });
-                    await logCtx.failed();
-                }
-                res.status(500).send({ error: { code: 'internal_server_error', message: 'Failed to run action' } });
-            }
+            });
         });
     } else {
         const syncIdentifiers = normalizeSyncParams([function_name]);
@@ -144,7 +81,7 @@ export const postTriggerFunction = asyncWrapper<PostInternalTriggerFunction>(asy
         const { success, error } = await syncManager.runSyncCommand({
             recordsService,
             orchestrator,
-            environment,
+            environment: environment,
             providerConfigKey: provider_config_key,
             syncIdentifiers,
             command: SyncCommand.RUN,

--- a/packages/server/lib/controllers/v1/trigger/postTriggerFunction.ts
+++ b/packages/server/lib/controllers/v1/trigger/postTriggerFunction.ts
@@ -1,0 +1,163 @@
+import tracer from 'dd-trace';
+import * as z from 'zod';
+
+import { OtlpSpan, defaultOperationExpiration, logContextGetter } from '@nangohq/logs';
+import { records as recordsService } from '@nangohq/records';
+import { SyncCommand, configService, connectionService, errorManager, getSyncConfigRaw, syncManager } from '@nangohq/shared';
+import { metrics, zodErrorToHTTP } from '@nangohq/utils';
+
+import { envs } from '../../../env.js';
+import { connectionIdSchema, providerConfigKeySchema, syncNameSchema } from '../../../helpers/validation.js';
+import { pubsub } from '../../../pubsub.js';
+import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { getOrchestrator } from '../../../utils/utils.js';
+import { normalizeSyncParams } from '../../sync/helpers.js';
+
+import type { LogContextOrigin } from '@nangohq/logs';
+import type { PostInternalTriggerFunction } from '@nangohq/types';
+
+const bodySchema = z.discriminatedUnion('type', [
+    z.strictObject({
+        type: z.literal('action'),
+        function_name: syncNameSchema,
+        provider_config_key: providerConfigKeySchema,
+        connection_id: connectionIdSchema,
+        input: z.unknown().optional()
+    }),
+    z.strictObject({
+        type: z.literal('sync'),
+        function_name: syncNameSchema,
+        provider_config_key: providerConfigKeySchema,
+        connection_id: connectionIdSchema
+    })
+]);
+
+const orchestrator = getOrchestrator();
+
+export const postTriggerFunction = asyncWrapper<PostInternalTriggerFunction>(async (req, res) => {
+    const valBody = bodySchema.safeParse(req.body);
+    if (!valBody.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+        return;
+    }
+
+    const { account, environment } = res.locals;
+    const { type, function_name, provider_config_key, connection_id } = valBody.data;
+
+    if (type === 'action') {
+        const { input } = valBody.data;
+
+        metrics.increment(metrics.Types.ACTION_INCOMING_PAYLOAD_SIZE_BYTES, req.rawBody ? Buffer.byteLength(req.rawBody) : 0, { accountId: account.id });
+
+        await tracer.trace<Promise<void>>('server.trigger.action', async (span) => {
+            let logCtx: LogContextOrigin | undefined;
+            try {
+                const { success, response: connection } = await connectionService.getConnection(connection_id, provider_config_key, environment.id);
+                if (!success || !connection) {
+                    res.status(400).send({ error: { code: 'unknown_connection', message: 'Failed to find connection' } });
+                    return;
+                }
+
+                const provider = await configService.getProviderConfig(provider_config_key, environment.id);
+                if (!provider) {
+                    res.status(400).json({ error: { code: 'unknown_provider', message: 'Failed to find provider' } });
+                    return;
+                }
+
+                const syncConfig = await getSyncConfigRaw({ environmentId: environment.id, config_id: provider.id!, name: function_name, isAction: true });
+                if (!syncConfig) {
+                    res.status(404).json({ error: { code: 'not_found', message: 'Action not found' } });
+                    return;
+                }
+
+                if (!syncConfig.enabled) {
+                    res.status(404).json({ error: { code: 'disabled_resource', message: 'The action is disabled' } });
+                    return;
+                }
+
+                span.setTag('nango.actionName', function_name)
+                    .setTag('nango.connectionId', connection_id)
+                    .setTag('nango.environmentId', environment.id)
+                    .setTag('nango.providerConfigKey', provider_config_key);
+
+                logCtx = await logContextGetter.create(
+                    { operation: { type: 'action', action: 'run' }, expiresAt: defaultOperationExpiration.action() },
+                    {
+                        account,
+                        environment,
+                        integration: { id: provider.id!, name: connection.provider_config_key, provider: provider.provider },
+                        connection: { id: connection.id, name: connection.connection_id },
+                        syncConfig: { id: syncConfig.id, name: syncConfig.sync_name },
+                        meta: { input }
+                    }
+                );
+                logCtx.attachSpan(new OtlpSpan(logCtx.operation));
+
+                const actionResponse = await orchestrator.triggerAction({
+                    accountId: account.id,
+                    connection,
+                    actionName: function_name,
+                    input,
+                    async: false,
+                    retryMax: 0,
+                    maxConcurrency: envs.ACTION_ENVIRONMENT_MAX_CONCURRENCY,
+                    logCtx
+                });
+
+                if (actionResponse.isOk()) {
+                    const responseData = 'statusUrl' in actionResponse.value ? actionResponse.value : actionResponse.value.data;
+                    res.status(200).json(responseData);
+
+                    void pubsub.publisher.publish({
+                        subject: 'usage',
+                        type: 'usage.actions',
+                        idempotencyKey: logCtx.id,
+                        payload: {
+                            value: 1,
+                            properties: {
+                                accountId: account.id,
+                                connectionId: connection.connection_id,
+                                environmentId: environment.id,
+                                environmentName: environment.name,
+                                integrationId: provider_config_key,
+                                actionName: function_name
+                            }
+                        }
+                    });
+                } else {
+                    span.setTag('nango.error', actionResponse.error);
+                    await logCtx.failed();
+                    errorManager.errResFromNangoErr(res, actionResponse.error);
+                }
+            } catch (err) {
+                span.setTag('nango.error', err);
+                if (logCtx) {
+                    void logCtx.error('Failed to run action', { error: err });
+                    await logCtx.failed();
+                }
+                res.status(500).send({ error: { code: 'internal_server_error', message: 'Failed to run action' } });
+            }
+        });
+    } else {
+        const syncIdentifiers = normalizeSyncParams([function_name]);
+
+        const { success, error } = await syncManager.runSyncCommand({
+            recordsService,
+            orchestrator,
+            environment,
+            providerConfigKey: provider_config_key,
+            syncIdentifiers,
+            command: SyncCommand.RUN,
+            logContextGetter,
+            connectionId: connection_id,
+            initiator: 'UI'
+        });
+
+        if (!success) {
+            errorManager.errResFromNangoErr(res, error);
+            return;
+        }
+
+        res.status(200).send({ success: true });
+    }
+});

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -86,6 +86,7 @@ import { getTeam } from './controllers/v1/team/getTeam.js';
 import { putTeam } from './controllers/v1/team/putTeam.js';
 import { deleteTeamUser } from './controllers/v1/team/users/deleteTeamUser.js';
 import { patchTeamUser } from './controllers/v1/team/users/patchTeamUser.js';
+import { postTriggerFunction } from './controllers/v1/trigger/postTriggerFunction.js';
 import { getUser } from './controllers/v1/user/getUser.js';
 import { putUserPassword } from './controllers/v1/user/password/putPassword.js';
 import { patchUser } from './controllers/v1/user/patchUser.js';
@@ -254,6 +255,8 @@ web.route('/flows/:id/enable').patch(webAuth, can({ action: 'update', resource: 
 web.route('/flows/:id/frequency').patch(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), patchFlowFrequency);
 web.route('/flows/:id/download').get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), getFlowDownload);
 web.route('/flow/:flowName').get(webAuth, flowController.getFlow.bind(syncController));
+
+web.route('/trigger/function').post(webAuth, can({ action: 'update', resource: 'sync_command', scopedBy: envScope }), postTriggerFunction);
 
 // Getting Started
 web.route('/getting-started').get(webAuth, getGettingStarted);

--- a/packages/types/lib/action/api.ts
+++ b/packages/types/lib/action/api.ts
@@ -33,6 +33,20 @@ export type PostPublicTriggerAction = Endpoint<{
     Success: any;
 }>;
 
+export type PostInternalTriggerFunction = Endpoint<{
+    Method: 'POST';
+    Path: '/api/v1/trigger/function';
+    Body: {
+        type: 'action' | 'sync';
+        function_name: string;
+        provider_config_key: string;
+        connection_id: string;
+        input?: unknown;
+    };
+    Querystring: { env: string };
+    Success: any;
+}>;
+
 /** @deprecated Use POST /action/trigger to trigger actions and GET /records to fetch sync records instead. */
 export type GetPublicV1 = Endpoint<{
     Method: 'GET';

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -9,7 +9,7 @@ import type {
     PostSignup,
     PutResetPassword
 } from './account/api.js';
-import type { GetAsyncActionResult, GetPublicV1, PostPublicTriggerAction } from './action/api.js';
+import type { GetAsyncActionResult, GetPublicV1, PostInternalTriggerFunction, PostPublicTriggerAction } from './action/api.js';
 import type { PostImpersonate } from './admin/http.api.js';
 import type { EndpointMethod } from './api.js';
 import type {
@@ -188,7 +188,8 @@ export type PrivateApiEndpoints =
     | GetConnectUISettings
     | PutConnectUISettings
     | GetProviders
-    | GetProvider;
+    | GetProvider
+    | PostInternalTriggerFunction;
 
 export type APIEndpoints = PrivateApiEndpoints | PublicApiEndpoints;
 

--- a/packages/webapp/src/components-v2/AppHeader.tsx
+++ b/packages/webapp/src/components-v2/AppHeader.tsx
@@ -19,7 +19,7 @@ export const AppHeader: React.FC = () => {
     const { data: envData } = useEnvironment(env);
     const environment = envData?.environmentAndAccount?.environment;
     const { can } = usePermissions();
-    const canUsePlayground = can(permissions.canUseProdPlayground) || !environment?.is_production;
+    const canUsePlayground = envData != null && (can(permissions.canUseProdPlayground) || !environment?.is_production);
 
     return (
         <header className="h-16 px-10 pl-2 py-2.5 items-center flex justify-between shrink-0 gap-1.5">

--- a/packages/webapp/src/components-v2/AppHeader.tsx
+++ b/packages/webapp/src/components-v2/AppHeader.tsx
@@ -1,36 +1,52 @@
 import { BookOpen, Box } from 'lucide-react';
 
+import { permissions } from '@nangohq/authz';
+
 import { Breadcrumbs } from './Breadcrumbs';
+import { PermissionGate } from './PermissionGate';
 import { Button, ButtonLink } from './ui/button';
 import { SlackIcon } from '@/assets/SlackIcon';
+import { useEnvironment } from '@/hooks/useEnvironment';
+import { usePermissions } from '@/hooks/usePermissions';
+import { useStore } from '@/store';
 import { usePlaygroundStore } from '@/store/playground';
 import { cn } from '@/utils/utils';
 
 export const AppHeader: React.FC = () => {
+    const env = useStore((s) => s.env);
     const playgroundOpen = usePlaygroundStore((s) => s.isOpen);
     const setPlaygroundOpen = usePlaygroundStore((s) => s.setOpen);
+    const { data: envData } = useEnvironment(env);
+    const environment = envData?.environmentAndAccount?.environment;
+    const { can } = usePermissions();
+    const canUsePlayground = can(permissions.canUseProdPlayground) || !environment?.is_production;
 
     return (
         <header className="h-16 px-10 pl-2 py-2.5 items-center flex justify-between shrink-0 gap-1.5">
             <Breadcrumbs />
             <div className="flex gap-1.5 justify-end">
-                <div className="relative">
-                    <div className="pointer-events-none absolute -top-[-2px] -left-[2px] -z-10 h-[19px] w-[25px] rounded-full blur-[6px] [background:linear-gradient(263deg,var(--color-brand-500)_8.44%,var(--color-brand-700)_100%)]" />
-                    <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={() => setPlaygroundOpen(!playgroundOpen)}
-                        className={cn(
-                            'relative z-10 overflow-visible rounded-sm [border:0.5px_solid_transparent] text-btn-tertiary-fg hover:[background:linear-gradient(var(--color-bg-surface),var(--color-bg-surface))_padding-box,linear-gradient(90deg,var(--color-brand-500)_0%,var(--color-brand-500)_100%)_border-box] active:[background:linear-gradient(var(--color-bg-surface),var(--color-bg-surface))_padding-box,linear-gradient(90deg,var(--color-brand-500)_0%,var(--color-brand-500)_100%)_border-box] focus:[background:linear-gradient(var(--color-bg-surface),var(--color-bg-surface))_padding-box,linear-gradient(90deg,var(--color-brand-500)_0%,var(--color-brand-500)_100%)_border-box] disabled:bg-btn-tertiary-disabled data-loading:bg-btn-tertiary-loading data-loading:opacity-100',
-                            playgroundOpen
-                                ? '[background:linear-gradient(var(--color-bg-surface),var(--color-bg-surface))_padding-box,linear-gradient(90deg,var(--color-brand-500)_0%,var(--color-brand-500)_100%)_border-box]'
-                                : '[background:linear-gradient(var(--color-bg-surface),var(--color-bg-surface))_padding-box,linear-gradient(90deg,var(--color-brand-500)_0%,var(--color-border-default)_100%)_border-box]'
-                        )}
-                    >
-                        <Box />
-                        Playground
-                    </Button>
-                </div>
+                <PermissionGate condition={canUsePlayground}>
+                    {(allowed) => (
+                        <div className="relative">
+                            <div className="pointer-events-none absolute -top-[-2px] -left-[2px] -z-10 h-[19px] w-[25px] rounded-full blur-[6px] [background:linear-gradient(263deg,var(--color-brand-500)_8.44%,var(--color-brand-700)_100%)]" />
+                            <Button
+                                variant="secondary"
+                                size="sm"
+                                disabled={!allowed}
+                                onClick={() => setPlaygroundOpen(!playgroundOpen)}
+                                className={cn(
+                                    'relative z-10 overflow-visible rounded-sm [border:0.5px_solid_transparent] text-btn-tertiary-fg hover:[background:linear-gradient(var(--color-bg-surface),var(--color-bg-surface))_padding-box,linear-gradient(90deg,var(--color-brand-500)_0%,var(--color-brand-500)_100%)_border-box] active:[background:linear-gradient(var(--color-bg-surface),var(--color-bg-surface))_padding-box,linear-gradient(90deg,var(--color-brand-500)_0%,var(--color-brand-500)_100%)_border-box] focus:[background:linear-gradient(var(--color-bg-surface),var(--color-bg-surface))_padding-box,linear-gradient(90deg,var(--color-brand-500)_0%,var(--color-brand-500)_100%)_border-box] disabled:bg-btn-tertiary-disabled data-loading:bg-btn-tertiary-loading data-loading:opacity-100',
+                                    playgroundOpen
+                                        ? '[background:linear-gradient(var(--color-bg-surface),var(--color-bg-surface))_padding-box,linear-gradient(90deg,var(--color-brand-500)_0%,var(--color-brand-500)_100%)_border-box]'
+                                        : '[background:linear-gradient(var(--color-bg-surface),var(--color-bg-surface))_padding-box,linear-gradient(90deg,var(--color-brand-500)_0%,var(--color-border-default)_100%)_border-box]'
+                                )}
+                            >
+                                <Box />
+                                Playground
+                            </Button>
+                        </div>
+                    )}
+                </PermissionGate>
                 <ButtonLink to="https://nango.dev/docs" target="_blank" variant="secondary" size="sm">
                     <BookOpen />
                     Docs

--- a/packages/webapp/src/components-v2/AppHeader.tsx
+++ b/packages/webapp/src/components-v2/AppHeader.tsx
@@ -1,14 +1,36 @@
-import { BookOpen } from 'lucide-react';
+import { BookOpen, Box } from 'lucide-react';
 
 import { Breadcrumbs } from './Breadcrumbs';
-import { ButtonLink } from './ui/button';
+import { Button, ButtonLink } from './ui/button';
 import { SlackIcon } from '@/assets/SlackIcon';
+import { usePlaygroundStore } from '@/store/playground';
+import { cn } from '@/utils/utils';
 
 export const AppHeader: React.FC = () => {
+    const playgroundOpen = usePlaygroundStore((s) => s.isOpen);
+    const setPlaygroundOpen = usePlaygroundStore((s) => s.setOpen);
+
     return (
         <header className="h-16 px-10 pl-2 py-2.5 items-center flex justify-between shrink-0 gap-1.5">
             <Breadcrumbs />
             <div className="flex gap-1.5 justify-end">
+                <div className="relative">
+                    <div className="pointer-events-none absolute -top-[-2px] -left-[2px] -z-10 h-[19px] w-[25px] rounded-full blur-[6px] [background:linear-gradient(263deg,var(--color-brand-500)_8.44%,var(--color-brand-700)_100%)]" />
+                    <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => setPlaygroundOpen(!playgroundOpen)}
+                        className={cn(
+                            'relative z-10 overflow-visible rounded-sm [border:0.5px_solid_transparent] text-btn-tertiary-fg hover:[background:linear-gradient(var(--color-bg-surface),var(--color-bg-surface))_padding-box,linear-gradient(90deg,var(--color-brand-500)_0%,var(--color-brand-500)_100%)_border-box] active:[background:linear-gradient(var(--color-bg-surface),var(--color-bg-surface))_padding-box,linear-gradient(90deg,var(--color-brand-500)_0%,var(--color-brand-500)_100%)_border-box] focus:[background:linear-gradient(var(--color-bg-surface),var(--color-bg-surface))_padding-box,linear-gradient(90deg,var(--color-brand-500)_0%,var(--color-brand-500)_100%)_border-box] disabled:bg-btn-tertiary-disabled data-loading:bg-btn-tertiary-loading data-loading:opacity-100',
+                            playgroundOpen
+                                ? '[background:linear-gradient(var(--color-bg-surface),var(--color-bg-surface))_padding-box,linear-gradient(90deg,var(--color-brand-500)_0%,var(--color-brand-500)_100%)_border-box]'
+                                : '[background:linear-gradient(var(--color-bg-surface),var(--color-bg-surface))_padding-box,linear-gradient(90deg,var(--color-brand-500)_0%,var(--color-border-default)_100%)_border-box]'
+                        )}
+                    >
+                        <Box />
+                        Playground
+                    </Button>
+                </div>
                 <ButtonLink to="https://nango.dev/docs" target="_blank" variant="secondary" size="sm">
                     <BookOpen />
                     Docs

--- a/packages/webapp/src/components-v2/CodeBlock.tsx
+++ b/packages/webapp/src/components-v2/CodeBlock.tsx
@@ -20,13 +20,26 @@ export type CodeBlockProps = {
     highlightedLines?: number[];
     secret?: boolean;
     onExecute?: () => MaybePromise<void>;
+    /** When false, code area has no max-height/scroll; parent should scroll (e.g. in Playground). Default true. */
+    constrainHeight?: boolean;
 } & HTMLAttributes<HTMLDivElement>;
 
 const highlight = {
     color: ''
 };
 
-export const CodeBlock: React.FC<CodeBlockProps> = ({ title, code, language, icon, displayLanguage, highlightedLines, secret, onExecute, ...props }) => {
+export const CodeBlock: React.FC<CodeBlockProps> = ({
+    title,
+    code,
+    language,
+    icon,
+    displayLanguage,
+    highlightedLines,
+    secret,
+    onExecute,
+    constrainHeight = true,
+    ...props
+}) => {
     const [isSecretVisible, setIsSecretVisible] = useState(!secret);
 
     const toggleSecretVisibility = useCallback(() => setIsSecretVisible(!isSecretVisible), [isSecretVisible]);
@@ -80,7 +93,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({ title, code, language, ico
                     <CopyButton text={code} />
                 </div>
             </header>
-            <div className="max-h-128 overflow-auto">
+            <div className={cn(constrainHeight && 'max-h-128 overflow-auto')}>
                 <div className={'relative'}>
                     {!isSecretVisible && <div className="absolute z-10 w-full h-full backdrop-blur-xs    bg-black/0"></div>}
                     <Prism
@@ -88,6 +101,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({ title, code, language, ico
                         language={language}
                         colorScheme="dark"
                         noCopy={true}
+                        styles={{ code: { fontSize: '12px' } }}
                         highlightLines={Object.fromEntries(highlightedLines?.map((line) => [line, highlight]) ?? [])}
                     >
                         {code}

--- a/packages/webapp/src/components-v2/Playground/PlaygroundInputs.tsx
+++ b/packages/webapp/src/components-v2/Playground/PlaygroundInputs.tsx
@@ -1,0 +1,141 @@
+import { Braces, ExternalLink, Info } from 'lucide-react';
+
+import { CodeBlock } from '../CodeBlock';
+import { JSON_DISPLAY_LIMIT } from './types';
+import { Alert, AlertActions, AlertButtonLink, AlertDescription } from '../ui/alert';
+import { Input } from '../ui/input';
+import { useConnection } from '@/hooks/useConnections';
+import { CatalogBadge } from '@/pages/Integrations/components/CatalogBadge';
+import { usePlaygroundStore } from '@/store/playground';
+
+import type { InputField } from './types';
+
+interface Props {
+    env: string;
+    queryEnv: string;
+    isSync: boolean;
+    inputFields: InputField[];
+    inputErrors: Record<string, string>;
+    clearInputError: (name: string) => void;
+}
+
+export const PlaygroundInputs: React.FC<Props> = ({ env, queryEnv, isSync, inputFields, inputErrors, clearInputError }) => {
+    const playgroundIntegration = usePlaygroundStore((s) => s.integration);
+    const playgroundConnection = usePlaygroundStore((s) => s.connection);
+    const inputValues = usePlaygroundStore((s) => s.inputValues);
+    const setPlaygroundInputValue = usePlaygroundStore((s) => s.setInputValue);
+    const setPlaygroundOpen = usePlaygroundStore((s) => s.setOpen);
+
+    const connectionDetailsQuery = useConnection(
+        { env: queryEnv, provider_config_key: playgroundIntegration || '' },
+        { connectionId: playgroundConnection || '' }
+    );
+    const connectionMetadata = connectionDetailsQuery.data?.connection?.metadata ?? null;
+
+    if (isSync) {
+        return (
+            <div className="grid grid-cols-[110px_1fr] gap-x-4">
+                <label className="text-text-primary text-label-large">Metadata</label>
+                <div className="min-w-0 flex flex-col gap-3">
+                    <Alert variant="info" className="px-3 py-2" actionsBelow>
+                        <Info />
+                        <AlertDescription className="text-body-small-regular">
+                            Sync inputs are read from the connection metadata, edited via the Nango API.
+                        </AlertDescription>
+                        <AlertActions>
+                            {playgroundIntegration && playgroundConnection && (
+                                <AlertButtonLink
+                                    to={`/${env}/connections/${playgroundIntegration}/${encodeURIComponent(playgroundConnection)}#auth`}
+                                    variant="info-secondary"
+                                    onClick={() => setPlaygroundOpen(false)}
+                                >
+                                    View metadata
+                                </AlertButtonLink>
+                            )}
+                            <AlertButtonLink
+                                to="https://nango.dev/docs/implementation-guides/use-cases/customer-configuration"
+                                variant="info"
+                                onClick={() => setPlaygroundOpen(false)}
+                            >
+                                Docs <ExternalLink />
+                            </AlertButtonLink>
+                        </AlertActions>
+                    </Alert>
+
+                    {inputFields.length > 0 && playgroundIntegration && playgroundConnection ? (
+                        inputFields.map((field) => {
+                            const rawValue =
+                                connectionMetadata && typeof connectionMetadata === 'object'
+                                    ? (connectionMetadata as Record<string, unknown>)[field.name]
+                                    : undefined;
+                            const isObjectValue = rawValue !== null && rawValue !== undefined && typeof rawValue === 'object';
+                            return (
+                                <div key={field.name} className="flex flex-col gap-1">
+                                    <div className="flex items-center justify-between gap-3">
+                                        <span className="text-text-primary text-body-medium-medium">
+                                            {field.name}
+                                            {field.required && <span className="text-feedback-error-fg text-body-medium-medium">*</span>}
+                                        </span>
+                                        <CatalogBadge variant="light">{field.type}</CatalogBadge>
+                                    </div>
+                                    {isObjectValue ? (
+                                        <CodeBlock
+                                            language="json"
+                                            displayLanguage="JSON"
+                                            icon={<Braces />}
+                                            code={
+                                                JSON.stringify(rawValue, null, 2).length < JSON_DISPLAY_LIMIT
+                                                    ? JSON.stringify(rawValue, null, 2)
+                                                    : 'Value too large to display'
+                                            }
+                                            constrainHeight={false}
+                                        />
+                                    ) : (
+                                        <p className="text-text-tertiary text-body-small-regular">
+                                            {rawValue !== undefined && rawValue !== null ? JSON.stringify(rawValue, null, 2) : '—'}
+                                        </p>
+                                    )}
+                                </div>
+                            );
+                        })
+                    ) : !playgroundIntegration || !playgroundConnection ? (
+                        <div className="text-text-tertiary text-body-small-regular">Select a connection to view its metadata.</div>
+                    ) : (
+                        <div className="text-text-tertiary text-body-small-regular">This sync doesn&apos;t take inputs.</div>
+                    )}
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="grid grid-cols-[110px_1fr] gap-x-4">
+            <label className="text-text-primary text-label-large">Inputs</label>
+            <div className="min-w-0 flex flex-col gap-3">
+                {inputFields.map((field) => (
+                    <div key={field.name} className="flex flex-col gap-1">
+                        <div className="flex items-center justify-between gap-3">
+                            <span className="text-text-primary text-body-medium-medium">
+                                {field.name}
+                                {field.required && <span className="text-feedback-error-fg text-body-medium-medium">*</span>}
+                            </span>
+                            <CatalogBadge variant="light">{field.type}</CatalogBadge>
+                        </div>
+                        {field.description && <p className="text-text-tertiary text-body-small-regular">{field.description}</p>}
+                        <Input
+                            className="border-border-muted data-[filled=true]:not-aria-invalid:border-border-muted"
+                            value={inputValues[field.name] || ''}
+                            aria-invalid={Boolean(inputErrors[field.name])}
+                            placeholder={field.type === 'object' ? '{}' : field.type === 'array' ? '[]' : undefined}
+                            onChange={(e) => {
+                                setPlaygroundInputValue(field.name, e.target.value);
+                                clearInputError(field.name);
+                            }}
+                        />
+                        {inputErrors[field.name] && <p className="text-feedback-error-fg text-body-small-regular">{inputErrors[field.name]}</p>}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};

--- a/packages/webapp/src/components-v2/Playground/PlaygroundResult.tsx
+++ b/packages/webapp/src/components-v2/Playground/PlaygroundResult.tsx
@@ -41,18 +41,35 @@ export const PlaygroundResult: React.FC<Props> = ({ env, isSync }) => {
                 <Separator className="bg-border-muted" />
                 <p className="text-text-primary text-body-small-semi">Results</p>
 
-                <Alert variant={result.state === 'waiting' || result.state === 'running' ? 'info' : result.success ? 'success' : 'error'} className="px-3 py-2">
-                    {result.state === 'waiting' || result.state === 'running' ? <Info /> : result.success ? <CheckCircle2 /> : <XCircle />}
+                <Alert
+                    variant={
+                        result.state === 'waiting' || result.state === 'running' || result.state === 'operation_not_found'
+                            ? 'info'
+                            : result.success
+                              ? 'success'
+                              : 'error'
+                    }
+                    className="px-3 py-2"
+                >
+                    {result.state === 'waiting' || result.state === 'running' || result.state === 'operation_not_found' ? (
+                        <Info />
+                    ) : result.success ? (
+                        <CheckCircle2 />
+                    ) : (
+                        <XCircle />
+                    )}
                     <AlertDescription className="text-body-small-regular">
                         {result.state === 'invalid_input'
                             ? 'Invalid input (see details below)'
-                            : result.state === 'metadata_update_failed'
-                              ? 'Failed to update connection metadata'
-                              : result.state === 'waiting' || result.state === 'running'
-                                ? `Running for ${(result.durationMs / 1000).toFixed(1)}s`
-                                : result.success
-                                  ? `Ran in ${(result.durationMs / 1000).toFixed(1)}s`
-                                  : `Failed after ${(result.durationMs / 1000).toFixed(1)}s`}
+                            : result.state === 'operation_not_found'
+                              ? 'Triggered successfully but could not track the operation'
+                              : result.state === 'metadata_update_failed'
+                                ? 'Failed to update connection metadata'
+                                : result.state === 'waiting' || result.state === 'running'
+                                  ? `Running for ${(result.durationMs / 1000).toFixed(1)}s`
+                                  : result.success
+                                    ? `Ran in ${(result.durationMs / 1000).toFixed(1)}s`
+                                    : `Failed after ${(result.durationMs / 1000).toFixed(1)}s`}
                     </AlertDescription>
                     <AlertActions>
                         {isSync && playgroundIntegration && playgroundConnection && showRecordsButton && (

--- a/packages/webapp/src/components-v2/Playground/PlaygroundResult.tsx
+++ b/packages/webapp/src/components-v2/Playground/PlaygroundResult.tsx
@@ -1,0 +1,91 @@
+import { Braces, CheckCircle2, ExternalLink, Info, XCircle } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { CodeBlock } from '../CodeBlock';
+import { JSON_DISPLAY_LIMIT } from './types';
+import { Alert, AlertActions, AlertButtonLink, AlertDescription } from '../ui/alert';
+import { Separator } from '../ui/separator';
+import { usePlaygroundStore } from '@/store/playground';
+import { getLogsUrl } from '@/utils/logs';
+
+// TODO: set to true once the records list page is ready
+const showRecordsButton = false;
+
+interface Props {
+    env: string;
+    isSync: boolean;
+}
+
+export const PlaygroundResult: React.FC<Props> = ({ env, isSync }) => {
+    const result = usePlaygroundStore((s) => s.result);
+    const playgroundIntegration = usePlaygroundStore((s) => s.integration);
+    const playgroundConnection = usePlaygroundStore((s) => s.connection);
+    const playgroundFunction = usePlaygroundStore((s) => s.function);
+    const setPlaygroundOpen = usePlaygroundStore((s) => s.setOpen);
+
+    const resultJson = useMemo(() => {
+        if (!result) return '';
+        try {
+            const json = JSON.stringify(result.data, null, 2);
+            return json.length >= JSON_DISPLAY_LIMIT ? 'Result too large to display' : json;
+        } catch {
+            return String(result.data);
+        }
+    }, [result]);
+
+    if (!result) return null;
+
+    return (
+        <>
+            <div className="flex flex-col gap-3">
+                <Separator className="bg-border-muted" />
+                <p className="text-text-primary text-body-small-semi">Results</p>
+
+                <Alert variant={result.state === 'waiting' || result.state === 'running' ? 'info' : result.success ? 'success' : 'error'} className="px-3 py-2">
+                    {result.state === 'waiting' || result.state === 'running' ? <Info /> : result.success ? <CheckCircle2 /> : <XCircle />}
+                    <AlertDescription className="text-body-small-regular">
+                        {result.state === 'invalid_input'
+                            ? 'Invalid input (see details below)'
+                            : result.state === 'metadata_update_failed'
+                              ? 'Failed to update connection metadata'
+                              : result.state === 'waiting' || result.state === 'running'
+                                ? `Running for ${(result.durationMs / 1000).toFixed(1)}s`
+                                : result.success
+                                  ? `Ran in ${(result.durationMs / 1000).toFixed(1)}s`
+                                  : `Failed after ${(result.durationMs / 1000).toFixed(1)}s`}
+                    </AlertDescription>
+                    <AlertActions>
+                        {isSync && playgroundIntegration && playgroundConnection && showRecordsButton && (
+                            <AlertButtonLink
+                                to={`/${env}/connections/${playgroundIntegration}/${encodeURIComponent(playgroundConnection)}`}
+                                variant={result.success ? 'success-secondary' : 'error-secondary'}
+                                onClick={() => setPlaygroundOpen(false)}
+                            >
+                                Records
+                            </AlertButtonLink>
+                        )}
+                        {playgroundIntegration && playgroundConnection && playgroundFunction && (
+                            <AlertButtonLink
+                                to={getLogsUrl({
+                                    env,
+                                    ...(result.operationId ? { operationId: result.operationId } : {}),
+                                    integrations: playgroundIntegration,
+                                    connections: playgroundConnection,
+                                    syncs: isSync ? playgroundFunction : undefined,
+                                    live: true
+                                })}
+                                variant={result.success ? 'success' : 'error'}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Logs <ExternalLink />
+                            </AlertButtonLink>
+                        )}
+                    </AlertActions>
+                </Alert>
+
+                <CodeBlock language="json" displayLanguage="JSON" icon={<Braces />} code={resultJson} constrainHeight={false} />
+            </div>
+        </>
+    );
+};

--- a/packages/webapp/src/components-v2/Playground/PlaygroundSelectors.tsx
+++ b/packages/webapp/src/components-v2/Playground/PlaygroundSelectors.tsx
@@ -1,0 +1,227 @@
+import { ExternalLink, Plus } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useDebounce } from 'react-use';
+
+import { IntegrationLogo } from '../IntegrationLogo';
+import { Badge } from '../ui/badge';
+import { Button } from '../ui/button';
+import { Combobox } from '../ui/combobox';
+import { useConnections } from '@/hooks/useConnections';
+import { useGetIntegrationFlows, useListIntegrations } from '@/hooks/useIntegration';
+import { usePlaygroundStore } from '@/store/playground';
+
+import type { ComboboxOption } from '../ui/combobox';
+import type { NangoSyncConfig } from '@nangohq/types';
+
+interface Props {
+    env: string;
+    queryEnv: string;
+}
+
+export const PlaygroundSelectors: React.FC<Props> = ({ env, queryEnv }) => {
+    const navigate = useNavigate();
+
+    const playgroundIntegration = usePlaygroundStore((s) => s.integration);
+    const playgroundConnection = usePlaygroundStore((s) => s.connection);
+    const playgroundFunction = usePlaygroundStore((s) => s.function);
+    const connectionSearch = usePlaygroundStore((s) => s.connectionSearch);
+    const setPlaygroundOpen = usePlaygroundStore((s) => s.setOpen);
+    const setPlaygroundIntegration = usePlaygroundStore((s) => s.setIntegration);
+    const setPlaygroundConnection = usePlaygroundStore((s) => s.setConnection);
+    const setPlaygroundFunction = usePlaygroundStore((s) => s.setFunction);
+    const setPlaygroundResult = usePlaygroundStore((s) => s.setResult);
+    const setPlaygroundInputErrors = usePlaygroundStore((s) => s.setInputErrors);
+    const setPlaygroundConnectionSearch = usePlaygroundStore((s) => s.setConnectionSearch);
+    const setPlaygroundPendingOperationId = usePlaygroundStore((s) => s.setPendingOperationId);
+    const setPlaygroundRunning = usePlaygroundStore((s) => s.setRunning);
+
+    const [debouncedConnectionSearch, setDebouncedConnectionSearch] = useState('');
+    useDebounce(() => setDebouncedConnectionSearch(connectionSearch || ''), 250, [connectionSearch]);
+
+    const { data: integrations } = useListIntegrations(queryEnv);
+    const { data: flowsData } = useGetIntegrationFlows(queryEnv, playgroundIntegration || '');
+    const connectionsQueryEnv = queryEnv && playgroundIntegration ? queryEnv : '';
+    const connectionsQuery = useConnections({
+        env: connectionsQueryEnv,
+        integrationIds: playgroundIntegration ? [playgroundIntegration] : undefined,
+        search: debouncedConnectionSearch || undefined
+    });
+
+    const connections = useMemo(() => {
+        return connectionsQuery.data?.pages.flatMap((p) => p.data) ?? [];
+    }, [connectionsQuery.data]);
+
+    const connectionOptions = useMemo(() => {
+        const opts = connections.map((c) => ({ value: c.connection_id, label: c.connection_id, filterValue: c.connection_id }));
+        if (playgroundConnection && !opts.some((o) => o.value === playgroundConnection)) {
+            opts.unshift({ value: playgroundConnection, label: playgroundConnection, filterValue: playgroundConnection });
+        }
+        return opts;
+    }, [connections, playgroundConnection]);
+
+    const allFlows: (NangoSyncConfig & { resolvedType: 'action' | 'sync' })[] = useMemo(() => {
+        if (!flowsData) return [];
+        return flowsData.data.flows.filter((f) => f.type === 'action' || f.type === 'sync').map((f) => ({ ...f, resolvedType: f.type as 'action' | 'sync' }));
+    }, [flowsData]);
+
+    const functionOptions = useMemo(() => {
+        const opts: ComboboxOption[] = allFlows
+            .filter((f) => f.enabled === true)
+            .map((f) => ({
+                value: f.name,
+                label: f.name,
+                filterValue: `${f.name} ${f.resolvedType}`,
+                tag: (
+                    <Badge variant="gray" size="xs" className="capitalize font-mono">
+                        {f.resolvedType}
+                    </Badge>
+                )
+            }));
+        if (playgroundFunction && !opts.some((o) => o.value === playgroundFunction)) {
+            opts.unshift({ value: playgroundFunction, label: playgroundFunction, filterValue: playgroundFunction });
+        }
+        return opts;
+    }, [allFlows, playgroundFunction]);
+
+    const integrationOptions = useMemo(() => {
+        const list = integrations?.data ?? [];
+        const opts: ComboboxOption[] = list.map((i) => ({
+            value: i.unique_key,
+            label: i.display_name || i.unique_key,
+            filterValue: `${i.display_name ?? ''} ${i.unique_key ?? ''} ${i.provider ?? ''}`,
+            icon: <IntegrationLogo provider={i.provider} className="size-7 rounded-[3.7px] p-[3.48px] bg-transparent border-transparent" />
+        }));
+        if (playgroundIntegration && !opts.some((o) => o.value === playgroundIntegration)) {
+            opts.unshift({ value: playgroundIntegration, label: playgroundIntegration, filterValue: playgroundIntegration });
+        }
+        return opts;
+    }, [integrations, playgroundIntegration]);
+
+    const handleIntegrationChange = useCallback(
+        (val: string) => {
+            setPlaygroundIntegration(val);
+            setPlaygroundInputErrors({});
+            setPlaygroundResult(null);
+            setPlaygroundPendingOperationId(null);
+            setPlaygroundRunning(false);
+        },
+        [setPlaygroundIntegration, setPlaygroundInputErrors, setPlaygroundResult, setPlaygroundPendingOperationId, setPlaygroundRunning]
+    );
+
+    const handleConnectionChange = useCallback(
+        (val: string) => {
+            setPlaygroundConnection(val);
+            setPlaygroundResult(null);
+            setPlaygroundPendingOperationId(null);
+            setPlaygroundRunning(false);
+        },
+        [setPlaygroundConnection, setPlaygroundResult, setPlaygroundPendingOperationId, setPlaygroundRunning]
+    );
+
+    const handleFunctionChange = useCallback(
+        (val: string) => {
+            const flow = allFlows.find((f) => f.name === val);
+            if (flow) setPlaygroundFunction(val, flow.resolvedType);
+            setPlaygroundInputErrors({});
+            setPlaygroundResult(null);
+            setPlaygroundPendingOperationId(null);
+            setPlaygroundRunning(false);
+        },
+        [allFlows, setPlaygroundFunction, setPlaygroundInputErrors, setPlaygroundResult, setPlaygroundPendingOperationId, setPlaygroundRunning]
+    );
+
+    return (
+        <div className="grid grid-cols-[110px_1fr] items-center gap-x-4 gap-y-6">
+            <label className="text-text-primary text-label-large">Integration</label>
+            <Combobox
+                value={playgroundIntegration || ''}
+                onValueChange={handleIntegrationChange}
+                placeholder="Pick integration"
+                options={integrationOptions}
+                searchPlaceholder="Search integrations"
+                showCheckbox={false}
+                emptyText="No integrations found"
+                footer={
+                    <div className="flex items-center justify-between gap-3">
+                        <span className="flex items-center justify-center gap-2 text-text-tertiary text-body-small-regular">Need a new integration?</span>
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            size="sm"
+                            className="h-auto rounded-full bg-btn-secondary-bg px-2 py-1 text-body-small-regular gap-0.5 justify-center items-center text-text-primary"
+                            onClick={() => {
+                                setPlaygroundOpen(false);
+                                navigate(`/${env}/integrations/create`);
+                            }}
+                        >
+                            <Plus /> Add
+                        </Button>
+                    </div>
+                }
+            />
+
+            <label className="text-text-primary text-label-large">Connection</label>
+            <Combobox
+                value={playgroundConnection || ''}
+                onValueChange={handleConnectionChange}
+                placeholder="Select connection"
+                disabled={!playgroundIntegration}
+                options={connectionOptions}
+                searchPlaceholder="Search connections"
+                searchValue={connectionSearch}
+                onSearchValueChange={setPlaygroundConnectionSearch}
+                showCheckbox={false}
+                emptyText="No connections found"
+                footer={
+                    <div className="flex items-center justify-between gap-3">
+                        <span className="flex items-center justify-center gap-2 text-text-tertiary text-body-small-regular">Need a new connection?</span>
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            size="sm"
+                            className="h-auto rounded-full bg-btn-secondary-bg px-2 py-1 text-body-small-regular gap-0.5 justify-center items-center text-text-primary"
+                            onClick={() => {
+                                setPlaygroundOpen(false);
+                                navigate(`/${env}/connections/create${playgroundIntegration ? `?integration_id=${playgroundIntegration}` : ''}`);
+                            }}
+                        >
+                            <Plus /> Add
+                        </Button>
+                    </div>
+                }
+            />
+
+            <label className="text-text-primary text-label-large">Function</label>
+            <Combobox
+                value={playgroundFunction || ''}
+                onValueChange={handleFunctionChange}
+                placeholder="Select function"
+                disabled={!playgroundIntegration}
+                options={functionOptions}
+                searchPlaceholder="Search functions"
+                showCheckbox={false}
+                emptyText="No functions found"
+                footer={
+                    playgroundIntegration ? (
+                        <div className="flex items-center justify-between gap-3">
+                            <span className="flex items-center justify-center gap-2 text-text-tertiary text-body-small-regular">Activate more functions</span>
+                            <Button
+                                type="button"
+                                variant="secondary"
+                                size="sm"
+                                className="h-auto rounded-full bg-btn-secondary-bg px-2 py-1 text-body-small-regular gap-0.5 justify-center items-center text-text-primary"
+                                onClick={() => {
+                                    setPlaygroundOpen(false);
+                                    navigate(`/${env}/integrations/${playgroundIntegration}`);
+                                }}
+                            >
+                                Activate <ExternalLink />
+                            </Button>
+                        </div>
+                    ) : undefined
+                }
+            />
+        </div>
+    );
+};

--- a/packages/webapp/src/components-v2/Playground/PlaygroundSelectors.tsx
+++ b/packages/webapp/src/components-v2/Playground/PlaygroundSelectors.tsx
@@ -35,6 +35,7 @@ export const PlaygroundSelectors: React.FC<Props> = ({ env, queryEnv }) => {
     const setPlaygroundConnectionSearch = usePlaygroundStore((s) => s.setConnectionSearch);
     const setPlaygroundPendingOperationId = usePlaygroundStore((s) => s.setPendingOperationId);
     const setPlaygroundRunning = usePlaygroundStore((s) => s.setRunning);
+    const running = usePlaygroundStore((s) => s.running);
 
     const [debouncedConnectionSearch, setDebouncedConnectionSearch] = useState('');
     useDebounce(() => setDebouncedConnectionSearch(connectionSearch || ''), 250, [connectionSearch]);
@@ -138,6 +139,7 @@ export const PlaygroundSelectors: React.FC<Props> = ({ env, queryEnv }) => {
                 value={playgroundIntegration || ''}
                 onValueChange={handleIntegrationChange}
                 placeholder="Pick integration"
+                disabled={running}
                 options={integrationOptions}
                 searchPlaceholder="Search integrations"
                 showCheckbox={false}
@@ -166,7 +168,7 @@ export const PlaygroundSelectors: React.FC<Props> = ({ env, queryEnv }) => {
                 value={playgroundConnection || ''}
                 onValueChange={handleConnectionChange}
                 placeholder="Select connection"
-                disabled={!playgroundIntegration}
+                disabled={running || !playgroundIntegration}
                 options={connectionOptions}
                 searchPlaceholder="Search connections"
                 searchValue={connectionSearch}
@@ -197,7 +199,7 @@ export const PlaygroundSelectors: React.FC<Props> = ({ env, queryEnv }) => {
                 value={playgroundFunction || ''}
                 onValueChange={handleFunctionChange}
                 placeholder="Select function"
-                disabled={!playgroundIntegration}
+                disabled={running || !playgroundIntegration}
                 options={functionOptions}
                 searchPlaceholder="Search functions"
                 showCheckbox={false}

--- a/packages/webapp/src/components-v2/Playground/index.tsx
+++ b/packages/webapp/src/components-v2/Playground/index.tsx
@@ -76,7 +76,7 @@ export const Playground: React.FC = () => {
     const { data: envData } = useEnvironment(env);
     const environment = envData?.environmentAndAccount?.environment;
     const { can } = usePermissions();
-    const canUsePlayground = can(permissions.canUseProdPlayground) || !environment?.is_production;
+    const canUsePlayground = envData != null && (can(permissions.canUseProdPlayground) || !environment?.is_production);
 
     const clearInputError = useCallback((name: string) => clearPlaygroundInputError(name), [clearPlaygroundInputError]);
 
@@ -156,7 +156,7 @@ export const Playground: React.FC = () => {
                                             )}
                                         </>
                                     ) : result ? (
-                                        <PermissionGate condition={canUsePlayground}>
+                                        <PermissionGate condition={canUsePlayground} message="Your role does not have permission to use the playground.">
                                             {(allowed) => (
                                                 <Button variant="primary" size="sm" onClick={handleRun} disabled={!canRun || !allowed}>
                                                     <RotateCcw />
@@ -165,7 +165,7 @@ export const Playground: React.FC = () => {
                                             )}
                                         </PermissionGate>
                                     ) : (
-                                        <PermissionGate condition={canUsePlayground}>
+                                        <PermissionGate condition={canUsePlayground} message="Your role does not have permission to use the playground.">
                                             {(allowed) => (
                                                 <Button variant="primary" size="sm" onClick={handleRun} disabled={!canRun || !allowed}>
                                                     <Play />

--- a/packages/webapp/src/components-v2/Playground/index.tsx
+++ b/packages/webapp/src/components-v2/Playground/index.tsx
@@ -2,15 +2,19 @@ import { Play, RotateCcw, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
+import { permissions } from '@nangohq/authz';
+
 import { PlaygroundInputs } from './PlaygroundInputs';
 import { PlaygroundResult } from './PlaygroundResult';
 import { PlaygroundSelectors } from './PlaygroundSelectors';
 import { getInputFields } from './types';
-import { usePlaygroundReattach } from './usePlaygroundReattach';
-import { usePlaygroundRun } from './usePlaygroundRun';
+import { usePlayground } from './usePlayground';
+import { PermissionGate } from '../PermissionGate';
 import { Button } from '../ui/button';
 import { Sheet, SheetContent } from '../ui/sheet';
+import { useEnvironment } from '@/hooks/useEnvironment';
 import { useGetIntegrationFlows } from '@/hooks/useIntegration';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useStore } from '@/store';
 import { usePlaygroundStore } from '@/store/playground';
 import { cn } from '@/utils/utils';
@@ -67,8 +71,12 @@ export const Playground: React.FC = () => {
 
     const inputFields = useMemo(() => getInputFields(inputSchema), [inputSchema]);
 
-    const { handleRun, handleCancel } = usePlaygroundRun(inputFields);
-    usePlaygroundReattach();
+    const { handleRun, handleCancel } = usePlayground(inputFields);
+
+    const { data: envData } = useEnvironment(env);
+    const environment = envData?.environmentAndAccount?.environment;
+    const { can } = usePermissions();
+    const canUsePlayground = can(permissions.canUseProdPlayground) || !environment?.is_production;
 
     const clearInputError = useCallback((name: string) => clearPlaygroundInputError(name), [clearPlaygroundInputError]);
 
@@ -148,15 +156,23 @@ export const Playground: React.FC = () => {
                                             )}
                                         </>
                                     ) : result ? (
-                                        <Button variant="primary" size="sm" onClick={handleRun} disabled={!canRun}>
-                                            <RotateCcw />
-                                            Run again
-                                        </Button>
+                                        <PermissionGate condition={canUsePlayground}>
+                                            {(allowed) => (
+                                                <Button variant="primary" size="sm" onClick={handleRun} disabled={!canRun || !allowed}>
+                                                    <RotateCcw />
+                                                    Run again
+                                                </Button>
+                                            )}
+                                        </PermissionGate>
                                     ) : (
-                                        <Button variant="primary" size="sm" onClick={handleRun} disabled={!canRun}>
-                                            <Play />
-                                            Run
-                                        </Button>
+                                        <PermissionGate condition={canUsePlayground}>
+                                            {(allowed) => (
+                                                <Button variant="primary" size="sm" onClick={handleRun} disabled={!canRun || !allowed}>
+                                                    <Play />
+                                                    Run
+                                                </Button>
+                                            )}
+                                        </PermissionGate>
                                     )}
                                 </div>
                             </div>

--- a/packages/webapp/src/components-v2/Playground/index.tsx
+++ b/packages/webapp/src/components-v2/Playground/index.tsx
@@ -1,0 +1,170 @@
+import { Play, RotateCcw, X } from 'lucide-react';
+import { useCallback, useEffect, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { PlaygroundInputs } from './PlaygroundInputs';
+import { PlaygroundResult } from './PlaygroundResult';
+import { PlaygroundSelectors } from './PlaygroundSelectors';
+import { getInputFields } from './types';
+import { usePlaygroundReattach } from './usePlaygroundReattach';
+import { usePlaygroundRun } from './usePlaygroundRun';
+import { Button } from '../ui/button';
+import { Sheet, SheetContent } from '../ui/sheet';
+import { useGetIntegrationFlows } from '@/hooks/useIntegration';
+import { useStore } from '@/store';
+import { usePlaygroundStore } from '@/store/playground';
+import { cn } from '@/utils/utils';
+
+import type { NangoSyncConfig } from '@nangohq/types';
+import type { JSONSchema7 } from 'json-schema';
+
+export const Playground: React.FC = () => {
+    const env = useStore((s) => s.env);
+    const playgroundOpen = usePlaygroundStore((s) => s.isOpen);
+    const playgroundIntegration = usePlaygroundStore((s) => s.integration);
+    const playgroundFunctionName = usePlaygroundStore((s) => s.function);
+    const playgroundFunctionType = usePlaygroundStore((s) => s.functionType);
+    const result = usePlaygroundStore((s) => s.result);
+    const running = usePlaygroundStore((s) => s.running);
+    const inputErrors = usePlaygroundStore((s) => s.inputErrors);
+    const setPlaygroundOpen = usePlaygroundStore((s) => s.setOpen);
+    const clearPlaygroundInputError = usePlaygroundStore((s) => s.clearInputError);
+
+    const location = useLocation();
+
+    useEffect(() => {
+        // Auto-close the sheet when the route changes
+        if (playgroundOpen) {
+            setPlaygroundOpen(false);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [location.pathname]);
+
+    const queryEnv = playgroundOpen ? env : '';
+
+    const { data: flowsData } = useGetIntegrationFlows(queryEnv, playgroundIntegration || '');
+
+    const allFlows: (NangoSyncConfig & { resolvedType: 'action' | 'sync' })[] = useMemo(() => {
+        if (!flowsData) return [];
+        return flowsData.data.flows.filter((f) => f.type === 'action' || f.type === 'sync').map((f) => ({ ...f, resolvedType: f.type as 'action' | 'sync' }));
+    }, [flowsData]);
+
+    const playgroundFunction = useMemo(() => {
+        if (!playgroundFunctionName) return undefined;
+        return allFlows.find((f) => f.name === playgroundFunctionName);
+    }, [allFlows, playgroundFunctionName]);
+
+    const inputSchema = useMemo((): JSONSchema7 | null => {
+        if (!playgroundFunction || !playgroundFunction.json_schema || typeof playgroundFunction.json_schema !== 'object') return null;
+        const defKey = playgroundFunction.input;
+        const schema =
+            (defKey ? (playgroundFunction.json_schema.definitions?.[defKey] as JSONSchema7 | undefined) : undefined) || playgroundFunction.json_schema;
+        if (!schema || typeof schema !== 'object') return null;
+        const props = schema.properties;
+        if (!props || Object.keys(props).length === 0) return null;
+        return schema;
+    }, [playgroundFunction]);
+
+    const inputFields = useMemo(() => getInputFields(inputSchema), [inputSchema]);
+
+    const { handleRun, handleCancel } = usePlaygroundRun(inputFields);
+    usePlaygroundReattach();
+
+    const clearInputError = useCallback((name: string) => clearPlaygroundInputError(name), [clearPlaygroundInputError]);
+
+    const playgroundConnection = usePlaygroundStore((s) => s.connection);
+    const canRun = Boolean(playgroundIntegration && playgroundConnection && playgroundFunctionName && playgroundFunctionType);
+    const isSync = playgroundFunctionType === 'sync';
+    const showInputs = Boolean(playgroundFunction && (isSync || inputFields.length > 0));
+
+    return (
+        <>
+            {/* Custom overlay — click to close, pointer-events-none so it never blocks the page */}
+            <div
+                className={cn(
+                    'fixed inset-0 z-50 bg-black/30 transition-opacity duration-300 ease-in-out',
+                    playgroundOpen ? 'opacity-100' : 'opacity-0 pointer-events-none invisible'
+                )}
+                onClick={() => setPlaygroundOpen(false)}
+            />
+            <Sheet open={playgroundOpen} onOpenChange={setPlaygroundOpen} modal={false}>
+                <SheetContent
+                    side="right"
+                    overlayClassName="hidden"
+                    insetTop={88}
+                    insetBottom={24}
+                    insetRight={24}
+                    onInteractOutside={(e) => e.preventDefault()}
+                    onPointerDownOutside={(e) => e.preventDefault()}
+                    onFocusOutside={(e) => e.preventDefault()}
+                    className={cn(
+                        'text-text-primary rounded-lg border border-border-muted shadow-lg p-6',
+                        'flex flex-col items-start gap-2.5',
+                        'w-[537px] max-w-none sm:max-w-none',
+                        'data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0',
+                        '[&>button]:hidden'
+                    )}
+                >
+                    <div className="flex flex-col gap-4">
+                        <div className="flex flex-col gap-8">
+                            {/* Header */}
+                            <div className="flex w-full items-start justify-between">
+                                <div className="min-w-0 flex flex-col gap-2">
+                                    <h2 className="text-text-primary text-heading-medium">Playground</h2>
+                                    <p className="text-body-medium-regular text-text-secondary">Quickly run any function.</p>
+                                </div>
+                                <Button variant="ghost" size="icon" onClick={() => setPlaygroundOpen(false)} aria-label="Close playground">
+                                    <X />
+                                </Button>
+                            </div>
+
+                            {/* Content */}
+                            <div className="flex w-full flex-col gap-6">
+                                <PlaygroundSelectors env={env} queryEnv={queryEnv} />
+
+                                {showInputs && (
+                                    <PlaygroundInputs
+                                        env={env}
+                                        queryEnv={queryEnv}
+                                        isSync={isSync}
+                                        inputFields={inputFields}
+                                        inputErrors={inputErrors}
+                                        clearInputError={clearInputError}
+                                    />
+                                )}
+
+                                {/* Run controls */}
+                                <div className="flex gap-2">
+                                    {running ? (
+                                        <>
+                                            <Button variant="primary" disabled loading={true} size="sm">
+                                                Running
+                                            </Button>
+                                            {isSync && (
+                                                <Button variant="destructive" size="sm" onClick={handleCancel}>
+                                                    <X />
+                                                    Cancel run
+                                                </Button>
+                                            )}
+                                        </>
+                                    ) : result ? (
+                                        <Button variant="primary" size="sm" onClick={handleRun} disabled={!canRun}>
+                                            <RotateCcw />
+                                            Run again
+                                        </Button>
+                                    ) : (
+                                        <Button variant="primary" size="sm" onClick={handleRun} disabled={!canRun}>
+                                            <Play />
+                                            Run
+                                        </Button>
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                        <PlaygroundResult env={env} isSync={isSync} />
+                    </div>
+                </SheetContent>
+            </Sheet>
+        </>
+    );
+};

--- a/packages/webapp/src/components-v2/Playground/playground.utils.ts
+++ b/packages/webapp/src/components-v2/Playground/playground.utils.ts
@@ -1,0 +1,220 @@
+import { apiFetch } from '@/utils/api';
+
+import type { InputField } from './types';
+import type { GetOperation, SearchOperations } from '@nangohq/types';
+
+// --- Input validation ---
+
+function validateConstraints(field: InputField, value: unknown): string | null {
+    if (field.enum !== undefined) {
+        if (!field.enum.includes(value)) {
+            return `Must be one of: ${field.enum.map(String).join(', ')}`;
+        }
+        return null;
+    }
+    if (field.type === 'string' && typeof value === 'string') {
+        if (field.minLength != null && value.length < field.minLength) {
+            return `Must be at least ${field.minLength} character${field.minLength === 1 ? '' : 's'}`;
+        }
+        if (field.maxLength != null && value.length > field.maxLength) {
+            return `Must be at most ${field.maxLength} character${field.maxLength === 1 ? '' : 's'}`;
+        }
+        if (field.pattern != null && !new RegExp(field.pattern).test(value)) {
+            return `Must match pattern: ${field.pattern}`;
+        }
+    }
+    if ((field.type === 'number' || field.type === 'integer') && typeof value === 'number') {
+        if (field.minimum != null && value < field.minimum) return `Must be ≥ ${field.minimum}`;
+        if (field.maximum != null && value > field.maximum) return `Must be ≤ ${field.maximum}`;
+        if (field.exclusiveMinimum != null && value <= field.exclusiveMinimum) return `Must be > ${field.exclusiveMinimum}`;
+        if (field.exclusiveMaximum != null && value >= field.exclusiveMaximum) return `Must be < ${field.exclusiveMaximum}`;
+    }
+    return null;
+}
+
+export type ParseResult = { ok: true; parsed: Record<string, unknown> } | { ok: false; errors: Record<string, string> };
+
+export function validateAndParseInputs(inputFields: InputField[], inputValues: Record<string, string>): ParseResult {
+    const parsedInput: Record<string, unknown> = {};
+    const errors: Record<string, string> = {};
+
+    for (const field of inputFields) {
+        const raw = inputValues[field.name] ?? '';
+        const trimmed = raw.trim();
+
+        if (!trimmed) {
+            if (field.required) {
+                errors[field.name] = 'Required';
+            }
+            continue;
+        }
+
+        let parsed: unknown;
+        try {
+            switch (field.type) {
+                case 'number': {
+                    const n = Number(trimmed);
+                    if (!Number.isFinite(n)) throw new Error('Expected a number');
+                    parsed = n;
+                    break;
+                }
+                case 'integer': {
+                    const n = Number(trimmed);
+                    if (!Number.isFinite(n) || !Number.isInteger(n)) throw new Error('Expected an integer');
+                    parsed = n;
+                    break;
+                }
+                case 'boolean': {
+                    const v = trimmed.toLowerCase();
+                    if (v !== 'true' && v !== 'false') throw new Error('Expected true or false');
+                    parsed = v === 'true';
+                    break;
+                }
+                case 'object': {
+                    const p = JSON.parse(trimmed);
+                    if (!p || typeof p !== 'object' || Array.isArray(p)) throw new Error('Expected a JSON object');
+                    parsed = p;
+                    break;
+                }
+                case 'array': {
+                    const p = JSON.parse(trimmed);
+                    if (!Array.isArray(p)) throw new Error('Expected a JSON array');
+                    parsed = p;
+                    break;
+                }
+                default:
+                    parsed = raw;
+            }
+        } catch (err) {
+            errors[field.name] = err instanceof Error ? err.message : 'Invalid value';
+            continue;
+        }
+
+        const constraintError = validateConstraints(field, parsed);
+        if (constraintError) {
+            errors[field.name] = constraintError;
+            continue;
+        }
+
+        parsedInput[field.name] = parsed;
+    }
+
+    if (Object.keys(errors).length > 0) {
+        return { ok: false, errors };
+    }
+    return { ok: true, parsed: parsedInput };
+}
+
+// --- Operation fetching ---
+
+export async function fetchOperation(operationId: string, env: string, signal?: AbortSignal): Promise<GetOperation['Success']['data'] | null> {
+    const res = await apiFetch(`/api/v1/logs/operations/${encodeURIComponent(operationId)}?env=${env}`, {
+        method: 'GET',
+        signal
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as GetOperation['Success'];
+    return json.data;
+}
+
+export interface FindOperationParams {
+    env: string;
+    triggerStartTime: number;
+    functionType: 'action' | 'sync';
+    integration: string;
+    connection: string;
+    functionName: string;
+}
+
+export async function findOperation(params: FindOperationParams, signal: AbortSignal): Promise<SearchOperations['Success']['data'][number] | null> {
+    const { env, triggerStartTime, functionType, integration, connection, functionName } = params;
+    const from = new Date(triggerStartTime - 60_000).toISOString();
+    const to = new Date().toISOString();
+
+    const body: SearchOperations['Body'] = {
+        limit: 25,
+        types: [functionType === 'sync' ? 'sync:run' : 'action'],
+        integrations: [integration],
+        connections: [connection],
+        syncs: functionType === 'sync' ? [functionName] : ['all'],
+        period: { from, to }
+    };
+
+    const res = await apiFetch(`/api/v1/logs/operations?env=${env}`, {
+        method: 'POST',
+        body: JSON.stringify(body),
+        signal
+    });
+
+    if (!res.ok) return null;
+
+    const json = (await res.json()) as SearchOperations['Success'];
+    if (!json.data || json.data.length === 0) return null;
+
+    const windowStart = triggerStartTime - 15_000;
+    const candidates = json.data
+        .map((op) => ({ op, ts: new Date(op.createdAt).getTime() }))
+        .filter(({ ts, op }) => {
+            if (Number.isNaN(ts) || ts < windowStart) return false;
+            if (functionType === 'sync' && op.syncConfigName && op.syncConfigName !== functionName) return false;
+            return true;
+        })
+        .sort((a, b) => b.ts - a.ts);
+
+    return candidates[0]?.op ?? null;
+}
+
+// --- Result building ---
+
+interface OperationLike {
+    meta?: unknown;
+    request?: unknown;
+    response?: unknown;
+    error?: { message: string; payload?: unknown };
+}
+
+export function buildResultData(op: OperationLike | null | undefined): unknown {
+    if (!op) return null;
+    if (!op.meta && !op.request && !op.response && !op.error) return null;
+
+    const pl: Record<string, unknown> = op.meta && typeof op.meta === 'object' ? { ...(op.meta as Record<string, unknown>) } : {};
+    if (op.request) pl.request = op.request;
+    if (op.response) pl.response = op.response;
+    if (op.error) {
+        pl.error = { message: op.error.message, ...(op.error.payload ? { payload: op.error.payload } : {}) };
+    }
+    return pl;
+}
+
+export function computeDurationMs(
+    op: { durationMs?: number | null; startedAt?: string | null; endedAt?: string | null } | null | undefined,
+    fallbackMs?: number
+): number {
+    if (!op) return fallbackMs ?? 0;
+    if (op.durationMs != null && !Number.isNaN(op.durationMs)) return op.durationMs;
+    if (op.startedAt && op.endedAt) {
+        const d = new Date(op.endedAt).getTime() - new Date(op.startedAt).getTime();
+        if (!Number.isNaN(d)) return d;
+    }
+    return fallbackMs ?? 0;
+}
+
+// --- Sleep utility ---
+
+export function sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        const onAbort = () => {
+            clearTimeout(t);
+            reject(new DOMException('Aborted', 'AbortError'));
+        };
+        const t = setTimeout(() => {
+            signal.removeEventListener('abort', onAbort);
+            resolve();
+        }, ms);
+        if (signal.aborted) {
+            onAbort();
+            return;
+        }
+        signal.addEventListener('abort', onAbort);
+    });
+}

--- a/packages/webapp/src/components-v2/Playground/playground.utils.ts
+++ b/packages/webapp/src/components-v2/Playground/playground.utils.ts
@@ -19,8 +19,14 @@ function validateConstraints(field: InputField, value: unknown): string | null {
         if (field.maxLength != null && value.length > field.maxLength) {
             return `Must be at most ${field.maxLength} character${field.maxLength === 1 ? '' : 's'}`;
         }
-        if (field.pattern != null && !new RegExp(field.pattern).test(value)) {
-            return `Must match pattern: ${field.pattern}`;
+        if (field.pattern != null) {
+            try {
+                if (!new RegExp(field.pattern).test(value)) {
+                    return `Must match pattern: ${field.pattern}`;
+                }
+            } catch {
+                // Invalid regex pattern in schema — skip constraint
+            }
         }
     }
     if ((field.type === 'number' || field.type === 'integer') && typeof value === 'number') {

--- a/packages/webapp/src/components-v2/Playground/playground.utils.unit.test.ts
+++ b/packages/webapp/src/components-v2/Playground/playground.utils.unit.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/api', () => ({ apiFetch: vi.fn() }));
+
+import { buildResultData, computeDurationMs, sleepWithAbort, validateAndParseInputs } from './playground.utils';
+
+import type { InputField } from './types';
+
+function field(overrides: Partial<InputField> & { name: string }): InputField {
+    return { type: 'string', required: false, ...overrides };
+}
+
+describe('validateAndParseInputs', () => {
+    it('parses string fields as-is (preserving raw value)', () => {
+        const result = validateAndParseInputs([field({ name: 'foo' })], { foo: 'hello' });
+        expect(result).toEqual({ ok: true, parsed: { foo: 'hello' } });
+    });
+
+    it('returns error for required empty field', () => {
+        const result = validateAndParseInputs([field({ name: 'foo', required: true })], { foo: '' });
+        expect(result).toEqual({ ok: false, errors: { foo: 'Required' } });
+    });
+
+    it('skips optional empty fields', () => {
+        const result = validateAndParseInputs([field({ name: 'foo', required: false })], { foo: '' });
+        expect(result).toEqual({ ok: true, parsed: {} });
+    });
+
+    it('parses number type', () => {
+        const result = validateAndParseInputs([field({ name: 'n', type: 'number' })], { n: '3.14' });
+        expect(result).toEqual({ ok: true, parsed: { n: 3.14 } });
+    });
+
+    it('rejects invalid number', () => {
+        const result = validateAndParseInputs([field({ name: 'n', type: 'number' })], { n: 'abc' });
+        expect(result).toEqual({ ok: false, errors: { n: 'Expected a number' } });
+    });
+
+    it('parses integer type', () => {
+        const result = validateAndParseInputs([field({ name: 'n', type: 'integer' })], { n: '42' });
+        expect(result).toEqual({ ok: true, parsed: { n: 42 } });
+    });
+
+    it('rejects non-integer for integer type', () => {
+        const result = validateAndParseInputs([field({ name: 'n', type: 'integer' })], { n: '3.5' });
+        expect(result).toEqual({ ok: false, errors: { n: 'Expected an integer' } });
+    });
+
+    it('parses boolean true/false', () => {
+        const r1 = validateAndParseInputs([field({ name: 'b', type: 'boolean' })], { b: 'true' });
+        expect(r1).toEqual({ ok: true, parsed: { b: true } });
+        const r2 = validateAndParseInputs([field({ name: 'b', type: 'boolean' })], { b: 'False' });
+        expect(r2).toEqual({ ok: true, parsed: { b: false } });
+    });
+
+    it('rejects invalid boolean', () => {
+        const result = validateAndParseInputs([field({ name: 'b', type: 'boolean' })], { b: 'yes' });
+        expect(result).toEqual({ ok: false, errors: { b: 'Expected true or false' } });
+    });
+
+    it('parses object type from JSON', () => {
+        const result = validateAndParseInputs([field({ name: 'o', type: 'object' })], { o: '{"a":1}' });
+        expect(result).toEqual({ ok: true, parsed: { o: { a: 1 } } });
+    });
+
+    it('rejects array for object type', () => {
+        const result = validateAndParseInputs([field({ name: 'o', type: 'object' })], { o: '[1]' });
+        expect(result).toEqual({ ok: false, errors: { o: 'Expected a JSON object' } });
+    });
+
+    it('parses array type from JSON', () => {
+        const result = validateAndParseInputs([field({ name: 'a', type: 'array' })], { a: '[1,2]' });
+        expect(result).toEqual({ ok: true, parsed: { a: [1, 2] } });
+    });
+
+    it('rejects object for array type', () => {
+        const result = validateAndParseInputs([field({ name: 'a', type: 'array' })], { a: '{"a":1}' });
+        expect(result).toEqual({ ok: false, errors: { a: 'Expected a JSON array' } });
+    });
+
+    describe('constraints', () => {
+        it('validates enum', () => {
+            const f = field({ name: 'e', enum: ['a', 'b'] });
+            expect(validateAndParseInputs([f], { e: 'a' })).toEqual({ ok: true, parsed: { e: 'a' } });
+            expect(validateAndParseInputs([f], { e: 'c' })).toEqual({ ok: false, errors: { e: 'Must be one of: a, b' } });
+        });
+
+        it('validates minLength', () => {
+            const f = field({ name: 's', minLength: 3 });
+            expect(validateAndParseInputs([f], { s: 'ab' })).toEqual({ ok: false, errors: { s: 'Must be at least 3 characters' } });
+            expect(validateAndParseInputs([f], { s: 'abc' })).toEqual({ ok: true, parsed: { s: 'abc' } });
+        });
+
+        it('validates maxLength', () => {
+            const f = field({ name: 's', maxLength: 2 });
+            expect(validateAndParseInputs([f], { s: 'abc' })).toEqual({ ok: false, errors: { s: 'Must be at most 2 characters' } });
+        });
+
+        it('validates pattern', () => {
+            const f = field({ name: 's', pattern: '^[a-z]+$' });
+            expect(validateAndParseInputs([f], { s: 'abc' })).toEqual({ ok: true, parsed: { s: 'abc' } });
+            expect(validateAndParseInputs([f], { s: 'ABC' })).toEqual({ ok: false, errors: { s: 'Must match pattern: ^[a-z]+$' } });
+        });
+
+        it('validates minimum/maximum for numbers', () => {
+            const f = field({ name: 'n', type: 'number', minimum: 1, maximum: 10 });
+            expect(validateAndParseInputs([f], { n: '0' })).toEqual({ ok: false, errors: { n: 'Must be ≥ 1' } });
+            expect(validateAndParseInputs([f], { n: '11' })).toEqual({ ok: false, errors: { n: 'Must be ≤ 10' } });
+            expect(validateAndParseInputs([f], { n: '5' })).toEqual({ ok: true, parsed: { n: 5 } });
+        });
+
+        it('validates exclusiveMinimum/exclusiveMaximum', () => {
+            const f = field({ name: 'n', type: 'number', exclusiveMinimum: 0, exclusiveMaximum: 10 });
+            expect(validateAndParseInputs([f], { n: '0' })).toEqual({ ok: false, errors: { n: 'Must be > 0' } });
+            expect(validateAndParseInputs([f], { n: '10' })).toEqual({ ok: false, errors: { n: 'Must be < 10' } });
+        });
+    });
+});
+
+describe('buildResultData', () => {
+    it('returns null for null/undefined input', () => {
+        expect(buildResultData(null)).toBeNull();
+        expect(buildResultData(undefined)).toBeNull();
+    });
+
+    it('returns null when no meta/request/response/error', () => {
+        expect(buildResultData({})).toBeNull();
+    });
+
+    it('spreads meta and includes request/response/error', () => {
+        const result = buildResultData({
+            meta: { foo: 'bar' },
+            request: { url: '/test' },
+            response: { status: 200 },
+            error: { message: 'oops', payload: { code: 42 } }
+        });
+        expect(result).toEqual({
+            foo: 'bar',
+            request: { url: '/test' },
+            response: { status: 200 },
+            error: { message: 'oops', payload: { code: 42 } }
+        });
+    });
+
+    it('omits error payload when not present', () => {
+        const result = buildResultData({ error: { message: 'fail' } });
+        expect(result).toEqual({ error: { message: 'fail' } });
+    });
+
+    it('handles meta-only', () => {
+        expect(buildResultData({ meta: { k: 'v' } })).toEqual({ k: 'v' });
+    });
+});
+
+describe('computeDurationMs', () => {
+    it('returns durationMs when present', () => {
+        expect(computeDurationMs({ durationMs: 500 })).toBe(500);
+    });
+
+    it('computes from startedAt/endedAt when durationMs is missing', () => {
+        expect(
+            computeDurationMs({
+                startedAt: '2024-01-01T00:00:00.000Z',
+                endedAt: '2024-01-01T00:00:05.000Z'
+            })
+        ).toBe(5000);
+    });
+
+    it('returns fallback when no data available', () => {
+        expect(computeDurationMs(null, 123)).toBe(123);
+        expect(computeDurationMs({}, 456)).toBe(456);
+    });
+
+    it('returns 0 when no data and no fallback', () => {
+        expect(computeDurationMs(null)).toBe(0);
+        expect(computeDurationMs({})).toBe(0);
+    });
+});
+
+describe('sleepWithAbort', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('resolves after the specified time', async () => {
+        const p = sleepWithAbort(1000, new AbortController().signal);
+        await vi.advanceTimersByTimeAsync(1000);
+        await expect(p).resolves.toBeUndefined();
+    });
+
+    it('rejects with AbortError when aborted during sleep', async () => {
+        const controller = new AbortController();
+        const p = sleepWithAbort(1000, controller.signal);
+        controller.abort();
+        await expect(p).rejects.toThrow('Aborted');
+    });
+
+    it('rejects immediately for pre-aborted signal', async () => {
+        const controller = new AbortController();
+        controller.abort();
+        await expect(sleepWithAbort(1000, controller.signal)).rejects.toThrow('Aborted');
+    });
+});

--- a/packages/webapp/src/components-v2/Playground/types.ts
+++ b/packages/webapp/src/components-v2/Playground/types.ts
@@ -1,0 +1,44 @@
+import type { JSONSchema7 } from 'json-schema';
+
+export const JSON_DISPLAY_LIMIT = 250_000;
+
+export interface InputField {
+    name: string;
+    type: string;
+    description?: string;
+    required: boolean;
+    // Scalar constraints from JSON Schema
+    minLength?: number;
+    maxLength?: number;
+    pattern?: string;
+    minimum?: number;
+    maximum?: number;
+    exclusiveMinimum?: number;
+    exclusiveMaximum?: number;
+    enum?: unknown[];
+}
+
+export function getInputFields(jsonSchema: JSONSchema7 | null | undefined): InputField[] {
+    if (!jsonSchema || typeof jsonSchema !== 'object') return [];
+    const props = jsonSchema.properties;
+    if (!props) return [];
+    const required = Array.isArray(jsonSchema.required) ? jsonSchema.required : [];
+    return Object.entries(props).flatMap(([name, def]): InputField[] => {
+        if (typeof def === 'boolean') {
+            // false means the property is explicitly disallowed; true means any value is allowed
+            if (!def) return [];
+            return [{ name, type: 'string', description: undefined, required: required.includes(name) }];
+        }
+        const type = Array.isArray(def.type) ? (def.type.find((t) => t !== 'null') ?? def.type[0] ?? 'string') : def.type || 'string';
+        const field: InputField = { name, type, description: def.description, required: required.includes(name) };
+        if (def.minLength != null) field.minLength = def.minLength;
+        if (def.maxLength != null) field.maxLength = def.maxLength;
+        if (def.pattern != null) field.pattern = def.pattern;
+        if (typeof def.minimum === 'number') field.minimum = def.minimum;
+        if (typeof def.maximum === 'number') field.maximum = def.maximum;
+        if (typeof def.exclusiveMinimum === 'number') field.exclusiveMinimum = def.exclusiveMinimum;
+        if (typeof def.exclusiveMaximum === 'number') field.exclusiveMaximum = def.exclusiveMaximum;
+        if (Array.isArray(def.enum)) field.enum = def.enum;
+        return [field];
+    });
+}

--- a/packages/webapp/src/components-v2/Playground/types.unit.test.ts
+++ b/packages/webapp/src/components-v2/Playground/types.unit.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+
+import { getInputFields } from './types.js';
+
+import type { JSONSchema7 } from 'json-schema';
+
+describe('getInputFields', () => {
+    it('returns [] for null, undefined, and non-object inputs', () => {
+        expect(getInputFields(null)).toEqual([]);
+        expect(getInputFields(undefined)).toEqual([]);
+        expect(getInputFields('string' as any)).toEqual([]);
+    });
+
+    it('returns [] when schema has no properties', () => {
+        expect(getInputFields({})).toEqual([]);
+        expect(getInputFields({ type: 'object' })).toEqual([]);
+    });
+
+    it('maps properties to InputFields with correct types', () => {
+        const schema: JSONSchema7 = {
+            properties: {
+                name: { type: 'string' },
+                count: { type: 'number' }
+            }
+        };
+        expect(getInputFields(schema)).toEqual([
+            { name: 'name', type: 'string', description: undefined, required: false },
+            { name: 'count', type: 'number', description: undefined, required: false }
+        ]);
+    });
+
+    it('marks fields listed in required as required=true', () => {
+        const schema: JSONSchema7 = {
+            properties: {
+                id: { type: 'string' },
+                label: { type: 'string' }
+            },
+            required: ['id']
+        };
+        const fields = getInputFields(schema);
+        expect(fields.find((f) => f.name === 'id')?.required).toBe(true);
+        expect(fields.find((f) => f.name === 'label')?.required).toBe(false);
+    });
+
+    it('uses the first non-null type from a union', () => {
+        const schema: JSONSchema7 = {
+            properties: {
+                value: { type: ['null', 'integer'] }
+            }
+        };
+        expect(getInputFields(schema)[0]?.type).toBe('integer');
+    });
+
+    it('uses the first type when the union contains no null', () => {
+        const schema: JSONSchema7 = {
+            properties: {
+                value: { type: ['integer', 'string'] }
+            }
+        };
+        expect(getInputFields(schema)[0]?.type).toBe('integer');
+    });
+
+    it('skips properties defined as false', () => {
+        const schema: JSONSchema7 = {
+            properties: {
+                allowed: { type: 'string' },
+                forbidden: false
+            }
+        };
+        const fields = getInputFields(schema);
+        expect(fields).toHaveLength(1);
+        expect(fields[0]?.name).toBe('allowed');
+    });
+
+    it('includes properties defined as true with type "string" fallback', () => {
+        const schema: JSONSchema7 = {
+            properties: {
+                anything: true
+            }
+        };
+        const fields = getInputFields(schema);
+        expect(fields).toHaveLength(1);
+        expect(fields[0]).toEqual({ name: 'anything', type: 'string', description: undefined, required: false });
+    });
+
+    it('falls back to "string" when type is missing', () => {
+        const schema: JSONSchema7 = {
+            properties: {
+                anything: {}
+            }
+        };
+        expect(getInputFields(schema)[0]?.type).toBe('string');
+    });
+
+    it('falls back to "string" when type array is empty', () => {
+        const schema: JSONSchema7 = {
+            properties: {
+                weird: { type: [] }
+            }
+        };
+        expect(getInputFields(schema)[0]?.type).toBe('string');
+    });
+
+    it('includes description when present', () => {
+        const schema: JSONSchema7 = {
+            properties: {
+                token: { type: 'string', description: 'API token' }
+            }
+        };
+        expect(getInputFields(schema)[0]?.description).toBe('API token');
+    });
+
+    it('treats a non-array required field gracefully (no required marks)', () => {
+        const schema = {
+            properties: { x: { type: 'string' } },
+            required: 'x' // malformed
+        } as any;
+        expect(getInputFields(schema)[0]?.required).toBe(false);
+    });
+
+    describe('scalar constraints', () => {
+        it('extracts string constraints', () => {
+            const schema: JSONSchema7 = {
+                properties: {
+                    token: { type: 'string', minLength: 3, maxLength: 50, pattern: '^[a-z]+$' }
+                }
+            };
+            const field = getInputFields(schema)[0];
+            expect(field?.minLength).toBe(3);
+            expect(field?.maxLength).toBe(50);
+            expect(field?.pattern).toBe('^[a-z]+$');
+        });
+
+        it('extracts number constraints', () => {
+            const schema: JSONSchema7 = {
+                properties: {
+                    count: { type: 'number', minimum: 0, maximum: 100 }
+                }
+            };
+            const field = getInputFields(schema)[0];
+            expect(field?.minimum).toBe(0);
+            expect(field?.maximum).toBe(100);
+        });
+
+        it('extracts exclusiveMinimum and exclusiveMaximum', () => {
+            const schema: JSONSchema7 = {
+                properties: {
+                    ratio: { type: 'number', exclusiveMinimum: 0, exclusiveMaximum: 1 }
+                }
+            };
+            const field = getInputFields(schema)[0];
+            expect(field?.exclusiveMinimum).toBe(0);
+            expect(field?.exclusiveMaximum).toBe(1);
+        });
+
+        it('extracts enum', () => {
+            const schema: JSONSchema7 = {
+                properties: {
+                    status: { type: 'string', enum: ['active', 'inactive'] }
+                }
+            };
+            const field = getInputFields(schema)[0];
+            expect(field?.enum).toEqual(['active', 'inactive']);
+        });
+
+        it('does not set constraint keys when absent', () => {
+            const schema: JSONSchema7 = {
+                properties: { name: { type: 'string' } }
+            };
+            const field = getInputFields(schema)[0];
+            expect('minLength' in field).toBe(false);
+            expect('maxLength' in field).toBe(false);
+            expect('pattern' in field).toBe(false);
+            expect('minimum' in field).toBe(false);
+            expect('maximum' in field).toBe(false);
+            expect('enum' in field).toBe(false);
+        });
+    });
+});

--- a/packages/webapp/src/components-v2/Playground/usePlayground.ts
+++ b/packages/webapp/src/components-v2/Playground/usePlayground.ts
@@ -1,0 +1,230 @@
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect, useRef } from 'react';
+
+import { buildResultData, computeDurationMs, fetchOperation, findOperation, sleepWithAbort, validateAndParseInputs } from './playground.utils';
+import { useEnvironment } from '@/hooks/useEnvironment';
+import { useStore } from '@/store';
+import { usePlaygroundStore } from '@/store/playground';
+import { apiFetch } from '@/utils/api';
+
+import type { InputField } from './types';
+import type { SyncResponse } from '@/types';
+
+const FIND_OP_POLL_INTERVAL_MS = 500;
+const STATUS_POLL_INTERVAL_MS = 1500;
+
+export function usePlayground(inputFields: InputField[]) {
+    const env = useStore((s) => s.env);
+    const baseUrl = useStore((s) => s.baseUrl);
+    const isOpen = usePlaygroundStore((s) => s.isOpen);
+    const playgroundIntegration = usePlaygroundStore((s) => s.integration);
+    const playgroundConnection = usePlaygroundStore((s) => s.connection);
+    const playgroundFunction = usePlaygroundStore((s) => s.function);
+    const playgroundFunctionType = usePlaygroundStore((s) => s.functionType);
+    const inputValues = usePlaygroundStore((s) => s.inputValues);
+    const pendingOperationId = usePlaygroundStore((s) => s.pendingOperationId);
+    const setResult = usePlaygroundStore((s) => s.setResult);
+    const setPendingOperationId = usePlaygroundStore((s) => s.setPendingOperationId);
+    const setRunning = usePlaygroundStore((s) => s.setRunning);
+    const setInputErrors = usePlaygroundStore((s) => s.setInputErrors);
+
+    const { data } = useEnvironment(env);
+    const environmentAndAccount = data?.environmentAndAccount;
+
+    const runAbortRef = useRef<AbortController | null>(null);
+
+    // --- useQuery: poll operation status when pendingOperationId is set ---
+    const { data: operationData } = useQuery({
+        queryKey: ['playground-operation', env, pendingOperationId],
+        queryFn: () => fetchOperation(pendingOperationId!, env),
+        enabled: !!pendingOperationId && isOpen,
+        refetchInterval: (query) => {
+            const state = query.state.data?.state;
+            return state === 'running' || state === 'waiting' ? STATUS_POLL_INTERVAL_MS : false;
+        }
+    });
+
+    // --- Process terminal state from useQuery ---
+    useEffect(() => {
+        if (!operationData || !pendingOperationId) return;
+        const state = operationData.state as string;
+        if (state === 'running' || state === 'waiting') {
+            // Still in progress — ensure UI shows running state (handles reattach case)
+            setRunning(true);
+            return;
+        }
+
+        // Terminal — process result
+        const success = state === 'success';
+        const durationMs = computeDurationMs(operationData);
+        const data = buildResultData(operationData);
+
+        setPendingOperationId(null);
+        setResult({ success, state, data, durationMs, operationId: pendingOperationId });
+        setRunning(false);
+    }, [operationData, pendingOperationId, setResult, setPendingOperationId, setRunning]);
+
+    // --- handleRun ---
+    const handleRun = useCallback(async () => {
+        if (!playgroundIntegration || !playgroundConnection || !playgroundFunction || !playgroundFunctionType || !environmentAndAccount) return;
+
+        const secretKey = environmentAndAccount.environment.secret_key;
+        const controller = new AbortController();
+        runAbortRef.current = controller;
+        setRunning(true);
+        setResult(null);
+        setInputErrors({});
+
+        const runStartTime = Date.now();
+        try {
+            let response: Response;
+            let triggerData: unknown = null;
+
+            const triggerStartTime = Date.now();
+            if (playgroundFunctionType === 'action') {
+                const parseResult = validateAndParseInputs(inputFields, inputValues);
+                if (!parseResult.ok) {
+                    setInputErrors(parseResult.errors);
+                    setResult({ success: false, state: 'invalid_input', data: { error: 'Invalid input', fields: parseResult.errors }, durationMs: 0 });
+                    setRunning(false);
+                    return;
+                }
+
+                response = await fetch(`${baseUrl}/action/trigger`, {
+                    method: 'POST',
+                    signal: controller.signal,
+                    headers: {
+                        Authorization: `Bearer ${secretKey}`,
+                        'Content-Type': 'application/json',
+                        'provider-config-key': playgroundIntegration,
+                        'connection-id': playgroundConnection
+                    },
+                    body: JSON.stringify({ action_name: playgroundFunction, input: parseResult.parsed })
+                });
+            } else {
+                response = await fetch(`${baseUrl}/sync/trigger`, {
+                    method: 'POST',
+                    signal: controller.signal,
+                    headers: {
+                        Authorization: `Bearer ${secretKey}`,
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        syncs: [playgroundFunction],
+                        provider_config_key: playgroundIntegration,
+                        connection_id: playgroundConnection
+                    })
+                });
+            }
+
+            try {
+                triggerData = await response.json();
+            } catch {
+                triggerData = null;
+            }
+
+            const triggerDurationMs = Date.now() - triggerStartTime;
+
+            // If the trigger failed immediately, surface the error right away.
+            if (!response.ok) {
+                setResult({ success: false, data: triggerData, durationMs: triggerDurationMs });
+                setRunning(false);
+                return;
+            }
+
+            // Poll until we find the matching operation in logs.
+            const findDeadlineMs = playgroundFunctionType === 'sync' ? 15_000 : 5_000;
+            const findStart = Date.now();
+            let operation = null as Awaited<ReturnType<typeof findOperation>>;
+            while (Date.now() - findStart < findDeadlineMs) {
+                operation = await findOperation(
+                    {
+                        env,
+                        triggerStartTime,
+                        functionType: playgroundFunctionType,
+                        integration: playgroundIntegration,
+                        connection: playgroundConnection,
+                        functionName: playgroundFunction
+                    },
+                    controller.signal
+                );
+                if (operation) break;
+                await sleepWithAbort(FIND_OP_POLL_INTERVAL_MS, controller.signal);
+            }
+
+            if (!operation) {
+                setResult({ success: false, data: triggerData, durationMs: triggerDurationMs });
+                setRunning(false);
+                return;
+            }
+
+            // Hand off to useQuery for status polling.
+            // running stays true — useQuery's useEffect will set it to false on terminal state.
+            setPendingOperationId(operation.id);
+        } catch (err: unknown) {
+            if (err instanceof Error && err.name === 'AbortError') {
+                setPendingOperationId(null);
+                setResult(null);
+            } else {
+                setPendingOperationId(null);
+                setResult({ success: false, data: { error: 'Network error' }, durationMs: Date.now() - runStartTime });
+            }
+            setRunning(false);
+        } finally {
+            runAbortRef.current = null;
+        }
+    }, [
+        playgroundIntegration,
+        playgroundConnection,
+        playgroundFunction,
+        playgroundFunctionType,
+        environmentAndAccount,
+        baseUrl,
+        env,
+        inputFields,
+        inputValues,
+        setResult,
+        setPendingOperationId,
+        setRunning,
+        setInputErrors
+    ]);
+
+    // --- handleCancel ---
+    const handleCancel = useCallback(async () => {
+        runAbortRef.current?.abort();
+        setPendingOperationId(null);
+        setRunning(false);
+        setResult(null);
+
+        // For syncs, also cancel the backend operation (best-effort)
+        if (playgroundFunctionType === 'sync' && playgroundIntegration && playgroundConnection && playgroundFunction) {
+            try {
+                const res = await apiFetch(
+                    `/api/v1/sync?env=${env}&connection_id=${encodeURIComponent(playgroundConnection)}&provider_config_key=${encodeURIComponent(playgroundIntegration)}`
+                );
+                if (res.ok) {
+                    const syncs = (await res.json()) as SyncResponse[];
+                    const sync = syncs.find((s) => s.name === playgroundFunction);
+                    if (sync) {
+                        await apiFetch(`/api/v1/sync/command?env=${env}`, {
+                            method: 'POST',
+                            body: JSON.stringify({
+                                command: 'CANCEL',
+                                schedule_id: sync.schedule_id,
+                                nango_connection_id: sync.nango_connection_id,
+                                sync_id: sync.id,
+                                sync_name: sync.name,
+                                sync_variant: sync.variant,
+                                provider: playgroundIntegration
+                            })
+                        });
+                    }
+                }
+            } catch {
+                // Best-effort: local state already cleared
+            }
+        }
+    }, [env, playgroundIntegration, playgroundConnection, playgroundFunction, playgroundFunctionType, setPendingOperationId, setRunning, setResult]);
+
+    return { handleRun, handleCancel };
+}

--- a/packages/webapp/src/components-v2/Playground/usePlayground.ts
+++ b/packages/webapp/src/components-v2/Playground/usePlayground.ts
@@ -127,6 +127,7 @@ export function usePlayground(inputFields: InputField[]) {
 
             // If the trigger failed immediately, surface the error right away.
             if (!response.ok) {
+                setPendingOperationId(null);
                 setResult({ success: false, data: triggerData, durationMs: triggerDurationMs });
                 setRunning(false);
                 return;
@@ -153,7 +154,8 @@ export function usePlayground(inputFields: InputField[]) {
             }
 
             if (!operation) {
-                setResult({ success: false, data: triggerData, durationMs: triggerDurationMs });
+                setPendingOperationId(null);
+                setResult({ success: false, state: 'operation_not_found', data: triggerData, durationMs: triggerDurationMs });
                 setRunning(false);
                 return;
             }

--- a/packages/webapp/src/components-v2/Playground/usePlayground.ts
+++ b/packages/webapp/src/components-v2/Playground/usePlayground.ts
@@ -35,7 +35,10 @@ export function usePlayground(inputFields: InputField[]) {
         enabled: !!pendingOperationId && isOpen,
         refetchInterval: (query) => {
             const state = query.state.data?.state;
-            return state === 'running' || state === 'waiting' ? STATUS_POLL_INTERVAL_MS : false;
+            // Keep polling if data is null (transient fetch failure) or still in progress.
+            // Only stop on a known terminal state.
+            if (state && state !== 'running' && state !== 'waiting') return false;
+            return STATUS_POLL_INTERVAL_MS;
         }
     });
 
@@ -143,18 +146,18 @@ export function usePlayground(inputFields: InputField[]) {
                 await sleepWithAbort(FIND_OP_POLL_INTERVAL_MS, controller.signal);
             }
 
-            if (!operation) {
+            // For actions, the full output is already in triggerData — use it directly.
+            // Log lookup failure only means no Logs link; it doesn't mean the action failed.
+            if (playgroundFunctionType === 'action') {
                 setPendingOperationId(null);
-                setResult({ success: false, state: 'operation_not_found', data: triggerData, durationMs: triggerDurationMs });
+                setResult({ success: true, data: triggerData, durationMs: triggerDurationMs, operationId: operation?.id });
                 setRunning(false);
                 return;
             }
 
-            // For actions, the full output is already in triggerData — use it directly.
-            // The operation is synchronous and complete; no need to poll status.
-            if (playgroundFunctionType === 'action') {
+            if (!operation) {
                 setPendingOperationId(null);
-                setResult({ success: true, data: triggerData, durationMs: triggerDurationMs, operationId: operation.id });
+                setResult({ success: false, state: 'operation_not_found', data: triggerData, durationMs: triggerDurationMs });
                 setRunning(false);
                 return;
             }

--- a/packages/webapp/src/components-v2/Playground/usePlayground.ts
+++ b/packages/webapp/src/components-v2/Playground/usePlayground.ts
@@ -25,13 +25,33 @@ export function usePlayground(inputFields: InputField[]) {
     const setPendingOperationId = usePlaygroundStore((s) => s.setPendingOperationId);
     const setRunning = usePlaygroundStore((s) => s.setRunning);
     const setInputErrors = usePlaygroundStore((s) => s.setInputErrors);
+    const setAbortActiveRun = usePlaygroundStore((s) => s.setAbortActiveRun);
 
     const runAbortRef = useRef<AbortController | null>(null);
+
+    useEffect(() => {
+        setAbortActiveRun(() => {
+            runAbortRef.current?.abort();
+            setPendingOperationId(null);
+            setRunning(false);
+            setResult(null);
+        });
+
+        return () => {
+            setAbortActiveRun(null);
+        };
+    }, [setAbortActiveRun, setPendingOperationId, setResult, setRunning]);
 
     // --- useQuery: poll operation status when pendingOperationId is set ---
     const { data: operationData } = useQuery({
         queryKey: ['playground-operation', env, pendingOperationId],
-        queryFn: () => fetchOperation(pendingOperationId!, env),
+        queryFn: async () => {
+            if (!pendingOperationId) {
+                return null;
+            }
+
+            return fetchOperation(pendingOperationId, env);
+        },
         enabled: !!pendingOperationId && isOpen,
         refetchInterval: (query) => {
             const state = query.state.data?.state;

--- a/packages/webapp/src/components-v2/Playground/usePlayground.ts
+++ b/packages/webapp/src/components-v2/Playground/usePlayground.ts
@@ -126,6 +126,15 @@ export function usePlayground(inputFields: InputField[]) {
                 return;
             }
 
+            // For actions, the full output is already in triggerData.
+            // Don't block the UI on log discovery.
+            if (playgroundFunctionType === 'action') {
+                setPendingOperationId(null);
+                setResult({ success: true, data: triggerData, durationMs: triggerDurationMs });
+                setRunning(false);
+                return;
+            }
+
             // Poll until we find the matching operation in logs.
             const findDeadlineMs = playgroundFunctionType === 'sync' ? 15_000 : 5_000;
             const findStart = Date.now();
@@ -144,15 +153,6 @@ export function usePlayground(inputFields: InputField[]) {
                 );
                 if (operation) break;
                 await sleepWithAbort(FIND_OP_POLL_INTERVAL_MS, controller.signal);
-            }
-
-            // For actions, the full output is already in triggerData — use it directly.
-            // Log lookup failure only means no Logs link; it doesn't mean the action failed.
-            if (playgroundFunctionType === 'action') {
-                setPendingOperationId(null);
-                setResult({ success: true, data: triggerData, durationMs: triggerDurationMs, operationId: operation?.id });
-                setRunning(false);
-                return;
             }
 
             if (!operation) {

--- a/packages/webapp/src/components-v2/Playground/usePlayground.ts
+++ b/packages/webapp/src/components-v2/Playground/usePlayground.ts
@@ -157,7 +157,7 @@ export function usePlayground(inputFields: InputField[]) {
 
             if (!operation) {
                 setPendingOperationId(null);
-                setResult({ success: false, state: 'operation_not_found', data: triggerData, durationMs: triggerDurationMs });
+                setResult({ success: true, state: 'operation_not_found', data: triggerData, durationMs: triggerDurationMs });
                 setRunning(false);
                 return;
             }

--- a/packages/webapp/src/components-v2/Playground/usePlayground.ts
+++ b/packages/webapp/src/components-v2/Playground/usePlayground.ts
@@ -2,7 +2,6 @@ import { useQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef } from 'react';
 
 import { buildResultData, computeDurationMs, fetchOperation, findOperation, sleepWithAbort, validateAndParseInputs } from './playground.utils';
-import { useEnvironment } from '@/hooks/useEnvironment';
 import { useStore } from '@/store';
 import { usePlaygroundStore } from '@/store/playground';
 import { apiFetch } from '@/utils/api';
@@ -15,7 +14,6 @@ const STATUS_POLL_INTERVAL_MS = 1500;
 
 export function usePlayground(inputFields: InputField[]) {
     const env = useStore((s) => s.env);
-    const baseUrl = useStore((s) => s.baseUrl);
     const isOpen = usePlaygroundStore((s) => s.isOpen);
     const playgroundIntegration = usePlaygroundStore((s) => s.integration);
     const playgroundConnection = usePlaygroundStore((s) => s.connection);
@@ -27,9 +25,6 @@ export function usePlayground(inputFields: InputField[]) {
     const setPendingOperationId = usePlaygroundStore((s) => s.setPendingOperationId);
     const setRunning = usePlaygroundStore((s) => s.setRunning);
     const setInputErrors = usePlaygroundStore((s) => s.setInputErrors);
-
-    const { data } = useEnvironment(env);
-    const environmentAndAccount = data?.environmentAndAccount;
 
     const runAbortRef = useRef<AbortController | null>(null);
 
@@ -66,9 +61,8 @@ export function usePlayground(inputFields: InputField[]) {
 
     // --- handleRun ---
     const handleRun = useCallback(async () => {
-        if (!playgroundIntegration || !playgroundConnection || !playgroundFunction || !playgroundFunctionType || !environmentAndAccount) return;
+        if (!playgroundIntegration || !playgroundConnection || !playgroundFunction || !playgroundFunctionType) return;
 
-        const secretKey = environmentAndAccount.environment.secret_key;
         const controller = new AbortController();
         runAbortRef.current = controller;
         setRunning(true);
@@ -89,28 +83,24 @@ export function usePlayground(inputFields: InputField[]) {
                     setRunning(false);
                     return;
                 }
-
-                response = await fetch(`${baseUrl}/action/trigger`, {
+                response = await apiFetch(`/api/v1/trigger/function?env=${env}`, {
                     method: 'POST',
                     signal: controller.signal,
-                    headers: {
-                        Authorization: `Bearer ${secretKey}`,
-                        'Content-Type': 'application/json',
-                        'provider-config-key': playgroundIntegration,
-                        'connection-id': playgroundConnection
-                    },
-                    body: JSON.stringify({ action_name: playgroundFunction, input: parseResult.parsed })
+                    body: JSON.stringify({
+                        type: 'action',
+                        function_name: playgroundFunction,
+                        provider_config_key: playgroundIntegration,
+                        connection_id: playgroundConnection,
+                        input: parseResult.parsed
+                    })
                 });
             } else {
-                response = await fetch(`${baseUrl}/sync/trigger`, {
+                response = await apiFetch(`/api/v1/trigger/function?env=${env}`, {
                     method: 'POST',
                     signal: controller.signal,
-                    headers: {
-                        Authorization: `Bearer ${secretKey}`,
-                        'Content-Type': 'application/json'
-                    },
                     body: JSON.stringify({
-                        syncs: [playgroundFunction],
+                        type: 'sync',
+                        function_name: playgroundFunction,
                         provider_config_key: playgroundIntegration,
                         connection_id: playgroundConnection
                     })
@@ -160,7 +150,16 @@ export function usePlayground(inputFields: InputField[]) {
                 return;
             }
 
-            // Hand off to useQuery for status polling.
+            // For actions, the full output is already in triggerData — use it directly.
+            // The operation is synchronous and complete; no need to poll status.
+            if (playgroundFunctionType === 'action') {
+                setPendingOperationId(null);
+                setResult({ success: true, data: triggerData, durationMs: triggerDurationMs, operationId: operation.id });
+                setRunning(false);
+                return;
+            }
+
+            // Syncs: hand off to useQuery for status polling.
             // running stays true — useQuery's useEffect will set it to false on terminal state.
             setPendingOperationId(operation.id);
         } catch (err: unknown) {
@@ -180,8 +179,6 @@ export function usePlayground(inputFields: InputField[]) {
         playgroundConnection,
         playgroundFunction,
         playgroundFunctionType,
-        environmentAndAccount,
-        baseUrl,
         env,
         inputFields,
         inputValues,

--- a/packages/webapp/src/components-v2/ui/alert.tsx
+++ b/packages/webapp/src/components-v2/ui/alert.tsx
@@ -21,7 +21,13 @@ const alertVariants = cva(
         'has-[>div[data-slot="alert-title"]]:has-[>div[data-slot="alert-description"]]:[&>[data-slot="alert-title"]]:self-end',
         'has-[>div[data-slot="alert-title"]]:has-[>div[data-slot="alert-description"]]:[&>[data-slot="alert-description"]]:self-start',
         'has-[>div[data-slot="alert-title"]]:has-[>div[data-slot="alert-description"]]:[&>[data-slot="alert-actions"]]:row-start-1',
-        'has-[>div[data-slot="alert-title"]]:has-[>div[data-slot="alert-description"]]:[&>[data-slot="alert-actions"]]:row-span-2'
+        'has-[>div[data-slot="alert-title"]]:has-[>div[data-slot="alert-description"]]:[&>[data-slot="alert-actions"]]:row-span-2',
+        // actionsBelow: override grid to place actions on a new row below the content
+        'data-[actions-below]:has-[>div[data-slot="alert-actions"]]:grid-cols-[0_1fr]',
+        'data-[actions-below]:has-[>svg]:has-[>div[data-slot="alert-actions"]]:grid-cols-[calc(var(--spacing)*4)_1fr]',
+        'data-[actions-below]:[&>[data-slot="alert-actions"]]:col-start-2 data-[actions-below]:[&>[data-slot="alert-actions"]]:row-start-auto',
+        'data-[actions-below]:has-[>div[data-slot="alert-title"]]:has-[>div[data-slot="alert-description"]]:[&>[data-slot="alert-actions"]]:row-start-auto',
+        'data-[actions-below]:has-[>div[data-slot="alert-title"]]:has-[>div[data-slot="alert-description"]]:[&>[data-slot="alert-actions"]]:row-span-1'
     ].join(' '),
     {
         variants: {
@@ -38,8 +44,15 @@ const alertVariants = cva(
     }
 );
 
-function Alert({ className, variant, ...props }: React.ComponentProps<'div'> & VariantProps<typeof alertVariants>) {
-    return <div data-slot="alert" role="alert" className={cn(alertVariants({ variant }), className)} {...props} />;
+function Alert({
+    className,
+    variant,
+    actionsBelow = false,
+    ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof alertVariants> & { actionsBelow?: boolean }) {
+    return (
+        <div data-slot="alert" role="alert" data-actions-below={actionsBelow || undefined} className={cn(alertVariants({ variant }), className)} {...props} />
+    );
 }
 
 function AlertTitle({ className, ...props }: React.ComponentProps<'div'>) {

--- a/packages/webapp/src/components-v2/ui/combobox.tsx
+++ b/packages/webapp/src/components-v2/ui/combobox.tsx
@@ -1,0 +1,259 @@
+import { Check, ChevronsUpDown, Search } from 'lucide-react';
+import * as React from 'react';
+
+import { Button } from './button';
+import { InputGroup, InputGroupAddon, InputGroupInput } from './input-group';
+import { Popover, PopoverContent, PopoverTrigger } from './popover';
+import { cn } from '@/utils/utils';
+
+export interface ComboboxOption<TValue extends string = string> {
+    value: TValue;
+    label: string;
+    filterValue?: string;
+    disabled?: boolean;
+    icon?: React.ReactNode;
+    tag?: React.ReactNode;
+}
+
+interface ComboboxBaseProps<T extends string = string> {
+    options: ComboboxOption<T>[];
+    disabled?: boolean;
+    searchPlaceholder?: string;
+    emptyText?: string;
+    footer?: React.ReactNode;
+    className?: string;
+    contentClassName?: string;
+}
+
+interface SingleProps<T extends string = string> extends ComboboxBaseProps<T> {
+    allowMultiple?: false;
+    value: T | '';
+    onValueChange: (value: T) => void;
+    placeholder: string;
+    showCheckbox?: boolean;
+    searchValue?: string;
+    onSearchValueChange?: (value: string) => void;
+    selected?: never;
+    label?: never;
+    defaultSelect?: never;
+    loading?: never;
+    onSelectedChange?: never;
+}
+
+interface MultiProps<T extends string = string> extends ComboboxBaseProps<T> {
+    allowMultiple: true;
+    selected: T[];
+    onSelectedChange: (selected: T[]) => void;
+    label: string;
+    defaultSelect?: T[];
+    loading?: boolean;
+    value?: never;
+    onValueChange?: never;
+    placeholder?: never;
+    showCheckbox?: never;
+    searchValue?: never;
+    onSearchValueChange?: never;
+}
+
+export type ComboboxProps<T extends string = string> = SingleProps<T> | MultiProps<T>;
+
+function ItemLabel<T extends string>({ opt }: { opt: ComboboxOption<T> }) {
+    return (
+        <>
+            {opt.icon}
+            <span className="truncate">{opt.label}</span>
+        </>
+    );
+}
+
+export function Combobox<T extends string = string>(props: ComboboxProps<T>) {
+    const { options, disabled, searchPlaceholder = 'Search', emptyText = 'No results found.', footer, className, contentClassName } = props;
+
+    const [open, setOpen] = React.useState(false);
+    const [internalSearch, setInternalSearch] = React.useState('');
+
+    const controlledSearch = !props.allowMultiple ? props.searchValue : undefined;
+    const search = controlledSearch !== undefined ? controlledSearch : internalSearch;
+
+    const setSearch = React.useCallback(
+        (next: string) => {
+            if (!props.allowMultiple && props.onSearchValueChange) {
+                props.onSearchValueChange(next);
+            } else {
+                setInternalSearch(next);
+            }
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [props.allowMultiple, !props.allowMultiple ? props.onSearchValueChange : null]
+    );
+
+    React.useEffect(() => {
+        if (!open) setSearch('');
+    }, [open, setSearch]);
+
+    const filteredOptions = React.useMemo(() => {
+        const q = search.trim().toLowerCase();
+        const filtered = q ? options.filter((opt) => (opt.filterValue ?? opt.label).toLowerCase().includes(q)) : options;
+
+        if (props.allowMultiple && !q) {
+            const selectedSet = new Set(props.selected);
+            const sel: typeof options = [];
+            const unsel: typeof options = [];
+            filtered.forEach((o) => (selectedSet.has(o.value) ? sel : unsel).push(o));
+            return [...sel, ...unsel];
+        }
+
+        return filtered;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [options, search, props.allowMultiple, props.allowMultiple ? props.selected : null]);
+
+    const handleSelect = React.useCallback(
+        (val: T) => {
+            if (props.allowMultiple) {
+                const isSelected = props.selected.includes(val);
+                const next = isSelected ? props.selected.filter((s) => s !== val) : [...props.selected, val];
+                const defaultSelect = props.defaultSelect ?? [];
+                props.onSelectedChange(next.length === 0 ? [...defaultSelect] : next);
+            } else {
+                props.onValueChange(val);
+                setOpen(false);
+            }
+        },
+
+        [props]
+    );
+
+    const selectedOption = React.useMemo(() => {
+        if (props.allowMultiple) return undefined;
+        return options.find((opt) => opt.value === props.value);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [options, props.allowMultiple, !props.allowMultiple ? props.value : null]);
+
+    const isDirty = React.useMemo(() => {
+        if (!props.allowMultiple) return false;
+        const def = props.defaultSelect ?? [];
+        return props.selected.length !== def.length || props.selected.some((s, i) => s !== def[i]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [props.allowMultiple, props.allowMultiple ? props.selected : null, props.allowMultiple ? props.defaultSelect : null]);
+
+    const showCheckbox = props.allowMultiple ? true : (props.showCheckbox ?? true);
+
+    const trigger = props.allowMultiple ? (
+        <Button
+            loading={props.loading}
+            disabled={disabled || options.length === 0}
+            variant="ghost"
+            size="lg"
+            className={cn('border border-border-muted', isDirty && 'bg-btn-tertiary-press', open ? 'bg-bg-subtle' : 'hover:bg-dropdown-bg-hover', className)}
+        >
+            {props.label}{' '}
+            {props.selected.length > 0 && (
+                <span className="text-text-primary text-body-small-semi bg-bg-subtle rounded-full h-5 min-w-5 flex items-center justify-center px-2">
+                    {props.selected.length}
+                </span>
+            )}
+        </Button>
+    ) : (
+        <button
+            type="button"
+            disabled={disabled}
+            className={cn(
+                'text-[14px] h-8 cursor-pointer flex w-full min-w-0 items-center justify-between gap-1.5 self-stretch rounded-[4px] bg-bg-surface px-2 py-0 text-body-medium-regular leading-[160%] tracking-normal outline-none transition-[color,box-shadow] focus-default hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50',
+                selectedOption ? 'text-text-primary' : 'text-text-secondary',
+                open ? 'bg-bg-subtle' : 'hover:bg-dropdown-bg-hover',
+                className
+            )}
+        >
+            {selectedOption ? (
+                <span className="flex items-center gap-2 min-w-0">
+                    <ItemLabel opt={selectedOption} />
+                    {selectedOption.tag}
+                </span>
+            ) : (
+                <span className="truncate">{props.placeholder}</span>
+            )}
+            <ChevronsUpDown className="size-3 shrink-0 text-text-secondary" />
+        </button>
+    );
+
+    return (
+        <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+            <PopoverContent
+                align={props.allowMultiple ? 'end' : 'start'}
+                sideOffset={0}
+                className={cn(
+                    'z-[70] flex w-[var(--radix-popover-trigger-width)] flex-col items-start overflow-hidden rounded-[4px] border-[0.5px] border-border-default bg-bg-subtle p-1 pb-0',
+                    props.allowMultiple && 'min-w-[312px]',
+                    contentClassName
+                )}
+            >
+                <div className="w-full border-b border-border-muted" onKeyDown={(e) => e.stopPropagation()}>
+                    <InputGroup className="h-auto flex-1 justify-between rounded-[4px] border-[0.5px] border-border-muted bg-bg-surface px-2.5 py-1.5">
+                        <InputGroupAddon className="p-0 pr-2">
+                            <Search className="size-4 text-text-tertiary" />
+                        </InputGroupAddon>
+                        <InputGroupInput
+                            type="text"
+                            placeholder={searchPlaceholder}
+                            value={search}
+                            onChange={(e) => setSearch(e.target.value)}
+                            className="h-auto p-0 text-body-medium-regular text-text-tertiary placeholder:text-text-tertiary"
+                        />
+                    </InputGroup>
+                </div>
+
+                <div className="max-h-72 w-full overflow-y-auto">
+                    {filteredOptions.length > 0 ? (
+                        filteredOptions.map((opt) => {
+                            const isSelected = props.allowMultiple ? props.selected.includes(opt.value) : opt.value === props.value;
+
+                            return (
+                                <div
+                                    key={opt.value}
+                                    role="option"
+                                    aria-selected={isSelected}
+                                    onClick={() => !opt.disabled && handleSelect(opt.value)}
+                                    className={cn(
+                                        'group flex w-full cursor-pointer items-center justify-between rounded-[4px] px-2 py-1 hover:bg-dropdown-bg-hover text-text-secondary hover:text-text-primary',
+                                        opt.disabled && 'cursor-not-allowed opacity-50 pointer-events-none',
+                                        isSelected &&
+                                            'border-[0.5px] border-bg-elevated bg-bg-elevated text-text-primary hover:bg-bg-elevated hover:text-text-primary'
+                                    )}
+                                >
+                                    <div className="flex min-w-0 items-center gap-2">
+                                        {showCheckbox && (
+                                            <span
+                                                className={cn(
+                                                    'flex size-5 shrink-0 items-center justify-center rounded-sm border',
+                                                    isSelected ? 'border-transparent bg-gray-50 text-gray-1000' : 'border-border-strong bg-transparent'
+                                                )}
+                                            >
+                                                {isSelected ? <Check className="size-3.5" /> : null}
+                                            </span>
+                                        )}
+                                        <div className="flex min-w-0 items-center gap-1 overflow-hidden text-body-medium-regular leading-[160%] tracking-normal">
+                                            <ItemLabel opt={opt} />
+                                        </div>
+                                    </div>
+
+                                    {opt.tag ? (
+                                        <div className="shrink-0">{opt.tag}</div>
+                                    ) : isSelected && !showCheckbox ? (
+                                        <Check className="size-4 shrink-0 text-text-primary" />
+                                    ) : null}
+                                </div>
+                            );
+                        })
+                    ) : (
+                        <div className="px-2 py-3 text-center">
+                            <p className="text-text-tertiary text-body-small-regular">{emptyText}</p>
+                        </div>
+                    )}
+                </div>
+
+                {footer && <div className="w-full border-t border-border-muted px-1 py-2">{footer}</div>}
+            </PopoverContent>
+        </Popover>
+    );
+}

--- a/packages/webapp/src/components-v2/ui/combobox.tsx
+++ b/packages/webapp/src/components-v2/ui/combobox.tsx
@@ -203,7 +203,7 @@ export function Combobox<T extends string = string>(props: ComboboxProps<T>) {
                     </InputGroup>
                 </div>
 
-                <div className="max-h-72 w-full overflow-y-auto">
+                <div className="max-h-72 w-full overflow-y-auto" role="listbox">
                     {filteredOptions.length > 0 ? (
                         filteredOptions.map((opt) => {
                             const isSelected = props.allowMultiple ? props.selected.includes(opt.value) : opt.value === props.value;
@@ -212,8 +212,16 @@ export function Combobox<T extends string = string>(props: ComboboxProps<T>) {
                                 <div
                                     key={opt.value}
                                     role="option"
+                                    tabIndex={opt.disabled ? -1 : 0}
                                     aria-selected={isSelected}
                                     onClick={() => !opt.disabled && handleSelect(opt.value)}
+                                    onKeyDown={(e) => {
+                                        if (opt.disabled) return;
+                                        if (e.key === 'Enter' || e.key === ' ') {
+                                            e.preventDefault();
+                                            handleSelect(opt.value);
+                                        }
+                                    }}
                                     className={cn(
                                         'group flex w-full cursor-pointer items-center justify-between rounded-[4px] px-2 py-1 hover:bg-dropdown-bg-hover text-text-secondary hover:text-text-primary',
                                         opt.disabled && 'cursor-not-allowed opacity-50 pointer-events-none',

--- a/packages/webapp/src/components-v2/ui/dropdown-menu.tsx
+++ b/packages/webapp/src/components-v2/ui/dropdown-menu.tsx
@@ -72,7 +72,7 @@ function DropdownMenuCheckboxItem({ className, children, checked, ...props }: Re
         >
             <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
                 <DropdownMenuPrimitive.ItemIndicator>
-                    <CheckIcon className="size-4" />
+                    <CheckIcon />
                 </DropdownMenuPrimitive.ItemIndicator>
             </span>
             {children}

--- a/packages/webapp/src/components-v2/ui/dropdown-menu.tsx
+++ b/packages/webapp/src/components-v2/ui/dropdown-menu.tsx
@@ -72,7 +72,7 @@ function DropdownMenuCheckboxItem({ className, children, checked, ...props }: Re
         >
             <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
                 <DropdownMenuPrimitive.ItemIndicator>
-                    <CheckIcon />
+                    <CheckIcon className="size-4 fill-current" />
                 </DropdownMenuPrimitive.ItemIndicator>
             </span>
             {children}

--- a/packages/webapp/src/components-v2/ui/select.tsx
+++ b/packages/webapp/src/components-v2/ui/select.tsx
@@ -112,7 +112,7 @@ function SelectScrollUpButton({ className, ...props }: React.ComponentProps<type
             className={cn('flex cursor-default items-center justify-center py-1', className)}
             {...props}
         >
-            <ChevronUpIcon className="size-4" />
+            <ChevronUpIcon />
         </SelectPrimitive.ScrollUpButton>
     );
 }
@@ -124,7 +124,7 @@ function SelectScrollDownButton({ className, ...props }: React.ComponentProps<ty
             className={cn('flex cursor-default items-center justify-center py-1', className)}
             {...props}
         >
-            <ChevronDownIcon className="size-4" />
+            <ChevronDownIcon />
         </SelectPrimitive.ScrollDownButton>
     );
 }

--- a/packages/webapp/src/components-v2/ui/select.tsx
+++ b/packages/webapp/src/components-v2/ui/select.tsx
@@ -112,7 +112,7 @@ function SelectScrollUpButton({ className, ...props }: React.ComponentProps<type
             className={cn('flex cursor-default items-center justify-center py-1', className)}
             {...props}
         >
-            <ChevronUpIcon />
+            <ChevronUpIcon className="size-4" />
         </SelectPrimitive.ScrollUpButton>
     );
 }
@@ -124,7 +124,7 @@ function SelectScrollDownButton({ className, ...props }: React.ComponentProps<ty
             className={cn('flex cursor-default items-center justify-center py-1', className)}
             {...props}
         >
-            <ChevronDownIcon />
+            <ChevronDownIcon className="size-4" />
         </SelectPrimitive.ScrollDownButton>
     );
 }

--- a/packages/webapp/src/components-v2/ui/sheet.tsx
+++ b/packages/webapp/src/components-v2/ui/sheet.tsx
@@ -27,7 +27,7 @@ function SheetOverlay({ className, ...props }: React.ComponentProps<typeof Sheet
         <SheetPrimitive.Overlay
             data-slot="sheet-overlay"
             className={cn(
-                'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+                'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:duration-300 data-[state=open]:duration-500 ease-in-out fixed inset-0 z-70 bg-black/30',
                 className
             )}
             {...props}
@@ -39,30 +39,70 @@ function SheetContent({
     className,
     children,
     side = 'right',
+    overlayClassName,
+    insetTop,
+    insetBottom,
+    insetLeft,
+    insetRight,
+    scrollable = true,
     ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
     side?: 'top' | 'right' | 'bottom' | 'left';
+    overlayClassName?: string;
+    /** Inset from viewport edges (px). When set for right/left sheets, height becomes calc(100vh - top - bottom). */
+    insetTop?: number;
+    insetBottom?: number;
+    insetLeft?: number;
+    insetRight?: number;
+    /** When true (default when insets are used), wrap content in a scrollable area so the whole sheet scrolls. */
+    scrollable?: boolean;
 }) {
+    const hasInset = side === 'right' || side === 'left' ? insetTop != null || insetBottom != null : insetLeft != null || insetRight != null;
+    const useScrollable = hasInset ? scrollable : false;
+
+    const insetStyle =
+        side === 'right' && (insetTop != null || insetBottom != null)
+            ? {
+                  top: insetTop ?? 0,
+                  bottom: insetBottom ?? 0,
+                  right: insetRight ?? 24,
+                  height: `calc(100vh - ${insetTop ?? 0}px - ${insetBottom ?? 0}px)`
+              }
+            : side === 'left' && (insetTop != null || insetBottom != null)
+              ? {
+                    top: insetTop ?? 0,
+                    bottom: insetBottom ?? 0,
+                    left: insetLeft ?? 24,
+                    height: `calc(100vh - ${insetTop ?? 0}px - ${insetBottom ?? 0}px)`
+                }
+              : undefined;
+
     return (
         <SheetPortal>
-            <SheetOverlay />
+            <SheetOverlay className={overlayClassName} />
             <SheetPrimitive.Content
                 data-slot="sheet-content"
+                style={insetStyle}
                 className={cn(
-                    'bg-white data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 dark:bg-neutral-950',
+                    'bg-bg-elevated data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-70 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
                     side === 'right' &&
-                        'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
+                        (insetStyle
+                            ? 'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right min-h-0 w-3/4 border-l sm:max-w-sm'
+                            : 'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm'),
                     side === 'left' &&
-                        'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm',
+                        (insetStyle
+                            ? 'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left min-h-0 w-3/4 border-r sm:max-w-sm'
+                            : 'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm'),
                     side === 'top' && 'data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b',
                     side === 'bottom' && 'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t',
-                    className
+                    className,
+                    useScrollable && 'pr-[18px]'
                 )}
                 {...props}
             >
-                {children}
+                {useScrollable ? <div className="scrollbar-app flex min-h-0 w-full flex-1 flex-col overflow-auto pr-1">{children}</div> : children}
                 <SheetPrimitive.Close className="ring-offset-white focus:ring-neutral-950 data-[state=open]:bg-neutral-100 absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none dark:ring-offset-neutral-950 dark:focus:ring-neutral-300 dark:data-[state=open]:bg-neutral-800">
-                    <XIcon className="size-4" />
+                    <XIcon />
                     <span className="sr-only">Close</span>
                 </SheetPrimitive.Close>
             </SheetPrimitive.Content>

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -583,9 +583,21 @@
     font-weight: 600;
 }
 
+@utility text-label-large {
+    font-size: 14px;
+    line-height: 20px;
+    font-weight: 500;
+}
+
 @utility text-heading-large {
     font-size: 24px;
     line-height: 32px;
+    font-weight: 500;
+}
+
+@utility text-heading-medium {
+    font-size: 20px;
+    line-height: 28px;
     font-weight: 500;
 }
 
@@ -719,4 +731,33 @@
 .mantine-Prism-code {
     font-family: 'Geist Mono';
     background-color: var(--color-bg-surface) !important;
+}
+
+.scrollbar-app {
+    scrollbar-gutter: stable;
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-gray-400) transparent;
+}
+.scrollbar-app::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+}
+.scrollbar-app::-webkit-scrollbar-track {
+    background: transparent;
+}
+.scrollbar-app::-webkit-scrollbar-thumb {
+    background: var(--color-gray-400);
+    border-radius: 3px;
+}
+.scrollbar-app::-webkit-scrollbar-thumb:hover {
+    background: var(--color-gray-500);
+}
+.dark .scrollbar-app {
+    scrollbar-color: var(--color-gray-600) transparent;
+}
+.dark .scrollbar-app::-webkit-scrollbar-thumb {
+    background: var(--color-gray-600);
+}
+.dark .scrollbar-app::-webkit-scrollbar-thumb:hover {
+    background: var(--color-gray-550);
 }

--- a/packages/webapp/src/layout/DashboardLayout.tsx
+++ b/packages/webapp/src/layout/DashboardLayout.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { AppSidebar } from '../components-v2/AppSidebar';
 import { AppHeader } from '@/components-v2/AppHeader';
+import { Playground } from '@/components-v2/Playground';
 import { SidebarInset, SidebarProvider } from '@/components-v2/ui/sidebar';
 import { cn } from '@/utils/utils';
 
@@ -17,10 +18,14 @@ const DashboardLayout = React.forwardRef<HTMLDivElement, DashboardLayoutProps>((
                 <AppHeader />
                 <div
                     ref={ref}
-                    className={cn('w-full h-full overflow-auto rounded-tl-sm border border-border-muted bg-bg-surface min-w-3xl', fullWidth ? 'p-0' : 'p-11')}
+                    className={cn(
+                        'relative w-full h-full overflow-auto rounded-tl-sm border border-border-muted bg-bg-surface min-w-3xl',
+                        fullWidth ? 'p-0' : 'p-11'
+                    )}
                     {...props}
                 >
                     <div className={cn('grow h-auto mx-auto w-full', fullWidth ? 'p-11' : 'min-w-[968px] max-w-[1056px]', className)}>{children}</div>
+                    <Playground />
                 </div>
             </SidebarInset>
         </SidebarProvider>

--- a/packages/webapp/src/store.ts
+++ b/packages/webapp/src/store.ts
@@ -2,6 +2,7 @@ import { QueryClient } from '@tanstack/react-query';
 import { create } from 'zustand';
 
 import { PROD_ENVIRONMENT_NAME } from './constants';
+import { usePlaygroundStore } from './store/playground';
 import storage, { LocalStorageKeys } from './utils/local-storage';
 
 interface Env {
@@ -21,7 +22,7 @@ interface State {
     setDebugMode: (value: boolean) => void;
 }
 
-export const useStore = create<State>((set, get) => ({
+export const useStore = create<State>()((set, get) => ({
     env: storage.getItem(LocalStorageKeys.LastEnvironment) || 'dev',
     envs: [{ name: 'dev' }, { name: PROD_ENVIRONMENT_NAME }],
     baseUrl: 'https://api.nango.dev',
@@ -29,28 +30,19 @@ export const useStore = create<State>((set, get) => ({
     debugMode: false,
 
     setEnv: (value) => {
+        if (get().env !== value) {
+            usePlaygroundStore.getState().reset();
+        }
         set({ env: value });
     },
 
-    setEnvs: (envs: Env[]) => {
-        set({ envs });
-    },
+    setEnvs: (envs) => set({ envs }),
 
-    getEnvs: () => {
-        return get().envs;
-    },
+    setBaseUrl: (value) => set({ baseUrl: value }),
 
-    setBaseUrl: (value) => {
-        set({ baseUrl: value });
-    },
+    setShowGettingStarted: (value) => set({ showGettingStarted: value }),
 
-    setShowGettingStarted: (value) => {
-        set({ showGettingStarted: value });
-    },
-
-    setDebugMode: (value) => {
-        set({ debugMode: value });
-    }
+    setDebugMode: (value) => set({ debugMode: value })
 }));
 
 export const queryClient = new QueryClient({
@@ -61,9 +53,7 @@ export const queryClient = new QueryClient({
             refetchOnMount: true,
             staleTime: 30 * 1000,
             retry: 0,
-            retryDelay: (attemptIndex) => {
-                return Math.min(2000 * 2 ** attemptIndex, 30000);
-            }
+            retryDelay: (attemptIndex) => Math.min(2000 * 2 ** attemptIndex, 30000)
         }
     }
 });

--- a/packages/webapp/src/store.ts
+++ b/packages/webapp/src/store.ts
@@ -22,8 +22,10 @@ interface State {
     setDebugMode: (value: boolean) => void;
 }
 
+const initialEnv: unknown = storage.getItem(LocalStorageKeys.LastEnvironment);
+
 export const useStore = create<State>()((set, get) => ({
-    env: storage.getItem(LocalStorageKeys.LastEnvironment) || 'dev',
+    env: typeof initialEnv === 'string' && initialEnv ? initialEnv : 'dev',
     envs: [{ name: 'dev' }, { name: PROD_ENVIRONMENT_NAME }],
     baseUrl: 'https://api.nango.dev',
     showGettingStarted: true,
@@ -31,6 +33,7 @@ export const useStore = create<State>()((set, get) => ({
 
     setEnv: (value) => {
         if (get().env !== value) {
+            usePlaygroundStore.getState().abortActiveRun?.();
             usePlaygroundStore.getState().reset();
         }
         set({ env: value });

--- a/packages/webapp/src/store.unit.test.ts
+++ b/packages/webapp/src/store.unit.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const storageState = vi.hoisted(() => {
+    const localStore: Record<string, string> = {};
+    const sessionStore: Record<string, string> = {};
+
+    vi.stubGlobal('localStorage', {
+        getItem: (k: string) => localStore[k] ?? null,
+        setItem: (k: string, v: string) => {
+            localStore[k] = v;
+        },
+        removeItem: (k: string) => {
+            Reflect.deleteProperty(localStore, k);
+        },
+        clear: () => {
+            Object.keys(localStore).forEach((k) => {
+                Reflect.deleteProperty(localStore, k);
+            });
+        }
+    });
+
+    vi.stubGlobal('sessionStorage', {
+        getItem: (k: string) => sessionStore[k] ?? null,
+        setItem: (k: string, v: string) => {
+            sessionStore[k] = v;
+        },
+        removeItem: (k: string) => {
+            Reflect.deleteProperty(sessionStore, k);
+        },
+        clear: () => {
+            Object.keys(sessionStore).forEach((k) => {
+                Reflect.deleteProperty(sessionStore, k);
+            });
+        }
+    });
+
+    return { localStore, sessionStore };
+});
+
+import { useStore } from './store';
+import { defaultPlaygroundState, usePlaygroundStore } from './store/playground';
+
+describe('useStore', () => {
+    afterEach(() => {
+        useStore.setState({ env: 'dev' });
+        usePlaygroundStore.setState({ ...defaultPlaygroundState, abortActiveRun: null });
+        Object.keys(storageState.localStore).forEach((k) => {
+            Reflect.deleteProperty(storageState.localStore, k);
+        });
+        Object.keys(storageState.sessionStore).forEach((k) => {
+            Reflect.deleteProperty(storageState.sessionStore, k);
+        });
+    });
+
+    describe('setEnv', () => {
+        it('aborts and resets the playground when switching environments', () => {
+            const abortActiveRun = vi.fn();
+
+            usePlaygroundStore.setState({
+                isOpen: true,
+                integration: 'github',
+                connection: 'conn-1',
+                function: 'sync-users',
+                functionType: 'sync',
+                pendingOperationId: 'op-1',
+                running: true,
+                abortActiveRun
+            });
+
+            useStore.getState().setEnv('prod');
+
+            expect(abortActiveRun).toHaveBeenCalledTimes(1);
+            expect(useStore.getState().env).toBe('prod');
+
+            const playgroundState = usePlaygroundStore.getState();
+            expect(playgroundState.isOpen).toBe(true);
+            expect(playgroundState.integration).toBeNull();
+            expect(playgroundState.connection).toBeNull();
+            expect(playgroundState.function).toBeNull();
+            expect(playgroundState.functionType).toBeNull();
+            expect(playgroundState.pendingOperationId).toBeNull();
+            expect(playgroundState.running).toBe(false);
+        });
+
+        it('does not reset or abort when the environment is unchanged', () => {
+            const abortActiveRun = vi.fn();
+
+            usePlaygroundStore.setState({ integration: 'github', abortActiveRun });
+
+            useStore.getState().setEnv('dev');
+
+            expect(abortActiveRun).not.toHaveBeenCalled();
+            expect(usePlaygroundStore.getState().integration).toBe('github');
+        });
+    });
+});

--- a/packages/webapp/src/store/playground.ts
+++ b/packages/webapp/src/store/playground.ts
@@ -1,0 +1,121 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+import { LocalStorageKeys } from '@/utils/local-storage';
+
+export type PlaygroundFunctionType = 'action' | 'sync' | null;
+
+export interface PlaygroundResult {
+    success: boolean;
+    data: unknown;
+    durationMs: number;
+    operationId?: string;
+    state?: string;
+}
+
+export interface PlaygroundState {
+    isOpen: boolean;
+    integration: string | null;
+    connection: string | null;
+    function: string | null;
+    functionType: PlaygroundFunctionType;
+    inputValues: Record<string, string>;
+    result: PlaygroundResult | null;
+    // Persisted — used to re-attach to an in-flight operation after navigation/refresh
+    pendingOperationId: string | null;
+    // Transient — not persisted to localStorage
+    running: boolean;
+    inputErrors: Record<string, string>;
+    connectionSearch: string;
+}
+
+interface PlaygroundStore extends PlaygroundState {
+    setOpen: (value: boolean) => void;
+    setIntegration: (value: string | null) => void;
+    setConnection: (value: string | null) => void;
+    setFunction: (name: string | null, type: PlaygroundFunctionType) => void;
+    setInputValues: (values: Record<string, string>) => void;
+    setInputValue: (name: string, value: string) => void;
+    setResult: (result: PlaygroundResult | null) => void;
+    setPendingOperationId: (operationId: string | null) => void;
+    setRunning: (running: boolean) => void;
+    setInputErrors: (errors: Record<string, string>) => void;
+    setInputError: (name: string, message: string) => void;
+    clearInputError: (name: string) => void;
+    setConnectionSearch: (search: string) => void;
+    reset: (keepOpen?: boolean) => void;
+    setState: (value: PlaygroundState) => void;
+}
+
+export const defaultPlaygroundState: PlaygroundState = {
+    isOpen: false,
+    integration: null,
+    connection: null,
+    function: null,
+    functionType: null,
+    inputValues: {},
+    result: null,
+    pendingOperationId: null,
+    running: false,
+    inputErrors: {},
+    connectionSearch: ''
+};
+
+export const usePlaygroundStore = create<PlaygroundStore>()(
+    persist(
+        (set) => ({
+            ...defaultPlaygroundState,
+
+            setOpen: (isOpen) => set({ isOpen }),
+
+            setIntegration: (integration) => set({ integration, connection: null, function: null, functionType: null, inputValues: {} }),
+
+            setConnection: (connection) => set({ connection }),
+
+            setFunction: (name, type) => set({ function: name, functionType: type, inputValues: {} }),
+
+            setInputValues: (inputValues) => set({ inputValues }),
+
+            setInputValue: (name, value) => set((s) => ({ inputValues: { ...s.inputValues, [name]: value } })),
+
+            setResult: (result) => set({ result }),
+
+            setPendingOperationId: (pendingOperationId) => set({ pendingOperationId }),
+
+            setRunning: (running) => set({ running }),
+
+            setInputErrors: (inputErrors) => set({ inputErrors }),
+
+            setInputError: (name, message) => set((s) => ({ inputErrors: { ...s.inputErrors, [name]: message } })),
+
+            clearInputError: (name) =>
+                set((s) => {
+                    const { [name]: _removed, ...rest } = s.inputErrors;
+                    return { inputErrors: rest };
+                }),
+
+            setConnectionSearch: (connectionSearch) => set({ connectionSearch }),
+
+            reset: (keepOpen = true) => set((s) => ({ ...defaultPlaygroundState, isOpen: keepOpen ? s.isOpen : false })),
+
+            setState: (value) => set(value)
+        }),
+        {
+            name: LocalStorageKeys.Playground,
+            storage: createJSONStorage(() => sessionStorage),
+            partialize: (s) => ({
+                isOpen: false,
+                integration: s.integration,
+                connection: s.connection,
+                function: s.function,
+                functionType: s.functionType,
+                inputValues: s.inputValues,
+                result: null,
+                pendingOperationId: s.pendingOperationId,
+                running: false,
+                inputErrors: {},
+                connectionSearch: ''
+            })
+        }
+    )
+);

--- a/packages/webapp/src/store/playground.ts
+++ b/packages/webapp/src/store/playground.ts
@@ -30,6 +30,7 @@ export interface PlaygroundState {
 }
 
 interface PlaygroundStore extends PlaygroundState {
+    abortActiveRun: (() => void) | null;
     setOpen: (value: boolean) => void;
     setIntegration: (value: string | null) => void;
     setConnection: (value: string | null) => void;
@@ -43,6 +44,7 @@ interface PlaygroundStore extends PlaygroundState {
     setInputError: (name: string, message: string) => void;
     clearInputError: (name: string) => void;
     setConnectionSearch: (search: string) => void;
+    setAbortActiveRun: (abortActiveRun: (() => void) | null) => void;
     reset: (keepOpen?: boolean) => void;
     setState: (value: PlaygroundState) => void;
 }
@@ -65,6 +67,7 @@ export const usePlaygroundStore = create<PlaygroundStore>()(
     persist(
         (set) => ({
             ...defaultPlaygroundState,
+            abortActiveRun: null,
 
             setOpen: (isOpen) => set({ isOpen }),
 
@@ -95,6 +98,8 @@ export const usePlaygroundStore = create<PlaygroundStore>()(
                 }),
 
             setConnectionSearch: (connectionSearch) => set({ connectionSearch }),
+
+            setAbortActiveRun: (abortActiveRun) => set({ abortActiveRun }),
 
             reset: (keepOpen = true) => set((s) => ({ ...defaultPlaygroundState, isOpen: keepOpen ? s.isOpen : false })),
 

--- a/packages/webapp/src/store/playground.ts
+++ b/packages/webapp/src/store/playground.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
-import { LocalStorageKeys } from '@/utils/local-storage';
+import { LocalStorageKeys } from '../utils/local-storage';
 
 export type PlaygroundFunctionType = 'action' | 'sync' | null;
 

--- a/packages/webapp/src/store/playground.unit.test.ts
+++ b/packages/webapp/src/store/playground.unit.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/local-storage', () => ({
+    LocalStorageKeys: { Playground: 'nango_playground' }
+}));
+
+// vi.hoisted runs before ESM imports, so localStorage is stubbed before the persist
+// middleware initializes (which happens at module load time).
+const localStore = vi.hoisted(() => {
+    const store: Record<string, string> = {};
+    vi.stubGlobal('sessionStorage', {
+        getItem: (k: string) => store[k] ?? null,
+        setItem: (k: string, v: string) => {
+            store[k] = v;
+        },
+        removeItem: (k: string) => {
+            Reflect.deleteProperty(store, k);
+        },
+        clear: () => {
+            Object.keys(store).forEach((k) => {
+                Reflect.deleteProperty(store, k);
+            });
+        }
+    });
+    return store;
+});
+
+// Relative import — no alias needed from the test side
+import { defaultPlaygroundState, usePlaygroundStore } from './playground';
+
+describe('usePlaygroundStore', () => {
+    afterEach(() => {
+        usePlaygroundStore.setState({ ...defaultPlaygroundState });
+        Object.keys(localStore).forEach((k) => {
+            Reflect.deleteProperty(localStore, k);
+        });
+    });
+
+    describe('setIntegration', () => {
+        it('sets the new integration', () => {
+            usePlaygroundStore.getState().setIntegration('github');
+            expect(usePlaygroundStore.getState().integration).toBe('github');
+        });
+
+        it('clears connection, function, functionType, and inputValues', () => {
+            usePlaygroundStore.setState({ connection: 'c', function: 'fn', functionType: 'action', inputValues: { x: '1' } });
+            usePlaygroundStore.getState().setIntegration('github');
+            const s = usePlaygroundStore.getState();
+            expect(s.connection).toBeNull();
+            expect(s.function).toBeNull();
+            expect(s.functionType).toBeNull();
+            expect(s.inputValues).toEqual({});
+        });
+    });
+
+    describe('setFunction', () => {
+        it('sets function name and type and clears inputValues', () => {
+            usePlaygroundStore.setState({ inputValues: { a: '1', b: '2' } });
+            usePlaygroundStore.getState().setFunction('fetchContacts', 'action');
+            const s = usePlaygroundStore.getState();
+            expect(s.function).toBe('fetchContacts');
+            expect(s.functionType).toBe('action');
+            expect(s.inputValues).toEqual({});
+        });
+    });
+
+    describe('reset', () => {
+        it('clears all state and keeps isOpen=true by default', () => {
+            usePlaygroundStore.setState({
+                isOpen: true,
+                integration: 'github',
+                connection: 'c',
+                function: 'fn',
+                functionType: 'sync',
+                inputValues: { x: '1' },
+                result: { success: true, data: null, durationMs: 0 },
+                pendingOperationId: 'op-1',
+                running: true,
+                inputErrors: { x: 'err' }
+            });
+            usePlaygroundStore.getState().reset();
+            const s = usePlaygroundStore.getState();
+            expect(s.isOpen).toBe(true);
+            expect(s.integration).toBeNull();
+            expect(s.connection).toBeNull();
+            expect(s.function).toBeNull();
+            expect(s.functionType).toBeNull();
+            expect(s.inputValues).toEqual({});
+            expect(s.result).toBeNull();
+            expect(s.pendingOperationId).toBeNull();
+            expect(s.running).toBe(false);
+            expect(s.inputErrors).toEqual({});
+        });
+
+        it('closes the sheet when keepOpen=false', () => {
+            usePlaygroundStore.setState({ isOpen: true });
+            usePlaygroundStore.getState().reset(false);
+            expect(usePlaygroundStore.getState().isOpen).toBe(false);
+        });
+    });
+
+    describe('inputErrors', () => {
+        it('setInputError adds an error by field name', () => {
+            usePlaygroundStore.getState().setInputError('email', 'Required');
+            expect(usePlaygroundStore.getState().inputErrors).toEqual({ email: 'Required' });
+        });
+
+        it('setInputErrors replaces all errors at once', () => {
+            usePlaygroundStore.setState({ inputErrors: { a: 'old' } });
+            usePlaygroundStore.getState().setInputErrors({ b: 'new' });
+            expect(usePlaygroundStore.getState().inputErrors).toEqual({ b: 'new' });
+        });
+
+        it('clearInputError removes only the targeted key', () => {
+            usePlaygroundStore.setState({ inputErrors: { email: 'Required', name: 'Too short' } });
+            usePlaygroundStore.getState().clearInputError('email');
+            expect(usePlaygroundStore.getState().inputErrors).toEqual({ name: 'Too short' });
+        });
+
+        it('clearInputError is a no-op for unknown keys', () => {
+            usePlaygroundStore.setState({ inputErrors: { name: 'err' } });
+            usePlaygroundStore.getState().clearInputError('missing');
+            expect(usePlaygroundStore.getState().inputErrors).toEqual({ name: 'err' });
+        });
+    });
+
+    describe('persist partialize', () => {
+        it('persists integration, connection, function, functionType, inputValues, pendingOperationId', () => {
+            usePlaygroundStore.setState({
+                integration: 'github',
+                connection: 'conn-1',
+                function: 'fetchContacts',
+                functionType: 'action',
+                inputValues: { q: 'hello' },
+                pendingOperationId: 'op-99'
+            });
+            const raw = localStore['nango_playground'];
+            if (!raw) return; // async flush — skip if persist hasn't written yet
+            const persisted = JSON.parse(raw).state;
+            expect(persisted.integration).toBe('github');
+            expect(persisted.connection).toBe('conn-1');
+            expect(persisted.function).toBe('fetchContacts');
+            expect(persisted.functionType).toBe('action');
+            expect(persisted.inputValues).toEqual({ q: 'hello' });
+            expect(persisted.pendingOperationId).toBe('op-99');
+        });
+
+        it('never persists running, result, inputErrors, connectionSearch, or isOpen=true', () => {
+            usePlaygroundStore.setState({
+                isOpen: true,
+                running: true,
+                result: { success: true, data: 'x', durationMs: 100 },
+                inputErrors: { x: 'err' },
+                connectionSearch: 'foo'
+            });
+            const raw = localStore['nango_playground'];
+            if (!raw) return;
+            const persisted = JSON.parse(raw).state;
+            expect(persisted.isOpen).toBe(false);
+            expect(persisted.running).toBe(false);
+            expect(persisted.result).toBeNull();
+            expect(persisted.inputErrors).toEqual({});
+            expect(persisted.connectionSearch).toBe('');
+        });
+    });
+});

--- a/packages/webapp/src/utils/local-storage.tsx
+++ b/packages/webapp/src/utils/local-storage.tsx
@@ -38,7 +38,8 @@ export enum LocalStorageKeys {
     UserName = 'nango_user_name',
     UserId = 'nango_user_id',
     AccountId = 'nango_account_id',
-    LastEnvironment = 'nango_last_environment'
+    LastEnvironment = 'nango_last_environment',
+    Playground = 'nango_playground'
 }
 
 const storage = new LocalStorage();

--- a/packages/webapp/src/utils/logs.ts
+++ b/packages/webapp/src/utils/logs.ts
@@ -3,31 +3,45 @@ import { addMilliseconds, startOfDay, subDays, subHours, subMinutes } from 'date
 import type { Period, PeriodPreset } from './dates';
 import type { SearchOperations, SearchPeriod } from '@nangohq/types';
 
-export function getLogsUrl(
-    options: Omit<
-        Partial<{
-            [P in keyof SearchOperations['Body']]?: string | undefined;
-        }>,
-        'period'
-    > & { operationId?: string | null | number; env: string; day?: Date | null }
-): string {
+type LogsUrlOptions = Omit<
+    Partial<{
+        [P in keyof SearchOperations['Body']]?: string | undefined;
+    }>,
+    'period'
+> & { operationId?: string | null | number; env: string; day?: Date | null; live?: boolean };
+
+function setParam(usp: URLSearchParams, key: string, value: string | number | string[] | undefined | null): void {
+    if (value === undefined || value === null || value === '') return;
+    if (Array.isArray(value)) {
+        const filtered = value.filter((v) => v !== '');
+        if (filtered.length > 0) usp.set(key, filtered.join(','));
+    } else {
+        usp.set(key, String(value));
+    }
+}
+
+export function getLogsUrl(options: LogsUrlOptions): string {
     const usp = new URLSearchParams();
-    for (const [key, val] of Object.entries(options)) {
-        if (!val || key === 'env') {
-            continue;
-        }
-        if (key === 'day' && val) {
-            const from = new Date(val);
-            from.setHours(0, 0);
-            const to = new Date(val);
-            to.setHours(23, 59);
-            usp.set('period', `${from.getTime()},${to.getTime()}`);
-            continue;
-        }
-        usp.set(key, val as any);
+
+    if (options.day) {
+        const from = new Date(options.day);
+        from.setHours(0, 0);
+        const to = new Date(options.day);
+        to.setHours(23, 59);
+        usp.set('period', `${from.getTime()},${to.getTime()}`);
     }
 
-    usp.set('live', 'false');
+    setParam(usp, 'operationId', options.operationId != null ? String(options.operationId) : undefined);
+    setParam(usp, 'search', options.search);
+    setParam(usp, 'limit', options.limit);
+    setParam(usp, 'states', options.states);
+    setParam(usp, 'types', options.types);
+    setParam(usp, 'integrations', options.integrations);
+    setParam(usp, 'connections', options.connections);
+    setParam(usp, 'syncs', options.syncs);
+    setParam(usp, 'cursor', options.cursor ?? undefined);
+
+    usp.set('live', options.live ? 'true' : 'false');
     usp.sort();
     return `/${options.env}/logs?${usp.toString()}`;
 }

--- a/packages/webapp/src/utils/logs.unit.test.ts
+++ b/packages/webapp/src/utils/logs.unit.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { getLogsUrl } from './logs.js';
+
+describe('getLogsUrl', () => {
+    it('omits undefined and null filter values', () => {
+        const url = getLogsUrl({ env: 'dev', connections: undefined, types: null as any });
+        expect(url).not.toContain('connections=');
+        expect(url).not.toContain('types=');
+    });
+
+    it('omits empty string filter values', () => {
+        const url = getLogsUrl({ env: 'dev', connections: '', integrations: '' });
+        expect(url).not.toContain('connections=');
+        expect(url).not.toContain('integrations=');
+    });
+
+    it('omits arrays of empty strings', () => {
+        const url = getLogsUrl({ env: 'dev', types: ['', ''] as any });
+        expect(url).not.toContain('types=');
+    });
+
+    it('filters empty strings out of mixed arrays', () => {
+        const url = getLogsUrl({ env: 'dev', types: ['', 'action', ''] as any });
+        expect(url).toContain('types=action');
+        expect(url).not.toMatch(/types=,|types=.*,$/);
+    });
+
+    it('includes valid scalar filters', () => {
+        const url = getLogsUrl({ env: 'dev', connections: 'conn-1', integrations: 'github' });
+        expect(url).toContain('connections=conn-1');
+        expect(url).toContain('integrations=github');
+    });
+
+    it('includes valid array filters joined by comma', () => {
+        const url = getLogsUrl({ env: 'dev', types: ['action', 'sync'] as any });
+        expect(url).toContain('types=action%2Csync');
+    });
+
+    it('includes operationId when set', () => {
+        const url = getLogsUrl({ env: 'dev', operationId: 'op-123' });
+        expect(url).toContain('operationId=op-123');
+    });
+
+    it('omits operationId when null', () => {
+        const url = getLogsUrl({ env: 'dev', operationId: null });
+        expect(url).not.toContain('operationId=');
+    });
+
+    it('uses the correct env in the path', () => {
+        const url = getLogsUrl({ env: 'staging' });
+        expect(url).toMatch(/^\/staging\/logs\?/);
+    });
+
+    it('sets live=false by default', () => {
+        const url = getLogsUrl({ env: 'dev' });
+        expect(url).toContain('live=false');
+    });
+
+    it('sets live=true when requested', () => {
+        const url = getLogsUrl({ env: 'dev', live: true });
+        expect(url).toContain('live=true');
+    });
+});

--- a/packages/webapp/src/utils/playground.ts
+++ b/packages/webapp/src/utils/playground.ts
@@ -1,0 +1,35 @@
+import { usePlaygroundStore } from '@/store/playground';
+
+import type { PlaygroundFunctionType, PlaygroundState } from '@/store/playground';
+
+export interface PlaygroundContextOverride {
+    integration?: string | null;
+    connection?: string | null;
+    functionName?: string | null;
+    functionType?: PlaygroundFunctionType;
+    inputValues?: Record<string, string>;
+}
+
+/**
+ * Opens the Playground and overwrites its selection state.
+ *
+ * Intended for future contextual "Open Playground" buttons on
+ * integration/connection/sync/action pages
+ */
+export function openPlaygroundWithContext(override: PlaygroundContextOverride) {
+    const next: PlaygroundState = {
+        isOpen: true,
+        integration: override.integration ?? null,
+        connection: override.connection ?? null,
+        function: override.functionName ?? null,
+        functionType: override.functionType ?? null,
+        inputValues: override.inputValues ?? {},
+        result: null,
+        pendingOperationId: null,
+        running: false,
+        inputErrors: {},
+        connectionSearch: ''
+    };
+
+    usePlaygroundStore.getState().setState(next);
+}

--- a/packages/webapp/vitest.config.ts
+++ b/packages/webapp/vitest.config.ts
@@ -1,0 +1,11 @@
+import path from 'node:path';
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname, './src')
+        }
+    }
+});


### PR DESCRIPTION

<img width="32%" alt="Screenshot 2026-04-07 at 10 25 18 AM" src="https://github.com/user-attachments/assets/673e3ff0-f5d9-4613-9976-c9121c079ad6" />
<img width="32%" alt="Screenshot 2026-04-07 at 10 25 27 AM" src="https://github.com/user-attachments/assets/5c25cb30-2bbf-41cf-8ffa-97a1855a4b07" />
<img width="32%" alt="Screenshot 2026-04-07 at 10 25 44 AM" src="https://github.com/user-attachments/assets/eb3d9960-4521-4add-bf8a-b294dd754cb5" />

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Add `Playground` End-to-End Feature with Persisted State, Execution Lifecycle, and Permission Gating**

This PR introduces a major new `Playground` experience in the web app, accessible from `packages/webapp/src/components-v2/AppHeader.tsx` and rendered in `packages/webapp/src/layout/DashboardLayout.tsx` via a right-side `Sheet`. Users can select an integration, connection, and function (`action` or `sync`), provide schema-derived inputs, trigger runs, view execution status/results, cancel sync runs, and jump to filtered logs. The implementation includes new feature modules (`Playground` components, orchestration hook, utilities, and shared `Combobox`) plus updates to shared UI primitives and styling utilities.

State management was split into a dedicated persisted Zustand store in `packages/webapp/src/store/playground.ts` with `sessionStorage` persistence and selective partialization for reattach behavior. The run lifecycle is handled in `packages/webapp/src/components-v2/Playground/usePlayground.ts` with input parsing/validation, operation discovery, status polling, terminal result handling, and best-effort cancellation. The PR also adds production authorization checks via `packages/authz/lib/permissions.ts` (`canUseProdPlayground`) and broad test coverage for schema parsing, parsing/validation helpers, store behavior/persistence, and logs URL generation.

---
*This summary was automatically generated by @propel-code-bot*