### PR TITLE
fix(cli): restore pagination logging after dryrun

### DIFF
--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -7,6 +7,7 @@ import * as url from 'url';
 
 import { AxiosError } from 'axios';
 import chalk from 'chalk';
+import inquirer from 'inquirer';
 import { serializeError } from 'serialize-error';
 import * as unzipper from 'unzipper';
 import * as zod from 'zod';
@@ -431,7 +432,42 @@ export class DryRunService {
             if (nangoInstance instanceof NangoSyncCLI) {
                 const logMessages = nangoInstance.logMessages;
                 if (logMessages && logMessages.messages.length > 0) {
-                    // ... (rest of the logging logic)
+                    const messages = logMessages.messages;
+                    let index = 0;
+                    const batchCount = 10;
+
+                    const displayBatch = () => {
+                        for (let i = 0; i < batchCount && index < messages.length; i++, index++) {
+                            const logs = messages[index];
+                            console.log(chalk.yellow(JSON.stringify(logs, null, 2)));
+                            resultOutput.push(JSON.stringify(logs, null, 2));
+                        }
+                    };
+
+                    console.log(chalk.yellow(`The dry run would produce the following results: ${JSON.stringify(logMessages.counts, null, 2)}`));
+                    resultOutput.push(`The dry run would produce the following results: ${JSON.stringify(logMessages.counts, null, 2)}`);
+                    console.log(chalk.yellow('The following log messages were generated:'));
+                    resultOutput.push('The following log messages were generated:');
+
+                    displayBatch();
+
+                    while (index < messages.length) {
+                        const remaining = messages.length - index;
+                        const { confirmation } = options.autoConfirm
+                            ? { confirmation: true }
+                            : await inquirer.prompt([
+                                  {
+                                      type: 'confirm',
+                                      name: 'confirmation',
+                                      message: `There are ${remaining} log messages remaining. Would you like to see the next 10 log messages?`
+                                  }
+                              ]);
+                        if (confirmation) {
+                            displayBatch();
+                        } else {
+                            break;
+                        }
+                    }
                 }
 
                 if (options.saveResponses) {


### PR DESCRIPTION
## Description
Restores the paginated log messages output during nango dryrun for syncs, which was accidentally removed in #5183. The underlying data collection in `NangoSyncCLI.logMessages` (populated by `batchSave`, `batchDelete`, `batchUpdate`) was never removed, only the console presentation was dropped.
This restores the original behavior:
- Prints a summary of dry run results (added/updated/deleted counts)
- Displays log messages in paginated batches of 10
- Prompts the user interactively to continue viewing (respects --auto-confirm)
- Uses inquirer.prompt instead of the previous promptly.confirm, for consistency with the rest of the CLI
## Issue
NAN-4955
## Testing (manual)
1. Run `nango dryrun <sync-name> --connection-id <id>` against a sync that produces records via `batchSave/batchDelete/batchUpdate`
2. Verify the dry run prints result counts and paginated log messages in yellow
3. When more than 10 messages exist, verify you are prompted to view the next batch
4. Verify `--auto-confirm` skips the prompt and displays all messages


<!-- Summary by @propel-code-bot -->

---

This PR restores the dry run console output for syncs by reintroducing paginated log message display and summary counts in `packages/cli/lib/services/dryrun.service.ts`. It adds interactive pagination using `inquirer` (with `--auto-confirm` support) and prints results/logs in yellow, aligning output with previous behavior.

---
*This summary was automatically generated by @propel-code-bot*