### PR TITLE
fix(docs): replace while loop with nango.paginate in checkpoints doc

### DIFF
--- a/docs/implementation-guides/use-cases/syncs/checkpoints.mdx
+++ b/docs/implementation-guides/use-cases/syncs/checkpoints.mdx
@@ -106,15 +106,16 @@ export default createSync({
         }
         query += ' ORDER BY LastModifiedDate ASC';
 
-        let endpoint = '/services/data/v53.0/query';
-
-        while (true) {
-            const response = await nango.get({
-                endpoint,
-                params: endpoint.includes('/query') ? { q: query } : {},
-            });
-
-            const contacts = mapContacts(response.data.records);
+        for await (const records of nango.paginate({
+            endpoint: '/services/data/v53.0/query',
+            params: { q: query },
+            paginate: {
+                type: 'link',
+                response_path: 'records',
+                link_path_in_response_body: 'nextRecordsUrl',
+            },
+        })) {
+            const contacts = mapContacts(records);
 
             // 2. Save records to the cache
             await nango.batchSave(contacts, 'Contact');
@@ -124,9 +125,6 @@ export default createSync({
             await nango.saveCheckpoint({
                 lastModifiedISO: lastContact.last_modified_date,
             });
-
-            if (response.data.done) break;
-            endpoint = response.data.nextRecordsUrl;
         }
     },
 });


### PR DESCRIPTION
cleaner example in docs using `paginate` instead of while true 

<!-- Summary by @propel-code-bot -->

---

The updated snippet demonstrates link-based pagination by iterating over records and using nextRecordsUrl from the response body.

---
*This summary was automatically generated by @propel-code-bot*