### PR TITLE
refactor(slack): remove legacy name-based connection ID fallback

### DIFF
--- a/packages/server/lib/controllers/v1/environment/getEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.integration.test.ts
@@ -105,29 +105,5 @@ describe(`GET ${route}`, () => {
             isSuccess(res.json);
             expect(res.json.environmentAndAccount.slack_notifications_channel).toBe('#new-format-alerts');
         });
-
-        it('should return channel using legacy name-based connection', async () => {
-            const { account: customerAccount, env: customerEnv, user } = await seeders.seedAccountEnvAndUser();
-            await db.knex('_nango_environments').where({ id: customerEnv.id }).update({ slack_notifications: true });
-
-            await seeders.createConnectionSeed({
-                env: adminProdEnv,
-                provider: 'slack',
-                connectionId: `account-${customerAccount.uuid}-${customerEnv.name}`,
-                connectionConfig: { 'incoming_webhook.channel': '#legacy-format-alerts' }
-            });
-
-            const session = await authenticateUser(api, user);
-            const res = await api.fetch(route, {
-                method: 'GET',
-                // @ts-expect-error query params are required
-                query: { env: customerEnv.name },
-                session
-            });
-
-            expect(res.res.status).toBe(200);
-            isSuccess(res.json);
-            expect(res.json.environmentAndAccount.slack_notifications_channel).toBe('#legacy-format-alerts');
-        });
     });
 });

--- a/packages/server/lib/controllers/v1/environment/getEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.ts
@@ -3,7 +3,6 @@ import {
     connectionService,
     environmentService,
     externalWebhookService,
-    generateLegacySlackConnectionId,
     generateSlackConnectionId,
     getGlobalWebhookReceiveUrl,
     getWebsocketsPath
@@ -50,19 +49,11 @@ export const getEnvironment = asyncWrapper<GetEnvironment>(async (req, res) => {
         const env = 'prod';
         const info = await accountService.getAccountAndEnvironmentIdByUUID(envs.NANGO_ADMIN_UUID!, env);
         if (info) {
-            // Try new ID-based connection ID first, fall back to legacy name-based for existing installations
-            let connectionConfig = await connectionService.getConnectionConfig({
+            const connectionConfig = await connectionService.getConnectionConfig({
                 provider_config_key: integrationId,
                 environment_id: info.environmentId,
                 connection_id: generateSlackConnectionId(account.uuid, environment.id)
             });
-            if (!connectionConfig || !connectionConfig['incoming_webhook.channel']) {
-                connectionConfig = await connectionService.getConnectionConfig({
-                    provider_config_key: integrationId,
-                    environment_id: info.environmentId,
-                    connection_id: generateLegacySlackConnectionId(account.uuid, environment.name)
-                });
-            }
             if (connectionConfig && connectionConfig['incoming_webhook.channel']) {
                 slack_notifications_channel = connectionConfig['incoming_webhook.channel'];
             }

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -11,7 +11,7 @@ import remoteFileService from './services/file/remote.service.js';
 import flowService from './services/flow.service.js';
 import hmacService from './services/hmac.service.js';
 import { errorNotificationService } from './services/notification/error.service.js';
-import { SlackService, generateLegacySlackConnectionId, generateSlackConnectionId } from './services/notification/slack.service.js';
+import { SlackService, generateSlackConnectionId } from './services/notification/slack.service.js';
 import secretService from './services/secret.service.js';
 import sharedCredentialsService from './services/shared-credentials.service.js';
 import syncManager, { syncCommandToOperation } from './services/sync/manager.service.js';
@@ -73,7 +73,6 @@ export {
     errorNotificationService,
     externalWebhookService,
     flowService,
-    generateLegacySlackConnectionId,
     generateSlackConnectionId,
     hmacService,
     localFileService,

--- a/packages/shared/lib/services/notification/slack.service.ts
+++ b/packages/shared/lib/services/notification/slack.service.ts
@@ -70,7 +70,6 @@ interface PostSlackMessageResponse {
 }
 
 export const generateSlackConnectionId = (accountUUID: string, environmentId: number) => `account-${accountUUID}-${environmentId}`;
-export const generateLegacySlackConnectionId = (accountUUID: string, environmentName: string) => `account-${accountUUID}-${environmentName}`;
 
 /**
  * _nango_slack_notifications
@@ -598,21 +597,11 @@ export class SlackService {
             return Err('failed_to_get_integration');
         }
 
-        // Try new ID-based connection ID first, fall back to legacy name-based for existing installations
-        let slackConnectionResult = await connectionService.getConnection(
-            generateSlackConnectionId(account.uuid, environment.id),
-            this.integrationKey,
-            adminRes.environment.id
-        );
-        if (slackConnectionResult.error?.type === 'unknown_connection') {
-            slackConnectionResult = await connectionService.getConnection(
-                generateLegacySlackConnectionId(account.uuid, environment.name),
-                this.integrationKey,
-                adminRes.environment.id
-            );
-        }
-
-        const { success: connectionSuccess, error: slackConnectionError, response: slackConnection } = slackConnectionResult;
+        const {
+            success: connectionSuccess,
+            error: slackConnectionError,
+            response: slackConnection
+        } = await connectionService.getConnection(generateSlackConnectionId(account.uuid, environment.id), this.integrationKey, adminRes.environment.id);
 
         if (!connectionSuccess || !slackConnection) {
             logger.error(slackConnectionError);

--- a/packages/webapp/src/pages/Environment/Settings/SlackAlerts.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/SlackAlerts.tsx
@@ -43,16 +43,9 @@ export const SlackAlertsSettings: React.FC = () => {
     };
 
     const slackDisconnect = async () => {
-        let res = await apiFetch(`/api/v1/connections/admin/account-${environmentAndAccount?.uuid}-${environmentAndAccount?.environment.id}?env=${env}`, {
+        const res = await apiFetch(`/api/v1/connections/admin/account-${environmentAndAccount?.uuid}-${environmentAndAccount?.environment.id}?env=${env}`, {
             method: 'DELETE'
         });
-
-        // Fall back to legacy name-based connection id for existing installations
-        if (res.status === 404) {
-            res = await apiFetch(`/api/v1/connections/admin/account-${environmentAndAccount?.uuid}-${env}?env=${env}`, {
-                method: 'DELETE'
-            });
-        }
 
         if (res.status !== 204) {
             toast({ title: 'There was a problem when disconnecting Slack', variant: 'error' });


### PR DESCRIPTION
The migration from env-name to env-id based Slack connection IDs is complete, so the dual lookup is no longer needed.


<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Remove legacy Slack connection ID fallback**

This PR removes the legacy name-based Slack connection ID lookup now that the env-id migration is complete. It simplifies Slack disconnection, environment lookup, and Slack notification retrieval to only use the ID-based connection ID.

---
*This summary was automatically generated by @propel-code-bot*